### PR TITLE
fix: fail fast when binary build lacks csproj

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -788,11 +788,27 @@ public sealed partial class ModulePipelineRunner
         bool binaryModuleDocumentationRequested)
     {
         var reasons = new List<string>();
+        var hasFrameworks = HasAnyConfiguredValues(dotnetFrameworksFromSegments)
+                            || HasAnyConfiguredValues(spec.Build.Frameworks);
+        var hasBinaryModules = HasAnyConfiguredValues(exportAssembliesFromSegments)
+                               || HasAnyConfiguredValues(spec.Build.ExportAssemblies);
+        var hasExplicitBinaryIntentBeyondFramework =
+            syncNETProjectVersion
+            || hasBinaryModules
+            || !string.IsNullOrWhiteSpace(resolveBinaryConflictsProjectName)
+            || HasAnyConfiguredValues(excludeLibraryFilterFromSegments)
+            || HasAnyConfiguredValues(spec.Build.ExcludeLibraryFilter)
+            || doNotCopyLibrariesRecursivelyFromSegments == true
+            || spec.Build.DoNotCopyLibrariesRecursively
+            || binaryModuleDocumentationRequested;
 
         if (syncNETProjectVersion)
             reasons.Add("SyncNETProjectVersion");
 
-        if (exportAssembliesFromSegments is { Length: > 0 } || spec.Build.ExportAssemblies is { Length: > 0 })
+        if (hasFrameworks && hasExplicitBinaryIntentBeyondFramework)
+            reasons.Add("NETFramework");
+
+        if (hasBinaryModules)
             reasons.Add("NETBinaryModule");
 
         if (!string.IsNullOrWhiteSpace(resolveBinaryConflictsProjectName))
@@ -811,6 +827,10 @@ public sealed partial class ModulePipelineRunner
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
     }
+
+    private static bool HasAnyConfiguredValues(string[]? values)
+        => values is { Length: > 0 } &&
+           values.Any(static value => !string.IsNullOrWhiteSpace(value));
 
     private bool TryAddExternalModuleDependency(
         string moduleName,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -72,6 +72,7 @@ public sealed partial class ModulePipelineRunner
         bool? doNotCopyLibrariesRecursivelyFromSegments = null;
         bool? disableBinaryCmdletScanFromSegments = null;
         string? resolveBinaryConflictsProjectName = null;
+        bool binaryModuleDocumentationRequested = false;
 
         InformationConfiguration? information = null;
         DocumentationConfiguration? documentation = null;
@@ -262,6 +263,7 @@ public sealed partial class ModulePipelineRunner
                     if (bl.ExcludeLibraryFilter is { Length: > 0 }) excludeLibraryFilterFromSegments = bl.ExcludeLibraryFilter;
                     if (bl.NETDoNotCopyLibrariesRecursively.HasValue) doNotCopyLibrariesRecursivelyFromSegments = bl.NETDoNotCopyLibrariesRecursively.Value;
                     if (bl.BinaryModuleCmdletScanDisabled.HasValue) disableBinaryCmdletScanFromSegments = bl.BinaryModuleCmdletScanDisabled.Value;
+                    if (bl.NETBinaryModuleDocumentation == true) binaryModuleDocumentationRequested = true;
                     break;
                 }
                 case ConfigurationModuleSegment moduleSeg:
@@ -495,9 +497,21 @@ public sealed partial class ModulePipelineRunner
                 resolveBinaryConflictsProjectName?.Trim()
                 ?? netProjectName?.Trim();
 
-            if (!string.IsNullOrWhiteSpace(inferred))
-                exportAssemblies = new[] { inferred! };
+        if (!string.IsNullOrWhiteSpace(inferred))
+            exportAssemblies = new[] { inferred! };
         }
+
+        var csprojRequiredReasons = refreshPsd1Only
+            ? Array.Empty<string>()
+            : BuildMissingCsprojReasonList(
+                spec,
+                syncNETProjectVersion,
+                dotnetFrameworksFromSegments,
+                exportAssembliesFromSegments,
+                excludeLibraryFilterFromSegments,
+                doNotCopyLibrariesRecursivelyFromSegments,
+                resolveBinaryConflictsProjectName,
+                binaryModuleDocumentationRequested);
 
         var buildSpec = new ModuleBuildSpec
         {
@@ -520,6 +534,7 @@ public sealed partial class ModulePipelineRunner
             ExcludeLibraryFilter = excludeLibraryFilterFromSegments ?? spec.Build.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively,
             DisableBinaryCmdletScan = disableBinaryCmdletScanFromSegments ?? spec.Build.DisableBinaryCmdletScan,
+            CsprojRequiredReasons = string.IsNullOrWhiteSpace(csproj) ? csprojRequiredReasons : Array.Empty<string>(),
             BinaryConflictPriorityModuleNames = requiredModulesDraft
                 .Select(static module => module.ModuleName)
                 .Where(static name => !string.IsNullOrWhiteSpace(name))
@@ -760,6 +775,44 @@ public sealed partial class ModulePipelineRunner
             installMissingModulesCredential: installMissingModulesCredential,
             stagingWasGenerated: stagingWasGenerated,
             deleteGeneratedStagingAfterRun: deleteAfter);
