### PR TITLE
Move ModulePublisher back to core

### DIFF
--- a/Docs/PowerForge.ModuleLayeringCleanup.md
+++ b/Docs/PowerForge.ModuleLayeringCleanup.md
@@ -73,7 +73,7 @@ These mostly represent reusable workflow, but they currently depend on PowerShel
 | `Services\ModuleTestFailureAnalyzer.cs` | Split: XML/core in `PowerForge`, Pester-object analysis in `PowerForge.PowerShell` | NUnit XML analysis is core, but Pester result-object inspection uses `PSObject`. | Split analyzers by input source. |
 | `Services\ModuleTestFailureWorkflowService.cs` | `PowerForge` after analyzer split | Workflow/path resolution is core, but it currently depends on the mixed analyzer. | Move after `ModuleTestFailureAnalyzer` is split. |
 | `Services\ModuleValidationService*.cs` | Split: validation coordinator in `PowerForge`, PowerShell validators in `PowerForge.PowerShell` | The coordinator is reusable, but script parsing/PSSA/import validation rely on PowerShell concepts. | Break into neutral validation pipeline plus PowerShell-backed validation adapters. |
-| `Services\ModulePublisher.cs` | Split: publish coordinator in `PowerForge`, PowerShell repository publishers in `PowerForge.PowerShell` | GitHub release publishing is host-neutral, but PowerShell repository publishing uses `PSResourceGet` / `PowerShellGet` clients. | Introduce publisher interfaces and separate repository-specific implementations. |
+| `Services\ModulePublisher.cs` | `PowerForge` | The host-neutral publish coordinator now lives in core and delegates repository publish work through shared helpers instead of depending on `ManifestEditor` / `BuildServices`-owned behavior. | Continue shrinking the remaining repository-specific helper surface if we want a narrower publish adapter later. |
 | `Services\ModulePipelineRunner*.cs` | Split: planning/result assembly in `PowerForge`, PowerShell-backed execution in `PowerForge.PowerShell` | The plan/result contracts are core, but execution currently mixes staging, manifest refresh, module import, dependency install, documentation, validation, and PowerShell-runner concerns. | First extract a core planner and immutable execution context, then keep a PowerShell execution adapter on top. |
 
 ## Recommended Extraction Order
@@ -164,9 +164,11 @@ Current status:
 
 These are worth doing separately because they mix reusable orchestration with PowerShell-specific implementations:
 
-- `ModulePublisher`
+- `RepositoryPublisher`
 - `ModuleValidationService*`
 - `BinaryDependencyPreflightService`
+
+- `ModulePublisher` now compiles in `PowerForge`. Repository publish registration/tool interactions are still an area we may narrow further, but the main publish coordinator is no longer stuck in the PowerShell-owned layer.
 
 ## First Concrete Slice
 

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -48,7 +48,6 @@
     <Compile Include="..\PowerForge\Services\ManifestEditor*.cs" Link="Services\%(Filename)%(Extension)" />
     <Compile Include="..\PowerForge\Services\MissingFunctionsAnalyzer.cs" Link="Services\MissingFunctionsAnalyzer.cs" />
     <Compile Include="..\PowerForge\Services\ModulePipelineRunner*.cs" Link="Services\%(Filename)%(Extension)" />
-    <Compile Include="..\PowerForge\Services\ModulePublisher.cs" Link="Services\ModulePublisher.cs" />
     <Compile Include="..\PowerForge\Services\ModuleTestFailureAnalyzer.cs" Link="Services\ModuleTestFailureAnalyzer.cs" />
     <Compile Include="..\PowerForge\Services\ModuleTestFailureWorkflowService.cs" Link="Services\ModuleTestFailureWorkflowService.cs" />
     <Compile Include="..\PowerForge\Services\ModuleTestSuiteService.cs" Link="Services\ModuleTestSuiteService.cs" />

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -66,7 +66,6 @@
     <Compile Remove="Services\\ManifestEditor*.cs" />
     <Compile Remove="Services\\MissingFunctionsAnalyzer.cs" />
     <Compile Remove="Services\\ModulePipelineRunner*.cs" />
