### PR TITLE
refactor: extract publish configuration factory

### DIFF
--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Management.Automation;
 using PowerForge;
 
@@ -35,9 +34,6 @@ namespace PSPublishModule;
 [Cmdlet(VerbsCommon.New, "ConfigurationPublish", DefaultParameterSetName = "ApiFromFile")]
 public sealed class NewConfigurationPublishCommand : PSCmdlet
 {
-    private const string AzureArtifactsApiKeyPlaceholder = "AzureDevOps";
-    private const string PowerShellGalleryRepositoryName = "PSGallery";
-
     /// <summary>Choose between PowerShellGallery and GitHub.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "ApiKey")]
     [Parameter(Mandatory = true, ParameterSetName = "ApiFromFile")]
@@ -179,139 +175,39 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     /// <summary>Emits publish configuration for the build pipeline.</summary>
     protected override void ProcessRecord()
     {
-        var isAzureArtifacts = ParameterSetName == "AzureArtifacts";
-        var destination = isAzureArtifacts ? PowerForge.PublishDestination.PowerShellGallery : Type;
-        var apiKeyToUse = ParameterSetName switch
+        var settings = new PublishConfigurationFactory().Create(new PublishConfigurationRequest
         {
-            "ApiFromFile" => File.ReadAllText(FilePath).Trim(),
-            // Azure Artifacts accepts any non-empty API key placeholder for NuGet publish operations.
-            "AzureArtifacts" => AzureArtifactsApiKeyPlaceholder,
-            _ => ApiKey
-        };
-
-        if (destination == PowerForge.PublishDestination.GitHub && string.IsNullOrWhiteSpace(UserName))
-            throw new PSArgumentException("UserName is required for GitHub. Please fix New-ConfigurationPublish and provide UserName");
-
-        var repositorySecret = string.Empty;
-        if (MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryCredentialSecretFilePath)) &&
-            !string.IsNullOrWhiteSpace(RepositoryCredentialSecretFilePath))
-        {
-            repositorySecret = File.ReadAllText(RepositoryCredentialSecretFilePath!).Trim();
-        }
-        else if (MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryCredentialSecret)) &&
-                 !string.IsNullOrWhiteSpace(RepositoryCredentialSecret))
-        {
-            repositorySecret = RepositoryCredentialSecret!.Trim();
-        }
-
-        var anyRepositoryUriProvided =
-            !string.IsNullOrWhiteSpace(RepositoryUri) ||
-            !string.IsNullOrWhiteSpace(RepositorySourceUri) ||
-            !string.IsNullOrWhiteSpace(RepositoryPublishUri);
-
-        var resolvedAzureArtifactsRepositoryName = string.IsNullOrWhiteSpace(RepositoryName)
-            ? AzureArtifactsFeed?.Trim()
-            : RepositoryName?.Trim();
-
-        if (isAzureArtifacts &&
-            !string.IsNullOrWhiteSpace(resolvedAzureArtifactsRepositoryName) &&
-            string.Equals(resolvedAzureArtifactsRepositoryName, PowerShellGalleryRepositoryName, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new PSArgumentException("RepositoryName cannot be 'PSGallery' when using the Azure Artifacts preset.");
-        }
-
-        if (isAzureArtifacts && anyRepositoryUriProvided)
-            throw new PSArgumentException("RepositoryUri/RepositorySourceUri/RepositoryPublishUri cannot be combined with the Azure Artifacts preset.");
-
-        if (!isAzureArtifacts && anyRepositoryUriProvided)
-        {
-            var resolvedRepositoryName = RepositoryName?.Trim();
-            if (string.IsNullOrWhiteSpace(resolvedRepositoryName))
-                throw new PSArgumentException("RepositoryName is required when RepositoryUri/RepositorySourceUri/RepositoryPublishUri is provided.");
-            if (string.Equals(resolvedRepositoryName, PowerShellGalleryRepositoryName, StringComparison.OrdinalIgnoreCase))
-                throw new PSArgumentException("RepositoryName cannot be 'PSGallery' when RepositoryUri/RepositorySourceUri/RepositoryPublishUri is provided.");
-        }
-
-        var hasRepoCredentialSecret = !string.IsNullOrWhiteSpace(repositorySecret);
-        if (hasRepoCredentialSecret && string.IsNullOrWhiteSpace(RepositoryCredentialUserName))
-            throw new PSArgumentException("RepositoryCredentialUserName is required when RepositoryCredentialSecret/RepositoryCredentialSecretFilePath is provided.");
-
-        PublishRepositoryConfiguration? repoConfig = null;
-        var hasRepoCred = !string.IsNullOrWhiteSpace(RepositoryCredentialUserName) && hasRepoCredentialSecret;
-        var hasRepoOptions = isAzureArtifacts ||
-                             anyRepositoryUriProvided ||
-                             hasRepoCred ||
-                             MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryPriority)) ||
-                             MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryApiVersion)) ||
-                             MyInvocation.BoundParameters.ContainsKey(nameof(EnsureRepositoryRegistered)) ||
-                             UnregisterRepositoryAfterPublish.IsPresent;
-
-        if (isAzureArtifacts)
-        {
-            repoConfig = AzureArtifactsRepositoryEndpoints.CreatePublishRepositoryConfiguration(
-                AzureDevOpsOrganization,
-                AzureDevOpsProject,
-                AzureArtifactsFeed!,
-                repositoryName: RepositoryName,
-                trusted: RepositoryTrusted,
-                priority: RepositoryPriority,
-                apiVersion: RepositoryApiVersion == PowerForge.RepositoryApiVersion.Auto ? PowerForge.RepositoryApiVersion.V3 : RepositoryApiVersion,
-                ensureRegistered: EnsureRepositoryRegistered,
-                unregisterAfterUse: UnregisterRepositoryAfterPublish.IsPresent,
-                credential: hasRepoCred
-                    ? new RepositoryCredential
-                    {
-                        UserName = RepositoryCredentialUserName!.Trim(),
-                        Secret = repositorySecret
-                    }
-                    : null);
-
-            RepositoryName = repoConfig.Name;
-        }
-        else if (hasRepoOptions)
-        {
-            repoConfig = new PublishRepositoryConfiguration
-            {
-                Name = RepositoryName,
-                Uri = RepositoryUri,
-                SourceUri = RepositorySourceUri,
-                PublishUri = RepositoryPublishUri,
-                Trusted = RepositoryTrusted,
-                Priority = RepositoryPriority,
-                ApiVersion = RepositoryApiVersion,
-                EnsureRegistered = EnsureRepositoryRegistered,
-                UnregisterAfterUse = UnregisterRepositoryAfterPublish.IsPresent,
-                Credential = hasRepoCred
-                    ? new RepositoryCredential
-                    {
-                        UserName = RepositoryCredentialUserName,
-                        Secret = repositorySecret
-                    }
-                    : null
-            };
-        }
-
-        var publish = new PublishConfiguration
-        {
-            Destination = destination,
-            Tool = Tool,
-            ApiKey = apiKeyToUse,
-            ID = ID,
-            Enabled = Enabled.IsPresent,
+            ParameterSetName = ParameterSetName,
+            Type = Type,
+            AzureDevOpsOrganization = AzureDevOpsOrganization,
+            AzureDevOpsProject = AzureDevOpsProject,
+            AzureArtifactsFeed = AzureArtifactsFeed,
+            FilePath = FilePath,
+            ApiKey = ApiKey,
             UserName = UserName,
             RepositoryName = RepositoryName,
-            Repository = repoConfig,
-            Force = Force.IsPresent,
+            Tool = Tool,
+            RepositoryUri = RepositoryUri,
+            RepositorySourceUri = RepositorySourceUri,
+            RepositoryPublishUri = RepositoryPublishUri,
+            RepositoryTrusted = RepositoryTrusted,
+            RepositoryPriority = RepositoryPriority,
+            RepositoryApiVersion = RepositoryApiVersion,
+            EnsureRepositoryRegistered = EnsureRepositoryRegistered,
+            UnregisterRepositoryAfterPublish = UnregisterRepositoryAfterPublish.IsPresent,
+            RepositoryCredentialUserName = RepositoryCredentialUserName,
+            RepositoryCredentialSecret = RepositoryCredentialSecret,
+            RepositoryCredentialSecretSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryCredentialSecret)),
+            RepositoryCredentialSecretFilePath = RepositoryCredentialSecretFilePath,
+            RepositoryCredentialSecretFilePathSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryCredentialSecretFilePath)),
+            Enabled = Enabled.IsPresent,
             OverwriteTagName = OverwriteTagName,
