### PR TITLE
Refactor Invoke-ProjectBuild GitHub publishing

### DIFF
--- a/Module/Docs/Invoke-ProjectBuild.md
+++ b/Module/Docs/Invoke-ProjectBuild.md
@@ -155,7 +155,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-- `PSPublishModule.ProjectBuildResult`
+- `PowerForge.ProjectBuildResult`
 
 ## RELATED LINKS
 

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -6596,7 +6596,7 @@ the local date (yyyy.MM.dd) unless a primary project version is available.</maml
     <command:returnValues>
       <command:returnValue>
         <dev:type>
-          <maml:name>PSPublishModule.ProjectBuildResult</maml:name>
+          <maml:name>PowerForge.ProjectBuildResult</maml:name>
         </dev:type>
       </command:returnValue>
     </command:returnValues>

--- a/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.GitHubPreflight.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.GitHubPreflight.cs
@@ -13,70 +13,13 @@ namespace PSPublishModule;
 public sealed partial class InvokeProjectBuildCommand
 {
     /// <summary>
-    /// Builds a preflight advisory when GitHub single-release reuse would publish a mixed-version asset set into an existing tag.
+    /// Validates whether GitHub single-release reuse is safe for the current plan.
     /// </summary>
-    /// <param name="tag">GitHub release tag being evaluated.</param>
-    /// <param name="projects">Packable projects participating in the release plan.</param>
-    /// <param name="plannedAssetNames">Asset names that would be published for the current plan.</param>
-    /// <param name="existingAssetNames">Asset names already attached to the existing GitHub release.</param>
-    /// <returns>An advisory message when the reuse is unsafe; otherwise <see langword="null"/>.</returns>
-    internal static string? BuildGitHubSingleReleaseReuseAdvisory(
-        string tag,
-        IReadOnlyList<DotNetRepositoryProjectResult> projects,
-        IReadOnlyCollection<string> plannedAssetNames,
-        IReadOnlyCollection<string> existingAssetNames)
-    {
-        if (string.IsNullOrWhiteSpace(tag))
-            return null;
-
-        var packable = projects
-            .Where(p => p.IsPackable && !string.IsNullOrWhiteSpace(p.NewVersion))
-            .ToArray();
-        var distinctVersions = packable
-            .Select(p => p.NewVersion!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        if (distinctVersions.Length <= 1)
-            return null;
-
-        var planned = new HashSet<string>(
-            plannedAssetNames.Where(name => !string.IsNullOrWhiteSpace(name)),
-            StringComparer.OrdinalIgnoreCase);
-        var existing = new HashSet<string>(
-            existingAssetNames.Where(name => !string.IsNullOrWhiteSpace(name)),
-            StringComparer.OrdinalIgnoreCase);
-
-        if (planned.Count == 0 || planned.SetEquals(existing))
-            return null;
-
-        var versionSummary = string.Join(", ",
-            packable
-                .OrderBy(p => p.ProjectName, StringComparer.OrdinalIgnoreCase)
-                .Select(p => $"{p.ProjectName}={p.NewVersion}"));
-        var missingAssets = planned
-            .Except(existing, StringComparer.OrdinalIgnoreCase)
-            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        var extraAssets = existing
-            .Except(planned, StringComparer.OrdinalIgnoreCase)
-            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        var details = new List<string>
-        {
-            $"GitHub preflight blocked publish: tag '{tag}' already exists and Single release mode would reuse it for a mixed-version package set ({versionSummary})."
-        };
-
-        if (missingAssets.Length > 0)
-            details.Add($"Planned assets missing from the existing release: {string.Join(", ", missingAssets)}.");
-        if (extraAssets.Length > 0)
-            details.Add($"Existing release contains different assets: {string.Join(", ", extraAssets)}.");
-
-        details.Add("Change one of: set GitHubReleaseMode to 'PerProject'; set GitHubTagConflictPolicy to 'Fail' or 'AppendUtcTimestamp'; or use a unique GitHubTagTemplate such as '{Repo}-v{UtcTimestamp}'. Keep GitHubPrimaryProject explicit when Single mode is intentional.");
-        return string.Join(" ", details);
-    }
-
+    /// <param name="config">Project build configuration.</param>
+    /// <param name="plan">Repository release plan used for the publish preflight.</param>
+    /// <param name="gitHubToken">Resolved GitHub access token.</param>
+    /// <param name="logger">Logger used for informational preflight messages.</param>
+    /// <returns>An advisory message when the publish should be blocked; otherwise <see langword="null"/>.</returns>
     private static string? ValidateGitHubPublishPreflight(
         ProjectBuildConfig config,
         DotNetRepositoryReleaseResult plan,
@@ -147,7 +90,7 @@ public sealed partial class InvokeProjectBuildCommand
             return existingRelease.ErrorMessage;
 
         logger.Info($"GitHub preflight: release tag '{tag}' already exists; validating asset set before publish.");
-        return BuildGitHubSingleReleaseReuseAdvisory(tag, plan.Projects, plannedAssetNames, existingRelease.AssetNames);
+        return ProjectBuildGitHubPublisher.BuildSingleReleaseReuseAdvisory(tag, plan.Projects, plannedAssetNames, existingRelease.AssetNames);
     }
 
     private static GitHubReleaseProbeResult ProbeGitHubReleaseByTag(

--- a/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
@@ -267,293 +267,34 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
         }
 
         var resolvedGitHubToken = gitHubToken!;
-
-        var releaseMode = string.IsNullOrWhiteSpace(config.GitHubReleaseMode)
-            ? "Single"
-            : config.GitHubReleaseMode!.Trim();
-        var perProject = string.Equals(releaseMode, "PerProject", StringComparison.OrdinalIgnoreCase);
-        var conflictPolicy = ParseGitHubTagConflictPolicy(config.GitHubTagConflictPolicy);
-        var reuseExistingReleaseOnConflict = conflictPolicy == GitHubTagConflictPolicy.Reuse;
-        var nowLocal = DateTime.Now;
-        var nowUtc = DateTime.UtcNow;
-        var dateToken = nowLocal.ToString("yyyy.MM.dd");
-        var utcDateToken = nowUtc.ToString("yyyy.MM.dd");
-        var dateTimeToken = nowLocal.ToString("yyyy.MM.dd-HH.mm.ss");
-        var utcDateTimeToken = nowUtc.ToString("yyyy.MM.dd-HH.mm.ss");
-        var timestampToken = nowLocal.ToString("yyyyMMddHHmmss");
-        var utcTimestampToken = nowUtc.ToString("yyyyMMddHHmmss");
-        var repoName = string.IsNullOrWhiteSpace(config.GitHubRepositoryName)
-            ? "repository"
-            : config.GitHubRepositoryName!.Trim();
-
-        if (perProject)
+        var publisher = new ProjectBuildGitHubPublisher(logger);
+        var publishSummary = publisher.Publish(new ProjectBuildGitHubPublishRequest
         {
-            foreach (var project in release.Projects)
-            {
-                if (!project.IsPackable) continue;
-                var r = new ProjectBuildGitHubResult { ProjectName = project.ProjectName };
+            Owner = config.GitHubUsername!,
+            Repository = config.GitHubRepositoryName!,
+            Token = resolvedGitHubToken,
+            Release = release,
+            ReleaseMode = config.GitHubReleaseMode ?? "Single",
+            IncludeProjectNameInTag = config.GitHubIncludeProjectNameInTag,
+            IsPreRelease = config.GitHubIsPreRelease,
+            GenerateReleaseNotes = config.GitHubGenerateReleaseNotes,
+            PublishFailFast = spec.PublishFailFast,
+            ReleaseName = config.GitHubReleaseName,
+            TagName = config.GitHubTagName,
+            TagTemplate = config.GitHubTagTemplate,
+            PrimaryProject = config.GitHubPrimaryProject,
+            TagConflictPolicy = config.GitHubTagConflictPolicy
+        });
 
-                if (string.IsNullOrWhiteSpace(project.NewVersion))
-                {
-                    r.Success = false;
-                    r.ErrorMessage = "Missing project version for GitHub release.";
-                    result.GitHub.Add(r);
-                    if (spec.PublishFailFast)
-                    {
-                        result.Success = false;
-                        result.ErrorMessage = r.ErrorMessage;
-                        break;
-                    }
-                    continue;
-                }
-
-                if (string.IsNullOrWhiteSpace(project.ReleaseZipPath))
-                {
-                    r.Success = false;
-                    r.ErrorMessage = "No release zip available for GitHub release.";
-                    result.GitHub.Add(r);
-                    if (spec.PublishFailFast)
-                    {
-                        result.Success = false;
-                        result.ErrorMessage = r.ErrorMessage;
-                        break;
-                    }
-                    continue;
-                }
-
-                if (!File.Exists(project.ReleaseZipPath))
-                {
-                    r.Success = false;
-                    r.ErrorMessage = $"Release zip not found: {project.ReleaseZipPath}";
-                    result.GitHub.Add(r);
-                    if (spec.PublishFailFast)
-                    {
-                        result.Success = false;
-                        result.ErrorMessage = r.ErrorMessage;
-                        break;
-                    }
-                    continue;
-                }
-
-                var tag = string.IsNullOrWhiteSpace(config.GitHubTagName)
-                    ? (config.GitHubIncludeProjectNameInTag == false ? $"v{project.NewVersion}" : $"{project.ProjectName}-v{project.NewVersion}")
-                    : config.GitHubTagName!;
-                if (!string.IsNullOrWhiteSpace(config.GitHubTagTemplate))
-                {
-                    tag = ApplyTemplate(
-                        config.GitHubTagTemplate!,
-                        project.ProjectName,
-                        project.NewVersion ?? project.OldVersion ?? string.Empty,
-                        config.GitHubPrimaryProject ?? project.ProjectName,
-                        project.NewVersion ?? project.OldVersion ?? string.Empty,
-                        repoName,
-                        dateToken,
-                        utcDateToken,
-                        dateTimeToken,
-                        utcDateTimeToken,
-                        timestampToken,
-                        utcTimestampToken);
-                }
-                tag = ApplyTagConflictPolicy(tag, conflictPolicy, utcTimestampToken);
-
-                var releaseName = string.IsNullOrWhiteSpace(config.GitHubReleaseName)
-                    ? tag
-                    : ApplyTemplate(
-                        config.GitHubReleaseName!,
-                        project.ProjectName,
-                        project.NewVersion ?? project.OldVersion ?? string.Empty,
-                        config.GitHubPrimaryProject ?? project.ProjectName,
-                        project.NewVersion ?? project.OldVersion ?? string.Empty,
-                        repoName,
-                        dateToken,
-                        utcDateToken,
-                        dateTimeToken,
-                        utcDateTimeToken,
-                        timestampToken,
-                        utcTimestampToken);
-
-                bool ok;
-                string? releaseUrl;
-                string? errorMessage;
-
-                try
-                {
-                    var gr = ExecuteGitHubReleasePublish(
-                        logger,
-                        config.GitHubUsername!,
-                        config.GitHubRepositoryName!,
-                        resolvedGitHubToken,
-                        tag,
-                        releaseName,
-                        new[] { project.ReleaseZipPath! },
-                        config.GitHubIsPreRelease,
-                        config.GitHubGenerateReleaseNotes,
-                        reuseExistingReleaseOnConflict);
-                    ok = gr.Succeeded;
-                    releaseUrl = gr.HtmlUrl;
-                    errorMessage = null;
-                    WriteGitHubPublishNotes(logger, tag, gr);
-                }
-                catch (Exception ex)
-                {
-                    ok = false;
-                    releaseUrl = null;
-                    errorMessage = ex.Message;
-                }
-
-                r.Success = ok;
-                r.TagName = tag;
-                r.ReleaseUrl = releaseUrl;
-                r.ErrorMessage = errorMessage;
-                result.GitHub.Add(r);
-
-                if (!ok)
-                {
-                    result.Success = false;
-                    result.ErrorMessage = errorMessage ?? "GitHub publish failed.";
-                    if (spec.PublishFailFast)
-                        break;
-                }
-            }
-        }
-        else
-        {
-            var assets = new List<string>();
-            foreach (var project in release.Projects)
-            {
-                if (!project.IsPackable) continue;
-                var zip = project.ReleaseZipPath;
-                if (string.IsNullOrWhiteSpace(zip))
-                    continue;
-                if (File.Exists(zip))
-                    assets.Add(zip!);
-            }
-
-            var distinctAssets = assets.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
-            if (distinctAssets.Length == 0)
-            {
-                result.Success = false;
-                result.ErrorMessage = "No release zips available for GitHub release.";
-                WriteObject(result);
-                return;
-            }
-
-            var baseVersion = ResolveGitHubBaseVersion(config, release);
-            var tagVersionToken = string.IsNullOrWhiteSpace(baseVersion) ? dateToken : baseVersion!;
-
-            var tag = !string.IsNullOrWhiteSpace(config.GitHubTagName)
-                ? config.GitHubTagName!
-                : (!string.IsNullOrWhiteSpace(config.GitHubTagTemplate)
-                    ? ApplyTemplate(
-                        config.GitHubTagTemplate!,
-                        repoName,
-                        tagVersionToken,
-                        config.GitHubPrimaryProject ?? repoName,
-                        tagVersionToken,
-                        repoName,
-                        dateToken,
-                        utcDateToken,
-                        dateTimeToken,
-                        utcDateTimeToken,
-                        timestampToken,
-                        utcTimestampToken)
-                    : $"v{tagVersionToken}");
-            tag = ApplyTagConflictPolicy(tag, conflictPolicy, utcTimestampToken);
-
-            var releaseName = string.IsNullOrWhiteSpace(config.GitHubReleaseName)
-                ? tag
-                : ApplyTemplate(
-                    config.GitHubReleaseName!,
-                    repoName,
-                    tagVersionToken,
-                    config.GitHubPrimaryProject ?? repoName,
-                    tagVersionToken,
-                    repoName,
-                    dateToken,
-                    utcDateToken,
-                    dateTimeToken,
-                    utcDateTimeToken,
-                    timestampToken,
-                    utcTimestampToken);
-
-            bool ok;
-            string? releaseUrl;
-            string? errorMessage;
-
-            try
-            {
-                var gr = ExecuteGitHubReleasePublish(
-                    logger,
-                    config.GitHubUsername!,
-                    config.GitHubRepositoryName!,
-                    resolvedGitHubToken,
-                    tag,
-                    releaseName,
-                    distinctAssets,
-                    config.GitHubIsPreRelease,
-                    config.GitHubGenerateReleaseNotes,
-                    reuseExistingReleaseOnConflict);
-                ok = gr.Succeeded;
-                releaseUrl = gr.HtmlUrl;
-                errorMessage = null;
-                WriteGitHubPublishNotes(logger, tag, gr);
-            }
-            catch (Exception ex)
-            {
-                ok = false;
-                releaseUrl = null;
-                errorMessage = ex.Message;
-            }
-
-            foreach (var project in release.Projects.Where(p => p.IsPackable))
-            {
-                result.GitHub.Add(new ProjectBuildGitHubResult
-                {
-                    ProjectName = project.ProjectName,
-                    Success = ok,
-                    TagName = tag,
-                    ReleaseUrl = releaseUrl,
-                    ErrorMessage = ok ? null : errorMessage
-                });
-            }
-
-            result.Success = ok;
-            result.ErrorMessage = ok ? null : (errorMessage ?? "GitHub publish failed.");
-            if (interactive)
-                WriteGitHubSummary(perProject, tag, releaseUrl, distinctAssets.Length, result.GitHub);
-        }
+        result.GitHub.AddRange(publishSummary.Results);
+        result.Success = publishSummary.Success;
+        result.ErrorMessage = publishSummary.ErrorMessage;
+        if (interactive && !publishSummary.PerProject)
+            WriteGitHubSummary(false, publishSummary.SummaryTag, publishSummary.SummaryReleaseUrl, publishSummary.SummaryAssetsCount, result.GitHub);
 
         if (result.ErrorMessage is null)
             result.Success = result.GitHub.Count == 0 || result.GitHub.TrueForAll(g => g.Success);
 
         WriteObject(result);
     }
