### PR TITLE
Refactor project consistency cmdlets into workflow service

### DIFF
--- a/PSPublishModule/Cmdlets/ConvertProjectConsistencyCommand.cs
+++ b/PSPublishModule/Cmdlets/ConvertProjectConsistencyCommand.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
 using PowerForge;
 
@@ -132,168 +130,53 @@ public sealed class ConvertProjectConsistencyCommand : PSCmdlet
     /// </summary>
     protected override void ProcessRecord()
     {
+        var logger = new CmdletLogger(this, MyInvocation.BoundParameters.ContainsKey("Verbose"));
+        var service = new ProjectConsistencyWorkflowService(logger);
         var root = System.IO.Path.GetFullPath(Path.Trim().Trim('"'));
-        if (!Directory.Exists(root))
-            throw new DirectoryNotFoundException($"Project path '{root}' not found or is not a directory");
-
-        var patterns = ResolvePatterns(ProjectType, CustomExtensions);
-        var kind = ResolveKind(ProjectType);
-
-        var enumeration = new ProjectEnumeration(
-            rootPath: root,
-            kind: kind,
-            customExtensions: ProjectType.Equals("Custom", StringComparison.OrdinalIgnoreCase) ? patterns : null,
-            excludeDirectories: ExcludeDirectories,
-            excludeFiles: ExcludeFiles);
-
-        var applyEncoding = FixEncoding.IsPresent || (!FixEncoding.IsPresent && !FixLineEndings.IsPresent);
-        var applyLineEndings = FixLineEndings.IsPresent || (!FixEncoding.IsPresent && !FixLineEndings.IsPresent);
-
-        var encodingOverrides = ParseEncodingOverrides(EncodingOverrides);
-        var lineEndingOverrides = ParseLineEndingOverrides(LineEndingOverrides);
-
-        ProjectConversionResult? encodingResult = null;
-        ProjectConversionResult? lineEndingResult = null;
+        var request = new ProjectConsistencyWorkflowRequest
+        {
+            Path = Path,
+            ProjectType = ProjectType,
+            CustomExtensions = CustomExtensions,
+            ExcludeDirectories = ExcludeDirectories,
+            ExcludeFiles = ExcludeFiles,
+            IncludeDetails = ShowDetails.IsPresent,
+            ExportPath = ExportPath,
+            RecommendedEncoding = RequiredEncoding.ToTextEncodingKind(),
+            RecommendedLineEnding = RequiredLineEnding,
+            EncodingOverrides = ProjectConsistencyWorkflowService.ParseEncodingOverrides(EncodingOverrides),
+            LineEndingOverrides = ProjectConsistencyWorkflowService.ParseLineEndingOverrides(LineEndingOverrides),
+            FixEncodingSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(FixEncoding)),
+            FixEncoding = FixEncoding.IsPresent,
+            FixLineEndingsSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(FixLineEndings)),
+            FixLineEndings = FixLineEndings.IsPresent,
+            SourceEncoding = SourceEncoding,
+            RequiredEncoding = RequiredEncoding,
+            RequiredLineEnding = RequiredLineEnding,
+            CreateBackups = CreateBackups.IsPresent,
+            BackupDirectory = BackupDirectory,
+            Force = Force.IsPresent,
+            NoRollbackOnMismatch = NoRollbackOnMismatch.IsPresent,
+            OnlyMixedLineEndings = OnlyMixedLineEndings.IsPresent,
+            EnsureFinalNewline = EnsureFinalNewline.IsPresent,
+            OnlyMissingFinalNewline = OnlyMissingFinalNewline.IsPresent
+        };
 
         var shouldProcess = ShouldProcess(root, "Convert project consistency");
         if (shouldProcess)
         {
-            if (applyEncoding)
-            {
-                var converter = new EncodingConverter();
-                var encOptions = new EncodingConversionOptions(
-                    enumeration: enumeration,
-                    sourceEncoding: SourceEncoding,
-                    targetEncoding: RequiredEncoding.ToTextEncodingKind(),
-                    createBackups: CreateBackups.IsPresent,
-                    backupDirectory: BackupDirectory,
-                    force: Force.IsPresent,
-                    noRollbackOnMismatch: NoRollbackOnMismatch.IsPresent,
-                    preferUtf8BomForPowerShell: RequiredEncoding == FileConsistencyEncoding.UTF8BOM);
-
-                if (encodingOverrides is { Count: > 0 })
-                {
-                    encOptions.TargetEncodingResolver = path =>
-                    {
-                        var rel = ProjectTextInspection.ComputeRelativePath(enumeration.RootPath, path);
-                        var overrideEncoding = FileConsistencyOverrideResolver.ResolveEncodingOverride(rel, encodingOverrides);
-                        return overrideEncoding?.ToTextEncodingKind();
-                    };
-                }
-
-                encodingResult = converter.Convert(encOptions);
-            }
-
-            if (applyLineEndings)
-            {
-                var converter = new LineEndingConverter();
-                var lineOptions = new LineEndingConversionOptions(
-                    enumeration: enumeration,
-                    target: RequiredLineEnding.ToLineEnding(),
-                    createBackups: CreateBackups.IsPresent,
-                    backupDirectory: BackupDirectory,
-                    force: Force.IsPresent,
-                    onlyMixed: OnlyMixedLineEndings.IsPresent,
-                    ensureFinalNewline: EnsureFinalNewline.IsPresent,
-                    onlyMissingNewline: OnlyMissingFinalNewline.IsPresent,
-                    preferUtf8BomForPowerShell: RequiredEncoding == FileConsistencyEncoding.UTF8BOM);
-
-                if (lineEndingOverrides is { Count: > 0 })
-                {
-                    lineOptions.TargetResolver = path =>
-                    {
-                        var rel = ProjectTextInspection.ComputeRelativePath(enumeration.RootPath, path);
-                        var overrideLineEnding = FileConsistencyOverrideResolver.ResolveLineEndingOverride(rel, lineEndingOverrides);
-                        return overrideLineEnding?.ToLineEnding();
-                    };
-                }
-
-                lineEndingResult = converter.Convert(lineOptions);
-            }
+            var result = service.ConvertAndAnalyze(request);
+            WriteSummary(result.RootPath, result.Report, result.EncodingConversion, result.LineEndingConversion);
+            WriteObject(new ProjectConsistencyConversionResult(result.Report, result.EncodingConversion, result.LineEndingConversion));
+            return;
         }
 
