### PR TITLE
Limit portable publish signing scope

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -180,9 +180,7 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             var method = typeof(DotNetPublishPipelineRunner).GetMethod("TrySignOutput", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(method);
 
-            var signed = (int)method!.Invoke(runner, new object[] { outputDir, sign })!;
-
-            Assert.Equal(1, signed);
+            _ = method!.Invoke(runner, new object[] { outputDir, sign });
             Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 1 file(s)", StringComparison.OrdinalIgnoreCase));
         }
         finally
@@ -218,9 +216,7 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             var method = typeof(DotNetPublishPipelineRunner).GetMethod("TrySignOutput", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(method);
 
-            var signed = (int)method!.Invoke(runner, new object[] { outputDir, sign })!;
-
-            Assert.Equal(2, signed);
+            _ = method!.Invoke(runner, new object[] { outputDir, sign });
             Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 2 file(s)", StringComparison.OrdinalIgnoreCase));
         }
         finally

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -138,8 +138,7 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             };
 
             var runner = new DotNetPublishPipelineRunner(new NullLogger());
-            var method = typeof(DotNetPublishPipelineRunner).GetMethod("TrySignOutput", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(method);
+            var method = GetTrySignOutputMethod();
 
             var ex = Assert.Throws<TargetInvocationException>(() => method!.Invoke(runner, new object[] { outputDir, sign }));
             Assert.IsType<InvalidOperationException>(ex.InnerException);
@@ -171,14 +170,13 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             var sign = new DotNetPublishSignOptions
             {
                 Enabled = true,
-                ToolPath = Environment.GetEnvironmentVariable("ComSpec"),
+                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
                 OnMissingTool = DotNetPublishPolicyMode.Fail,
                 OnSignFailure = DotNetPublishPolicyMode.Skip
             };
 
             var runner = new DotNetPublishPipelineRunner(logger);
-            var method = typeof(DotNetPublishPipelineRunner).GetMethod("TrySignOutput", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(method);
+            var method = GetTrySignOutputMethod();
 
             _ = method!.Invoke(runner, new object[] { outputDir, sign });
             Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 1 file(s)", StringComparison.OrdinalIgnoreCase));
@@ -207,14 +205,13 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             {
                 Enabled = true,
                 IncludeDlls = true,
-                ToolPath = Environment.GetEnvironmentVariable("ComSpec"),
+                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
                 OnMissingTool = DotNetPublishPolicyMode.Fail,
                 OnSignFailure = DotNetPublishPolicyMode.Skip
             };
 
             var runner = new DotNetPublishPipelineRunner(logger);
-            var method = typeof(DotNetPublishPipelineRunner).GetMethod("TrySignOutput", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(method);
+            var method = GetTrySignOutputMethod();
 
             _ = method!.Invoke(runner, new object[] { outputDir, sign });
             Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 2 file(s)", StringComparison.OrdinalIgnoreCase));
@@ -444,6 +441,15 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
         var projectPath = Path.Combine(root, fileName);
         File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>");
         return projectPath;
+    }
+
+    private static MethodInfo GetTrySignOutputMethod()
+    {
+        var method = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "TrySignOutput",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(method is not null, "TrySignOutput private method not found. Was it renamed or made public?");
+        return method!;
     }
 
     private static string CreateTempRoot()

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -223,6 +223,40 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     }
 
     [Fact]
+    public void TrySignOutput_WhenDllOnlyAndIncludeDllsDisabled_HonorsFailurePolicy()
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
+
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                ToolPath = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Fail
+            };
+
+            var runner = new DotNetPublishPipelineRunner(new NullLogger());
+            var method = GetTrySignOutputMethod();
+
+            var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(runner, new object[] { outputDir, sign }));
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("no matching files were found", ex.InnerException!.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("IncludeDlls=true", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void BuildPublishMsBuildProperties_MergesGlobalTargetAndStyleOverrides()
     {
         var plan = new DotNetPublishPlan

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xunit;
@@ -146,6 +147,81 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
                 ex.InnerException!.Message.Contains("Signing requested", StringComparison.OrdinalIgnoreCase)
                 || ex.InnerException!.Message.Contains("Signing failed", StringComparison.OrdinalIgnoreCase),
                 $"Unexpected message: {ex.InnerException!.Message}");
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void TrySignOutput_DefaultsToExecutablesOnly()
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
+            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
+
+            var logger = new CollectingLogger();
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                ToolPath = Environment.GetEnvironmentVariable("ComSpec"),
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Skip
+            };
+
+            var runner = new DotNetPublishPipelineRunner(logger);
+            var method = typeof(DotNetPublishPipelineRunner).GetMethod("TrySignOutput", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var signed = (int)method!.Invoke(runner, new object[] { outputDir, sign })!;
+
+            Assert.Equal(1, signed);
+            Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 1 file(s)", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void TrySignOutput_IncludeDllsSignsExecutablesAndLibraries()
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var outputDir = Directory.CreateDirectory(Path.Combine(root, "out")).FullName;
+            File.WriteAllText(Path.Combine(outputDir, "app.exe"), "dummy");
+            File.WriteAllText(Path.Combine(outputDir, "lib.dll"), "dummy");
+
+            var logger = new CollectingLogger();
+            var sign = new DotNetPublishSignOptions
+            {
+                Enabled = true,
+                IncludeDlls = true,
+                ToolPath = Environment.GetEnvironmentVariable("ComSpec"),
+                OnMissingTool = DotNetPublishPolicyMode.Fail,
+                OnSignFailure = DotNetPublishPolicyMode.Skip
+            };
+
+            var runner = new DotNetPublishPipelineRunner(logger);
+            var method = typeof(DotNetPublishPipelineRunner).GetMethod("TrySignOutput", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var signed = (int)method!.Invoke(runner, new object[] { outputDir, sign })!;
+
+            Assert.Equal(2, signed);
+            Assert.Contains(logger.InfoMessages, message => message.Contains("Signing 2 file(s)", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -392,5 +468,16 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
         {
             // best effort
         }
+    }
+
+    private sealed class CollectingLogger : ILogger
+    {
+        public List<string> InfoMessages { get; } = new();
+        public bool IsVerbose => false;
+        public void Info(string message) => InfoMessages.Add(message);
+        public void Success(string message) { }
+        public void Warn(string message) { }
+        public void Error(string message) { }
+        public void Verbose(string message) { }
     }
 }

--- a/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
@@ -222,7 +222,7 @@ public sealed class DotNetPublishSignPatch
     /// <summary>Optional enable/disable override.</summary>
     public bool? Enabled { get; set; }
 
-    /// <summary>Optional include-DLLs override.</summary>
+    /// <summary>Optional include-DLLs override. Set <c>false</c> to explicitly disable DLL signing even if the base profile enables it.</summary>
     public bool? IncludeDlls { get; set; }
 
     /// <summary>Optional path to signtool.exe override.</summary>

--- a/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishTarget.cs
@@ -173,8 +173,11 @@ public sealed class DotNetPublishStyleOverride
 /// </summary>
 public sealed class DotNetPublishSignOptions
 {
-    /// <summary>Enables Authenticode signing of *.exe and *.dll under the output folder.</summary>
+    /// <summary>Enables Authenticode signing of executables under the output folder.</summary>
     public bool Enabled { get; set; }
+
+    /// <summary>Opts into signing *.dll files in addition to executables.</summary>
+    public bool IncludeDlls { get; set; }
 
     /// <summary>Optional path to signtool.exe (defaults to "signtool.exe").</summary>
     public string? ToolPath { get; set; } = "signtool.exe";
@@ -218,6 +221,9 @@ public sealed class DotNetPublishSignPatch
 {
     /// <summary>Optional enable/disable override.</summary>
     public bool? Enabled { get; set; }
+
+    /// <summary>Optional include-DLLs override.</summary>
+    public bool? IncludeDlls { get; set; }
 
     /// <summary>Optional path to signtool.exe override.</summary>
     public string? ToolPath { get; set; }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -68,7 +68,13 @@ public sealed partial class DotNetPublishPipelineRunner
             .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
             .ToArray();
         if (targets.Length == 0)
+        {
+            var noTargetsScope = string.IsNullOrWhiteSpace(scope) ? "outputs" : scope!.Trim();
+            HandlePolicy(
+                sign.OnSignFailure,
+                $"Signing requested for {noTargetsScope}, but no matching files were found. Set IncludeDlls=true to include DLL outputs when a publish produces no executables.");
             return Array.Empty<string>();
+        }
 
         var label = string.IsNullOrWhiteSpace(scope) ? string.Empty : $" ({scope!.Trim()})";
         _logger.Info($"Signing {targets.Length} file(s){label} using {Path.GetFileName(signToolPath)}");

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -14,7 +14,8 @@ public sealed partial class DotNetPublishPipelineRunner
         try
         {
             targets.AddRange(Directory.EnumerateFiles(outputDir, "*.exe", SearchOption.AllDirectories));
-            targets.AddRange(Directory.EnumerateFiles(outputDir, "*.dll", SearchOption.AllDirectories));
+            if (sign.IncludeDlls)
+                targets.AddRange(Directory.EnumerateFiles(outputDir, "*.dll", SearchOption.AllDirectories));
         }
         catch
         {

--- a/PowerForge/Services/DotNetPublishSigningProfileResolver.cs
+++ b/PowerForge/Services/DotNetPublishSigningProfileResolver.cs
@@ -58,6 +58,7 @@ internal static class DotNetPublishSigningProfileResolver
         return new DotNetPublishSignOptions
         {
             Enabled = sign.Enabled,
+            IncludeDlls = sign.IncludeDlls,
             ToolPath = sign.ToolPath,
             OnMissingTool = sign.OnMissingTool,
             OnSignFailure = sign.OnSignFailure,
@@ -77,6 +78,7 @@ internal static class DotNetPublishSigningProfileResolver
         return new DotNetPublishSignPatch
         {
             Enabled = signOverrides.Enabled,
+            IncludeDlls = signOverrides.IncludeDlls,
             ToolPath = signOverrides.ToolPath,
             OnMissingTool = signOverrides.OnMissingTool,
             OnSignFailure = signOverrides.OnSignFailure,
@@ -99,6 +101,8 @@ internal static class DotNetPublishSigningProfileResolver
 
         if (patch.Enabled.HasValue)
             sign.Enabled = patch.Enabled.Value;
+        if (patch.IncludeDlls.HasValue)
+            sign.IncludeDlls = patch.IncludeDlls.Value;
         if (patch.OnMissingTool.HasValue)
             sign.OnMissingTool = patch.OnMissingTool.Value;
         if (patch.OnSignFailure.HasValue)

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -156,6 +156,7 @@
       "additionalProperties": false,
       "properties": {
         "Enabled": { "type": "boolean" },
+        "IncludeDlls": { "type": "boolean" },
         "ToolPath": { "type": ["string", "null"] },
         "OnMissingTool": { "$ref": "#/$defs/DotNetPublishPolicyMode" },
         "OnSignFailure": { "$ref": "#/$defs/DotNetPublishPolicyMode" },
@@ -173,6 +174,7 @@
       "additionalProperties": false,
       "properties": {
         "Enabled": { "type": ["boolean", "null"] },
+        "IncludeDlls": { "type": ["boolean", "null"] },
         "ToolPath": { "type": ["string", "null"] },
         "OnMissingTool": { "anyOf": [{ "$ref": "#/$defs/DotNetPublishPolicyMode" }, { "type": "null" }] },
         "OnSignFailure": { "anyOf": [{ "$ref": "#/$defs/DotNetPublishPolicyMode" }, { "type": "null" }] },


### PR DESCRIPTION
## Summary
- change dotnet publish signing to sign executables by default instead of every dll in the output tree
- add explicit `IncludeDlls` opt-in on publish signing profiles and overrides
- cover the new default and opt-in behavior with hardening tests

## Why
During the signed IntelligenceX release rehearsal on April 6, 2026, a portable release spent an unreasonable amount of time inside token-backed signing because PowerForge was recursively signing the full portable payload. That is too expensive for normal desktop-app portable releases and does not match the common expectation of signing the app binary layer by default.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter DotNetPublishPipelineRunnerHardeningTests`
- `dotnet build .\PowerForge.Cli\PowerForge.Cli.csproj -c Release -f net10.0`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net8.0`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472`
