### PR TITLE
fix: avoid string binding for test suite verbose switch

### DIFF
--- a/PowerForge.PowerShell/Services/ModuleTestSuiteService.cs
+++ b/PowerForge.PowerShell/Services/ModuleTestSuiteService.cs
@@ -82,7 +82,7 @@ public sealed class ModuleTestSuiteService
             spec.SkipImport ? "1" : "0",
             spec.Force ? "1" : "0",
             importModulesB64,
-            spec.ImportModulesVerbose ? "1" : "0"
+            spec.ImportModulesVerbose ? "-ImportVerbose:$true" : "-ImportVerbose:$false"
         };
 
         PowerShellRunResult runResult;

--- a/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
+++ b/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class ModuleTestSuiteServiceTests
+{
+    [Fact]
+    public void Run_PassesNamedBooleanTokenForImportVerbose()
+    {
+        var projectRoot = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            const string moduleName = "SampleModule";
+            Directory.CreateDirectory(Path.Combine(projectRoot.FullName, "Tests"));
+            File.WriteAllText(Path.Combine(projectRoot.FullName, $"{moduleName}.psm1"), string.Empty);
+            File.WriteAllText(
+                Path.Combine(projectRoot.FullName, $"{moduleName}.psd1"),
+                "@{ RootModule = 'SampleModule.psm1'; ModuleVersion = '1.0.0'; FunctionsToExport = @(); CmdletsToExport = @(); AliasesToExport = @() }");
+
+            PowerShellRunRequest? capturedRequest = null;
+            var runner = new RecordingPowerShellRunner(request =>
+            {
+                capturedRequest = request;
+                return new PowerShellRunResult(0, "PFTEST::COUNTS::0::0::0::0", string.Empty, "pwsh.exe");
+            });
+
+            var service = new ModuleTestSuiteService(runner, new NullLogger());
+
+            _ = service.Run(new ModuleTestSuiteSpec
+            {
+                ProjectPath = projectRoot.FullName,
+                SkipDependencies = true,
+                ImportModulesVerbose = true
+            });
+
+            Assert.NotNull(capturedRequest);
+            Assert.Equal("-ImportVerbose:$true", capturedRequest!.Arguments[^1]);
+        }
+        finally
+        {
+            try { projectRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private sealed class RecordingPowerShellRunner : IPowerShellRunner
+    {
+        private readonly Func<PowerShellRunRequest, PowerShellRunResult> _run;
+
+        public RecordingPowerShellRunner(Func<PowerShellRunRequest, PowerShellRunResult> run)
+        {
+            _run = run;
+        }
+
+        public PowerShellRunResult Run(PowerShellRunRequest request)
+            => _run(request);
+    }
+}

--- a/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
+++ b/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
@@ -38,7 +38,7 @@ public sealed class ModuleTestSuiteServiceTests
             });
 
             Assert.NotNull(capturedRequest);
-            Assert.Equal("-ImportVerbose:$true", capturedRequest!.Arguments[^1]);
+            Assert.Contains("-ImportVerbose:$true", capturedRequest!.Arguments);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeScriptsTests.cs
+++ b/PowerForge.Tests/PowerForgeScriptsTests.cs
@@ -29,7 +29,7 @@ public sealed class PowerForgeScriptsTests
 
         Assert.Matches(@"\[bool\]\s*\$ImportVerbose\b", script);
         Assert.Contains("function Import-TestSuiteModule", script, StringComparison.Ordinal);
-        Assert.Contains("-Verbose:$ImportVerbose", script, StringComparison.Ordinal);
+        Assert.Contains("-ShowVerbose:$ImportVerbose", script, StringComparison.Ordinal);
         Assert.DoesNotContain("$importModulesVerboseEnabled", script, StringComparison.Ordinal);
     }
 }

--- a/PowerForge.Tests/PowerForgeScriptsTests.cs
+++ b/PowerForge.Tests/PowerForgeScriptsTests.cs
@@ -21,4 +21,14 @@ public sealed class PowerForgeScriptsTests
         Assert.True(initializeCallIndex > resetIndex);
         Assert.True(importRequiredIndex > initializeCallIndex);
     }
+
+    [Fact]
+    public void Load_InvokeTestSuiteScript_UsesDedicatedBooleanForVerboseSwitch()
+    {
+        var script = PowerForgeScripts.Load("Scripts/Tests/Invoke-TestSuite.ps1");
+
+        Assert.Contains("$importModulesVerboseEnabled = ($ImportVerbose -eq '1')", script, StringComparison.Ordinal);
+        Assert.Contains("-Verbose:$importModulesVerboseEnabled", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("-Verbose:$importVerbose", script, StringComparison.Ordinal);
+    }
 }