-        var logger = new CmdletLogger(this, MyInvocation.BoundParameters.ContainsKey("Verbose"));
-        var analyzer = new ProjectConsistencyAnalyzer(logger);
-        var report = analyzer.Analyze(
-            enumeration: enumeration,
-            projectType: ProjectType,
-            recommendedEncoding: RequiredEncoding.ToTextEncodingKind(),
-            recommendedLineEnding: RequiredLineEnding,
-            includeDetails: ShowDetails.IsPresent,
-            exportPath: ExportPath,
-            encodingOverrides: encodingOverrides,
-            lineEndingOverrides: lineEndingOverrides);
-
-        WriteSummary(root, report, encodingResult, lineEndingResult);
-
-        WriteObject(new ProjectConsistencyConversionResult(report, encodingResult, lineEndingResult));
-    }
-
-    private static Dictionary<string, FileConsistencyEncoding>? ParseEncodingOverrides(IDictionary? overrides)
-    {
-        if (overrides is null || overrides.Count == 0) return null;
-        var dict = new Dictionary<string, FileConsistencyEncoding>(StringComparer.OrdinalIgnoreCase);
-        foreach (DictionaryEntry entry in overrides)
-        {
-            var key = entry.Key?.ToString();
-            if (string.IsNullOrWhiteSpace(key)) continue;
-            if (TryParseEnum(entry.Value, out FileConsistencyEncoding value))
-                dict[key!] = value;
-        }
-        return dict.Count == 0 ? null : dict;
-    }
-
-    private static Dictionary<string, FileConsistencyLineEnding>? ParseLineEndingOverrides(IDictionary? overrides)
-    {
-        if (overrides is null || overrides.Count == 0) return null;
-        var dict = new Dictionary<string, FileConsistencyLineEnding>(StringComparer.OrdinalIgnoreCase);
-        foreach (DictionaryEntry entry in overrides)
-        {
-            var key = entry.Key?.ToString();
-            if (string.IsNullOrWhiteSpace(key)) continue;
-            if (TryParseEnum(entry.Value, out FileConsistencyLineEnding value))
-                dict[key!] = value;
-        }
-        return dict.Count == 0 ? null : dict;
-    }
-
-    private static bool TryParseEnum<T>(object? raw, out T value) where T : struct
-    {
-        value = default;
-        if (raw is null) return false;
-        if (raw is T typed)
-        {
-            value = typed;
-            return true;
-        }
-        var text = raw.ToString();
-        return !string.IsNullOrWhiteSpace(text) && Enum.TryParse(text, true, out value);
-    }
-
-    private static string[] ResolvePatterns(string projectType, string[]? custom)
-    {
-        if (projectType.Equals("Custom", StringComparison.OrdinalIgnoreCase))
-            return (custom is null || custom.Length == 0) ? Array.Empty<string>() : custom;
-
-        return projectType switch
-        {
-            "PowerShell" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml" },
-            "CSharp" => new[] { "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml", "*.resx" },
-            "Mixed" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml" },
-            "All" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml", "*.js", "*.ts", "*.py", "*.rb", "*.java", "*.cpp", "*.h", "*.hpp", "*.sql", "*.md", "*.txt", "*.yaml", "*.yml" },
-            _ => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml" }
-        };
-    }
-
-    private static ProjectKind ResolveKind(string projectType)
-    {
-        return projectType switch
-        {
-            "PowerShell" => ProjectKind.PowerShell,
-            "CSharp" => ProjectKind.CSharp,
-            "All" => ProjectKind.All,
-            _ => ProjectKind.Mixed
-        };
+        WriteVerbose($"Project type: {ProjectType} with patterns: {string.Join(", ", ProjectConsistencyWorkflowService.ResolvePatterns(ProjectType, CustomExtensions))}");
+        WriteWarning("WhatIf/ShouldProcess declined project consistency conversion.");
+        WriteObject(new ProjectConsistencyConversionResult(
+            service.Analyze(request).Report,
+            null,
+            null));
     }
 
     private void WriteSummary(string root, ProjectConsistencyReport report, ProjectConversionResult? encodingResult, ProjectConversionResult? lineEndingResult)

