### PR TITLE
refactor: extract project build preparation service

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.Helpers.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.Helpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,6 +11,14 @@ namespace PSPublishModule;
 
 public sealed partial class InvokeProjectBuildCommand
 {
+    private static bool? ResolveRequestedAction(IDictionary? boundParameters, string parameterName)
+    {
+        if (boundParameters?.Contains(parameterName) != true)
+            return null;
+
+        return ProjectBuildSupportService.IsTrue(boundParameters[parameterName]);
+    }
+
     private string ResolveConfigPath(string path)
     {
         if (string.IsNullOrWhiteSpace(path))

--- a/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
@@ -1,12 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Management.Automation;
-using System.Linq;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using PowerForge;
+using System.Management.Automation;
 using Spectre.Console;
 
 namespace PSPublishModule;
@@ -86,38 +82,20 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
         var configFullPath = ResolveConfigPath(ConfigPath);
         var configDir = Path.GetDirectoryName(configFullPath) ?? SessionState.Path.CurrentFileSystemLocation.Path;
         var config = support.LoadConfig(configFullPath);
+        var preparation = new ProjectBuildPreparationService().Prepare(
+            config,
+            configDir,
+            PlanPath,
+            new ProjectBuildRequestedActions
+            {
+                PlanOnly = ResolveRequestedAction(bound, nameof(Plan)),
+                UpdateVersions = ResolveRequestedAction(bound, nameof(UpdateVersions)),
+                Build = ResolveRequestedAction(bound, nameof(Build)),
+                PublishNuget = ResolveRequestedAction(bound, nameof(PublishNuget)),
+                PublishGitHub = ResolveRequestedAction(bound, nameof(PublishGitHub))
+            });
 
-        object? planValue = null;
-        object? updateValue = null;
-        object? buildValue = null;
-        object? publishNugetValue = null;
-        object? publishGitHubValue = null;
-
-        var planProvided = bound?.TryGetValue(nameof(Plan), out planValue) == true;
-        var updateProvided = bound?.TryGetValue(nameof(UpdateVersions), out updateValue) == true;
-        var buildProvided = bound?.TryGetValue(nameof(Build), out buildValue) == true;
-        var publishNugetProvided = bound?.TryGetValue(nameof(PublishNuget), out publishNugetValue) == true;
-        var publishGitHubProvided = bound?.TryGetValue(nameof(PublishGitHub), out publishGitHubValue) == true;
-
-        bool planOnly = planProvided ? ProjectBuildSupportService.IsTrue(planValue) : (config.PlanOnly ?? false);
-        bool updateVersions = updateProvided ? ProjectBuildSupportService.IsTrue(updateValue) : (config.UpdateVersions ?? false);
-        bool build = buildProvided ? ProjectBuildSupportService.IsTrue(buildValue) : (config.Build ?? false);
-        bool publishNuget = publishNugetProvided ? ProjectBuildSupportService.IsTrue(publishNugetValue) : (config.PublishNuget ?? false);
-        bool publishGitHub = publishGitHubProvided ? ProjectBuildSupportService.IsTrue(publishGitHubValue) : (config.PublishGitHub ?? false);
-
-        var anyConfigSpecified = config.UpdateVersions is not null || config.Build is not null ||
-                                 config.PublishNuget is not null || config.PublishGitHub is not null;
-        var anyProvided = updateProvided || buildProvided || publishNugetProvided || publishGitHubProvided;
-
-        if (!anyConfigSpecified && !anyProvided)
-        {
-            updateVersions = true;
-            build = true;
-            publishNuget = true;
-            publishGitHub = true;
-        }
-
-        if (!updateVersions && !build && !publishNuget && !publishGitHub)
+        if (!preparation.HasWork)
         {
             WriteObject(new ProjectBuildResult
             {
@@ -127,70 +105,17 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
             return;
         }
 
-        var rootPath = ProjectBuildSupportService.ResolveOptionalPath(config.RootPath, configDir) ?? configDir;
-        var stagingPath = ProjectBuildSupportService.ResolveOptionalPath(config.StagingPath, rootPath);
-        var outputPath = ProjectBuildSupportService.ResolveOptionalPath(config.OutputPath, rootPath);
-        var releaseZipOutputPath = ProjectBuildSupportService.ResolveOptionalPath(config.ReleaseZipOutputPath, rootPath);
-        var planOutputPath = ProjectBuildSupportService.ResolveOptionalPath(PlanPath ?? config.PlanOutputPath, configDir);
-
-        if (string.IsNullOrWhiteSpace(outputPath) && !string.IsNullOrWhiteSpace(stagingPath))
-            outputPath = Path.Combine(stagingPath, "packages");
-        if (string.IsNullOrWhiteSpace(releaseZipOutputPath) && !string.IsNullOrWhiteSpace(stagingPath))
-            releaseZipOutputPath = Path.Combine(stagingPath, "releases");
-
-        var nugetCredentialSecret = ProjectBuildSupportService.ResolveSecret(config.NugetCredentialSecret, config.NugetCredentialSecretFilePath, config.NugetCredentialSecretEnvName, configDir);
-        var nugetUser = string.IsNullOrWhiteSpace(config.NugetCredentialUserName) ? null : config.NugetCredentialUserName!.Trim();
-        var nugetCredential = (!string.IsNullOrWhiteSpace(nugetUser) || !string.IsNullOrWhiteSpace(nugetCredentialSecret))
-            ? new RepositoryCredential
-            {
-                UserName = nugetUser,
-                Secret = nugetCredentialSecret
-            }
-            : null;
-
-        var publishApiKey = ProjectBuildSupportService.ResolveSecret(config.PublishApiKey, config.PublishApiKeyFilePath, config.PublishApiKeyEnvName, configDir);
-
-        var store = ProjectBuildSupportService.ParseCertificateStore(config.CertificateStore);
-        var createReleaseZip = config.CreateReleaseZip ?? true;
-        var spec = new DotNetRepositoryReleaseSpec
-        {
-            RootPath = rootPath,
-            ExpectedVersion = config.ExpectedVersion,
-            ExpectedVersionsByProject = config.ExpectedVersionMap,
-            ExpectedVersionMapAsInclude = config.ExpectedVersionMapAsInclude,
-            ExpectedVersionMapUseWildcards = config.ExpectedVersionMapUseWildcards,
-            IncludeProjects = config.IncludeProjects,
-            ExcludeProjects = config.ExcludeProjects,
-            ExcludeDirectories = config.ExcludeDirectories,
-            VersionSources = config.NugetSource,
-            VersionSourceCredential = nugetCredential,
-            IncludePrerelease = config.IncludePrerelease,
-            Configuration = string.IsNullOrWhiteSpace(config.Configuration) ? "Release" : config.Configuration!,
-            OutputPath = outputPath,
-            ReleaseZipOutputPath = releaseZipOutputPath,
-            CertificateThumbprint = config.CertificateThumbprint,
-            CertificateStore = store,
-            TimeStampServer = config.TimeStampServer,
-            Pack = build || publishNuget || publishGitHub,
-            CreateReleaseZip = createReleaseZip,
-            Publish = publishNuget,
-            PublishSource = config.PublishSource,
-            PublishApiKey = publishApiKey,
-            SkipDuplicate = config.SkipDuplicate ?? true,
-            PublishFailFast = config.PublishFailFast ?? true,
-            UpdateVersions = updateVersions
-        };
-
         var runner = new DotNetRepositoryReleaseService(logger);
+        var spec = preparation.Spec;
         spec.WhatIf = true;
         var plan = runner.Execute(spec);
         var preflightErrors = new List<string>();
         if (!plan.Success)
             preflightErrors.Add(plan.ErrorMessage ?? "Plan/preflight validation failed.");
 
-        if (planOnly || !ShouldProcess(rootPath, "Build project repository"))
+        if (preparation.PlanOnly || !ShouldProcess(preparation.RootPath, "Build project repository"))
         {
-            support.TryWritePlan(plan, planOutputPath);
+            support.TryWritePlan(plan, preparation.PlanOutputPath);
             WriteObject(new ProjectBuildResult
             {
                 Success = preflightErrors.Count == 0,
@@ -200,14 +125,12 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
             return;
         }
 
-        var preflightError = support.ValidatePreflight(publishNuget, publishGitHub, createReleaseZip, publishApiKey, config, configDir);
+        var preflightError = support.ValidatePreflight(preparation.PublishNuget, preparation.PublishGitHub, preparation.CreateReleaseZip, preparation.PublishApiKey, config, configDir);
         if (!string.IsNullOrWhiteSpace(preflightError))
             preflightErrors.Add(preflightError!);
 
-        var gitHubToken = publishGitHub
-            ? ProjectBuildSupportService.ResolveSecret(config.GitHubAccessToken, config.GitHubAccessTokenFilePath, config.GitHubAccessTokenEnvName, configDir)
-            : null;
-        if (publishGitHub && string.IsNullOrWhiteSpace(preflightError))
+        var gitHubToken = preparation.PublishGitHub ? preparation.GitHubToken : null;
+        if (preparation.PublishGitHub && string.IsNullOrWhiteSpace(preflightError))
         {
             var gitHubPreflightError = ValidateGitHubPublishPreflight(config, plan, gitHubToken!, logger);
             if (!string.IsNullOrWhiteSpace(gitHubPreflightError))
@@ -225,11 +148,11 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
             return;
         }
 
-        if (!string.IsNullOrWhiteSpace(stagingPath))
-            support.PrepareStaging(stagingPath!, config.CleanStaging ?? false);
-        ProjectBuildSupportService.EnsureDirectory(outputPath);
-        ProjectBuildSupportService.EnsureDirectory(releaseZipOutputPath);
-        support.TryWritePlan(plan, planOutputPath);
+        if (!string.IsNullOrWhiteSpace(preparation.StagingPath))
+            support.PrepareStaging(preparation.StagingPath!, config.CleanStaging ?? false);
+        ProjectBuildSupportService.EnsureDirectory(preparation.OutputPath);
+        ProjectBuildSupportService.EnsureDirectory(preparation.ReleaseZipOutputPath);
+        support.TryWritePlan(plan, preparation.PlanOutputPath);
 
         spec.WhatIf = false;
         var release = runner.Execute(spec);
@@ -243,14 +166,14 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
             return;
         }
 
-        if (!publishGitHub)
+        if (!preparation.PublishGitHub)
         {
             result.Success = true;
             WriteObject(result);
             return;
         }
 
-        gitHubToken ??= ProjectBuildSupportService.ResolveSecret(config.GitHubAccessToken, config.GitHubAccessTokenFilePath, config.GitHubAccessTokenEnvName, configDir);
+        gitHubToken ??= preparation.GitHubToken;
         if (string.IsNullOrWhiteSpace(gitHubToken))
         {
             result.Success = false;

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -1,0 +1,140 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class ProjectBuildPreparationServiceTests
+{
+    [Fact]
+    public void Prepare_enables_full_run_when_no_actions_are_configured()
+    {
+        var service = new ProjectBuildPreparationService();
+
+        var context = service.Prepare(
+            new ProjectBuildConfiguration(),
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions());
+
+        Assert.True(context.UpdateVersions);
+        Assert.True(context.Build);
+        Assert.True(context.PublishNuget);
+        Assert.True(context.PublishGitHub);
+        Assert.True(context.HasWork);
+        Assert.True(context.Spec.Pack);
+        Assert.True(context.Spec.Publish);
+    }
+
+    [Fact]
+    public void Prepare_honors_explicit_action_overrides_and_derives_default_output_paths()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-prepare-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var service = new ProjectBuildPreparationService();
+            var config = new ProjectBuildConfiguration
+            {
+                RootPath = "repo",
+                StagingPath = "artifacts",
+                PublishNuget = true,
+                PublishGitHub = true
+            };
+
+            var context = service.Prepare(
+                config,
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions
+                {
+                    PublishNuget = false,
+                    PublishGitHub = true
+                });
+
+            Assert.False(context.PublishNuget);
+            Assert.True(context.PublishGitHub);
+            Assert.Equal(Path.Combine(root.FullName, "repo"), context.RootPath);
+            Assert.Equal(Path.Combine(root.FullName, "repo", "artifacts"), context.StagingPath);
+            Assert.Equal(Path.Combine(root.FullName, "repo", "artifacts", "packages"), context.OutputPath);
+            Assert.Equal(Path.Combine(root.FullName, "repo", "artifacts", "releases"), context.ReleaseZipOutputPath);
+            Assert.True(context.Spec.Pack);
+            Assert.False(context.Spec.Publish);
+            Assert.True(context.Spec.CreateReleaseZip);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_resolves_credentials_tokens_and_spec_settings()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-prepare-secret-" + Guid.NewGuid().ToString("N")));
+        var publishEnv = "PF_TEST_PUBLISH_" + Guid.NewGuid().ToString("N");
+        var gitHubEnv = "PF_TEST_GITHUB_" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            var secretPath = Path.Combine(root.FullName, "nuget.secret");
+            File.WriteAllText(secretPath, " secret-from-file ");
+            Environment.SetEnvironmentVariable(publishEnv, "publish-from-env");
+            Environment.SetEnvironmentVariable(gitHubEnv, "github-from-env");
+
+            var service = new ProjectBuildPreparationService();
+            var config = new ProjectBuildConfiguration
+            {
+                NugetCredentialUserName = "user",
+                NugetCredentialSecretFilePath = secretPath,
+                PublishApiKeyEnvName = publishEnv,
+                GitHubAccessTokenEnvName = gitHubEnv,
+                CertificateStore = "LocalMachine",
+                Configuration = "Debug",
+                PublishNuget = true,
+                PublishGitHub = true
+            };
+
+            var context = service.Prepare(
+                config,
+                root.FullName,
+                "plan.json",
+                new ProjectBuildRequestedActions());
+
+            Assert.Equal("publish-from-env", context.PublishApiKey);
+            Assert.Equal("github-from-env", context.GitHubToken);
+            Assert.Equal(Path.Combine(root.FullName, "plan.json"), context.PlanOutputPath);
+            Assert.NotNull(context.Spec.VersionSourceCredential);
+            Assert.Equal("user", context.Spec.VersionSourceCredential!.UserName);
+            Assert.Equal("secret-from-file", context.Spec.VersionSourceCredential.Secret);
+            Assert.Equal(CertificateStoreLocation.LocalMachine, context.Spec.CertificateStore);
+            Assert.Equal("Debug", context.Spec.Configuration);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(publishEnv, null);
+            Environment.SetEnvironmentVariable(gitHubEnv, null);
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_can_resolve_to_no_work_when_all_actions_are_disabled()
+    {
+        var service = new ProjectBuildPreparationService();
+
+        var context = service.Prepare(
+            new ProjectBuildConfiguration
+            {
+                UpdateVersions = false,
+                Build = false,
+                PublishNuget = false,
+                PublishGitHub = false
+            },
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions());
+
+        Assert.False(context.HasWork);
+        Assert.False(context.Spec.Pack);
+        Assert.False(context.Spec.Publish);
+    }
+}

--- a/PowerForge/Models/ProjectBuildPreparedContext.cs
+++ b/PowerForge/Models/ProjectBuildPreparedContext.cs
@@ -1,0 +1,24 @@
+namespace PowerForge;
+
+/// <summary>
+/// Resolved project build preparation state used by the cmdlet workflow.
+/// </summary>
+internal sealed class ProjectBuildPreparedContext
+{
+    public bool PlanOnly { get; set; }
+    public bool UpdateVersions { get; set; }
+    public bool Build { get; set; }
+    public bool PublishNuget { get; set; }
+    public bool PublishGitHub { get; set; }
+    public bool CreateReleaseZip { get; set; }
+    public string RootPath { get; set; } = string.Empty;
+    public string? StagingPath { get; set; }
+    public string? OutputPath { get; set; }
+    public string? ReleaseZipOutputPath { get; set; }
+    public string? PlanOutputPath { get; set; }
+    public string? PublishApiKey { get; set; }
+    public string? GitHubToken { get; set; }
+    public DotNetRepositoryReleaseSpec Spec { get; set; } = new();
+
+    public bool HasWork => UpdateVersions || Build || PublishNuget || PublishGitHub;
+}

--- a/PowerForge/Models/ProjectBuildRequestedActions.cs
+++ b/PowerForge/Models/ProjectBuildRequestedActions.cs
@@ -1,0 +1,13 @@
+namespace PowerForge;
+
+/// <summary>
+/// Optional action overrides supplied by the caller for project builds.
+/// </summary>
+internal sealed class ProjectBuildRequestedActions
+{
+    public bool? PlanOnly { get; set; }
+    public bool? UpdateVersions { get; set; }
+    public bool? Build { get; set; }
+    public bool? PublishNuget { get; set; }
+    public bool? PublishGitHub { get; set; }
+}

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -1,0 +1,118 @@
+namespace PowerForge;
+
+/// <summary>
+/// Resolves project build action flags, credentials, paths, and repository release specifications.
+/// </summary>
+internal sealed class ProjectBuildPreparationService
+{
+    /// <summary>
+    /// Builds the prepared execution context for the project build workflow.
+    /// </summary>
+    public ProjectBuildPreparedContext Prepare(
+        ProjectBuildConfiguration config,
+        string configDir,
+        string? planPath,
+        ProjectBuildRequestedActions requestedActions)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+        if (string.IsNullOrWhiteSpace(configDir))
+            throw new ArgumentException("Configuration directory is required.", nameof(configDir));
+        if (requestedActions is null)
+            throw new ArgumentNullException(nameof(requestedActions));
+
+        var anyConfigSpecified = config.UpdateVersions is not null ||
+                                 config.Build is not null ||
+                                 config.PublishNuget is not null ||
+                                 config.PublishGitHub is not null;
+        var anyOverrideSpecified = requestedActions.UpdateVersions is not null ||
+                                   requestedActions.Build is not null ||
+                                   requestedActions.PublishNuget is not null ||
+                                   requestedActions.PublishGitHub is not null;
+
+        var context = new ProjectBuildPreparedContext
+        {
+            PlanOnly = requestedActions.PlanOnly ?? (config.PlanOnly ?? false),
+            UpdateVersions = requestedActions.UpdateVersions ?? (config.UpdateVersions ?? false),
+            Build = requestedActions.Build ?? (config.Build ?? false),
+            PublishNuget = requestedActions.PublishNuget ?? (config.PublishNuget ?? false),
+            PublishGitHub = requestedActions.PublishGitHub ?? (config.PublishGitHub ?? false),
+            CreateReleaseZip = config.CreateReleaseZip ?? true
+        };
+
+        if (!anyConfigSpecified && !anyOverrideSpecified)
+        {
+            context.UpdateVersions = true;
+            context.Build = true;
+            context.PublishNuget = true;
+            context.PublishGitHub = true;
+        }
+
+        context.RootPath = ProjectBuildSupportService.ResolveOptionalPath(config.RootPath, configDir) ?? configDir;
+        context.StagingPath = ProjectBuildSupportService.ResolveOptionalPath(config.StagingPath, context.RootPath);
+        context.OutputPath = ProjectBuildSupportService.ResolveOptionalPath(config.OutputPath, context.RootPath);
+        context.ReleaseZipOutputPath = ProjectBuildSupportService.ResolveOptionalPath(config.ReleaseZipOutputPath, context.RootPath);
+        context.PlanOutputPath = ProjectBuildSupportService.ResolveOptionalPath(planPath ?? config.PlanOutputPath, configDir);
+
+        if (string.IsNullOrWhiteSpace(context.OutputPath) && !string.IsNullOrWhiteSpace(context.StagingPath))
+            context.OutputPath = Path.Combine(context.StagingPath, "packages");
+        if (string.IsNullOrWhiteSpace(context.ReleaseZipOutputPath) && !string.IsNullOrWhiteSpace(context.StagingPath))
+            context.ReleaseZipOutputPath = Path.Combine(context.StagingPath, "releases");
+
+        var nugetCredentialSecret = ProjectBuildSupportService.ResolveSecret(
+            config.NugetCredentialSecret,
+            config.NugetCredentialSecretFilePath,
+            config.NugetCredentialSecretEnvName,
+            configDir);
+        var nugetUser = string.IsNullOrWhiteSpace(config.NugetCredentialUserName) ? null : config.NugetCredentialUserName!.Trim();
+        var nugetCredential = (!string.IsNullOrWhiteSpace(nugetUser) || !string.IsNullOrWhiteSpace(nugetCredentialSecret))
+            ? new RepositoryCredential
+            {
+                UserName = nugetUser,
+                Secret = nugetCredentialSecret
+            }
+            : null;
+
+        context.PublishApiKey = ProjectBuildSupportService.ResolveSecret(
+            config.PublishApiKey,
+            config.PublishApiKeyFilePath,
+            config.PublishApiKeyEnvName,
+            configDir);
+        context.GitHubToken = ProjectBuildSupportService.ResolveSecret(
+            config.GitHubAccessToken,
+            config.GitHubAccessTokenFilePath,
+            config.GitHubAccessTokenEnvName,
+            configDir);
+
+        context.Spec = new DotNetRepositoryReleaseSpec
+        {
+            RootPath = context.RootPath,
+            ExpectedVersion = config.ExpectedVersion,
+            ExpectedVersionsByProject = config.ExpectedVersionMap,
+            ExpectedVersionMapAsInclude = config.ExpectedVersionMapAsInclude,
+            ExpectedVersionMapUseWildcards = config.ExpectedVersionMapUseWildcards,
+            IncludeProjects = config.IncludeProjects,
+            ExcludeProjects = config.ExcludeProjects,
+            ExcludeDirectories = config.ExcludeDirectories,
+            VersionSources = config.NugetSource,
+            VersionSourceCredential = nugetCredential,
+            IncludePrerelease = config.IncludePrerelease,
+            Configuration = string.IsNullOrWhiteSpace(config.Configuration) ? "Release" : config.Configuration!,
+            OutputPath = context.OutputPath,
+            ReleaseZipOutputPath = context.ReleaseZipOutputPath,
+            CertificateThumbprint = config.CertificateThumbprint,
+            CertificateStore = ProjectBuildSupportService.ParseCertificateStore(config.CertificateStore),
+            TimeStampServer = config.TimeStampServer,
+            Pack = context.Build || context.PublishNuget || context.PublishGitHub,
+            CreateReleaseZip = context.CreateReleaseZip,
+            Publish = context.PublishNuget,
+            PublishSource = config.PublishSource,
+            PublishApiKey = context.PublishApiKey,
+            SkipDuplicate = config.SkipDuplicate ?? true,
+            PublishFailFast = config.PublishFailFast ?? true,
+            UpdateVersions = context.UpdateVersions
+        };
+
+        return context;
+    }
+}


### PR DESCRIPTION
## Summary
- move Invoke-ProjectBuild action resolution, path derivation, secret resolution, and DotNetRepositoryReleaseSpec construction into a dedicated preparation service
- introduce internal preparation/request models so the cmdlet only maps PowerShell input into workflow orchestration
- add focused tests for default action behavior, override precedence, credential/token resolution, and no-work scenarios

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "ProjectBuildPreparationServiceTests|ProjectBuildSupportServiceTests|ProjectBuildGitHubPreflightTests|ProjectBuildGitHubPublisherTests"
- pwsh .\Module\Build\Build-Module.ps1 -NoSign

## Stacked On
- Base branch: `codex/thin-cmdlets-project-build-support`
- Review after #186
