### PR TITLE
feat(web): add package-hub generator pipeline task

### DIFF
--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -371,6 +371,31 @@ Template usage (Scriban):
 {{ end }}
 ```
 
+#### package-hub
+Generates a unified package/module metadata JSON file from `.csproj` and `.psd1` inputs.
+```json
+{
+  "task": "package-hub",
+  "title": "IntelligenceX Package Hub",
+  "projectFiles": [
+    "../IntelligenceX/IntelligenceX.csproj",
+    "../IntelligenceX.Cli/IntelligenceX.Cli.csproj"
+  ],
+  "moduleFiles": [
+    "../Module/IntelligenceX.psd1"
+  ],
+  "out": "./data/package-hub.json"
+}
+```
+Notes:
+- Supports `project` / `projects` / `projectFiles` (`project-files`) for `.csproj` inputs.
+- Supports `module` / `modules` / `moduleFiles` (`module-files`) for `.psd1` inputs.
+- Output includes:
+  - libraries: package id/version, target frameworks, and package references
+  - modules: module version, PowerShell compatibility, required modules
+  - warnings: missing files or parse issues
+- Best used before `build` so templates can consume `data/package-hub.json`.
+
 #### llms
 Generates `llms.txt`, `llms.json`, and `llms-full.txt`.
 ```json