--- a/PowerForge.Tests/PowerForgeScriptsTests.cs
+++ b/PowerForge.Tests/PowerForgeScriptsTests.cs
@@ -27,8 +27,9 @@ public sealed class PowerForgeScriptsTests
     {
         var script = PowerForgeScripts.Load("Scripts/Tests/Invoke-TestSuite.ps1");
 
-        Assert.Contains("$importModulesVerboseEnabled = ($ImportVerbose -eq '1')", script, StringComparison.Ordinal);
-        Assert.Contains("-Verbose:$importModulesVerboseEnabled", script, StringComparison.Ordinal);
-        Assert.DoesNotContain("-Verbose:$importVerbose", script, StringComparison.Ordinal);
+        Assert.Matches(@"\[bool\]\s*\$ImportVerbose\b", script);
+        Assert.Contains("function Import-TestSuiteModule", script, StringComparison.Ordinal);
+        Assert.Contains("-Verbose:$ImportVerbose", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("$importModulesVerboseEnabled", script, StringComparison.Ordinal);
     }
 }

--- a/PowerForge/Scripts/Tests/Invoke-TestSuite.ps1
+++ b/PowerForge/Scripts/Tests/Invoke-TestSuite.ps1
@@ -9,7 +9,7 @@
   [string]$SkipImport,
   [string]$ForceImport,
   [string]$ImportModulesB64,
