### PR TITLE
Polish markdown and html builders

### DIFF
--- a/PowerForge.Web/Services/HtmlFragmentBuilder.cs
+++ b/PowerForge.Web/Services/HtmlFragmentBuilder.cs
@@ -34,6 +34,11 @@ internal sealed class HtmlFragmentBuilder
         _builder.AppendLine(text ?? string.Empty);
     }
 
+    public void BlankLine()
+    {
+        _builder.AppendLine();
+    }
+
     public void AppendRaw(string? text)
     {
         if (string.IsNullOrEmpty(text))

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
@@ -464,7 +464,7 @@ $@"<!doctype html>
         if (!string.IsNullOrWhiteSpace(siteName))
             html.Line($"<meta property=\"og:site_name\" content=\"{System.Web.HttpUtility.HtmlEncode(siteName)}\" />");
 
-        html.Line(string.Empty);
+        html.BlankLine();
         html.Line("<!-- Twitter Card -->");
         html.Line($"<meta name=\"twitter:card\" content=\"{System.Web.HttpUtility.HtmlEncode(twitterCard)}\" />");
         html.Line($"<meta name=\"twitter:title\" content=\"{System.Web.HttpUtility.HtmlEncode(title)}\" />");

--- a/PowerForge/Services/Documentation/MarkdownDocumentBuilder.cs
+++ b/PowerForge/Services/Documentation/MarkdownDocumentBuilder.cs
@@ -6,19 +6,19 @@ internal sealed class MarkdownDocumentBuilder
 {
     private readonly StringBuilder _body = new();
     private readonly StringBuilder _frontMatter = new();
+    private readonly YamlTextWriter _frontMatterWriter;
     private readonly bool _blankLineAfterFrontMatter;
     private bool _hasFrontMatter;
 
     public MarkdownDocumentBuilder(bool blankLineAfterFrontMatter = true)
     {
         _blankLineAfterFrontMatter = blankLineAfterFrontMatter;
+        _frontMatterWriter = new YamlTextWriter(_frontMatter);
     }
 
     public void FrontMatter(string key, string value)
     {
-        var yaml = new YamlTextWriter();
-        yaml.WriteScalar(key, value);
-        _frontMatter.Append(yaml.ToString());
+        _frontMatterWriter.WriteScalar(key, value);
         _hasFrontMatter = true;
     }
 
@@ -27,9 +27,7 @@ internal sealed class MarkdownDocumentBuilder
         if (values is null || values.Count == 0)
             return;
 
-        var yaml = new YamlTextWriter();
-        yaml.WriteSequence(key, values);
-        _frontMatter.Append(yaml.ToString());
+        _frontMatterWriter.WriteSequence(key, values);
         _hasFrontMatter = true;
     }
 

--- a/PowerForge/Services/YamlTextWriter.cs
+++ b/PowerForge/Services/YamlTextWriter.cs
@@ -29,6 +29,11 @@ internal sealed class YamlTextWriter
         _builder = capacity > 0 ? new StringBuilder(capacity) : new StringBuilder();
     }
 
+    public YamlTextWriter(StringBuilder builder)
+    {
+        _builder = builder ?? throw new ArgumentNullException(nameof(builder));
+    }
+
     public IDisposable Indent()
     {
         _indent += 2;


### PR DESCRIPTION
## Summary
- reuse a single YamlTextWriter for markdown front matter to avoid per-call allocations
- add HtmlFragmentBuilder.BlankLine and use it for Open Graph meta spacing

## Testing
- dotnet test .\\PowerForge.Tests\\PowerForge.Tests.csproj -c Release --filter "MarkdownDocumentBuilderTests|HtmlFragmentBuilderTests"
