### PR TITLE
Restore runtime bootstrapper handling for binary modules

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
@@ -337,12 +337,16 @@ public sealed partial class ModulePipelineRunner
         return null;
     }
 
-    private void TryRegenerateBootstrapperFromManifest(ModuleBuildResult buildResult, string moduleName, IReadOnlyList<string>? exportAssemblies)
+    private void TryRegenerateBootstrapperFromManifest(
+        ModuleBuildResult buildResult,
+        string moduleName,
+        IReadOnlyList<string>? exportAssemblies,
+        bool handleRuntimes)
     {
         try
         {
             var exports = ModuleManifestExportReader.ReadExports(buildResult.ManifestPath);
-            ModuleBootstrapperGenerator.Generate(buildResult.StagingPath, moduleName, exports, exportAssemblies);
+            ModuleBootstrapperGenerator.Generate(buildResult.StagingPath, moduleName, exports, exportAssemblies, handleRuntimes);
         }
         catch (Exception ex)
         {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -70,6 +70,7 @@ public sealed partial class ModulePipelineRunner
         string[]? exportAssembliesFromSegments = null;
         string[]? excludeLibraryFilterFromSegments = null;
         bool? doNotCopyLibrariesRecursivelyFromSegments = null;
+        bool? handleRuntimesFromSegments = null;
         bool? disableBinaryCmdletScanFromSegments = null;
         string? resolveBinaryConflictsProjectName = null;
         bool? binaryModuleDocumentationRequested = null;
@@ -262,6 +263,7 @@ public sealed partial class ModulePipelineRunner
                     if (bl.BinaryModule is { Length: > 0 }) exportAssembliesFromSegments = bl.BinaryModule;
                     if (bl.ExcludeLibraryFilter is { Length: > 0 }) excludeLibraryFilterFromSegments = bl.ExcludeLibraryFilter;
                     if (bl.NETDoNotCopyLibrariesRecursively.HasValue) doNotCopyLibrariesRecursivelyFromSegments = bl.NETDoNotCopyLibrariesRecursively.Value;
+                    if (bl.HandleRuntimes.HasValue) handleRuntimesFromSegments = bl.HandleRuntimes.Value;
                     if (bl.BinaryModuleCmdletScanDisabled.HasValue) disableBinaryCmdletScanFromSegments = bl.BinaryModuleCmdletScanDisabled.Value;
                     if (bl.NETBinaryModuleDocumentation.HasValue) binaryModuleDocumentationRequested = bl.NETBinaryModuleDocumentation.Value;
                     break;
@@ -510,6 +512,7 @@ public sealed partial class ModulePipelineRunner
                 exportAssembliesFromSegments,
                 excludeLibraryFilterFromSegments,
                 doNotCopyLibrariesRecursivelyFromSegments,
+                handleRuntimesFromSegments,
                 resolveBinaryConflictsProjectName,
                 binaryModuleDocumentationRequested == true);
 
@@ -533,6 +536,7 @@ public sealed partial class ModulePipelineRunner
             ExportAssemblies = exportAssemblies,
             ExcludeLibraryFilter = excludeLibraryFilterFromSegments ?? spec.Build.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively,
+            HandleRuntimes = handleRuntimesFromSegments ?? spec.Build.HandleRuntimes,
             DisableBinaryCmdletScan = disableBinaryCmdletScanFromSegments ?? spec.Build.DisableBinaryCmdletScan,
             CsprojRequiredReasons = string.IsNullOrWhiteSpace(csproj) ? csprojRequiredReasons : Array.Empty<string>(),
             BinaryConflictPriorityModuleNames = requiredModulesDraft
@@ -784,6 +788,7 @@ public sealed partial class ModulePipelineRunner
         string[]? exportAssembliesFromSegments,
         string[]? excludeLibraryFilterFromSegments,
         bool? doNotCopyLibrariesRecursivelyFromSegments,
+        bool? handleRuntimesFromSegments,
         string? resolveBinaryConflictsProjectName,
         bool binaryModuleDocumentationRequested)
     {
@@ -794,6 +799,8 @@ public sealed partial class ModulePipelineRunner
                                || HasAnyConfiguredValues(spec.Build.ExportAssemblies);
         var effectiveDoNotCopyLibrariesRecursively =
             doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively;
+        var effectiveHandleRuntimes =
+            handleRuntimesFromSegments ?? spec.Build.HandleRuntimes;
         var hasExplicitBinaryIntentBeyondFramework =
             syncNETProjectVersion
             || hasBinaryModules
@@ -801,6 +808,7 @@ public sealed partial class ModulePipelineRunner
             || HasAnyConfiguredValues(excludeLibraryFilterFromSegments)
             || HasAnyConfiguredValues(spec.Build.ExcludeLibraryFilter)
             || effectiveDoNotCopyLibrariesRecursively
+            || effectiveHandleRuntimes
             || binaryModuleDocumentationRequested;
 
         if (syncNETProjectVersion)
@@ -820,6 +828,9 @@ public sealed partial class ModulePipelineRunner
 
         if (effectiveDoNotCopyLibrariesRecursively)
             reasons.Add("NETDoNotCopyLibrariesRecursively");
+
+        if (effectiveHandleRuntimes)
+            reasons.Add("NETHandleRuntimes");
 
         if (binaryModuleDocumentationRequested)
             reasons.Add("NETBinaryModuleDocumentation");

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -65,7 +65,11 @@ public sealed partial class ModulePipelineRunner
             }
 
             if (!state.PackageWithoutScriptFolders && !plan.BuildSpec.RefreshManifestOnly)