+    }
+
+    private static string[] BuildMissingCsprojReasonList(
+        ModulePipelineSpec spec,
+        bool syncNETProjectVersion,
+        string[]? dotnetFrameworksFromSegments,
+        string[]? exportAssembliesFromSegments,
+        string[]? excludeLibraryFilterFromSegments,
+        bool? doNotCopyLibrariesRecursivelyFromSegments,
+        string? resolveBinaryConflictsProjectName,
+        bool binaryModuleDocumentationRequested)
+    {
+        var reasons = new List<string>();
+
+        if (syncNETProjectVersion)
+            reasons.Add("SyncNETProjectVersion");
+
+        if (dotnetFrameworksFromSegments is { Length: > 0 } || spec.Build.Frameworks is { Length: > 0 })
+            reasons.Add("NETFramework");
+
+        if (exportAssembliesFromSegments is { Length: > 0 } || spec.Build.ExportAssemblies is { Length: > 0 })
+            reasons.Add("NETBinaryModule");
+
+        if (!string.IsNullOrWhiteSpace(resolveBinaryConflictsProjectName))
+            reasons.Add("ResolveBinaryConflictsName");
+
+        if (excludeLibraryFilterFromSegments is { Length: > 0 } || spec.Build.ExcludeLibraryFilter is { Length: > 0 })
+            reasons.Add("NETExcludeLibraryFilter");
+
+        if (doNotCopyLibrariesRecursivelyFromSegments == true || spec.Build.DoNotCopyLibrariesRecursively)
+            reasons.Add("NETDoNotCopyLibrariesRecursively");
+
+        if (binaryModuleDocumentationRequested)
+            reasons.Add("NETBinaryModuleDocumentation");
+
+        return reasons
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private bool TryAddExternalModuleDependency(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -792,14 +792,15 @@ public sealed partial class ModulePipelineRunner
                             || HasAnyConfiguredValues(spec.Build.Frameworks);
         var hasBinaryModules = HasAnyConfiguredValues(exportAssembliesFromSegments)
                                || HasAnyConfiguredValues(spec.Build.ExportAssemblies);
+        var effectiveDoNotCopyLibrariesRecursively =
+            doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively;
         var hasExplicitBinaryIntentBeyondFramework =
             syncNETProjectVersion
             || hasBinaryModules
             || !string.IsNullOrWhiteSpace(resolveBinaryConflictsProjectName)
             || HasAnyConfiguredValues(excludeLibraryFilterFromSegments)
             || HasAnyConfiguredValues(spec.Build.ExcludeLibraryFilter)
-            || doNotCopyLibrariesRecursivelyFromSegments == true
-            || spec.Build.DoNotCopyLibrariesRecursively
+            || effectiveDoNotCopyLibrariesRecursively
             || binaryModuleDocumentationRequested;
 
         if (syncNETProjectVersion)
@@ -817,7 +818,7 @@ public sealed partial class ModulePipelineRunner
         if (HasAnyConfiguredValues(excludeLibraryFilterFromSegments) || HasAnyConfiguredValues(spec.Build.ExcludeLibraryFilter))
             reasons.Add("NETExcludeLibraryFilter");
 
-        if (doNotCopyLibrariesRecursivelyFromSegments == true || spec.Build.DoNotCopyLibrariesRecursively)
+        if (effectiveDoNotCopyLibrariesRecursively)
             reasons.Add("NETDoNotCopyLibrariesRecursively");
 
         if (binaryModuleDocumentationRequested)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -72,7 +72,7 @@ public sealed partial class ModulePipelineRunner
         bool? doNotCopyLibrariesRecursivelyFromSegments = null;
         bool? disableBinaryCmdletScanFromSegments = null;
         string? resolveBinaryConflictsProjectName = null;
-        bool binaryModuleDocumentationRequested = false;
+        bool? binaryModuleDocumentationRequested = null;
 
         InformationConfiguration? information = null;
         DocumentationConfiguration? documentation = null;
@@ -263,7 +263,7 @@ public sealed partial class ModulePipelineRunner
                     if (bl.ExcludeLibraryFilter is { Length: > 0 }) excludeLibraryFilterFromSegments = bl.ExcludeLibraryFilter;
                     if (bl.NETDoNotCopyLibrariesRecursively.HasValue) doNotCopyLibrariesRecursivelyFromSegments = bl.NETDoNotCopyLibrariesRecursively.Value;
                     if (bl.BinaryModuleCmdletScanDisabled.HasValue) disableBinaryCmdletScanFromSegments = bl.BinaryModuleCmdletScanDisabled.Value;
-                    if (bl.NETBinaryModuleDocumentation == true) binaryModuleDocumentationRequested = true;
+                    if (bl.NETBinaryModuleDocumentation.HasValue) binaryModuleDocumentationRequested = bl.NETBinaryModuleDocumentation.Value;
                     break;
                 }
                 case ConfigurationModuleSegment moduleSeg:
@@ -511,7 +511,7 @@ public sealed partial class ModulePipelineRunner
                 excludeLibraryFilterFromSegments,
                 doNotCopyLibrariesRecursivelyFromSegments,
                 resolveBinaryConflictsProjectName,
-                binaryModuleDocumentationRequested);
+                binaryModuleDocumentationRequested == true);
 
         var buildSpec = new ModuleBuildSpec
         {
@@ -791,9 +791,6 @@ public sealed partial class ModulePipelineRunner
 
         if (syncNETProjectVersion)
             reasons.Add("SyncNETProjectVersion");
-
-        if (dotnetFrameworksFromSegments is { Length: > 0 } || spec.Build.Frameworks is { Length: > 0 })
-            reasons.Add("NETFramework");
 
         if (exportAssembliesFromSegments is { Length: > 0 } || spec.Build.ExportAssemblies is { Length: > 0 })
             reasons.Add("NETBinaryModule");

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -814,7 +814,7 @@ public sealed partial class ModulePipelineRunner
         if (!string.IsNullOrWhiteSpace(resolveBinaryConflictsProjectName))
             reasons.Add("ResolveBinaryConflictsName");
 
-        if (excludeLibraryFilterFromSegments is { Length: > 0 } || spec.Build.ExcludeLibraryFilter is { Length: > 0 })
+        if (HasAnyConfiguredValues(excludeLibraryFilterFromSegments) || HasAnyConfiguredValues(spec.Build.ExcludeLibraryFilter))
             reasons.Add("NETExcludeLibraryFilter");
 
         if (doNotCopyLibrariesRecursivelyFromSegments == true || spec.Build.DoNotCopyLibrariesRecursively)

--- a/PowerForge.Tests/ModuleBuilderDependencyCopyTests.cs
+++ b/PowerForge.Tests/ModuleBuilderDependencyCopyTests.cs
@@ -320,6 +320,49 @@ public sealed class ModuleBuilderDependencyCopyTests
     }
 
     [Fact]