--- a/PSPublishModule/Cmdlets/GetProjectConsistencyCommand.cs
+++ b/PSPublishModule/Cmdlets/GetProjectConsistencyCommand.cs
@@ -79,36 +79,37 @@ public sealed class GetProjectConsistencyCommand : PSCmdlet
     protected override void ProcessRecord()
     {
         var root = System.IO.Path.GetFullPath(Path.Trim().Trim('"'));
-        if (!Directory.Exists(root))
-            throw new DirectoryNotFoundException($"Project path '{root}' not found or is not a directory");
-
-        if (RecommendedEncoding == TextEncodingKind.Any)
-            throw new PSArgumentException("RecommendedEncoding cannot be Any for project consistency analysis.");
-
-        var patterns = ResolvePatterns(ProjectType, CustomExtensions);
+        var logger = new CmdletLogger(this, MyInvocation.BoundParameters.ContainsKey("Verbose"));
+        var service = new ProjectConsistencyWorkflowService(logger);
+        var request = new ProjectConsistencyWorkflowRequest
+        {
+            Path = Path,
+            ProjectType = ProjectType,
+            CustomExtensions = CustomExtensions,
+            ExcludeDirectories = ExcludeDirectories,
+            RecommendedEncoding = RecommendedEncoding,
+            RecommendedLineEnding = RecommendedLineEnding,
+            IncludeDetails = ShowDetails.IsPresent,
+            ExportPath = ExportPath
+        };
+        var patterns = ProjectConsistencyWorkflowService.ResolvePatterns(ProjectType, CustomExtensions);
         WriteVerbose($"Project type: {ProjectType} with patterns: {string.Join(", ", patterns)}");
 
         HostWriteLineSafe("🔎 Analyzing project consistency...", ConsoleColor.Cyan);
         HostWriteLineSafe($"Project: {root}");
         HostWriteLineSafe($"Type: {ProjectType}");
 
-        var enumeration = new ProjectEnumeration(
-            rootPath: root,
-            kind: ResolveKind(ProjectType),
-            customExtensions: ProjectType.Equals("Custom", StringComparison.OrdinalIgnoreCase) ? patterns : null,
-            excludeDirectories: ExcludeDirectories);
+        ProjectConsistencyWorkflowResult workflow;
+        try
+        {
+            workflow = service.Analyze(request);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new PSArgumentException(ex.Message, ex);
+        }
 
-        var logger = new CmdletLogger(this, MyInvocation.BoundParameters.ContainsKey("Verbose"));
-        var analyzer = new ProjectConsistencyAnalyzer(logger);
-        var report = analyzer.Analyze(
-            enumeration: enumeration,
-            projectType: ProjectType,
-            recommendedEncoding: RecommendedEncoding,
-            recommendedLineEnding: RecommendedLineEnding,
-            includeDetails: ShowDetails.IsPresent,
-            exportPath: ExportPath,
-            encodingOverrides: null,
-            lineEndingOverrides: null);
+        var report = workflow.Report;
 
         if (report.Summary.TotalFiles == 0)
         {
@@ -165,32 +166,6 @@ public sealed class GetProjectConsistencyCommand : PSCmdlet
         }
 
         WriteObject(report);
-    }
-
-    private static string[] ResolvePatterns(string projectType, string[]? custom)
-    {
-        if (projectType.Equals("Custom", StringComparison.OrdinalIgnoreCase))
-            return (custom is null || custom.Length == 0) ? Array.Empty<string>() : custom;
-
-        return projectType switch
-        {
-            "PowerShell" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml" },
-            "CSharp" => new[] { "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml", "*.resx" },
-            "Mixed" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml" },
-            "All" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml", "*.js", "*.ts", "*.py", "*.rb", "*.java", "*.cpp", "*.h", "*.hpp", "*.sql", "*.md", "*.txt", "*.yaml", "*.yml" },
-            _ => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml" }
-        };
-    }
-
-    private static ProjectKind ResolveKind(string projectType)
-    {
-        return projectType switch
-        {
-            "PowerShell" => ProjectKind.PowerShell,
-            "CSharp" => ProjectKind.CSharp,
-            "All" => ProjectKind.All,
-            _ => ProjectKind.Mixed
-        };
     }
 
     private void HostWriteLineSafe(string text, ConsoleColor? fg = null)

