### PR TITLE
refactor: extract validation and format configuration factories

### DIFF
--- a/PSPublishModule/Cmdlets/NewConfigurationFormatCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationFormatCommand.cs
@@ -165,186 +165,49 @@ public sealed class NewConfigurationFormatCommand : PSCmdlet
     /// <summary>Emits formatting configuration for the build pipeline.</summary>
     protected override void ProcessRecord()
     {
-        var settingsCount = 0;
-
-        var options = new FormattingOptions();
-
-        foreach (var apply in ApplyTo)
+        var factory = new FormatConfigurationFactory();
+        var configuration = factory.Create(new FormatConfigurationRequest
         {
-            var hasFormattingSettings = false;
-            var formatting = new FormatCodeOptions
-            {
-                Sort = Sort
-            };
-            if (!string.IsNullOrWhiteSpace(Sort))
-                hasFormattingSettings = true;
+            ApplyTo = ApplyTo,
+            EnableFormatting = EnableFormatting.IsPresent,
+            Sort = Sort,
+            RemoveCommentsSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RemoveComments)),
+            RemoveComments = RemoveComments.IsPresent,
+            RemoveEmptyLinesSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RemoveEmptyLines)),
+            RemoveEmptyLines = RemoveEmptyLines.IsPresent,
+            RemoveAllEmptyLinesSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RemoveAllEmptyLines)),
+            RemoveAllEmptyLines = RemoveAllEmptyLines.IsPresent,
+            RemoveCommentsInParamBlockSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RemoveCommentsInParamBlock)),
+            RemoveCommentsInParamBlock = RemoveCommentsInParamBlock.IsPresent,
+            RemoveCommentsBeforeParamBlockSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RemoveCommentsBeforeParamBlock)),
+            RemoveCommentsBeforeParamBlock = RemoveCommentsBeforeParamBlock.IsPresent,
+            UpdateProjectRoot = UpdateProjectRoot.IsPresent,
+            PlaceOpenBraceEnable = PlaceOpenBraceEnable.IsPresent,
+            PlaceOpenBraceOnSameLine = PlaceOpenBraceOnSameLine.IsPresent,
+            PlaceOpenBraceNewLineAfter = PlaceOpenBraceNewLineAfter.IsPresent,
+            PlaceOpenBraceIgnoreOneLineBlock = PlaceOpenBraceIgnoreOneLineBlock.IsPresent,
+            PlaceCloseBraceEnable = PlaceCloseBraceEnable.IsPresent,
+            PlaceCloseBraceNewLineAfter = PlaceCloseBraceNewLineAfter.IsPresent,
+            PlaceCloseBraceIgnoreOneLineBlock = PlaceCloseBraceIgnoreOneLineBlock.IsPresent,
+            PlaceCloseBraceNoEmptyLineBefore = PlaceCloseBraceNoEmptyLineBefore.IsPresent,
+            UseConsistentIndentationEnable = UseConsistentIndentationEnable.IsPresent,
+            UseConsistentIndentationKind = UseConsistentIndentationKind,
+            UseConsistentIndentationPipelineIndentation = UseConsistentIndentationPipelineIndentation,
+            UseConsistentIndentationIndentationSize = UseConsistentIndentationIndentationSize,
+            UseConsistentWhitespaceEnable = UseConsistentWhitespaceEnable.IsPresent,
+            UseConsistentWhitespaceCheckInnerBrace = UseConsistentWhitespaceCheckInnerBrace.IsPresent,
+            UseConsistentWhitespaceCheckOpenBrace = UseConsistentWhitespaceCheckOpenBrace.IsPresent,
+            UseConsistentWhitespaceCheckOpenParen = UseConsistentWhitespaceCheckOpenParen.IsPresent,
+            UseConsistentWhitespaceCheckOperator = UseConsistentWhitespaceCheckOperator.IsPresent,
+            UseConsistentWhitespaceCheckPipe = UseConsistentWhitespaceCheckPipe.IsPresent,
+            UseConsistentWhitespaceCheckSeparator = UseConsistentWhitespaceCheckSeparator.IsPresent,
+            AlignAssignmentStatementEnable = AlignAssignmentStatementEnable.IsPresent,
+            AlignAssignmentStatementCheckHashtable = AlignAssignmentStatementCheckHashtable.IsPresent,
+            UseCorrectCasingEnable = UseCorrectCasingEnable.IsPresent,
+            PSD1Style = PSD1Style
+        });
 
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(RemoveComments)))
-            {
-                formatting.RemoveComments = RemoveComments.IsPresent;
-                hasFormattingSettings = true;
-            }
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(RemoveEmptyLines)))
-            {
-                formatting.RemoveEmptyLines = RemoveEmptyLines.IsPresent;
-                hasFormattingSettings = true;
-            }
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(RemoveAllEmptyLines)))
-            {
-                formatting.RemoveAllEmptyLines = RemoveAllEmptyLines.IsPresent;
-                hasFormattingSettings = true;
-            }
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(RemoveCommentsInParamBlock)))
-            {
-                formatting.RemoveCommentsInParamBlock = RemoveCommentsInParamBlock.IsPresent;
-                hasFormattingSettings = true;
-            }
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(RemoveCommentsBeforeParamBlock)))
-            {
-                formatting.RemoveCommentsBeforeParamBlock = RemoveCommentsBeforeParamBlock.IsPresent;
-                hasFormattingSettings = true;
-            }
-
-            var includeRules = new List<string>();
-            var rules = new FormatterRulesOptions();
-
-            if (PlaceOpenBraceEnable.IsPresent)
-            {
-                includeRules.Add("PSPlaceOpenBrace");
-                rules.PSPlaceOpenBrace = new BraceRuleOptions
-                {
-                    Enable = true,
-                    OnSameLine = PlaceOpenBraceOnSameLine.IsPresent,
-                    NewLineAfter = PlaceOpenBraceNewLineAfter.IsPresent,
-                    IgnoreOneLineBlock = PlaceOpenBraceIgnoreOneLineBlock.IsPresent
-                };
-                hasFormattingSettings = true;
-            }
-
-            if (PlaceCloseBraceEnable.IsPresent)
-            {
-                includeRules.Add("PSPlaceCloseBrace");
-                rules.PSPlaceCloseBrace = new CloseBraceRuleOptions
-                {
-                    Enable = true,
-                    NewLineAfter = PlaceCloseBraceNewLineAfter.IsPresent,
-                    IgnoreOneLineBlock = PlaceCloseBraceIgnoreOneLineBlock.IsPresent,
-                    NoEmptyLineBefore = PlaceCloseBraceNoEmptyLineBefore.IsPresent
-                };
-                hasFormattingSettings = true;
-            }
-
-            if (UseConsistentIndentationEnable.IsPresent)
-            {
-                includeRules.Add("PSUseConsistentIndentation");
-                rules.PSUseConsistentIndentation = new IndentationRuleOptions
-                {
-                    Enable = true,
-                    Kind = UseConsistentIndentationKind,
-                    PipelineIndentation = UseConsistentIndentationPipelineIndentation,
-                    IndentationSize = UseConsistentIndentationIndentationSize
-                };
-                hasFormattingSettings = true;
-            }
-
-            if (UseConsistentWhitespaceEnable.IsPresent)
-            {
-                includeRules.Add("PSUseConsistentWhitespace");
-                rules.PSUseConsistentWhitespace = new WhitespaceRuleOptions
-                {
-                    Enable = true,
-                    CheckInnerBrace = UseConsistentWhitespaceCheckInnerBrace.IsPresent,
-                    CheckOpenBrace = UseConsistentWhitespaceCheckOpenBrace.IsPresent,
-                    CheckOpenParen = UseConsistentWhitespaceCheckOpenParen.IsPresent,
-                    CheckOperator = UseConsistentWhitespaceCheckOperator.IsPresent,
-                    CheckPipe = UseConsistentWhitespaceCheckPipe.IsPresent,
-                    CheckSeparator = UseConsistentWhitespaceCheckSeparator.IsPresent
-                };
-                hasFormattingSettings = true;
-            }
-
-            if (AlignAssignmentStatementEnable.IsPresent)
-            {
-                includeRules.Add("PSAlignAssignmentStatement");
-                rules.PSAlignAssignmentStatement = new AlignAssignmentRuleOptions
-                {
-                    Enable = true,
-                    CheckHashtable = AlignAssignmentStatementCheckHashtable.IsPresent
-                };
-                hasFormattingSettings = true;
-            }
-
-            if (UseCorrectCasingEnable.IsPresent)
-            {
-                includeRules.Add("PSUseCorrectCasing");
-                rules.PSUseCorrectCasing = new EnableOnlyRuleOptions
-                {
-                    Enable = true
-                };
-                hasFormattingSettings = true;
-            }
-
-            if (includeRules.Count > 0)
-            {
-                formatting.FormatterSettings = new FormatterSettingsOptions
-                {
-                    IncludeRules = includeRules.ToArray(),
-                    Rules = rules
-                };
-                hasFormattingSettings = true;
-            }
-
-            if (hasFormattingSettings || EnableFormatting.IsPresent)
-            {
-                settingsCount++;
-                formatting.Enabled = true;
-
-                switch (apply)
-                {
-                    case "OnMergePSM1":
-                        options.Merge.FormatCodePSM1 = formatting;
-                        break;
-                    case "OnMergePSD1":
-                        options.Merge.FormatCodePSD1 = formatting;
-                        break;
-                    case "DefaultPSM1":
-                        options.Standard.FormatCodePSM1 = formatting;
-                        break;
-                    case "DefaultPS1":
-                        options.Standard.FormatCodePS1 = formatting;
-                        break;
-                    case "DefaultPSD1":
-                        options.Standard.FormatCodePSD1 = formatting;
-                        break;
-                    default:
-                        throw new PSArgumentException($"Unknown ApplyTo: {apply}");
-                }
-            }
-
-            if (!string.IsNullOrWhiteSpace(PSD1Style))
-            {
-                if (apply == "OnMergePSD1")
-                {
-                    settingsCount++;
-                    options.Merge.Style = new FormattingStyleOptions { PSD1 = PSD1Style };
-                }
-                else if (apply == "DefaultPSD1")
-                {
-                    settingsCount++;
-                    options.Standard.Style = new FormattingStyleOptions { PSD1 = PSD1Style };
-                }
-            }
-        }
-
-        if (UpdateProjectRoot.IsPresent)
-        {
-            options.UpdateProjectRoot = true;
-            settingsCount++;
-        }
-
-        if (settingsCount > 0)
-        {
-            WriteObject(new ConfigurationFormattingSegment { Options = options });
-        }
+        if (configuration is not null)
+            WriteObject(configuration);
     }
 }