+            Force = Force.IsPresent,
+            ID = ID,
             DoNotMarkAsPreRelease = DoNotMarkAsPreRelease.IsPresent,
             GenerateReleaseNotes = GenerateReleaseNotes.IsPresent,
             Verbose = MyInvocation.BoundParameters.ContainsKey("Verbose")
-        };
-
-        var settings = new ConfigurationPublishSegment
-        {
-            Configuration = publish
-        };
+        });
 
         WriteObject(settings);
     }

--- a/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
@@ -1,0 +1,35 @@
+namespace PowerForge;
+
+internal sealed class PublishConfigurationRequest
+{
+    public string ParameterSetName { get; set; } = string.Empty;
+    public PublishDestination Type { get; set; }
+    public string AzureDevOpsOrganization { get; set; } = string.Empty;
+    public string? AzureDevOpsProject { get; set; }
+    public string AzureArtifactsFeed { get; set; } = string.Empty;
+    public string FilePath { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;
+    public string? UserName { get; set; }
+    public string? RepositoryName { get; set; }
+    public PublishTool Tool { get; set; } = PublishTool.Auto;
+    public string? RepositoryUri { get; set; }
+    public string? RepositorySourceUri { get; set; }
+    public string? RepositoryPublishUri { get; set; }
+    public bool RepositoryTrusted { get; set; } = true;
+    public int? RepositoryPriority { get; set; }
+    public RepositoryApiVersion RepositoryApiVersion { get; set; } = RepositoryApiVersion.Auto;
+    public bool EnsureRepositoryRegistered { get; set; } = true;
+    public bool UnregisterRepositoryAfterPublish { get; set; }
+    public string? RepositoryCredentialUserName { get; set; }
+    public string? RepositoryCredentialSecret { get; set; }
+    public bool RepositoryCredentialSecretSpecified { get; set; }
+    public string? RepositoryCredentialSecretFilePath { get; set; }
+    public bool RepositoryCredentialSecretFilePathSpecified { get; set; }
+    public bool Enabled { get; set; }
+    public string? OverwriteTagName { get; set; }
+    public bool Force { get; set; }
+    public string? ID { get; set; }
+    public bool DoNotMarkAsPreRelease { get; set; }
+    public bool GenerateReleaseNotes { get; set; }
+    public bool Verbose { get; set; }
+}

--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -1,0 +1,151 @@
+using System.IO;
+
+namespace PowerForge;
+
+internal sealed class PublishConfigurationFactory
+{
+    private const string AzureArtifactsApiKeyPlaceholder = "AzureDevOps";
+    private const string PowerShellGalleryRepositoryName = "PSGallery";
+
+    public ConfigurationPublishSegment Create(PublishConfigurationRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        var isAzureArtifacts = string.Equals(request.ParameterSetName, "AzureArtifacts", StringComparison.Ordinal);
+        var destination = isAzureArtifacts ? PublishDestination.PowerShellGallery : request.Type;
+        var apiKeyToUse = request.ParameterSetName switch
+        {
+            "ApiFromFile" => File.ReadAllText(request.FilePath).Trim(),
+            "AzureArtifacts" => AzureArtifactsApiKeyPlaceholder,
+            _ => request.ApiKey
+        };
+
+        if (destination == PublishDestination.GitHub && string.IsNullOrWhiteSpace(request.UserName))
+            throw new ArgumentException("UserName is required for GitHub. Please fix New-ConfigurationPublish and provide UserName", nameof(request));
+
+        var repositorySecret = ResolveSecret(
+            request.RepositoryCredentialSecretSpecified,
+            request.RepositoryCredentialSecret,
+            request.RepositoryCredentialSecretFilePathSpecified,
+            request.RepositoryCredentialSecretFilePath);
+
+        var anyRepositoryUriProvided =
+            !string.IsNullOrWhiteSpace(request.RepositoryUri) ||
+            !string.IsNullOrWhiteSpace(request.RepositorySourceUri) ||
+            !string.IsNullOrWhiteSpace(request.RepositoryPublishUri);
+
+        var resolvedAzureArtifactsRepositoryName = string.IsNullOrWhiteSpace(request.RepositoryName)
+            ? request.AzureArtifactsFeed?.Trim()
+            : request.RepositoryName?.Trim();
+
+        if (isAzureArtifacts &&
+            !string.IsNullOrWhiteSpace(resolvedAzureArtifactsRepositoryName) &&
+            string.Equals(resolvedAzureArtifactsRepositoryName, PowerShellGalleryRepositoryName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("RepositoryName cannot be 'PSGallery' when using the Azure Artifacts preset.", nameof(request));
+        }
+
+        if (isAzureArtifacts && anyRepositoryUriProvided)
+            throw new ArgumentException("RepositoryUri/RepositorySourceUri/RepositoryPublishUri cannot be combined with the Azure Artifacts preset.", nameof(request));
+
+        if (!isAzureArtifacts && anyRepositoryUriProvided)
+        {
+            var resolvedRepositoryName = request.RepositoryName?.Trim();
+            if (string.IsNullOrWhiteSpace(resolvedRepositoryName))
+                throw new ArgumentException("RepositoryName is required when RepositoryUri/RepositorySourceUri/RepositoryPublishUri is provided.", nameof(request));
+            if (string.Equals(resolvedRepositoryName, PowerShellGalleryRepositoryName, StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("RepositoryName cannot be 'PSGallery' when RepositoryUri/RepositorySourceUri/RepositoryPublishUri is provided.", nameof(request));
+        }
+
+        var hasRepoCredentialSecret = !string.IsNullOrWhiteSpace(repositorySecret);
+        if (hasRepoCredentialSecret && string.IsNullOrWhiteSpace(request.RepositoryCredentialUserName))
+            throw new ArgumentException("RepositoryCredentialUserName is required when RepositoryCredentialSecret/RepositoryCredentialSecretFilePath is provided.", nameof(request));
+
+        PublishRepositoryConfiguration? repository = null;
+        var hasRepoCredential = !string.IsNullOrWhiteSpace(request.RepositoryCredentialUserName) && hasRepoCredentialSecret;
+        var hasRepoOptions = isAzureArtifacts ||
+                             anyRepositoryUriProvided ||
+                             hasRepoCredential ||
+                             request.RepositoryPriority is not null ||
+                             request.RepositoryApiVersion != RepositoryApiVersion.Auto ||
+                             !request.EnsureRepositoryRegistered ||
+                             request.UnregisterRepositoryAfterPublish;
+
+        if (isAzureArtifacts)
+        {
+            repository = AzureArtifactsRepositoryEndpoints.CreatePublishRepositoryConfiguration(
+                request.AzureDevOpsOrganization,
+                request.AzureDevOpsProject,
+                request.AzureArtifactsFeed!,
+                repositoryName: request.RepositoryName,
+                trusted: request.RepositoryTrusted,
+                priority: request.RepositoryPriority,
+                apiVersion: request.RepositoryApiVersion == RepositoryApiVersion.Auto ? RepositoryApiVersion.V3 : request.RepositoryApiVersion,
+                ensureRegistered: request.EnsureRepositoryRegistered,
+                unregisterAfterUse: request.UnregisterRepositoryAfterPublish,
+                credential: hasRepoCredential
+                    ? new RepositoryCredential
+                    {
+                        UserName = request.RepositoryCredentialUserName!.Trim(),
+                        Secret = repositorySecret
+                    }
+                    : null);
+
+            request.RepositoryName = repository.Name;
+        }
+        else if (hasRepoOptions)
+        {
+            repository = new PublishRepositoryConfiguration
+            {
+                Name = request.RepositoryName,
+                Uri = request.RepositoryUri,
+                SourceUri = request.RepositorySourceUri,
+                PublishUri = request.RepositoryPublishUri,
+                Trusted = request.RepositoryTrusted,
+                Priority = request.RepositoryPriority,
+                ApiVersion = request.RepositoryApiVersion,
+                EnsureRegistered = request.EnsureRepositoryRegistered,
+                UnregisterAfterUse = request.UnregisterRepositoryAfterPublish,
+                Credential = hasRepoCredential
+                    ? new RepositoryCredential
+                    {
+                        UserName = request.RepositoryCredentialUserName,
+                        Secret = repositorySecret
+                    }
+                    : null
+            };
+        }
+
+        return new ConfigurationPublishSegment
+        {
+            Configuration = new PublishConfiguration
+            {
+                Destination = destination,
+                Tool = request.Tool,
+                ApiKey = apiKeyToUse,
+                ID = request.ID,
+                Enabled = request.Enabled,
+                UserName = request.UserName,
+                RepositoryName = request.RepositoryName,
+                Repository = repository,
+                Force = request.Force,
+                OverwriteTagName = request.OverwriteTagName,
+                DoNotMarkAsPreRelease = request.DoNotMarkAsPreRelease,
+                GenerateReleaseNotes = request.GenerateReleaseNotes,
+                Verbose = request.Verbose
+            }
+        };
+    }
+
+    private static string ResolveSecret(bool secretSpecified, string? secret, bool secretFileSpecified, string? secretFilePath)
+    {
+        if (secretFileSpecified && !string.IsNullOrWhiteSpace(secretFilePath))
+            return File.ReadAllText(secretFilePath!.Trim()).Trim();
+
+        if (secretSpecified && !string.IsNullOrWhiteSpace(secret))
+            return secret!.Trim();
+
+        return string.Empty;
+    }
+}

--- a/PowerForge.Tests/PublishConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/PublishConfigurationFactoryTests.cs
@@ -1,0 +1,116 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class PublishConfigurationFactoryTests
+{
+    [Fact]
+    public void Create_reads_publish_api_key_from_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, " api-key ");
+        try
+        {
+            var factory = new PublishConfigurationFactory();
+
+            var segment = factory.Create(new PublishConfigurationRequest
+            {
+                ParameterSetName = "ApiFromFile",
+                Type = PublishDestination.PowerShellGallery,
+                FilePath = path,
+                Enabled = true
+            });
+
+            Assert.Equal("api-key", segment.Configuration.ApiKey);
+            Assert.Equal(PublishDestination.PowerShellGallery, segment.Configuration.Destination);
+            Assert.True(segment.Configuration.Enabled);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Create_throws_when_github_username_missing()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "ApiKey",
+            Type = PublishDestination.GitHub,
+            ApiKey = "token"
+        }));
+
+        Assert.Contains("UserName", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Create_builds_azure_artifacts_repository_configuration()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var segment = factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "AzureArtifacts",
+            AzureDevOpsOrganization = "contoso",
+            AzureDevOpsProject = "Platform",
+            AzureArtifactsFeed = "Modules",
+            RepositoryCredentialUserName = "user@contoso.com",
+            RepositoryCredentialSecret = "pat",
+            RepositoryCredentialSecretSpecified = true,
+            Enabled = true
+        });
+
+        Assert.Equal(PublishDestination.PowerShellGallery, segment.Configuration.Destination);
+        Assert.Equal("AzureDevOps", segment.Configuration.ApiKey);
+        Assert.Equal("Modules", segment.Configuration.RepositoryName);
+
+        var repository = Assert.IsType<PublishRepositoryConfiguration>(segment.Configuration.Repository);
+        Assert.Equal("Modules", repository.Name);
+        Assert.Equal(RepositoryApiVersion.V3, repository.ApiVersion);
+        Assert.Equal("https://pkgs.dev.azure.com/contoso/Platform/_packaging/Modules/nuget/v3/index.json", repository.Uri);
+        Assert.Equal("https://pkgs.dev.azure.com/contoso/Platform/_packaging/Modules/nuget/v2", repository.SourceUri);
+        Assert.Equal("https://pkgs.dev.azure.com/contoso/Platform/_packaging/Modules/nuget/v2", repository.PublishUri);
+
+        var credential = Assert.IsType<RepositoryCredential>(repository.Credential);
+        Assert.Equal("user@contoso.com", credential.UserName);
+        Assert.Equal("pat", credential.Secret);
+    }
+
+    [Fact]
+    public void Create_throws_when_repository_secret_has_no_username()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "ApiKey",
+            Type = PublishDestination.PowerShellGallery,
+            ApiKey = "token",
+            RepositoryCredentialSecret = "secret",
+            RepositoryCredentialSecretSpecified = true
+        }));
+
+        Assert.Contains("RepositoryCredentialUserName", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Create_throws_when_custom_repository_uses_psgallery_name()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "ApiKey",
+            Type = PublishDestination.PowerShellGallery,
+            ApiKey = "token",
+            RepositoryName = "PSGallery",
+            RepositoryUri = "https://example.test/v3/index.json"
+        }));
+
+        Assert.Contains("RepositoryName cannot be 'PSGallery'", ex.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- extract `New-ConfigurationPublish` request mapping and validation into a typed factory
- move secret-file loading and Azure Artifacts repository resolution out of the cmdlet
- add focused tests for file-backed API keys, repository credentials, and Azure Artifacts presets

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "PublishConfigurationFactoryTests|FormatConfigurationFactoryTests|ValidationConfigurationFactoryTests"`
- `pwsh .\Module\Build\Build-Module.ps1 -NoSign`

Stacked on #203.