### PR TITLE
Extract core module validation checks

### DIFF
--- a/Docs/PowerForge.ModuleLayeringCleanup.md
+++ b/Docs/PowerForge.ModuleLayeringCleanup.md
@@ -1,6 +1,6 @@
 # PowerForge Module Layering Cleanup
 
-Last updated: 2026-04-02
+Last updated: 2026-04-03
 
 ## Goal
 
@@ -157,6 +157,7 @@ Current status:
 - `ModulePipelineExecutionSession` now owns planned step lookup, artefact/publish step mapping, progress callbacks, and skipped-step reporting, which removes the bulk of the run-loop bookkeeping from `ModulePipelineRunner.Run`.
 - The validation, test, packaging, publish, and install phases now run through dedicated runner helper methods backed by a shared run-state object, so `ModulePipelineRunner.Run` is acting more like an orchestrator than a giant mutable script.
 - The stage/build/manifest/docs/format/sign phases now also run through dedicated helpers, leaving `ModulePipelineRunner.Run` as a thin phase orchestrator with shared cleanup/failure handling.
+- The host-neutral structure, binary-export, and csproj validation checks now flow through `ModuleValidationCoreChecks` in `PowerForge`, while documentation extraction, PSScriptAnalyzer, file syntax/token checks, and test execution remain PowerShell-hosted in `ModuleValidationService`.
 - The next extraction target is the remaining bootstrapper/delivery result-shaping surface in `ModulePipelineRunner`, plus eventual retirement of the legacy analyzer output models that now sit entirely behind the PowerShell adapter seam.
 
 ### Phase 4: Publish and validation decomposition