--- a/PSPublishModule/Cmdlets/NewConfigurationValidationCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationValidationCommand.cs
@@ -155,77 +155,52 @@ public sealed class NewConfigurationValidationCommand : PSCmdlet
     /// <summary>Emits validation configuration for the build pipeline.</summary>
     protected override void ProcessRecord()
     {
-        var settings = new ModuleValidationSettings
+        var factory = new ValidationConfigurationFactory();
+        var configuration = factory.Create(new ValidationConfigurationRequest
         {
             Enable = Enable.IsPresent,
-            Structure = new ModuleStructureValidationSettings
-            {
-                Severity = StructureSeverity,
-                PublicFunctionPaths = PublicFunctionPaths ?? Array.Empty<string>(),
-                InternalFunctionPaths = InternalFunctionPaths ?? Array.Empty<string>(),
-                ValidateManifestFiles = ValidateManifestFiles,
-                ValidateExports = ValidateExports,
-                ValidateInternalNotExported = ValidateInternalNotExported,
-                AllowWildcardExports = AllowWildcardExports
-            },
-            Documentation = new DocumentationValidationSettings
-            {
-                Severity = DocumentationSeverity,
-                MinSynopsisPercent = MinSynopsisPercent,
-                MinDescriptionPercent = MinDescriptionPercent,
-                MinExampleCountPerCommand = MinExamplesPerCommand,
-                ExcludeCommands = ExcludeCommands ?? Array.Empty<string>()
-            },
-            ScriptAnalyzer = new ScriptAnalyzerValidationSettings
-            {
-                Severity = ScriptAnalyzerSeverity,
-                Enable = EnableScriptAnalyzer.IsPresent,
-                ExcludeDirectories = ScriptAnalyzerExcludeDirectories ?? Array.Empty<string>(),
-                ExcludeRules = ScriptAnalyzerExcludeRules ?? Array.Empty<string>(),
-                SkipIfUnavailable = ScriptAnalyzerSkipIfUnavailable,
-                TimeoutSeconds = Math.Max(1, ScriptAnalyzerTimeoutSeconds)
-            },
-            FileIntegrity = new FileIntegrityValidationSettings
-            {
-                Severity = FileIntegritySeverity,
-                ExcludeDirectories = FileIntegrityExcludeDirectories ?? Array.Empty<string>(),
-                CheckTrailingWhitespace = FileIntegrityCheckTrailingWhitespace,
-                CheckSyntax = FileIntegrityCheckSyntax,
-                BannedCommands = BannedCommands ?? Array.Empty<string>(),
-                AllowBannedCommandsIn = AllowBannedCommandsIn ?? Array.Empty<string>()
-            },
-            Tests = new TestSuiteValidationSettings
-            {
-                Severity = TestsSeverity,
-                Enable = EnableTests.IsPresent,
-                TestPath = TestsPath,
-                AdditionalModules = TestAdditionalModules ?? Array.Empty<string>(),
-                SkipModules = TestSkipModules ?? Array.Empty<string>(),
-                SkipDependencies = TestSkipDependencies.IsPresent,
-                SkipImport = TestSkipImport.IsPresent,
-                Force = TestForce.IsPresent,
-                TimeoutSeconds = Math.Max(1, TestTimeoutSeconds)
-            },
-            Binary = new BinaryModuleValidationSettings
-            {
-                Severity = BinarySeverity,
-                ValidateAssembliesExist = ValidateBinaryAssemblies,
-                ValidateManifestExports = ValidateBinaryExports,
-                AllowWildcardExports = AllowBinaryWildcardExports
-            },
-            Csproj = new CsprojValidationSettings
-            {
-                Severity = CsprojSeverity,
-                RequireTargetFramework = RequireTargetFramework,
-                RequireLibraryOutput = RequireLibraryOutput
-            }
-        };
+            StructureSeverity = StructureSeverity,
+            DocumentationSeverity = DocumentationSeverity,
+            ScriptAnalyzerSeverity = ScriptAnalyzerSeverity,
+            FileIntegritySeverity = FileIntegritySeverity,
+            TestsSeverity = TestsSeverity,
+            BinarySeverity = BinarySeverity,
+            CsprojSeverity = CsprojSeverity,
+            PublicFunctionPaths = PublicFunctionPaths,
+            InternalFunctionPaths = InternalFunctionPaths,
+            ValidateManifestFiles = ValidateManifestFiles,
+            ValidateExports = ValidateExports,
+            ValidateInternalNotExported = ValidateInternalNotExported,
+            AllowWildcardExports = AllowWildcardExports,
+            MinSynopsisPercent = MinSynopsisPercent,
+            MinDescriptionPercent = MinDescriptionPercent,
+            MinExamplesPerCommand = MinExamplesPerCommand,
+            ExcludeCommands = ExcludeCommands,
+            EnableScriptAnalyzer = EnableScriptAnalyzer.IsPresent,
+            ScriptAnalyzerExcludeDirectories = ScriptAnalyzerExcludeDirectories,
+            ScriptAnalyzerExcludeRules = ScriptAnalyzerExcludeRules,
+            ScriptAnalyzerSkipIfUnavailable = ScriptAnalyzerSkipIfUnavailable,
+            ScriptAnalyzerTimeoutSeconds = ScriptAnalyzerTimeoutSeconds,
+            FileIntegrityExcludeDirectories = FileIntegrityExcludeDirectories,
+            FileIntegrityCheckTrailingWhitespace = FileIntegrityCheckTrailingWhitespace,
+            FileIntegrityCheckSyntax = FileIntegrityCheckSyntax,
+            BannedCommands = BannedCommands,
+            AllowBannedCommandsIn = AllowBannedCommandsIn,
+            EnableTests = EnableTests.IsPresent,
+            TestsPath = TestsPath,
+            TestAdditionalModules = TestAdditionalModules,
+            TestSkipModules = TestSkipModules,
+            TestSkipDependencies = TestSkipDependencies.IsPresent,
+            TestSkipImport = TestSkipImport.IsPresent,
+            TestForce = TestForce.IsPresent,
+            TestTimeoutSeconds = TestTimeoutSeconds,
+            ValidateBinaryAssemblies = ValidateBinaryAssemblies,
+            ValidateBinaryExports = ValidateBinaryExports,
+            AllowBinaryWildcardExports = AllowBinaryWildcardExports,
+            RequireTargetFramework = RequireTargetFramework,
+            RequireLibraryOutput = RequireLibraryOutput
+        });
 
