### PR TITLE
Add delivery install policies and bootstrap support

### DIFF
--- a/Module/Docs/New-ConfigurationDelivery.md
+++ b/Module/Docs/New-ConfigurationDelivery.md
@@ -11,7 +11,7 @@ Configures delivery metadata for bundling and installing internal docs/examples.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-ConfigurationDelivery [-Enable] [-InternalsPath <string>] [-IncludeRootReadme] [-IncludeRootChangelog] [-IncludeRootLicense] [-ReadmeDestination <DeliveryBundleDestination>] [-ChangelogDestination <DeliveryBundleDestination>] [-LicenseDestination <DeliveryBundleDestination>] [-ImportantLinks <DeliveryImportantLink[]>] [-IntroText <string[]>] [-UpgradeText <string[]>] [-IntroFile <string>] [-UpgradeFile <string>] [-RepositoryPaths <string[]>] [-RepositoryBranch <string>] [-DocumentationOrder <string[]>] [-GenerateInstallCommand] [-GenerateUpdateCommand] [-InstallCommandName <string>] [-UpdateCommandName <string>] [<CommonParameters>]
+New-ConfigurationDelivery [-Enable] [-InternalsPath <string>] [-IncludeRootReadme] [-IncludeRootChangelog] [-IncludeRootLicense] [-ReadmeDestination <DeliveryBundleDestination>] [-ChangelogDestination <DeliveryBundleDestination>] [-LicenseDestination <DeliveryBundleDestination>] [-ImportantLinks <DeliveryImportantLink[]>] [-IntroText <string[]>] [-UpgradeText <string[]>] [-IntroFile <string>] [-UpgradeFile <string>] [-RepositoryPaths <string[]>] [-RepositoryBranch <string>] [-DocumentationOrder <string[]>] [-PreservePaths <string[]>] [-OverwritePaths <string[]>] [-GenerateInstallCommand] [-GenerateUpdateCommand] [-InstallCommandName <string>] [-UpdateCommandName <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -254,6 +254,38 @@ Type: DeliveryBundleDestination
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values: Internals, Root, Both, None
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -OverwritePaths
+Optional wildcard patterns (relative to Internals) that should be overwritten during merge installs. Example: Artefacts/**.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -PreservePaths
+Optional wildcard patterns (relative to Internals) that should be preserved during merge installs. Example: Config/**.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
 
 Required: False
 Position: named

--- a/PSPublishModule/Cmdlets/NewConfigurationDeliveryCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationDeliveryCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
 using PowerForge;
 
@@ -83,6 +84,18 @@ public sealed class NewConfigurationDeliveryCommand : PSCmdlet
     [Parameter] public string[]? DocumentationOrder { get; set; }
 
     /// <summary>
+    /// Optional wildcard patterns (relative to Internals) that should be preserved during merge installs.
+    /// Example: <c>Config/**</c>.
+    /// </summary>
+    [Parameter] public string[]? PreservePaths { get; set; }
+
+    /// <summary>
+    /// Optional wildcard patterns (relative to Internals) that should be overwritten during merge installs.
+    /// Example: <c>Artefacts/**</c>.
+    /// </summary>
+    [Parameter] public string[]? OverwritePaths { get; set; }
+
+    /// <summary>
     /// When set, generates a public Install-&lt;ModuleName&gt; helper function during build that copies Internals to a destination folder.
     /// </summary>
     [Parameter] public SwitchParameter GenerateInstallCommand { get; set; }
@@ -125,6 +138,8 @@ public sealed class NewConfigurationDeliveryCommand : PSCmdlet
             RepositoryPaths = RepositoryPaths,
             RepositoryBranch = RepositoryBranch,
             DocumentationOrder = DocumentationOrder,
+            PreservePaths = NormalizeStringArray(PreservePaths),
+            OverwritePaths = NormalizeStringArray(OverwritePaths),
             GenerateInstallCommand = GenerateInstallCommand.IsPresent || !string.IsNullOrWhiteSpace(InstallCommandName),
             GenerateUpdateCommand = GenerateUpdateCommand.IsPresent || !string.IsNullOrWhiteSpace(UpdateCommandName),
             InstallCommandName = string.IsNullOrWhiteSpace(InstallCommandName) ? null : InstallCommandName!.Trim(),
@@ -156,5 +171,18 @@ public sealed class NewConfigurationDeliveryCommand : PSCmdlet
         }
 
         return output.Count == 0 ? null : output.ToArray();
+    }
+
+    private static string[]? NormalizeStringArray(string[]? values)
+    {
+        if (values is null || values.Length == 0) return null;
+
+        var output = values
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(v => v.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return output.Length == 0 ? null : output;
     }
 }

--- a/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
+++ b/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Management.Automation;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -35,11 +37,19 @@ public sealed class DeliveryCommandGeneratorTests
             var installContent = File.ReadAllText(installPath);
             Assert.Contains("function Install-EFAdminManager", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("function Copy-DeliveryRootFiles", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string[]] $PreservePaths", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string[]] $OverwritePaths", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[switch] $Bootstrap", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string] $Version", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string] $Repository", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Install-Module @installParams", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("{{", installContent, StringComparison.Ordinal);
 
             var updateContent = File.ReadAllText(updatePath);
             Assert.Contains("function Update-EFAdminManager", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Install-EFAdminManager", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[switch] $Bootstrap", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string[]] $PreservePaths", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("{{", updateContent, StringComparison.Ordinal);
         }
         finally
@@ -68,6 +78,74 @@ public sealed class DeliveryCommandGeneratorTests
             var generated = generator.Generate(root.FullName, "EFAdminManager", delivery);
 
             Assert.DoesNotContain(generated, g => g.Name == "Install-EFAdminManager");
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void InstallCommand_MergeRespectsPreserveAndOverwritePatterns()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "ContosoPackage";
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, moduleName));
+
+            Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Internals", "Config"));
+            Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Internals", "Artefacts"));
+            Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Internals", "Other"));
+
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "Internals", "Config", "settings.json"), "package-config");
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "Internals", "Artefacts", "script.ps1"), "package-artefact");
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "Internals", "Other", "notes.txt"), "package-notes");
+
+            var delivery = new DeliveryOptionsConfiguration
+            {
+                Enable = true,
+                InternalsPath = "Internals",
+                GenerateInstallCommand = true,
+                PreservePaths = new[] { "Config/**" },
+                OverwritePaths = new[] { "Artefacts/**" }
+            };
+
+            var generator = new DeliveryCommandGenerator(new NullLogger());
+            _ = generator.Generate(moduleRoot.FullName, moduleName, delivery);
+
+            var moduleScriptPath = Path.Combine(moduleRoot.FullName, $"{moduleName}.psm1");
+            File.WriteAllText(
+                moduleScriptPath,
+                $". $PSScriptRoot{Path.DirectorySeparatorChar}Public{Path.DirectorySeparatorChar}Install-{moduleName}.ps1");
+
+            var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
+            Directory.CreateDirectory(Path.Combine(destination.FullName, "Config"));
+            Directory.CreateDirectory(Path.Combine(destination.FullName, "Artefacts"));
+            Directory.CreateDirectory(Path.Combine(destination.FullName, "Other"));
+
+            File.WriteAllText(Path.Combine(destination.FullName, "Config", "settings.json"), "local-config");
+            File.WriteAllText(Path.Combine(destination.FullName, "Artefacts", "script.ps1"), "local-artefact");
+            File.WriteAllText(Path.Combine(destination.FullName, "Other", "notes.txt"), "local-notes");
+
+            using var ps = PowerShell.Create();
+            ps.AddScript("if ($env:OS -eq 'Windows_NT') { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force }");
+            ps.AddStatement();
+            ps.AddCommand("Import-Module")
+                .AddParameter("Name", moduleScriptPath)
+                .AddParameter("Force");
+            ps.AddStatement();
+            ps.AddCommand($"Install-{moduleName}")
+                .AddParameter("Path", destination.FullName);
+
+            _ = ps.Invoke();
+            Assert.False(
+                ps.HadErrors,
+                "PowerShell errors: " + string.Join(" | ", ps.Streams.Error.Select(e => e.ToString())));
+
+            Assert.Equal("local-config", File.ReadAllText(Path.Combine(destination.FullName, "Config", "settings.json")));
+            Assert.Equal("package-artefact", File.ReadAllText(Path.Combine(destination.FullName, "Artefacts", "script.ps1")));
+            Assert.Equal("local-notes", File.ReadAllText(Path.Combine(destination.FullName, "Other", "notes.txt")));
         }
         finally
         {

--- a/PowerForge/Models/Configuration/ConfigurationOptionsSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationOptionsSegment.cs
@@ -120,6 +120,18 @@ public sealed class DeliveryOptionsConfiguration
     public string[]? DocumentationOrder { get; set; }
 
     /// <summary>
+    /// Optional wildcard patterns (relative to Internals) that should be preserved during merge installs.
+    /// Example: <c>Config/**</c>.
+    /// </summary>
+    public string[]? PreservePaths { get; set; }
+
+    /// <summary>
+    /// Optional wildcard patterns (relative to Internals) that should be overwritten during merge installs.
+    /// Example: <c>Artefacts/**</c>.
+    /// </summary>
+    public string[]? OverwritePaths { get; set; }
+
+    /// <summary>
     /// When true, generates a public <c>Install-&lt;ModuleName&gt;</c> helper function during build that copies Internals
     /// to a destination folder (script-package workflow).
     /// </summary>

--- a/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
@@ -82,6 +82,7 @@ function {{CommandName}} {
         [string] $RepositoryCredentialSecret,
         [string] $RepositoryCredentialSecretFilePath,
 
+        [Parameter(DontShow)]
         [switch] $__DeliveryNoBootstrap
     )
 

--- a/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
@@ -6,6 +6,8 @@ function {{CommandName}} {
     .DESCRIPTION
     Copies files from the module's '{{InternalsPath}}' folder into a destination path.
     By default, existing files are preserved (OnExists=Merge) so local configuration is not overwritten.
+    You can define default merge behavior for relative paths using PreservePaths/OverwritePaths.
+    Optional bootstrap parameters can install/import a selected module version before extraction.
 
     .PARAMETER Path
     Destination folder for extracted artefacts.
@@ -26,6 +28,33 @@ function {{CommandName}} {
     .PARAMETER Unblock
     On Windows, removes Zone.Identifier (best effort) from copied files.
 
+    .PARAMETER PreservePaths
+    Optional wildcard patterns (relative to Internals) to preserve during merge, for example: Config/**.
+
+    .PARAMETER OverwritePaths
+    Optional wildcard patterns (relative to Internals) to overwrite during merge, for example: Artefacts/**.
+
+    .PARAMETER Bootstrap
+    Forces bootstrap behavior: installs/imports this module before extraction.
+
+    .PARAMETER Version
+    Optional module version to bootstrap before extraction.
+
+    .PARAMETER Repository
+    Optional repository name used by Install-Module during bootstrap.
+
+    .PARAMETER AllowPrerelease
+    Allows prerelease versions during bootstrap install.
+
+    .PARAMETER RepositoryCredentialUserName
+    Optional repository credential username used during bootstrap install.
+
+    .PARAMETER RepositoryCredentialSecret
+    Optional repository credential secret used during bootstrap install.
+
+    .PARAMETER RepositoryCredentialSecretFilePath
+    Optional path to a file containing repository credential secret used during bootstrap install.
+
     .EXAMPLE
     {{CommandName}} -Path 'C:\Tools' -Verbose
     #>
@@ -40,8 +69,161 @@ function {{CommandName}} {
 
         [switch] $Force,
         [switch] $ListOnly,
-        [switch] $Unblock
+        [switch] $Unblock,
+
+        [string[]] $PreservePaths = {{PreservePathsArray}},
+        [string[]] $OverwritePaths = {{OverwritePathsArray}},
+
+        [switch] $Bootstrap,
+        [string] $Version,
+        [string] $Repository,
+        [switch] $AllowPrerelease,
+        [string] $RepositoryCredentialUserName,
+        [string] $RepositoryCredentialSecret,
+        [string] $RepositoryCredentialSecretFilePath,
+
+        [switch] $__DeliveryNoBootstrap
     )
+
+    function Resolve-DeliverySecret {
+        [CmdletBinding()]
+        param(
+            [string] $InlineValue,
+            [string] $PathValue
+        )
+
+        if (-not [string]::IsNullOrWhiteSpace($PathValue)) {
+            if (-not (Test-Path -LiteralPath $PathValue)) {
+                throw "[{{ModuleName}}] RepositoryCredentialSecretFilePath was provided but file does not exist: $PathValue"
+            }
+
+            return (Get-Content -LiteralPath $PathValue -Raw -ErrorAction Stop).Trim()
+        }
+
+        return $InlineValue
+    }
+
+    function Test-DeliveryPathMatch {
+        [CmdletBinding()]
+        param(
+            [string] $RelativePath,
+            [string[]] $Patterns
+        )
+
+        if ([string]::IsNullOrWhiteSpace($RelativePath)) { return $false }
+        if (-not $Patterns -or $Patterns.Count -eq 0) { return $false }
+
+        $normalizedPath = $RelativePath.Replace('\', '/')
+        foreach ($raw in $Patterns) {
+            if ([string]::IsNullOrWhiteSpace($raw)) { continue }
+
+            $pattern = $raw.Trim().Replace('\', '/')
+            if ([string]::IsNullOrWhiteSpace($pattern)) { continue }
+            if ($pattern.EndsWith('/')) { $pattern = "$pattern*" }
+            $pattern = $pattern.Replace('**', '*')
+
+            if ($normalizedPath -like $pattern) { return $true }
+
+            if ($pattern.IndexOf('*') -lt 0 -and $pattern.IndexOf('?') -lt 0) {
+                if ($normalizedPath.StartsWith("$pattern/", [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
+                if ([string]::Equals($normalizedPath, $pattern, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
+            }
+        }
+
+        return $false
+    }
+
+    $bootstrapRequested = (-not $__DeliveryNoBootstrap) -and (
+        $Bootstrap -or
+        $PSBoundParameters.ContainsKey('Version') -or
+        $PSBoundParameters.ContainsKey('Repository') -or
+        $AllowPrerelease -or
+        $PSBoundParameters.ContainsKey('RepositoryCredentialUserName') -or
+        $PSBoundParameters.ContainsKey('RepositoryCredentialSecret') -or
+        $PSBoundParameters.ContainsKey('RepositoryCredentialSecretFilePath')
+    )
+
+    if ($bootstrapRequested) {
+        $resolvedSecret = Resolve-DeliverySecret -InlineValue $RepositoryCredentialSecret -PathValue $RepositoryCredentialSecretFilePath
+        if (-not [string]::IsNullOrWhiteSpace($resolvedSecret) -and [string]::IsNullOrWhiteSpace($RepositoryCredentialUserName)) {
+            throw "[{{ModuleName}}] RepositoryCredentialUserName is required when repository secret is provided."
+        }
+
+        $installCommand = Get-Command -Name 'Install-Module' -ErrorAction SilentlyContinue
+        if (-not $installCommand) {
+            throw "[{{ModuleName}}] Install-Module is not available in this session."
+        }
+
+        if (-not $PSCmdlet.ShouldProcess('{{ModuleName}}', "Bootstrap module package before running {{CommandName}}")) { return }
+
+        $installParams = @{
+            Name        = '{{ModuleName}}'
+            Scope       = 'CurrentUser'
+            Force       = $true
+            ErrorAction = 'Stop'
+        }
+
+        if ($PSBoundParameters.ContainsKey('Repository')) { $installParams.Repository = $Repository }
+        if ($PSBoundParameters.ContainsKey('Version')) { $installParams.RequiredVersion = $Version }
+        if ($AllowPrerelease) { $installParams.AllowPrerelease = $true }
+
+        if (-not [string]::IsNullOrWhiteSpace($RepositoryCredentialUserName) -and -not [string]::IsNullOrWhiteSpace($resolvedSecret)) {
+            $secure = ConvertTo-SecureString -String $resolvedSecret -AsPlainText -Force
+            $credential = [pscredential]::new($RepositoryCredentialUserName, $secure)
+            $installParams.Credential = $credential
+        }
+
+        Install-Module @installParams | Out-Null
+
+        $importParams = @{
+            Name        = '{{ModuleName}}'
+            Force       = $true
+            ErrorAction = 'Stop'
+        }
+        if ($PSBoundParameters.ContainsKey('Version')) { $importParams.RequiredVersion = $Version }
+        Import-Module @importParams | Out-Null
+
+        $targetCandidates = Get-Command -Name '{{CommandName}}' -CommandType Function -All -ErrorAction SilentlyContinue |
+            Where-Object { $_.ModuleName -eq '{{ModuleName}}' }
+        if ($PSBoundParameters.ContainsKey('Version')) {
+            $targetCandidates = $targetCandidates | Where-Object {
+                $_.Version -and ([string]::Equals($_.Version.ToString(), $Version, [System.StringComparison]::OrdinalIgnoreCase))
+            }
+        }
+
+        $targetCommand = $targetCandidates | Sort-Object -Property Version -Descending | Select-Object -First 1
+        if (-not $targetCommand -and $PSBoundParameters.ContainsKey('Version')) {
+            throw "[{{ModuleName}}] Unable to resolve {{CommandName}} for version '$Version' after bootstrap."
+        }
+
+        if ($targetCommand) {
+            $currentPath = $null
+            $targetPath = $null
+            $currentVersion = $null
+
+            try { $currentPath = $MyInvocation.MyCommand.ScriptBlock.File } catch { $currentPath = $null }
+            try { $targetPath = $targetCommand.ScriptBlock.File } catch { $targetPath = $null }
+            try { $currentVersion = $MyInvocation.MyCommand.Module.Version } catch { $currentVersion = $null }
+
+            $differentPath = -not [string]::IsNullOrWhiteSpace($targetPath) -and
+                -not [string]::IsNullOrWhiteSpace($currentPath) -and
+                -not [string]::Equals($targetPath, $currentPath, [System.StringComparison]::OrdinalIgnoreCase)
+            $newerVersion = $targetCommand.Version -and $currentVersion -and ($targetCommand.Version -gt $currentVersion)
+            $requestedVersionDifferent = $PSBoundParameters.ContainsKey('Version') -and $currentVersion -and
+                -not [string]::Equals($currentVersion.ToString(), $Version, [System.StringComparison]::OrdinalIgnoreCase)
+
+            if ($differentPath -or $newerVersion -or $requestedVersionDifferent) {
+                $forward = @{}
+                foreach ($entry in $PSBoundParameters.GetEnumerator()) {
+                    if ($entry.Key -eq '__DeliveryNoBootstrap') { continue }
+                    $forward[$entry.Key] = $entry.Value
+                }
+                $forward['__DeliveryNoBootstrap'] = $true
+
+                return & $targetCommand @forward
+            }
+        }
+    }
 
     $moduleBase = $null
     try { $moduleBase = $MyInvocation.MyCommand.Module.ModuleBase } catch { $moduleBase = $null }
@@ -72,13 +254,32 @@ function {{CommandName}} {
 
     New-Item -ItemType Directory -Force -Path $dest | Out-Null
 
+    function Get-DeliveryAction {
+        [CmdletBinding()]
+        param(
+            [bool] $TargetExists,
+            [string] $RelativePath
+        )
+
+        if (-not $TargetExists) { return 'Copy' }
+        if ($Force) { return 'Overwrite' }
+
+        if ($OnExists -eq 'Merge') {
+            if (Test-DeliveryPathMatch -RelativePath $RelativePath -Patterns $PreservePaths) { return 'Keep' }
+            if (Test-DeliveryPathMatch -RelativePath $RelativePath -Patterns $OverwritePaths) { return 'Overwrite' }
+            return 'Keep'
+        }
+
+        return 'Overwrite'
+    }
+
     $files = [System.IO.Directory]::GetFiles($internalsRoot, '*', [System.IO.SearchOption]::AllDirectories)
     if ($ListOnly) {
         foreach ($file in $files) {
             $rel = $file.Substring($internalsRoot.Length).TrimStart('\','/')
             $target = [System.IO.Path]::Combine($dest, $rel)
             $exists = Test-Path -LiteralPath $target
-            $action = if ($exists) { if ($Force) { 'Overwrite' } else { 'Keep' } } else { 'Copy' }
+            $action = Get-DeliveryAction -TargetExists $exists -RelativePath $rel
             [pscustomobject]@{ Source = $file; Destination = $target; Exists = $exists; Action = $action }
         }
         return
@@ -94,7 +295,9 @@ function {{CommandName}} {
             New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
         }
 
-        if ((Test-Path -LiteralPath $target) -and (-not $Force)) {
+        $exists = Test-Path -LiteralPath $target
+        $action = Get-DeliveryAction -TargetExists $exists -RelativePath $rel
+        if ($action -eq 'Keep') {
             continue
         }
 

--- a/PowerForge/Scripts/DeliveryCommands/Update-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Update-Delivery.Template.ps1
@@ -20,7 +20,20 @@ function {{UpdateCommandName}} {
 
         [switch] $Force,
         [switch] $ListOnly,
-        [switch] $Unblock
+        [switch] $Unblock,
+
+        [string[]] $PreservePaths,
+        [string[]] $OverwritePaths,
+
+        [switch] $Bootstrap,
+        [string] $Version,
+        [string] $Repository,
+        [switch] $AllowPrerelease,
+        [string] $RepositoryCredentialUserName,
+        [string] $RepositoryCredentialSecret,
+        [string] $RepositoryCredentialSecretFilePath,
+
+        [switch] $__DeliveryNoBootstrap
     )
 
     if (-not (Get-Command -Name '{{InstallCommandName}}' -ErrorAction SilentlyContinue)) {

--- a/PowerForge/Services/DeliveryCommandGenerator.cs
+++ b/PowerForge/Services/DeliveryCommandGenerator.cs
@@ -122,6 +122,8 @@ public sealed class DeliveryCommandGenerator
         var includeRootReadme = delivery.IncludeRootReadme ? "$true" : "$false";
         var includeRootChangelog = delivery.IncludeRootChangelog ? "$true" : "$false";
         var includeRootLicense = delivery.IncludeRootLicense ? "$true" : "$false";
+        var preservePaths = BuildPowerShellStringArrayLiteral(delivery.PreservePaths);
+        var overwritePaths = BuildPowerShellStringArrayLiteral(delivery.OverwritePaths);
 
         var escInternals = EscapeSingleQuotes(internalsPath);
         var escModule = EscapeSingleQuotes(moduleName);
@@ -134,7 +136,9 @@ public sealed class DeliveryCommandGenerator
             ["InternalsPath"] = escInternals,
             ["IncludeRootReadme"] = includeRootReadme,
             ["IncludeRootChangelog"] = includeRootChangelog,
-            ["IncludeRootLicense"] = includeRootLicense
+            ["IncludeRootLicense"] = includeRootLicense,
+            ["PreservePathsArray"] = preservePaths,
+            ["OverwritePathsArray"] = overwritePaths
         };
 
         return RenderDeliveryTemplate(
@@ -160,6 +164,21 @@ public sealed class DeliveryCommandGenerator
             "Update-Delivery.ps1",
             "Scripts/DeliveryCommands/Update-Delivery.Template.ps1",
             tokens);
+    }
+
+    private static string BuildPowerShellStringArrayLiteral(string[]? values)
+    {
+        if (values is null || values.Length == 0) return "@()";
+
+        var items = values
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(v => $"'{EscapeSingleQuotes(v.Trim())}'")
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return items.Length == 0
+            ? "@()"
+            : "@(" + string.Join(", ", items) + ")";
     }
 
     private static string RenderDeliveryTemplate(

--- a/PowerForge/Services/ModulePipelineRunner.FormattingSigningDelivery.cs
+++ b/PowerForge/Services/ModulePipelineRunner.FormattingSigningDelivery.cs
@@ -453,6 +453,26 @@ public sealed partial class ModulePipelineRunner
                         ManifestEditor.TrySetPsDataSubStringArray(manifestPath, parentKey, "RepositoryPaths", repoPaths);
                 }
 
+                if (delivery.PreservePaths is { Length: > 0 })
+                {
+                    var preserve = delivery.PreservePaths
+                        .Where(s => !string.IsNullOrWhiteSpace(s))
+                        .Select(s => s.Trim())
+                        .ToArray();
+                    if (preserve.Length > 0)
+                        ManifestEditor.TrySetPsDataSubStringArray(manifestPath, parentKey, "PreservePaths", preserve);
+                }
+
+                if (delivery.OverwritePaths is { Length: > 0 })
+                {
+                    var overwrite = delivery.OverwritePaths
+                        .Where(s => !string.IsNullOrWhiteSpace(s))
+                        .Select(s => s.Trim())
+                        .ToArray();
+                    if (overwrite.Length > 0)
+                        ManifestEditor.TrySetPsDataSubStringArray(manifestPath, parentKey, "OverwritePaths", overwrite);
+                }
+
                 if (!string.IsNullOrWhiteSpace(delivery.RepositoryBranch))
                     ManifestEditor.TrySetPsDataSubString(manifestPath, parentKey, "RepositoryBranch", delivery.RepositoryBranch!.Trim());
 

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -299,6 +299,8 @@
         "RepositoryPaths": { "type": ["array", "null"], "items": { "type": "string" } },
         "RepositoryBranch": { "type": ["string", "null"] },
         "DocumentationOrder": { "type": ["array", "null"], "items": { "type": "string" } },
+        "PreservePaths": { "type": ["array", "null"], "items": { "type": "string" } },
+        "OverwritePaths": { "type": ["array", "null"], "items": { "type": "string" } },
         "GenerateInstallCommand": { "type": "boolean" },
         "GenerateUpdateCommand": { "type": "boolean" },
         "InstallCommandName": { "type": ["string", "null"] },


### PR DESCRIPTION
## Summary
- add PreservePaths and OverwritePaths to New-ConfigurationDelivery / delivery config model
- extend generated Install-<ModuleName> and Update-<ModuleName> commands with optional bootstrap parameters (-Bootstrap, -Version, -Repository, prerelease/credential options)
- apply preserve/overwrite path policy during merge installs and keep existing defaults
- persist new delivery metadata fields to manifest and update schema/docs
- add behavioral tests for config-preserve + artefact-overwrite merge behavior

## Validation
- dotnet test .\\PowerForge.Tests\\PowerForge.Tests.csproj -c Release --filter DeliveryCommandGeneratorTests
- dotnet build .\\PSPublishModule.sln -c Release