--- a/PowerForge.Tests/ModuleValidationCoreChecksTests.cs
+++ b/PowerForge.Tests/ModuleValidationCoreChecksTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Management.Automation;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class ModuleValidationCoreChecksTests
+{
+    [Fact]
+    public void ValidateStructure_ReportsExportAndManifestFileIssues()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Public"));
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Internal"));
+
+            File.WriteAllText(Path.Combine(root.FullName, "Public", "Get-PublicThing.ps1"), "function Get-PublicThing { }");
+            File.WriteAllText(Path.Combine(root.FullName, "Internal", "Invoke-HiddenThing.ps1"), "function Invoke-HiddenThing { }");
+
+            var manifestPath = Path.Combine(root.FullName, "SampleModule.psd1");
+            File.WriteAllText(manifestPath, """
+@{
+    RootModule = 'SampleModule.psm1'
+    FunctionsToExport = @('Invoke-HiddenThing')
+    FormatsToProcess = @('SampleModule.format.ps1xml')
+    TypesToProcess = @('SampleModule.types.ps1xml')
+    RequiredAssemblies = @('MissingBinary.dll')
+}
+""");
+
+            var result = ModuleValidationCoreChecks.ValidateStructure(
+                new ModuleValidationSpec
+                {
+                    ProjectRoot = root.FullName,
+                    StagingPath = root.FullName,
+                    ManifestPath = manifestPath
+                },
+                new ModuleStructureValidationSettings
+                {
+                    Severity = ValidationSeverity.Warning,
+                    PublicFunctionPaths = new[] { "Public" },
+                    InternalFunctionPaths = new[] { "Internal" },
+                    ValidateExports = true,
+                    ValidateInternalNotExported = true,
+                    ValidateManifestFiles = true,
+                    AllowWildcardExports = false
+                });
+
+            Assert.NotNull(result);
+            Assert.Equal("Module structure", result!.Name);
+            Assert.Equal(CheckStatus.Warning, result.Status);
+            Assert.Contains("public functions 1", result.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("internal functions 1", result.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(result.Issues, issue => issue.Contains("Public functions not exported: Get-PublicThing", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Exports not found in public folder: Invoke-HiddenThing", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Internal functions exported: Invoke-HiddenThing", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("RootModule missing: SampleModule.psm1", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Format file missing: SampleModule.format.ps1xml", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Type file missing: SampleModule.types.ps1xml", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Required assembly missing: MissingBinary.dll", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ValidateBinary_ReportsManifestExportMismatchAgainstDetectedBinaryExports()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var manifestPath = Path.Combine(root.FullName, "BinaryModule.psd1");
+            File.WriteAllText(manifestPath,
+                "@{" + Environment.NewLine +
+                $"    RootModule = '{typeof(GetValidationExampleCommand).Assembly.Location}'" + Environment.NewLine +
+                "    CmdletsToExport = @('Set-OtherCommand')" + Environment.NewLine +
+                "    AliasesToExport = @('missing-alias')" + Environment.NewLine +
+                "}");
+
+            var result = ModuleValidationCoreChecks.ValidateBinary(
+                new ModuleValidationSpec
+                {
+                    ProjectRoot = root.FullName,
+                    StagingPath = root.FullName,
+                    ManifestPath = manifestPath
+                },
+                new BinaryModuleValidationSettings
+                {
+                    Severity = ValidationSeverity.Warning,
+                    ValidateAssembliesExist = true,
+                    ValidateManifestExports = true,
+                    AllowWildcardExports = false
+                });
+
+            Assert.NotNull(result);
+            Assert.Equal("Binary exports", result!.Name);
+            Assert.Equal(CheckStatus.Warning, result.Status);
+            Assert.Contains("cmdlets", result.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("aliases", result.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(result.Issues, issue => issue.Contains("Binary cmdlets not exported:", StringComparison.Ordinal) &&
+                                                    issue.Contains("Get-ValidationExample", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Manifest cmdlets missing from binaries: Set-OtherCommand", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Binary aliases not exported:", StringComparison.Ordinal) &&
+                                                    issue.Contains("gvx", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("Manifest aliases missing from binaries: missing-alias", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ValidateCsproj_ReportsMissingTargetFrameworkAndInvalidOutputType()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectPath = Path.Combine(root.FullName, "SampleModule.csproj");
+            File.WriteAllText(projectPath, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>
+""");
+
+            var result = ModuleValidationCoreChecks.ValidateCsproj(
+                new ModuleValidationSpec
+                {
+                    ProjectRoot = root.FullName,
+                    BuildSpec = new ModuleBuildSpec
+                    {
+                        CsprojPath = "SampleModule.csproj"
+                    }
+                },
+                new CsprojValidationSettings
+                {
+                    Severity = ValidationSeverity.Warning,
+                    RequireTargetFramework = true,
+                    RequireLibraryOutput = true
+                });
+
+            Assert.NotNull(result);
+            Assert.Equal("Csproj", result!.Name);
+            Assert.Equal(CheckStatus.Warning, result.Status);
+            Assert.Contains(result.Issues, issue => issue.Contains("TargetFramework/TargetFrameworks not set.", StringComparison.Ordinal));
+            Assert.Contains(result.Issues, issue => issue.Contains("OutputType is 'Exe' (expected Library).", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Cmdlet(VerbsCommon.Get, "ValidationExample")]
+    [Alias("gvx")]
+    private sealed class GetValidationExampleCommand : PSCmdlet
+    {
+    }
+}

--- a/PowerForge.Tests/ModuleValidationCoreChecksTests.cs
+++ b/PowerForge.Tests/ModuleValidationCoreChecksTests.cs
@@ -68,6 +68,51 @@ public sealed class ModuleValidationCoreChecksTests
     }
 
     [Fact]
+    public void ValidateStructure_SkipsStrictExportComparisonForMixedManifestExpressions()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Public"));
+            File.WriteAllText(Path.Combine(root.FullName, "Public", "Get-PublicThing.ps1"), "function Get-PublicThing { }");
+
+            var manifestPath = Path.Combine(root.FullName, "SampleModule.psd1");
+            File.WriteAllText(manifestPath, """
+@{
+    FunctionsToExport = @('Get-PublicThing', $DynamicExport)
+}
+""");
+
+            var result = ModuleValidationCoreChecks.ValidateStructure(
+                new ModuleValidationSpec
+                {
+                    ProjectRoot = root.FullName,
+                    StagingPath = root.FullName,
+                    ManifestPath = manifestPath
+                },
+                new ModuleStructureValidationSettings
+                {
+                    Severity = ValidationSeverity.Warning,
+                    PublicFunctionPaths = new[] { "Public" },
+                    InternalFunctionPaths = Array.Empty<string>(),
+                    ValidateExports = true,
+                    ValidateInternalNotExported = false,
+                    ValidateManifestFiles = false,
+                    AllowWildcardExports = false
+                });
+
+            Assert.NotNull(result);
+            Assert.Equal(CheckStatus.Pass, result!.Status);
+            Assert.DoesNotContain(result.Issues, issue => issue.Contains("not exported", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(result.Issues, issue => issue.Contains("public folder", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void ValidateBinary_ReportsManifestExportMismatchAgainstDetectedBinaryExports()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Services/ModuleManifestTextParser.cs
+++ b/PowerForge/Services/ModuleManifestTextParser.cs
@@ -94,6 +94,16 @@ internal static class ModuleManifestTextParser
         return true;
     }
 
+    internal static bool TryGetStrictStringArrayValue(string manifestText, string key, out string[]? values)
+    {
+        values = null;
+        if (!TryReadAssignedExpressionByKey(manifestText, key, out var expression) ||
+            string.IsNullOrWhiteSpace(expression))
+            return false;
+
+        return TryParseStrictStringArrayExpression(expression!, out values);
+    }
+
     internal static bool TryParseStringArrayExpression(string expression, out string[]? values)
     {
         values = null;
@@ -105,6 +115,37 @@ internal static class ModuleManifestTextParser
             .ToArray();
 
         values = parsed;
+        return true;
+    }
+
+    internal static bool TryParseStrictStringArrayExpression(string expression, out string[]? values)
+    {
+        values = null;
+        if (string.IsNullOrWhiteSpace(expression))
+            return false;
+
+        var trimmed = expression.Trim();
+        if (TryUnquote(trimmed, out var singleValue) && !string.IsNullOrWhiteSpace(singleValue))
+        {
+            values = new[] { singleValue };
+            return true;
+        }
+
+        if (!IsArrayExpression(trimmed))
+            return false;
+
+        var parsed = new List<string>();
+        var body = TrimCompositeWrapper(trimmed);
+        var index = 0;
+        while (TryReadValueExpression(body, ref index, out var itemExpression))
+        {
+            if (!TryUnquote(itemExpression, out var value) || string.IsNullOrWhiteSpace(value))
+                return false;
+
+            parsed.Add(value);
+        }
+
+        values = parsed.ToArray();
         return true;
     }
 

--- a/PowerForge/Services/ModuleManifestValueReader.cs
+++ b/PowerForge/Services/ModuleManifestValueReader.cs
@@ -33,6 +33,17 @@ internal static class ModuleManifestValueReader
         return Array.Empty<string>();
     }
 
+    internal static string[]? ReadTopLevelLiteralStringOrArray(string manifestPath, string key)
+    {
+        if (!TryReadManifestText(manifestPath, out var manifestText))
+            return null;
+
+        if (ModuleManifestTextParser.TryGetStrictStringArrayValue(manifestText, key, out var values) && values is not null)
+            return values;
+
+        return null;
+    }
+
     internal static string[] ReadPsDataStringOrArray(string manifestPath, string key)
     {
         if (!TryReadManifestText(manifestPath, out var manifestText))

--- a/PowerForge/Services/ModuleValidationCoreChecks.cs
+++ b/PowerForge/Services/ModuleValidationCoreChecks.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace PowerForge;
+
+internal static class ModuleValidationCoreChecks
+{
+    internal static ModuleValidationCheckResult? ValidateStructure(
+        ModuleValidationSpec spec,
+        ModuleStructureValidationSettings settings)
+    {
+        if (settings.Severity == ValidationSeverity.Off) return null;
+
+        var issues = new List<string>();
+        var summaryParts = new List<string>(4);
+
+        var manifestPath = spec.ManifestPath ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(manifestPath) || !File.Exists(manifestPath))
+        {
+            issues.Add("Manifest not found.");
+            return BuildResult("Module structure", settings.Severity, issues, "manifest missing");
+        }
+
+        var moduleRoot = string.IsNullOrWhiteSpace(spec.StagingPath)
+            ? Path.GetDirectoryName(manifestPath) ?? string.Empty
+            : spec.StagingPath;
+
+        var publicFunctions = DiscoverFunctionFileNames(moduleRoot, settings.PublicFunctionPaths);
+        if (publicFunctions.Count > 0)
+            summaryParts.Add($"public functions {publicFunctions.Count}");
+
+        var internalFunctions = DiscoverFunctionFileNames(moduleRoot, settings.InternalFunctionPaths);
+        if (internalFunctions.Count > 0)
+            summaryParts.Add($"internal functions {internalFunctions.Count}");
+
+        if (settings.ValidateExports)
+        {
+            var (exportedFunctions, wildcardExport) = GetManifestStringArray(manifestPath, "FunctionsToExport");
+            if (wildcardExport && !settings.AllowWildcardExports)
+            {
+                issues.Add("FunctionsToExport uses wildcard; cannot validate exports.");
+            }
+            else if (exportedFunctions is { Length: > 0 } && !wildcardExport)
+            {
+                var exportedSet = new HashSet<string>(exportedFunctions, StringComparer.OrdinalIgnoreCase);
+                summaryParts.Add($"exports {exportedSet.Count}");
+
+                var missing = publicFunctions.Where(f => !exportedSet.Contains(f)).ToArray();
+                var extra = exportedSet.Where(f => !publicFunctions.Contains(f)).ToArray();
+
+                if (missing.Length > 0)
+                    issues.Add($"Public functions not exported: {FormatList(missing)}");
+                if (extra.Length > 0)
+                    issues.Add($"Exports not found in public folder: {FormatList(extra)}");
+            }
+        }
+
+        if (settings.ValidateInternalNotExported && internalFunctions.Count > 0)
+        {
+            var (exportedFunctions, wildcardExport) = GetManifestStringArray(manifestPath, "FunctionsToExport");
+            if (exportedFunctions is { Length: > 0 } && !wildcardExport)
+            {
+                var exportedSet = new HashSet<string>(exportedFunctions, StringComparer.OrdinalIgnoreCase);
+                var leaked = internalFunctions.Where(f => exportedSet.Contains(f)).ToArray();
+                if (leaked.Length > 0)
+                    issues.Add($"Internal functions exported: {FormatList(leaked)}");
+            }
+        }
+
+        if (settings.ValidateManifestFiles)
+        {
+            if (ModuleManifestValueReader.TryGetTopLevelString(manifestPath, "RootModule", out var root) &&
+                !string.IsNullOrWhiteSpace(root) &&
+                !File.Exists(Path.Combine(moduleRoot, root)))
+            {
+                issues.Add($"RootModule missing: {root}");
+            }
+
+            foreach (var format in ModuleManifestValueReader.ReadTopLevelStringOrArray(manifestPath, "FormatsToProcess"))
+            {
+                if (string.IsNullOrWhiteSpace(format)) continue;
+                if (!File.Exists(Path.Combine(moduleRoot, format)))
+                    issues.Add($"Format file missing: {format}");
+            }
+
+            foreach (var type in ModuleManifestValueReader.ReadTopLevelStringOrArray(manifestPath, "TypesToProcess"))
+            {
+                if (string.IsNullOrWhiteSpace(type)) continue;
+                if (!File.Exists(Path.Combine(moduleRoot, type)))
+                    issues.Add($"Type file missing: {type}");
+            }
+
+            foreach (var assembly in ModuleManifestValueReader.ReadTopLevelStringOrArray(manifestPath, "RequiredAssemblies"))
+            {
+                if (string.IsNullOrWhiteSpace(assembly)) continue;
+                if (assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!File.Exists(Path.Combine(moduleRoot, assembly)))
+                        issues.Add($"Required assembly missing: {assembly}");
+                }
+                else if (!TryLoadAssembly(assembly, out var error))
+                {
+                    issues.Add($"Required assembly failed to load: {assembly} ({error})");
+                }
+            }
+        }
+
+        var summary = summaryParts.Count == 0 ? "structure verified" : string.Join(", ", summaryParts);
+        return BuildResult("Module structure", settings.Severity, issues, summary);
+    }
+
+    internal static ModuleValidationCheckResult? ValidateBinary(
+        ModuleValidationSpec spec,
+        BinaryModuleValidationSettings settings)
+    {
+        if (settings.Severity == ValidationSeverity.Off) return null;
+
+        var issues = new List<string>();
+        var summaryParts = new List<string>(3);
+        var manifestPath = spec.ManifestPath ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(manifestPath) || !File.Exists(manifestPath))
+        {
+            issues.Add("Manifest not found.");
+            return BuildResult("Binary exports", settings.Severity, issues, "manifest missing");
+        }
+
+        var moduleRoot = string.IsNullOrWhiteSpace(spec.StagingPath)
+            ? Path.GetDirectoryName(manifestPath) ?? string.Empty
+            : spec.StagingPath;
+
+        var assemblyPaths = ResolveManifestAssemblies(manifestPath)
+            .Where(a => !string.IsNullOrWhiteSpace(a) && a.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .Select(a => Path.Combine(moduleRoot, a))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (assemblyPaths.Length == 0)
+            return BuildResult("Binary exports", settings.Severity, issues, "no binaries");
+
+        if (settings.ValidateAssembliesExist)
+        {
+            foreach (var asm in assemblyPaths)
+            {
+                if (!File.Exists(asm))
+                    issues.Add($"Assembly missing: {Path.GetFileName(asm)}");
+            }
+        }
+
+        var existingAssemblies = assemblyPaths.Where(File.Exists).ToArray();
+        if (existingAssemblies.Length == 0)
+            return BuildResult("Binary exports", settings.Severity, issues, "no binaries");
+
+        if (settings.ValidateManifestExports)
+        {
+            var detectedCmdlets = BinaryExportDetector.DetectBinaryCmdlets(existingAssemblies);
+            var detectedAliases = BinaryExportDetector.DetectBinaryAliases(existingAssemblies);
+
+            var (manifestCmdlets, cmdletWildcard) = GetManifestStringArray(manifestPath, "CmdletsToExport");
+            var (manifestAliases, aliasWildcard) = GetManifestStringArray(manifestPath, "AliasesToExport");
+
+            if (cmdletWildcard && !settings.AllowWildcardExports)
+                issues.Add("CmdletsToExport uses wildcard; cannot validate binary exports.");
+            else if (manifestCmdlets is { Length: > 0 } && !cmdletWildcard)
+            {
+                var cmdletSet = new HashSet<string>(manifestCmdlets, StringComparer.OrdinalIgnoreCase);
+                var missing = detectedCmdlets.Where(c => !cmdletSet.Contains(c)).ToArray();
+                var extra = cmdletSet.Where(c => !detectedCmdlets.Contains(c)).ToArray();
+                if (missing.Length > 0)
+                    issues.Add($"Binary cmdlets not exported: {FormatList(missing)}");
+                if (extra.Length > 0)
+                    issues.Add($"Manifest cmdlets missing from binaries: {FormatList(extra)}");
+            }
+
+            if (aliasWildcard && !settings.AllowWildcardExports)
+                issues.Add("AliasesToExport uses wildcard; cannot validate binary exports.");
+            else if (manifestAliases is { Length: > 0 } && !aliasWildcard)
+            {
+                var aliasSet = new HashSet<string>(manifestAliases, StringComparer.OrdinalIgnoreCase);
+                var missing = detectedAliases.Where(a => !aliasSet.Contains(a)).ToArray();
+                var extra = aliasSet.Where(a => !detectedAliases.Contains(a)).ToArray();
+                if (missing.Length > 0)
+                    issues.Add($"Binary aliases not exported: {FormatList(missing)}");
+                if (extra.Length > 0)
+                    issues.Add($"Manifest aliases missing from binaries: {FormatList(extra)}");
+            }
+
+            summaryParts.Add($"cmdlets {detectedCmdlets.Count}");
+            summaryParts.Add($"aliases {detectedAliases.Count}");
+        }
+
+        var summary = summaryParts.Count == 0 ? "ok" : string.Join(", ", summaryParts);
+        return BuildResult("Binary exports", settings.Severity, issues, summary);
+    }
+
+    internal static ModuleValidationCheckResult? ValidateCsproj(
+        ModuleValidationSpec spec,
+        CsprojValidationSettings settings)
+    {
+        if (settings.Severity == ValidationSeverity.Off) return null;
+
+        var issues = new List<string>();
+        var summaryParts = new List<string>(2);
+
+        var csproj = spec.BuildSpec?.CsprojPath ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(csproj))
+        {
+            issues.Add("CsprojPath is not configured.");
+            return BuildResult("Csproj", settings.Severity, issues, "missing csproj");
+        }
+
+        var csprojPath = Path.IsPathRooted(csproj)
+            ? csproj
+            : Path.GetFullPath(Path.Combine(spec.ProjectRoot ?? string.Empty, csproj));
+
+        if (!File.Exists(csprojPath))
+        {
+            issues.Add($"Csproj not found: {csproj}");
+            return BuildResult("Csproj", settings.Severity, issues, "missing csproj");
+        }
+
+        try
+        {
+            var doc = XDocument.Load(csprojPath);
+            var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+
+            string? targetFramework = doc.Descendants(ns + "TargetFramework").Select(e => e.Value).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+            string? targetFrameworks = doc.Descendants(ns + "TargetFrameworks").Select(e => e.Value).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+            string? outputType = doc.Descendants(ns + "OutputType").Select(e => e.Value).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+
+            if (settings.RequireTargetFramework && string.IsNullOrWhiteSpace(targetFramework) && string.IsNullOrWhiteSpace(targetFrameworks))
+                issues.Add("TargetFramework/TargetFrameworks not set.");
+            else
+                summaryParts.Add($"tfm {(targetFramework ?? targetFrameworks)}");
+
+            if (settings.RequireLibraryOutput && !string.IsNullOrWhiteSpace(outputType) &&
+                !string.Equals(outputType, "Library", StringComparison.OrdinalIgnoreCase))
+                issues.Add($"OutputType is '{outputType}' (expected Library).");
+            else if (!string.IsNullOrWhiteSpace(outputType))
+                summaryParts.Add($"output {outputType}");
+        }
+        catch (Exception ex)
+        {
+            issues.Add($"Csproj parse failed: {ex.Message}");
+        }
+
+        var summary = summaryParts.Count == 0 ? "ok" : string.Join(", ", summaryParts);
+        return BuildResult("Csproj", settings.Severity, issues, summary);
+    }
+
+    private static ModuleValidationCheckResult BuildResult(
+        string name,
+        ValidationSeverity severity,
+        List<string> issues,
+        string summary)
+    {
+        var issueArray = issues?.Where(i => !string.IsNullOrWhiteSpace(i)).ToArray() ?? Array.Empty<string>();
+        var status = issueArray.Length == 0
+            ? CheckStatus.Pass
+            : severity == ValidationSeverity.Error
+                ? CheckStatus.Fail
+                : CheckStatus.Warning;
+        return new ModuleValidationCheckResult(name, severity, status, summary, issueArray);
+    }
+
+    private static bool TryLoadAssembly(string name, out string? error)
+    {
+        error = null;
+        try
+        {
+            Assembly.Load(new AssemblyName(name));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    private static HashSet<string> DiscoverFunctionFileNames(string moduleRoot, string[]? paths)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (paths is null) return names;
+
+        foreach (var rel in paths)
+        {
+            if (string.IsNullOrWhiteSpace(rel)) continue;
+            var full = Path.IsPathRooted(rel) ? rel : Path.Combine(moduleRoot, rel);
+            if (!Directory.Exists(full)) continue;
+
+            foreach (var file in Directory.EnumerateFiles(full, "*.ps1", SearchOption.AllDirectories))
+                names.Add(Path.GetFileNameWithoutExtension(file));
+        }
+
+        return names;
+    }
+
+    private static (string[]? Values, bool Wildcard) GetManifestStringArray(string manifestPath, string key)
+    {
+        var values = ModuleManifestValueReader.ReadTopLevelStringOrArray(manifestPath, key)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .ToArray();
+
+        if (values.Length == 1 && string.Equals(values[0].Trim(), "*", StringComparison.OrdinalIgnoreCase))
+            return (Array.Empty<string>(), true);
+
+        return (values.Length == 0 ? null : values, false);
+    }
+
+    private static string[] ResolveManifestAssemblies(string manifestPath)
+    {
+        var list = new List<string>();
+
+        var rootModule = ModuleManifestValueReader.ReadTopLevelString(manifestPath, "RootModule");
+        if (!string.IsNullOrWhiteSpace(rootModule))
+            list.Add(rootModule!);
+
+        list.AddRange(ModuleManifestValueReader.ReadTopLevelStringOrArray(manifestPath, "NestedModules"));
+        list.AddRange(ModuleManifestValueReader.ReadTopLevelStringOrArray(manifestPath, "RequiredAssemblies"));
+
+        return list
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string FormatList(IEnumerable<string> items, int max = 8)
+    {
+        var list = items.Where(i => !string.IsNullOrWhiteSpace(i)).ToArray();
+        if (list.Length == 0) return string.Empty;
+        if (list.Length <= max) return string.Join(", ", list);
+        return string.Join(", ", list.Take(max)) + ", ...";
+    }
+}

--- a/PowerForge/Services/ModuleValidationCoreChecks.cs
+++ b/PowerForge/Services/ModuleValidationCoreChecks.cs
@@ -301,7 +301,7 @@ internal static class ModuleValidationCoreChecks
 
     private static (string[]? Values, bool Wildcard) GetManifestStringArray(string manifestPath, string key)
     {
-        var values = ModuleManifestValueReader.ReadTopLevelStringOrArray(manifestPath, key)
+        var values = (ModuleManifestValueReader.ReadTopLevelLiteralStringOrArray(manifestPath, key) ?? Array.Empty<string>())
             .Where(v => !string.IsNullOrWhiteSpace(v))
             .ToArray();
 

--- a/PowerForge/Services/ModuleValidationService.Checks.cs
+++ b/PowerForge/Services/ModuleValidationService.Checks.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
-using System.Xml.Linq;
 using System.Management.Automation.Language;
 
 namespace PowerForge;
@@ -18,119 +16,7 @@ public sealed partial class ModuleValidationService
     private static ModuleValidationCheckResult? ValidateStructure(
         ModuleValidationSpec spec,
         ModuleStructureValidationSettings settings)
-    {
-        if (settings.Severity == ValidationSeverity.Off) return null;
-
-        var issues = new List<string>();
-        var summaryParts = new List<string>(4);
-
-        var manifestPath = spec.ManifestPath ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(manifestPath) || !File.Exists(manifestPath))
-        {
-            issues.Add("Manifest not found.");
-            return BuildResult("Module structure", settings.Severity, issues, "manifest missing");
-        }
-
-        var moduleRoot = string.IsNullOrWhiteSpace(spec.StagingPath)
-            ? Path.GetDirectoryName(manifestPath) ?? string.Empty
-            : spec.StagingPath;
-
-        var publicFunctions = DiscoverFunctionFileNames(moduleRoot, settings.PublicFunctionPaths);
-        if (publicFunctions.Count > 0)
-            summaryParts.Add($"public functions {publicFunctions.Count}");
-
-        var internalFunctions = DiscoverFunctionFileNames(moduleRoot, settings.InternalFunctionPaths);
-        if (internalFunctions.Count > 0)
-            summaryParts.Add($"internal functions {internalFunctions.Count}");
-
-        if (settings.ValidateExports)
-        {
-            var (exportedFunctions, wildcardExport) = GetManifestStringArray(manifestPath, "FunctionsToExport");
-            if (wildcardExport && !settings.AllowWildcardExports)
-            {
-                issues.Add("FunctionsToExport uses wildcard; cannot validate exports.");
-            }
-            else if (exportedFunctions is { Length: > 0 } && !wildcardExport)
-            {
-                var exportedSet = new HashSet<string>(exportedFunctions, StringComparer.OrdinalIgnoreCase);
-                summaryParts.Add($"exports {exportedSet.Count}");
-
-                var missing = publicFunctions.Where(f => !exportedSet.Contains(f)).ToArray();
-                var extra = exportedSet.Where(f => !publicFunctions.Contains(f)).ToArray();
-
-                if (missing.Length > 0)
-                    issues.Add($"Public functions not exported: {FormatList(missing)}");
-                if (extra.Length > 0)
-                    issues.Add($"Exports not found in public folder: {FormatList(extra)}");
-            }
-        }
-
-        if (settings.ValidateInternalNotExported && internalFunctions.Count > 0)
-        {
-            var (exportedFunctions, wildcardExport) = GetManifestStringArray(manifestPath, "FunctionsToExport");
-            if (exportedFunctions is { Length: > 0 } && !wildcardExport)
-            {
-                var exportedSet = new HashSet<string>(exportedFunctions, StringComparer.OrdinalIgnoreCase);
-                var leaked = internalFunctions.Where(f => exportedSet.Contains(f)).ToArray();
-                if (leaked.Length > 0)
-                    issues.Add($"Internal functions exported: {FormatList(leaked)}");
-            }
-        }
-
-        if (settings.ValidateManifestFiles)
-        {
-            if (ManifestEditor.TryGetTopLevelString(manifestPath, "RootModule", out var root) &&
-                !string.IsNullOrWhiteSpace(root))
-            {
-                if (!File.Exists(Path.Combine(moduleRoot, root)))
-                    issues.Add($"RootModule missing: {root}");
-            }
-
-            if (ManifestEditor.TryGetTopLevelStringArray(manifestPath, "FormatsToProcess", out var formats) &&
-                formats is { Length: > 0 })
-            {
-                foreach (var f in formats)
-                {
-                    if (string.IsNullOrWhiteSpace(f)) continue;
-                    if (!File.Exists(Path.Combine(moduleRoot, f)))
-                        issues.Add($"Format file missing: {f}");
-                }
-            }
-
-            if (ManifestEditor.TryGetTopLevelStringArray(manifestPath, "TypesToProcess", out var types) &&
-                types is { Length: > 0 })
-            {
-                foreach (var t in types)
-                {
-                    if (string.IsNullOrWhiteSpace(t)) continue;
-                    if (!File.Exists(Path.Combine(moduleRoot, t)))
-                        issues.Add($"Type file missing: {t}");
-                }
-            }
-
-            if (ManifestEditor.TryGetTopLevelStringArray(manifestPath, "RequiredAssemblies", out var assemblies) &&
-                assemblies is { Length: > 0 })
-            {
-                foreach (var a in assemblies)
-                {
-                    if (string.IsNullOrWhiteSpace(a)) continue;
-                    if (a.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (!File.Exists(Path.Combine(moduleRoot, a)))
-                            issues.Add($"Required assembly missing: {a}");
-                    }
-                    else
-                    {
-                        if (!TryLoadAssembly(a, out var error))
-                            issues.Add($"Required assembly failed to load: {a} ({error})");
-                    }
-                }
-            }
-        }
-
-        var summary = summaryParts.Count == 0 ? "structure verified" : string.Join(", ", summaryParts);
-        return BuildResult("Module structure", settings.Severity, issues, summary);
-    }
+        => ModuleValidationCoreChecks.ValidateStructure(spec, settings);
 
     private ModuleValidationCheckResult? ValidateDocumentation(
         ModuleValidationSpec spec,
@@ -482,140 +368,11 @@ public sealed partial class ModuleValidationService
     private static ModuleValidationCheckResult? ValidateBinary(
         ModuleValidationSpec spec,
         BinaryModuleValidationSettings settings)
-    {
-        if (settings.Severity == ValidationSeverity.Off) return null;
-
-        var issues = new List<string>();
-        var summaryParts = new List<string>(3);
-        var manifestPath = spec.ManifestPath ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(manifestPath) || !File.Exists(manifestPath))
-        {
-            issues.Add("Manifest not found.");
-            return BuildResult("Binary exports", settings.Severity, issues, "manifest missing");
-        }
-
-        var moduleRoot = string.IsNullOrWhiteSpace(spec.StagingPath)
-            ? Path.GetDirectoryName(manifestPath) ?? string.Empty
-            : spec.StagingPath;
-
-        var assemblies = ResolveManifestAssemblies(manifestPath);
-        var assemblyPaths = assemblies
-            .Where(a => !string.IsNullOrWhiteSpace(a) && a.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-            .Select(a => Path.Combine(moduleRoot, a))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        if (assemblyPaths.Length == 0)
-            return BuildResult("Binary exports", settings.Severity, issues, "no binaries");
-
-        if (settings.ValidateAssembliesExist)
-        {
-            foreach (var asm in assemblyPaths)
-            {
-                if (!File.Exists(asm))
-                    issues.Add($"Assembly missing: {Path.GetFileName(asm)}");
-            }
-        }
-
-        var existingAssemblies = assemblyPaths.Where(File.Exists).ToArray();
-        if (existingAssemblies.Length == 0)
-            return BuildResult("Binary exports", settings.Severity, issues, "no binaries");
-
-        if (settings.ValidateManifestExports)
-        {
-            var detectedCmdlets = BinaryExportDetector.DetectBinaryCmdlets(existingAssemblies);
-            var detectedAliases = BinaryExportDetector.DetectBinaryAliases(existingAssemblies);
-
-            var (manifestCmdlets, cmdletWildcard) = GetManifestStringArray(manifestPath, "CmdletsToExport");
-            var (manifestAliases, aliasWildcard) = GetManifestStringArray(manifestPath, "AliasesToExport");
-
-            if (cmdletWildcard && !settings.AllowWildcardExports)
-                issues.Add("CmdletsToExport uses wildcard; cannot validate binary exports.");
-            else if (manifestCmdlets is { Length: > 0 } && !cmdletWildcard)
-            {
-                var cmdletSet = new HashSet<string>(manifestCmdlets, StringComparer.OrdinalIgnoreCase);
-                var missing = detectedCmdlets.Where(c => !cmdletSet.Contains(c)).ToArray();
-                var extra = cmdletSet.Where(c => !detectedCmdlets.Contains(c)).ToArray();
-                if (missing.Length > 0)
-                    issues.Add($"Binary cmdlets not exported: {FormatList(missing)}");
-                if (extra.Length > 0)
-                    issues.Add($"Manifest cmdlets missing from binaries: {FormatList(extra)}");
-            }
-
-            if (aliasWildcard && !settings.AllowWildcardExports)
-                issues.Add("AliasesToExport uses wildcard; cannot validate binary exports.");
-            else if (manifestAliases is { Length: > 0 } && !aliasWildcard)
-            {
-                var aliasSet = new HashSet<string>(manifestAliases, StringComparer.OrdinalIgnoreCase);
-                var missing = detectedAliases.Where(a => !aliasSet.Contains(a)).ToArray();
-                var extra = aliasSet.Where(a => !detectedAliases.Contains(a)).ToArray();
-                if (missing.Length > 0)
-                    issues.Add($"Binary aliases not exported: {FormatList(missing)}");
-                if (extra.Length > 0)
-                    issues.Add($"Manifest aliases missing from binaries: {FormatList(extra)}");
-            }
-
-            summaryParts.Add($"cmdlets {detectedCmdlets.Count}");
-            summaryParts.Add($"aliases {detectedAliases.Count}");
-        }
-
-        var summary = summaryParts.Count == 0 ? "ok" : string.Join(", ", summaryParts);
-        return BuildResult("Binary exports", settings.Severity, issues, summary);
-    }
+        => ModuleValidationCoreChecks.ValidateBinary(spec, settings);
 
     private static ModuleValidationCheckResult? ValidateCsproj(
         ModuleValidationSpec spec,
         CsprojValidationSettings settings)
-    {
-        if (settings.Severity == ValidationSeverity.Off) return null;
-
-        var issues = new List<string>();
-        var summaryParts = new List<string>(2);
-
-        var csproj = spec.BuildSpec?.CsprojPath ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(csproj))
-        {
-            issues.Add("CsprojPath is not configured.");
-            return BuildResult("Csproj", settings.Severity, issues, "missing csproj");
-        }
-
-        var csprojPath = Path.IsPathRooted(csproj)
-            ? csproj
-            : Path.GetFullPath(Path.Combine(spec.ProjectRoot ?? string.Empty, csproj));
-
-        if (!File.Exists(csprojPath))
-        {
-            issues.Add($"Csproj not found: {csproj}");
-            return BuildResult("Csproj", settings.Severity, issues, "missing csproj");
-        }
-
-        try
-        {
-            var doc = XDocument.Load(csprojPath);
-            var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
-
-            string? targetFramework = doc.Descendants(ns + "TargetFramework").Select(e => e.Value).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
-            string? targetFrameworks = doc.Descendants(ns + "TargetFrameworks").Select(e => e.Value).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
-            string? outputType = doc.Descendants(ns + "OutputType").Select(e => e.Value).FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
-
-            if (settings.RequireTargetFramework && string.IsNullOrWhiteSpace(targetFramework) && string.IsNullOrWhiteSpace(targetFrameworks))
-                issues.Add("TargetFramework/TargetFrameworks not set.");
-            else
-                summaryParts.Add($"tfm {(targetFramework ?? targetFrameworks)}");
-
-            if (settings.RequireLibraryOutput && !string.IsNullOrWhiteSpace(outputType) &&
-                !string.Equals(outputType, "Library", StringComparison.OrdinalIgnoreCase))
-                issues.Add($"OutputType is '{outputType}' (expected Library).");
-            else if (!string.IsNullOrWhiteSpace(outputType))
-                summaryParts.Add($"output {outputType}");
-        }
-        catch (Exception ex)
-        {
-            issues.Add($"Csproj parse failed: {ex.Message}");
-        }
-
-        var summary = summaryParts.Count == 0 ? "ok" : string.Join(", ", summaryParts);
-        return BuildResult("Csproj", settings.Severity, issues, summary);
-    }
+        => ModuleValidationCoreChecks.ValidateCsproj(spec, settings);
 
 }

--- a/PowerForge/Services/ModuleValidationService.Utils.cs
+++ b/PowerForge/Services/ModuleValidationService.Utils.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
-using System.Xml.Linq;
 using System.Management.Automation.Language;
 
 namespace PowerForge;
@@ -33,73 +31,6 @@ public sealed partial class ModuleValidationService
     {
         if (total <= 0) return 0;
         return (part / (double)total) * 100.0;
-    }
-
-    private static bool TryLoadAssembly(string name, out string? error)
-    {
-        error = null;
-        try
-        {
-            Assembly.Load(new AssemblyName(name));
-            return true;
-        }
-        catch (Exception ex)
-        {
-            error = ex.Message;
-            return false;
-        }
-    }
-
-    private static HashSet<string> DiscoverFunctionFileNames(string moduleRoot, string[]? paths)
-    {
-        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (paths is null) return names;
-
-        foreach (var rel in paths)
-        {
-            if (string.IsNullOrWhiteSpace(rel)) continue;
-            var full = Path.IsPathRooted(rel) ? rel : Path.Combine(moduleRoot, rel);
-            if (!Directory.Exists(full)) continue;
-
-            foreach (var file in Directory.EnumerateFiles(full, "*.ps1", SearchOption.AllDirectories))
-                names.Add(Path.GetFileNameWithoutExtension(file));
-        }
-
-        return names;
-    }
-
-    private static (string[]? Values, bool Wildcard) GetManifestStringArray(string manifestPath, string key)
-    {
-        if (ManifestEditor.TryGetTopLevelStringArray(manifestPath, key, out var values) && values is { Length: > 0 })
-            return (values, false);
-
-        if (ManifestEditor.TryGetTopLevelString(manifestPath, key, out var raw))
-        {
-            var trimmed = raw?.Trim();
-            if (!string.IsNullOrWhiteSpace(trimmed))
-            {
-                if (string.Equals(trimmed, "*", StringComparison.OrdinalIgnoreCase))
-                    return (Array.Empty<string>(), true);
-                return (new[] { trimmed! }, false);
-            }
-        }
-
-        return (null, false);
-    }
-
-    private static string[] ResolveManifestAssemblies(string manifestPath)
-    {
-        var list = new List<string>();
-        if (ManifestEditor.TryGetTopLevelString(manifestPath, "RootModule", out var root) && !string.IsNullOrWhiteSpace(root))
-            list.Add(root!);
-
-        if (ManifestEditor.TryGetTopLevelStringArray(manifestPath, "NestedModules", out var nested) && nested is { Length: > 0 })
-            list.AddRange(nested.Where(n => !string.IsNullOrWhiteSpace(n)));
-
-        if (ManifestEditor.TryGetTopLevelStringArray(manifestPath, "RequiredAssemblies", out var assemblies) && assemblies is { Length: > 0 })
-            list.AddRange(assemblies.Where(a => !string.IsNullOrWhiteSpace(a)));
-
-        return list.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
     private static string ResolveModuleRoot(ModuleValidationSpec spec)


### PR DESCRIPTION
## Summary
- extract host-neutral structure, binary export, and csproj validation into `ModuleValidationCoreChecks` in `PowerForge`
- keep `ModuleValidationService` focused on PowerShell-hosted validation concerns while delegating the neutral checks
- add focused tests for the extracted helper and update the layering cleanup note

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ModuleValidationCoreChecksTests|FullyQualifiedName~ModuleValidationServiceTests" /m:1`
- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release /m:1`
- `dotnet build .\PowerForge.Cli\PowerForge.Cli.csproj -c Release /m:1`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release /m:1`