-        var cfg = new ConfigurationValidationSegment
-        {
-            Settings = settings
-        };
-
-        WriteObject(cfg);
+        WriteObject(configuration);
     }
 }

--- a/PowerForge.PowerShell/Models/FormatConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/FormatConfigurationRequest.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace PowerForge;
+
+internal sealed class FormatConfigurationRequest
+{
+    public string[] ApplyTo { get; set; } = Array.Empty<string>();
+    public bool EnableFormatting { get; set; }
+    public string? Sort { get; set; }
+    public bool RemoveCommentsSpecified { get; set; }
+    public bool RemoveComments { get; set; }
+    public bool RemoveEmptyLinesSpecified { get; set; }
+    public bool RemoveEmptyLines { get; set; }
+    public bool RemoveAllEmptyLinesSpecified { get; set; }
+    public bool RemoveAllEmptyLines { get; set; }
+    public bool RemoveCommentsInParamBlockSpecified { get; set; }
+    public bool RemoveCommentsInParamBlock { get; set; }
+    public bool RemoveCommentsBeforeParamBlockSpecified { get; set; }
+    public bool RemoveCommentsBeforeParamBlock { get; set; }
+    public bool UpdateProjectRoot { get; set; }
+    public bool PlaceOpenBraceEnable { get; set; }
+    public bool PlaceOpenBraceOnSameLine { get; set; }
+    public bool PlaceOpenBraceNewLineAfter { get; set; }
+    public bool PlaceOpenBraceIgnoreOneLineBlock { get; set; }
+    public bool PlaceCloseBraceEnable { get; set; }
+    public bool PlaceCloseBraceNewLineAfter { get; set; }
+    public bool PlaceCloseBraceIgnoreOneLineBlock { get; set; }
+    public bool PlaceCloseBraceNoEmptyLineBefore { get; set; }
+    public bool UseConsistentIndentationEnable { get; set; }
+    public string? UseConsistentIndentationKind { get; set; }
+    public string? UseConsistentIndentationPipelineIndentation { get; set; }
+    public int UseConsistentIndentationIndentationSize { get; set; }
+    public bool UseConsistentWhitespaceEnable { get; set; }
+    public bool UseConsistentWhitespaceCheckInnerBrace { get; set; }
+    public bool UseConsistentWhitespaceCheckOpenBrace { get; set; }
+    public bool UseConsistentWhitespaceCheckOpenParen { get; set; }
+    public bool UseConsistentWhitespaceCheckOperator { get; set; }
+    public bool UseConsistentWhitespaceCheckPipe { get; set; }
+    public bool UseConsistentWhitespaceCheckSeparator { get; set; }
+    public bool AlignAssignmentStatementEnable { get; set; }
+    public bool AlignAssignmentStatementCheckHashtable { get; set; }
+    public bool UseCorrectCasingEnable { get; set; }
+    public string? PSD1Style { get; set; }
+}

