### PR TITLE
fix: address TestsAfterMerge review follow-ups

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
@@ -282,15 +282,18 @@ public sealed partial class ModulePipelineRunner
         var message = $"TestsAfterMerge failed ({result.FailedCount} failed).";
         if (result.FailureAnalysis is { FailedTests.Length: > 0 } analysis)
         {
-            var lines = analysis.FailedTests
+            var filteredFailures = analysis.FailedTests
                 .Where(static failure => !string.IsNullOrWhiteSpace(failure.Name) || !string.IsNullOrWhiteSpace(failure.ErrorMessage))
+                .ToArray();
+
+            var lines = filteredFailures
                 .Take(5)
-                .Select(static failure => FormatTestsAfterMergeFailureLine(failure))
+                .Select(FormatTestsAfterMergeFailureLine)
                 .ToArray();
 
             if (lines.Length > 0)
             {
-                var omittedCount = analysis.FailedTests.Length - lines.Length;
+                var omittedCount = filteredFailures.Length - lines.Length;
                 var details = string.Join(Environment.NewLine, lines);
                 if (omittedCount > 0)
                     details = $"{details}{Environment.NewLine}Additional failed tests omitted: {omittedCount}.";
@@ -321,11 +324,10 @@ public sealed partial class ModulePipelineRunner
 
     private static string? GetFirstMeaningfulLine(string? text)
     {
-        if (string.IsNullOrWhiteSpace(text))
+        if (text is null || text.Length == 0 || string.IsNullOrWhiteSpace(text))
             return null;
 
-        var nonEmptyText = text!;
-        foreach (var line in nonEmptyText.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+        foreach (var line in text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
         {
             var trimmed = line.Trim();
             if (trimmed.Length > 0)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
@@ -34,6 +34,7 @@ public sealed partial class ModulePipelineRunner
             ExecutePreparationAndBuildPhases(plan, session, manifestRequiredModules, manifestExternalModuleDependencies, pipeline, state);
             ExecuteDocumentationPhase(plan, session, session.Reporter, state);
             ExecuteFormattingAndSigningPhases(plan, session, manifestRequiredModules, manifestExternalModuleDependencies, state);
+            // Refresh the project-root manifest before validation or tests can abort the run so callers always see current metadata.
             state.ProjectManifestSyncMessage = SyncBuildManifestToProjectRoot(plan);
             ExecuteValidationPhases(plan, session, state);
             ExecuteTestPhases(plan, session, state);

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -310,6 +310,97 @@ public sealed class ModulePipelineHostedOperationsTests
         }
     }
 
+    [Fact]
+    public void RunTestsAfterMerge_OmittedCount_IgnoresBlankFailuresFilteredOutOfOutput()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+            var testsPath = Directory.CreateDirectory(Path.Combine(root.FullName, "Tests")).FullName;
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var hostedOperations = new FakeHostedOperations
+            {
+                NextTestSuiteResult = new ModuleTestSuiteResult(
+                    projectPath: root.FullName,
+                    testPath: testsPath,
+                    moduleName: moduleName,
+                    moduleVersion: "1.0.0",
+                    manifestPath: Path.Combine(root.FullName, $"{moduleName}.psd1"),
+                    requiredModules: Array.Empty<RequiredModuleReference>(),
+                    dependencyResults: Array.Empty<ModuleDependencyInstallResult>(),
+                    moduleImported: true,
+                    exportedFunctionCount: null,
+                    exportedCmdletCount: null,
+                    exportedAliasCount: null,
+                    pesterVersion: "5.7.1",
+                    totalCount: 7,
+                    passedCount: 0,
+                    failedCount: 7,
+                    skippedCount: 0,
+                    duration: null,
+                    coveragePercent: null,
+                    failureAnalysis: new ModuleTestFailureAnalysis
+                    {
+                        Source = "PesterResults",
+                        Timestamp = DateTime.Now,
+                        TotalCount = 7,
+                        PassedCount = 0,
+                        FailedCount = 7,
+                        FailedTests = new[]
+                        {
+                            new ModuleTestFailureInfo { Name = "Broken.Test1", ErrorMessage = "boom1" },
+                            new ModuleTestFailureInfo { Name = "Broken.Test2", ErrorMessage = "boom2" },
+                            new ModuleTestFailureInfo { Name = "Broken.Test3", ErrorMessage = "boom3" },
+                            new ModuleTestFailureInfo { Name = "Broken.Test4", ErrorMessage = "boom4" },
+                            new ModuleTestFailureInfo { Name = "Broken.Test5", ErrorMessage = "boom5" },
+                            new ModuleTestFailureInfo(),
+                            new ModuleTestFailureInfo()
+                        }
+                    },
+                    exitCode: 1,
+                    stdOut: string.Empty,
+                    stdErr: string.Empty,
+                    resultsXmlPath: null)
+            };
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var buildResult = new ModuleBuildResult(
+                stagingPath: root.FullName,
+                manifestPath: Path.Combine(root.FullName, $"{moduleName}.psd1"),
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                InvokeRunTestsAfterMerge(runner, plan, buildResult, new TestConfiguration { TestsPath = testsPath }));
+
+            var actual = Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.DoesNotContain("Additional failed tests omitted", actual.Message, StringComparison.Ordinal);
+            Assert.Contains("Broken.Test5", actual.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static ModuleDependencyInstallResult[] InvokeEnsureBuildDependenciesInstalledIfNeeded(ModulePipelineRunner runner, ModulePipelinePlan plan)
     {
         var method = typeof(ModulePipelineRunner).GetMethod("EnsureBuildDependenciesInstalledIfNeeded", BindingFlags.Instance | BindingFlags.NonPublic);


### PR DESCRIPTION
## Summary
- fix the omitted-count calculation so blank filtered failures do not inflate the "Additional failed tests omitted" message
- simplify the TestsAfterMerge failure-formatting helpers
- document why project-root manifest sync happens before validation and tests
- add a regression test for the filtered-failure omitted-count case

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~ModulePipelineHostedOperationsTests.RunTestsAfterMerge|FullyQualifiedName~ModulePipelineManifestRefreshTests.Run_RefreshesProjectManifestBeforeTestsAfterMergeCanFail"
- dotnet build PowerForge.PowerShell/PowerForge.PowerShell.csproj -c Debug -f net472 --nologo