### PR TITLE
Add unified staged release publishing

### DIFF
--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -114,7 +114,8 @@ Unified release entrypoint
   - `Outputs.Staging` in `release.json` for default folder names when you want the same categorized layout without repeating CLI switches
   - `Outputs.Staging.*Path` values may point multiple categories at the same folder when you want a flat `UploadReady` layout such as `NuGet` + `GitHub`
   - `Outputs.Staging.*NameTemplate` values let the staged copies use release-facing names instead of raw internal build names
-  - `Winget` in `release.json` when you want PowerForge to emit portable/signed release manifests from the same staged assets
+- `Winget` in `release.json` when you want PowerForge to emit portable/signed release manifests from the same staged assets
+- top-level `GitHub` in `release.json` when you want the unified staged release itself uploaded as one repo release instead of using package-host or per-target tool release publishing
   - `--keep-symbols` for symbol-preserving tool/app outputs
   - `--skip-release-checksums` when you want the staged release folder but do not want a top-level `SHA256SUMS.txt`
   - `--sign`, `--sign-profile`, and raw overrides such as `--sign-thumbprint`, `--sign-subject-name`, `--sign-timestamp-url`, `--sign-tool-path`
@@ -197,7 +198,22 @@ Example Winget generation from staged assets:
 
 - `InstallerUrlTemplate` tokens are URL-encoded automatically
 - `{FileName}` resolves to the staged filename after any `*NameTemplate` rewrite, not the raw internal artifact filename
+- when `--stage-root` (or `Outputs.Staging.RootPath`) is active, a relative `Winget.OutputPath` is resolved under that active staged release root so per-run `UploadReady\<release-id>\Winget` layouts work without hard-coded absolute paths
 - set `NestedInstallerType` explicitly for archive-based installers when you want a reusable config that is not implicitly “portable zip only”
