### PR TITLE
fix: surface TestsAfterMerge failure details

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
@@ -265,15 +265,74 @@ public sealed partial class ModulePipelineRunner
         var result = _hostedOperations.RunModuleTestSuite(spec);
         if (result.FailedCount > 0)
         {
+            var failureMessage = BuildTestsAfterMergeFailureMessage(result);
             if (testConfiguration.Force)
             {
-                _logger.Warn($"TestsAfterMerge failed ({result.FailedCount} failed) but Force was set; continuing.");
+                _logger.Warn($"{failureMessage}{Environment.NewLine}Force was set; continuing.");
             }
             else
             {
-                throw new InvalidOperationException($"TestsAfterMerge failed ({result.FailedCount} failed).");
+                throw new InvalidOperationException(failureMessage);
             }
         }
+    }
+
+    private static string BuildTestsAfterMergeFailureMessage(ModuleTestSuiteResult result)
+    {
+        var message = $"TestsAfterMerge failed ({result.FailedCount} failed).";
+        if (result.FailureAnalysis is { FailedTests.Length: > 0 } analysis)
+        {
+            var lines = analysis.FailedTests
+                .Where(static failure => !string.IsNullOrWhiteSpace(failure.Name) || !string.IsNullOrWhiteSpace(failure.ErrorMessage))
+                .Take(5)
+                .Select(static failure => FormatTestsAfterMergeFailureLine(failure))
+                .ToArray();
+
+            if (lines.Length > 0)
+            {
+                var omittedCount = analysis.FailedTests.Length - lines.Length;
+                var details = string.Join(Environment.NewLine, lines);
+                if (omittedCount > 0)
+                    details = $"{details}{Environment.NewLine}Additional failed tests omitted: {omittedCount}.";
+
+                return $"{message}{Environment.NewLine}Failed tests:{Environment.NewLine}{details}";
+            }
+        }
+
+        var stdErrLine = GetFirstMeaningfulLine(result.StdErr);
+        if (!string.IsNullOrWhiteSpace(stdErrLine))
+            return $"{message}{Environment.NewLine}stderr: {stdErrLine}";
+
+        var stdOutLine = GetFirstMeaningfulLine(result.StdOut);
+        if (!string.IsNullOrWhiteSpace(stdOutLine))
+            return $"{message}{Environment.NewLine}stdout: {stdOutLine}";
+
+        return message;
+    }
+
+    private static string FormatTestsAfterMergeFailureLine(ModuleTestFailureInfo failure)
+    {
+        var testName = string.IsNullOrWhiteSpace(failure.Name) ? "<unnamed test>" : failure.Name.Trim();
+        var errorLine = GetFirstMeaningfulLine(failure.ErrorMessage);
+        return string.IsNullOrWhiteSpace(errorLine)
+            ? $"- {testName}"
+            : $"- {testName}: {errorLine}";
+    }
+
+    private static string? GetFirstMeaningfulLine(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var nonEmptyText = text!;
+        foreach (var line in nonEmptyText.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length > 0)
+                return trimmed;
+        }
+
+        return null;
     }
 
     private void TryRegenerateBootstrapperFromManifest(ModuleBuildResult buildResult, string moduleName, IReadOnlyList<string>? exportAssemblies)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
@@ -34,11 +34,10 @@ public sealed partial class ModulePipelineRunner
             ExecutePreparationAndBuildPhases(plan, session, manifestRequiredModules, manifestExternalModuleDependencies, pipeline, state);
             ExecuteDocumentationPhase(plan, session, session.Reporter, state);
             ExecuteFormattingAndSigningPhases(plan, session, manifestRequiredModules, manifestExternalModuleDependencies, state);
+            state.ProjectManifestSyncMessage = SyncBuildManifestToProjectRoot(plan);
             ExecuteValidationPhases(plan, session, state);
             ExecuteTestPhases(plan, session, state);
             ExecutePackagingPublishAndInstallPhases(spec, plan, session, packagingRequiredModules, pipeline, state);
-
-            state.ProjectManifestSyncMessage = SyncBuildManifestToProjectRoot(plan);
 
             return BuildPipelineResult(spec, plan, state);
         }

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -147,11 +147,181 @@ public sealed class ModulePipelineHostedOperationsTests
         Assert.Equal(1, result.SignedNew);
     }
 
