### PR TITLE
Follow up social card media handling fixes

### DIFF
--- a/PowerForge.Tests/WebSocialCardGeneratorTests.cs
+++ b/PowerForge.Tests/WebSocialCardGeneratorTests.cs
@@ -424,6 +424,34 @@ public class WebSocialCardGeneratorTests
     }
 
     [Fact]
+    public void IsRenderableImageSource_ReturnsFalse_WhenRemoteFetchFails()
+    {
+        WebSocialCardGenerator.ClearRemoteImageCache();
+
+        var renderable = WebSocialCardGenerator.IsRenderableImageSource(
+            "https://cdn.example.test/logo.svg",
+            allowRemoteMediaFetch: true,
+            _ => null);
+
+        Assert.False(renderable);
+        WebSocialCardGenerator.ClearRemoteImageCache();
+    }
+
+    [Fact]
+    public void IsRenderableImageSource_ReturnsTrue_WhenRemoteFetchSucceeds()
+    {
+        WebSocialCardGenerator.ClearRemoteImageCache();
+
+        var renderable = WebSocialCardGenerator.IsRenderableImageSource(
+            "https://cdn.example.test/logo.svg",
+            allowRemoteMediaFetch: true,
+            _ => Encoding.UTF8.GetBytes("remote-logo"));
+
+        Assert.True(renderable);
+        WebSocialCardGenerator.ClearRemoteImageCache();
+    }
+
+    [Fact]
     public void RenderSvg_FallsBackToMonogram_WhenRemoteLogoCannotBeRendered()
     {
         var svg = WebSocialCardGenerator.RenderSvg(new WebSocialCardGenerator.SocialCardRenderOptions

--- a/PowerForge.Web/Services/WebSiteBuilder.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.cs
@@ -103,6 +103,7 @@ public static partial class WebSiteBuilder
             Language = language,
             LanguageAsRoot = languageAsRoot
         };
+        WebSocialCardGenerator.ClearRemoteImageCache();
         BuildRenderCacheScope.Value = CreateBuildRenderCache(spec, plan.RootPath);
         BuildRootPathScope.Value = plan.RootPath;
         BuildProgressSink.Value = ReportProgress;

--- a/PowerForge.Web/Services/WebSocialCardGenerator.Renderer.cs
+++ b/PowerForge.Web/Services/WebSocialCardGenerator.Renderer.cs
@@ -171,7 +171,7 @@ internal static partial class WebSocialCardGenerator
         };
     }
 
-    internal static bool IsRenderableImageSource(string? source, bool allowRemoteMediaFetch)
+    internal static bool IsRenderableImageSource(string? source, bool allowRemoteMediaFetch, Func<string, byte[]?>? remoteFetcher = null)
     {
         if (string.IsNullOrWhiteSpace(source))
             return false;
@@ -180,7 +180,7 @@ internal static partial class WebSocialCardGenerator
             return true;
 
         if (IsRemoteMediaSource(source))
-            return allowRemoteMediaFetch;
+            return GetRemoteImageBytes(source, allowRemoteMediaFetch, remoteFetcher) is { Length: > 0 };
 
         if (Uri.TryCreate(source, UriKind.Absolute, out var absoluteUri) && absoluteUri.IsFile)
             return File.Exists(absoluteUri.LocalPath);

--- a/PowerForge.Web/Services/WebSocialCardGenerator.Renderer.cs
+++ b/PowerForge.Web/Services/WebSocialCardGenerator.Renderer.cs
@@ -18,7 +18,7 @@ internal static partial class WebSocialCardGenerator
     {
         var rasterOptions = CloneRenderOptions(options, embedReferencedMediaInSvg: false);
         var state = CreateState(rasterOptions);
-        var svg = RenderSvg(rasterOptions);
+        var svg = RenderSvg(state);
         if (string.IsNullOrWhiteSpace(svg))
             return null;
 
@@ -48,6 +48,11 @@ internal static partial class WebSocialCardGenerator
     internal static string RenderSvg(SocialCardRenderOptions options)
     {
         var state = CreateState(options);
+        return RenderSvg(state);
+    }
+
+    private static string RenderSvg(SocialCardRenderState state)
+    {
         var svg = new StringBuilder();
         svg.AppendLine($@"<svg xmlns=""http://www.w3.org/2000/svg"" xmlns:xlink=""http://www.w3.org/1999/xlink"" width=""{state.Width}"" height=""{state.Height}"" viewBox=""0 0 {state.Width} {state.Height}"">");
         svg.AppendLine($@"  <!-- layout:{state.LayoutKey} style:{state.StyleKey} variant:{state.VariantKey} -->");


### PR DESCRIPTION
## Summary
- honor vertical social card safe margins in renderer layout math
- base remote-media layout and logo fallbacks on successful fetches
- clear remote social-card media cache at build boundaries

## Testing
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~WebSocialCardGeneratorTests|FullyQualifiedName~WebSiteSocialCardsTests"