--- a/PowerForge.PowerShell/Models/ValidationConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/ValidationConfigurationRequest.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace PowerForge;
+
+internal sealed class ValidationConfigurationRequest
+{
+    public bool Enable { get; set; }
+    public ValidationSeverity StructureSeverity { get; set; } = ValidationSeverity.Warning;
+    public ValidationSeverity DocumentationSeverity { get; set; } = ValidationSeverity.Warning;
+    public ValidationSeverity ScriptAnalyzerSeverity { get; set; } = ValidationSeverity.Warning;
+    public ValidationSeverity FileIntegritySeverity { get; set; } = ValidationSeverity.Warning;
+    public ValidationSeverity TestsSeverity { get; set; } = ValidationSeverity.Warning;
+    public ValidationSeverity BinarySeverity { get; set; } = ValidationSeverity.Off;
+    public ValidationSeverity CsprojSeverity { get; set; } = ValidationSeverity.Off;
+    public string[] PublicFunctionPaths { get; set; } = new[] { "functions" };
+    public string[] InternalFunctionPaths { get; set; } = new[] { @"internal\functions" };
+    public bool ValidateManifestFiles { get; set; } = true;
+    public bool ValidateExports { get; set; } = true;
+    public bool ValidateInternalNotExported { get; set; } = true;
+    public bool AllowWildcardExports { get; set; } = true;
+    public int MinSynopsisPercent { get; set; } = 100;
+    public int MinDescriptionPercent { get; set; } = 100;
+    public int MinExamplesPerCommand { get; set; } = 1;
+    public string[] ExcludeCommands { get; set; } = Array.Empty<string>();
+    public bool EnableScriptAnalyzer { get; set; }
+    public string[] ScriptAnalyzerExcludeDirectories { get; set; } = new[] { "tests", "TestResults", ".git", ".vs", "bin", "obj", "packages", "node_modules", "Artefacts", "Ignore" };
+    public string[] ScriptAnalyzerExcludeRules { get; set; } = new[] { "PSAvoidTrailingWhitespace", "PSShouldProcess" };
+    public bool ScriptAnalyzerSkipIfUnavailable { get; set; } = true;
+    public int ScriptAnalyzerTimeoutSeconds { get; set; } = 300;
+    public string[] FileIntegrityExcludeDirectories { get; set; } = new[] { "tests", "TestResults", ".git", ".vs", "bin", "obj", "packages", "node_modules", "Artefacts", "Ignore" };
+    public bool FileIntegrityCheckTrailingWhitespace { get; set; } = true;
+    public bool FileIntegrityCheckSyntax { get; set; } = true;
+    public string[] BannedCommands { get; set; } = Array.Empty<string>();
+    public string[] AllowBannedCommandsIn { get; set; } = Array.Empty<string>();
+    public bool EnableTests { get; set; }
+    public string? TestsPath { get; set; }
+    public string[] TestAdditionalModules { get; set; } = new[] { "Pester", "PSWriteColor" };
+    public string[] TestSkipModules { get; set; } = Array.Empty<string>();
+    public bool TestSkipDependencies { get; set; }
+    public bool TestSkipImport { get; set; }
+    public bool TestForce { get; set; }
+    public int TestTimeoutSeconds { get; set; } = 600;
+    public bool ValidateBinaryAssemblies { get; set; } = true;
+    public bool ValidateBinaryExports { get; set; } = true;
+    public bool AllowBinaryWildcardExports { get; set; } = true;
+    public bool RequireTargetFramework { get; set; } = true;
+    public bool RequireLibraryOutput { get; set; } = true;
+}