+    public void BuildInPlace_ThrowsWhenExistingLibPayloadWouldMaskExplicitBinaryBuildIntent()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            const string moduleName = "TestModule";
+            File.WriteAllText(Path.Combine(root, $"{moduleName}.psm1"), string.Empty);
+            File.WriteAllText(Path.Combine(root, $"{moduleName}.psd1"), "@{ RootModule = 'TestModule.psm1'; ModuleVersion = '1.0.0' }");
+
+            var libDefault = Directory.CreateDirectory(Path.Combine(root, "Lib", "Default"));
+            File.WriteAllText(Path.Combine(libDefault.FullName, "Existing.Binary.dll"), "placeholder");
+
+            var builder = ModuleBuilderTestDependencies.Create(new CollectingLogger());
+            var ex = Assert.Throws<InvalidOperationException>(() => builder.BuildInPlace(new ModuleBuilder.Options
+            {
+                ProjectRoot = root,
+                ModuleName = moduleName,
+                ModuleVersion = "1.0.0",
+                CsprojPath = string.Empty,
+                CsprojRequiredReasons = new[] { "NETFramework", "NETBinaryModule" }
+            }));
+
+            Assert.Contains("No CsprojPath could be resolved", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("NETFramework", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("NETBinaryModule", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+    }
+
+    [Fact]
     public void CopyPublishOutputBinaries_SkipsRuntimeTargets_WhenDoNotCopyLibrariesRecursively()
     {
         var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -133,4 +133,71 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
             try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
         }
     }
+
+    [Fact]
+    public void Plan_RecordsMissingCsprojReasons_WhenExplicitBinaryBuildSettingsAreConfigured()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            SyncNETProjectVersion = true,
+                            ResolveBinaryConflicts = new ResolveBinaryConflictsConfiguration
+                            {
+                                ProjectName = "PSParseHTML.PowerShell"
+                            }
+                        }
+                    },
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            Framework = new[] { "net8.0" },
+                            BinaryModule = new[] { "PSParseHTML.PowerShell.dll" },
+                            ExcludeLibraryFilter = new[] { "System.Management.*.dll" },
+                            NETDoNotCopyLibrariesRecursively = true,
+                            NETBinaryModuleDocumentation = true
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath));
+            Assert.Equal(
+                new[]
+                {
+                    "SyncNETProjectVersion",
+                    "NETFramework",
+                    "NETBinaryModule",
+                    "ResolveBinaryConflictsName",
+                    "NETExcludeLibraryFilter",
+                    "NETDoNotCopyLibrariesRecursively",
+                    "NETBinaryModuleDocumentation"
+                },
+                plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -186,6 +186,7 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
                 new[]
                 {
                     "SyncNETProjectVersion",
+                    "NETFramework",
                     "NETBinaryModule",
                     "ResolveBinaryConflictsName",
                     "NETExcludeLibraryFilter",
@@ -234,6 +235,88 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
 
             Assert.True(string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath));
             Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_IgnoresBlankBinaryModuleEntries_WhenDerivingMissingCsprojReasons()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            BinaryModule = new[] { "", "   " }
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath));
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_RecordsNetFrameworkReason_WhenFrameworksPairWithExplicitBinaryIntent()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            Framework = new[] { "net8.0" },
+                            BinaryModule = new[] { "PSParseHTML.PowerShell.dll" }
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.Equal(new[] { "NETFramework", "NETBinaryModule" }, plan.BuildSpec.CsprojRequiredReasons);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -284,6 +284,47 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void Plan_IgnoresBlankExcludeLibraryFilterEntries_WhenDerivingMissingCsprojReasons()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            ExcludeLibraryFilter = new[] { "", "   " }
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath));
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_RecordsNetFrameworkReason_WhenFrameworksPairWithExplicitBinaryIntent()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -186,7 +186,6 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
                 new[]
                 {
                     "SyncNETProjectVersion",
-                    "NETFramework",
                     "NETBinaryModule",
                     "ResolveBinaryConflictsName",
                     "NETExcludeLibraryFilter",
@@ -194,6 +193,95 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
                     "NETBinaryModuleDocumentation"
                 },
                 plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_DoesNotTreatNetFrameworkAlone_AsMissingCsprojBinaryIntent()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            Framework = new[] { "net8.0" }
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath));
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_UsesLastBuildLibrariesValue_ForBinaryModuleDocumentationReason()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            NETBinaryModuleDocumentation = true
+                        }
+                    },
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            NETBinaryModuleDocumentation = false
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath));
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -366,6 +366,48 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void Plan_UsesLastBuildLibrariesValue_ForDoNotCopyLibrariesRecursivelyReason()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0",
+                    DoNotCopyLibrariesRecursively = true
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            NETDoNotCopyLibrariesRecursively = false
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(string.IsNullOrWhiteSpace(plan.BuildSpec.CsprojPath));
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_UsesLastBuildLibrariesValue_ForBinaryModuleDocumentationReason()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelineRefreshManifestOnlyTests.cs
+++ b/PowerForge.Tests/ModulePipelineRefreshManifestOnlyTests.cs
@@ -104,6 +104,58 @@ public sealed class ModulePipelineRefreshManifestOnlyTests
     }
 
     [Fact]