+    [Fact]
+    public void RunTestsAfterMerge_IncludesFailedTestNamesAndMessages()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+            var testsPath = Directory.CreateDirectory(Path.Combine(root.FullName, "Tests")).FullName;
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var hostedOperations = new FakeHostedOperations
+            {
+                NextTestSuiteResult = new ModuleTestSuiteResult(
+                    projectPath: root.FullName,
+                    testPath: testsPath,
+                    moduleName: moduleName,
+                    moduleVersion: "1.0.0",
+                    manifestPath: Path.Combine(root.FullName, $"{moduleName}.psd1"),
+                    requiredModules: Array.Empty<RequiredModuleReference>(),
+                    dependencyResults: Array.Empty<ModuleDependencyInstallResult>(),
+                    moduleImported: true,
+                    exportedFunctionCount: null,
+                    exportedCmdletCount: null,
+                    exportedAliasCount: null,
+                    pesterVersion: "5.7.1",
+                    totalCount: 3,
+                    passedCount: 2,
+                    failedCount: 1,
+                    skippedCount: 0,
+                    duration: null,
+                    coveragePercent: null,
+                    failureAnalysis: new ModuleTestFailureAnalysis
+                    {
+                        Source = "PesterResults",
+                        Timestamp = DateTime.Now,
+                        TotalCount = 3,
+                        PassedCount = 2,
+                        FailedCount = 1,
+                        FailedTests = new[]
+                        {
+                            new ModuleTestFailureInfo
+                            {
+                                Name = "Broken.Test",
+                                ErrorMessage = "boom"
+                            }
+                        }
+                    },
+                    exitCode: 1,
+                    stdOut: string.Empty,
+                    stdErr: string.Empty,
+                    resultsXmlPath: null)
+            };
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var buildResult = new ModuleBuildResult(
+                stagingPath: root.FullName,
+                manifestPath: Path.Combine(root.FullName, $"{moduleName}.psd1"),
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                InvokeRunTestsAfterMerge(runner, plan, buildResult, new TestConfiguration { TestsPath = testsPath }));
+
+            var actual = Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("TestsAfterMerge failed (1 failed).", actual.Message, StringComparison.Ordinal);
+            Assert.Contains("Broken.Test", actual.Message, StringComparison.Ordinal);
+            Assert.Contains("boom", actual.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RunTestsAfterMerge_FallsBackToCapturedErrorOutput()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+            var testsPath = Directory.CreateDirectory(Path.Combine(root.FullName, "Tests")).FullName;
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var hostedOperations = new FakeHostedOperations
+            {
+                NextTestSuiteResult = new ModuleTestSuiteResult(
+                    projectPath: root.FullName,
+                    testPath: testsPath,
+                    moduleName: moduleName,
+                    moduleVersion: "1.0.0",
+                    manifestPath: Path.Combine(root.FullName, $"{moduleName}.psd1"),
+                    requiredModules: Array.Empty<RequiredModuleReference>(),
+                    dependencyResults: Array.Empty<ModuleDependencyInstallResult>(),
+                    moduleImported: true,
+                    exportedFunctionCount: null,
+                    exportedCmdletCount: null,
+                    exportedAliasCount: null,
+                    pesterVersion: "5.7.1",
+                    totalCount: 3,
+                    passedCount: 2,
+                    failedCount: 1,
+                    skippedCount: 0,
+                    duration: null,
+                    coveragePercent: null,
+                    failureAnalysis: null,
+                    exitCode: 1,
+                    stdOut: "ignored output",
+                    stdErr: "\r\nfirst error line\r\nsecond error line",
+                    resultsXmlPath: null)
+            };
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var buildResult = new ModuleBuildResult(
+                stagingPath: root.FullName,
+                manifestPath: Path.Combine(root.FullName, $"{moduleName}.psd1"),
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                InvokeRunTestsAfterMerge(runner, plan, buildResult, new TestConfiguration { TestsPath = testsPath }));
+
+            var actual = Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("stderr: first error line", actual.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static ModuleDependencyInstallResult[] InvokeEnsureBuildDependenciesInstalledIfNeeded(ModulePipelineRunner runner, ModulePipelinePlan plan)
     {
         var method = typeof(ModulePipelineRunner).GetMethod("EnsureBuildDependenciesInstalledIfNeeded", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.True(method is not null, "EnsureBuildDependenciesInstalledIfNeeded method signature may have changed.");
         return (ModuleDependencyInstallResult[])method!.Invoke(runner, new object?[] { plan })!;
+    }
+
+    private static void InvokeRunTestsAfterMerge(ModulePipelineRunner runner, ModulePipelinePlan plan, ModuleBuildResult buildResult, TestConfiguration configuration)
+    {
+        var method = typeof(ModulePipelineRunner).GetMethod("RunTestsAfterMerge", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(method is not null, "RunTestsAfterMerge method signature may have changed.");
+        method!.Invoke(runner, new object?[] { plan, buildResult, configuration });
     }
 
     private static void WriteMinimalModule(string moduleRoot, string moduleName, string version)
@@ -199,6 +369,7 @@ public sealed class ModulePipelineHostedOperationsTests
         public int DependencyInstallCalls { get; private set; }
         public IReadOnlyList<ModuleDependency> LastDependencies { get; private set; } = Array.Empty<ModuleDependency>();
         public string? LastRepository { get; private set; }
+        public ModuleTestSuiteResult? NextTestSuiteResult { get; set; }
 
         public IReadOnlyList<ModuleDependencyInstallResult> EnsureDependenciesInstalled(
             ModuleDependency[] dependencies,
@@ -245,7 +416,7 @@ public sealed class ModulePipelineHostedOperationsTests
             => throw new InvalidOperationException("Not used in this test.");
 
         public ModuleTestSuiteResult RunModuleTestSuite(ModuleTestSuiteSpec spec)
-            => throw new InvalidOperationException("Not used in this test.");
+            => NextTestSuiteResult ?? throw new InvalidOperationException("Not used in this test.");
 
         public ModulePublishResult PublishModule(
             PublishConfiguration publish,

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -246,6 +246,113 @@ public sealed class ModulePipelineManifestRefreshTests
     }
 
     [Fact]
+    public void Run_RefreshesProjectManifestBeforeTestsAfterMergeCanFail()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteModuleWithStaleManifest(root.FullName, moduleName, "1.0.0");
+            var testsPath = Directory.CreateDirectory(Path.Combine(root.FullName, "Tests")).FullName;
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "3.0.0",
+                    CsprojPath = null,
+                    KeepStaging = true
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationManifestSegment
+                    {
+                        Configuration = new ManifestConfiguration
+                        {
+                            ModuleVersion = "3.0.0",
+                            Guid = "22222222-2222-2222-2222-222222222222",
+                            Author = "New Author",
+                            Prerelease = null
+                        }
+                    },
+                    new ConfigurationTestSegment
+                    {
+                        Configuration = new TestConfiguration
+                        {
+                            TestsPath = testsPath,
+                            Force = false
+                        }
+                    }
+                }
+            };
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeDependencyMetadataProvider(),
+                new FakeHostedOperations
+                {
+                    NextTestSuiteResult = new ModuleTestSuiteResult(
+                        projectPath: root.FullName,
+                        testPath: testsPath,
+                        moduleName: moduleName,
+                        moduleVersion: "3.0.0",
+                        manifestPath: Path.Combine(root.FullName, $"{moduleName}.psd1"),
+                        requiredModules: Array.Empty<RequiredModuleReference>(),
+                        dependencyResults: Array.Empty<ModuleDependencyInstallResult>(),
+                        moduleImported: true,
+                        exportedFunctionCount: null,
+                        exportedCmdletCount: null,
+                        exportedAliasCount: null,
+                        pesterVersion: "5.7.1",
+                        totalCount: 2,
+                        passedCount: 1,
+                        failedCount: 1,
+                        skippedCount: 0,
+                        duration: null,
+                        coveragePercent: null,
+                        failureAnalysis: new ModuleTestFailureAnalysis
+                        {
+                            Source = "PesterResults",
+                            Timestamp = DateTime.Now,
+                            TotalCount = 2,
+                            PassedCount = 1,
+                            FailedCount = 1,
+                            FailedTests = new[]
+                            {
+                                new ModuleTestFailureInfo
+                                {
+                                    Name = "Broken.Test",
+                                    ErrorMessage = "boom"
+                                }
+                            }
+                        },
+                        exitCode: 1,
+                        stdOut: string.Empty,
+                        stdErr: string.Empty,
+                        resultsXmlPath: null)
+                });
+
+            var plan = runner.Plan(spec);
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec, plan));
+            Assert.Contains("Broken.Test", ex.Message, StringComparison.Ordinal);
+
+            var projectManifestPath = Path.Combine(root.FullName, $"{moduleName}.psd1");
+            Assert.False(ManifestEditor.TryGetTopLevelString(projectManifestPath, "Prerelease", out _));
+            Assert.False(ManifestEditor.TryGetPsDataStringArray(projectManifestPath, "Prerelease", out _));
+            Assert.True(ManifestEditor.TryGetTopLevelString(projectManifestPath, "ModuleVersion", out var version));
+            Assert.Equal("3.0.0", version);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Run_RemovesInboxAndDuplicatedExternalDependenciesFromManifest()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -415,6 +522,8 @@ public sealed class ModulePipelineManifestRefreshTests
 
     private sealed class FakeHostedOperations : IModulePipelineHostedOperations
     {
+        public ModuleTestSuiteResult? NextTestSuiteResult { get; set; }
+
         public IReadOnlyList<ModuleDependencyInstallResult> EnsureDependenciesInstalled(
             ModuleDependency[] dependencies,
             ModuleSkipConfiguration? skipModules,
@@ -443,7 +552,7 @@ public sealed class ModulePipelineManifestRefreshTests
             => throw new InvalidOperationException("Not used in this test.");
 
         public ModuleTestSuiteResult RunModuleTestSuite(ModuleTestSuiteSpec spec)
-            => throw new InvalidOperationException("Not used in this test.");
+            => NextTestSuiteResult ?? throw new InvalidOperationException("Not used in this test.");
 
         public ModulePublishResult PublishModule(
             PublishConfiguration publish,


### PR DESCRIPTION
## Summary
- include failing test names and first error lines in TestsAfterMerge failures
- fall back to captured stderr/stdout when structured failure analysis is unavailable
- add regression tests for both paths

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~ModulePipelineHostedOperationsTests.RunTestsAfterMerge"
- dotnet build PowerForge.PowerShell/PowerForge.PowerShell.csproj -c Debug -f net472 --nologo