--- a/PowerForge.PowerShell/Services/FormatConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/FormatConfigurationFactory.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+
+namespace PowerForge;
+
+internal sealed class FormatConfigurationFactory
+{
+    public ConfigurationFormattingSegment? Create(FormatConfigurationRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        var settingsCount = 0;
+        var options = new FormattingOptions();
+
+        foreach (var apply in request.ApplyTo ?? Array.Empty<string>())
+        {
+            var hasFormattingSettings = false;
+            var formatting = new FormatCodeOptions
+            {
+                Sort = request.Sort
+            };
+
+            if (!string.IsNullOrWhiteSpace(request.Sort))
+                hasFormattingSettings = true;
+
+            if (request.RemoveCommentsSpecified)
+            {
+                formatting.RemoveComments = request.RemoveComments;
+                hasFormattingSettings = true;
+            }
+            if (request.RemoveEmptyLinesSpecified)
+            {
+                formatting.RemoveEmptyLines = request.RemoveEmptyLines;
+                hasFormattingSettings = true;
+            }
+            if (request.RemoveAllEmptyLinesSpecified)
+            {
+                formatting.RemoveAllEmptyLines = request.RemoveAllEmptyLines;
+                hasFormattingSettings = true;
+            }
+            if (request.RemoveCommentsInParamBlockSpecified)
+            {
+                formatting.RemoveCommentsInParamBlock = request.RemoveCommentsInParamBlock;
+                hasFormattingSettings = true;
+            }
+            if (request.RemoveCommentsBeforeParamBlockSpecified)
+            {
+                formatting.RemoveCommentsBeforeParamBlock = request.RemoveCommentsBeforeParamBlock;
+                hasFormattingSettings = true;
+            }
+
+            var includeRules = new List<string>();
+            var rules = new FormatterRulesOptions();
+
+            if (request.PlaceOpenBraceEnable)
+            {
+                includeRules.Add("PSPlaceOpenBrace");
+                rules.PSPlaceOpenBrace = new BraceRuleOptions
+                {
+                    Enable = true,
+                    OnSameLine = request.PlaceOpenBraceOnSameLine,
+                    NewLineAfter = request.PlaceOpenBraceNewLineAfter,
+                    IgnoreOneLineBlock = request.PlaceOpenBraceIgnoreOneLineBlock
+                };
+                hasFormattingSettings = true;
+            }
+
+            if (request.PlaceCloseBraceEnable)
+            {
+                includeRules.Add("PSPlaceCloseBrace");
+                rules.PSPlaceCloseBrace = new CloseBraceRuleOptions
+                {
+                    Enable = true,
+                    NewLineAfter = request.PlaceCloseBraceNewLineAfter,
+                    IgnoreOneLineBlock = request.PlaceCloseBraceIgnoreOneLineBlock,
+                    NoEmptyLineBefore = request.PlaceCloseBraceNoEmptyLineBefore
+                };
+                hasFormattingSettings = true;
+            }
+
+            if (request.UseConsistentIndentationEnable)
+            {
+                includeRules.Add("PSUseConsistentIndentation");
+                rules.PSUseConsistentIndentation = new IndentationRuleOptions
+                {
+                    Enable = true,
+                    Kind = request.UseConsistentIndentationKind,
+                    PipelineIndentation = request.UseConsistentIndentationPipelineIndentation,
+                    IndentationSize = request.UseConsistentIndentationIndentationSize
+                };
+                hasFormattingSettings = true;
+            }
+
+            if (request.UseConsistentWhitespaceEnable)
+            {
+                includeRules.Add("PSUseConsistentWhitespace");
+                rules.PSUseConsistentWhitespace = new WhitespaceRuleOptions
+                {
+                    Enable = true,
+                    CheckInnerBrace = request.UseConsistentWhitespaceCheckInnerBrace,
+                    CheckOpenBrace = request.UseConsistentWhitespaceCheckOpenBrace,
+                    CheckOpenParen = request.UseConsistentWhitespaceCheckOpenParen,
+                    CheckOperator = request.UseConsistentWhitespaceCheckOperator,
+                    CheckPipe = request.UseConsistentWhitespaceCheckPipe,
+                    CheckSeparator = request.UseConsistentWhitespaceCheckSeparator
+                };
+                hasFormattingSettings = true;
+            }
+
+            if (request.AlignAssignmentStatementEnable)
+            {
+                includeRules.Add("PSAlignAssignmentStatement");
+                rules.PSAlignAssignmentStatement = new AlignAssignmentRuleOptions
+                {
+                    Enable = true,
+                    CheckHashtable = request.AlignAssignmentStatementCheckHashtable
+                };
+                hasFormattingSettings = true;
+            }
+
+            if (request.UseCorrectCasingEnable)
+            {
+                includeRules.Add("PSUseCorrectCasing");
+                rules.PSUseCorrectCasing = new EnableOnlyRuleOptions
+                {
+                    Enable = true
+                };
+                hasFormattingSettings = true;
+            }
+
+            if (includeRules.Count > 0)
+            {
+                formatting.FormatterSettings = new FormatterSettingsOptions
+                {
+                    IncludeRules = includeRules.ToArray(),
+                    Rules = rules
+                };
+                hasFormattingSettings = true;
+            }
+
+            if (hasFormattingSettings || request.EnableFormatting)
+            {
+                settingsCount++;
+                formatting.Enabled = true;
+
+                switch (apply)
+                {
+                    case "OnMergePSM1":
+                        options.Merge.FormatCodePSM1 = formatting;
+                        break;
+                    case "OnMergePSD1":
+                        options.Merge.FormatCodePSD1 = formatting;
+                        break;
+                    case "DefaultPSM1":
+                        options.Standard.FormatCodePSM1 = formatting;
+                        break;
+                    case "DefaultPS1":
+                        options.Standard.FormatCodePS1 = formatting;
+                        break;
+                    case "DefaultPSD1":
+                        options.Standard.FormatCodePSD1 = formatting;
+                        break;
+                    default:
+                        throw new ArgumentException($"Unknown ApplyTo: {apply}", nameof(request));
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.PSD1Style))
+            {
+                if (apply == "OnMergePSD1")
+                {
+                    settingsCount++;
+                    options.Merge.Style = new FormattingStyleOptions { PSD1 = request.PSD1Style };
+                }
+                else if (apply == "DefaultPSD1")
+                {
+                    settingsCount++;
+                    options.Standard.Style = new FormattingStyleOptions { PSD1 = request.PSD1Style };
+                }
+            }
+        }
+
+        if (request.UpdateProjectRoot)
+        {
+            options.UpdateProjectRoot = true;
+            settingsCount++;
+        }
+
+        return settingsCount > 0
+            ? new ConfigurationFormattingSegment { Options = options }
+            : null;
+    }
+}