--- a/PowerForge.Tests/ProjectConsistencyWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ProjectConsistencyWorkflowServiceTests.cs
@@ -1,0 +1,93 @@
+using System.Collections;
+using System.Text;
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class ProjectConsistencyWorkflowServiceTests
+{
+    [Fact]
+    public void Analyze_filters_files_by_project_type_and_returns_resolved_patterns()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-consistency-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Module.ps1"), "Write-Host 'ok'", new UTF8Encoding(true));
+            File.WriteAllText(Path.Combine(root.FullName, "notes.txt"), "ignore me", new UTF8Encoding(false));
+
+            var service = new ProjectConsistencyWorkflowService(new NullLogger());
+            var result = service.Analyze(new ProjectConsistencyWorkflowRequest
+            {
+                Path = root.FullName,
+                ProjectType = "PowerShell",
+                IncludeDetails = true
+            });
+
+            Assert.Equal(Path.GetFullPath(root.FullName), result.RootPath);
+            Assert.Contains("*.ps1", result.Patterns, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(ProjectKind.PowerShell, result.Kind);
+            Assert.Equal(1, result.Report.Summary.TotalFiles);
+            Assert.Single(result.Report.Files!);
+            Assert.Equal("Module.ps1", result.Report.Files![0].RelativePath);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ConvertAndAnalyze_runs_both_conversions_when_no_specific_switch_is_provided()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-convert-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var filePath = Path.Combine(root.FullName, "Module.ps1");
+            File.WriteAllText(filePath, "function Test-Me {\n    'ok'\n}\n", new UTF8Encoding(false));
+
+            var service = new ProjectConsistencyWorkflowService(new NullLogger());
+            var result = service.ConvertAndAnalyze(new ProjectConsistencyWorkflowRequest
+            {
+                Path = root.FullName,
+                ProjectType = "PowerShell",
+                RequiredEncoding = FileConsistencyEncoding.UTF8BOM,
+                RequiredLineEnding = FileConsistencyLineEnding.CRLF
+            });
+
+            Assert.NotNull(result.EncodingConversion);
+            Assert.NotNull(result.LineEndingConversion);
+            Assert.Equal(1, result.Report.Summary.TotalFiles);
+
+            var bytes = File.ReadAllBytes(filePath);
+            Assert.True(bytes.Length >= 3);
+            Assert.Equal((byte)0xEF, bytes[0]);
+            Assert.Equal((byte)0xBB, bytes[1]);
+            Assert.Equal((byte)0xBF, bytes[2]);
+
+            var text = File.ReadAllText(filePath);
+            Assert.Contains("\r\n", text, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ParseEncodingOverrides_reads_hashtable_values_case_insensitively()
+    {
+        var overrides = new Hashtable(StringComparer.OrdinalIgnoreCase)
+        {
+            ["*.xml"] = "utf8",
+            ["*.ps1"] = FileConsistencyEncoding.UTF8BOM
+        };
+
+        var parsed = ProjectConsistencyWorkflowService.ParseEncodingOverrides(overrides);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(FileConsistencyEncoding.UTF8, parsed!["*.xml"]);
+        Assert.Equal(FileConsistencyEncoding.UTF8BOM, parsed["*.ps1"]);
+    }
+}

--- a/PowerForge/Models/ProjectConsistencyWorkflowRequest.cs
+++ b/PowerForge/Models/ProjectConsistencyWorkflowRequest.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+
+namespace PowerForge;
+
+/// <summary>
+/// Input used by <see cref="ProjectConsistencyWorkflowService"/> for project consistency analysis and conversion.
+/// </summary>
+public sealed class ProjectConsistencyWorkflowRequest
+{
+    /// <summary>Path to the project directory.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Logical project type used to resolve default file patterns.</summary>
+    public string ProjectType { get; set; } = "Mixed";
+
+    /// <summary>Custom file extensions used when <see cref="ProjectType"/> is Custom.</summary>
+    public string[]? CustomExtensions { get; set; }
+
+    /// <summary>Directory names to exclude from enumeration.</summary>
+    public string[] ExcludeDirectories { get; set; } = new[] { ".git", ".vs", "bin", "obj", "packages", "node_modules", ".vscode" };
+
+    /// <summary>File patterns to exclude from enumeration.</summary>
+    public string[] ExcludeFiles { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Recommended encoding for analysis mode.</summary>
+    public TextEncodingKind? RecommendedEncoding { get; set; }
+
+    /// <summary>Recommended line ending for analysis mode.</summary>
+    public FileConsistencyLineEnding? RecommendedLineEnding { get; set; }
+
+    /// <summary>Include detailed file-by-file analysis in the returned report.</summary>
+    public bool IncludeDetails { get; set; }
+
+    /// <summary>Optional CSV export path for the consistency report.</summary>
+    public string? ExportPath { get; set; }
+
+    /// <summary>Optional per-path encoding overrides.</summary>
+    public IReadOnlyDictionary<string, FileConsistencyEncoding>? EncodingOverrides { get; set; }
+
+    /// <summary>Optional per-path line ending overrides.</summary>
+    public IReadOnlyDictionary<string, FileConsistencyLineEnding>? LineEndingOverrides { get; set; }
+
+    /// <summary>Whether the encoding conversion switch was explicitly provided.</summary>
+    public bool FixEncodingSpecified { get; set; }
+
+    /// <summary>Whether encoding conversion should run.</summary>
+    public bool FixEncoding { get; set; }
+
+    /// <summary>Whether the line ending conversion switch was explicitly provided.</summary>
+    public bool FixLineEndingsSpecified { get; set; }
+
+    /// <summary>Whether line ending conversion should run.</summary>
+    public bool FixLineEndings { get; set; }
+
+    /// <summary>Source encoding filter for conversion mode.</summary>
+    public TextEncodingKind SourceEncoding { get; set; } = TextEncodingKind.Any;
+
+    /// <summary>Required encoding for conversion mode.</summary>
+    public FileConsistencyEncoding RequiredEncoding { get; set; } = FileConsistencyEncoding.UTF8BOM;
+
+    /// <summary>Required line ending for conversion mode.</summary>
+    public FileConsistencyLineEnding RequiredLineEnding { get; set; } = FileConsistencyLineEnding.CRLF;
+
+    /// <summary>Create backups before conversion.</summary>
+    public bool CreateBackups { get; set; }
+
+    /// <summary>Optional backup directory for conversion mode.</summary>
+    public string? BackupDirectory { get; set; }
+
+    /// <summary>Force conversion even when files already match the target.</summary>
+    public bool Force { get; set; }
+
+    /// <summary>Do not rollback from backup on encoding verification mismatch.</summary>
+    public bool NoRollbackOnMismatch { get; set; }
+
+    /// <summary>Only convert files with mixed line endings.</summary>
+    public bool OnlyMixedLineEndings { get; set; }
+
+    /// <summary>Ensure a final newline exists after line ending conversion.</summary>
+    public bool EnsureFinalNewline { get; set; }
+
+    /// <summary>Only fix files missing the final newline.</summary>
+    public bool OnlyMissingFinalNewline { get; set; }
+}

--- a/PowerForge/Models/ProjectConsistencyWorkflowResult.cs
+++ b/PowerForge/Models/ProjectConsistencyWorkflowResult.cs
@@ -1,0 +1,44 @@
+namespace PowerForge;
+
+/// <summary>
+/// Combined workflow result for project consistency analysis and optional conversion.
+/// </summary>
+public sealed class ProjectConsistencyWorkflowResult
+{
+    /// <summary>
+    /// Creates a new workflow result.
+    /// </summary>
+    public ProjectConsistencyWorkflowResult(
+        string rootPath,
+        string[] patterns,
+        ProjectKind kind,
+        ProjectConsistencyReport report,
+        ProjectConversionResult? encodingConversion,
+        ProjectConversionResult? lineEndingConversion)
+    {
+        RootPath = rootPath;
+        Patterns = patterns ?? System.Array.Empty<string>();
+        Kind = kind;
+        Report = report;
+        EncodingConversion = encodingConversion;
+        LineEndingConversion = lineEndingConversion;
+    }
+
+    /// <summary>Normalized project root path.</summary>
+    public string RootPath { get; }
+
+    /// <summary>Resolved include patterns used by the enumeration.</summary>
+    public string[] Patterns { get; }
+
+    /// <summary>Resolved project kind.</summary>
+    public ProjectKind Kind { get; }
+
+    /// <summary>Final consistency report.</summary>
+    public ProjectConsistencyReport Report { get; }
+
+    /// <summary>Encoding conversion summary when conversion mode ran.</summary>
+    public ProjectConversionResult? EncodingConversion { get; }
+
+    /// <summary>Line ending conversion summary when conversion mode ran.</summary>
+    public ProjectConversionResult? LineEndingConversion { get; }
+}

--- a/PowerForge/Services/ProjectConsistencyWorkflowService.cs
+++ b/PowerForge/Services/ProjectConsistencyWorkflowService.cs
@@ -1,0 +1,269 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace PowerForge;
+
+/// <summary>
+/// Reusable workflow service for project consistency analysis and conversion.
+/// </summary>
+public sealed class ProjectConsistencyWorkflowService
+{
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Creates a new workflow service.
+    /// </summary>
+    public ProjectConsistencyWorkflowService(ILogger logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Runs consistency analysis only.
+    /// </summary>
+    public ProjectConsistencyWorkflowResult Analyze(ProjectConsistencyWorkflowRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        if (request.RecommendedEncoding == TextEncodingKind.Any)
+            throw new ArgumentException("RecommendedEncoding cannot be Any for project consistency analysis.", nameof(request));
+
+        var context = BuildContext(request);
+        var analyzer = new ProjectConsistencyAnalyzer(_logger);
+        var report = analyzer.Analyze(
+            enumeration: context.Enumeration,
+            projectType: request.ProjectType,
+            recommendedEncoding: request.RecommendedEncoding,
+            recommendedLineEnding: request.RecommendedLineEnding,
+            includeDetails: request.IncludeDetails,
+            exportPath: request.ExportPath,
+            encodingOverrides: request.EncodingOverrides,
+            lineEndingOverrides: request.LineEndingOverrides);
+
+        return new ProjectConsistencyWorkflowResult(
+            context.RootPath,
+            context.Patterns,
+            context.Kind,
+            report,
+            null,
+            null);
+    }
+
+    /// <summary>
+    /// Runs conversion and then re-analyzes the project for a combined result.
+    /// </summary>
+    public ProjectConsistencyWorkflowResult ConvertAndAnalyze(ProjectConsistencyWorkflowRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        var context = BuildContext(request);
+        var encodingOverrides = request.EncodingOverrides;
+        var lineEndingOverrides = request.LineEndingOverrides;
+        var applyEncoding = request.FixEncodingSpecified ? request.FixEncoding : !request.FixLineEndingsSpecified;
+        var applyLineEndings = request.FixLineEndingsSpecified ? request.FixLineEndings : !request.FixEncodingSpecified;
+
+        ProjectConversionResult? encodingResult = null;
+        ProjectConversionResult? lineEndingResult = null;
+
+        if (applyEncoding)
+        {
+            var encOptions = new EncodingConversionOptions(
+                enumeration: context.Enumeration,
+                sourceEncoding: request.SourceEncoding,
+                targetEncoding: request.RequiredEncoding.ToTextEncodingKind(),
+                createBackups: request.CreateBackups,
+                backupDirectory: request.BackupDirectory,
+                force: request.Force,
+                noRollbackOnMismatch: request.NoRollbackOnMismatch,
+                preferUtf8BomForPowerShell: request.RequiredEncoding == FileConsistencyEncoding.UTF8BOM);
+
+            if (encodingOverrides is { Count: > 0 })
+            {
+                encOptions.TargetEncodingResolver = path =>
+                {
+                    var rel = ProjectTextInspection.ComputeRelativePath(context.Enumeration.RootPath, path);
+                    var overrideEncoding = FileConsistencyOverrideResolver.ResolveEncodingOverride(rel, encodingOverrides);
+                    return overrideEncoding?.ToTextEncodingKind();
+                };
+            }
+
+            encodingResult = new EncodingConverter().Convert(encOptions);
+        }
+
+        if (applyLineEndings)
+        {
+            var lineOptions = new LineEndingConversionOptions(
+                enumeration: context.Enumeration,
+                target: request.RequiredLineEnding.ToLineEnding(),
+                createBackups: request.CreateBackups,
+                backupDirectory: request.BackupDirectory,
+                force: request.Force,
+                onlyMixed: request.OnlyMixedLineEndings,
+                ensureFinalNewline: request.EnsureFinalNewline,
+                onlyMissingNewline: request.OnlyMissingFinalNewline,
+                preferUtf8BomForPowerShell: request.RequiredEncoding == FileConsistencyEncoding.UTF8BOM);
+
+            if (lineEndingOverrides is { Count: > 0 })
+            {
+                lineOptions.TargetResolver = path =>
+                {
+                    var rel = ProjectTextInspection.ComputeRelativePath(context.Enumeration.RootPath, path);
+                    var overrideLineEnding = FileConsistencyOverrideResolver.ResolveLineEndingOverride(rel, lineEndingOverrides);
+                    return overrideLineEnding?.ToLineEnding();
+                };
+            }
+
+            lineEndingResult = new LineEndingConverter().Convert(lineOptions);
+        }
+
+        var analyzer = new ProjectConsistencyAnalyzer(_logger);
+        var report = analyzer.Analyze(
+            enumeration: context.Enumeration,
+            projectType: request.ProjectType,
+            recommendedEncoding: request.RequiredEncoding.ToTextEncodingKind(),
+            recommendedLineEnding: request.RequiredLineEnding,
+            includeDetails: request.IncludeDetails,
+            exportPath: request.ExportPath,
+            encodingOverrides: encodingOverrides,
+            lineEndingOverrides: lineEndingOverrides);
+
+        return new ProjectConsistencyWorkflowResult(
+            context.RootPath,
+            context.Patterns,
+            context.Kind,
+            report,
+            encodingResult,
+            lineEndingResult);
+    }
+
+    /// <summary>
+    /// Parses per-path encoding overrides from a hashtable-like input.
+    /// </summary>
+    public static Dictionary<string, FileConsistencyEncoding>? ParseEncodingOverrides(IDictionary? overrides)
+    {
+        if (overrides is null || overrides.Count == 0)
+            return null;
+
+        var dict = new Dictionary<string, FileConsistencyEncoding>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in overrides)
+        {
+            var key = entry.Key?.ToString();
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+
+            if (TryParseEnum(entry.Value, out FileConsistencyEncoding value))
+                dict[key!] = value;
+        }
+
+        return dict.Count == 0 ? null : dict;
+    }
+
+    /// <summary>
+    /// Parses per-path line ending overrides from a hashtable-like input.
+    /// </summary>
+    public static Dictionary<string, FileConsistencyLineEnding>? ParseLineEndingOverrides(IDictionary? overrides)
+    {
+        if (overrides is null || overrides.Count == 0)
+            return null;
+
+        var dict = new Dictionary<string, FileConsistencyLineEnding>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in overrides)
+        {
+            var key = entry.Key?.ToString();
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+
+            if (TryParseEnum(entry.Value, out FileConsistencyLineEnding value))
+                dict[key!] = value;
+        }
+
+        return dict.Count == 0 ? null : dict;
+    }
+
+    /// <summary>
+    /// Resolves effective include patterns for the specified project type.
+    /// </summary>
+    public static string[] ResolvePatterns(string projectType, string[]? custom)
+    {
+        if (projectType.Equals("Custom", StringComparison.OrdinalIgnoreCase))
+            return custom is null || custom.Length == 0 ? Array.Empty<string>() : custom;
+
+        return projectType switch
+        {
+            "PowerShell" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml" },
+            "CSharp" => new[] { "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml", "*.resx" },
+            "Mixed" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml" },
+            "All" => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml", "*.js", "*.ts", "*.py", "*.rb", "*.java", "*.cpp", "*.h", "*.hpp", "*.sql", "*.md", "*.txt", "*.yaml", "*.yml" },
+            _ => new[] { "*.ps1", "*.psm1", "*.psd1", "*.ps1xml", "*.cs", "*.csx", "*.csproj", "*.sln", "*.config", "*.json", "*.xml" }
+        };
+    }
+
+    /// <summary>
+    /// Resolves effective project kind for the specified project type.
+    /// </summary>
+    public static ProjectKind ResolveKind(string projectType)
+    {
+        return projectType switch
+        {
+            "PowerShell" => ProjectKind.PowerShell,
+            "CSharp" => ProjectKind.CSharp,
+            "All" => ProjectKind.All,
+            _ => ProjectKind.Mixed
+        };
+    }
+
+    private static bool TryParseEnum<T>(object? raw, out T value) where T : struct
+    {
+        value = default;
+        if (raw is null)
+            return false;
+
+        if (raw is T typed)
+        {
+            value = typed;
+            return true;
+        }
+
+        var text = raw.ToString();
+        return !string.IsNullOrWhiteSpace(text) && Enum.TryParse(text, true, out value);
+    }
+
+    private static ProjectConsistencyWorkflowContext BuildContext(ProjectConsistencyWorkflowRequest request)
+    {
+        var rootPath = System.IO.Path.GetFullPath(request.Path.Trim().Trim('"'));
+        if (!Directory.Exists(rootPath))
+            throw new DirectoryNotFoundException($"Project path '{rootPath}' not found or is not a directory");
+
+        var patterns = ResolvePatterns(request.ProjectType, request.CustomExtensions);
+        var kind = ResolveKind(request.ProjectType);
+        var enumeration = new ProjectEnumeration(
+            rootPath: rootPath,
+            kind: kind,
+            customExtensions: request.ProjectType.Equals("Custom", StringComparison.OrdinalIgnoreCase) ? patterns : null,
+            excludeDirectories: request.ExcludeDirectories,
+            excludeFiles: request.ExcludeFiles);
+
+        return new ProjectConsistencyWorkflowContext(rootPath, patterns, kind, enumeration);
+    }
+
+    private sealed class ProjectConsistencyWorkflowContext
+    {
+        internal ProjectConsistencyWorkflowContext(string rootPath, string[] patterns, ProjectKind kind, ProjectEnumeration enumeration)
+        {
+            RootPath = rootPath;
+            Patterns = patterns;
+            Kind = kind;
+            Enumeration = enumeration;
+        }
+
+        internal string RootPath { get; }
+
+        internal string[] Patterns { get; }
+
+        internal ProjectKind Kind { get; }
+
+        internal ProjectEnumeration Enumeration { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared project consistency path/pattern resolution, override parsing, and conversion/analyze orchestration into a reusable PowerForge workflow service
- thin `Convert-ProjectConsistency` and `Get-ProjectConsistency` so they mostly map parameters and keep only host output formatting
- add focused workflow tests for project-type filtering, default conversion behavior, and override parsing

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "ProjectConsistencyWorkflowServiceTests|EncodingConverterTests|LineEndingConverterTests|BuildDiagnosticsFactoryTests"`
- `pwsh .\Module\Build\Build-Module.ps1 -NoSign`

## Stacked On
- base branch: `codex/thin-cmdlets-pass-two`
- review after #181