+
+Example unified GitHub release publishing from staged assets:
+
+```json
+"GitHub": {
+  "Publish": true,
+  "TagTemplate": "v{Version}",
+  "ReleaseNameTemplate": "{Repository} {Version}"
+}
+```
+
+- use `--publish-project-github` (or set `GitHub.Publish: true`) to upload the unified staged release as one repo release
+- when top-level `GitHub` is active, package-host GitHub publishing is suppressed and the staged release assets are uploaded instead
+- uploaded assets include staged `NuGet`, `Portable`, `Installer`, `Tool`, metadata files, top-level `release-manifest.json` / `SHA256SUMS.txt`, and any generated Winget manifests
 
 - Plan or build preview executables only:
 

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -2518,6 +2518,355 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_Winget_RelativeOutputPath_UsesResolvedStageRoot_AndIsIncludedInReleaseAssets()
+    {
+        var root = CreateSandbox();
+        var trayX64 = Path.Combine(root, "tray-x64.zip");
+        var trayProject = Path.Combine(root, "IntelligenceX.Tray.csproj");
+        File.WriteAllText(trayX64, "zip", new UTF8Encoding(false));
+        File.WriteAllText(trayProject, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+</Project>
+""", new UTF8Encoding(false));
+
+        try
+        {
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (new DotNetPublishSpec(), configPath),
+                planDotNetTools: (_, _, _, _) => new DotNetPublishPlan
+                {
+                    ProjectRoot = root,
+                    Configuration = "Release",
+                    Targets = new[]
+                    {
+                        new DotNetPublishTargetPlan
+                        {
+                            Name = "IntelligenceX.Tray",
+                            ProjectPath = trayProject,
+                            Publish = new DotNetPublishPublishOptions
+                            {
+                                Framework = "net10.0-windows10.0.19041.0",
+                                Runtimes = new[] { "win-x64" },
+                                Style = DotNetPublishStyle.PortableCompat,
+                                Zip = true
+                            },
+                            Combinations = new[]
+                            {
+                                new DotNetPublishTargetCombination
+                                {
+                                    Framework = "net10.0-windows10.0.19041.0",
+                                    Runtime = "win-x64",
+                                    Style = DotNetPublishStyle.PortableCompat
+                                }
+                            }
+                        }
+                    }
+                },
+                runDotNetTools: _ => new DotNetPublishResult
+                {
+                    Succeeded = true,
+                    Artefacts = new[]
+                    {
+                        new DotNetPublishArtefactResult
+                        {
+                            Category = DotNetPublishArtefactCategory.Bundle,
+                            Target = "IntelligenceX.Tray",
+                            Framework = "net10.0-windows10.0.19041.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat,
+                            OutputDir = root,
+                            PublishDir = root,
+                            ZipPath = trayX64
+                        }
+                    }
+                },
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."));
+
+            var stageRoot = Path.Combine(root, "upload-ready");
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublish = new DotNetPublishSpec()
+                    },
+                    Outputs = new PowerForgeReleaseOutputsOptions
+                    {
+                        Staging = new PowerForgeReleaseStagingOptions
+                        {
+                            RootPath = "Artifacts/UploadReady",
+                            PortablePath = "GitHub",
+                            PortableNameTemplate = "{Target}-{Version}-{Runtime}-portable{Extension}"
+                        }
+                    },
+                    Winget = new PowerForgeReleaseWingetOptions
+                    {
+                        Enabled = true,
+                        OutputPath = "Winget",
+                        InstallerUrlTemplate = "https://github.com/EvotecIT/IntelligenceX/releases/download/v{PackageVersion}/{FileName}",
+                        Packages = new[]
+                        {
+                            new PowerForgeReleaseWingetPackage
+                            {
+                                PackageIdentifier = "EvotecIT.IntelligenceX.Tray",
+                                PackageVersion = "1.0.0",
+                                Publisher = "Evotec",
+                                PackageName = "IntelligenceX Tray",
+                                License = "MIT",
+                                ShortDescription = "Windows tray app for IntelligenceX.",
+                                Installers = new[]
+                                {
+                                    new PowerForgeReleaseWingetInstaller
+                                    {
+                                        Category = PowerForgeReleaseAssetCategory.Portable,
+                                        Target = "IntelligenceX.Tray",
+                                        Runtime = "win-x64",
+                                        InstallerType = "zip",
+                                        NestedInstallerType = "portable",
+                                        RelativeFilePath = "IntelligenceX.Tray.exe"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "release.json"),
+                    ToolsOnly = true,
+                    StageRoot = stageRoot
+                });
+
+            Assert.True(result.Success);
+            var manifestPath = Assert.Single(result.WingetManifestPaths);
+            Assert.StartsWith(Path.Combine(stageRoot, "Winget"), manifestPath, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(manifestPath, result.ReleaseAssets, StringComparer.OrdinalIgnoreCase);
+            Assert.NotNull(result.ReleaseChecksumsPath);
+            var releaseChecksums = result.ReleaseChecksumsPath;
+            var checksumText = File.ReadAllText(releaseChecksums!);
+            Assert.Contains("Winget/", checksumText.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_UnifiedGitHubPublish_UsesStagedReleaseAssets_AndSuppressesPackageGitHubPublish()
+    {
+        var root = CreateSandbox();
+        var trayX64 = Path.Combine(root, "tray-x64.zip");
+        var trayProject = Path.Combine(root, "IntelligenceX.Tray.csproj");
+        var packagePath = Path.Combine(root, "IntelligenceX.0.1.0.nupkg");
+        var releaseZipPath = Path.Combine(root, "IntelligenceX.0.1.0.zip");
+        File.WriteAllText(trayX64, "zip", new UTF8Encoding(false));
+        File.WriteAllText(packagePath, "nupkg", new UTF8Encoding(false));
+        File.WriteAllText(releaseZipPath, "zip", new UTF8Encoding(false));
+        File.WriteAllText(trayProject, """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <Version>9.9.9</Version>
+  </PropertyGroup>
+</Project>
+""", new UTF8Encoding(false));
+
+        try
+        {
+            bool? capturedPackagePublishGitHub = null;
+            GitHubReleasePublishRequest? capturedGitHubRequest = null;
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (request, _, _) =>
+                {
+                    capturedPackagePublishGitHub = request.PublishGitHub;
+
+                    var release = new DotNetRepositoryReleaseResult
+                    {
+                        Success = true,
+                        ResolvedVersion = "0.1.0"
+                    };
+                    release.ResolvedVersionsByProject["IntelligenceX"] = "0.1.0";
+                    release.Projects.Add(new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "IntelligenceX",
+                        PackageId = "IntelligenceX",
+                        IsPackable = true,
+                        NewVersion = "0.1.0",
+                        ReleaseZipPath = releaseZipPath
+                    });
+                    release.Projects[0].Packages.Add(packagePath);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                },
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (new DotNetPublishSpec(), configPath),
+                planDotNetTools: (_, _, _, _) => new DotNetPublishPlan
+                {
+                    ProjectRoot = root,
+                    Configuration = "Release",
+                    Targets = new[]
+                    {
+                        new DotNetPublishTargetPlan
+                        {
+                            Name = "IntelligenceX.Tray",
+                            ProjectPath = trayProject,
+                            Publish = new DotNetPublishPublishOptions
+                            {
+                                Framework = "net10.0-windows10.0.19041.0",
+                                Runtimes = new[] { "win-x64" },
+                                Style = DotNetPublishStyle.PortableCompat,
+                                Zip = true
+                            },
+                            Combinations = new[]
+                            {
+                                new DotNetPublishTargetCombination
+                                {
+                                    Framework = "net10.0-windows10.0.19041.0",
+                                    Runtime = "win-x64",
+                                    Style = DotNetPublishStyle.PortableCompat
+                                }
+                            }
+                        }
+                    }
+                },
+                runDotNetTools: _ => new DotNetPublishResult
+                {
+                    Succeeded = true,
+                    Artefacts = new[]
+                    {
+                        new DotNetPublishArtefactResult
+                        {
+                            Category = DotNetPublishArtefactCategory.Bundle,
+                            Target = "IntelligenceX.Tray",
+                            Framework = "net10.0-windows10.0.19041.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat,
+                            OutputDir = root,
+                            PublishDir = root,
+                            ZipPath = trayX64
+                        }
+                    }
+                },
+                publishGitHubRelease: request =>
+                {
+                    capturedGitHubRequest = request;
+                    return new GitHubReleasePublishResult
+                    {
+                        Succeeded = true,
+                        ReleaseCreationSucceeded = true,
+                        HtmlUrl = "https://github.com/EvotecIT/IntelligenceX/releases/tag/v0.1.0"
+                    };
+                });
+
+            var stageRoot = Path.Combine(root, "upload-ready");
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        GitHubUsername = "EvotecIT",
+                        GitHubRepositoryName = "IntelligenceX"
+                    },
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublish = new DotNetPublishSpec()
+                    },
+                    Outputs = new PowerForgeReleaseOutputsOptions
+                    {
+                        Staging = new PowerForgeReleaseStagingOptions
+                        {
+                            RootPath = "Artifacts/UploadReady",
+                            PackagesPath = "NuGet",
+                            PortablePath = "GitHub",
+                            PortableNameTemplate = "{Target}-{Version}-{Runtime}-portable{Extension}"
+                        }
+                    },
+                    GitHub = new PowerForgeReleaseGitHubOptions
+                    {
+                        Publish = true,
+                        Token = "token"
+                    },
+                    Winget = new PowerForgeReleaseWingetOptions
+                    {
+                        Enabled = true,
+                        OutputPath = "Winget",
+                        InstallerUrlTemplate = "https://github.com/EvotecIT/IntelligenceX/releases/download/v{PackageVersion}/{FileName}",
+                        Packages = new[]
+                        {
+                            new PowerForgeReleaseWingetPackage
+                            {
+                                PackageIdentifier = "EvotecIT.IntelligenceX.Tray",
+                                Publisher = "Evotec",
+                                PackageName = "IntelligenceX Tray",
+                                License = "MIT",
+                                ShortDescription = "Windows tray app for IntelligenceX.",
+                                Installers = new[]
+                                {
+                                    new PowerForgeReleaseWingetInstaller
+                                    {
+                                        Category = PowerForgeReleaseAssetCategory.Portable,
+                                        Target = "IntelligenceX.Tray",
+                                        Runtime = "win-x64",
+                                        InstallerType = "zip",
+                                        NestedInstallerType = "portable",
+                                        RelativeFilePath = "IntelligenceX.Tray.exe"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "release.json"),
+                    PublishProjectGitHub = true,
+                    StageRoot = stageRoot
+                });
+
+            Assert.True(result.Success);
+            Assert.False(capturedPackagePublishGitHub ?? true);
+            Assert.NotNull(result.UnifiedGitHubRelease);
+            var unified = result.UnifiedGitHubRelease;
+            Assert.True(unified!.Success);
+            Assert.Equal("v0.1.0", unified.TagName);
+            Assert.NotNull(capturedGitHubRequest);
+            Assert.Equal("EvotecIT", capturedGitHubRequest!.Owner);
+            Assert.Equal("IntelligenceX", capturedGitHubRequest.Repository);
+            Assert.Contains(Path.Combine(stageRoot, "NuGet", "IntelligenceX.0.1.0.nupkg"), capturedGitHubRequest.AssetFilePaths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(Path.Combine(stageRoot, "GitHub", "IntelligenceX.Tray-0.1.0-win-x64-portable.zip"), capturedGitHubRequest.AssetFilePaths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(Path.Combine(stageRoot, "Winget", "EvotecIT.IntelligenceX.Tray.yaml"), capturedGitHubRequest.AssetFilePaths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(Path.Combine(stageRoot, "release-manifest.json"), capturedGitHubRequest.AssetFilePaths, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(Path.Combine(stageRoot, "SHA256SUMS.txt"), capturedGitHubRequest.AssetFilePaths, StringComparer.OrdinalIgnoreCase);
+            var manifestText = File.ReadAllText(Path.Combine(stageRoot, "release-manifest.json"));
+            Assert.Contains("unifiedGithubRelease", manifestText, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_Winget_UsesRawAssetPathWhenStagingDisabled_EncodesUrlAndEscapesYaml()
     {
         var root = CreateSandbox();

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -22,6 +22,8 @@ internal sealed class PowerForgeReleaseSpec
 
     public PowerForgeReleaseOutputsOptions Outputs { get; set; } = new();
 
+    public PowerForgeReleaseGitHubOptions? GitHub { get; set; }
+
     public PowerForgeReleaseWingetOptions? Winget { get; set; }
 }
 
@@ -176,6 +178,8 @@ internal sealed class PowerForgeReleaseResult
 
     public PowerForgeReleaseAssetEntry[] ReleaseAssetEntries { get; set; } = Array.Empty<PowerForgeReleaseAssetEntry>();
 
+    public PowerForgeUnifiedGitHubReleaseResult? UnifiedGitHubRelease { get; set; }
+
     public string? ReleaseManifestPath { get; set; }
 
     public string? ReleaseChecksumsPath { get; set; }
@@ -230,6 +234,29 @@ internal sealed class PowerForgeReleaseStagingOptions
     public string? MetadataNameTemplate { get; set; }
 
     public string? OtherNameTemplate { get; set; }
+}
+
+internal sealed class PowerForgeReleaseGitHubOptions
+{
+    public bool Publish { get; set; }
+
+    public string? Owner { get; set; }
+
+    public string? Repository { get; set; }
+
+    public string? Token { get; set; }
+
+    public string? TokenFilePath { get; set; }
+
+    public string? TokenEnvName { get; set; }
+
+    public bool GenerateReleaseNotes { get; set; } = true;
+
+    public bool IsPreRelease { get; set; }
+
+    public string? TagTemplate { get; set; }
+
+    public string? ReleaseNameTemplate { get; set; }
 }
 
 internal sealed class PowerForgeReleaseWingetOptions
@@ -415,6 +442,31 @@ internal sealed class PowerForgeToolGitHubReleaseResult
     public string Repository { get; set; } = string.Empty;
 
     public string Target { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    public string TagName { get; set; } = string.Empty;
+
+    public string ReleaseName { get; set; } = string.Empty;
+
+    public string[] AssetPaths { get; set; } = Array.Empty<string>();
+
+    public bool Success { get; set; }
+
+    public string? ReleaseUrl { get; set; }
+
+    public bool ReusedExistingRelease { get; set; }
+
+    public string? ErrorMessage { get; set; }
+
+    public string[] SkippedExistingAssets { get; set; } = Array.Empty<string>();
+}
+
+internal sealed class PowerForgeUnifiedGitHubReleaseResult
+{
+    public string Owner { get; set; } = string.Empty;
+
+    public string Repository { get; set; } = string.Empty;
 
     public string Version { get; set; } = string.Empty;
 

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -127,6 +127,7 @@ internal sealed class PowerForgeReleaseService
         var runTools = spec.Tools is not null && !request.ModuleOnly && !request.PackagesOnly;
         var configurationOverride = NormalizeConfiguration(request.Configuration);
         var runWorkspaceValidation = spec.WorkspaceValidation is not null && !request.SkipWorkspaceValidation;
+        var publishUnifiedGitHub = ShouldPublishUnifiedGitHub(spec, request);
 
         if (!runModule && !runPackages && !runTools && !runWorkspaceValidation)
         {
@@ -190,7 +191,7 @@ internal sealed class PowerForgeReleaseService
                 ExecuteBuild = !request.PlanOnly && !request.ValidateOnly,
                 PlanOnly = request.PlanOnly || request.ValidateOnly ? true : null,
                 PublishNuget = request.PublishNuget,
-                PublishGitHub = request.PublishProjectGitHub
+                PublishGitHub = publishUnifiedGitHub ? false : request.PublishProjectGitHub
             };
 
             var packages = _executePackages(packageRequest, spec.Packages!, configPath);
@@ -279,7 +280,20 @@ internal sealed class PowerForgeReleaseService
         if (!request.PlanOnly && !request.ValidateOnly)
         {
             PopulateReleaseOutputs(spec, request, configDirectory, result, sharedReleaseVersion);
-            GenerateWingetOutputs(spec, configDirectory, result);
+            GenerateWingetOutputs(spec, request, configDirectory, result);
+            IncludeWingetOutputsInReleaseAssets(result);
+            if (publishUnifiedGitHub)
+            {
+                var unifiedGitHubRelease = PublishUnifiedGitHubRelease(spec, configDirectory, result, sharedReleaseVersion);
+                result.UnifiedGitHubRelease = unifiedGitHubRelease;
+                if (!unifiedGitHubRelease.Success)
+                {
+                    result.Success = false;
+                    result.ErrorMessage = unifiedGitHubRelease.ErrorMessage ?? "Unified GitHub release publishing failed.";
+                    return result;
+                }
+            }
+            RewriteReleaseSummaryFiles(result);
         }
 
         return result;
@@ -562,67 +576,37 @@ internal sealed class PowerForgeReleaseService
 
         if (!string.IsNullOrWhiteSpace(manifestPath))
         {
-            var resolvedManifestPath = manifestPath!;
-            var manifest = new
-            {
-                schemaVersion = 1,
-                createdUtc = DateTime.UtcNow.ToString("o"),
-                configPath = result.ConfigPath,
-                assets = result.ReleaseAssets,
-                assetEntries = assetEntries.Select(entry => new
-                {
-                    entry.Path,
-                    category = entry.Category.ToString(),
-                    entry.Source,
-                    entry.Target,
-                    entry.PackageId,
-                    entry.Version,
-                    entry.Runtime,
-                    entry.Framework,
-                    entry.Style,
-                    entry.BundleId,
-                    entry.RelativeStagePath,
-                    entry.StagedPath
-                }).ToArray(),
-                module = BuildModuleManifestSection(result.ModulePlan, result.Module, result.ModuleAssets),
-                packages = BuildPackageManifestSection(result.Packages),
-                legacyTools = BuildLegacyToolsManifestSection(result.Tools),
-                dotNetTools = BuildDotNetToolsManifestSection(result.DotNetTools),
-                githubReleases = result.ToolGitHubReleases
-            };
-
-            Directory.CreateDirectory(Path.GetDirectoryName(resolvedManifestPath)!);
-            var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine;
-            File.WriteAllText(resolvedManifestPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-            result.ReleaseManifestPath = resolvedManifestPath;
+            result.ReleaseManifestPath = manifestPath!;
+            WriteReleaseManifest(result, manifestPath!);
         }
 
         if (!string.IsNullOrWhiteSpace(checksumsPath))
         {
-            var resolvedChecksumsPath = checksumsPath!;
-            var checksumInputs = new List<string>(result.ReleaseAssets);
-            var releaseManifestPath = result.ReleaseManifestPath;
-            if (!string.IsNullOrWhiteSpace(releaseManifestPath) && File.Exists(releaseManifestPath))
-                checksumInputs.Add(releaseManifestPath!);
-
-            var uniqueChecksumInputs = checksumInputs
-                .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-
-            Directory.CreateDirectory(Path.GetDirectoryName(resolvedChecksumsPath)!);
-            var relativeTo = Path.GetDirectoryName(resolvedChecksumsPath)!;
-            var lines = uniqueChecksumInputs
-                .Select(path => $"{ComputeSha256(path!)} *{GetRelativePathCompat(relativeTo, path!).Replace('\\', '/')}")
-                .ToArray();
-            File.WriteAllLines(resolvedChecksumsPath, lines, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-            result.ReleaseChecksumsPath = resolvedChecksumsPath;
+            result.ReleaseChecksumsPath = checksumsPath!;
+            WriteReleaseChecksums(result, checksumsPath!);
         }
+    }
+
+    private static bool ShouldPublishUnifiedGitHub(PowerForgeReleaseSpec spec, PowerForgeReleaseRequest request)
+    {
+        return spec.GitHub is not null && (request.PublishProjectGitHub ?? spec.GitHub.Publish);
+    }
+
+    private static string? ResolveConfiguredStageRoot(
+        PowerForgeReleaseSpec spec,
+        PowerForgeReleaseRequest request,
+        string configDirectory)
+    {
+        var stageRootTemplate = request.StageRoot ?? spec.Outputs?.Staging?.RootPath;
+        if (string.IsNullOrWhiteSpace(stageRootTemplate))
+            return null;
+
+        return ResolveOutputPath(configDirectory, stageRootTemplate!);
     }
 
     private void GenerateWingetOutputs(
         PowerForgeReleaseSpec spec,
+        PowerForgeReleaseRequest request,
         string configDirectory,
         PowerForgeReleaseResult result)
     {
@@ -630,9 +614,8 @@ internal sealed class PowerForgeReleaseService
         if (winget is null || !winget.Enabled || winget.Packages.Length == 0)
             return;
 
-        var outputPath = string.IsNullOrWhiteSpace(winget.OutputPath)
-            ? ResolveOutputPath(configDirectory, Path.Combine("Artifacts", "Winget"))
-            : ResolveOutputPath(configDirectory, winget.OutputPath!);
+        var stageRoot = ResolveConfiguredStageRoot(spec, request, configDirectory);
+        var outputPath = ResolveWingetOutputPath(winget, configDirectory, stageRoot);
         Directory.CreateDirectory(outputPath);
 
         var manifestPaths = new List<string>();
@@ -669,6 +652,162 @@ internal sealed class PowerForgeReleaseService
         }
 
         result.WingetManifestPaths = manifestPaths.ToArray();
+    }
+
+    private static string ResolveWingetOutputPath(
+        PowerForgeReleaseWingetOptions winget,
+        string configDirectory,
+        string? stageRoot)
+    {
+        if (string.IsNullOrWhiteSpace(winget.OutputPath))
+        {
+            return !string.IsNullOrWhiteSpace(stageRoot)
+                ? Path.Combine(stageRoot!, "Winget")
+                : ResolveOutputPath(configDirectory, Path.Combine("Artifacts", "Winget"));
+        }
+
+        if (!Path.IsPathRooted(winget.OutputPath) && !string.IsNullOrWhiteSpace(stageRoot))
+            return Path.GetFullPath(Path.Combine(stageRoot!, winget.OutputPath!));
+
+        return ResolveOutputPath(configDirectory, winget.OutputPath!);
+    }
+
+    private static void IncludeWingetOutputsInReleaseAssets(PowerForgeReleaseResult result)
+    {
+        if (result.WingetManifestPaths.Length == 0)
+            return;
+
+        var entries = result.ReleaseAssetEntries.ToList();
+        foreach (var path in result.WingetManifestPaths
+                     .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (entries.Any(entry => string.Equals(entry.Path, path, StringComparison.OrdinalIgnoreCase)
+                                     || string.Equals(entry.StagedPath, path, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            entries.Add(new PowerForgeReleaseAssetEntry
+            {
+                Path = path,
+                Category = PowerForgeReleaseAssetCategory.Other,
+                Source = "Winget"
+            });
+        }
+
+        result.ReleaseAssetEntries = entries.ToArray();
+        result.ReleaseAssets = result.ReleaseAssetEntries
+            .Select(entry => entry.StagedPath ?? entry.Path)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray()!;
+    }
+
+    private static void RewriteReleaseSummaryFiles(PowerForgeReleaseResult result)
+    {
+        if (!string.IsNullOrWhiteSpace(result.ReleaseManifestPath))
+            WriteReleaseManifest(result, result.ReleaseManifestPath!);
+        if (!string.IsNullOrWhiteSpace(result.ReleaseChecksumsPath))
+            WriteReleaseChecksums(result, result.ReleaseChecksumsPath!);
+    }
+
+    private PowerForgeUnifiedGitHubReleaseResult PublishUnifiedGitHubRelease(
+        PowerForgeReleaseSpec spec,
+        string configDirectory,
+        PowerForgeReleaseResult result,
+        string? sharedReleaseVersion)
+    {
+        var gitHub = spec.GitHub ?? throw new InvalidOperationException("Unified GitHub release options were not configured.");
+        var version = ResolveUnifiedReleaseVersion(result, sharedReleaseVersion);
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return new PowerForgeUnifiedGitHubReleaseResult
+            {
+                Success = false,
+                ErrorMessage = "Unable to resolve a shared release version for unified GitHub publishing."
+            };
+        }
+
+        var resolved = ResolveUnifiedGitHubConfiguration(spec, gitHub, configDirectory);
+        if (resolved.Error is not null)
+            return resolved.Error;
+
+        var assets = result.ReleaseAssets
+            .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            .Concat(new[]
+            {
+                result.ReleaseManifestPath,
+                result.ReleaseChecksumsPath
+            }.Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path)))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path => path!)
+            .ToArray();
+        if (assets.Length == 0)
+        {
+            return new PowerForgeUnifiedGitHubReleaseResult
+            {
+                Owner = resolved.Owner ?? string.Empty,
+                Repository = resolved.Repository ?? string.Empty,
+                Version = version!,
+                Success = false,
+                ErrorMessage = "No staged release assets were available for unified GitHub publishing."
+            };
+        }
+
+        var tagTemplate = string.IsNullOrWhiteSpace(gitHub.TagTemplate)
+            ? "v{Version}"
+            : gitHub.TagTemplate!;
+        var releaseNameTemplate = string.IsNullOrWhiteSpace(gitHub.ReleaseNameTemplate)
+            ? "{Repository} {Version}"
+            : gitHub.ReleaseNameTemplate!;
+        var tagName = ApplyUnifiedGitHubTemplate(tagTemplate, resolved.Repository!, version!);
+        var releaseName = ApplyUnifiedGitHubTemplate(releaseNameTemplate, resolved.Repository!, version!);
+
+        try
+        {
+            var publishResult = _publishGitHubRelease(new GitHubReleasePublishRequest
+            {
+                Owner = resolved.Owner!,
+                Repository = resolved.Repository!,
+                Token = resolved.Token!,
+                TagName = tagName,
+                ReleaseName = releaseName,
+                GenerateReleaseNotes = gitHub.GenerateReleaseNotes,
+                IsPreRelease = gitHub.IsPreRelease,
+                ReuseExistingReleaseOnConflict = true,
+                AssetFilePaths = assets
+            });
+
+            return new PowerForgeUnifiedGitHubReleaseResult
+            {
+                Owner = resolved.Owner!,
+                Repository = resolved.Repository!,
+                Version = version!,
+                TagName = tagName,
+                ReleaseName = releaseName,
+                AssetPaths = assets,
+                Success = publishResult.Succeeded,
+                ReleaseUrl = publishResult.HtmlUrl,
+                ReusedExistingRelease = publishResult.ReusedExistingRelease,
+                ErrorMessage = publishResult.Succeeded ? null : "Unified GitHub release publish failed.",
+                SkippedExistingAssets = publishResult.SkippedExistingAssets?.ToArray() ?? Array.Empty<string>()
+            };
+        }
+        catch (Exception ex)
+        {
+            return new PowerForgeUnifiedGitHubReleaseResult
+            {
+                Owner = resolved.Owner ?? string.Empty,
+                Repository = resolved.Repository ?? string.Empty,
+                Version = version!,
+                TagName = tagName,
+                ReleaseName = releaseName,
+                AssetPaths = assets,
+                Success = false,
+                ErrorMessage = ex.Message
+            };
+        }
     }
 
     private PowerForgeToolGitHubReleaseResult[] PublishLegacyToolGitHubReleases(
@@ -1459,6 +1598,111 @@ internal sealed class PowerForgeReleaseService
             .Replace("{UtcTimestamp}", utcNow.ToString("yyyyMMddHHmmss"));
     }
 
+    private static string ApplyUnifiedGitHubTemplate(string template, string repository, string version)
+    {
+        var now = DateTime.Now;
+        var utcNow = DateTime.UtcNow;
+        return template
+            .Replace("{Target}", string.Empty)
+            .Replace("{Project}", string.Empty)
+            .Replace("{Version}", version)
+            .Replace("{Repo}", repository)
+            .Replace("{Repository}", repository)
+            .Replace("{Date}", now.ToString("yyyy.MM.dd"))
+            .Replace("{UtcDate}", utcNow.ToString("yyyy.MM.dd"))
+            .Replace("{DateTime}", now.ToString("yyyyMMddHHmmss"))
+            .Replace("{UtcDateTime}", utcNow.ToString("yyyyMMddHHmmss"))
+            .Replace("{Timestamp}", now.ToString("yyyyMMddHHmmss"))
+            .Replace("{UtcTimestamp}", utcNow.ToString("yyyyMMddHHmmss"));
+    }
+
+    private static string? ResolveUnifiedReleaseVersion(PowerForgeReleaseResult result, string? sharedReleaseVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(sharedReleaseVersion))
+            return sharedReleaseVersion;
+
+        var versions = result.ReleaseAssetEntries
+            .Select(entry => entry.Version)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (versions.Length == 1)
+            return versions[0];
+
+        return null;
+    }
+
+    private static (string? Owner, string? Repository, string? Token, PowerForgeUnifiedGitHubReleaseResult? Error) ResolveUnifiedGitHubConfiguration(
+        PowerForgeReleaseSpec spec,
+        PowerForgeReleaseGitHubOptions gitHub,
+        string configDirectory)
+    {
+        var owner = FirstNonEmpty(gitHub.Owner, spec.Packages?.GitHubUsername)?.Trim();
+        var repository = FirstNonEmpty(gitHub.Repository, spec.Packages?.GitHubRepositoryName)?.Trim();
+        var token = ResolveSecret(FirstNonEmpty(gitHub.Token, spec.Packages?.GitHubAccessToken), FirstNonEmpty(gitHub.TokenFilePath, spec.Packages?.GitHubAccessTokenFilePath), FirstNonEmpty(gitHub.TokenEnvName, spec.Packages?.GitHubAccessTokenEnvName), configDirectory);
+
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repository))
+        {
+            return (owner, repository, token, new PowerForgeUnifiedGitHubReleaseResult
+            {
+                Owner = owner ?? string.Empty,
+                Repository = repository ?? string.Empty,
+                Success = false,
+                ErrorMessage = "Unified GitHub release publishing requires Owner and Repository (or package GitHub defaults)."
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return (owner, repository, token, new PowerForgeUnifiedGitHubReleaseResult
+            {
+                Owner = owner!,
+                Repository = repository!,
+                Success = false,
+                ErrorMessage = "Unified GitHub release publishing requires a GitHub token (direct value, file, or environment variable)."
+            });
+        }
+
+        return (owner, repository, token, null);
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        return null;
+    }
+
+    private static string? ResolveSecret(string? directValue, string? filePath, string? envName, string configDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(directValue))
+            return directValue!.Trim();
+
+        if (!string.IsNullOrWhiteSpace(filePath))
+        {
+            var resolvedPath = ResolveOutputPath(configDirectory, filePath!);
+            if (File.Exists(resolvedPath))
+            {
+                var fileValue = File.ReadAllText(resolvedPath).Trim();
+                if (!string.IsNullOrWhiteSpace(fileValue))
+                    return fileValue;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(envName))
+        {
+            var envValue = Environment.GetEnvironmentVariable(envName!.Trim());
+            if (!string.IsNullOrWhiteSpace(envValue))
+                return envValue.Trim();
+        }
+
+        return null;
+    }
+
     private static PowerForgeReleaseAssetEntry[] CollectReleaseAssetEntries(
         PowerForgeReleaseResult result,
         DotNetPublishPlan? dotNetPlan,
@@ -1974,6 +2218,62 @@ internal sealed class PowerForgeReleaseService
                 project.ReleaseZipPath
             }).ToArray()
         };
+    }
+
+    private static void WriteReleaseManifest(PowerForgeReleaseResult result, string manifestPath)
+    {
+        var manifest = new
+        {
+            schemaVersion = 1,
+            createdUtc = DateTime.UtcNow.ToString("o"),
+            configPath = result.ConfigPath,
+            assets = result.ReleaseAssets,
+            assetEntries = result.ReleaseAssetEntries.Select(entry => new
+            {
+                entry.Path,
+                category = entry.Category.ToString(),
+                entry.Source,
+                entry.Target,
+                entry.PackageId,
+                entry.Version,
+                entry.Runtime,
+                entry.Framework,
+                entry.Style,
+                entry.BundleId,
+                entry.RelativeStagePath,
+                entry.StagedPath
+            }).ToArray(),
+            module = BuildModuleManifestSection(result.ModulePlan, result.Module, result.ModuleAssets),
+            packages = BuildPackageManifestSection(result.Packages),
+            legacyTools = BuildLegacyToolsManifestSection(result.Tools),
+            dotNetTools = BuildDotNetToolsManifestSection(result.DotNetTools),
+            githubReleases = result.ToolGitHubReleases,
+            unifiedGithubRelease = result.UnifiedGitHubRelease
+        };
+
+        Directory.CreateDirectory(Path.GetDirectoryName(manifestPath)!);
+        var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine;
+        File.WriteAllText(manifestPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static void WriteReleaseChecksums(PowerForgeReleaseResult result, string checksumsPath)
+    {
+        var checksumInputs = new List<string>(result.ReleaseAssets);
+        if (!string.IsNullOrWhiteSpace(result.ReleaseManifestPath) && File.Exists(result.ReleaseManifestPath))
+            checksumInputs.Add(result.ReleaseManifestPath!);
+
+        var uniqueChecksumInputs = checksumInputs
+            .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Directory.CreateDirectory(Path.GetDirectoryName(checksumsPath)!);
+        var relativeTo = Path.GetDirectoryName(checksumsPath)!;
+        var lines = uniqueChecksumInputs
+            .Select(path => $"{ComputeSha256(path!)} *{GetRelativePathCompat(relativeTo, path!).Replace('\\', '/')}")
+            .ToArray();
+        File.WriteAllLines(checksumsPath, lines, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
     }
 
     private static object? BuildLegacyToolsManifestSection(PowerForgeToolReleaseResult? tools)

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -41,6 +41,22 @@
         }
       }
     },
+    "GitHub": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Publish": { "type": "boolean" },
+        "Owner": { "type": [ "string", "null" ] },
+        "Repository": { "type": [ "string", "null" ] },
+        "Token": { "type": [ "string", "null" ] },
+        "TokenFilePath": { "type": [ "string", "null" ] },
+        "TokenEnvName": { "type": [ "string", "null" ] },
+        "GenerateReleaseNotes": { "type": "boolean" },
+        "IsPreRelease": { "type": "boolean" },
+        "TagTemplate": { "type": [ "string", "null" ] },
+        "ReleaseNameTemplate": { "type": [ "string", "null" ] }
+      }
+    },
     "Winget": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary
- add a first-class unified `GitHub` section to `powerforge release` so staged `UploadReady` assets can publish as one repo release
- resolve relative Winget output under the active staged release root and include generated Winget manifests in release assets/checksums
- keep IX-style wrappers thin by moving the repo-release orchestration into PowerForge instead of custom repo scripts

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "PowerForgeReleaseServiceTests"`
- `dotnet build .\PowerForge.Cli\PowerForge.Cli.csproj -c Release -f net10.0`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net8.0`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472`