-                TryRegenerateBootstrapperFromManifest(buildResult, plan.ModuleName, plan.BuildSpec.ExportAssemblies);
+                TryRegenerateBootstrapperFromManifest(
+                    buildResult,
+                    plan.ModuleName,
+                    plan.BuildSpec.ExportAssemblies,
+                    plan.BuildSpec.HandleRuntimes);
 
             session.Done(session.ManifestStep);
         }

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -93,6 +93,30 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void Generate_WithScriptLayoutOnlyAndHandleRuntimes_DoesNotEmitBinaryRuntimeBlock()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-script-runtime-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Public"));
+        File.WriteAllText(Path.Combine(root, "Public", "Get-Demo.ps1"), "function Get-Demo {}");
+
+        try
+        {
+            var exports = new ExportSet(new[] { "Get-Demo" }, Array.Empty<string>(), Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, exportAssemblies: null, handleRuntimes: true);
+
+            var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
+            Assert.DoesNotContain("ProcessArchitecture", bootstrapper);
+            Assert.DoesNotContain("IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)", bootstrapper);
+            Assert.DoesNotContain("Lib\\{0}\\runtimes\\{1}\\native", bootstrapper);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Generate_WithoutLibOrScriptFolders_DoesNotOverwriteExistingPsm1()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-no-layout-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -28,6 +28,31 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("$LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'DemoModule.Libraries.ps1')", bootstrapper);
             Assert.Contains("$FunctionsToExport = @('Get-Demo')", bootstrapper);
             Assert.Contains("$AliasesToExport = @('gdemo')", bootstrapper);
+            Assert.DoesNotContain("ProcessArchitecture", bootstrapper);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_WithHandleRuntimes_EmitsRuntimeBootstrapperBlock()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-runtime-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
+        File.WriteAllText(Path.Combine(root, "Lib", "Core", "DemoModule.dll"), string.Empty);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, new[] { "DemoModule.dll" }, handleRuntimes: true);
+
+            var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
+            Assert.Contains("ProcessArchitecture", bootstrapper);
+            Assert.Contains("Lib\\{0}\\runtimes\\{1}\\native", bootstrapper);
+            Assert.Contains("$env:PATH = \"$NativePath;$env:PATH\"", bootstrapper);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -12,7 +12,7 @@ public class ModuleBootstrapperGeneratorTests
         try
         {
             var exports = new ExportSet(new[] { "Get-Demo" }, Array.Empty<string>(), new[] { "gdemo" });
-            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, new[] { "DemoModule.dll" });
+            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, new[] { "DemoModule.dll" }, handleRuntimes: false);
 
             var librariesPath = Path.Combine(root, "DemoModule.Libraries.ps1");
             var bootstrapperPath = Path.Combine(root, "DemoModule.psm1");
@@ -51,8 +51,12 @@ public class ModuleBootstrapperGeneratorTests
 
             var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
             Assert.Contains("ProcessArchitecture", bootstrapper);