--- a/PowerForge.PowerShell/Services/ValidationConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/ValidationConfigurationFactory.cs
@@ -1,0 +1,81 @@
+using System;
+
+namespace PowerForge;
+
+internal sealed class ValidationConfigurationFactory
+{
+    public ConfigurationValidationSegment Create(ValidationConfigurationRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        return new ConfigurationValidationSegment
+        {
+            Settings = new ModuleValidationSettings
+            {
+                Enable = request.Enable,
+                Structure = new ModuleStructureValidationSettings
+                {
+                    Severity = request.StructureSeverity,
+                    PublicFunctionPaths = request.PublicFunctionPaths ?? Array.Empty<string>(),
+                    InternalFunctionPaths = request.InternalFunctionPaths ?? Array.Empty<string>(),
+                    ValidateManifestFiles = request.ValidateManifestFiles,
+                    ValidateExports = request.ValidateExports,
+                    ValidateInternalNotExported = request.ValidateInternalNotExported,
+                    AllowWildcardExports = request.AllowWildcardExports
+                },
+                Documentation = new DocumentationValidationSettings
+                {
+                    Severity = request.DocumentationSeverity,
+                    MinSynopsisPercent = request.MinSynopsisPercent,
+                    MinDescriptionPercent = request.MinDescriptionPercent,
+                    MinExampleCountPerCommand = request.MinExamplesPerCommand,
+                    ExcludeCommands = request.ExcludeCommands ?? Array.Empty<string>()
+                },
+                ScriptAnalyzer = new ScriptAnalyzerValidationSettings
+                {
+                    Severity = request.ScriptAnalyzerSeverity,
+                    Enable = request.EnableScriptAnalyzer,
+                    ExcludeDirectories = request.ScriptAnalyzerExcludeDirectories ?? Array.Empty<string>(),
+                    ExcludeRules = request.ScriptAnalyzerExcludeRules ?? Array.Empty<string>(),
+                    SkipIfUnavailable = request.ScriptAnalyzerSkipIfUnavailable,
+                    TimeoutSeconds = Math.Max(1, request.ScriptAnalyzerTimeoutSeconds)
+                },
+                FileIntegrity = new FileIntegrityValidationSettings
+                {
+                    Severity = request.FileIntegritySeverity,
+                    ExcludeDirectories = request.FileIntegrityExcludeDirectories ?? Array.Empty<string>(),
+                    CheckTrailingWhitespace = request.FileIntegrityCheckTrailingWhitespace,
+                    CheckSyntax = request.FileIntegrityCheckSyntax,
+                    BannedCommands = request.BannedCommands ?? Array.Empty<string>(),
+                    AllowBannedCommandsIn = request.AllowBannedCommandsIn ?? Array.Empty<string>()
+                },
+                Tests = new TestSuiteValidationSettings
+                {
+                    Severity = request.TestsSeverity,
+                    Enable = request.EnableTests,
+                    TestPath = request.TestsPath,
+                    AdditionalModules = request.TestAdditionalModules ?? Array.Empty<string>(),
+                    SkipModules = request.TestSkipModules ?? Array.Empty<string>(),
+                    SkipDependencies = request.TestSkipDependencies,
+                    SkipImport = request.TestSkipImport,
+                    Force = request.TestForce,
+                    TimeoutSeconds = Math.Max(1, request.TestTimeoutSeconds)
+                },
+                Binary = new BinaryModuleValidationSettings
+                {
+                    Severity = request.BinarySeverity,
+                    ValidateAssembliesExist = request.ValidateBinaryAssemblies,
+                    ValidateManifestExports = request.ValidateBinaryExports,
+                    AllowWildcardExports = request.AllowBinaryWildcardExports
+                },
+                Csproj = new CsprojValidationSettings
+                {
+                    Severity = request.CsprojSeverity,
+                    RequireTargetFramework = request.RequireTargetFramework,
+                    RequireLibraryOutput = request.RequireLibraryOutput
+                }
+            }
+        };
+    }
+}