--- a/PowerForge.Tests/WebPipelineRunnerPackageHubTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerPackageHubTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using PowerForge.Web.Cli;
+using Xunit;
+
+public class WebPipelineRunnerPackageHubTests
+{
+    [Fact]
+    public void RunPipeline_PackageHub_GeneratesLibraryAndModuleMetadata()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-package-hub-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var srcDir = Path.Combine(root, "src");
+            Directory.CreateDirectory(srcDir);
+            var projectPath = Path.Combine(srcDir, "Contoso.Core.csproj");
+            File.WriteAllText(projectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+                    <PackageId>Contoso.Core</PackageId>
+                    <Version>1.2.3</Version>
+                    <Description>Core library</Description>
+                    <RepositoryUrl>https://github.com/contoso/core</RepositoryUrl>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            var moduleDir = Path.Combine(root, "module");
+            Directory.CreateDirectory(moduleDir);
+            var manifestPath = Path.Combine(moduleDir, "Contoso.Tools.psd1");
+            File.WriteAllText(manifestPath,
+                """
+                @{
+                  RootModule = 'Contoso.Tools.psm1'
+                  ModuleVersion = '2.1.0'
+                  Author = 'Contoso'
+                  Description = 'Tooling module'
+                  PowerShellVersion = '7.2'
+                  CompatiblePSEditions = @('Desktop','Core')
+                  RequiredModules = @('Pester','PSFramework')
+                }
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "package-hub",
+                      "title": "Contoso Hub",
+                      "projectFiles": [ "./src/Contoso.Core.csproj" ],
+                      "moduleFiles": [ "./module/Contoso.Tools.psd1" ],
+                      "out": "./data/package-hub.json"
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.True(result.Success);
+            Assert.Single(result.Steps);
+            Assert.True(result.Steps[0].Success);
+            Assert.Contains("Package hub 1 libraries, 1 modules", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+
+            var outputPath = Path.Combine(root, "data", "package-hub.json");
+            Assert.True(File.Exists(outputPath));
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(outputPath));
+            var rootJson = doc.RootElement;
+            Assert.Equal("Contoso Hub", rootJson.GetProperty("title").GetString());
+
+            var libraries = rootJson.GetProperty("libraries");
+            Assert.Equal(1, libraries.GetArrayLength());
+            var firstLibrary = libraries[0];
+            Assert.Equal("Contoso.Core", firstLibrary.GetProperty("packageId").GetString());
+            Assert.Equal("1.2.3", firstLibrary.GetProperty("version").GetString());
+
+            var modules = rootJson.GetProperty("modules");
+            Assert.Equal(1, modules.GetArrayLength());
+            var firstModule = modules[0];
+            Assert.Equal("2.1.0", firstModule.GetProperty("version").GetString());
+            Assert.Equal("7.2", firstModule.GetProperty("powerShellVersion").GetString());
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void RunPipeline_PackageHub_FailsWithoutInputs()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-package-hub-invalid-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "package-hub",
+                      "out": "./data/package-hub.json"
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.False(result.Success);
+            Assert.Single(result.Steps);
+            Assert.False(result.Steps[0].Success);
+            Assert.Contains("requires at least one project or module input", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, true);
+        }
+        catch
+        {
+            // ignore cleanup failures in tests
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
@@ -209,6 +209,8 @@ internal static partial class WebPipelineRunner
                 return ResolveOutputCandidates(baseDir, GetString(step, "out") ?? GetString(step, "output"));
             case "xref-merge":
                 return ResolveOutputCandidates(baseDir, GetString(step, "out") ?? GetString(step, "output"));
+            case "package-hub":
+                return ResolveOutputCandidates(baseDir, GetString(step, "out") ?? GetString(step, "output"));
             case "llms":
             {
                 var siteRoot = ResolvePath(baseDir, GetString(step, "siteRoot") ?? GetString(step, "site-root"));

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
@@ -712,6 +712,46 @@ internal static partial class WebPipelineRunner
         stepResult.Message = $"Changelog {res.ReleaseCount} releases{note}";
     }
 
+    private static void ExecutePackageHub(JsonElement step, string baseDir, WebPipelineStepResult stepResult)
+    {
+        var outPath = ResolvePath(baseDir, GetString(step, "out") ?? GetString(step, "output"));
+        if (string.IsNullOrWhiteSpace(outPath))
+            throw new InvalidOperationException("package-hub requires out.");
+
+        var title = GetString(step, "title");
+        var projects = new List<string>();
+        AddInputPaths(projects, GetString(step, "project"));
+        AddInputPaths(projects, GetString(step, "projects"));
+        AddInputPaths(projects, GetArrayOfStrings(step, "projectFiles"));
+        AddInputPaths(projects, GetArrayOfStrings(step, "project-files"));
+
+        var modules = new List<string>();
+        AddInputPaths(modules, GetString(step, "module"));
+        AddInputPaths(modules, GetString(step, "modules"));
+        AddInputPaths(modules, GetArrayOfStrings(step, "moduleFiles"));
+        AddInputPaths(modules, GetArrayOfStrings(step, "module-files"));
+
+        var options = new WebPackageHubOptions
+        {
+            OutputPath = outPath,
+            BaseDirectory = baseDir,
+            Title = title
+        };
+        options.ProjectPaths.AddRange(projects
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase));
+        options.ModulePaths.AddRange(modules
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase));
+
+        var result = WebPackageHubGenerator.Generate(options);
+        var warningNote = result.Warnings.Length > 0
+            ? $" ({result.Warnings.Length} warnings)"
+            : string.Empty;
+        stepResult.Success = true;
+        stepResult.Message = $"Package hub {result.LibraryCount} libraries, {result.ModuleCount} modules{warningNote}";
+    }
+
     private static void ExecuteLlms(JsonElement step, string baseDir, WebPipelineStepResult stepResult)
     {
         var siteRoot = ResolvePath(baseDir, GetString(step, "siteRoot") ?? GetString(step, "site-root"));

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.cs
@@ -34,6 +34,9 @@ internal static partial class WebPipelineRunner
             case "changelog":
                 ExecuteChangelog(step, baseDir, stepResult);
                 break;
+            case "package-hub":
+                ExecutePackageHub(step, baseDir, stepResult);
+                break;
             case "llms":
                 ExecuteLlms(step, baseDir, stepResult);
                 break;

--- a/PowerForge.Web.Cli/WebPipelineRunner.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.cs
@@ -21,6 +21,8 @@ internal static partial class WebPipelineRunner
     private static readonly HashSet<string> FingerprintPathKeys = new(StringComparer.OrdinalIgnoreCase)
     {
         "config", "siteRoot", "site-root", "project", "solution", "path",
+        "projects", "projectFiles", "project-files",
+        "module", "modules", "moduleFiles", "module-files",
         "out", "output", "source", "destination", "dest",
         "map", "maps", "input", "inputs", "sources", "mapFiles", "map-files",
         "xml", "help", "helpPath", "assembly",

--- a/PowerForge.Web/Models/WebPackageHub.cs
+++ b/PowerForge.Web/Models/WebPackageHub.cs
@@ -1,0 +1,97 @@
+namespace PowerForge.Web;
+
+/// <summary>Options for package hub generation.</summary>
+public sealed class WebPackageHubOptions
+{
+    /// <summary>Output JSON path.</summary>
+    public string OutputPath { get; set; } = string.Empty;
+    /// <summary>Optional base directory for resolving relative paths.</summary>
+    public string? BaseDirectory { get; set; }
+    /// <summary>Optional title override.</summary>
+    public string? Title { get; set; }
+    /// <summary>Project file paths (.csproj).</summary>
+    public List<string> ProjectPaths { get; set; } = new();
+    /// <summary>PowerShell module manifest paths (.psd1).</summary>
+    public List<string> ModulePaths { get; set; } = new();
+}
+
+/// <summary>Result payload for package hub generation.</summary>
+public sealed class WebPackageHubResult
+{
+    /// <summary>Output JSON path.</summary>
+    public string OutputPath { get; set; } = string.Empty;
+    /// <summary>Number of .NET libraries included.</summary>
+    public int LibraryCount { get; set; }
+    /// <summary>Number of PowerShell modules included.</summary>
+    public int ModuleCount { get; set; }
+    /// <summary>Warnings emitted during generation.</summary>
+    public string[] Warnings { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>Unified package/module hub document.</summary>
+public sealed class WebPackageHubDocument
+{
+    /// <summary>Document title.</summary>
+    public string Title { get; set; } = "Package Hub";
+    /// <summary>Generation timestamp in UTC.</summary>
+    public string GeneratedAtUtc { get; set; } = string.Empty;
+    /// <summary>Library records discovered from project files.</summary>
+    public List<WebPackageHubLibrary> Libraries { get; set; } = new();
+    /// <summary>Module records discovered from module manifests.</summary>
+    public List<WebPackageHubModule> Modules { get; set; } = new();
+    /// <summary>Warnings emitted during generation.</summary>
+    public List<string> Warnings { get; set; } = new();
+}
+
+/// <summary>Represents a discovered .NET library.</summary>
+public sealed class WebPackageHubLibrary
+{
+    /// <summary>Source project path (relative when possible).</summary>
+    public string Path { get; set; } = string.Empty;
+    /// <summary>Project display name.</summary>
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Package identifier.</summary>
+    public string? PackageId { get; set; }
+    /// <summary>Library version.</summary>
+    public string? Version { get; set; }
+    /// <summary>Short description.</summary>
+    public string? Description { get; set; }
+    /// <summary>Author string.</summary>
+    public string? Authors { get; set; }
+    /// <summary>Repository URL.</summary>
+    public string? RepositoryUrl { get; set; }
+    /// <summary>Target frameworks.</summary>
+    public List<string> TargetFrameworks { get; set; } = new();
+    /// <summary>NuGet package references.</summary>
+    public List<WebPackageHubDependency> Dependencies { get; set; } = new();
+}
+
+/// <summary>Represents a discovered PowerShell module.</summary>
+public sealed class WebPackageHubModule
+{
+    /// <summary>Source module manifest path (relative when possible).</summary>
+    public string Path { get; set; } = string.Empty;
+    /// <summary>Module name.</summary>
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Module version.</summary>
+    public string? Version { get; set; }
+    /// <summary>Short description.</summary>
+    public string? Description { get; set; }
+    /// <summary>Module author.</summary>
+    public string? Author { get; set; }
+    /// <summary>Minimum PowerShell version.</summary>
+    public string? PowerShellVersion { get; set; }
+    /// <summary>Compatible PowerShell editions.</summary>
+    public List<string> CompatiblePSEditions { get; set; } = new();
+    /// <summary>Required module dependencies.</summary>
+    public List<WebPackageHubDependency> RequiredModules { get; set; } = new();
+}
+
+/// <summary>Simple dependency record.</summary>
+public sealed class WebPackageHubDependency
+{
+    /// <summary>Dependency name.</summary>
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Dependency version constraint when known.</summary>
+    public string? Version { get; set; }
+}

--- a/PowerForge.Web/Services/WebPackageHubGenerator.cs
+++ b/PowerForge.Web/Services/WebPackageHubGenerator.cs
@@ -1,0 +1,348 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace PowerForge.Web;
+
+/// <summary>Generates unified package/module hub metadata from .csproj and .psd1 files.</summary>
+public static class WebPackageHubGenerator
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    /// <summary>Generates package hub JSON output.</summary>
+    /// <param name="options">Generator options.</param>
+    /// <returns>Result payload.</returns>
+    public static WebPackageHubResult Generate(WebPackageHubOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        if (string.IsNullOrWhiteSpace(options.OutputPath))
+            throw new ArgumentException("OutputPath is required.", nameof(options));
+
+        var warnings = new List<string>();
+        var baseDir = ResolveBaseDirectory(options.BaseDirectory);
+        var outputPath = ResolvePath(options.OutputPath, baseDir, warnings, "OutputPath");
+        if (string.IsNullOrWhiteSpace(outputPath))
+            throw new ArgumentException("OutputPath is invalid.", nameof(options));
+
+        var projectPaths = ResolveInputs(options.ProjectPaths, baseDir, warnings, "ProjectPath")
+            .Where(path => path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var modulePaths = ResolveInputs(options.ModulePaths, baseDir, warnings, "ModulePath")
+            .Where(path => path.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (projectPaths.Count == 0 && modulePaths.Count == 0)
+            throw new InvalidOperationException("package-hub requires at least one project or module input.");
+
+        var libraries = new List<WebPackageHubLibrary>();
+        foreach (var projectPath in projectPaths)
+        {
+            if (!File.Exists(projectPath))
+            {
+                warnings.Add($"Project file not found: {projectPath}");
+                continue;
+            }
+
+            if (TryParseProject(projectPath, baseDir, warnings, out var library) && library is not null)
+                libraries.Add(library);
+        }
+
+        var modules = new List<WebPackageHubModule>();
+        foreach (var modulePath in modulePaths)
+        {
+            if (!File.Exists(modulePath))
+            {
+                warnings.Add($"Module manifest not found: {modulePath}");
+                continue;
+            }
+
+            if (TryParseModuleManifest(modulePath, baseDir, warnings, out var module) && module is not null)
+                modules.Add(module);
+        }
+
+        var document = new WebPackageHubDocument
+        {
+            Title = string.IsNullOrWhiteSpace(options.Title) ? "Package Hub" : options.Title!.Trim(),
+            GeneratedAtUtc = DateTime.UtcNow.ToString("O"),
+            Libraries = libraries,
+            Modules = modules,
+            Warnings = warnings
+        };
+
+        var outputDir = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrWhiteSpace(outputDir))
+            Directory.CreateDirectory(outputDir);
+        File.WriteAllText(outputPath, JsonSerializer.Serialize(document, WebJson.Options));
+
+        return new WebPackageHubResult
+        {
+            OutputPath = outputPath,
+            LibraryCount = libraries.Count,
+            ModuleCount = modules.Count,
+            Warnings = warnings.ToArray()
+        };
+    }
+
+    private static List<string> ResolveInputs(IEnumerable<string>? inputs, string? baseDir, List<string> warnings, string label)
+    {
+        var results = new List<string>();
+        if (inputs is null)
+            return results;
+
+        foreach (var input in inputs)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                continue;
+
+            var resolved = ResolvePath(input, baseDir, warnings, label);
+            if (!string.IsNullOrWhiteSpace(resolved))
+                results.Add(resolved);
+        }
+
+        return results
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool TryParseProject(string projectPath, string? baseDir, List<string> warnings, out WebPackageHubLibrary? library)
+    {
+        library = null;
+        try
+        {
+            var doc = XDocument.Load(projectPath, LoadOptions.PreserveWhitespace);
+            var packageId = FirstElementValue(doc, "PackageId");
+            var assemblyName = FirstElementValue(doc, "AssemblyName");
+            var name = packageId ?? assemblyName ?? Path.GetFileNameWithoutExtension(projectPath);
+            var tfm = FirstElementValue(doc, "TargetFramework");
+            var tfms = FirstElementValue(doc, "TargetFrameworks");
+
+            var frameworks = new List<string>();
+            if (!string.IsNullOrWhiteSpace(tfms))
+                frameworks.AddRange(SplitList(tfms));
+            else if (!string.IsNullOrWhiteSpace(tfm))
+                frameworks.AddRange(SplitList(tfm));
+
+            var dependencies = new List<WebPackageHubDependency>();
+            foreach (var packageReference in doc.Descendants().Where(e => e.Name.LocalName.Equals("PackageReference", StringComparison.OrdinalIgnoreCase)))
+            {
+                var depName = packageReference.Attribute("Include")?.Value?.Trim();
+                if (string.IsNullOrWhiteSpace(depName))
+                    depName = packageReference.Attribute("Update")?.Value?.Trim();
+                if (string.IsNullOrWhiteSpace(depName))
+                    continue;
+
+                var depVersion = packageReference.Attribute("Version")?.Value?.Trim();
+                if (string.IsNullOrWhiteSpace(depVersion))
+                {
+                    depVersion = packageReference.Elements()
+                        .FirstOrDefault(e => e.Name.LocalName.Equals("Version", StringComparison.OrdinalIgnoreCase))
+                        ?.Value?.Trim();
+                }
+
+                dependencies.Add(new WebPackageHubDependency
+                {
+                    Name = depName,
+                    Version = string.IsNullOrWhiteSpace(depVersion) ? null : depVersion
+                });
+            }
+
+            library = new WebPackageHubLibrary
+            {
+                Path = ToRelativePath(projectPath, baseDir),
+                Name = name,
+                PackageId = packageId,
+                Version = FirstElementValue(doc, "Version") ?? FirstElementValue(doc, "PackageVersion"),
+                Description = FirstElementValue(doc, "Description") ?? FirstElementValue(doc, "PackageDescription"),
+                Authors = FirstElementValue(doc, "Authors") ?? FirstElementValue(doc, "Author"),
+                RepositoryUrl = FirstElementValue(doc, "RepositoryUrl") ?? FirstElementValue(doc, "PackageProjectUrl"),
+                TargetFrameworks = frameworks
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList(),
+                Dependencies = dependencies
+                    .GroupBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(group => group.First())
+                    .OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToList()
+            };
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"Failed to parse project '{projectPath}': {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static bool TryParseModuleManifest(string manifestPath, string? baseDir, List<string> warnings, out WebPackageHubModule? module)
+    {
+        module = null;
+        try
+        {
+            var content = File.ReadAllText(manifestPath);
+            var moduleName = Path.GetFileNameWithoutExtension(manifestPath);
+            var version = ReadPsd1Scalar(content, "ModuleVersion");
+            var description = ReadPsd1Scalar(content, "Description");
+            var author = ReadPsd1Scalar(content, "Author");
+            var powershellVersion = ReadPsd1Scalar(content, "PowerShellVersion");
+            var editions = ReadPsd1Array(content, "CompatiblePSEditions");
+            var requiredModules = ReadPsd1Array(content, "RequiredModules")
+                .Select(name => new WebPackageHubDependency { Name = name })
+                .ToList();
+
+            module = new WebPackageHubModule
+            {
+                Path = ToRelativePath(manifestPath, baseDir),
+                Name = moduleName,
+                Version = version,
+                Description = description,
+                Author = author,
+                PowerShellVersion = powershellVersion,
+                CompatiblePSEditions = editions,
+                RequiredModules = requiredModules
+            };
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"Failed to parse module manifest '{manifestPath}': {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static string? FirstElementValue(XDocument doc, string localName)
+    {
+        return doc.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))
+            ?.Value
+            ?.Trim();
+    }
+
+    private static string? ReadPsd1Scalar(string content, string key)
+    {
+        var pattern = $"(?im)^\\s*['\\\"']?{Regex.Escape(key)}['\\\"']?\\s*=\\s*(?<value>.+)$";
+        var match = Regex.Match(content, pattern, RegexOptions.CultureInvariant, RegexTimeout);
+        if (!match.Success)
+            return null;
+
+        var value = match.Groups["value"].Value;
+        var commentIndex = value.IndexOf('#');
+        if (commentIndex >= 0)
+            value = value.Substring(0, commentIndex);
+        value = value.Trim().TrimEnd(',').Trim();
+        if (value.StartsWith("'", StringComparison.Ordinal) && value.EndsWith("'", StringComparison.Ordinal) && value.Length >= 2)
+            value = value.Substring(1, value.Length - 2);
+        if (value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal) && value.Length >= 2)
+            value = value.Substring(1, value.Length - 2);
+
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static List<string> ReadPsd1Array(string content, string key)
+    {
+        var pattern = $"(?ims)^\\s*['\\\"']?{Regex.Escape(key)}['\\\"']?\\s*=\\s*@\\((?<items>.*?)\\)";
+        var match = Regex.Match(content, pattern, RegexOptions.CultureInvariant, RegexTimeout);
+        if (!match.Success)
+            return new List<string>();
+
+        var body = match.Groups["items"].Value;
+        var values = new List<string>();
+
+        foreach (Match quoted in Regex.Matches(body, "['\"](?<value>[^'\"]+)['\"]", RegexOptions.CultureInvariant, RegexTimeout))
+        {
+            var value = quoted.Groups["value"].Value?.Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+                values.Add(value);
+        }
+
+        if (values.Count == 0)
+        {
+            values.AddRange(SplitList(body));
+        }
+
+        return values
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static List<string> SplitList(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return new List<string>();
+
+        return value
+            .Split(new[] { ',', ';', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(item => item.Trim().Trim('\'', '\"'))
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string ToRelativePath(string path, string? baseDir)
+    {
+        if (string.IsNullOrWhiteSpace(baseDir))
+            return path;
+
+        try
+        {
+            var relative = Path.GetRelativePath(baseDir, path);
+            if (!relative.StartsWith("..", StringComparison.Ordinal))
+                return relative.Replace('\\', '/');
+        }
+        catch
+        {
+            // ignore
+        }
+
+        return path;
+    }
+
+    private static string? ResolveBaseDirectory(string? baseDir)
+    {
+        if (string.IsNullOrWhiteSpace(baseDir))
+            return null;
+        try
+        {
+            return Path.GetFullPath(baseDir.Trim().Trim('\"'));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? ResolvePath(string path, string? baseDir, List<string> warnings, string label)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var trimmed = path.Trim().Trim('\"');
+        string full;
+        try
+        {
+            full = Path.IsPathRooted(trimmed) || string.IsNullOrWhiteSpace(baseDir)
+                ? Path.GetFullPath(trimmed)
+                : Path.GetFullPath(Path.Combine(baseDir, trimmed));
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"{label} could not be resolved: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(baseDir) && !IsUnderRoot(full, baseDir))
+            warnings.Add($"{label} resolves outside base directory: {full}");
+
+        return full;
+    }
+
+    private static bool IsUnderRoot(string path, string root)
+    {
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.Equals(path, normalizedRoot, StringComparison.OrdinalIgnoreCase))
+            return true;
+        normalizedRoot += Path.DirectorySeparatorChar;
+        return path.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -29,6 +29,7 @@
         { "$ref": "#/$defs/ApiDocsStep" },
         { "$ref": "#/$defs/XrefMergeStep" },
         { "$ref": "#/$defs/ChangelogStep" },
+        { "$ref": "#/$defs/PackageHubStep" },
         { "$ref": "#/$defs/LlmsStep" },
         { "$ref": "#/$defs/SitemapStep" },
         { "$ref": "#/$defs/OptimizeStep" },
@@ -511,6 +512,53 @@
         "output": { "type": "string" }
       },
       "required": ["task", "out"]
+    },
+    "PackageHubStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "task": { "const": "package-hub" },
+        "id": { "type": "string" },
+        "dependsOn": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+        "mode": { "type": "string" },
+        "modes": { "type": "array", "items": { "type": "string" } },
+        "onlyModes": { "type": "array", "items": { "type": "string" } },
+        "only-modes": { "type": "array", "items": { "type": "string" } },
+        "skipModes": { "type": "array", "items": { "type": "string" } },
+        "skip-modes": { "type": "array", "items": { "type": "string" } },
+        "title": { "type": "string" },
+        "project": { "type": "string", "description": "Single .csproj path." },
+        "projects": { "type": "string", "description": "Comma-separated .csproj paths." },
+        "projectFiles": { "type": "array", "items": { "type": "string" }, "description": "Array of .csproj paths." },
+        "project-files": { "type": "array", "items": { "type": "string" }, "description": "Alias for projectFiles." },
+        "module": { "type": "string", "description": "Single .psd1 manifest path." },
+        "modules": { "type": "string", "description": "Comma-separated .psd1 manifest paths." },
+        "moduleFiles": { "type": "array", "items": { "type": "string" }, "description": "Array of .psd1 manifest paths." },
+        "module-files": { "type": "array", "items": { "type": "string" }, "description": "Alias for moduleFiles." },
+        "out": { "type": "string" },
+        "output": { "type": "string" }
+      },
+      "required": ["task"],
+      "allOf": [
+        {
+          "anyOf": [
+            { "required": ["out"] },
+            { "required": ["output"] }
+          ]
+        },
+        {
+          "anyOf": [
+            { "required": ["project"] },
+            { "required": ["projects"] },
+            { "required": ["projectFiles"] },
+            { "required": ["project-files"] },
+            { "required": ["module"] },
+            { "required": ["modules"] },
+            { "required": ["moduleFiles"] },
+            { "required": ["module-files"] }
+          ]
+        }
+      ]
     },
     "LlmsStep": {
       "type": "object",


### PR DESCRIPTION
## Summary
- add new `package-hub` pipeline task for generating unified package/module metadata JSON
- add new engine service `WebPackageHubGenerator` with support for:
  - `.csproj` discovery (package id, version, target frameworks, package references)
  - `.psd1` discovery (module version, PS compatibility, required modules)
- wire task execution and cache output tracking in pipeline runner
- extend pipeline schema (`PackageHubStep`) and documentation with examples
- add tests (`WebPipelineRunnerPackageHubTests`)

## Why
- makes release/package intelligence first-class in the engine (not per-site script glue)
- directly supports HtmlForgeX, IntelligenceX, and CodeGlyphX sites with consistent package/module hub data
- improves parity with docs engines that provide package-centric docs generation patterns

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter FullyQualifiedName~WebPipelineRunnerPackageHubTests`
- `dotnet test .\PSPublishModule.sln -c Release`