-}
-
-/// <summary>Aggregate result for project builds.</summary>
-public sealed class ProjectBuildResult
-{
-    /// <summary>True when the pipeline completed successfully.</summary>
-    public bool Success { get; set; }
-    /// <summary>Error message when <see cref="Success"/> is false.</summary>
-    public string? ErrorMessage { get; set; }
-    /// <summary>Release pipeline result.</summary>
-    public DotNetRepositoryReleaseResult? Release { get; set; }
-    /// <summary>GitHub publishing results.</summary>
-    public List<ProjectBuildGitHubResult> GitHub { get; } = new();
-}
-
-/// <summary>GitHub publish result per project.</summary>
-public sealed class ProjectBuildGitHubResult
-{
-    /// <summary>Project name.</summary>
-    public string ProjectName { get; set; } = string.Empty;
-    /// <summary>True when publishing succeeded.</summary>
-    public bool Success { get; set; }
-    /// <summary>Computed tag name.</summary>
-    public string? TagName { get; set; }
-    /// <summary>Release URL when publishing succeeded.</summary>
-    public string? ReleaseUrl { get; set; }
-    /// <summary>Error message when publishing failed.</summary>
-    public string? ErrorMessage { get; set; }
 }

--- a/PowerForge.Tests/ProjectBuildGitHubPreflightTests.cs
+++ b/PowerForge.Tests/ProjectBuildGitHubPreflightTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using PowerForge;
-using PSPublishModule;
-
 namespace PowerForge.Tests;
 
 public sealed class ProjectBuildGitHubPreflightTests