+            Assert.Contains("IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)", bootstrapper);
             Assert.Contains("Lib\\{0}\\runtimes\\{1}\\native", bootstrapper);
-            Assert.Contains("$env:PATH = \"$NativePath;$env:PATH\"", bootstrapper);
+            Assert.Contains("$PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }", bootstrapper);
+            Assert.Contains("($PathEntries -notcontains $NativePath)", bootstrapper);
+            Assert.Contains("Unknown Windows architecture", bootstrapper);
+            Assert.DoesNotContain("\r\n\r\ntry {", bootstrapper);
         }
         finally
         {
@@ -71,7 +75,7 @@ public class ModuleBootstrapperGeneratorTests
         try
         {
             var exports = new ExportSet(new[] { "Get-Demo" }, Array.Empty<string>(), Array.Empty<string>());
-            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, exportAssemblies: null);
+            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, exportAssemblies: null, handleRuntimes: false);
 
             var bootstrapperPath = Path.Combine(root, "DemoModule.psm1");
             Assert.True(File.Exists(bootstrapperPath));
@@ -101,7 +105,7 @@ public class ModuleBootstrapperGeneratorTests
         try
         {
             var exports = new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
-            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, exportAssemblies: null);
+            ModuleBootstrapperGenerator.Generate(root, "DemoModule", exports, exportAssemblies: null, handleRuntimes: false);
 
             var after = File.ReadAllText(psm1Path);
             Assert.Equal(existing, after);

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -135,6 +135,47 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void Plan_CarriesHandleRuntimes_IntoBuildSpec()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            HandleRuntimes = true
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(plan.BuildSpec.HandleRuntimes);
+            Assert.Equal(new[] { "NETHandleRuntimes" }, plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_RecordsMissingCsprojReasons_WhenExplicitBinaryBuildSettingsAreConfigured()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Models/ModuleBuildSpec.cs
+++ b/PowerForge/Models/ModuleBuildSpec.cs
@@ -100,7 +100,8 @@ public sealed class ModuleBuildSpec
     public bool DoNotCopyLibrariesRecursively { get; set; }
 
     /// <summary>
-    /// When true, the generated binary bootstrapper adds supported runtime-native folders to PATH.
+    /// When true, the generated binary bootstrapper adds supported Windows runtime-native folders to PATH.
+    /// Non-Windows platforms keep their default native library probing behavior.
     /// </summary>
     public bool HandleRuntimes { get; set; }
 

--- a/PowerForge/Models/ModuleBuildSpec.cs
+++ b/PowerForge/Models/ModuleBuildSpec.cs
@@ -100,6 +100,11 @@ public sealed class ModuleBuildSpec
     public bool DoNotCopyLibrariesRecursively { get; set; }
 
     /// <summary>
+    /// When true, the generated binary bootstrapper adds supported runtime-native folders to PATH.
+    /// </summary>
+    public bool HandleRuntimes { get; set; }
+
+    /// <summary>
     /// When true, keeps the staging directory after a successful build.
     /// </summary>
     public bool KeepStaging { get; set; }

--- a/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
@@ -48,6 +48,7 @@ if ($PSEdition -eq 'Core') {
     $LibFolder = $FrameworkNet
 }
 
+{{RuntimeHandlerBlock}}
 try {
     $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
 

--- a/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
@@ -48,8 +48,7 @@ if ($PSEdition -eq 'Core') {
     $LibFolder = $FrameworkNet
 }
 
-{{RuntimeHandlerBlock}}
-try {
+{{RuntimeHandlerBlock}}try {
     $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
 
     if (-not ($Class -as [type])) {

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -10,7 +10,12 @@ internal static class ModuleBootstrapperGenerator
 {
     private static readonly UTF8Encoding Utf8Bom = new(encoderShouldEmitUTF8Identifier: true);
 
-    internal static void Generate(string moduleRoot, string moduleName, ExportSet exports, IReadOnlyList<string>? exportAssemblies)
+    internal static void Generate(
+        string moduleRoot,
+        string moduleName,
+        ExportSet exports,
+        IReadOnlyList<string>? exportAssemblies,
+        bool handleRuntimes = false)
     {
         if (string.IsNullOrWhiteSpace(moduleRoot)) throw new ArgumentException("Module root is required.", nameof(moduleRoot));
         if (string.IsNullOrWhiteSpace(moduleName)) throw new ArgumentException("Module name is required.", nameof(moduleName));
@@ -44,7 +49,8 @@ internal static class ModuleBootstrapperGenerator
             primaryLibraryName,
             exports,
             includeBinaryLoader: hasLib,
-            includeScriptLoader: hasScriptFolders);
+            includeScriptLoader: hasScriptFolders,
+            handleRuntimes: handleRuntimes);
         WritePowerShellFile(psm1Path, psm1Content);
     }
 
@@ -200,7 +206,8 @@ internal static class ModuleBootstrapperGenerator
         string libraryName,
         ExportSet exports,
         bool includeBinaryLoader,
-        bool includeScriptLoader)
+        bool includeScriptLoader,
+        bool handleRuntimes)
     {
         var binaryLoaderBlock = includeBinaryLoader
             ? RenderModuleBootstrapperTemplate(
@@ -209,7 +216,8 @@ internal static class ModuleBootstrapperGenerator
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
                     ["LibraryName"] = EscapePsSingleQuoted(libraryName),
-                    ["ModuleName"] = EscapePsSingleQuoted(moduleName)
+                    ["ModuleName"] = EscapePsSingleQuoted(moduleName),
+                    ["RuntimeHandlerBlock"] = handleRuntimes ? BuildRuntimeHandlerBlock() : string.Empty
                 })
             : string.Empty;
 
@@ -232,6 +240,32 @@ internal static class ModuleBootstrapperGenerator
 
         var template = EmbeddedScripts.Load("Scripts/ModuleBootstrapper/Bootstrapper.Template.ps1");
         return ScriptTemplateRenderer.Render("ModuleBootstrapper.Bootstrapper", template, tokens);
+    }
+
+    private static string BuildRuntimeHandlerBlock()
+    {
+        return string.Join(
+            "\r\n",
+            new[]
+            {
+                "# Ensure native runtime libraries are discoverable on Windows",
+                "if ($IsWindows -and $LibFolder) {",
+                "    $Arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
+                "    $ArchFolder = switch ($Arch) {",
+                "        'X64'   { 'win-x64' }",
+                "        'X86'   { 'win-x86' }",
+                "        'Arm64' { 'win-arm64' }",
+                "        'Arm'   { 'win-arm' }",
+                "        Default { 'win-x64' }",
+                "    }",
+                string.Empty,
+                "    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath (\"Lib\\{0}\\runtimes\\{1}\\native\" -f $LibFolder, $ArchFolder)",
+                "    if ((Test-Path -LiteralPath $NativePath) -and ($env:PATH -notlike \"*$NativePath*\")) {",
+                "        $env:PATH = \"$NativePath;$env:PATH\"",
+                "    }",
+                "}",
+                string.Empty
+            });
     }
 
     private static string RenderModuleBootstrapperTemplate(

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -250,8 +250,10 @@ internal static class ModuleBootstrapperGenerator
                    {
                        "# Ensure native runtime libraries are discoverable on Windows",
                        "$IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
+                       "# Skip probing when the current host cannot resolve a Windows-facing Lib folder (for example Desktop + Core-only payloads).",
                        "if ($IsWindowsPlatform -and $LibFolder) {",
                        "    $Arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
+                       "    # PowerShell switch matches the Architecture enum by its string representation here.",
                        "    $ArchFolder = switch ($Arch) {",
                        "        'X64'   { 'win-x64' }",
                        "        'X86'   { 'win-x86' }",
@@ -266,6 +268,7 @@ internal static class ModuleBootstrapperGenerator
                        "    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath (\"Lib\\{0}\\runtimes\\{1}\\native\" -f $LibFolder, $ArchFolder)",
                        "    $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }",
                        "    if ((Test-Path -LiteralPath $NativePath) -and ($PathEntries -notcontains $NativePath)) {",
+                       "        # Prepend the module-native runtime path so the packaged payload wins over unrelated machine-wide copies.",
                        "        if ([string]::IsNullOrWhiteSpace($env:PATH)) {",
                        "            $env:PATH = $NativePath",
                        "        } else {",

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -15,7 +15,7 @@ internal static class ModuleBootstrapperGenerator
         string moduleName,
         ExportSet exports,
         IReadOnlyList<string>? exportAssemblies,
-        bool handleRuntimes = false)
+        bool handleRuntimes)
     {
         if (string.IsNullOrWhiteSpace(moduleRoot)) throw new ArgumentException("Module root is required.", nameof(moduleRoot));
         if (string.IsNullOrWhiteSpace(moduleName)) throw new ArgumentException("Module name is required.", nameof(moduleName));
@@ -245,27 +245,36 @@ internal static class ModuleBootstrapperGenerator
     private static string BuildRuntimeHandlerBlock()
     {
         return string.Join(
-            "\r\n",
-            new[]
-            {
-                "# Ensure native runtime libraries are discoverable on Windows",
-                "if ($IsWindows -and $LibFolder) {",
-                "    $Arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
-                "    $ArchFolder = switch ($Arch) {",
-                "        'X64'   { 'win-x64' }",
-                "        'X86'   { 'win-x86' }",
-                "        'Arm64' { 'win-arm64' }",
-                "        'Arm'   { 'win-arm' }",
-                "        Default { 'win-x64' }",
-                "    }",
-                string.Empty,
-                "    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath (\"Lib\\{0}\\runtimes\\{1}\\native\" -f $LibFolder, $ArchFolder)",
-                "    if ((Test-Path -LiteralPath $NativePath) -and ($env:PATH -notlike \"*$NativePath*\")) {",
-                "        $env:PATH = \"$NativePath;$env:PATH\"",
-                "    }",
-                "}",
-                string.Empty
-            });
+                   "\r\n",
+                   new[]
+                   {
+                       "# Ensure native runtime libraries are discoverable on Windows",
+                       "$IsWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)",
+                       "if ($IsWindowsPlatform -and $LibFolder) {",
+                       "    $Arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture",
+                       "    $ArchFolder = switch ($Arch) {",
+                       "        'X64'   { 'win-x64' }",
+                       "        'X86'   { 'win-x86' }",
+                       "        'Arm64' { 'win-arm64' }",
+                       "        'Arm'   { 'win-arm' }",
+                       "        Default {",
+                       "            Write-Warning -Message (\"Unknown Windows architecture '{0}'. Falling back to win-x64 native runtime probing.\" -f $Arch)",
+                       "            'win-x64'",
+                       "        }",
+                       "    }",
+                       string.Empty,
+                       "    $NativePath = Join-Path -Path $PSScriptRoot -ChildPath (\"Lib\\{0}\\runtimes\\{1}\\native\" -f $LibFolder, $ArchFolder)",
+                       "    $PathEntries = if ([string]::IsNullOrWhiteSpace($env:PATH)) { @() } else { @($env:PATH -split [IO.Path]::PathSeparator) }",
+                       "    if ((Test-Path -LiteralPath $NativePath) -and ($PathEntries -notcontains $NativePath)) {",
+                       "        if ([string]::IsNullOrWhiteSpace($env:PATH)) {",
+                       "            $env:PATH = $NativePath",
+                       "        } else {",
+                       "            $env:PATH = \"$NativePath$([IO.Path]::PathSeparator)$env:PATH\"",
+                       "        }",
+                       "    }",
+                       "}",
+                       string.Empty
+                   });
     }
 
     private static string RenderModuleBootstrapperTemplate(

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -155,7 +155,7 @@ public sealed class ModuleBuildPipeline
         // This keeps artefacts and installs aligned with historical PSPublishModule behavior for binary/mixed modules.
         if (!spec.RefreshManifestOnly)
         {
-            ModuleBootstrapperGenerator.Generate(staging, spec.Name, exports, spec.ExportAssemblies);
+            ModuleBootstrapperGenerator.Generate(staging, spec.Name, exports, spec.ExportAssemblies, spec.HandleRuntimes);
         }
         else
         {


### PR DESCRIPTION
## Summary
- carry the runtime-handling flag through the PowerForge build plan and build spec
- emit Windows runtime PATH bootstrap code when binary modules request runtime handling
- cover the restored behavior with generator and planning tests

## Testing
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --nologo --filter "FullyQualifiedName~ModuleBootstrapperGeneratorTests|FullyQualifiedName~ModulePipelineExportAssemblyInferenceTests"