### PR TITLE
PowerShell API docs: render command syntax and metadata natively

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorPowerShellTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorPowerShellTests.cs
@@ -95,8 +95,13 @@ public class WebApiDocsGeneratorPowerShellTests
             var examples = rootElement.GetProperty("examples");
             Assert.True(examples.GetArrayLength() >= 2);
             Assert.Contains(examples.EnumerateArray(),
-                ex => ex.GetProperty("kind").GetString() == "text" &&
-                      ex.GetProperty("text").GetString()!.Contains("Example 1: Basic usage.", StringComparison.Ordinal));
+                ex =>
+                {
+                    var kind = ex.GetProperty("kind").GetString();
+                    return (string.Equals(kind, "heading", StringComparison.Ordinal) ||
+                            string.Equals(kind, "text", StringComparison.Ordinal)) &&
+                           ex.GetProperty("text").GetString()!.Contains("Example 1: Basic usage.", StringComparison.Ordinal);
+                });
             Assert.Contains(examples.EnumerateArray(),
                 ex => ex.GetProperty("kind").GetString() == "code" &&
                       ex.GetProperty("text").GetString()!.Contains("New-SampleCmdlet -Name \"Demo\"", StringComparison.Ordinal));

--- a/PowerForge.Web/Assets/ApiDocs/fallback.css
+++ b/PowerForge.Web/Assets/ApiDocs/fallback.css
@@ -253,9 +253,20 @@ body.pf-api-docs .quick-card-header strong{line-height:1.25}
 [data-theme="light"] body.pf-api-docs .pf-combobox-option,
 [data-theme="light"] body.pf-api-docs .type-item,
 [data-theme="light"] body.pf-api-docs .current{color:var(--pf-ink,#0f172a)}
+[data-theme="light"] body.pf-api-docs .member-card pre code{color:var(--pf-ink,#0f172a)}
 [data-theme="light"] body.pf-api-docs .member-source a,
 [data-theme="light"] body.pf-api-docs .type-meta-source a,
 [data-theme="light"] body.pf-api-docs .type-source-action{color:var(--pf-accent,#0e7490)}
+[data-theme="light"] body.pf-api-docs .filter-button.active,
+[data-theme="light"] body.pf-api-docs .member-kind.active{
+  background:rgba(14,116,144,.12);
+  border-color:rgba(14,116,144,.35);
+  color:var(--pf-accent,#0e7490)
+}
+[data-theme="light"] body.pf-api-docs .type-item.active{
+  background:rgba(14,116,144,.12);
+  color:var(--pf-accent,#0e7490)
+}
 [data-theme="light"] body.pf-api-docs .type-source-action{
   border-color:rgba(14,116,144,.35);
   background:rgba(14,116,144,.1)

--- a/PowerForge.Web/Assets/ApiDocs/fallback.css
+++ b/PowerForge.Web/Assets/ApiDocs/fallback.css
@@ -146,6 +146,7 @@ body.pf-api-docs .type-icon-glyph,body.pf-api-docs .chip-icon-glyph{display:bloc
 .member-source a,.type-meta-source a{color:#a78bfa}
 .member-summary{margin:0;color:#e2e8f0}
 .type-parameters,.type-examples,.type-see-also{margin:12px 0}
+.example-title{margin:8px 0 2px;font-size:1rem;color:#e6e9f3}
 .typeparam-list,.exception-list,.see-also-list{list-style:none;padding:0;margin:0;display:grid;gap:6px}
 .typeparam-list dt{font-weight:600}
 .typeparam-list dd{margin:0;color:#94a3b8}
@@ -249,6 +250,7 @@ body.pf-api-docs .quick-card-header strong{line-height:1.25}
 [data-theme="light"] body.pf-api-docs .type-summary,
 [data-theme="light"] body.pf-api-docs .inheritance-current,
 [data-theme="light"] body.pf-api-docs .member-summary,
+[data-theme="light"] body.pf-api-docs .example-title,
 [data-theme="light"] body.pf-api-docs .type-toc a,
 [data-theme="light"] body.pf-api-docs .pf-combobox-option,
 [data-theme="light"] body.pf-api-docs .type-item,

--- a/PowerForge.Web/Assets/ApiDocs/fallback.css
+++ b/PowerForge.Web/Assets/ApiDocs/fallback.css
@@ -202,3 +202,76 @@ body.pf-api-docs .chip-icon{width:1.1rem;height:1.1rem;font-size:.62rem;font-fam
 body.pf-api-docs .chip-name{display:block;line-height:1.2;font-weight:600;text-decoration:none}
 body.pf-api-docs .type-badge{display:inline-flex;align-items:center;justify-content:center;min-height:1.45rem;line-height:1}
 body.pf-api-docs .quick-card-header strong{line-height:1.25}
+
+/* Light-mode safety net:
+   API docs fallback styles are dark-first, so provide explicit light overrides
+   when a site enables theme switching via html[data-theme="light"]. */
+[data-theme="light"] body.pf-api-docs{color:var(--pf-ink,#1e293b)}
+[data-theme="light"] body.pf-api-docs .api-sidebar,
+[data-theme="light"] body.pf-api-docs .type-toc,
+[data-theme="light"] body.pf-api-docs .remarks,
+[data-theme="light"] body.pf-api-docs .member-card,
+[data-theme="light"] body.pf-api-docs .member-group,
+[data-theme="light"] body.pf-api-docs .pf-combobox-panel,
+[data-theme="light"] body.pf-api-docs .nav-dropdown-menu,
+[data-theme="light"] body.pf-api-docs .pf-api-result,
+[data-theme="light"] body.pf-api-docs .type-chip,
+[data-theme="light"] body.pf-api-docs .type-badge,
+[data-theme="light"] body.pf-api-docs .member-signature,
+[data-theme="light"] body.pf-api-docs .member-card pre,
+[data-theme="light"] body.pf-api-docs .member-attributes code,
+[data-theme="light"] body.pf-api-docs .type-meta-list code,
+[data-theme="light"] body.pf-api-docs .param-meta-chip,
+[data-theme="light"] body.pf-api-docs .filter-button,
+[data-theme="light"] body.pf-api-docs .member-kind,
+[data-theme="light"] body.pf-api-docs .sidebar-tools button,
+[data-theme="light"] body.pf-api-docs .sidebar-reset,
+[data-theme="light"] body.pf-api-docs .namespace-select,
+[data-theme="light"] body.pf-api-docs .pf-combobox-trigger,
+[data-theme="light"] body.pf-api-docs .sidebar-search input,
+[data-theme="light"] body.pf-api-docs .member-filter input{
+  background:var(--pf-card-bg,#ffffff);
+  border-color:var(--pf-border,rgba(148,163,184,.45));
+  color:var(--pf-ink,#0f172a)
+}
+[data-theme="light"] body.pf-api-docs .type-toc-title,
+[data-theme="light"] body.pf-api-docs .member-return,
+[data-theme="light"] body.pf-api-docs .member-inherited,
+[data-theme="light"] body.pf-api-docs .member-source,
+[data-theme="light"] body.pf-api-docs .member-value,
+[data-theme="light"] body.pf-api-docs .param-list dd,
+[data-theme="light"] body.pf-api-docs .type-meta-label,
+[data-theme="light"] body.pf-api-docs .member-filter label,
+[data-theme="light"] body.pf-api-docs .sidebar-count,
+[data-theme="light"] body.pf-api-docs .filter-label,
+[data-theme="light"] body.pf-api-docs .nav-section-header,
+[data-theme="light"] body.pf-api-docs .nav-dropdown-menu .nav-dropdown-label{color:var(--pf-muted,#64748b)}
+[data-theme="light"] body.pf-api-docs .type-summary,
+[data-theme="light"] body.pf-api-docs .inheritance-current,
+[data-theme="light"] body.pf-api-docs .member-summary,
+[data-theme="light"] body.pf-api-docs .type-toc a,
+[data-theme="light"] body.pf-api-docs .pf-combobox-option,
+[data-theme="light"] body.pf-api-docs .type-item,
+[data-theme="light"] body.pf-api-docs .current{color:var(--pf-ink,#0f172a)}
+[data-theme="light"] body.pf-api-docs .member-source a,
+[data-theme="light"] body.pf-api-docs .type-meta-source a,
+[data-theme="light"] body.pf-api-docs .type-source-action{color:var(--pf-accent,#0e7490)}
+[data-theme="light"] body.pf-api-docs .type-source-action{
+  border-color:rgba(14,116,144,.35);
+  background:rgba(14,116,144,.1)
+}
+[data-theme="light"] body.pf-api-docs .nav-dropdown-menu a:hover,
+[data-theme="light"] body.pf-api-docs .pf-combobox-option:hover,
+[data-theme="light"] body.pf-api-docs .pf-combobox-option:focus-visible{
+  background:rgba(14,116,144,.12);
+  color:var(--pf-ink,#0f172a)
+}
+[data-theme="light"] body.pf-api-docs .member-toggle input{
+  background:#ffffff;
+  border-color:var(--pf-border,rgba(148,163,184,.55))
+}
+[data-theme="light"] body.pf-api-docs .member-toggle input:checked{
+  background:var(--pf-accent,#0e7490);
+  border-color:var(--pf-accent,#0e7490)
+}
+[data-theme="light"] body.pf-api-docs .member-toggle input:checked::after{border-color:#ffffff}

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
@@ -26,6 +26,9 @@ public static partial class WebApiDocsGenerator
         public string Name { get; set; } = string.Empty;
         public string FullName { get; set; } = string.Empty;
         public string Namespace { get; set; } = string.Empty;
+        public List<string> Aliases { get; } = new();
+        public List<string> InputTypes { get; } = new();
+        public List<string> OutputTypes { get; } = new();
         public string? Assembly { get; set; }
         public ApiSourceLink? Source { get; set; }
         public string? BaseType { get; set; }
@@ -81,6 +84,7 @@ public static partial class WebApiDocsGenerator
         public string Name { get; set; } = string.Empty;
         public string? Type { get; set; }
         public string? Summary { get; set; }
+        public List<string> Aliases { get; } = new();
         public bool IsOptional { get; set; }
         public string? DefaultValue { get; set; }
         public string? Position { get; set; }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TypeIndexing.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TypeIndexing.cs
@@ -108,6 +108,9 @@ public static partial class WebApiDocsGenerator
 
     private static List<(string id, string label)> BuildTypeToc(ApiTypeModel type, bool hasInheritance, bool hasDerived)
     {
+        var isPowerShellCommand = IsPowerShellCommandType(type);
+        var methodSectionId = isPowerShellCommand ? "syntax" : "methods";
+        var methodSectionLabel = isPowerShellCommand ? "Syntax" : "Methods";
         var list = new List<(string id, string label)>
         {
             ("overview", "Overview")
@@ -127,7 +130,7 @@ public static partial class WebApiDocsGenerator
         if (type.Constructors.Count > 0)
             list.Add(("constructors", "Constructors"));
         if (type.Methods.Count > 0)
-            list.Add(("methods", "Methods"));
+            list.Add((methodSectionId, methodSectionLabel));
         if (type.Properties.Count > 0)
             list.Add(("properties", "Properties"));
         if (type.Fields.Count > 0)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Parse.PowerShellExamples.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Parse.PowerShellExamples.cs
@@ -300,7 +300,8 @@ public static partial class WebApiDocsGenerator
 
     private static bool IsPowerShellSwitchParameter(string? typeName)
         => !string.IsNullOrWhiteSpace(typeName) &&
-           typeName.Equals("SwitchParameter", StringComparison.OrdinalIgnoreCase);
+           (typeName.Equals("SwitchParameter", StringComparison.OrdinalIgnoreCase) ||
+            typeName.EndsWith(".SwitchParameter", StringComparison.OrdinalIgnoreCase));
 
     private static string GetPowerShellSampleValue(string parameterName, string? typeName)
     {
@@ -341,7 +342,7 @@ public static partial class WebApiDocsGenerator
     {
         try
         {
-            return Directory.EnumerateDirectories(path, pattern, searchOption);
+            return Directory.GetDirectories(path, pattern, searchOption);
         }
         catch
         {
@@ -353,7 +354,7 @@ public static partial class WebApiDocsGenerator
     {
         try
         {
-            return Directory.EnumerateFiles(path, pattern, searchOption);
+            return Directory.GetFiles(path, pattern, searchOption);
         }
         catch
         {

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
@@ -124,6 +124,14 @@ public static partial class WebApiDocsGenerator
                 Position = p.Position,
                 PipelineInput = p.PipelineInput
             }).ToList();
+        for (var i = 0; i < clone.Parameters.Count && i < source.Parameters.Count; i++)
+        {
+            foreach (var alias in source.Parameters[i].Aliases)
+            {
+                if (!string.IsNullOrWhiteSpace(alias))
+                    clone.Parameters[i].Aliases.Add(alias);
+            }
+        }
         return clone;
     }
 

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Xref.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Xref.cs
@@ -369,6 +369,22 @@ public static partial class WebApiDocsGenerator
                     aliases.Add($"{module}:{command}.{paramName}");
                     aliases.Add($"{module}::{command}.{paramName}");
                 }
+                if (parameter?.Aliases is not null)
+                {
+                    foreach (var parameterAlias in parameter.Aliases)
+                    {
+                        if (string.IsNullOrWhiteSpace(parameterAlias))
+                            continue;
+                        aliases.Add($"{command}.{parameterAlias}");
+                        aliases.Add($"{command}/-{parameterAlias}");
+                        aliases.Add($"param:{command}.{parameterAlias}");
+                        if (!string.IsNullOrWhiteSpace(module))
+                        {
+                            aliases.Add($"{module}\\{command}.{parameterAlias}");
+                            aliases.Add($"{module}:{command}.{parameterAlias}");
+                        }
+                    }
+                }
 
                 refs[uid] = new ApiXrefReference
                 {

--- a/PowerForge.Web/Services/WebApiDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.cs
@@ -379,8 +379,11 @@ public static partial class WebApiDocsGenerator
                 ["name"] = type.Name,
                 ["displayName"] = displayName,
                 ["aliases"] = aliases,
+                ["commandAliases"] = type.Aliases,
                 ["fullName"] = type.FullName,
                 ["namespace"] = type.Namespace,
+                ["inputTypes"] = type.InputTypes,
+                ["outputTypes"] = type.OutputTypes,
                 ["assembly"] = type.Assembly,
                 ["source"] = BuildSourceJson(type.Source),
                 ["baseType"] = type.BaseType,
@@ -445,6 +448,7 @@ public static partial class WebApiDocsGenerator
                         ["name"] = p.Name,
                         ["type"] = p.Type,
                         ["summary"] = p.Summary,
+                        ["aliases"] = p.Aliases,
                         ["isOptional"] = p.IsOptional,
                         ["defaultValue"] = p.DefaultValue,
                         ["position"] = p.Position,
@@ -491,6 +495,7 @@ public static partial class WebApiDocsGenerator
                         ["name"] = p.Name,
                         ["type"] = p.Type,
                         ["summary"] = p.Summary,
+                        ["aliases"] = p.Aliases,
                         ["isOptional"] = p.IsOptional,
                         ["defaultValue"] = p.DefaultValue,
                         ["position"] = p.Position,
@@ -619,8 +624,11 @@ public static partial class WebApiDocsGenerator
                         ["name"] = p.Name,
                         ["type"] = p.Type,
                         ["summary"] = p.Summary,
+                        ["aliases"] = p.Aliases,
                         ["isOptional"] = p.IsOptional,
-                        ["defaultValue"] = p.DefaultValue
+                        ["defaultValue"] = p.DefaultValue,
+                        ["position"] = p.Position,
+                        ["pipelineInput"] = p.PipelineInput
                     }).ToList()
                 }).ToList()
             };


### PR DESCRIPTION
## Summary
- make PowerShell API pages render command-native sections (`Syntax`, `Outputs`) instead of method-centric labels
- parse richer MAML data: parameter aliases, input/output types, and multi-paragraph text blocks
- improve PowerShell example rendering to preserve multiple examples and titles cleanly
- expose new metadata in JSON/xref (`commandAliases`, `inputTypes`, `outputTypes`, parameter `aliases`)
- harden recursive file discovery for examples/about topics to avoid deferred enumeration access errors

## Validation
- `dotnet build PowerForge.Web/PowerForge.Web.csproj -c Release`
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~WebApiDocsGeneratorPowerShellTests"`
- `dotnet test PSPublishModule.sln -c Release --no-build`
- `dotnet run --framework net8.0 --project PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -- apidocs --type powershell --help-path Module/en-US/PSPublishModule-help.xml --out _temp/apidocs-ps --format hybrid --template docs --title "PS API Test" --base-url /api/powershell`

## Why this matters
This aligns PowerShell API docs with PowerShell expectations (commands/parameter sets/examples) and fixes the current mismatch where cmdlets look like .NET methods.