@@ -11,7 +9,7 @@ public sealed class ProjectBuildGitHubPreflightTests
     public void BuildGitHubSingleReleaseReuseAdvisory_ReturnsMessage_WhenMixedVersionsWouldReuseDifferentAssets()
     {
         var projects = CreateProjects();
-        var advisory = InvokeProjectBuildCommand.BuildGitHubSingleReleaseReuseAdvisory(
+        var advisory = ProjectBuildGitHubPublisher.BuildSingleReleaseReuseAdvisory(
             tag: "DbaClientX-v0.2.0",
             projects: projects,
             plannedAssetNames: new[]
@@ -53,7 +51,7 @@ public sealed class ProjectBuildGitHubPreflightTests
             "DbaClientX.SqlServer.0.1.0.zip"
         };
 
-        var advisory = InvokeProjectBuildCommand.BuildGitHubSingleReleaseReuseAdvisory(
+        var advisory = ProjectBuildGitHubPublisher.BuildSingleReleaseReuseAdvisory(
             tag: "DbaClientX-v0.2.0",
             projects: CreateProjects(),
             plannedAssetNames: plannedAssets,

--- a/PowerForge.Tests/ProjectBuildGitHubPublisherTests.cs
+++ b/PowerForge.Tests/ProjectBuildGitHubPublisherTests.cs
@@ -1,0 +1,90 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class ProjectBuildGitHubPublisherTests
+{
+    [Fact]
+    public void Publish_per_project_builds_project_tags_and_collects_results()
+    {
+        var requests = new List<GitHubReleasePublishRequest>();
+        var publisher = new ProjectBuildGitHubPublisher(
+            new NullLogger(),
+            request =>
+            {
+                requests.Add(request);
+                return new GitHubReleasePublishResult
+                {
+                    Succeeded = true,
+                    HtmlUrl = $"https://example.test/{request.TagName}"
+                };
+            },
+            localNow: () => new DateTime(2026, 3, 11, 12, 0, 0, DateTimeKind.Local),
+            utcNow: () => new DateTime(2026, 3, 11, 11, 0, 0, DateTimeKind.Utc));
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-gh-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var assetA = Path.Combine(root.FullName, "ProjectA.1.2.3.zip");
+            var assetB = Path.Combine(root.FullName, "ProjectB.2.0.0.zip");
+            File.WriteAllText(assetA, "a");
+            File.WriteAllText(assetB, "b");
+
+            var summary = publisher.Publish(new ProjectBuildGitHubPublishRequest
+            {
+                Owner = "EvotecIT",
+                Repository = "PSPublishModule",
+                Token = "token",
+                ReleaseMode = "PerProject",
+                TagTemplate = "{Project}-v{Version}",
+                ReleaseName = "{Project} {Version}",
+                Release = new DotNetRepositoryReleaseResult
+                {
+                    Success = true,
+                    Projects =
+                    {
+                        new DotNetRepositoryProjectResult
+                        {
+                            ProjectName = "ProjectA",
+                            IsPackable = true,
+                            NewVersion = "1.2.3",
+                            ReleaseZipPath = assetA
+                        },
+                        new DotNetRepositoryProjectResult
+                        {
+                            ProjectName = "ProjectB",
+                            IsPackable = true,
+                            NewVersion = "2.0.0",
+                            ReleaseZipPath = assetB
+                        }
+                    }
+                }
+            });
+
+            Assert.True(summary.Success);
+            Assert.True(summary.PerProject);
+            Assert.Equal(2, summary.Results.Count);
+            Assert.Collection(
+                requests.OrderBy(request => request.TagName, StringComparer.OrdinalIgnoreCase),
+                first =>
+                {
+                    Assert.Equal("ProjectA-v1.2.3", first.TagName);
+                    Assert.Equal("ProjectA 1.2.3", first.ReleaseName);
+                    Assert.Single(first.AssetFilePaths!);
+                    Assert.Equal(assetA, first.AssetFilePaths![0]);
+                },
+                second =>
+                {
+                    Assert.Equal("ProjectB-v2.0.0", second.TagName);
+                    Assert.Equal("ProjectB 2.0.0", second.ReleaseName);
+                    Assert.Single(second.AssetFilePaths!);
+                    Assert.Equal(assetB, second.AssetFilePaths![0]);
+                });
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+}

--- a/PowerForge/Models/ProjectBuildGitHubPublishRequest.cs
+++ b/PowerForge/Models/ProjectBuildGitHubPublishRequest.cs
@@ -1,0 +1,49 @@
+namespace PowerForge;
+
+/// <summary>
+/// Input used by <see cref="ProjectBuildGitHubPublisher"/> for GitHub release publishing.
+/// </summary>
+public sealed class ProjectBuildGitHubPublishRequest
+{
+    /// <summary>Repository owner.</summary>
+    public string Owner { get; set; } = string.Empty;
+
+    /// <summary>Repository name.</summary>
+    public string Repository { get; set; } = string.Empty;
+
+    /// <summary>GitHub access token.</summary>
+    public string Token { get; set; } = string.Empty;
+
+    /// <summary>Release workflow result to publish.</summary>
+    public DotNetRepositoryReleaseResult Release { get; set; } = new();
+
+    /// <summary>Release mode (Single or PerProject).</summary>
+    public string ReleaseMode { get; set; } = "Single";
+
+    /// <summary>Whether to include the project name in the default tag.</summary>
+    public bool IncludeProjectNameInTag { get; set; } = true;
+
+    /// <summary>Whether the published GitHub release is a prerelease.</summary>
+    public bool IsPreRelease { get; set; }
+
+    /// <summary>Whether GitHub should auto-generate release notes.</summary>
+    public bool GenerateReleaseNotes { get; set; }
+
+    /// <summary>Whether publishing failures should stop on first error.</summary>
+    public bool PublishFailFast { get; set; } = true;
+
+    /// <summary>Explicit release name override or template.</summary>
+    public string? ReleaseName { get; set; }
+
+    /// <summary>Explicit tag name override.</summary>
+    public string? TagName { get; set; }
+
+    /// <summary>Tag template used when computing tag names.</summary>
+    public string? TagTemplate { get; set; }
+
+    /// <summary>Primary project used for single-release version resolution.</summary>
+    public string? PrimaryProject { get; set; }
+
+    /// <summary>Conflict policy when a tag already exists.</summary>
+    public string? TagConflictPolicy { get; set; }
+}

--- a/PowerForge/Models/ProjectBuildGitHubPublishSummary.cs
+++ b/PowerForge/Models/ProjectBuildGitHubPublishSummary.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace PowerForge;
+
+/// <summary>
+/// Summary returned by <see cref="ProjectBuildGitHubPublisher"/>.
+/// </summary>
+public sealed class ProjectBuildGitHubPublishSummary
+{
+    /// <summary>Whether the publish workflow succeeded.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Top-level error message when the workflow failed.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>Whether publishing ran in per-project mode.</summary>
+    public bool PerProject { get; set; }
+
+    /// <summary>Tag name used for single-release mode.</summary>
+    public string? SummaryTag { get; set; }
+
+    /// <summary>Release URL used for single-release mode.</summary>
+    public string? SummaryReleaseUrl { get; set; }
+
+    /// <summary>Number of assets published in single-release mode.</summary>
+    public int SummaryAssetsCount { get; set; }
+
+    /// <summary>Per-project publish results.</summary>
+    public List<ProjectBuildGitHubResult> Results { get; } = new();
+}

--- a/PowerForge/Models/ProjectBuildGitHubResult.cs
+++ b/PowerForge/Models/ProjectBuildGitHubResult.cs
@@ -1,0 +1,22 @@
+namespace PowerForge;
+
+/// <summary>
+/// GitHub publish result per project.
+/// </summary>
+public sealed class ProjectBuildGitHubResult
+{
+    /// <summary>Project name.</summary>
+    public string ProjectName { get; set; } = string.Empty;
+
+    /// <summary>True when publishing succeeded.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Computed tag name.</summary>
+    public string? TagName { get; set; }
+
+    /// <summary>Release URL when publishing succeeded.</summary>
+    public string? ReleaseUrl { get; set; }
+
+    /// <summary>Error message when publishing failed.</summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/PowerForge/Models/ProjectBuildResult.cs
+++ b/PowerForge/Models/ProjectBuildResult.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace PowerForge;
+
+/// <summary>
+/// Aggregate result for project builds.
+/// </summary>
+public sealed class ProjectBuildResult
+{
+    /// <summary>True when the pipeline completed successfully.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Error message when <see cref="Success"/> is false.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>Release pipeline result.</summary>
+    public DotNetRepositoryReleaseResult? Release { get; set; }
+
+    /// <summary>GitHub publishing results.</summary>
+    public List<ProjectBuildGitHubResult> GitHub { get; } = new();
+}

--- a/PowerForge/Services/ProjectBuildGitHubPublisher.cs
+++ b/PowerForge/Services/ProjectBuildGitHubPublisher.cs
@@ -1,0 +1,578 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+/// <summary>
+/// Publishes repository release artefacts to GitHub releases.
+/// </summary>
+public sealed class ProjectBuildGitHubPublisher
+{
+    private readonly ILogger _logger;
+    private readonly Func<GitHubReleasePublishRequest, GitHubReleasePublishResult> _publishRelease;
+    private readonly Func<DateTime> _localNow;
+    private readonly Func<DateTime> _utcNow;
+
+    /// <summary>
+    /// Creates a new GitHub publisher workflow service.
+    /// </summary>
+    public ProjectBuildGitHubPublisher(
+        ILogger logger,
+        Func<GitHubReleasePublishRequest, GitHubReleasePublishResult>? publishRelease = null,
+        Func<DateTime>? localNow = null,
+        Func<DateTime>? utcNow = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _publishRelease = publishRelease ?? (request => new GitHubReleasePublisher(_logger).PublishRelease(request));
+        _localNow = localNow ?? (() => DateTime.Now);
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Builds a preflight advisory when GitHub single-release reuse would publish a mixed-version asset set into an existing tag.
+    /// </summary>
+    public static string? BuildSingleReleaseReuseAdvisory(
+        string tag,
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        IReadOnlyCollection<string> plannedAssetNames,
+        IReadOnlyCollection<string> existingAssetNames)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+            return null;
+
+        var packable = projects
+            .Where(p => p.IsPackable && !string.IsNullOrWhiteSpace(p.NewVersion))
+            .ToArray();
+        var distinctVersions = packable
+            .Select(p => p.NewVersion!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (distinctVersions.Length <= 1)
+            return null;
+
+        var planned = new HashSet<string>(
+            plannedAssetNames.Where(name => !string.IsNullOrWhiteSpace(name)),
+            StringComparer.OrdinalIgnoreCase);
+        var existing = new HashSet<string>(
+            existingAssetNames.Where(name => !string.IsNullOrWhiteSpace(name)),
+            StringComparer.OrdinalIgnoreCase);
+
+        if (planned.Count == 0 || planned.SetEquals(existing))
+            return null;
+
+        var versionSummary = string.Join(", ",
+            packable
+                .OrderBy(p => p.ProjectName, StringComparer.OrdinalIgnoreCase)
+                .Select(p => $"{p.ProjectName}={p.NewVersion}"));
+        var missingAssets = planned
+            .Except(existing, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var extraAssets = existing
+            .Except(planned, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var details = new List<string>
+        {
+            $"GitHub preflight blocked publish: tag '{tag}' already exists and Single release mode would reuse it for a mixed-version package set ({versionSummary})."
+        };
+
+        if (missingAssets.Length > 0)
+            details.Add($"Planned assets missing from the existing release: {string.Join(", ", missingAssets)}.");
+        if (extraAssets.Length > 0)
+            details.Add($"Existing release contains different assets: {string.Join(", ", extraAssets)}.");
+
+        details.Add("Change one of: set GitHubReleaseMode to 'PerProject'; set GitHubTagConflictPolicy to 'Fail' or 'AppendUtcTimestamp'; or use a unique GitHubTagTemplate such as '{Repo}-v{UtcTimestamp}'. Keep GitHubPrimaryProject explicit when Single mode is intentional.");
+        return string.Join(" ", details);
+    }
+
+    /// <summary>
+    /// Publishes release artefacts to GitHub and returns a summarized result.
+    /// </summary>
+    public ProjectBuildGitHubPublishSummary Publish(ProjectBuildGitHubPublishRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        if (request.Release is null)
+            throw new ArgumentException("Release is required.", nameof(request));
+
+        var summary = new ProjectBuildGitHubPublishSummary();
+        if (string.IsNullOrWhiteSpace(request.Token))
+        {
+            summary.Success = false;
+            summary.ErrorMessage = "GitHub access token is required for GitHub publishing.";
+            return summary;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Owner) || string.IsNullOrWhiteSpace(request.Repository))
+        {
+            summary.Success = false;
+            summary.ErrorMessage = "GitHub owner and repository are required for GitHub publishing.";
+            return summary;
+        }
+
+        var releaseMode = string.IsNullOrWhiteSpace(request.ReleaseMode) ? "Single" : request.ReleaseMode.Trim();
+        var perProject = string.Equals(releaseMode, "PerProject", StringComparison.OrdinalIgnoreCase);
+        summary.PerProject = perProject;
+
+        var conflictPolicy = ParseTagConflictPolicy(request.TagConflictPolicy);
+        var reuseExistingReleaseOnConflict = string.Equals(conflictPolicy, "Reuse", StringComparison.OrdinalIgnoreCase);
+
+        var nowLocal = _localNow();
+        var nowUtc = _utcNow();
+        var dateToken = nowLocal.ToString("yyyy.MM.dd");
+        var utcDateToken = nowUtc.ToString("yyyy.MM.dd");
+        var dateTimeToken = nowLocal.ToString("yyyy.MM.dd-HH.mm.ss");
+        var utcDateTimeToken = nowUtc.ToString("yyyy.MM.dd-HH.mm.ss");
+        var timestampToken = nowLocal.ToString("yyyyMMddHHmmss");
+        var utcTimestampToken = nowUtc.ToString("yyyyMMddHHmmss");
+        var repoName = request.Repository.Trim();
+
+        if (perProject)
+        {
+            PublishPerProject(
+                summary,
+                request,
+                repoName,
+                conflictPolicy,
+                reuseExistingReleaseOnConflict,
+                dateToken,
+                utcDateToken,
+                dateTimeToken,
+                utcDateTimeToken,
+                timestampToken,
+                utcTimestampToken);
+        }
+        else
+        {
+            PublishSingleRelease(
+                summary,
+                request,
+                repoName,
+                conflictPolicy,
+                reuseExistingReleaseOnConflict,
+                dateToken,
+                utcDateToken,
+                dateTimeToken,
+                utcDateTimeToken,
+                timestampToken,
+                utcTimestampToken);
+        }
+
+        if (summary.ErrorMessage is null)
+            summary.Success = summary.Results.Count == 0 || summary.Results.TrueForAll(result => result.Success);
+
+        return summary;
+    }
+
+    private void PublishPerProject(
+        ProjectBuildGitHubPublishSummary summary,
+        ProjectBuildGitHubPublishRequest request,
+        string repoName,
+        string conflictPolicy,
+        bool reuseExistingReleaseOnConflict,
+        string dateToken,
+        string utcDateToken,
+        string dateTimeToken,
+        string utcDateTimeToken,
+        string timestampToken,
+        string utcTimestampToken)
+    {
+        foreach (var project in request.Release.Projects)
+        {
+            if (!project.IsPackable)
+                continue;
+
+            var result = new ProjectBuildGitHubResult { ProjectName = project.ProjectName };
+            var error = ValidateProjectPublishInput(project);
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                result.Success = false;
+                result.ErrorMessage = error;
+                summary.Results.Add(result);
+                if (request.PublishFailFast)
+                {
+                    summary.Success = false;
+                    summary.ErrorMessage = error;
+                    break;
+                }
+
+                continue;
+            }
+
+            var projectVersion = project.NewVersion ?? project.OldVersion ?? string.Empty;
+            var tag = BuildProjectTag(
+                request,
+                repoName,
+                project.ProjectName,
+                projectVersion,
+                conflictPolicy,
+                dateToken,
+                utcDateToken,
+                dateTimeToken,
+                utcDateTimeToken,
+                timestampToken,
+                utcTimestampToken);
+
+            var releaseName = BuildReleaseName(
+                request.ReleaseName,
+                repoName,
+                project.ProjectName,
+                projectVersion,
+                request.PrimaryProject ?? project.ProjectName,
+                projectVersion,
+                tag,
+                dateToken,
+                utcDateToken,
+                dateTimeToken,
+                utcDateTimeToken,
+                timestampToken,
+                utcTimestampToken);
+
+            TryPublishRelease(
+                request,
+                tag,
+                releaseName,
+                new[] { project.ReleaseZipPath! },
+                reuseExistingReleaseOnConflict,
+                result);
+
+            summary.Results.Add(result);
+            if (!result.Success)
+            {
+                summary.Success = false;
+                summary.ErrorMessage = result.ErrorMessage ?? "GitHub publish failed.";
+                if (request.PublishFailFast)
+                    break;
+            }
+        }
+    }
+
+    private void PublishSingleRelease(
+        ProjectBuildGitHubPublishSummary summary,
+        ProjectBuildGitHubPublishRequest request,
+        string repoName,
+        string conflictPolicy,
+        bool reuseExistingReleaseOnConflict,
+        string dateToken,
+        string utcDateToken,
+        string dateTimeToken,
+        string utcDateTimeToken,
+        string timestampToken,
+        string utcTimestampToken)
+    {
+        var assets = request.Release.Projects
+            .Where(project => project.IsPackable && !string.IsNullOrWhiteSpace(project.ReleaseZipPath) && File.Exists(project.ReleaseZipPath))
+            .Select(project => project.ReleaseZipPath!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (assets.Length == 0)
+        {
+            summary.Success = false;
+            summary.ErrorMessage = "No release zips available for GitHub release.";
+            return;
+        }
+
+        var baseVersion = ResolveGitHubBaseVersion(request.PrimaryProject, request.Release);
+        var versionToken = string.IsNullOrWhiteSpace(baseVersion) ? dateToken : baseVersion!;
+        var tag = BuildSingleReleaseTag(
+            request,
+            repoName,
+            versionToken,
+            conflictPolicy,
+            dateToken,
+            utcDateToken,
+            dateTimeToken,
+            utcDateTimeToken,
+            timestampToken,
+            utcTimestampToken);
+        var releaseName = BuildReleaseName(
+            request.ReleaseName,
+            repoName,
+            repoName,
+            versionToken,
+            request.PrimaryProject ?? repoName,
+            versionToken,
+            tag,
+            dateToken,
+            utcDateToken,
+            dateTimeToken,
+            utcDateTimeToken,
+            timestampToken,
+            utcTimestampToken);
+
+        var publishResult = new ProjectBuildGitHubResult();
+        TryPublishRelease(
+            request,
+            tag,
+            releaseName,
+            assets,
+            reuseExistingReleaseOnConflict,
+            publishResult);
+
+        foreach (var project in request.Release.Projects.Where(project => project.IsPackable))
+        {
+            summary.Results.Add(new ProjectBuildGitHubResult
+            {
+                ProjectName = project.ProjectName,
+                Success = publishResult.Success,
+                TagName = publishResult.TagName,
+                ReleaseUrl = publishResult.ReleaseUrl,
+                ErrorMessage = publishResult.ErrorMessage
+            });
+        }
+
+        summary.Success = publishResult.Success;
+        summary.ErrorMessage = publishResult.ErrorMessage;
+        summary.SummaryTag = tag;
+        summary.SummaryReleaseUrl = publishResult.ReleaseUrl;
+        summary.SummaryAssetsCount = assets.Length;
+    }
+
+    private void TryPublishRelease(
+        ProjectBuildGitHubPublishRequest request,
+        string tag,
+        string releaseName,
+        IReadOnlyList<string> assets,
+        bool reuseExistingReleaseOnConflict,
+        ProjectBuildGitHubResult result)
+    {
+        try
+        {
+            var publishResult = _publishRelease(new GitHubReleasePublishRequest
+            {
+                Owner = request.Owner,
+                Repository = request.Repository,
+                Token = request.Token,
+                TagName = tag,
+                ReleaseName = releaseName,
+                GenerateReleaseNotes = request.GenerateReleaseNotes,
+                IsPreRelease = request.IsPreRelease,
+                ReuseExistingReleaseOnConflict = reuseExistingReleaseOnConflict,
+                AssetFilePaths = assets
+            });
+
+            result.Success = publishResult.Succeeded;
+            result.TagName = tag;
+            result.ReleaseUrl = publishResult.HtmlUrl;
+            result.ErrorMessage = null;
+            WriteGitHubPublishNotes(tag, publishResult);
+        }
+        catch (Exception ex)
+        {
+            result.Success = false;
+            result.TagName = tag;
+            result.ReleaseUrl = null;
+            result.ErrorMessage = ex.Message;
+        }
+    }
+
+    private void WriteGitHubPublishNotes(string? tag, GitHubReleasePublishResult result)
+    {
+        if (result.ReusedExistingRelease && !string.IsNullOrWhiteSpace(tag))
+            _logger.Info($"GitHub release for tag '{tag}' already exists; reusing existing release.");
+
+        foreach (var asset in result.SkippedExistingAssets
+                     .Where(name => !string.IsNullOrWhiteSpace(name))
+                     .Distinct(StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(name => name, StringComparer.OrdinalIgnoreCase))
+        {
+            _logger.Info($"GitHub release asset '{asset}' already exists; skipping upload.");
+        }
+    }
+
+    private static string? ValidateProjectPublishInput(DotNetRepositoryProjectResult project)
+    {
+        if (string.IsNullOrWhiteSpace(project.NewVersion))
+            return "Missing project version for GitHub release.";
+
+        if (string.IsNullOrWhiteSpace(project.ReleaseZipPath))
+            return "No release zip available for GitHub release.";
+
+        return File.Exists(project.ReleaseZipPath)
+            ? null
+            : $"Release zip not found: {project.ReleaseZipPath}";
+    }
+
+    private static string BuildProjectTag(
+        ProjectBuildGitHubPublishRequest request,
+        string repoName,
+        string projectName,
+        string version,
+        string conflictPolicy,
+        string dateToken,
+        string utcDateToken,
+        string dateTimeToken,
+        string utcDateTimeToken,
+        string timestampToken,
+        string utcTimestampToken)
+    {
+        var tag = string.IsNullOrWhiteSpace(request.TagName)
+            ? (request.IncludeProjectNameInTag ? $"{projectName}-v{version}" : $"v{version}")
+            : request.TagName!;
+
+        if (!string.IsNullOrWhiteSpace(request.TagTemplate))
+        {
+            tag = ApplyTemplate(
+                request.TagTemplate!,
+                projectName,
+                version,
+                request.PrimaryProject ?? projectName,
+                version,
+                repoName,
+                dateToken,
+                utcDateToken,
+                dateTimeToken,
+                utcDateTimeToken,
+                timestampToken,
+                utcTimestampToken);
+        }
+
+        return ApplyTagConflictPolicy(tag, conflictPolicy, utcTimestampToken);
+    }
+
+    private static string BuildSingleReleaseTag(
+        ProjectBuildGitHubPublishRequest request,
+        string repoName,
+        string versionToken,
+        string conflictPolicy,
+        string dateToken,
+        string utcDateToken,
+        string dateTimeToken,
+        string utcDateTimeToken,
+        string timestampToken,
+        string utcTimestampToken)
+    {
+        var tag = !string.IsNullOrWhiteSpace(request.TagName)
+            ? request.TagName!
+            : (!string.IsNullOrWhiteSpace(request.TagTemplate)
+                ? ApplyTemplate(
+                    request.TagTemplate!,
+                    repoName,
+                    versionToken,
+                    request.PrimaryProject ?? repoName,
+                    versionToken,
+                    repoName,
+                    dateToken,
+                    utcDateToken,
+                    dateTimeToken,
+                    utcDateTimeToken,
+                    timestampToken,
+                    utcTimestampToken)
+                : $"v{versionToken}");
+
+        return ApplyTagConflictPolicy(tag, conflictPolicy, utcTimestampToken);
+    }
+
+    private static string BuildReleaseName(
+        string? template,
+        string repoName,
+        string projectName,
+        string version,
+        string primaryProject,
+        string primaryVersion,
+        string fallbackTag,
+        string dateToken,
+        string utcDateToken,
+        string dateTimeToken,
+        string utcDateTimeToken,
+        string timestampToken,
+        string utcTimestampToken)
+    {
+        return string.IsNullOrWhiteSpace(template)
+            ? fallbackTag
+            : ApplyTemplate(
+                template!,
+                projectName,
+                version,
+                primaryProject,
+                primaryVersion,
+                repoName,
+                dateToken,
+                utcDateToken,
+                dateTimeToken,
+                utcDateTimeToken,
+                timestampToken,
+                utcTimestampToken);
+    }
+
+    private static string? ResolveGitHubBaseVersion(string? primaryProject, DotNetRepositoryReleaseResult release)
+    {
+        if (!string.IsNullOrWhiteSpace(primaryProject))
+        {
+            var match = release.Projects.FirstOrDefault(project =>
+                string.Equals(project.ProjectName, primaryProject, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+                return match.NewVersion ?? match.OldVersion;
+        }
+
+        var versions = release.Projects
+            .Where(project => project.IsPackable && !string.IsNullOrWhiteSpace(project.NewVersion))
+            .Select(project => project.NewVersion!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return versions.Length == 1 ? versions[0] : null;
+    }
+
+    private static string ParseTagConflictPolicy(string? value)
+    {
+        var text = value?.Trim();
+        if (string.IsNullOrWhiteSpace(text))
+            return "Reuse";
+
+        var resolvedText = text;
+        return resolvedText!.Equals("AppendUtcTimestamp", StringComparison.OrdinalIgnoreCase)
+            ? "AppendUtcTimestamp"
+            : resolvedText.Equals("Fail", StringComparison.OrdinalIgnoreCase)
+                ? "Fail"
+                : "Reuse";
+    }
+
+    private static string ApplyTagConflictPolicy(string tag, string policy, string utcTimestampToken)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+            return tag;
+
+        return string.Equals(policy, "AppendUtcTimestamp", StringComparison.OrdinalIgnoreCase)
+            ? $"{tag}-{utcTimestampToken}"
+            : tag;
+    }
+
+    private static string ApplyTemplate(
+        string template,
+        string project,
+        string version,
+        string primaryProject,
+        string primaryVersion,
+        string repo,
+        string date,
+        string utcDate,
+        string dateTime,
+        string utcDateTime,
+        string timestamp,
+        string utcTimestamp)
+    {
+        if (string.IsNullOrWhiteSpace(template))
+            return template;
+
+        return template
+            .Replace("{Project}", project ?? string.Empty)
+            .Replace("{Version}", version ?? string.Empty)
+            .Replace("{PrimaryProject}", primaryProject ?? string.Empty)
+            .Replace("{PrimaryVersion}", primaryVersion ?? string.Empty)
+            .Replace("{Repo}", repo ?? string.Empty)
+            .Replace("{Repository}", repo ?? string.Empty)
+            .Replace("{Date}", date ?? string.Empty)
+            .Replace("{UtcDate}", utcDate ?? string.Empty)
+            .Replace("{DateTime}", dateTime ?? string.Empty)
+            .Replace("{UtcDateTime}", utcDateTime ?? string.Empty)
+            .Replace("{Timestamp}", timestamp ?? string.Empty)
+            .Replace("{UtcTimestamp}", utcTimestamp ?? string.Empty);
+    }
+}


### PR DESCRIPTION
## Summary
- move `Invoke-ProjectBuild` GitHub publish orchestration into a reusable `ProjectBuildGitHubPublisher` service
- move project-build result models into PowerForge so the cmdlet stops owning those reusable workflow types
- keep cmdlet output/summary behavior while deleting the large in-cmdlet per-project and single-release GitHub loops
- add focused tests for the extracted publisher and update preflight coverage to use the shared advisory helper

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "ProjectBuildGitHubPreflightTests|ProjectBuildGitHubPublisherTests"`
- `pwsh .\Module\Build\Build-Module.ps1 -NoSign`

## Stacked On
- base branch: `codex/thin-cmdlets-consistency-main`
- review after #183