### PR TITLE
fix: clear stale prerelease during manifest refresh

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -202,7 +202,7 @@ public sealed partial class ModulePipelineRunner
 
                     if (!string.IsNullOrWhiteSpace(m.ModuleVersion)) expectedVersion = m.ModuleVersion;
                     if (m.CompatiblePSEditions is { Length: > 0 }) compatible = m.CompatiblePSEditions;
-                    if (!string.IsNullOrWhiteSpace(m.Prerelease)) preRelease = m.Prerelease;
+                    preRelease = string.IsNullOrWhiteSpace(m.Prerelease) ? null : m.Prerelease.Trim();
 
                     if (!string.IsNullOrWhiteSpace(m.Author)) author = m.Author;
                     if (!string.IsNullOrWhiteSpace(m.CompanyName)) companyName = m.CompanyName;

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -202,7 +202,8 @@ public sealed partial class ModulePipelineRunner
 
                     if (!string.IsNullOrWhiteSpace(m.ModuleVersion)) expectedVersion = m.ModuleVersion;
                     if (m.CompatiblePSEditions is { Length: > 0 }) compatible = m.CompatiblePSEditions;
-                    preRelease = string.IsNullOrWhiteSpace(m.Prerelease) ? null : m.Prerelease.Trim();
+                    // Unconditional: an absent Prerelease explicitly clears any baseline prerelease value.
+                    preRelease = string.IsNullOrWhiteSpace(m.Prerelease) ? null : m.Prerelease!.Trim();
 
                     if (!string.IsNullOrWhiteSpace(m.Author)) author = m.Author;
                     if (!string.IsNullOrWhiteSpace(m.CompanyName)) companyName = m.CompanyName;

--- a/PowerForge.Tests/ModulePipelineRefreshManifestOnlyTests.cs
+++ b/PowerForge.Tests/ModulePipelineRefreshManifestOnlyTests.cs
@@ -368,6 +368,63 @@ public sealed class ModulePipelineRefreshManifestOnlyTests
     }
 
     [Fact]
+    public void Run_RefreshPSD1Only_ClearsStalePrereleaseWhenManifestSegmentOmitsIt()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var projectManifest = Path.Combine(root.FullName, moduleName + ".psd1");
+            Assert.True(ManifestEditor.TrySetTopLevelString(projectManifest, "Prerelease", "Preview1"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0",
+                    KeepStaging = true
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationManifestSegment
+                    {
+                        Configuration = new ManifestConfiguration
+                        {
+                            ModuleVersion = "1.0.0",
+                            Author = "Tests"
+                        }
+                    },
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            RefreshPSD1Only = true
+                        }
+                    }
+                }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+            Assert.Null(plan.PreRelease);
+
+            var result = runner.Run(spec, plan);
+
+            Assert.NotNull(result.BuildResult);
+            Assert.False(ManifestEditor.TryGetTopLevelString(projectManifest, "Prerelease", out _));
+            Assert.False(ManifestEditor.TryGetPsDataStringArray(projectManifest, "Prerelease", out _));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Run_NormalBuild_UpdatesProjectRootManifestOnly()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));


### PR DESCRIPTION
## Summary
- clear the in-memory prerelease value when a manifest segment omits `Prerelease`
- stop refresh-only builds from carrying forward a stale prerelease tag from the existing psd1
- add a regression test covering the `RefreshPSD1Only` rebuild path

## Why
When a module manifest already contained a prerelease value such as `Preview1`, removing `Prerelease` from the build configuration did not actually clear it during a rebuild. `ModulePipelineRunner.Plan` seeded `plan.PreRelease` from the existing psd1 and only overwrote it when the new manifest configuration supplied a non-empty prerelease value.

That meant:
- the manifest refresh could remove the psd1 key
- but the in-memory plan still carried the old prerelease value
- downstream version formatting and build summaries could continue showing `-Preview1`

## Validation
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~Run_RefreshPSD1Only_ClearsStalePrereleaseWhenManifestSegmentOmitsIt|FullyQualifiedName~Run_WritesPrereleaseToPsDataAndRemovesTopLevelPrerelease|FullyQualifiedName~Run_RefreshesManifestMetadataAndClearsStaleValues"`

## Notes
A broader manifest-refresh test slice on current `main` still has one unrelated pre-existing failure in `Run_RemovesInboxAndDuplicatedExternalDependenciesFromManifest`, so I validated this change with the prerelease-focused regression slice above.