+    public void Plan_RefreshPSD1Only_ClearsMissingCsprojReasons_ForExplicitBinarySettings()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            RefreshPSD1Only = true,
+                            ResolveBinaryConflicts = new ResolveBinaryConflictsConfiguration
+                            {
+                                ProjectName = "TestModule.PowerShell"
+                            }
+                        }
+                    },
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            BinaryModule = new[] { "TestModule.PowerShell.dll" },
+                            NETBinaryModuleDocumentation = true
+                        }
+                    }
+                }
+            };
+
+            var plan = new ModulePipelineRunner(new NullLogger()).Plan(spec);
+
+            Assert.True(plan.BuildSpec.RefreshManifestOnly);
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Run_RefreshPSD1Only_SkipsInstallAndPublishing()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Models/ModuleBuildSpec.cs
+++ b/PowerForge/Models/ModuleBuildSpec.cs
@@ -105,6 +105,12 @@ public sealed class ModuleBuildSpec
     public bool KeepStaging { get; set; }
 
     /// <summary>
+    /// Explicit binary-build settings that require a resolvable .csproj path for this build.
+    /// When populated and <see cref="CsprojPath"/> is empty, the builder should fail rather than reuse a stale Lib payload.
+    /// </summary>
+    public string[] CsprojRequiredReasons { get; set; } = Array.Empty<string>();
+
+    /// <summary>
     /// When true, only refreshes the manifest (PSD1) and skips binary publish/merge operations.
     /// </summary>
     public bool RefreshManifestOnly { get; set; }

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -142,7 +142,7 @@ public sealed class ModuleBuildPipeline
             BinaryConflictReportRoot = spec.BinaryConflictReportRoot,
             ExcludeLibraryFilter = spec.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = spec.DoNotCopyLibrariesRecursively,