-    <Compile Remove="Services\\ModulePublisher.cs" />
     <Compile Remove="Services\\ModuleTestFailureAnalyzer.cs" />
     <Compile Remove="Services\\ModuleTestFailureWorkflowService.cs" />
     <Compile Remove="Services\\ModuleTestSuiteService.cs" />

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -12,6 +12,7 @@ namespace PowerForge;
 public sealed class ModulePublisher
 {
     private readonly ILogger _logger;
+    private readonly RepositoryPublisher _repositoryPublisher;
     private readonly PSResourceGetClient _psResourceGet;
     private readonly PowerShellGetClient _powerShellGet;
     private readonly GitHubReleasePublisher _gitHub;
@@ -37,6 +38,7 @@ public sealed class ModulePublisher
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         if (runner is null) throw new ArgumentNullException(nameof(runner));
+        _repositoryPublisher = new RepositoryPublisher(_logger, runner);
         _psResourceGet = new PSResourceGetClient(runner, _logger);
         _powerShellGet = new PowerShellGetClient(runner, _logger);
         _gitHub = new GitHubReleasePublisher(_logger);
@@ -123,9 +125,8 @@ public sealed class ModulePublisher
         bool includeScriptFolders)
     {
         var credential = repoConfig?.Credential;
-        bool createdRepository = false;
         string? temporaryPublishPath = null;
-        var versionText = BuildServices.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
+        var versionText = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
 
         try
         {
@@ -136,11 +137,6 @@ public sealed class ModulePublisher
                 delivery: plan.Delivery,
                 includeScriptFolders: includeScriptFolders);
 
-            if (repoConfig is not null && repoConfig.EnsureRegistered && HasRepositoryUris(repoConfig))
-            {
-                createdRepository = EnsureRepositoryRegistered(tool, repositoryName, repoConfig);
-            }
-
             if (!publish.Force)
                 EnsureVersionIsGreaterThanRepository(tool, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease, repositoryName, credential);
 
@@ -148,30 +144,24 @@ public sealed class ModulePublisher
 
             var modulePath = Path.GetFullPath(temporaryPublishPath);
 
-            if (tool == PublishTool.PowerShellGet)
-            {
-                _powerShellGet.Publish(
-                    new PowerShellGetPublishOptions(
-                        path: modulePath,
-                        repository: repositoryName,
-                        apiKey: string.IsNullOrWhiteSpace(publish.ApiKey) ? null : publish.ApiKey,
-                        credential: credential));
-            }
-            else
+            if (tool != PublishTool.PowerShellGet)
             {
                 ValidateRequiredModulesForRepositoryPublish(repositoryName, credential, plan, buildResult);
-
-                _psResourceGet.Publish(
-                    new PSResourcePublishOptions(
-                        path: modulePath,
-                        isNupkg: false,
-                        repository: repositoryName,
-                        apiKey: string.IsNullOrWhiteSpace(publish.ApiKey) ? null : publish.ApiKey,
-                        destinationPath: null,
-                        skipDependenciesCheck: true,
-                        skipModuleManifestValidate: false,
-                        credential: credential));
             }
+
+            _repositoryPublisher.Publish(
+                new RepositoryPublishRequest
+                {
+                    Path = modulePath,
+                    IsNupkg = false,
+                    RepositoryName = repositoryName,
+                    Tool = tool,
+                    ApiKey = string.IsNullOrWhiteSpace(publish.ApiKey) ? null : publish.ApiKey,
+                    Repository = repoConfig,
+                    DestinationPath = null,
+                    SkipDependenciesCheck = tool != PublishTool.PowerShellGet,
+                    SkipModuleManifestValidate = false
+                });
 
             _logger.Info($"Published {plan.ModuleName} {versionText} to repository '{repositoryName}' using {tool}.");
 
@@ -182,18 +172,6 @@ public sealed class ModulePublisher
         {
             if (!string.IsNullOrWhiteSpace(temporaryPublishPath))
                 CleanupTemporaryPublishPath(temporaryPublishPath);
-
-            if (createdRepository && repoConfig is not null && repoConfig.UnregisterAfterUse)
-            {
-                try
-                {
-                    UnregisterRepository(tool, repositoryName);
-                }
-                catch (Exception ex)
-                {
-                    _logger.Warn($"Failed to unregister repository '{repositoryName}': {ex.Message}");
-                }
-            }
         }
 
         return new ModulePublishResult(
@@ -317,8 +295,7 @@ public sealed class ModulePublisher
     {
         if (!string.IsNullOrWhiteSpace(buildResult.ManifestPath) &&
             File.Exists(buildResult.ManifestPath) &&
-            ManifestEditor.TryGetPsDataStringArray(buildResult.ManifestPath, "ExternalModuleDependencies", out var manifestExternalModules) &&
-            manifestExternalModules is { Length: > 0 })
+            ModuleManifestValueReader.ReadPsDataStringOrArray(buildResult.ManifestPath, "ExternalModuleDependencies") is { Length: > 0 } manifestExternalModules)
         {
             return manifestExternalModules
                 .Where(n => !string.IsNullOrWhiteSpace(n))
@@ -338,8 +315,7 @@ public sealed class ModulePublisher
     {
         if (!string.IsNullOrWhiteSpace(buildResult.ManifestPath) &&
             File.Exists(buildResult.ManifestPath) &&
-            ManifestEditor.TryGetRequiredModules(buildResult.ManifestPath, out RequiredModuleReference[]? manifestModules) &&
-            manifestModules is { Length: > 0 })
+            ModuleManifestValueReader.ReadRequiredModules(buildResult.ManifestPath) is { Length: > 0 } manifestModules)
         {
             return manifestModules
                 .Where(m => m is not null && !string.IsNullOrWhiteSpace(m.ModuleName))
@@ -555,56 +531,6 @@ public sealed class ModulePublisher
         return (name, repoConfig);
     }
 
-    private static bool HasRepositoryUris(PublishRepositoryConfiguration repo)
-        => repo is not null &&
-           (!string.IsNullOrWhiteSpace(repo.Uri) ||
-            !string.IsNullOrWhiteSpace(repo.SourceUri) ||
-            !string.IsNullOrWhiteSpace(repo.PublishUri));
-
-    private bool EnsureRepositoryRegistered(PublishTool tool, string repositoryName, PublishRepositoryConfiguration repo)
-    {
-        if (tool == PublishTool.PowerShellGet)
-        {
-            var sourceUri = string.IsNullOrWhiteSpace(repo.SourceUri)
-                ? (string.IsNullOrWhiteSpace(repo.Uri) ? repo.PublishUri : repo.Uri)
-                : repo.SourceUri;
-            var publishUri = string.IsNullOrWhiteSpace(repo.PublishUri)
-                ? (string.IsNullOrWhiteSpace(repo.Uri) ? repo.SourceUri : repo.Uri)
-                : repo.PublishUri;
-
-            if (string.IsNullOrWhiteSpace(sourceUri) || string.IsNullOrWhiteSpace(publishUri))
-                throw new InvalidOperationException($"Repository '{repositoryName}' is missing SourceUri/PublishUri/Uri for PowerShellGet registration.");
-
-            return _powerShellGet.EnsureRepositoryRegistered(repositoryName, sourceUri!, publishUri!, trusted: repo.Trusted, timeout: TimeSpan.FromMinutes(2));
-        }
-
-        var uri = string.IsNullOrWhiteSpace(repo.Uri)
-            ? (string.IsNullOrWhiteSpace(repo.PublishUri) ? repo.SourceUri : repo.PublishUri)
-            : repo.Uri;
-
-        if (string.IsNullOrWhiteSpace(uri))
-            throw new InvalidOperationException($"Repository '{repositoryName}' is missing Uri/PublishUri/SourceUri for PSResourceGet registration.");
-
-        return _psResourceGet.EnsureRepositoryRegistered(
-            name: repositoryName,
-            uri: uri!,
-            trusted: repo.Trusted,
-            priority: repo.Priority,
-            apiVersion: repo.ApiVersion,
-            timeout: TimeSpan.FromMinutes(2));
-    }
-
-    private void UnregisterRepository(PublishTool tool, string repositoryName)
-    {
-        if (tool == PublishTool.PowerShellGet)
-        {
-            _powerShellGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
-            return;
-        }
-
-        _psResourceGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
-    }
-
     private ModulePublishResult PublishToGitHub(PublishConfiguration publish, ModulePipelinePlan plan, IReadOnlyList<ArtefactBuildResult> artefactResults)
     {
         if (string.IsNullOrWhiteSpace(publish.UserName))
@@ -614,7 +540,7 @@ public sealed class ModulePublisher
 
         var owner = publish.UserName!.Trim();
         var repo = string.IsNullOrWhiteSpace(publish.RepositoryName) ? plan.ModuleName : publish.RepositoryName!.Trim();
-        var versionText = BuildServices.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
+        var versionText = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
         var tag = GetGitHubTag(publish, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease);
 
         var isPreRelease = !string.IsNullOrWhiteSpace(plan.PreRelease) && !publish.DoNotMarkAsPreRelease;
@@ -661,9 +587,9 @@ public sealed class ModulePublisher
             throw new ArgumentNullException(nameof(publish));
 
         if (string.IsNullOrWhiteSpace(publish.OverwriteTagName))
-            return "v" + BuildServices.FormatVersionWithPreRelease(resolvedVersion, preRelease);
+            return "v" + ModulePathTokenFormatter.FormatVersionWithPreRelease(resolvedVersion, preRelease);
 
-        return BuildServices.ReplacePathTokens(publish.OverwriteTagName!, moduleName, resolvedVersion, preRelease);
+        return ModulePathTokenFormatter.ReplacePathTokens(publish.OverwriteTagName!, moduleName, resolvedVersion, preRelease);
     }
 
     private static ArtefactBuildResult[] SelectPackedArtefacts(IReadOnlyList<ArtefactBuildResult> artefactResults, string? id)


### PR DESCRIPTION
## Summary
- move `ModulePublisher` ownership back to `PowerForge`
- delegate repository publish execution through the shared `RepositoryPublisher`
- replace `BuildServices` and `ManifestEditor` usage with neutral core helpers

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ModulePublisherRepositoryVersionTests|FullyQualifiedName~ModulePublisherRequiredModulesTests" /m:1
- dotnet build .\PowerForge\PowerForge.csproj -c Release /m:1
- dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release /m:1
- dotnet build .\PowerForge.Cli\PowerForge.Cli.csproj -c Release /m:1
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release /m:1
- dotnet build .\PowerForgeStudio.Orchestrator\PowerForgeStudio.Orchestrator.csproj -c Release /m:1