### PR TITLE
Unify shared release versioning for app releases

### DIFF
--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -1242,6 +1242,203 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_PlanOnly_UsesResolvedPackageVersionForDotNetPublishPlan()
+    {
+        var service = new PowerForgeReleaseService(
+            new NullLogger(),
+            executePackages: (_, _, _) =>
+            {
+                var release = new DotNetRepositoryReleaseResult
+                {
+                    Success = true,
+                    ResolvedVersion = "0.1.5"
+                };
+                release.ResolvedVersionsByProject["IntelligenceX"] = "0.1.5";
+
+                return new ProjectBuildHostExecutionResult
+                {
+                    Success = true,
+                    Result = new ProjectBuildResult
+                    {
+                        Success = true,
+                        Release = release
+                    }
+                };
+            },
+            planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+            runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+            loadDotNetToolsSpec: (_, configPath) => (new DotNetPublishSpec(), configPath),
+            planDotNetTools: (_, _, _, _) => new DotNetPublishPlan
+            {
+                ProjectRoot = Path.GetTempPath(),
+                Configuration = "Release"
+            },
+            runDotNetTools: _ => throw new InvalidOperationException("DotNet publish should not run."),
+            publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."));
+
+        var result = service.Execute(
+            new PowerForgeReleaseSpec
+            {
+                Packages = new ProjectBuildConfiguration
+                {
+                    GitHubPrimaryProject = "IntelligenceX"
+                },
+                Tools = new PowerForgeToolReleaseSpec
+                {
+                    DotNetPublish = new DotNetPublishSpec()
+                }
+            },
+            new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(Path.GetTempPath(), "release.json"),
+                PlanOnly = true
+            });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.DotNetToolPlan);
+        Assert.Equal("0.1.5", result.DotNetToolPlan!.MsBuildProperties["Version"]);
+        Assert.Equal("0.1.5", result.DotNetToolPlan.MsBuildProperties["PackageVersion"]);
+        Assert.Equal("0.1.5", result.DotNetToolPlan.MsBuildProperties["AssemblyVersion"]);
+        Assert.Equal("0.1.5", result.DotNetToolPlan.MsBuildProperties["FileVersion"]);
+        Assert.Equal("0.1.5", result.DotNetToolPlan.MsBuildProperties["InformationalVersion"]);
+    }
+
+    [Fact]
+    public void Execute_PublishesDotNetPublishAssetsToGitHub_UsingResolvedPackageVersionWhenProjectVersionIsMissing()
+    {
+        var root = CreateSandbox();
+        var zip = Path.Combine(root, "tray-portable.zip");
+        var projectPath = Path.Combine(root, "IntelligenceX.Tray.csproj");
+        File.WriteAllText(zip, "zip", new UTF8Encoding(false));
+        File.WriteAllText(projectPath, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+""", new UTF8Encoding(false));
+
+        try
+        {
+            var publishCalls = new List<GitHubReleasePublishRequest>();
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) =>
+                {
+                    var release = new DotNetRepositoryReleaseResult
+                    {
+                        Success = true,
+                        ResolvedVersion = "0.1.5"
+                    };
+                    release.ResolvedVersionsByProject["IntelligenceX"] = "0.1.5";
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                },
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (new DotNetPublishSpec(), configPath),
+                planDotNetTools: (_, _, _, _) => new DotNetPublishPlan
+                {
+                    ProjectRoot = root,
+                    Configuration = "Release",
+                    Targets = new[]
+                    {
+                        new DotNetPublishTargetPlan
+                        {
+                            Name = "IntelligenceX.Tray",
+                            ProjectPath = projectPath,
+                            Publish = new DotNetPublishPublishOptions
+                            {
+                                Framework = "net10.0-windows10.0.19041.0",
+                                Runtimes = new[] { "win-x64" },
+                                Style = DotNetPublishStyle.PortableCompat,
+                                Zip = true
+                            },
+                            Combinations = new[]
+                            {
+                                new DotNetPublishTargetCombination
+                                {
+                                    Framework = "net10.0-windows10.0.19041.0",
+                                    Runtime = "win-x64",
+                                    Style = DotNetPublishStyle.PortableCompat
+                                }
+                            }
+                        }
+                    }
+                },
+                runDotNetTools: _ => new DotNetPublishResult
+                {
+                    Succeeded = true,
+                    Artefacts = new[]
+                    {
+                        new DotNetPublishArtefactResult
+                        {
+                            Target = "IntelligenceX.Tray",
+                            Framework = "net10.0-windows10.0.19041.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat,
+                            OutputDir = root,
+                            ZipPath = zip
+                        }
+                    }
+                },
+                publishGitHubRelease: request =>
+                {
+                    publishCalls.Add(request);
+                    return new GitHubReleasePublishResult
+                    {
+                        Succeeded = true,
+                        HtmlUrl = "https://example.test/release",
+                        ReusedExistingRelease = true
+                    };
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        GitHubPrimaryProject = "IntelligenceX"
+                    },
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublish = new DotNetPublishSpec(),
+                        GitHub = new PowerForgeToolReleaseGitHubOptions
+                        {
+                            Publish = true,
+                            Owner = "EvotecIT",
+                            Repository = "IntelligenceX",
+                            Token = "token",
+                            TagTemplate = "{Target}-v{Version}",
+                            ReleaseNameTemplate = "{Target} {Version}"
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "release.json")
+                });
+
+            Assert.True(result.Success);
+            var publish = Assert.Single(publishCalls);
+            Assert.Equal("IntelligenceX.Tray-v0.1.5", publish.TagName);
+            Assert.Equal("IntelligenceX.Tray 0.1.5", publish.ReleaseName);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_PublishesDotNetPublishPreviewAssetsToStablePreviewTag()
     {
         var root = CreateSandbox();
@@ -2002,6 +2199,164 @@ public sealed class PowerForgeReleaseServiceTests
             Assert.Contains("RelativeFilePath: IntelligenceX.Tray.exe", yaml, StringComparison.Ordinal);
             Assert.Contains("Architecture: x64", yaml, StringComparison.Ordinal);
             Assert.Contains("Architecture: arm64", yaml, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_Winget_UsesResolvedPackageVersionWhenPortableTargetVersionIsMissing()
+    {
+        var root = CreateSandbox();
+        var trayX64 = Path.Combine(root, "tray-x64.zip");
+        var trayProject = Path.Combine(root, "IntelligenceX.Tray.csproj");
+        File.WriteAllText(trayX64, "zip", new UTF8Encoding(false));
+        File.WriteAllText(trayProject, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+""", new UTF8Encoding(false));
+
+        try
+        {
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) =>
+                {
+                    var release = new DotNetRepositoryReleaseResult
+                    {
+                        Success = true,
+                        ResolvedVersion = "0.1.5"
+                    };
+                    release.ResolvedVersionsByProject["IntelligenceX"] = "0.1.5";
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                },
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (new DotNetPublishSpec(), configPath),
+                planDotNetTools: (_, _, _, _) => new DotNetPublishPlan
+                {
+                    ProjectRoot = root,
+                    Configuration = "Release",
+                    Targets = new[]
+                    {
+                        new DotNetPublishTargetPlan
+                        {
+                            Name = "IntelligenceX.Tray",
+                            ProjectPath = trayProject,
+                            Publish = new DotNetPublishPublishOptions
+                            {
+                                Framework = "net10.0-windows10.0.19041.0",
+                                Runtimes = new[] { "win-x64" },
+                                Style = DotNetPublishStyle.PortableCompat,
+                                Zip = true
+                            },
+                            Combinations = new[]
+                            {
+                                new DotNetPublishTargetCombination
+                                {
+                                    Framework = "net10.0-windows10.0.19041.0",
+                                    Runtime = "win-x64",
+                                    Style = DotNetPublishStyle.PortableCompat
+                                }
+                            }
+                        }
+                    }
+                },
+                runDotNetTools: _ => new DotNetPublishResult
+                {
+                    Succeeded = true,
+                    Artefacts = new[]
+                    {
+                        new DotNetPublishArtefactResult
+                        {
+                            Category = DotNetPublishArtefactCategory.Bundle,
+                            Target = "IntelligenceX.Tray",
+                            Framework = "net10.0-windows10.0.19041.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat,
+                            OutputDir = root,
+                            PublishDir = root,
+                            ZipPath = trayX64
+                        }
+                    }
+                },
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        GitHubPrimaryProject = "IntelligenceX"
+                    },
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublish = new DotNetPublishSpec()
+                    },
+                    Outputs = new PowerForgeReleaseOutputsOptions
+                    {
+                        Staging = new PowerForgeReleaseStagingOptions
+                        {
+                            RootPath = "Artifacts/UploadReady",
+                            PortablePath = "GitHub",
+                            PortableNameTemplate = "{Target}-{Version}-{Runtime}-portable{Extension}"
+                        }
+                    },
+                    Winget = new PowerForgeReleaseWingetOptions
+                    {
+                        Enabled = true,
+                        OutputPath = "Artifacts/UploadReady/Winget",
+                        InstallerUrlTemplate = "https://github.com/EvotecIT/IntelligenceX/releases/download/v{PackageVersion}/{FileName}",
+                        Packages = new[]
+                        {
+                            new PowerForgeReleaseWingetPackage
+                            {
+                                PackageIdentifier = "EvotecIT.IntelligenceX.Tray",
+                                Publisher = "Evotec",
+                                PackageName = "IntelligenceX Tray",
+                                License = "MIT",
+                                ShortDescription = "Windows tray app for IntelligenceX.",
+                                Installers = new[]
+                                {
+                                    new PowerForgeReleaseWingetInstaller
+                                    {
+                                        Category = PowerForgeReleaseAssetCategory.Portable,
+                                        Target = "IntelligenceX.Tray",
+                                        Runtime = "win-x64",
+                                        InstallerType = "zip",
+                                        NestedInstallerType = "portable",
+                                        RelativeFilePath = "IntelligenceX.Tray.exe"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "release.json"),
+                    StageRoot = Path.Combine(root, "upload-ready")
+                });
+
+            Assert.True(result.Success);
+            var manifestPath = Assert.Single(result.WingetManifestPaths);
+            var yaml = File.ReadAllText(manifestPath);
+            Assert.Contains("PackageVersion: 0.1.5", yaml, StringComparison.Ordinal);
+            Assert.Contains("IntelligenceX.Tray-0.1.5-win-x64-portable.zip", yaml, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -1304,7 +1304,7 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
-    public void Execute_PublishesDotNetPublishAssetsToGitHub_UsingResolvedPackageVersionWhenProjectVersionIsMissing()
+    public void Execute_PublishesDotNetPublishAssetsToGitHub_PrefersResolvedPackageVersionOverProjectVersion()
     {
         var root = CreateSandbox();
         var zip = Path.Combine(root, "tray-portable.zip");
@@ -1314,6 +1314,7 @@ public sealed class PowerForgeReleaseServiceTests
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <Version>9.9.9</Version>
   </PropertyGroup>
 </Project>
 """, new UTF8Encoding(false));
@@ -2207,7 +2208,7 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
-    public void Execute_Winget_UsesResolvedPackageVersionWhenPortableTargetVersionIsMissing()
+    public void Execute_Winget_PrefersResolvedPackageVersionOverPortableTargetVersion()
     {
         var root = CreateSandbox();
         var trayX64 = Path.Combine(root, "tray-x64.zip");
@@ -2217,6 +2218,7 @@ public sealed class PowerForgeReleaseServiceTests
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <Version>9.9.9</Version>
   </PropertyGroup>
 </Project>
 """, new UTF8Encoding(false));

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -895,6 +895,9 @@ internal sealed class PowerForgeReleaseService
 
     private static string? ResolveDotNetTargetVersion(DotNetPublishTargetPlan target, DotNetPublishResult result, string? sharedReleaseVersion)
     {
+        if (!string.IsNullOrWhiteSpace(sharedReleaseVersion))
+            return sharedReleaseVersion;
+
         if (!string.IsNullOrWhiteSpace(target.ProjectPath)
             && File.Exists(target.ProjectPath)
             && CsprojVersionEditor.TryGetVersion(target.ProjectPath, out var version)
@@ -1914,13 +1917,16 @@ internal sealed class PowerForgeReleaseService
 
     private static string? ResolveDotNetArtefactVersion(DotNetPublishArtefactResult artifact, DotNetPublishPlan? plan, string? sharedReleaseVersion)
     {
+        if (!string.IsNullOrWhiteSpace(sharedReleaseVersion))
+            return sharedReleaseVersion;
+
         if (plan?.Targets is null)
-            return string.IsNullOrWhiteSpace(sharedReleaseVersion) ? null : sharedReleaseVersion;
+            return null;
 
         var target = plan.Targets.FirstOrDefault(candidate =>
             string.Equals(candidate.Name, artifact.Target, StringComparison.OrdinalIgnoreCase));
         if (target is null)
-            return string.IsNullOrWhiteSpace(sharedReleaseVersion) ? null : sharedReleaseVersion;
+            return null;
 
         var version = !string.IsNullOrWhiteSpace(target.ProjectPath)
             && File.Exists(target.ProjectPath)
@@ -1929,7 +1935,7 @@ internal sealed class PowerForgeReleaseService
             ? resolvedVersion
             : null;
 
-        return string.IsNullOrWhiteSpace(version) ? sharedReleaseVersion : version;
+        return version;
     }
 
     private sealed class ResolvedWingetInstallerEntry

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -203,6 +203,8 @@ internal sealed class PowerForgeReleaseService
             }
         }
 
+        var sharedReleaseVersion = ResolveSharedReleaseVersion(spec, result);
+
         if (runTools)
         {
             ApplyToolRequestOverrides(spec.Tools!, request, configurationOverride);
@@ -210,6 +212,7 @@ internal sealed class PowerForgeReleaseService
             {
                 var (dotNetSpec, dotNetSourcePath) = _loadDotNetToolsSpec(spec.Tools!, configPath);
                 var dotNetPlan = _planDotNetTools(dotNetSpec, dotNetSourcePath, request, selectedToolOutputs);
+                ApplySharedReleaseVersion(dotNetPlan, sharedReleaseVersion);
                 ApplyDotNetPublishSkipFlags(dotNetPlan, request.SkipRestore, request.SkipBuild);
                 result.DotNetToolPlan = dotNetPlan;
 
@@ -228,7 +231,7 @@ internal sealed class PowerForgeReleaseService
                     var publishToolGitHub = request.PublishToolGitHub ?? spec.Tools!.GitHub.Publish;
                     if (publishToolGitHub)
                     {
-                        var releases = PublishDotNetToolGitHubReleases(spec, configDirectory, dotNetPlan, dotNetTools);
+                        var releases = PublishDotNetToolGitHubReleases(spec, configDirectory, dotNetPlan, dotNetTools, sharedReleaseVersion);
                         result.ToolGitHubReleases = releases;
                         var failures = releases.Where(entry => !entry.Success).ToArray();
                         if (failures.Length > 0)
@@ -275,7 +278,7 @@ internal sealed class PowerForgeReleaseService
 
         if (!request.PlanOnly && !request.ValidateOnly)
         {
-            PopulateReleaseOutputs(spec, request, configDirectory, result);
+            PopulateReleaseOutputs(spec, request, configDirectory, result, sharedReleaseVersion);
             GenerateWingetOutputs(spec, configDirectory, result);
         }
 
@@ -399,13 +402,99 @@ internal sealed class PowerForgeReleaseService
         return options;
     }
 
+    private static string? ResolveSharedReleaseVersion(PowerForgeReleaseSpec spec, PowerForgeReleaseResult result)
+    {
+        var release = result.Packages?.Result.Release;
+        if (release is null)
+            return null;
+
+        var primaryProject = string.IsNullOrWhiteSpace(spec.Packages?.GitHubPrimaryProject)
+            ? null
+            : spec.Packages!.GitHubPrimaryProject!.Trim();
+        if (!string.IsNullOrWhiteSpace(primaryProject))
+        {
+            if (release.ResolvedVersionsByProject.TryGetValue(primaryProject!, out var primaryVersion)
+                && !string.IsNullOrWhiteSpace(primaryVersion))
+            {
+                return primaryVersion;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(release.ResolvedVersion))
+            return release.ResolvedVersion;
+
+        var distinctVersions = release.ResolvedVersionsByProject.Values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return distinctVersions.Length == 1 ? distinctVersions[0] : null;
+    }
+
+    private static void ApplySharedReleaseVersion(DotNetPublishPlan plan, string? sharedReleaseVersion)
+    {
+        if (plan is null)
+            throw new ArgumentNullException(nameof(plan));
+        if (string.IsNullOrWhiteSpace(sharedReleaseVersion))
+            return;
+
+        foreach (var entry in BuildSharedReleaseVersionProperties(sharedReleaseVersion!))
+            plan.MsBuildProperties[entry.Key] = entry.Value;
+    }
+
+    private static Dictionary<string, string> BuildSharedReleaseVersionProperties(string sharedReleaseVersion)
+    {
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Version"] = sharedReleaseVersion,
+            ["PackageVersion"] = sharedReleaseVersion,
+            ["InformationalVersion"] = sharedReleaseVersion
+        };
+
+        var numericVersion = NormalizeSharedReleaseAssemblyVersion(sharedReleaseVersion);
+        if (!string.IsNullOrWhiteSpace(numericVersion))
+        {
+            properties["VersionPrefix"] = numericVersion!;
+            properties["AssemblyVersion"] = numericVersion!;
+            properties["FileVersion"] = numericVersion!;
+        }
+
+        return properties;
+    }
+
+    private static string? NormalizeSharedReleaseAssemblyVersion(string version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+
+        var core = version.Trim();
+        var separatorIndex = core.IndexOfAny(new[] { '-', '+' });
+        if (separatorIndex >= 0)
+            core = core.Substring(0, separatorIndex);
+
+        if (string.IsNullOrWhiteSpace(core))
+            return null;
+
+        var segments = core.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(segment => segment.Trim())
+            .ToArray();
+        if (segments.Length == 0 || segments.Length > 4)
+            return null;
+
+        if (segments.Any(segment => !int.TryParse(segment, out _)))
+            return null;
+
+        return string.Join(".", segments);
+    }
+
     private void PopulateReleaseOutputs(
         PowerForgeReleaseSpec spec,
         PowerForgeReleaseRequest request,
         string configDirectory,
-        PowerForgeReleaseResult result)
+        PowerForgeReleaseResult result,
+        string? sharedReleaseVersion)
     {
-        var assetEntries = CollectReleaseAssetEntries(result, result.DotNetToolPlan)
+        var assetEntries = CollectReleaseAssetEntries(result, result.DotNetToolPlan, sharedReleaseVersion)
             .GroupBy(entry => entry.Path, StringComparer.OrdinalIgnoreCase)
             .Select(group => group.First())
             .ToArray();
@@ -647,7 +736,8 @@ internal sealed class PowerForgeReleaseService
         PowerForgeReleaseSpec spec,
         string configDirectory,
         DotNetPublishPlan plan,
-        DotNetPublishResult result)
+        DotNetPublishResult result,
+        string? sharedReleaseVersion)
     {
         var gitHub = spec.Tools?.GitHub ?? new PowerForgeToolReleaseGitHubOptions();
         var resolved = ResolveGitHubConfiguration(spec, gitHub, configDirectory);
@@ -668,7 +758,7 @@ internal sealed class PowerForgeReleaseService
         var releases = new List<PowerForgeToolGitHubReleaseResult>();
         foreach (var target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
         {
-            var version = ResolveDotNetTargetVersion(target, result);
+            var version = ResolveDotNetTargetVersion(target, result, sharedReleaseVersion);
             if (string.IsNullOrWhiteSpace(version))
             {
                 releases.Add(new PowerForgeToolGitHubReleaseResult
@@ -803,7 +893,7 @@ internal sealed class PowerForgeReleaseService
         }
     }
 
-    private static string? ResolveDotNetTargetVersion(DotNetPublishTargetPlan target, DotNetPublishResult result)
+    private static string? ResolveDotNetTargetVersion(DotNetPublishTargetPlan target, DotNetPublishResult result, string? sharedReleaseVersion)
     {
         if (!string.IsNullOrWhiteSpace(target.ProjectPath)
             && File.Exists(target.ProjectPath)
@@ -818,7 +908,10 @@ internal sealed class PowerForgeReleaseService
             .Select(entry => entry.Version)
             .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 
-        return string.IsNullOrWhiteSpace(msiVersion) ? null : msiVersion;
+        if (!string.IsNullOrWhiteSpace(msiVersion))
+            return msiVersion;
+
+        return string.IsNullOrWhiteSpace(sharedReleaseVersion) ? null : sharedReleaseVersion;
     }
 
     private static (string? Owner, string? Repository, string? Token, PowerForgeToolGitHubReleaseResult? Error) ResolveGitHubConfiguration(
@@ -1365,7 +1458,8 @@ internal sealed class PowerForgeReleaseService
 
     private static PowerForgeReleaseAssetEntry[] CollectReleaseAssetEntries(
         PowerForgeReleaseResult result,
-        DotNetPublishPlan? dotNetPlan)
+        DotNetPublishPlan? dotNetPlan,
+        string? sharedReleaseVersion)
     {
         var assets = new List<PowerForgeReleaseAssetEntry>();
 
@@ -1394,7 +1488,7 @@ internal sealed class PowerForgeReleaseService
 
         assets.AddRange(
             (result.DotNetTools?.Artefacts ?? Array.Empty<DotNetPublishArtefactResult>())
-            .SelectMany(artifact => CreateDotNetArtefactEntries(artifact, dotNetPlan)));
+            .SelectMany(artifact => CreateDotNetArtefactEntries(artifact, dotNetPlan, sharedReleaseVersion)));
 
         assets.AddRange(
             (result.DotNetTools?.MsiBuilds ?? Array.Empty<DotNetPublishMsiBuildResult>())
@@ -1486,12 +1580,13 @@ internal sealed class PowerForgeReleaseService
 
     private static IEnumerable<PowerForgeReleaseAssetEntry> CreateDotNetArtefactEntries(
         DotNetPublishArtefactResult artifact,
-        DotNetPublishPlan? dotNetPlan)
+        DotNetPublishPlan? dotNetPlan,
+        string? sharedReleaseVersion)
     {
         if (string.IsNullOrWhiteSpace(artifact.ZipPath) || !File.Exists(artifact.ZipPath))
             yield break;
 
-        var version = ResolveDotNetArtefactVersion(artifact, dotNetPlan);
+        var version = ResolveDotNetArtefactVersion(artifact, dotNetPlan, sharedReleaseVersion);
 
         yield return new PowerForgeReleaseAssetEntry
         {
@@ -1817,22 +1912,24 @@ internal sealed class PowerForgeReleaseService
         throw new InvalidOperationException($"Could not infer Winget architecture from runtime '{runtime ?? "<null>"}'. Set the installer Architecture explicitly.");
     }
 
-    private static string? ResolveDotNetArtefactVersion(DotNetPublishArtefactResult artifact, DotNetPublishPlan? plan)
+    private static string? ResolveDotNetArtefactVersion(DotNetPublishArtefactResult artifact, DotNetPublishPlan? plan, string? sharedReleaseVersion)
     {
         if (plan?.Targets is null)
-            return null;
+            return string.IsNullOrWhiteSpace(sharedReleaseVersion) ? null : sharedReleaseVersion;
 
         var target = plan.Targets.FirstOrDefault(candidate =>
             string.Equals(candidate.Name, artifact.Target, StringComparison.OrdinalIgnoreCase));
         if (target is null)
-            return null;
+            return string.IsNullOrWhiteSpace(sharedReleaseVersion) ? null : sharedReleaseVersion;
 
-        return !string.IsNullOrWhiteSpace(target.ProjectPath)
+        var version = !string.IsNullOrWhiteSpace(target.ProjectPath)
             && File.Exists(target.ProjectPath)
-            && CsprojVersionEditor.TryGetVersion(target.ProjectPath, out var version)
-            && !string.IsNullOrWhiteSpace(version)
-            ? version
+            && CsprojVersionEditor.TryGetVersion(target.ProjectPath, out var resolvedVersion)
+            && !string.IsNullOrWhiteSpace(resolvedVersion)
+            ? resolvedVersion
             : null;
+
+        return string.IsNullOrWhiteSpace(version) ? sharedReleaseVersion : version;
     }
 
     private sealed class ResolvedWingetInstallerEntry


### PR DESCRIPTION
## Summary
- use the unified package release result as the shared release version for dotnet app/tool releases
- stamp that shared version into dotnet publish MSBuild properties so app binaries, GitHub tags, staged asset names, and Winget can stay aligned
- add regression coverage for shared-version planning, GitHub publishing, and Winget fallback behavior

## Testing
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter PowerForgeReleaseServiceTests
- dotnet build .\PowerForge.Cli\PowerForge.Cli.csproj -c Release -f net10.0
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net8.0
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472