-            CsprojRequiredReasons = spec.CsprojRequiredReasons ?? Array.Empty<string>(),
+            CsprojRequiredReasons = spec.RefreshManifestOnly ? Array.Empty<string>() : spec.CsprojRequiredReasons ?? Array.Empty<string>(),
         });
 
         var psd1 = Path.Combine(staging, $"{spec.Name}.psd1");

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -142,6 +142,7 @@ public sealed class ModuleBuildPipeline
             BinaryConflictReportRoot = spec.BinaryConflictReportRoot,
             ExcludeLibraryFilter = spec.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = spec.DoNotCopyLibrariesRecursively,
+            CsprojRequiredReasons = spec.CsprojRequiredReasons ?? Array.Empty<string>(),
         });
 
         var psd1 = Path.Combine(staging, $"{spec.Name}.psd1");

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -105,6 +105,12 @@ public sealed class ModuleBuilder
         /// When true, copies only top-level published binaries and skips recursive runtime/native payload folders.
         /// </summary>
         public bool DoNotCopyLibrariesRecursively { get; set; }
+
+        /// <summary>
+        /// Explicit binary-build settings that require a resolvable .csproj path for this build.
+        /// When populated and <see cref="CsprojPath"/> is empty, the builder fails instead of reusing an existing Lib payload.
+        /// </summary>
+        public IReadOnlyList<string> CsprojRequiredReasons { get; set; } = Array.Empty<string>();
     }
 
     /// <summary>
@@ -189,6 +195,19 @@ public sealed class ModuleBuilder
         }
         else
         {
+            var csprojRequiredReasons = (opts.CsprojRequiredReasons ?? Array.Empty<string>())
+                .Where(static reason => !string.IsNullOrWhiteSpace(reason))
+                .Select(static reason => reason.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (csprojRequiredReasons.Length > 0)
+            {
+                throw new InvalidOperationException(
+                    $"No CsprojPath could be resolved for '{opts.ModuleName}', but the build explicitly configured binary module settings that require a .NET project: {string.Join(", ", csprojRequiredReasons)}. " +
+                    "Configure Build.CsprojPath or NETProjectPath, or remove those binary build settings if this module intentionally ships a prebuilt Lib payload.");
+            }
+
             var existingLibRoot = Path.Combine(opts.ProjectRoot, "Lib");
             var hasExistingBinaryPayload = Directory.Exists(existingLibRoot) &&
                                            Directory.EnumerateFiles(existingLibRoot, "*.dll", SearchOption.AllDirectories).Any();


### PR DESCRIPTION
## Summary
- fail fast when explicit binary-build settings are configured but no .csproj can be resolved
- keep the warning-only fallback for intentional prebuilt Lib payload scenarios with no explicit binary build intent
- record the specific binary-build reasons in the pipeline plan so the failure message is actionable
- add regressions for both the preserved warning path and the new fail-fast path

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~ModuleBuilderDependencyCopyTests.BuildInPlace_WarnsWhenUsingExistingLibPayloadWithoutCsproj|FullyQualifiedName~ModuleBuilderDependencyCopyTests.BuildInPlace_ThrowsWhenExistingLibPayloadWouldMaskExplicitBinaryBuildIntent|FullyQualifiedName~ModulePipelineExportAssemblyInferenceTests.Plan_RecordsMissingCsprojReasons_WhenExplicitBinaryBuildSettingsAreConfigured|FullyQualifiedName~ModulePipelineExportAssemblyInferenceTests.Plan_InferExportAssembly_FromLegacyProjectName_WhenNotExplicitlyProvided"
- dotnet build PowerForge.PowerShell/PowerForge.PowerShell.csproj -c Debug -f net472 --nologo