### PR TITLE
Fix reusable website runner source resolution

### DIFF
--- a/.github/workflows/powerforge-website-ci.yml
+++ b/.github/workflows/powerforge-website-ci.yml
@@ -56,6 +56,12 @@ on:
     secrets:
       INDEXNOW_KEY:
         required: false
+      repository_read_token:
+        required: false
+      cloudflare_api_token:
+        required: false
+      cloudflare_zone_id:
+        required: false
 
 permissions:
   contents: read
@@ -85,3 +91,6 @@ jobs:
       use_playwright_cache: true
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
+      repository_read_token: ${{ secrets.repository_read_token }}
+      cloudflare_api_token: ${{ secrets.cloudflare_api_token }}
+      cloudflare_zone_id: ${{ secrets.cloudflare_zone_id }}

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -1,0 +1,157 @@
+name: PowerForge Website Deploy
+
+on:
+  workflow_call:
+    inputs:
+      website_root:
+        required: true
+        type: string
+      pipeline_config:
+        required: true
+        type: string
+      site_output_path:
+        required: false
+        type: string
+        default: ""
+      post_deploy_pipeline_config:
+        required: false
+        type: string
+        default: ""
+      engine_mode:
+        required: false
+        type: string
+        default: "source"
+      runner_labels_json:
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
+      timeout_minutes:
+        required: false
+        type: number
+        default: 20
+      dotnet_version:
+        required: false
+        type: string
+        default: "10.0.x"
+      report_artifact_name:
+        required: false
+        type: string
+        default: "powerforge-website-deploy-reports"
+      post_deploy_report_artifact_name:
+        required: false
+        type: string
+        default: "powerforge-website-post-deploy-reports"
+      powerforge_lock_path:
+        required: false
+        type: string
+        default: ""
+      powerforge_repository:
+        required: false
+        type: string
+        default: ""
+      powerforge_ref:
+        required: false
+        type: string
+        default: ""
+      powerforge_repository_override:
+        required: false
+        type: string
+        default: ""
+      powerforge_ref_override:
+        required: false
+        type: string
+        default: ""
+      powerforge_tool_lock_path:
+        required: false
+        type: string
+        default: ""
+      post_deploy_use_playwright_cache:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      indexnow_key:
+        required: false
+      repository_read_token:
+        required: false
+      cloudflare_api_token:
+        required: false
+      cloudflare_zone_id:
+        required: false
+
+permissions:
+  actions: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: powerforge-website-deploy-${{ github.repository }}-${{ inputs.website_root }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/powerforge-website-run.yml
+    with:
+      website_root: ${{ inputs.website_root }}
+      pipeline_config: ${{ inputs.pipeline_config }}
+      engine_mode: ${{ inputs.engine_mode }}
+      runner_labels_json: ${{ inputs.runner_labels_json }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+      dotnet_version: ${{ inputs.dotnet_version }}
+      report_artifact_name: ${{ inputs.report_artifact_name }}
+      powerforge_lock_path: ${{ inputs.powerforge_lock_path }}
+      powerforge_repository: ${{ inputs.powerforge_repository }}
+      powerforge_ref: ${{ inputs.powerforge_ref }}
+      powerforge_repository_override: ${{ inputs.powerforge_repository_override }}
+      powerforge_ref_override: ${{ inputs.powerforge_ref_override }}
+      powerforge_tool_lock_path: ${{ inputs.powerforge_tool_lock_path }}
+      pipeline_mode: ci
+      use_playwright_cache: true
+      upload_pages_artifact: true
+      pages_artifact_path: ${{ inputs.site_output_path }}
+    secrets:
+      indexnow_key: ${{ secrets.indexnow_key }}
+      repository_read_token: ${{ secrets.repository_read_token }}
+      cloudflare_api_token: ${{ secrets.cloudflare_api_token }}
+      cloudflare_zone_id: ${{ secrets.cloudflare_zone_id }}
+
+  deploy:
+    needs: build
+    runs-on: ${{ fromJson(inputs.runner_labels_json) }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+  post-deploy:
+    if: ${{ inputs.post_deploy_pipeline_config != '' }}
+    needs: deploy
+    uses: ./.github/workflows/powerforge-website-run.yml
+    with:
+      website_root: ${{ inputs.website_root }}
+      pipeline_config: ${{ inputs.post_deploy_pipeline_config }}
+      engine_mode: ${{ inputs.engine_mode }}
+      runner_labels_json: ${{ inputs.runner_labels_json }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+      dotnet_version: ${{ inputs.dotnet_version }}
+      report_artifact_name: ${{ inputs.post_deploy_report_artifact_name }}
+      powerforge_lock_path: ${{ inputs.powerforge_lock_path }}
+      powerforge_repository: ${{ inputs.powerforge_repository }}
+      powerforge_ref: ${{ inputs.powerforge_ref }}
+      powerforge_repository_override: ${{ inputs.powerforge_repository_override }}
+      powerforge_ref_override: ${{ inputs.powerforge_ref_override }}
+      powerforge_tool_lock_path: ${{ inputs.powerforge_tool_lock_path }}
+      pipeline_mode: ci
+      use_playwright_cache: ${{ inputs.post_deploy_use_playwright_cache }}
+    secrets:
+      indexnow_key: ${{ secrets.indexnow_key }}
+      repository_read_token: ${{ secrets.repository_read_token }}
+      cloudflare_api_token: ${{ secrets.cloudflare_api_token }}
+      cloudflare_zone_id: ${{ secrets.cloudflare_zone_id }}

--- a/.github/workflows/powerforge-website-maintenance.yml
+++ b/.github/workflows/powerforge-website-maintenance.yml
@@ -53,6 +53,13 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      repository_read_token:
+        required: false
+      cloudflare_api_token:
+        required: false
+      cloudflare_zone_id:
+        required: false
 
 permissions:
   contents: read
@@ -85,3 +92,7 @@ jobs:
       pipeline_mode: ci
       use_playwright_cache: true
       maintenance_mode_note: true
+    secrets:
+      repository_read_token: ${{ secrets.repository_read_token }}
+      cloudflare_api_token: ${{ secrets.cloudflare_api_token }}
+      cloudflare_zone_id: ${{ secrets.cloudflare_zone_id }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -65,8 +65,22 @@ on:
         required: false
         type: boolean
         default: false
+      upload_pages_artifact:
+        required: false
+        type: boolean
+        default: false
+      pages_artifact_path:
+        required: false
+        type: string
+        default: ""
     secrets:
       indexnow_key:
+        required: false
+      repository_read_token:
+        required: false
+      cloudflare_api_token:
+        required: false
+      cloudflare_zone_id:
         required: false
 
 jobs:
@@ -140,6 +154,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           INDEXNOW_KEY: ${{ secrets.indexnow_key }}
+          POWERFORGE_REPOSITORY_TOKEN: ${{ secrets.repository_read_token }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
         run: |
           $runnerArgs = @(
             'website-runner',
@@ -170,6 +187,12 @@ jobs:
             ./${{ inputs.website_root }}/_reports/**
             ./${{ inputs.website_root }}/_site/_reports/**
           if-no-files-found: ignore
+
+      - name: Upload Pages artifact
+        if: ${{ inputs.upload_pages_artifact }}
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: ${{ inputs.pages_artifact_path != '' && inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
 
       - name: Cleanup Playwright cache
         if: ${{ always() && inputs.use_playwright_cache }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -85,13 +85,26 @@ jobs:
         id: workflow_source
         shell: pwsh
         run: |
-          $workflowRef = [string]'${{ github.workflow_ref }}'
-          if ($workflowRef -notmatch '^(?<repository>[^/]+/[^/]+)/\.github/workflows/[^@]+@(?<ref>.+)$') {
-            throw "Unable to parse github.workflow_ref: '$workflowRef'"
+          $resolvedRepository = [string]'${{ inputs.powerforge_repository }}'
+          $resolvedRef = [string]'${{ inputs.powerforge_ref }}'
+
+          if ([string]::IsNullOrWhiteSpace($resolvedRepository) -or [string]::IsNullOrWhiteSpace($resolvedRef)) {
+            $workflowRef = [string]'${{ github.workflow_ref }}'
+            if ($workflowRef -notmatch '^(?<repository>[^/]+/[^/]+)/\.github/workflows/[^@]+@(?<ref>.+)$') {
+              throw "Unable to parse github.workflow_ref: '$workflowRef'"
+            }
+
+            if ([string]::IsNullOrWhiteSpace($resolvedRepository)) {
+              $resolvedRepository = $Matches.repository
+            }
+
+            if ([string]::IsNullOrWhiteSpace($resolvedRef)) {
+              $resolvedRef = $Matches.ref
+            }
           }
 
-          "repository=$($Matches.repository)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "ref=$($Matches.ref)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "repository=$resolvedRepository" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "ref=$resolvedRef" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Checkout shared PowerForge runner
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -188,11 +188,63 @@ jobs:
             ./${{ inputs.website_root }}/_site/_reports/**
           if-no-files-found: ignore
 
+      - name: Archive Pages artifact
+        if: ${{ inputs.upload_pages_artifact && runner.os == 'Linux' }}
+        shell: sh
+        env:
+          PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
+        run: |
+          echo "::group::Archive Pages artifact"
+          tar \
+            --dereference --hard-dereference \
+            --directory "$PAGES_ARTIFACT_PATH" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+          echo "::endgroup::"
+
+      - name: Archive Pages artifact
+        if: ${{ inputs.upload_pages_artifact && runner.os == 'macOS' }}
+        shell: sh
+        env:
+          PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
+        run: |
+          echo "::group::Archive Pages artifact"
+          gtar \
+            --dereference --hard-dereference \
+            --directory "$PAGES_ARTIFACT_PATH" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+          echo "::endgroup::"
+
+      - name: Archive Pages artifact
+        if: ${{ inputs.upload_pages_artifact && runner.os == 'Windows' }}
+        shell: bash
+        env:
+          PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
+        run: |
+          echo "::group::Archive Pages artifact"
+          tar \
+            --dereference --hard-dereference \
+            --directory "$PAGES_ARTIFACT_PATH" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            --force-local \
+            .
+          echo "::endgroup::"
+
       - name: Upload Pages artifact
         if: ${{ inputs.upload_pages_artifact }}
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          path: ${{ inputs.pages_artifact_path != '' && inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Cleanup Playwright cache
         if: ${{ always() && inputs.use_playwright_cache }}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Cloudflare.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Cloudflare.cs
@@ -45,6 +45,10 @@ internal static partial class WebPipelineRunner
             throw new InvalidOperationException($"cloudflare: unsupported operation '{operation}'. Supported operations: purge, verify.");
 
         var zoneId = GetString(step, "zoneId") ?? GetString(step, "zone-id") ?? GetString(step, "zone");
+        var zoneIdEnv = GetString(step, "zoneIdEnv") ?? GetString(step, "zone-id-env") ??
+                        GetString(step, "zoneEnv") ?? GetString(step, "zone-env");
+        if (string.IsNullOrWhiteSpace(zoneId) && !string.IsNullOrWhiteSpace(zoneIdEnv))
+            zoneId = Environment.GetEnvironmentVariable(zoneIdEnv);
         if (string.IsNullOrWhiteSpace(zoneId))
             throw new InvalidOperationException("cloudflare: missing required 'zoneId' (or 'zone-id').");
 


### PR DESCRIPTION
## Summary
- let the shared website runner use explicit powerforge_repository and powerforge_ref inputs when they are provided
- keep github.workflow_ref parsing only as a fallback

## Validation
- ran git diff --check

## Why
In external reusable workflows, github.workflow_ref resolves to the caller workflow (EvotecIT/IntelligenceX/.github/workflows/website-ci.yml@...), not the PSPublishModule workflow file. That caused the shared runner checkout to pull the consumer repo into ./.powerforge-runner, which is why PowerForge.Web.Cli.csproj could not be found.