--- a/PowerForge.Tests/FormatConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/FormatConfigurationFactoryTests.cs
@@ -1,0 +1,57 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class FormatConfigurationFactoryTests
+{
+    [Fact]
+    public void Create_builds_merge_and_standard_formatting_options()
+    {
+        var factory = new FormatConfigurationFactory();
+
+        var segment = factory.Create(new FormatConfigurationRequest
+        {
+            ApplyTo = new[] { "OnMergePSM1", "DefaultPSD1" },
+            EnableFormatting = true,
+            Sort = "Asc",
+            RemoveCommentsSpecified = true,
+            RemoveComments = true,
+            RemoveEmptyLinesSpecified = true,
+            RemoveEmptyLines = true,
+            PlaceOpenBraceEnable = true,
+            PlaceOpenBraceOnSameLine = true,
+            UseCorrectCasingEnable = true,
+            PSD1Style = "Native",
+            UpdateProjectRoot = true
+        });
+
+        var config = Assert.IsType<ConfigurationFormattingSegment>(segment);
+        Assert.True(config.Options.UpdateProjectRoot);
+        var mergePsm1 = Assert.IsType<FormatCodeOptions>(config.Options.Merge.FormatCodePSM1);
+        Assert.True(mergePsm1.Enabled);
+        Assert.Equal("Asc", mergePsm1.Sort);
+        Assert.True(mergePsm1.RemoveComments);
+        Assert.True(mergePsm1.RemoveEmptyLines);
+        var formatterSettings = Assert.IsType<FormatterSettingsOptions>(mergePsm1.FormatterSettings);
+        var includeRules = Assert.IsType<string[]>(formatterSettings.IncludeRules);
+        Assert.Contains("PSPlaceOpenBrace", includeRules);
+        Assert.Contains("PSUseCorrectCasing", includeRules);
+        var standardPsd1 = Assert.IsType<FormatCodeOptions>(config.Options.Standard.FormatCodePSD1);
+        Assert.True(standardPsd1.Enabled);
+        var style = Assert.IsType<FormattingStyleOptions>(config.Options.Standard.Style);
+        Assert.Equal("Native", style.PSD1);
+    }
+
+    [Fact]
+    public void Create_returns_null_when_no_settings_are_requested()
+    {
+        var factory = new FormatConfigurationFactory();
+
+        var segment = factory.Create(new FormatConfigurationRequest
+        {
+            ApplyTo = new[] { "OnMergePSM1" }
+        });
+
+        Assert.Null(segment);
+    }
+}

