### PR TITLE
refactor: extract information configuration factory

### DIFF
--- a/PSPublishModule/Cmdlets/NewConfigurationInformationCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationInformationCommand.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 using PowerForge;
 
@@ -72,7 +69,7 @@ public sealed class NewConfigurationInformationCommand : PSCmdlet
     /// <summary>Emits information configuration for the build pipeline.</summary>
     protected override void ProcessRecord()
     {
-        var configuration = new InformationConfiguration
+        WriteObject(new InformationConfigurationFactory().Create(new InformationConfigurationRequest
         {
             FunctionsToExportFolder = FunctionsToExportFolder,
             AliasesToExportFolder = AliasesToExportFolder,
@@ -81,34 +78,10 @@ public sealed class NewConfigurationInformationCommand : PSCmdlet
             IncludePS1 = IncludePS1,
             IncludeAll = IncludeAll,
             IncludeCustomCode = IncludeCustomCode?.ToString(),
-            IncludeToArray = NormalizeIncludeToArray(IncludeToArray),
+            IncludeToArray = IncludeToArray,
             LibrariesCore = LibrariesCore,
             LibrariesDefault = LibrariesDefault,
             LibrariesStandard = LibrariesStandard
-        };
-
-        WriteObject(new ConfigurationInformationSegment { Configuration = configuration });
-    }
-
-    private static IncludeToArrayEntry[]? NormalizeIncludeToArray(IncludeToArrayEntry[]? input)
-    {
-        if (input is null || input.Length == 0) return null;
-
-        var output = new List<IncludeToArrayEntry>();
-        foreach (var entry in input)
-        {
-            if (entry is null) continue;
-            if (string.IsNullOrWhiteSpace(entry.Key)) continue;
-
-            var values = (entry.Values ?? Array.Empty<string>())
-                .Where(v => !string.IsNullOrWhiteSpace(v))
-                .Select(v => v.Trim())
-                .ToArray();
-            if (values.Length == 0) continue;
-
-            output.Add(new IncludeToArrayEntry { Key = entry.Key.Trim(), Values = values });
-        }
-
-        return output.Count == 0 ? null : output.ToArray();
+        }));
     }
 }

--- a/PowerForge.PowerShell/Models/InformationConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/InformationConfigurationRequest.cs
@@ -1,0 +1,16 @@
+namespace PowerForge;
+
+internal sealed class InformationConfigurationRequest
+{
+    public string? FunctionsToExportFolder { get; set; }
+    public string? AliasesToExportFolder { get; set; }
+    public string[]? ExcludeFromPackage { get; set; }
+    public string[]? IncludeRoot { get; set; }
+    public string[]? IncludePS1 { get; set; }
+    public string[]? IncludeAll { get; set; }
+    public string? IncludeCustomCode { get; set; }
+    public IncludeToArrayEntry[]? IncludeToArray { get; set; }
+    public string? LibrariesCore { get; set; }
+    public string? LibrariesDefault { get; set; }
+    public string? LibrariesStandard { get; set; }
+}

--- a/PowerForge.PowerShell/Services/InformationConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/InformationConfigurationFactory.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+
+namespace PowerForge;
+
+internal sealed class InformationConfigurationFactory
+{
+    public ConfigurationInformationSegment Create(InformationConfigurationRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        return new ConfigurationInformationSegment
+        {
+            Configuration = new InformationConfiguration
+            {
+                FunctionsToExportFolder = request.FunctionsToExportFolder,
+                AliasesToExportFolder = request.AliasesToExportFolder,
+                ExcludeFromPackage = request.ExcludeFromPackage,
+                IncludeRoot = request.IncludeRoot,
+                IncludePS1 = request.IncludePS1,
+                IncludeAll = request.IncludeAll,
+                IncludeCustomCode = request.IncludeCustomCode,
+                IncludeToArray = NormalizeIncludeToArray(request.IncludeToArray),
+                LibrariesCore = request.LibrariesCore,
+                LibrariesDefault = request.LibrariesDefault,
+                LibrariesStandard = request.LibrariesStandard
+            }
+        };
+    }
+
+    private static IncludeToArrayEntry[]? NormalizeIncludeToArray(IncludeToArrayEntry[]? input)
+    {
+        if (input is null || input.Length == 0)
+            return null;
+
+        var output = new List<IncludeToArrayEntry>();
+        foreach (var entry in input)
+        {
+            if (entry is null || string.IsNullOrWhiteSpace(entry.Key))
+                continue;
+
+            var values = (entry.Values ?? Array.Empty<string>())
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v.Trim())
+                .ToArray();
+
+            if (values.Length == 0)
+                continue;
+
+            output.Add(new IncludeToArrayEntry
+            {
+                Key = entry.Key.Trim(),
+                Values = values
+            });
+        }
+
+        return output.Count == 0 ? null : output.ToArray();
+    }
+}

--- a/PowerForge.Tests/InformationConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/InformationConfigurationFactoryTests.cs
@@ -1,0 +1,71 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class InformationConfigurationFactoryTests
+{
+    [Fact]
+    public void Create_normalizes_include_to_array_entries()
+    {
+        var factory = new InformationConfigurationFactory();
+
+        var segment = factory.Create(new InformationConfigurationRequest
+        {
+            FunctionsToExportFolder = "Public",
+            IncludeCustomCode = "Write-Host 'hello'",
+            IncludeToArray =
+            [
+                new IncludeToArrayEntry
+                {
+                    Key = " Docs ",
+                    Values = [" README.md ", " CHANGELOG.md "]
+                },
+                new IncludeToArrayEntry
+                {
+                    Key = " ",
+                    Values = ["ignored"]
+                },
+                new IncludeToArrayEntry
+                {
+                    Key = "Empty",
+                    Values = [" ", ""]
+                }
+            ]
+        });
+
+        var config = Assert.IsType<InformationConfiguration>(segment.Configuration);
+        Assert.Equal("Public", config.FunctionsToExportFolder);
+        Assert.Equal("Write-Host 'hello'", config.IncludeCustomCode);
+
+        var entries = Assert.IsType<IncludeToArrayEntry[]>(config.IncludeToArray);
+        var entry = Assert.Single(entries);
+        Assert.Equal("Docs", entry.Key);
+        Assert.Equal(["README.md", "CHANGELOG.md"], entry.Values);
+    }
+
+    [Fact]
+    public void Create_returns_null_include_to_array_when_entries_do_not_resolve()
+    {
+        var factory = new InformationConfigurationFactory();
+
+        var segment = factory.Create(new InformationConfigurationRequest
+        {
+            IncludeToArray =
+            [
+                new IncludeToArrayEntry
+                {
+                    Key = " ",
+                    Values = ["x"]
+                },
+                new IncludeToArrayEntry
+                {
+                    Key = "Docs",
+                    Values = [" "]
+                }
+            ]
+        });
+
+        var config = Assert.IsType<InformationConfiguration>(segment.Configuration);
+        Assert.Null(config.IncludeToArray);
+    }
+}


### PR DESCRIPTION
## Summary
- extract `New-ConfigurationInformation` normalization and configuration construction into a typed factory
- keep include-array normalization and scriptblock serialization out of the cmdlet
- add focused tests for include-array cleanup behavior

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "InformationConfigurationFactoryTests|FileConsistencyConfigurationFactoryTests|DeliveryConfigurationFactoryTests"`
- `pwsh .\Module\Build\Build-Module.ps1 -NoSign`

Stacked on #207.