-  [string]$ImportVerbose
+  [bool]$ImportVerbose
 )
 
 function Encode([string]$s) {
@@ -24,6 +24,31 @@ function DecodeModules([string]$b64) {
   try { return $json | ConvertFrom-Json } catch { return @() }
 }
 
+function Import-TestSuiteModule {
+  param(
+    [string]$Name,
+    [string]$RequiredVersion,
+    [string]$MinimumVersion,
+    [bool]$Force = $true,
+    [bool]$Verbose = $false
+  )
+
+  $importParams = @{
+    Name = $Name
+    Force = $Force
+    ErrorAction = 'Stop'
+    Verbose = $Verbose
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($RequiredVersion)) {
+    $importParams.RequiredVersion = $RequiredVersion
+  } elseif (-not [string]::IsNullOrWhiteSpace($MinimumVersion)) {
+    $importParams.MinimumVersion = $MinimumVersion
+  }
+
+  Import-Module @importParams | Out-Null
+}
+
 try {
   Import-Module -Name Pester -Force -ErrorAction Stop
   $p = Get-Module -Name Pester
@@ -31,24 +56,17 @@ try {
     Write-Output ('PFTEST::PESTER::' + $p.Version.ToString())
   }
 
-  $importModulesVerboseEnabled = ($ImportVerbose -eq '1')
   $importModules = DecodeModules $ImportModulesB64
   if ($importModules) {
     foreach ($m in $importModules) {
       if (-not $m -or [string]::IsNullOrWhiteSpace($m.Name)) { continue }
-      if ($m.RequiredVersion) {
-        Import-Module -Name $m.Name -RequiredVersion $m.RequiredVersion -Force -ErrorAction Stop -Verbose:$importModulesVerboseEnabled
-      } elseif ($m.MinimumVersion) {
-        Import-Module -Name $m.Name -MinimumVersion $m.MinimumVersion -Force -ErrorAction Stop -Verbose:$importModulesVerboseEnabled
-      } else {
-        Import-Module -Name $m.Name -Force -ErrorAction Stop -Verbose:$importModulesVerboseEnabled
-      }
+      Import-TestSuiteModule -Name $m.Name -RequiredVersion $m.RequiredVersion -MinimumVersion $m.MinimumVersion -Verbose:$ImportVerbose
     }
   }
 
   $doImport = ($SkipImport -ne '1') -and (-not [string]::IsNullOrWhiteSpace($ModuleImportPath))
   if ($doImport) {
-    Import-Module -Name $ModuleImportPath -Force:($ForceImport -eq '1') -ErrorAction Stop -Verbose:$importModulesVerboseEnabled | Out-Null
+    Import-TestSuiteModule -Name $ModuleImportPath -Force:($ForceImport -eq '1') -Verbose:$ImportVerbose
     Write-Output 'PFTEST::IMPORT::OK'
     try {
       $m = Get-Module -Name $ModuleName | Select-Object -First 1

--- a/PowerForge/Scripts/Tests/Invoke-TestSuite.ps1
+++ b/PowerForge/Scripts/Tests/Invoke-TestSuite.ps1
@@ -31,24 +31,24 @@ try {
     Write-Output ('PFTEST::PESTER::' + $p.Version.ToString())
   }
 
-  $importVerbose = ($ImportVerbose -eq '1')
+  $importModulesVerboseEnabled = ($ImportVerbose -eq '1')
   $importModules = DecodeModules $ImportModulesB64
   if ($importModules) {
     foreach ($m in $importModules) {
       if (-not $m -or [string]::IsNullOrWhiteSpace($m.Name)) { continue }
       if ($m.RequiredVersion) {
-        Import-Module -Name $m.Name -RequiredVersion $m.RequiredVersion -Force -ErrorAction Stop -Verbose:$importVerbose
+        Import-Module -Name $m.Name -RequiredVersion $m.RequiredVersion -Force -ErrorAction Stop -Verbose:$importModulesVerboseEnabled
       } elseif ($m.MinimumVersion) {
-        Import-Module -Name $m.Name -MinimumVersion $m.MinimumVersion -Force -ErrorAction Stop -Verbose:$importVerbose
+        Import-Module -Name $m.Name -MinimumVersion $m.MinimumVersion -Force -ErrorAction Stop -Verbose:$importModulesVerboseEnabled
       } else {
-        Import-Module -Name $m.Name -Force -ErrorAction Stop -Verbose:$importVerbose
+        Import-Module -Name $m.Name -Force -ErrorAction Stop -Verbose:$importModulesVerboseEnabled
       }
     }
   }
 
   $doImport = ($SkipImport -ne '1') -and (-not [string]::IsNullOrWhiteSpace($ModuleImportPath))
   if ($doImport) {
-    Import-Module -Name $ModuleImportPath -Force:($ForceImport -eq '1') -ErrorAction Stop -Verbose:$importVerbose | Out-Null
+    Import-Module -Name $ModuleImportPath -Force:($ForceImport -eq '1') -ErrorAction Stop -Verbose:$importModulesVerboseEnabled | Out-Null
     Write-Output 'PFTEST::IMPORT::OK'
     try {
       $m = Get-Module -Name $ModuleName | Select-Object -First 1

--- a/PowerForge/Scripts/Tests/Invoke-TestSuite.ps1
+++ b/PowerForge/Scripts/Tests/Invoke-TestSuite.ps1
@@ -30,14 +30,14 @@ function Import-TestSuiteModule {
     [string]$RequiredVersion,
     [string]$MinimumVersion,
     [bool]$Force = $true,
-    [bool]$Verbose = $false
+    [bool]$ShowVerbose = $false
   )
 
   $importParams = @{
     Name = $Name
     Force = $Force
     ErrorAction = 'Stop'
-    Verbose = $Verbose
+    Verbose = $ShowVerbose
   }
 
   if (-not [string]::IsNullOrWhiteSpace($RequiredVersion)) {
@@ -46,7 +46,7 @@ function Import-TestSuiteModule {
     $importParams.MinimumVersion = $MinimumVersion
   }
 
-  Import-Module @importParams | Out-Null
+  Import-Module @importParams
 }
 
 try {
@@ -60,13 +60,13 @@ try {
   if ($importModules) {
     foreach ($m in $importModules) {
       if (-not $m -or [string]::IsNullOrWhiteSpace($m.Name)) { continue }
-      Import-TestSuiteModule -Name $m.Name -RequiredVersion $m.RequiredVersion -MinimumVersion $m.MinimumVersion -Verbose:$ImportVerbose
+      Import-TestSuiteModule -Name $m.Name -RequiredVersion $m.RequiredVersion -MinimumVersion $m.MinimumVersion -ShowVerbose:$ImportVerbose
     }
   }
 
   $doImport = ($SkipImport -ne '1') -and (-not [string]::IsNullOrWhiteSpace($ModuleImportPath))
   if ($doImport) {
-    Import-TestSuiteModule -Name $ModuleImportPath -Force:($ForceImport -eq '1') -Verbose:$ImportVerbose
+    Import-TestSuiteModule -Name $ModuleImportPath -Force:($ForceImport -eq '1') -ShowVerbose:$ImportVerbose
     Write-Output 'PFTEST::IMPORT::OK'
     try {
       $m = Get-Module -Name $ModuleName | Select-Object -First 1


### PR DESCRIPTION
## Summary
- fix the embedded module test suite script so import verbosity uses a dedicated boolean variable
- avoid the PowerShell case-insensitive variable collision that coerced the value back to string
- add a regression test covering the embedded script contract for the verbose switch

## Why
`Invoke-TestSuite.ps1` accepted `ImportVerbose` as a string parameter and then assigned to `$importVerbose`, which is the same variable name in PowerShell because variable names are case-insensitive. That caused the boolean result to be coerced back to a string and later passed into `-Verbose`, which fails with:

`Cannot convert 'System.String' to the type 'System.Management.Automation.SwitchParameter' required by parameter 'Verbose'.`

This was breaking downstream module builds that run tests through `PSPublishModule`, including PSPGP.

## Validation
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter PowerForgeScriptsTests`
- direct file-mode execution of `PowerForge/Scripts/Tests/Invoke-TestSuite.ps1` against `C:\Support\GitHub\PSPGP\Tests` completed with `EXIT=0`