--- a/PowerForge.Tests/ValidationConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/ValidationConfigurationFactoryTests.cs
@@ -1,0 +1,74 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class ValidationConfigurationFactoryTests
+{
+    [Fact]
+    public void Create_builds_validation_segment_from_request()
+    {
+        var factory = new ValidationConfigurationFactory();
+
+        var segment = factory.Create(new ValidationConfigurationRequest
+        {
+            Enable = true,
+            StructureSeverity = ValidationSeverity.Error,
+            DocumentationSeverity = ValidationSeverity.Warning,
+            ScriptAnalyzerSeverity = ValidationSeverity.Error,
+            EnableScriptAnalyzer = true,
+            ScriptAnalyzerTimeoutSeconds = 0,
+            FileIntegritySeverity = ValidationSeverity.Error,
+            BannedCommands = new[] { "Invoke-Expression" },
+            TestsSeverity = ValidationSeverity.Error,
+            EnableTests = true,
+            TestTimeoutSeconds = 0,
+            TestSkipDependencies = true,
+            BinarySeverity = ValidationSeverity.Warning,
+            ValidateBinaryAssemblies = false,
+            CsprojSeverity = ValidationSeverity.Warning,
+            RequireLibraryOutput = false
+        });
+
+        Assert.True(segment.Settings.Enable);
+        Assert.Equal(ValidationSeverity.Error, segment.Settings.Structure.Severity);
+        Assert.True(segment.Settings.ScriptAnalyzer.Enable);
+        Assert.Equal(1, segment.Settings.ScriptAnalyzer.TimeoutSeconds);
+        Assert.Equal("Invoke-Expression", Assert.Single(segment.Settings.FileIntegrity.BannedCommands));
+        Assert.True(segment.Settings.Tests.Enable);
+        Assert.True(segment.Settings.Tests.SkipDependencies);
+        Assert.Equal(1, segment.Settings.Tests.TimeoutSeconds);
+        Assert.False(segment.Settings.Binary.ValidateAssembliesExist);
+        Assert.False(segment.Settings.Csproj.RequireLibraryOutput);
+    }
+
+    [Fact]
+    public void Create_normalizes_null_arrays_to_empty()
+    {
+        var factory = new ValidationConfigurationFactory();
+
+        var segment = factory.Create(new ValidationConfigurationRequest
+        {
+            PublicFunctionPaths = null!,
+            InternalFunctionPaths = null!,
+            ExcludeCommands = null!,
+            ScriptAnalyzerExcludeDirectories = null!,
+            ScriptAnalyzerExcludeRules = null!,
+            FileIntegrityExcludeDirectories = null!,
+            BannedCommands = null!,
+            AllowBannedCommandsIn = null!,
+            TestAdditionalModules = null!,
+            TestSkipModules = null!
+        });
+
+        Assert.Empty(segment.Settings.Structure.PublicFunctionPaths);
+        Assert.Empty(segment.Settings.Structure.InternalFunctionPaths);
+        Assert.Empty(segment.Settings.Documentation.ExcludeCommands);
+        Assert.Empty(segment.Settings.ScriptAnalyzer.ExcludeDirectories);
+        Assert.Empty(segment.Settings.ScriptAnalyzer.ExcludeRules);
+        Assert.Empty(segment.Settings.FileIntegrity.ExcludeDirectories);
+        Assert.Empty(segment.Settings.FileIntegrity.BannedCommands);
+        Assert.Empty(segment.Settings.FileIntegrity.AllowBannedCommandsIn);
+        Assert.Empty(segment.Settings.Tests.AdditionalModules);
+        Assert.Empty(segment.Settings.Tests.SkipModules);
+    }
+}


### PR DESCRIPTION
## Summary
- move `New-ConfigurationValidation` request-to-model mapping into a typed factory under `PowerForge.PowerShell`
- move `New-ConfigurationFormat` request-to-model mapping into a typed factory under `PowerForge.PowerShell`
- keep both cmdlets focused on PowerShell parameter binding and `WriteObject`

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FormatConfigurationFactoryTests|ValidationConfigurationFactoryTests|NuGetPackagePublishServiceTests"`
- `pwsh .\Module\Build\Build-Module.ps1 -NoSign`
