### PR TITLE
Add PowerForge.Web agent readiness support

### DIFF
--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -1,0 +1,212 @@
+# PowerForge.Web Agent Readiness
+
+PowerForge.Web includes an `agent-ready` surface for the emerging checks used by
+Cloudflare's Is Your Site Agent-Ready scanner and similar tools.
+
+The goal is not to pretend every static documentation site is an API platform.
+The goal is to make the site explicit about what agents can discover, crawl,
+read, and use.
+
+## What The Current Scanners Check
+
+The scanner families currently group checks roughly like this:
+
+- Discoverability:
+  - `/robots.txt`
+  - `/sitemap.xml`
+  - response `Link` headers on the homepage
+- Content:
+  - `Accept: text/markdown` negotiation
+- Bot access control:
+  - crawler rules in `robots.txt`
+  - `Content-Signal` directives for `search`, `ai-input`, and `ai-train`
+  - optional Web Bot Auth request-signing metadata
+- AI content discovery:
+  - AI crawler directives
+  - meta robots
+  - sitemap freshness signals
+- AI search signals:
+  - JSON-LD
+  - Schema.org types
+  - entity links such as `sameAs` or `@id`
+  - BreadcrumbList
+  - Organization and FAQPage schemas where applicable
+  - author or publisher attribution
+- Content and semantics:
+  - server-rendered HTML
+  - heading hierarchy
+  - semantic landmarks
+  - ARIA landmarks
+  - image alt text
+  - language
+  - useful link text
+  - question headings where applicable
+- Security and trust:
+  - HTTPS
+  - HSTS
+  - CSP
+  - X-Content-Type-Options
+  - X-Frame-Options or CSP `frame-ancestors`
+  - CORS for agent/API discovery resources
+  - Referrer-Policy
+- API, auth, MCP, and skill discovery:
+  - `/.well-known/api-catalog` as `application/linkset+json`
+  - OAuth / OIDC discovery files where protected APIs exist
+  - `/.well-known/oauth-protected-resource` where protected resources exist
+  - `/.well-known/mcp/server-card.json` where an MCP server exists
+  - `/.well-known/agent-skills/index.json`
+  - `/agents.json` and `/.well-known/agents.json`
+  - `/.well-known/agent-card.json` for A2A discovery where a site can truthfully describe an agent surface
+  - OpenAPI where a programmable HTTP API exists
+  - optional WebMCP browser tools
+- Commerce:
+  - x402, UCP, and ACP discovery for commerce sites
+
+PowerForge.Web can prepare and verify the common static-site subset:
+
+- robots.txt with Content Signals
+- sitemap.xml integration
+- static host `_headers` with Link headers and well-known content types
+- static security headers for HSTS, CSP, X-Content-Type-Options,
+  X-Frame-Options, Referrer-Policy, and discovery-resource CORS
+- API catalog Linkset generation
+- Agent Skills index + default SKILL.md generation
+- agents.json generation
+- optional A2A Agent Card generation
+- optional MCP server card
+- OpenAPI detection/configuration
+- local HTML, JSON-LD, and semantic checks aligned with AI-readiness scanners
+- local WebMCP smoke detection
+- remote scan of live headers and well-known URLs
+
+Cloudflare Markdown for Agents is a host-level feature. PowerForge verifies it
+with a live scan, but static output cannot prove that `Accept: text/markdown`
+will be negotiated by the deployed edge or origin.
+
+## Site Configuration
+
+Add an `agentReadiness` block to `site.json`:
+
+```json
+{
+  "agentReadiness": {
+    "enabled": true,
+    "contentSignals": {
+      "enabled": true,
+      "search": true,
+      "aiInput": true,
+      "aiTrain": false
+    },
+    "securityHeaders": {
+      "enabled": true,
+      "contentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    },
+    "apiCatalog": {
+      "enabled": true,
+      "entries": [
+        {
+          "anchor": "/api/",
+          "serviceDesc": "/api/index.json",
+          "serviceDoc": "/api/"
+        }
+      ]
+    },
+    "agentSkills": {
+      "enabled": true
+    },
+    "agentsJson": {
+      "enabled": true
+    },
+    "a2aAgentCard": {
+      "enabled": false
+    },
+    "mcpServerCard": {
+      "enabled": false
+    },
+    "openApi": {
+      "enabled": false
+    },
+    "markdownNegotiation": true
+  }
+}
+```
+
+If `agentSkills.skills` is empty, PowerForge writes a conservative default
+`site-assistant` skill and computes the SHA-256 digest required by the Agent
+Skills Discovery index.
+
+If `apiCatalog.entries` is empty but `_site/api/index.json` exists, PowerForge
+infers a basic API documentation entry. For public programmable APIs, prefer
+explicit entries that point `serviceDesc` at an OpenAPI document.
+
+Do not enable MCP, WebMCP, OAuth, OpenAPI, A2A, or commerce settings just to
+make a scanner green. These discovery files are contracts. Publish them only
+when the site really has the corresponding endpoint, tool surface, protected
+resource, or commerce flow.
+
+## Pipeline
+
+Run `agent-ready` after `sitemap` and after any step that writes `_headers`.
+For optimized static sites, put it after `optimize` so discovery and security
+headers are appended after cache headers:
+
+```json
+{
+  "task": "agent-ready",
+  "id": "agent-ready",
+  "dependsOn": "optimize-site",
+  "operation": "prepare",
+  "config": "./site.json",
+  "siteRoot": "./_site",
+  "failOnFailures": true,
+  "modes": ["ci"]
+}
+```
+
+Use `operation: "verify"` when you only want to check already-generated output.
+Use `operation: "scan"` when CI should check a deployed URL:
+
+```json
+{
+  "task": "agent-ready",
+  "id": "agent-ready-live",
+  "operation": "scan",
+  "url": "https://example.com",
+  "failOnFailures": true,
+  "modes": ["ci"]
+}
+```
+
+## CLI
+
+Prepare local static output:
+
+```powershell
+powerforge-web agent-ready prepare --site-root .\_site --config .\site.json
+```
+
+Verify local output:
+
+```powershell
+powerforge-web agent-ready verify --site-root .\_site --config .\site.json --fail-on-failures
+```
+
+Scan a deployed site:
+
+```powershell
+powerforge-web agent-ready scan --url https://example.com --fail-on-failures
+```
+
+## Deployment Notes
+
+The generated `_headers` file is compatible with Cloudflare Pages-style static
+headers. Other hosts may need their own response-header configuration.
+
+For Cloudflare zones, enable Markdown for Agents in AI Crawl Control or with a
+Configuration Rule. PowerForge can scan the deployed behavior, but it does not
+toggle Cloudflare zone settings by itself.
+
+Cloudflare's Markdown for Agents checks the deployed edge behavior: requests
+with `Accept: text/markdown` should return markdown content. A local static
+site build can prepare everything around that feature, but only the deployed
+zone or origin can prove the negotiation result.

--- a/PSPublishModule/packages.lock.json
+++ b/PSPublishModule/packages.lock.json
@@ -670,8 +670,8 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ULmp3xoOwNYjOYp4JZ2NK/6NdTgiN1GQXzVVN1njQ7LOZ0d0B9vyMnhyqbIi9Qw4JXj1JgCsitkTShboHRx7Eg=="
+        "resolved": "10.0.6",
+        "contentHash": "88tquaGJ1htm4DHWS6x9jwER7sFET2SVRN7HqO1FYZwE0diDcUmz0ajhVa8ZD2HGhDJBueSPjP/gqyP3gXtT2A=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -680,10 +680,10 @@
       },
       "System.Security.Cryptography.Xml": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "HQSFbakswZ1OXFz2Bt3AJlC6ENDqWeVpgqhf213xqQUMDifzydOHIKVb1RV4prayobvR3ETIScMaQdDF2hwGZA==",
+        "resolved": "10.0.6",
+        "contentHash": "71yFkEElPZKZ9jbZQTe1CWeHYXEtnCXwZnHnfeA8pP47tCXBUoWk+6zSIZ7RXO90nZjXgPNil6BFGWb1OBqA5w==",
         "dependencies": {
-          "System.Security.Cryptography.Pkcs": "8.0.0"
+          "System.Security.Cryptography.Pkcs": "10.0.6"
         }
       },
       "System.Security.Permissions": {
@@ -777,7 +777,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.1, )",
-          "PowerForge": "[1.0.0, )"
+          "PowerForge": "[1.0.0, )",
+          "System.Security.Cryptography.Xml": "[10.0.6, )"
         }
       }
     },
@@ -848,6 +849,14 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "Z0snzY7+gh+kjU3v9hQuu2q54eF0hosTTaI+aLYzFP2uUzySGHAxukjqWpeOioGUTZsM3PmPCn98OvJeD3KmkA==",
+        "dependencies": {
+          "System.Formats.Asn1": "10.0.6"
+        }
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -1227,6 +1236,11 @@
           "Microsoft.Win32.SystemEvents": "8.0.0"
         }
       },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "/YXowB3idLgb3ix8pkZdr08EKSWoH9xyxywvXebcZnA1o1xUtSK3M8udHqN4xI50Ni6BuaOE1E9iCBiVpzkr7Q=="
+      },
       "System.IO.Ports": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1292,8 +1306,12 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ULmp3xoOwNYjOYp4JZ2NK/6NdTgiN1GQXzVVN1njQ7LOZ0d0B9vyMnhyqbIi9Qw4JXj1JgCsitkTShboHRx7Eg=="
+        "resolved": "10.0.6",
+        "contentHash": "88tquaGJ1htm4DHWS6x9jwER7sFET2SVRN7HqO1FYZwE0diDcUmz0ajhVa8ZD2HGhDJBueSPjP/gqyP3gXtT2A==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.6",
+          "System.Formats.Asn1": "10.0.6"
+        }
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -1302,10 +1320,11 @@
       },
       "System.Security.Cryptography.Xml": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "HQSFbakswZ1OXFz2Bt3AJlC6ENDqWeVpgqhf213xqQUMDifzydOHIKVb1RV4prayobvR3ETIScMaQdDF2hwGZA==",
+        "resolved": "10.0.6",
+        "contentHash": "71yFkEElPZKZ9jbZQTe1CWeHYXEtnCXwZnHnfeA8pP47tCXBUoWk+6zSIZ7RXO90nZjXgPNil6BFGWb1OBqA5w==",
         "dependencies": {
-          "System.Security.Cryptography.Pkcs": "8.0.0"
+          "Microsoft.Bcl.Cryptography": "10.0.6",
+          "System.Security.Cryptography.Pkcs": "10.0.6"
         }
       },
       "System.Security.Permissions": {
@@ -1404,7 +1423,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.1, )",
-          "PowerForge": "[1.0.0, )"
+          "PowerForge": "[1.0.0, )",
+          "System.Security.Cryptography.Xml": "[10.0.6, )"
         }
       }
     }

--- a/PowerForge.Cli/packages.lock.json
+++ b/PowerForge.Cli/packages.lock.json
@@ -502,8 +502,8 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ULmp3xoOwNYjOYp4JZ2NK/6NdTgiN1GQXzVVN1njQ7LOZ0d0B9vyMnhyqbIi9Qw4JXj1JgCsitkTShboHRx7Eg=="
+        "resolved": "10.0.6",
+        "contentHash": "88tquaGJ1htm4DHWS6x9jwER7sFET2SVRN7HqO1FYZwE0diDcUmz0ajhVa8ZD2HGhDJBueSPjP/gqyP3gXtT2A=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -512,10 +512,10 @@
       },
       "System.Security.Cryptography.Xml": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "HQSFbakswZ1OXFz2Bt3AJlC6ENDqWeVpgqhf213xqQUMDifzydOHIKVb1RV4prayobvR3ETIScMaQdDF2hwGZA==",
+        "resolved": "10.0.6",
+        "contentHash": "71yFkEElPZKZ9jbZQTe1CWeHYXEtnCXwZnHnfeA8pP47tCXBUoWk+6zSIZ7RXO90nZjXgPNil6BFGWb1OBqA5w==",
         "dependencies": {
-          "System.Security.Cryptography.Pkcs": "8.0.0"
+          "System.Security.Cryptography.Pkcs": "10.0.6"
         }
       },
       "System.Security.Permissions": {
@@ -609,7 +609,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.1, )",
-          "PowerForge": "[1.0.0, )"
+          "PowerForge": "[1.0.0, )",
+          "System.Security.Cryptography.Xml": "[10.0.6, )"
         }
       }
     },
@@ -662,6 +663,14 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "Z0snzY7+gh+kjU3v9hQuu2q54eF0hosTTaI+aLYzFP2uUzySGHAxukjqWpeOioGUTZsM3PmPCn98OvJeD3KmkA==",
+        "dependencies": {
+          "System.Formats.Asn1": "10.0.6"
+        }
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -1041,6 +1050,11 @@
           "Microsoft.Win32.SystemEvents": "8.0.0"
         }
       },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "/YXowB3idLgb3ix8pkZdr08EKSWoH9xyxywvXebcZnA1o1xUtSK3M8udHqN4xI50Ni6BuaOE1E9iCBiVpzkr7Q=="
+      },
       "System.IO.Packaging": {
         "type": "Transitive",
         "resolved": "8.0.1",
@@ -1116,8 +1130,12 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ULmp3xoOwNYjOYp4JZ2NK/6NdTgiN1GQXzVVN1njQ7LOZ0d0B9vyMnhyqbIi9Qw4JXj1JgCsitkTShboHRx7Eg=="
+        "resolved": "10.0.6",
+        "contentHash": "88tquaGJ1htm4DHWS6x9jwER7sFET2SVRN7HqO1FYZwE0diDcUmz0ajhVa8ZD2HGhDJBueSPjP/gqyP3gXtT2A==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.6",
+          "System.Formats.Asn1": "10.0.6"
+        }
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -1126,10 +1144,11 @@
       },
       "System.Security.Cryptography.Xml": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "HQSFbakswZ1OXFz2Bt3AJlC6ENDqWeVpgqhf213xqQUMDifzydOHIKVb1RV4prayobvR3ETIScMaQdDF2hwGZA==",
+        "resolved": "10.0.6",
+        "contentHash": "71yFkEElPZKZ9jbZQTe1CWeHYXEtnCXwZnHnfeA8pP47tCXBUoWk+6zSIZ7RXO90nZjXgPNil6BFGWb1OBqA5w==",
         "dependencies": {
-          "System.Security.Cryptography.Pkcs": "8.0.0"
+          "Microsoft.Bcl.Cryptography": "10.0.6",
+          "System.Security.Cryptography.Pkcs": "10.0.6"
         }
       },
       "System.Security.Permissions": {
@@ -1228,7 +1247,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.1, )",
-          "PowerForge": "[1.0.0, )"
+          "PowerForge": "[1.0.0, )",
+          "System.Security.Cryptography.Xml": "[10.0.6, )"
         }
       }
     }

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/PowerForge.PowerShell/packages.lock.json
+++ b/PowerForge.PowerShell/packages.lock.json
@@ -158,6 +158,15 @@
           "System.Web.Services.Description": "4.10.3"
         }
       },
+      "System.Security.Cryptography.Xml": {
+        "type": "Direct",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "71yFkEElPZKZ9jbZQTe1CWeHYXEtnCXwZnHnfeA8pP47tCXBUoWk+6zSIZ7RXO90nZjXgPNil6BFGWb1OBqA5w==",
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "10.0.6"
+        }
+      },
       "JetBrains.Annotations": {
         "type": "Transitive",
         "resolved": "2021.2.0",
@@ -625,21 +634,13 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ULmp3xoOwNYjOYp4JZ2NK/6NdTgiN1GQXzVVN1njQ7LOZ0d0B9vyMnhyqbIi9Qw4JXj1JgCsitkTShboHRx7Eg=="
+        "resolved": "10.0.6",
+        "contentHash": "88tquaGJ1htm4DHWS6x9jwER7sFET2SVRN7HqO1FYZwE0diDcUmz0ajhVa8ZD2HGhDJBueSPjP/gqyP3gXtT2A=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
-      },
-      "System.Security.Cryptography.Xml": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "HQSFbakswZ1OXFz2Bt3AJlC6ENDqWeVpgqhf213xqQUMDifzydOHIKVb1RV4prayobvR3ETIScMaQdDF2hwGZA==",
-        "dependencies": {
-          "System.Security.Cryptography.Pkcs": "8.0.0"
-        }
       },
       "System.Security.Permissions": {
         "type": "Transitive",
@@ -758,6 +759,16 @@
           "System.Web.Services.Description": "4.10.3"
         }
       },
+      "System.Security.Cryptography.Xml": {
+        "type": "Direct",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "71yFkEElPZKZ9jbZQTe1CWeHYXEtnCXwZnHnfeA8pP47tCXBUoWk+6zSIZ7RXO90nZjXgPNil6BFGWb1OBqA5w==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.6",
+          "System.Security.Cryptography.Pkcs": "10.0.6"
+        }
+      },
       "JetBrains.Annotations": {
         "type": "Transitive",
         "resolved": "2021.2.0",
@@ -800,6 +811,14 @@
         "type": "Transitive",
         "resolved": "5.0.0",
         "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "Z0snzY7+gh+kjU3v9hQuu2q54eF0hosTTaI+aLYzFP2uUzySGHAxukjqWpeOioGUTZsM3PmPCn98OvJeD3KmkA==",
+        "dependencies": {
+          "System.Formats.Asn1": "10.0.6"
+        }
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
@@ -1152,6 +1171,11 @@
           "Microsoft.Win32.SystemEvents": "8.0.0"
         }
       },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "/YXowB3idLgb3ix8pkZdr08EKSWoH9xyxywvXebcZnA1o1xUtSK3M8udHqN4xI50Ni6BuaOE1E9iCBiVpzkr7Q=="
+      },
       "System.IO.Packaging": {
         "type": "Transitive",
         "resolved": "8.0.1",
@@ -1227,21 +1251,17 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ULmp3xoOwNYjOYp4JZ2NK/6NdTgiN1GQXzVVN1njQ7LOZ0d0B9vyMnhyqbIi9Qw4JXj1JgCsitkTShboHRx7Eg=="
+        "resolved": "10.0.6",
+        "contentHash": "88tquaGJ1htm4DHWS6x9jwER7sFET2SVRN7HqO1FYZwE0diDcUmz0ajhVa8ZD2HGhDJBueSPjP/gqyP3gXtT2A==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.6",
+          "System.Formats.Asn1": "10.0.6"
+        }
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
-      },
-      "System.Security.Cryptography.Xml": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "HQSFbakswZ1OXFz2Bt3AJlC6ENDqWeVpgqhf213xqQUMDifzydOHIKVb1RV4prayobvR3ETIScMaQdDF2hwGZA==",
-        "dependencies": {
-          "System.Security.Cryptography.Pkcs": "8.0.0"
-        }
       },
       "System.Security.Permissions": {
         "type": "Transitive",

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -292,6 +292,31 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void AgentReadyExpectedOutputsUseLastBuildOutputWhenSiteRootIsImplicit()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-agent-ready-cache-outputs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var siteRoot = Path.Combine(root, "site");
+            var step = JsonDocument.Parse("""{ "task": "agent-ready", "config": "./site.json" }""").RootElement.Clone();
+            var method = typeof(WebPipelineRunner).GetMethod("GetExpectedStepOutputs", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+            Assert.NotNull(method);
+
+            var outputs = Assert.IsType<string[]>(method.Invoke(null, new object[] { "agent-ready", step, root, siteRoot }));
+
+            Assert.Contains(Path.Combine(siteRoot, "robots.txt"), outputs);
+            Assert.Contains(Path.Combine(siteRoot, "_headers"), outputs);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Verify_HonorsDisabledOptionalAgentReadinessChecks()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-disabled-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using PowerForge.Web;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public class WebAgentReadinessTests
+{
+    [Fact]
+    public void Prepare_WritesDiscoveryFilesAndHeaders()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-prepare-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            Directory.CreateDirectory(Path.Combine(root, "api"));
+            File.WriteAllText(Path.Combine(root, "api", "index.json"), "{}");
+            File.WriteAllText(Path.Combine(root, "llms.txt"), "# Example");
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head>
+                  <meta name="robots" content="index,follow">
+                  <script type="application/ld+json">
+                  {"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}
+                  </script>
+                </head>
+                <body>
+                  <header><nav><a href="/docs/">Documentation</a></nav></header>
+                  <main><h1>Example?</h1><p>Hello agents.</p><img src="/logo.png" alt=""></main>
+                  <footer>Example</footer>
+                </body>
+                </html>
+                """);
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    ContentSignals = new AgentContentSignalsSpec { Search = true, AiInput = false, AiTrain = false },
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = true },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = true },
+                    A2AAgentCard = new AgentA2ACardSpec { Enabled = true }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            Assert.True(File.Exists(Path.Combine(root, "robots.txt")));
+            Assert.True(File.Exists(Path.Combine(root, ".well-known", "api-catalog")));
+            Assert.True(File.Exists(Path.Combine(root, ".well-known", "agent-skills", "index.json")));
+            Assert.True(File.Exists(Path.Combine(root, "agents.json")));
+            Assert.True(File.Exists(Path.Combine(root, ".well-known", "agent-card.json")));
+            Assert.True(File.Exists(Path.Combine(root, "_headers")));
+
+            var robots = File.ReadAllText(Path.Combine(root, "robots.txt"));
+            Assert.Contains("Content-Signal: search=yes, ai-input=no, ai-train=no", robots, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Sitemap: https://example.test/sitemap.xml", robots, StringComparison.OrdinalIgnoreCase);
+
+            var headers = File.ReadAllText(Path.Combine(root, "_headers"));
+            Assert.Contains("rel=\"api-catalog\"", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("application/linkset+json", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Strict-Transport-Security", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Access-Control-Allow-Origin", headers, StringComparison.OrdinalIgnoreCase);
+
+            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
+            Assert.True(apiCatalog.RootElement.TryGetProperty("linkset", out var linkset));
+            Assert.True(linkset.GetArrayLength() > 0);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void RunPipeline_AgentReady_PreparesAfterBuildAndSitemap()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-agent-ready-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var contentRoot = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(contentRoot);
+            File.WriteAllText(Path.Combine(contentRoot, "index.md"),
+                """
+                ---
+                title: Home
+                ---
+
+                Hello
+                """);
+
+            var themeRoot = Path.Combine(root, "themes", "base", "layouts");
+            Directory.CreateDirectory(themeRoot);
+            File.WriteAllText(Path.Combine(themeRoot, "page.html"),
+                """
+                <!doctype html><html lang="en"><head><title>{{TITLE}}</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Agent Ready Pipeline","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Agent Ready Pipeline"},"dateModified":"2026-04-17"}</script></head><body><header><nav><a href="/">Home</a></nav></header><main><h1>{{TITLE}}?</h1>{{CONTENT}}</main><footer>Footer</footer></body></html>
+                """);
+
+            File.WriteAllText(Path.Combine(root, "site.json"),
+                """
+                {
+                  "name": "Agent Ready Pipeline",
+                  "baseUrl": "https://example.test",
+                  "contentRoot": "content",
+                  "themesRoot": "themes",
+                  "defaultTheme": "base",
+                  "agentReadiness": {
+                    "enabled": true,
+                    "apiCatalog": {
+                      "enabled": true,
+                      "entries": [
+                        { "anchor": "/api/", "serviceDesc": "/api/index.json", "serviceDoc": "/api/" }
+                      ]
+                    },
+                    "agentSkills": { "enabled": true },
+                    "a2aAgentCard": { "enabled": true }
+                  },
+                  "collections": [
+                    { "name": "pages", "input": "content/pages", "output": "/", "defaultLayout": "page" }
+                  ]
+                }
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    { "task": "build", "config": "./site.json", "out": "./site", "clean": true },
+                    { "task": "sitemap", "dependsOn": "build", "config": "./site.json" },
+                    { "task": "agent-ready", "dependsOn": "sitemap", "operation": "prepare", "config": "./site.json" }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.Equal(3, result.Steps.Count);
+            Assert.True(result.Steps[2].Success, result.Steps[2].Message);
+            Assert.True(File.Exists(Path.Combine(root, "site", ".well-known", "agent-skills", "index.json")));
+            Assert.True(File.Exists(Path.Combine(root, "site", "_headers")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, true);
+        }
+        catch
+        {
+            // Ignore cleanup failures in tests.
+        }
+    }
+}

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -70,6 +70,8 @@ public class WebAgentReadinessTests
 
             var headers = File.ReadAllText(Path.Combine(root, "_headers"));
             Assert.Contains("</.well-known/custom-api-catalog>; rel=\"api-catalog\"", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("/.well-known/custom-api-catalog" + Environment.NewLine + "  Content-Type: application/linkset+json", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/.well-known/api-catalog" + Environment.NewLine + "  Content-Type:", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("rel=\"api-catalog\"", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("application/linkset+json", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Strict-Transport-Security", headers, StringComparison.OrdinalIgnoreCase);
@@ -81,6 +83,132 @@ public class WebAgentReadinessTests
             using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "custom-api-catalog")));
             Assert.True(apiCatalog.RootElement.TryGetProperty("linkset", out var linkset));
             Assert.True(linkset.GetArrayLength() > 0);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Prepare_WritesSecurityHeadersWhenLinkHeadersAreDisabled()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-security-headers-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    LinkHeaders = false,
+                    MarkdownNegotiation = false,
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = true }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            var headers = File.ReadAllText(Path.Combine(root, "_headers"));
+            Assert.Contains("Strict-Transport-Security", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Content-Security-Policy", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Link:", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/.well-known/api-catalog", headers, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Verify_DisabledAgentReadinessShortCircuits()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-disabled-all-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                AgentReadiness = new AgentReadinessSpec { Enabled = false }
+            });
+
+            Assert.True(result.Success);
+            Assert.Empty(result.Checks);
+            Assert.Contains(result.Warnings, warning => warning.Contains("disabled", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void ResolveSpec_DoesNotMutateCallerSpec()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-no-mutate-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var spec = new AgentReadinessSpec
+            {
+                Enabled = true,
+                MarkdownNegotiation = false
+            };
+
+            _ = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = spec
+            });
+
+            Assert.Null(spec.SecurityHeaders);
+            Assert.Null(spec.ContentSignals);
+            Assert.Null(spec.ApiCatalog);
+            Assert.Null(spec.AgentSkills);
+            Assert.Null(spec.AgentsJson);
         }
         finally
         {

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -317,6 +317,63 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void AgentReadyScanStepsAreNotCacheable()
+    {
+        var step = JsonDocument.Parse("""{ "task": "agent-ready", "operation": "scan", "url": "https://example.test" }""").RootElement.Clone();
+        var method = typeof(WebPipelineRunner).GetMethod("IsCacheableStep", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        var cacheable = Assert.IsType<bool>(method.Invoke(null, new object[] { "agent-ready", step }));
+
+        Assert.False(cacheable);
+    }
+
+    [Fact]
+    public void AgentReadyExpectedOutputsHonorConfiguredOptionalArtifacts()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-agent-ready-optional-outputs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var siteRoot = Path.Combine(root, "site");
+            Directory.CreateDirectory(siteRoot);
+            File.WriteAllText(Path.Combine(root, "site.json"),
+                """
+                {
+                  "name": "Agent Ready Optional Outputs",
+                  "agentReadiness": {
+                    "enabled": true,
+                    "apiCatalog": { "enabled": false },
+                    "agentSkills": { "enabled": true, "indexPath": ".well-known/skills.json" },
+                    "agentsJson": { "enabled": false },
+                    "a2aAgentCard": { "enabled": false },
+                    "mcpServerCard": { "enabled": false }
+                  }
+                }
+                """);
+            var step = JsonDocument.Parse("""{ "task": "agent-ready", "operation": "prepare", "config": "./site.json" }""").RootElement.Clone();
+            var method = typeof(WebPipelineRunner).GetMethod("GetExpectedStepOutputs", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+            Assert.NotNull(method);
+
+            var outputs = Assert.IsType<string[]>(method.Invoke(null, new object[] { "agent-ready", step, root, siteRoot }));
+
+            Assert.Contains(Path.Combine(siteRoot, "robots.txt"), outputs);
+            Assert.Contains(Path.Combine(siteRoot, ".well-known", "skills.json"), outputs);
+            Assert.Contains(Path.Combine(siteRoot, "_headers"), outputs);
+            Assert.DoesNotContain(Path.Combine(siteRoot, ".well-known", "api-catalog"), outputs);
+            Assert.DoesNotContain(Path.Combine(siteRoot, ".well-known", "mcp", "server-card.json"), outputs);
+            Assert.DoesNotContain(Path.Combine(siteRoot, "agents.json"), outputs);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Verify_HonorsDisabledOptionalAgentReadinessChecks()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-disabled-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -50,7 +50,7 @@ public class WebAgentReadinessTests
                 {
                     Enabled = true,
                     ContentSignals = new AgentContentSignalsSpec { Search = true, AiInput = false, AiTrain = false },
-                    ApiCatalog = new AgentApiCatalogSpec { Enabled = true },
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = true, OutputPath = ".well-known/custom-api-catalog" },
                     AgentSkills = new AgentSkillsDiscoverySpec { Enabled = true },
                     A2AAgentCard = new AgentA2ACardSpec { Enabled = true }
                 }
@@ -58,7 +58,7 @@ public class WebAgentReadinessTests
 
             Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
             Assert.True(File.Exists(Path.Combine(root, "robots.txt")));
-            Assert.True(File.Exists(Path.Combine(root, ".well-known", "api-catalog")));
+            Assert.True(File.Exists(Path.Combine(root, ".well-known", "custom-api-catalog")));
             Assert.True(File.Exists(Path.Combine(root, ".well-known", "agent-skills", "index.json")));
             Assert.True(File.Exists(Path.Combine(root, "agents.json")));
             Assert.True(File.Exists(Path.Combine(root, ".well-known", "agent-card.json")));
@@ -69,12 +69,16 @@ public class WebAgentReadinessTests
             Assert.Contains("Sitemap: https://example.test/sitemap.xml", robots, StringComparison.OrdinalIgnoreCase);
 
             var headers = File.ReadAllText(Path.Combine(root, "_headers"));
+            Assert.Contains("</.well-known/custom-api-catalog>; rel=\"api-catalog\"", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("rel=\"api-catalog\"", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("application/linkset+json", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Strict-Transport-Security", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Access-Control-Allow-Origin", headers, StringComparison.OrdinalIgnoreCase);
 
-            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
+            using var agentsJson = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "agents.json")));
+            Assert.Contains("/.well-known/custom-api-catalog", agentsJson.RootElement.GetProperty("resources").GetProperty("apiCatalog").GetString(), StringComparison.OrdinalIgnoreCase);
+
+            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "custom-api-catalog")));
             Assert.True(apiCatalog.RootElement.TryGetProperty("linkset", out var linkset));
             Assert.True(linkset.GetArrayLength() > 0);
         }
@@ -152,6 +156,89 @@ public class WebAgentReadinessTests
             Assert.True(result.Steps[2].Success, result.Steps[2].Message);
             Assert.True(File.Exists(Path.Combine(root, "site", ".well-known", "agent-skills", "index.json")));
             Assert.True(File.Exists(Path.Combine(root, "site", "_headers")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Verify_HonorsDisabledOptionalAgentReadinessChecks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-disabled-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ContentSignals = new AgentContentSignalsSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
+                    MarkdownNegotiation = false
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            Assert.DoesNotContain(result.Checks, check => string.Equals(check.Status, "fail", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Prepare_RejectsAgentOutputPathOutsideSiteRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-path-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "api"));
+            File.WriteAllText(Path.Combine(root, "api", "index.json"), "{}");
+
+            var ex = Assert.Throws<ArgumentException>(() => WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = true, OutputPath = "../outside-api-catalog" },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false }
+                }
+            }));
+
+            Assert.Contains("outside the site root", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -689,8 +689,8 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ULmp3xoOwNYjOYp4JZ2NK/6NdTgiN1GQXzVVN1njQ7LOZ0d0B9vyMnhyqbIi9Qw4JXj1JgCsitkTShboHRx7Eg=="
+        "resolved": "10.0.6",
+        "contentHash": "88tquaGJ1htm4DHWS6x9jwER7sFET2SVRN7HqO1FYZwE0diDcUmz0ajhVa8ZD2HGhDJBueSPjP/gqyP3gXtT2A=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -699,10 +699,10 @@
       },
       "System.Security.Cryptography.Xml": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "HQSFbakswZ1OXFz2Bt3AJlC6ENDqWeVpgqhf213xqQUMDifzydOHIKVb1RV4prayobvR3ETIScMaQdDF2hwGZA==",
+        "resolved": "10.0.6",
+        "contentHash": "71yFkEElPZKZ9jbZQTe1CWeHYXEtnCXwZnHnfeA8pP47tCXBUoWk+6zSIZ7RXO90nZjXgPNil6BFGWb1OBqA5w==",
         "dependencies": {
-          "System.Security.Cryptography.Pkcs": "8.0.0"
+          "System.Security.Cryptography.Pkcs": "10.0.6"
         }
       },
       "System.Security.Permissions": {
@@ -841,7 +841,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.1, )",
-          "PowerForge": "[1.0.0, )"
+          "PowerForge": "[1.0.0, )",
+          "System.Security.Cryptography.Xml": "[10.0.6, )"
         }
       },
       "powerforge.web": {

--- a/PowerForge.Web.Cli/PowerForgeWebCliJsonContext.cs
+++ b/PowerForge.Web.Cli/PowerForgeWebCliJsonContext.cs
@@ -24,6 +24,8 @@ namespace PowerForge.Web.Cli;
 [JsonSerializable(typeof(WebContentScaffoldResult))]
 [JsonSerializable(typeof(WebLlmsResult))]
 [JsonSerializable(typeof(WebSitemapResult))]
+[JsonSerializable(typeof(WebAgentReadinessResult))]
+[JsonSerializable(typeof(WebAgentReadinessCheck))]
 [JsonSerializable(typeof(WebApiDocsResult))]
 [JsonSerializable(typeof(WebXrefMergeResult))]
 [JsonSerializable(typeof(WebChangelogResult))]

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.AgentReady.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.AgentReady.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using PowerForge.Web;
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static int HandleAgentReady(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        if (subArgs.Length == 0)
+            return Fail("agent-ready requires an operation: prepare, verify, or scan.", outputJson, logger, "web.agent-ready");
+
+        var operation = subArgs[0].Trim();
+        var args = subArgs.Skip(1).ToArray();
+        return operation.ToLowerInvariant() switch
+        {
+            "prepare" => HandleAgentReadyPrepare(args, outputJson, logger, outputSchemaVersion),
+            "verify" => HandleAgentReadyVerify(args, outputJson, logger, outputSchemaVersion),
+            "scan" => HandleAgentReadyScan(args, outputJson, logger, outputSchemaVersion),
+            _ => Fail("agent-ready operation must be prepare, verify, or scan.", outputJson, logger, "web.agent-ready")
+        };
+    }
+
+    private static int HandleAgentReadyPrepare(string[] args, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var configPath = TryGetOptionValue(args, "--config");
+        var siteRoot = TryGetOptionValue(args, "--site-root") ?? TryGetOptionValue(args, "--out");
+        var baseUrl = TryGetOptionValue(args, "--base-url") ?? TryGetOptionValue(args, "--url");
+        var failOnFailures = HasOption(args, "--fail-on-failures") || HasOption(args, "--fail-on-warnings");
+        SiteSpec? siteSpec = null;
+
+        if (!string.IsNullOrWhiteSpace(configPath))
+        {
+            var loaded = WebSiteSpecLoader.LoadWithPath(configPath, WebCliJson.Options);
+            siteSpec = loaded.Spec;
+            baseUrl ??= siteSpec.BaseUrl;
+        }
+
+        if (string.IsNullOrWhiteSpace(siteRoot))
+            return Fail("Missing required --site-root.", outputJson, logger, "web.agent-ready.prepare");
+
+        var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+        {
+            SiteRoot = siteRoot,
+            BaseUrl = baseUrl,
+            SiteName = siteSpec?.Name,
+            AgentReadiness = siteSpec?.AgentReadiness
+        });
+
+        return WriteAgentReadyResult(result, outputJson, logger, outputSchemaVersion, "web.agent-ready.prepare", failOnFailures);
+    }
+
+    private static int HandleAgentReadyVerify(string[] args, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var configPath = TryGetOptionValue(args, "--config");
+        var siteRoot = TryGetOptionValue(args, "--site-root") ?? TryGetOptionValue(args, "--out");
+        var baseUrl = TryGetOptionValue(args, "--base-url") ?? TryGetOptionValue(args, "--url");
+        var failOnFailures = HasOption(args, "--fail-on-failures") || HasOption(args, "--fail-on-warnings");
+        SiteSpec? siteSpec = null;
+
+        if (!string.IsNullOrWhiteSpace(configPath))
+        {
+            var loaded = WebSiteSpecLoader.LoadWithPath(configPath, WebCliJson.Options);
+            siteSpec = loaded.Spec;
+            baseUrl ??= siteSpec.BaseUrl;
+        }
+
+        if (string.IsNullOrWhiteSpace(siteRoot))
+            return Fail("Missing required --site-root.", outputJson, logger, "web.agent-ready.verify");
+
+        var result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+        {
+            SiteRoot = siteRoot,
+            BaseUrl = baseUrl,
+            AgentReadiness = siteSpec?.AgentReadiness
+        });
+
+        return WriteAgentReadyResult(result, outputJson, logger, outputSchemaVersion, "web.agent-ready.verify", failOnFailures);
+    }
+
+    private static int HandleAgentReadyScan(string[] args, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var url = TryGetOptionValue(args, "--url") ?? TryGetOptionValue(args, "--base-url");
+        var timeoutMs = TryParseInt(TryGetOptionValue(args, "--timeout-ms")) ?? 15000;
+        var failOnFailures = HasOption(args, "--fail-on-failures") || HasOption(args, "--fail-on-warnings");
+
+        if (string.IsNullOrWhiteSpace(url))
+            return Fail("Missing required --url.", outputJson, logger, "web.agent-ready.scan");
+
+        var result = WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+        {
+            BaseUrl = url,
+            TimeoutMs = timeoutMs
+        }).GetAwaiter().GetResult();
+
+        return WriteAgentReadyResult(result, outputJson, logger, outputSchemaVersion, "web.agent-ready.scan", failOnFailures);
+    }
+
+    private static int WriteAgentReadyResult(
+        WebAgentReadinessResult result,
+        bool outputJson,
+        WebConsoleLogger logger,
+        int outputSchemaVersion,
+        string command,
+        bool failOnFailures)
+    {
+        var exitCode = failOnFailures && !result.Success ? 1 : 0;
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = command,
+                Success = exitCode == 0,
+                ExitCode = exitCode,
+                Result = WebCliJson.SerializeToElement(result, WebCliJson.Context.WebAgentReadinessResult)
+            });
+            return exitCode;
+        }
+
+        logger.Info($"Agent readiness {result.Operation}: {(result.Success ? "passed" : "issues found")}");
+        if (result.WrittenFiles.Length > 0)
+            logger.Info($"Written: {string.Join(", ", result.WrittenFiles)}");
+        foreach (var check in result.Checks)
+        {
+            var line = $"[{check.Status}] {check.Name}: {check.Message}";
+            if (string.Equals(check.Status, "fail", StringComparison.OrdinalIgnoreCase))
+                logger.Error(line);
+            else if (string.Equals(check.Status, "warn", StringComparison.OrdinalIgnoreCase))
+                logger.Warn(line);
+            else
+                logger.Info(line);
+        }
+
+        foreach (var warning in result.Warnings)
+            logger.Warn(warning);
+
+        return exitCode;
+    }
+
+    private static int? TryParseInt(string? value)
+        => int.TryParse(value, out var parsed) ? parsed : null;
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Dispatch.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Dispatch.cs
@@ -48,6 +48,8 @@ collection: {{collection}}
             "overlay" => HandleOverlay(subArgs, outputJson, logger, outputSchemaVersion),
             "llms" => HandleLlms(subArgs, outputJson, logger, outputSchemaVersion),
             "sitemap" => HandleSitemap(subArgs, outputJson, logger, outputSchemaVersion),
+            "agent-ready" => HandleAgentReady(subArgs, outputJson, logger, outputSchemaVersion),
+            "agentready" => HandleAgentReady(subArgs, outputJson, logger, outputSchemaVersion),
             "xref-merge" => HandleXrefMerge(subArgs, outputJson, logger, outputSchemaVersion),
             "cloudflare" => HandleCloudflare(subArgs, outputJson, logger, outputSchemaVersion),
             _ => HandleUnknownCommand()

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -123,6 +123,9 @@ internal static class WebCliHelpers
         Console.WriteLine("                     [--sitemap-json] [--sitemap-json-out <file>] [--html] [--html-out <file>] [--html-template <file>] [--html-css <href>] [--html-title <text>]");
         Console.WriteLine("                     [--no-html-files] [--include-noindex-html] [--exclude <glob[,glob...]>] [--no-default-excludes]");
         Console.WriteLine("                     [--no-text-files] [--no-language-alternates] [--include-html-sitemap-route]");
+        Console.WriteLine("  powerforge-web agent-ready prepare --site-root <dir> [--config <site.json>] [--base-url <url>] [--fail-on-failures] [--output json]");
+        Console.WriteLine("  powerforge-web agent-ready verify --site-root <dir> [--config <site.json>] [--base-url <url>] [--fail-on-failures] [--output json]");
+        Console.WriteLine("  powerforge-web agent-ready scan --url <url> [--timeout-ms <n>] [--fail-on-failures] [--output json]");
         Console.WriteLine("  powerforge-web xref-merge --out <file> --map <file|dir[,file|dir...]> [--pattern *.json] [--top-only]");
         Console.WriteLine("                     [--prefer-last] [--fail-on-duplicates] [--max-references <n>] [--max-duplicates <n>]");
         Console.WriteLine("                     [--max-reference-growth-count <n>] [--max-reference-growth-percent <n>] [--fail-on-warnings]");

--- a/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
@@ -252,7 +252,7 @@ internal static partial class WebPipelineRunner
                uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string[] GetExpectedStepOutputs(string task, JsonElement step, string baseDir)
+    private static string[] GetExpectedStepOutputs(string task, JsonElement step, string baseDir, string lastBuildOutPath)
     {
         switch (task)
         {
@@ -543,6 +543,8 @@ internal static partial class WebPipelineRunner
                     GetString(step, "site-root") ??
                     GetString(step, "out") ??
                     GetString(step, "output"));
+                if (string.IsNullOrWhiteSpace(siteRoot) && !string.IsNullOrWhiteSpace(lastBuildOutPath))
+                    siteRoot = lastBuildOutPath;
                 if (string.IsNullOrWhiteSpace(siteRoot))
                     return Array.Empty<string>();
 

--- a/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
@@ -535,6 +535,27 @@ internal static partial class WebPipelineRunner
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToArray();
             }
+            case "agent-ready":
+            case "agentready":
+            {
+                var siteRoot = ResolvePath(baseDir,
+                    GetString(step, "siteRoot") ??
+                    GetString(step, "site-root") ??
+                    GetString(step, "out") ??
+                    GetString(step, "output"));
+                if (string.IsNullOrWhiteSpace(siteRoot))
+                    return Array.Empty<string>();
+
+                var headersPath = GetString(step, "headersPath") ?? GetString(step, "headers-path") ?? "_headers";
+                return new[]
+                {
+                    Path.Combine(siteRoot, "robots.txt"),
+                    Path.Combine(siteRoot, ".well-known", "api-catalog"),
+                    Path.Combine(siteRoot, ".well-known", "agent-skills", "index.json"),
+                    Path.Combine(siteRoot, ".well-known", "mcp", "server-card.json"),
+                    Path.Combine(siteRoot, headersPath)
+                };
+            }
             case "optimize":
             {
                 var outputs = new List<string>();

--- a/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
@@ -62,6 +62,21 @@ internal static partial class WebPipelineRunner
         return true;
     }
 
+    private static bool IsCacheableStep(string task, JsonElement step)
+    {
+        if (!IsCacheableTask(task))
+            return false;
+
+        if (task.Equals("agent-ready", StringComparison.OrdinalIgnoreCase) ||
+            task.Equals("agentready", StringComparison.OrdinalIgnoreCase))
+        {
+            var operation = (GetString(step, "operation") ?? "prepare").Trim();
+            return operation.Equals("prepare", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return true;
+    }
+
     private static WebPipelineCacheState LoadPipelineCache(string cachePath, WebConsoleLogger? logger)
     {
         try
@@ -537,27 +552,7 @@ internal static partial class WebPipelineRunner
             }
             case "agent-ready":
             case "agentready":
-            {
-                var siteRoot = ResolvePath(baseDir,
-                    GetString(step, "siteRoot") ??
-                    GetString(step, "site-root") ??
-                    GetString(step, "out") ??
-                    GetString(step, "output"));
-                if (string.IsNullOrWhiteSpace(siteRoot) && !string.IsNullOrWhiteSpace(lastBuildOutPath))
-                    siteRoot = lastBuildOutPath;
-                if (string.IsNullOrWhiteSpace(siteRoot))
-                    return Array.Empty<string>();
-
-                var headersPath = GetString(step, "headersPath") ?? GetString(step, "headers-path") ?? "_headers";
-                return new[]
-                {
-                    Path.Combine(siteRoot, "robots.txt"),
-                    Path.Combine(siteRoot, ".well-known", "api-catalog"),
-                    Path.Combine(siteRoot, ".well-known", "agent-skills", "index.json"),
-                    Path.Combine(siteRoot, ".well-known", "mcp", "server-card.json"),
-                    Path.Combine(siteRoot, headersPath)
-                };
-            }
+                return GetExpectedAgentReadyPrepareOutputs(step, baseDir, lastBuildOutPath);
             case "optimize":
             {
                 var outputs = new List<string>();
@@ -979,6 +974,179 @@ internal static partial class WebPipelineRunner
             default:
                 return Array.Empty<string>();
         }
+    }
+
+    private static string[] GetExpectedAgentReadyPrepareOutputs(JsonElement step, string baseDir, string lastBuildOutPath)
+    {
+        var operation = (GetString(step, "operation") ?? "prepare").Trim();
+        if (!operation.Equals("prepare", StringComparison.OrdinalIgnoreCase))
+            return Array.Empty<string>();
+
+        var siteRoot = ResolvePath(baseDir,
+            GetString(step, "siteRoot") ??
+            GetString(step, "site-root") ??
+            GetString(step, "out") ??
+            GetString(step, "output"));
+        if (string.IsNullOrWhiteSpace(siteRoot) && !string.IsNullOrWhiteSpace(lastBuildOutPath))
+            siteRoot = lastBuildOutPath;
+        if (string.IsNullOrWhiteSpace(siteRoot))
+            return Array.Empty<string>();
+
+        var spec = ResolveAgentReadinessSpecForCache(step, baseDir);
+        if (!spec.Enabled)
+            return Array.Empty<string>();
+
+        var outputs = new List<string>();
+        if (spec.Robots)
+            outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, "robots.txt"));
+
+        if (spec.ApiCatalog?.Enabled == true && AgentReadyApiCatalogWillWrite(siteRoot, spec.ApiCatalog))
+            outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, string.IsNullOrWhiteSpace(spec.ApiCatalog.OutputPath) ? ".well-known/api-catalog" : spec.ApiCatalog.OutputPath!));
+
+        if (spec.AgentSkills?.Enabled == true)
+            outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, string.IsNullOrWhiteSpace(spec.AgentSkills.IndexPath) ? ".well-known/agent-skills/index.json" : spec.AgentSkills.IndexPath!));
+
+        if (spec.AgentsJson?.Enabled == true)
+        {
+            var agentsPaths = new[]
+            {
+                string.IsNullOrWhiteSpace(spec.AgentsJson.OutputPath) ? "agents.json" : spec.AgentsJson.OutputPath!,
+                string.IsNullOrWhiteSpace(spec.AgentsJson.WellKnownOutputPath) ? ".well-known/agents.json" : spec.AgentsJson.WellKnownOutputPath!
+            };
+
+            foreach (var path in agentsPaths.Where(static value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.OrdinalIgnoreCase))
+                outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, path));
+        }
+
+        if (spec.A2AAgentCard?.Enabled == true)
+            outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, string.IsNullOrWhiteSpace(spec.A2AAgentCard.OutputPath) ? ".well-known/agent-card.json" : spec.A2AAgentCard.OutputPath!));
+
+        if (spec.McpServerCard?.Enabled == true && !string.IsNullOrWhiteSpace(spec.McpServerCard.Endpoint))
+            outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, string.IsNullOrWhiteSpace(spec.McpServerCard.OutputPath) ? ".well-known/mcp/server-card.json" : spec.McpServerCard.OutputPath!));
+
+        if (ShouldExpectAgentReadyHeaders(siteRoot, spec))
+            outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, string.IsNullOrWhiteSpace(spec.HeadersPath) ? "_headers" : spec.HeadersPath!));
+
+        return outputs
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static AgentReadinessSpec ResolveAgentReadinessSpecForCache(JsonElement step, string baseDir)
+    {
+        var configPath = ResolvePath(baseDir, GetString(step, "config"));
+        if (!string.IsNullOrWhiteSpace(configPath) && File.Exists(configPath))
+        {
+            var loaded = WebSiteSpecLoader.LoadWithPath(configPath, WebCliJson.Options);
+            return NormalizeAgentReadinessSpecForCache(loaded.Spec.AgentReadiness);
+        }
+
+        return NormalizeAgentReadinessSpecForCache(null);
+    }
+
+    private static AgentReadinessSpec NormalizeAgentReadinessSpecForCache(AgentReadinessSpec? spec)
+    {
+        if (spec is null)
+        {
+            return new AgentReadinessSpec
+            {
+                Enabled = true,
+                SecurityHeaders = new AgentSecurityHeadersSpec(),
+                ContentSignals = new AgentContentSignalsSpec(),
+                ApiCatalog = new AgentApiCatalogSpec(),
+                AgentSkills = new AgentSkillsDiscoverySpec(),
+                AgentsJson = new AgentDiscoveryDocumentSpec()
+            };
+        }
+
+        var resolved = new AgentReadinessSpec
+        {
+            Enabled = spec.Enabled,
+            HeadersPath = spec.HeadersPath,
+            LinkHeaders = spec.LinkHeaders,
+            SecurityHeaders = spec.SecurityHeaders,
+            Robots = spec.Robots,
+            ContentSignals = spec.ContentSignals,
+            BotRules = spec.BotRules,
+            ApiCatalog = spec.ApiCatalog,
+            AgentSkills = spec.AgentSkills,
+            AgentsJson = spec.AgentsJson,
+            A2AAgentCard = spec.A2AAgentCard,
+            McpServerCard = spec.McpServerCard,
+            OpenApi = spec.OpenApi,
+            WebMcp = spec.WebMcp,
+            MarkdownNegotiation = spec.MarkdownNegotiation
+        };
+
+        if (resolved.Enabled)
+        {
+            resolved.SecurityHeaders ??= new AgentSecurityHeadersSpec();
+            resolved.ContentSignals ??= new AgentContentSignalsSpec();
+            resolved.ApiCatalog ??= new AgentApiCatalogSpec();
+            resolved.AgentSkills ??= new AgentSkillsDiscoverySpec();
+            resolved.AgentsJson ??= new AgentDiscoveryDocumentSpec();
+        }
+
+        return resolved;
+    }
+
+    private static bool AgentReadyApiCatalogWillWrite(string siteRoot, AgentApiCatalogSpec spec)
+    {
+        if (spec.Entries?.Any(static entry => !string.IsNullOrWhiteSpace(entry.Anchor)) == true)
+            return true;
+
+        return File.Exists(Path.Combine(siteRoot, "api", "index.json"));
+    }
+
+    private static bool ShouldExpectAgentReadyHeaders(string siteRoot, AgentReadinessSpec spec)
+        => spec.SecurityHeaders?.Enabled == true ||
+           (spec.LinkHeaders && File.Exists(Path.Combine(siteRoot, "llms.txt"))) ||
+           (spec.LinkHeaders && AgentReadyOpenApiRouteExists(siteRoot, spec.OpenApi)) ||
+           spec.ApiCatalog?.Enabled == true ||
+           spec.AgentSkills?.Enabled == true ||
+           spec.AgentsJson?.Enabled == true ||
+           spec.A2AAgentCard?.Enabled == true ||
+           spec.McpServerCard?.Enabled == true;
+
+    private static bool AgentReadyOpenApiRouteExists(string siteRoot, AgentOpenApiSpec? spec)
+    {
+        if (spec?.Enabled != true)
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(spec.Path) &&
+            !Uri.TryCreate(spec.Path, UriKind.Absolute, out _))
+        {
+            return File.Exists(ResolveAgentReadySiteOutputPath(siteRoot, spec.Path!));
+        }
+
+        foreach (var candidate in new[] { "/openapi.json", "/api/openapi.json", "/swagger.json", "/api/swagger.json", "/.well-known/openapi.json" })
+        {
+            if (File.Exists(ResolveAgentReadySiteOutputPath(siteRoot, candidate)))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string ResolveAgentReadySiteOutputPath(string siteRoot, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Path is required.", nameof(path));
+
+        var root = Path.GetFullPath(siteRoot.Trim().Trim('"'));
+        var normalized = path.Trim().Trim('"').Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar);
+        var resolved = Path.GetFullPath(Path.Combine(root, normalized));
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!resolved.Equals(root, FileSystemPathComparison) &&
+            !resolved.StartsWith(rootWithSeparator, FileSystemPathComparison))
+        {
+            throw new ArgumentException($"Path '{path}' resolves outside the site root.", nameof(path));
+        }
+
+        return resolved;
     }
 
     private static string[] GetExpectedRouteFallbackOutputs(string baseDir, JsonElement step)

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.AgentReady.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.AgentReady.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using PowerForge.Web;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebPipelineRunner
+{
+    private static void ExecuteAgentReady(JsonElement step, string baseDir, string lastBuildOutPath, WebPipelineStepResult stepResult)
+    {
+        var operation = GetString(step, "operation") ?? GetString(step, "mode") ?? "prepare";
+        var configPath = ResolvePath(baseDir, GetString(step, "config"));
+        var siteRoot = ResolvePath(baseDir, GetString(step, "siteRoot") ?? GetString(step, "site-root") ?? GetString(step, "out") ?? GetString(step, "output"));
+        var baseUrl = GetString(step, "baseUrl") ?? GetString(step, "base-url") ?? GetString(step, "url");
+        var failOnFailures = GetBool(step, "failOnFailures") ?? GetBool(step, "fail-on-failures") ?? false;
+        var timeoutMs = GetInt(step, "timeoutMs") ?? GetInt(step, "timeout-ms") ?? 15000;
+
+        SiteSpec? siteSpec = null;
+        if (!string.IsNullOrWhiteSpace(configPath) && File.Exists(configPath))
+        {
+            var loaded = WebSiteSpecLoader.LoadWithPath(configPath, WebCliJson.Options);
+            siteSpec = loaded.Spec;
+            baseUrl ??= siteSpec.BaseUrl;
+        }
+
+        if (string.IsNullOrWhiteSpace(siteRoot) && !string.IsNullOrWhiteSpace(lastBuildOutPath))
+            siteRoot = lastBuildOutPath;
+
+        WebAgentReadinessResult result;
+        switch (operation.Trim().ToLowerInvariant())
+        {
+            case "prepare":
+                if (string.IsNullOrWhiteSpace(siteRoot))
+                    throw new InvalidOperationException("agent-ready prepare requires siteRoot or a prior build step.");
+                result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+                {
+                    SiteRoot = siteRoot,
+                    BaseUrl = baseUrl,
+                    SiteName = siteSpec?.Name,
+                    AgentReadiness = siteSpec?.AgentReadiness
+                });
+                break;
+            case "verify":
+                if (string.IsNullOrWhiteSpace(siteRoot))
+                    throw new InvalidOperationException("agent-ready verify requires siteRoot or a prior build step.");
+                result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+                {
+                    SiteRoot = siteRoot,
+                    BaseUrl = baseUrl,
+                    AgentReadiness = siteSpec?.AgentReadiness
+                });
+                break;
+            case "scan":
+                if (string.IsNullOrWhiteSpace(baseUrl))
+                    throw new InvalidOperationException("agent-ready scan requires baseUrl/url or config.BaseUrl.");
+                result = WebAgentReadiness.ScanAsync(new WebAgentReadinessScanOptions
+                {
+                    BaseUrl = baseUrl,
+                    TimeoutMs = timeoutMs
+                }).GetAwaiter().GetResult();
+                break;
+            default:
+                throw new InvalidOperationException("agent-ready operation must be prepare, verify, or scan.");
+        }
+
+        if (failOnFailures && !result.Success)
+        {
+            var failed = result.Checks.FirstOrDefault(static c => string.Equals(c.Status, "fail", StringComparison.OrdinalIgnoreCase));
+            throw new InvalidOperationException(failed is null
+                ? "agent-ready checks failed."
+                : $"agent-ready {failed.Name}: {failed.Message}");
+        }
+
+        stepResult.Success = true;
+        var failedCount = result.Checks.Count(static c => string.Equals(c.Status, "fail", StringComparison.OrdinalIgnoreCase));
+        var warnCount = result.Checks.Count(static c => string.Equals(c.Status, "warn", StringComparison.OrdinalIgnoreCase));
+        stepResult.Message = $"Agent-ready {result.Operation}: {result.Checks.Length} checks, {failedCount} failed, {warnCount} warnings";
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.AgentReady.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.AgentReady.cs
@@ -7,7 +7,7 @@ internal static partial class WebPipelineRunner
 {
     private static void ExecuteAgentReady(JsonElement step, string baseDir, string lastBuildOutPath, WebPipelineStepResult stepResult)
     {
-        var operation = GetString(step, "operation") ?? GetString(step, "mode") ?? "prepare";
+        var operation = GetString(step, "operation") ?? "prepare";
         var configPath = ResolvePath(baseDir, GetString(step, "config"));
         var siteRoot = ResolvePath(baseDir, GetString(step, "siteRoot") ?? GetString(step, "site-root") ?? GetString(step, "out") ?? GetString(step, "output"));
         var baseUrl = GetString(step, "baseUrl") ?? GetString(step, "base-url") ?? GetString(step, "url");

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.cs
@@ -60,6 +60,10 @@ internal static partial class WebPipelineRunner
             case "sitemap":
                 ExecuteSitemap(step, baseDir, lastBuildOutPath, stepResult);
                 break;
+            case "agent-ready":
+            case "agentready":
+                ExecuteAgentReady(step, baseDir, lastBuildOutPath, stepResult);
+                break;
             case "xref-merge":
                 ExecuteXrefMerge(step, label, baseDir, fast, effectiveMode, logger, stepResult);
                 break;

--- a/PowerForge.Web.Cli/WebPipelineRunner.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.cs
@@ -181,7 +181,7 @@ internal static partial class WebPipelineRunner
             var dependencyMiss = definition.DependencyIndexes.Any(index =>
                 !stepResultsByIndex.TryGetValue(index, out var dependencyResult) || !dependencyResult.Cached);
             var cacheStateLocal = cacheState;
-            var cacheable = cacheEnabled && cacheStateLocal is not null && IsCacheableTask(task);
+            var cacheable = cacheEnabled && cacheStateLocal is not null && IsCacheableStep(task, step);
             if (cacheable)
             {
                 var fingerprintSalt = fast ? $"fast|{PipelineToolFingerprint}" : PipelineToolFingerprint;

--- a/PowerForge.Web.Cli/WebPipelineRunner.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.cs
@@ -166,7 +166,7 @@ internal static partial class WebPipelineRunner
             var stopwatch = Stopwatch.StartNew();
             var cacheKey = $"{stepIndex}:{task}";
             var stepFingerprint = string.Empty;
-            var expectedOutputs = GetExpectedStepOutputs(task, step, baseDir);
+            var expectedOutputs = GetExpectedStepOutputs(task, step, baseDir, lastBuildOutPath);
             if (definition.DependencyIndexes.Length > 0)
             {
                 foreach (var dependencyIndex in definition.DependencyIndexes)
@@ -195,6 +195,12 @@ internal static partial class WebPipelineRunner
                     stepResult.Cached = true;
                     stepResult.Message = AppendDuration(cacheEntry.Message ?? "cache hit", stopwatch);
                     stepResult.DurationMs = (long)Math.Round(stopwatch.Elapsed.TotalMilliseconds);
+                    if (task.Equals("build", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var cachedBuildOut = ResolvePath(baseDir, GetString(step, "out") ?? GetString(step, "output"));
+                        if (!string.IsNullOrWhiteSpace(cachedBuildOut))
+                            lastBuildOutPath = cachedBuildOut;
+                    }
                     result.Steps.Add(stepResult);
                     stepResultsByIndex[stepIndex] = stepResult;
                     if (profileEnabled)

--- a/PowerForge.Web/Models/AgentReadinessSpec.cs
+++ b/PowerForge.Web/Models/AgentReadinessSpec.cs
@@ -1,0 +1,225 @@
+namespace PowerForge.Web;
+
+/// <summary>Agent-readiness discovery and policy output settings.</summary>
+public sealed class AgentReadinessSpec
+{
+    /// <summary>Enable agent-readiness output generation and checks.</summary>
+    public bool Enabled { get; set; }
+    /// <summary>Optional output path for static host headers (default: _headers).</summary>
+    public string? HeadersPath { get; set; }
+    /// <summary>When true, write Link response header hints for agent discovery resources.</summary>
+    public bool LinkHeaders { get; set; } = true;
+    /// <summary>Security and trust response headers expected by agent-readiness scanners.</summary>
+    public AgentSecurityHeadersSpec? SecurityHeaders { get; set; }
+    /// <summary>When true, update robots.txt with sitemap and Content-Signal directives.</summary>
+    public bool Robots { get; set; } = true;
+    /// <summary>Content Signals preferences written to robots.txt.</summary>
+    public AgentContentSignalsSpec? ContentSignals { get; set; }
+    /// <summary>Optional AI crawler user-agent rules written to robots.txt.</summary>
+    public AgentBotRuleSpec[] BotRules { get; set; } = Array.Empty<AgentBotRuleSpec>();
+    /// <summary>API catalog output configuration.</summary>
+    public AgentApiCatalogSpec? ApiCatalog { get; set; }
+    /// <summary>Agent Skills discovery output configuration.</summary>
+    public AgentSkillsDiscoverySpec? AgentSkills { get; set; }
+    /// <summary>Generic agent discovery metadata output configuration.</summary>
+    public AgentDiscoveryDocumentSpec? AgentsJson { get; set; }
+    /// <summary>A2A Agent Card output configuration.</summary>
+    public AgentA2ACardSpec? A2AAgentCard { get; set; }
+    /// <summary>MCP server card output configuration.</summary>
+    public AgentMcpServerCardSpec? McpServerCard { get; set; }
+    /// <summary>OpenAPI discovery settings used for checks and API catalog links.</summary>
+    public AgentOpenApiSpec? OpenApi { get; set; }
+    /// <summary>When true, verify that rendered HTML exposes WebMCP browser tools.</summary>
+    public bool WebMcp { get; set; }
+    /// <summary>When true, treat markdown negotiation as expected during remote scans.</summary>
+    public bool MarkdownNegotiation { get; set; } = true;
+}
+
+/// <summary>Security headers that agent and AI-readiness scanners commonly expect.</summary>
+public sealed class AgentSecurityHeadersSpec
+{
+    /// <summary>Enable generated security headers in the static host headers file.</summary>
+    public bool Enabled { get; set; } = true;
+    /// <summary>Emit Strict-Transport-Security. Only meaningful when the deployed site is HTTPS.</summary>
+    public bool Hsts { get; set; } = true;
+    /// <summary>Strict-Transport-Security value.</summary>
+    public string? HstsValue { get; set; } = "max-age=31536000; includeSubDomains; preload";
+    /// <summary>Emit Content-Security-Policy.</summary>
+    public bool ContentSecurityPolicy { get; set; } = true;
+    /// <summary>Content-Security-Policy value. Override for sites that load external assets.</summary>
+    public string? ContentSecurityPolicyValue { get; set; } =
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'";
+    /// <summary>Emit X-Content-Type-Options.</summary>
+    public bool XContentTypeOptions { get; set; } = true;
+    /// <summary>Emit X-Frame-Options.</summary>
+    public bool XFrameOptions { get; set; } = true;
+    /// <summary>Emit Referrer-Policy.</summary>
+    public bool ReferrerPolicy { get; set; } = true;
+    /// <summary>Referrer-Policy value.</summary>
+    public string? ReferrerPolicyValue { get; set; } = "strict-origin-when-cross-origin";
+    /// <summary>Emit permissive CORS only for agent well-known JSON resources.</summary>
+    public bool CorsForWellKnown { get; set; } = true;
+    /// <summary>Access-Control-Allow-Origin value for agent discovery resources.</summary>
+    public string? CorsAllowOrigin { get; set; } = "*";
+}
+
+/// <summary>Content Signals preferences for automated content usage.</summary>
+public sealed class AgentContentSignalsSpec
+{
+    /// <summary>Enable Content-Signal directives.</summary>
+    public bool Enabled { get; set; } = true;
+    /// <summary>Allow search indexing and excerpts.</summary>
+    public bool Search { get; set; } = true;
+    /// <summary>Allow query-time AI input or grounding.</summary>
+    public bool AiInput { get; set; } = true;
+    /// <summary>Allow AI model training or fine-tuning.</summary>
+    public bool AiTrain { get; set; }
+}
+
+/// <summary>Optional robots.txt rule for a specific crawler.</summary>
+public sealed class AgentBotRuleSpec
+{
+    /// <summary>User-agent token, for example GPTBot.</summary>
+    public string UserAgent { get; set; } = string.Empty;
+    /// <summary>Allow or disallow path. Defaults to Allow: /.</summary>
+    public string? Allow { get; set; }
+    /// <summary>Disallowed path. When set, Disallow is emitted instead of Allow.</summary>
+    public string? Disallow { get; set; }
+}
+
+/// <summary>API catalog output settings.</summary>
+public sealed class AgentApiCatalogSpec
+{
+    /// <summary>Enable /.well-known/api-catalog generation.</summary>
+    public bool Enabled { get; set; } = true;
+    /// <summary>Output path relative to site root.</summary>
+    public string? OutputPath { get; set; }
+    /// <summary>API catalog entries.</summary>
+    public AgentApiCatalogEntrySpec[] Entries { get; set; } = Array.Empty<AgentApiCatalogEntrySpec>();
+}
+
+/// <summary>Single API catalog entry.</summary>
+public sealed class AgentApiCatalogEntrySpec
+{
+    /// <summary>API anchor URL or route.</summary>
+    public string Anchor { get; set; } = string.Empty;
+    /// <summary>Machine-readable service description URL, usually OpenAPI.</summary>
+    public string? ServiceDesc { get; set; }
+    /// <summary>Human-readable service documentation URL.</summary>
+    public string? ServiceDoc { get; set; }
+    /// <summary>Optional health/status URL.</summary>
+    public string? Status { get; set; }
+    /// <summary>Optional title.</summary>
+    public string? Title { get; set; }
+}
+
+/// <summary>Agent Skills discovery output settings.</summary>
+public sealed class AgentSkillsDiscoverySpec
+{
+    /// <summary>Enable /.well-known/agent-skills/index.json generation.</summary>
+    public bool Enabled { get; set; } = true;
+    /// <summary>Index output path relative to site root.</summary>
+    public string? IndexPath { get; set; }
+    /// <summary>Skill entries.</summary>
+    public AgentSkillSpec[] Skills { get; set; } = Array.Empty<AgentSkillSpec>();
+}
+
+/// <summary>Generic agent discovery document settings.</summary>
+public sealed class AgentDiscoveryDocumentSpec
+{
+    /// <summary>Enable /agents.json and /.well-known/agents.json generation.</summary>
+    public bool Enabled { get; set; } = true;
+    /// <summary>Main output path relative to site root.</summary>
+    public string? OutputPath { get; set; } = "agents.json";
+    /// <summary>Optional well-known mirror path relative to site root.</summary>
+    public string? WellKnownOutputPath { get; set; } = ".well-known/agents.json";
+    /// <summary>Human-readable description of the agent-facing site surface.</summary>
+    public string? Description { get; set; }
+}
+
+/// <summary>A2A Agent Card output settings.</summary>
+public sealed class AgentA2ACardSpec
+{
+    /// <summary>Enable /.well-known/agent-card.json generation.</summary>
+    public bool Enabled { get; set; }
+    /// <summary>Output path relative to site root.</summary>
+    public string? OutputPath { get; set; } = ".well-known/agent-card.json";
+    /// <summary>Agent or site name.</summary>
+    public string? Name { get; set; }
+    /// <summary>Agent or site description.</summary>
+    public string? Description { get; set; }
+    /// <summary>Service endpoint URL. If omitted, the site base URL is used for a discoverability-only card.</summary>
+    public string? Url { get; set; }
+    /// <summary>Agent card version.</summary>
+    public string? Version { get; set; } = "1.0.0";
+    /// <summary>Documentation route or absolute URL.</summary>
+    public string? DocumentationUrl { get; set; }
+    /// <summary>Supported default input modes.</summary>
+    public string[] DefaultInputModes { get; set; } = new[] { "text/plain", "text/markdown" };
+    /// <summary>Supported default output modes.</summary>
+    public string[] DefaultOutputModes { get; set; } = new[] { "text/plain", "text/markdown" };
+    /// <summary>Advertised A2A skills.</summary>
+    public AgentA2ASkillSpec[] Skills { get; set; } = Array.Empty<AgentA2ASkillSpec>();
+}
+
+/// <summary>A2A Agent Card skill entry.</summary>
+public sealed class AgentA2ASkillSpec
+{
+    /// <summary>Skill identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+    /// <summary>Skill name.</summary>
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Skill description.</summary>
+    public string Description { get; set; } = string.Empty;
+    /// <summary>Skill tags.</summary>
+    public string[] Tags { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>Single Agent Skill discovery entry.</summary>
+public sealed class AgentSkillSpec
+{
+    /// <summary>Skill identifier.</summary>
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Skill type, usually skill-md.</summary>
+    public string Type { get; set; } = "skill-md";
+    /// <summary>Short description used for progressive disclosure.</summary>
+    public string Description { get; set; } = string.Empty;
+    /// <summary>Public URL to the skill artifact. If omitted, a local skill file is generated.</summary>
+    public string? Url { get; set; }
+    /// <summary>Local file path to an existing SKILL.md source.</summary>
+    public string? SourcePath { get; set; }
+    /// <summary>Inline SKILL.md content used when SourcePath is not set.</summary>
+    public string? Content { get; set; }
+}
+
+/// <summary>OpenAPI discovery settings.</summary>
+public sealed class AgentOpenApiSpec
+{
+    /// <summary>Enable OpenAPI checks and API catalog linking.</summary>
+    public bool Enabled { get; set; }
+    /// <summary>OpenAPI document path or absolute URL. If omitted, common static paths are checked.</summary>
+    public string? Path { get; set; }
+}
+
+/// <summary>MCP server card output settings.</summary>
+public sealed class AgentMcpServerCardSpec
+{
+    /// <summary>Enable /.well-known/mcp/server-card.json generation.</summary>
+    public bool Enabled { get; set; }
+    /// <summary>Output path relative to site root.</summary>
+    public string? OutputPath { get; set; }
+    /// <summary>MCP server name.</summary>
+    public string? Name { get; set; }
+    /// <summary>MCP server version.</summary>
+    public string? Version { get; set; }
+    /// <summary>Transport endpoint URL or route.</summary>
+    public string? Endpoint { get; set; }
+    /// <summary>Transport type, for example streamable-http.</summary>
+    public string? Transport { get; set; }
+    /// <summary>Advertise tool support.</summary>
+    public bool Tools { get; set; } = true;
+    /// <summary>Advertise resource support.</summary>
+    public bool Resources { get; set; }
+    /// <summary>Advertise prompt support.</summary>
+    public bool Prompts { get; set; }
+}

--- a/PowerForge.Web/Models/SiteSpec.cs
+++ b/PowerForge.Web/Models/SiteSpec.cs
@@ -102,6 +102,8 @@ public sealed class SiteSpec
     public XrefSpec? Xref { get; set; }
     /// <summary>Verification policy defaults for verify/doctor commands.</summary>
     public VerifyPolicySpec? Verify { get; set; }
+    /// <summary>Agent-readiness discovery and policy output settings.</summary>
+    public AgentReadinessSpec? AgentReadiness { get; set; }
     /// <summary>Build cache configuration.</summary>
     public BuildCacheSpec? Cache { get; set; }
 }

--- a/PowerForge.Web/Models/WebAgentReadinessResult.cs
+++ b/PowerForge.Web/Models/WebAgentReadinessResult.cs
@@ -1,0 +1,37 @@
+namespace PowerForge.Web;
+
+/// <summary>Result from preparing, verifying, or scanning agent-readiness signals.</summary>
+public sealed class WebAgentReadinessResult
+{
+    /// <summary>Site root used for local checks.</summary>
+    public string? SiteRoot { get; set; }
+    /// <summary>Base URL used for URL generation or remote scans.</summary>
+    public string? BaseUrl { get; set; }
+    /// <summary>Operation name: prepare, verify, or scan.</summary>
+    public string Operation { get; set; } = string.Empty;
+    /// <summary>Whether all required checks passed.</summary>
+    public bool Success { get; set; }
+    /// <summary>Files written during prepare.</summary>
+    public string[] WrittenFiles { get; set; } = Array.Empty<string>();
+    /// <summary>Check results.</summary>
+    public WebAgentReadinessCheck[] Checks { get; set; } = Array.Empty<WebAgentReadinessCheck>();
+    /// <summary>Informational warnings emitted during the operation.</summary>
+    public string[] Warnings { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>Single agent-readiness check result.</summary>
+public sealed class WebAgentReadinessCheck
+{
+    /// <summary>Stable check identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+    /// <summary>Check category.</summary>
+    public string Category { get; set; } = string.Empty;
+    /// <summary>Human-readable check name.</summary>
+    public string Name { get; set; } = string.Empty;
+    /// <summary>Status: pass, fail, warn, or info.</summary>
+    public string Status { get; set; } = string.Empty;
+    /// <summary>Short detail message.</summary>
+    public string Message { get; set; } = string.Empty;
+    /// <summary>Relevant local path or URL.</summary>
+    public string? Target { get; set; }
+}

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -13,8 +13,6 @@ public static class WebAgentReadiness
 {
     private const string AgentBlockStart = "# BEGIN PowerForge Agent Readiness";
     private const string AgentBlockEnd = "# END PowerForge Agent Readiness";
-    private const string HeadersBlockStart = "# BEGIN PowerForge Agent Readiness";
-    private const string HeadersBlockEnd = "# END PowerForge Agent Readiness";
     private const string AgentSkillsSchema = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
     private static readonly Regex GeneratedBlockRegex = new(
         @"(?ms)^\s*# BEGIN PowerForge Agent Readiness\s*$.*?^\s*# END PowerForge Agent Readiness\s*$\r?\n?",
@@ -58,7 +56,7 @@ public static class WebAgentReadiness
             if (!string.IsNullOrWhiteSpace(apiCatalogPath))
             {
                 written.Add(apiCatalogPath!);
-                linkTargets.Add(new HeaderLinkTarget("/.well-known/api-catalog", "api-catalog", "application/linkset+json"));
+                linkTargets.Add(new HeaderLinkTarget(ToSiteRoute(siteRoot, apiCatalogPath!), "api-catalog", "application/linkset+json"));
             }
         }
 
@@ -68,7 +66,7 @@ public static class WebAgentReadiness
             if (!string.IsNullOrWhiteSpace(agentSkillsPath))
             {
                 written.Add(agentSkillsPath!);
-                linkTargets.Add(new HeaderLinkTarget("/.well-known/agent-skills/index.json", "describedby", "application/json"));
+                linkTargets.Add(new HeaderLinkTarget(ToSiteRoute(siteRoot, agentSkillsPath!), "describedby", "application/json"));
             }
         }
 
@@ -77,7 +75,7 @@ public static class WebAgentReadiness
             var agentsPaths = WriteAgentsJson(siteRoot, baseUrl, siteName, spec, warnings);
             written.AddRange(agentsPaths);
             if (agentsPaths.Length > 0)
-                linkTargets.Add(new HeaderLinkTarget("/agents.json", "describedby", "application/json"));
+                linkTargets.Add(new HeaderLinkTarget(ToSiteRoute(siteRoot, agentsPaths[0]), "describedby", "application/json"));
         }
 
         if (spec.A2AAgentCard?.Enabled == true)
@@ -86,7 +84,7 @@ public static class WebAgentReadiness
             if (!string.IsNullOrWhiteSpace(agentCardPath))
             {
                 written.Add(agentCardPath!);
-                linkTargets.Add(new HeaderLinkTarget("/.well-known/agent-card.json", "service-desc", "application/json"));
+                linkTargets.Add(new HeaderLinkTarget(ToSiteRoute(siteRoot, agentCardPath!), "service-desc", "application/json"));
             }
         }
 
@@ -96,7 +94,7 @@ public static class WebAgentReadiness
             if (!string.IsNullOrWhiteSpace(serverCardPath))
             {
                 written.Add(serverCardPath!);
-                linkTargets.Add(new HeaderLinkTarget("/.well-known/mcp/server-card.json", "service-desc", "application/json"));
+                linkTargets.Add(new HeaderLinkTarget(ToSiteRoute(siteRoot, serverCardPath!), "service-desc", "application/json"));
             }
         }
 
@@ -146,17 +144,20 @@ public static class WebAgentReadiness
 
         var robotsPath = Path.Combine(siteRoot, "robots.txt");
         var robotsText = File.Exists(robotsPath) ? File.ReadAllText(robotsPath) : null;
-        AddCheck(checks, "robots-txt", "discoverability", "robots.txt", File.Exists(robotsPath) ? "pass" : "fail",
-            File.Exists(robotsPath) ? "robots.txt exists." : "robots.txt is missing.", robotsPath);
+        var robotsExists = File.Exists(robotsPath);
+        AddCheck(checks, "robots-txt", "discoverability", "robots.txt", robotsExists ? "pass" : (spec.Robots ? "fail" : "info"),
+            robotsExists ? "robots.txt exists." : (spec.Robots ? "robots.txt is missing." : "robots.txt generation is disabled."), robotsPath);
         if (!string.IsNullOrWhiteSpace(robotsText))
         {
+            var botRulesExpected = spec.Robots;
             AddCheck(checks, "ai-bot-rules", "bot-access-control", "AI bot rules in robots.txt",
-                HasRobotsUserAgent(robotsText!) ? "pass" : "fail",
-                HasRobotsUserAgent(robotsText!) ? "robots.txt declares crawler rules." : "robots.txt has no User-agent rules.",
+                HasRobotsUserAgent(robotsText!) ? "pass" : (botRulesExpected ? "fail" : "info"),
+                HasRobotsUserAgent(robotsText!) ? "robots.txt declares crawler rules." : (botRulesExpected ? "robots.txt has no User-agent rules." : "robots.txt generation is disabled."),
                 robotsPath);
+            var contentSignalsExpected = spec.Robots && spec.ContentSignals?.Enabled == true;
             AddCheck(checks, "content-signals", "bot-access-control", "Content Signals in robots.txt",
-                HasContentSignals(robotsText!) ? "pass" : "fail",
-                HasContentSignals(robotsText!) ? "robots.txt declares Content-Signal preferences." : "No Content-Signal directive found.",
+                HasContentSignals(robotsText!) ? "pass" : (contentSignalsExpected ? "fail" : "info"),
+                HasContentSignals(robotsText!) ? "robots.txt declares Content-Signal preferences." : (contentSignalsExpected ? "No Content-Signal directive found." : "Content Signals are disabled."),
                 robotsPath);
         }
 
@@ -164,24 +165,28 @@ public static class WebAgentReadiness
         AddCheck(checks, "sitemap", "discoverability", "sitemap.xml", ValidateSitemap(sitemapPath, out var sitemapMessage) ? "pass" : "fail",
             sitemapMessage, sitemapPath);
 
-        var headersPath = Path.Combine(siteRoot, string.IsNullOrWhiteSpace(spec.HeadersPath) ? "_headers" : spec.HeadersPath!.TrimStart('/', '\\'));
+        var headersPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.HeadersPath) ? "_headers" : spec.HeadersPath!);
         var headersText = File.Exists(headersPath) ? File.ReadAllText(headersPath) : string.Empty;
+        var linkHeadersPresent = File.Exists(headersPath) && headersText.Contains("Link:", StringComparison.OrdinalIgnoreCase);
         AddCheck(checks, "link-headers", "discoverability", "Link headers (RFC 8288)",
-            File.Exists(headersPath) && headersText.Contains("Link:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            File.Exists(headersPath) && headersText.Contains("Link:", StringComparison.OrdinalIgnoreCase)
+            linkHeadersPresent ? "pass" : (spec.LinkHeaders ? "fail" : "info"),
+            linkHeadersPresent
                 ? "Static host headers include Link discovery hints."
-                : "No static host Link headers found. Add _headers output or configure host-level response headers.",
+                : (spec.LinkHeaders ? "No static host Link headers found. Add _headers output or configure host-level response headers." : "Link header generation is disabled."),
             headersPath);
 
-        AddSecurityHeaderChecks(checks, headersText, headersPath);
+        AddSecurityHeaderChecks(checks, headersText, headersPath, spec.SecurityHeaders);
 
         var rootHtml = ReadFirstHtml(siteRoot);
         AddHtmlSemanticsChecks(checks, rootHtml.Text, rootHtml.Path);
 
-        var apiCatalogPath = Path.Combine(siteRoot, ".well-known", "api-catalog");
+        var apiCatalogPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.ApiCatalog?.OutputPath) ? ".well-known/api-catalog" : spec.ApiCatalog!.OutputPath!);
+        var apiCatalogValid = ValidateApiCatalog(apiCatalogPath, out var apiCatalogMessage);
+        var apiCatalogExpected = spec.ApiCatalog?.Enabled == true;
         AddCheck(checks, "api-catalog", "api-auth-mcp-skill-discovery", "API Catalog (RFC 9727)",
-            ValidateApiCatalog(apiCatalogPath, out var apiCatalogMessage) ? "pass" : "fail",
-            apiCatalogMessage, apiCatalogPath);
+            apiCatalogValid ? "pass" : (apiCatalogExpected ? "fail" : "info"),
+            apiCatalogValid ? apiCatalogMessage : (apiCatalogExpected ? apiCatalogMessage : "API catalog generation is disabled."),
+            apiCatalogPath);
 
         var openApi = ResolveOpenApiRoute(siteRoot, spec.OpenApi);
         AddCheck(checks, "openapi", "agent-protocols", "OpenAPI",
@@ -191,22 +196,28 @@ public static class WebAgentReadiness
                 : "No OpenAPI document configured or detected. Skip this for pure documentation sites.",
             siteRoot);
 
-        var skillsIndexPath = Path.Combine(siteRoot, ".well-known", "agent-skills", "index.json");
+        var skillsIndexPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.AgentSkills?.IndexPath) ? ".well-known/agent-skills/index.json" : spec.AgentSkills!.IndexPath!);
+        var skillsValid = ValidateAgentSkillsIndex(skillsIndexPath, siteRoot, out var skillsMessage);
+        var skillsExpected = spec.AgentSkills?.Enabled == true;
         AddCheck(checks, "agent-skills", "api-auth-mcp-skill-discovery", "Agent Skills index",
-            ValidateAgentSkillsIndex(skillsIndexPath, siteRoot, out var skillsMessage) ? "pass" : "fail",
-            skillsMessage, skillsIndexPath);
+            skillsValid ? "pass" : (skillsExpected ? "fail" : "info"),
+            skillsValid ? skillsMessage : (skillsExpected ? skillsMessage : "Agent Skills index generation is disabled."),
+            skillsIndexPath);
 
-        var agentsJsonPath = Path.Combine(siteRoot, "agents.json");
+        var agentsJsonPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.AgentsJson?.OutputPath) ? "agents.json" : spec.AgentsJson!.OutputPath!);
+        var agentsJsonValid = ValidateAgentsJson(agentsJsonPath, out var agentsMessage);
+        var agentsJsonExpected = spec.AgentsJson?.Enabled == true;
         AddCheck(checks, "agents-json", "agent-protocols", "agents.json",
-            ValidateAgentsJson(agentsJsonPath, out var agentsMessage) ? "pass" : "fail",
-            agentsMessage, agentsJsonPath);
+            agentsJsonValid ? "pass" : (agentsJsonExpected ? "fail" : "info"),
+            agentsJsonValid ? agentsMessage : (agentsJsonExpected ? agentsMessage : "agents.json generation is disabled."),
+            agentsJsonPath);
 
-        var a2aPath = Path.Combine(siteRoot, ".well-known", "agent-card.json");
+        var a2aPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.A2AAgentCard?.OutputPath) ? ".well-known/agent-card.json" : spec.A2AAgentCard!.OutputPath!);
         var a2aExpected = spec.A2AAgentCard?.Enabled == true;
         var a2aStatus = ValidateA2AAgentCard(a2aPath, out var a2aMessage) ? "pass" : (a2aExpected ? "fail" : "info");
         AddCheck(checks, "a2a-agent-card", "agent-protocols", "A2A Agent Card", a2aStatus, a2aMessage, a2aPath);
 
-        var mcpCardPath = Path.Combine(siteRoot, ".well-known", "mcp", "server-card.json");
+        var mcpCardPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.McpServerCard?.OutputPath) ? ".well-known/mcp/server-card.json" : spec.McpServerCard!.OutputPath!);
         var mcpExpected = spec.McpServerCard?.Enabled == true;
         var mcpStatus = ValidateMcpServerCard(mcpCardPath, out var mcpMessage) ? "pass" : (mcpExpected ? "fail" : "info");
         AddCheck(checks, "mcp-server-card", "api-auth-mcp-skill-discovery", "MCP Server Card", mcpStatus, mcpMessage, mcpCardPath);
@@ -531,10 +542,10 @@ public static class WebAgentReadiness
             ["robots"] = ToAbsoluteUrl(baseUrl, "/robots.txt"),
             ["sitemap"] = ToAbsoluteUrl(baseUrl, "/sitemap.xml"),
             ["llms"] = File.Exists(Path.Combine(siteRoot, "llms.txt")) ? ToAbsoluteUrl(baseUrl, "/llms.txt") : null,
-            ["apiCatalog"] = spec.ApiCatalog?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/api-catalog") : null,
-            ["agentSkills"] = spec.AgentSkills?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/agent-skills/index.json") : null,
-            ["mcpServerCard"] = spec.McpServerCard?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/mcp/server-card.json") : null,
-            ["a2aAgentCard"] = spec.A2AAgentCard?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/agent-card.json") : null
+            ["apiCatalog"] = spec.ApiCatalog?.Enabled == true ? ToAbsoluteUrl(baseUrl, ResolveSiteRoute(siteRoot, spec.ApiCatalog.OutputPath, ".well-known/api-catalog")) : null,
+            ["agentSkills"] = spec.AgentSkills?.Enabled == true ? ToAbsoluteUrl(baseUrl, ResolveSiteRoute(siteRoot, spec.AgentSkills.IndexPath, ".well-known/agent-skills/index.json")) : null,
+            ["mcpServerCard"] = spec.McpServerCard?.Enabled == true ? ToAbsoluteUrl(baseUrl, ResolveSiteRoute(siteRoot, spec.McpServerCard.OutputPath, ".well-known/mcp/server-card.json")) : null,
+            ["a2aAgentCard"] = spec.A2AAgentCard?.Enabled == true ? ToAbsoluteUrl(baseUrl, ResolveSiteRoute(siteRoot, spec.A2AAgentCard.OutputPath, ".well-known/agent-card.json")) : null
         };
 
         var root = new JsonObject
@@ -662,7 +673,7 @@ public static class WebAgentReadiness
         var existing = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
         var cleaned = RemoveGeneratedBlock(existing).TrimEnd();
         var sb = new StringBuilder();
-        sb.AppendLine(HeadersBlockStart);
+        sb.AppendLine(AgentBlockStart);
         var security = spec.SecurityHeaders ?? new AgentSecurityHeadersSpec();
         if (linkTargets.Count > 0)
         {
@@ -695,7 +706,7 @@ public static class WebAgentReadiness
         sb.AppendLine("/.well-known/mcp/server-card.json");
         sb.AppendLine("  Content-Type: application/json");
         AppendCorsHeaders(sb, security);
-        sb.AppendLine(HeadersBlockEnd);
+        sb.AppendLine(AgentBlockEnd);
 
         var next = string.IsNullOrWhiteSpace(cleaned)
             ? sb.ToString()
@@ -951,45 +962,37 @@ public static class WebAgentReadiness
         => text.Contains("<urlset", StringComparison.OrdinalIgnoreCase) ||
            text.Contains("<sitemapindex", StringComparison.OrdinalIgnoreCase);
 
-    private static void AddSecurityHeaderChecks(List<WebAgentReadinessCheck> checks, string headersText, string target)
+    private static void AddSecurityHeaderChecks(List<WebAgentReadinessCheck> checks, string headersText, string target, AgentSecurityHeadersSpec? spec)
     {
-        AddCheck(checks, "security-hsts", "security-trust", "HSTS",
-            headersText.Contains("Strict-Transport-Security:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            headersText.Contains("Strict-Transport-Security:", StringComparison.OrdinalIgnoreCase)
-                ? "Static host headers include HSTS."
-                : "Static host headers do not include Strict-Transport-Security.",
-            target);
-        AddCheck(checks, "security-csp", "security-trust", "CSP",
-            headersText.Contains("Content-Security-Policy:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            headersText.Contains("Content-Security-Policy:", StringComparison.OrdinalIgnoreCase)
-                ? "Static host headers include Content-Security-Policy."
-                : "Static host headers do not include Content-Security-Policy.",
-            target);
-        AddCheck(checks, "security-xcto", "security-trust", "X-Content-Type-Options",
-            headersText.Contains("X-Content-Type-Options:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            headersText.Contains("X-Content-Type-Options:", StringComparison.OrdinalIgnoreCase)
-                ? "Static host headers include X-Content-Type-Options."
-                : "Static host headers do not include X-Content-Type-Options.",
-            target);
+        var expected = spec?.Enabled == true;
+        AddConfiguredHeaderCheck(checks, "security-hsts", "HSTS", headersText, target, expected && spec!.Hsts, "Strict-Transport-Security:",
+            "Static host headers include HSTS.", "Static host headers do not include Strict-Transport-Security.");
+        AddConfiguredHeaderCheck(checks, "security-csp", "CSP", headersText, target, expected && spec!.ContentSecurityPolicy, "Content-Security-Policy:",
+            "Static host headers include Content-Security-Policy.", "Static host headers do not include Content-Security-Policy.");
+        AddConfiguredHeaderCheck(checks, "security-xcto", "X-Content-Type-Options", headersText, target, expected && spec!.XContentTypeOptions, "X-Content-Type-Options:",
+            "Static host headers include X-Content-Type-Options.", "Static host headers do not include X-Content-Type-Options.");
+
+        var hasFrameProtection = headersText.Contains("X-Frame-Options:", StringComparison.OrdinalIgnoreCase) ||
+                                 headersText.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase);
         AddCheck(checks, "security-xfo", "security-trust", "X-Frame-Options",
-            headersText.Contains("X-Frame-Options:", StringComparison.OrdinalIgnoreCase) ||
-            headersText.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            headersText.Contains("X-Frame-Options:", StringComparison.OrdinalIgnoreCase) ||
-            headersText.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase)
+            hasFrameProtection ? "pass" : (expected && spec!.XFrameOptions ? "fail" : "info"),
+            hasFrameProtection
                 ? "Static host headers include clickjacking protection."
-                : "Static host headers do not include X-Frame-Options or CSP frame-ancestors.",
+                : (expected && spec!.XFrameOptions ? "Static host headers do not include X-Frame-Options or CSP frame-ancestors." : "Clickjacking protection header generation is disabled."),
             target);
-        AddCheck(checks, "security-referrer-policy", "security-trust", "Referrer-Policy",
-            headersText.Contains("Referrer-Policy:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            headersText.Contains("Referrer-Policy:", StringComparison.OrdinalIgnoreCase)
-                ? "Static host headers include Referrer-Policy."
-                : "Static host headers do not include Referrer-Policy.",
-            target);
-        AddCheck(checks, "security-cors", "security-trust", "CORS",
-            headersText.Contains("Access-Control-Allow-Origin:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            headersText.Contains("Access-Control-Allow-Origin:", StringComparison.OrdinalIgnoreCase)
-                ? "Agent discovery resources include CORS headers."
-                : "No Access-Control-Allow-Origin header configured for agent discovery resources.",
+
+        AddConfiguredHeaderCheck(checks, "security-referrer-policy", "Referrer-Policy", headersText, target, expected && spec!.ReferrerPolicy, "Referrer-Policy:",
+            "Static host headers include Referrer-Policy.", "Static host headers do not include Referrer-Policy.");
+        AddConfiguredHeaderCheck(checks, "security-cors", "CORS", headersText, target, expected && spec!.CorsForWellKnown, "Access-Control-Allow-Origin:",
+            "Agent discovery resources include CORS headers.", "No Access-Control-Allow-Origin header configured for agent discovery resources.");
+    }
+
+    private static void AddConfiguredHeaderCheck(List<WebAgentReadinessCheck> checks, string id, string name, string headersText, string target, bool expected, string headerName, string passMessage, string failMessage)
+    {
+        var present = headersText.Contains(headerName, StringComparison.OrdinalIgnoreCase);
+        AddCheck(checks, id, "security-trust", name,
+            present ? "pass" : (expected ? "fail" : "info"),
+            present ? passMessage : (expected ? failMessage : $"{name} header generation is disabled."),
             target);
     }
 
@@ -1334,8 +1337,44 @@ public static class WebAgentReadiness
 
     private static string ResolveSitePath(string siteRoot, string path)
     {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Path is required.", nameof(path));
+
+        var root = Path.GetFullPath(siteRoot.Trim().Trim('"'));
         var normalized = path.Trim().Trim('"').Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar);
-        return Path.GetFullPath(Path.Combine(siteRoot, normalized));
+        var resolved = Path.GetFullPath(Path.Combine(root, normalized));
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!resolved.Equals(root, StringComparison.OrdinalIgnoreCase) &&
+            !resolved.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Path '{path}' resolves outside the site root.", nameof(path));
+        }
+
+        return resolved;
+    }
+
+    private static string ResolveSiteRoute(string siteRoot, string? path, string defaultPath)
+        => ToSiteRoute(siteRoot, ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(path) ? defaultPath : path!));
+
+    private static string ToSiteRoute(string siteRoot, string path)
+    {
+        var root = Path.GetFullPath(siteRoot.Trim().Trim('"'));
+        var resolved = Path.GetFullPath(path);
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!resolved.Equals(root, StringComparison.OrdinalIgnoreCase) &&
+            !resolved.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Path '{path}' resolves outside the site root.", nameof(path));
+        }
+
+        var relative = Path.GetRelativePath(root, resolved).Replace(Path.DirectorySeparatorChar, '/');
+        return NormalizeRoute(relative);
     }
 
     private static string Slugify(string value)

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -105,7 +105,7 @@ public static class WebAgentReadiness
         if (!string.IsNullOrWhiteSpace(openApiPath))
             linkTargets.Add(new HeaderLinkTarget(openApiPath!, "service-desc", "application/openapi+json"));
 
-        if (spec.LinkHeaders)
+        if (ShouldWriteHeaders(spec, linkTargets))
             written.Add(UpdateHeaders(siteRoot, spec, linkTargets));
 
         var verify = Verify(new WebAgentReadinessVerifyOptions
@@ -141,6 +141,18 @@ public static class WebAgentReadiness
         var spec = ResolveSpec(options.AgentReadiness);
         var checks = new List<WebAgentReadinessCheck>();
         var warnings = new List<string>();
+
+        if (!spec.Enabled)
+        {
+            return new WebAgentReadinessResult
+            {
+                Operation = "verify",
+                SiteRoot = siteRoot,
+                BaseUrl = NormalizeBaseUrl(options.BaseUrl),
+                Success = true,
+                Warnings = new[] { "AgentReadiness is disabled." }
+            };
+        }
 
         var robotsPath = Path.Combine(siteRoot, "robots.txt");
         var robotsText = File.Exists(robotsPath) ? File.ReadAllText(robotsPath) : null;
@@ -356,16 +368,35 @@ public static class WebAgentReadiness
     {
         if (spec is not null)
         {
-            if (spec.Enabled)
+            var resolved = new AgentReadinessSpec
             {
-                spec.SecurityHeaders ??= new AgentSecurityHeadersSpec();
-                spec.ContentSignals ??= new AgentContentSignalsSpec();
-                spec.ApiCatalog ??= new AgentApiCatalogSpec();
-                spec.AgentSkills ??= new AgentSkillsDiscoverySpec();
-                spec.AgentsJson ??= new AgentDiscoveryDocumentSpec();
+                Enabled = spec.Enabled,
+                HeadersPath = spec.HeadersPath,
+                LinkHeaders = spec.LinkHeaders,
+                SecurityHeaders = spec.SecurityHeaders,
+                Robots = spec.Robots,
+                ContentSignals = spec.ContentSignals,
+                BotRules = spec.BotRules,
+                ApiCatalog = spec.ApiCatalog,
+                AgentSkills = spec.AgentSkills,
+                AgentsJson = spec.AgentsJson,
+                A2AAgentCard = spec.A2AAgentCard,
+                McpServerCard = spec.McpServerCard,
+                OpenApi = spec.OpenApi,
+                WebMcp = spec.WebMcp,
+                MarkdownNegotiation = spec.MarkdownNegotiation
+            };
+
+            if (resolved.Enabled)
+            {
+                resolved.SecurityHeaders ??= new AgentSecurityHeadersSpec();
+                resolved.ContentSignals ??= new AgentContentSignalsSpec();
+                resolved.ApiCatalog ??= new AgentApiCatalogSpec();
+                resolved.AgentSkills ??= new AgentSkillsDiscoverySpec();
+                resolved.AgentsJson ??= new AgentDiscoveryDocumentSpec();
             }
 
-            return spec;
+            return resolved;
         }
 
         return new AgentReadinessSpec
@@ -666,6 +697,15 @@ public static class WebAgentReadiness
         return outputPath;
     }
 
+    private static bool ShouldWriteHeaders(AgentReadinessSpec spec, List<HeaderLinkTarget> linkTargets)
+        => spec.SecurityHeaders?.Enabled == true ||
+           (spec.LinkHeaders && linkTargets.Count > 0) ||
+           spec.ApiCatalog?.Enabled == true ||
+           spec.AgentSkills?.Enabled == true ||
+           spec.AgentsJson?.Enabled == true ||
+           spec.A2AAgentCard?.Enabled == true ||
+           spec.McpServerCard?.Enabled == true;
+
     private static string UpdateHeaders(string siteRoot, AgentReadinessSpec spec, List<HeaderLinkTarget> linkTargets)
     {
         var headersPath = spec.HeadersPath;
@@ -675,37 +715,24 @@ public static class WebAgentReadiness
         var sb = new StringBuilder();
         sb.AppendLine(AgentBlockStart);
         var security = spec.SecurityHeaders ?? new AgentSecurityHeadersSpec();
-        if (linkTargets.Count > 0)
+        var writeLinkHeaders = spec.LinkHeaders && linkTargets.Count > 0;
+        if (security.Enabled || writeLinkHeaders)
         {
             sb.AppendLine("/");
             AppendSecurityHeaders(sb, security);
-            foreach (var target in linkTargets.DistinctBy(static t => t.Href, StringComparer.OrdinalIgnoreCase))
+            if (writeLinkHeaders)
             {
-                sb.Append("  Link: <").Append(target.Href).Append(">; rel=\"").Append(target.Rel).Append("\"");
-                if (!string.IsNullOrWhiteSpace(target.Type))
-                    sb.Append("; type=\"").Append(target.Type).Append("\"");
-                sb.AppendLine();
+                foreach (var target in linkTargets.DistinctBy(static t => t.Href, StringComparer.OrdinalIgnoreCase))
+                {
+                    sb.Append("  Link: <").Append(target.Href).Append(">; rel=\"").Append(target.Rel).Append("\"");
+                    if (!string.IsNullOrWhiteSpace(target.Type))
+                        sb.Append("; type=\"").Append(target.Type).Append("\"");
+                    sb.AppendLine();
+                }
             }
         }
 
-        sb.AppendLine("/.well-known/api-catalog");
-        sb.AppendLine("  Content-Type: application/linkset+json; profile=\"https://www.rfc-editor.org/info/rfc9727\"");
-        AppendCorsHeaders(sb, security);
-        sb.AppendLine("/.well-known/agent-skills/index.json");
-        sb.AppendLine("  Content-Type: application/json");
-        AppendCorsHeaders(sb, security);
-        sb.AppendLine("/agents.json");
-        sb.AppendLine("  Content-Type: application/json");
-        AppendCorsHeaders(sb, security);
-        sb.AppendLine("/.well-known/agents.json");
-        sb.AppendLine("  Content-Type: application/json");
-        AppendCorsHeaders(sb, security);
-        sb.AppendLine("/.well-known/agent-card.json");
-        sb.AppendLine("  Content-Type: application/json");
-        AppendCorsHeaders(sb, security);
-        sb.AppendLine("/.well-known/mcp/server-card.json");
-        sb.AppendLine("  Content-Type: application/json");
-        AppendCorsHeaders(sb, security);
+        AppendDiscoveryResourceHeaders(sb, siteRoot, spec, security);
         sb.AppendLine(AgentBlockEnd);
 
         var next = string.IsNullOrWhiteSpace(cleaned)
@@ -714,6 +741,56 @@ public static class WebAgentReadiness
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllText(path, next);
         return path;
+    }
+
+    private static void AppendDiscoveryResourceHeaders(StringBuilder sb, string siteRoot, AgentReadinessSpec spec, AgentSecurityHeadersSpec security)
+    {
+        if (spec.ApiCatalog?.Enabled == true)
+        {
+            AppendResourceHeaders(sb, ResolveSiteRoute(siteRoot, spec.ApiCatalog.OutputPath, ".well-known/api-catalog"),
+                "application/linkset+json; profile=\"https://www.rfc-editor.org/info/rfc9727\"", security);
+        }
+
+        if (spec.AgentSkills?.Enabled == true)
+        {
+            AppendResourceHeaders(sb, ResolveSiteRoute(siteRoot, spec.AgentSkills.IndexPath, ".well-known/agent-skills/index.json"),
+                "application/json", security);
+        }
+
+        if (spec.AgentsJson?.Enabled == true)
+        {
+            var routes = new[]
+                {
+                    ResolveSiteRoute(siteRoot, spec.AgentsJson.OutputPath, "agents.json"),
+                    ResolveSiteRoute(siteRoot, spec.AgentsJson.WellKnownOutputPath, ".well-known/agents.json")
+                }
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var route in routes)
+                AppendResourceHeaders(sb, route, "application/json", security);
+        }
+
+        if (spec.A2AAgentCard?.Enabled == true)
+        {
+            AppendResourceHeaders(sb, ResolveSiteRoute(siteRoot, spec.A2AAgentCard.OutputPath, ".well-known/agent-card.json"),
+                "application/json", security);
+        }
+
+        if (spec.McpServerCard?.Enabled == true)
+        {
+            AppendResourceHeaders(sb, ResolveSiteRoute(siteRoot, spec.McpServerCard.OutputPath, ".well-known/mcp/server-card.json"),
+                "application/json", security);
+        }
+    }
+
+    private static void AppendResourceHeaders(StringBuilder sb, string route, string contentType, AgentSecurityHeadersSpec security)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return;
+
+        sb.AppendLine(NormalizeRoute(route));
+        sb.Append("  Content-Type: ").Append(contentType).AppendLine();
+        AppendCorsHeaders(sb, security);
     }
 
     private static void AppendSecurityHeaders(StringBuilder sb, AgentSecurityHeadersSpec security)

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -1,0 +1,1400 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace PowerForge.Web;
+
+/// <summary>Prepares and checks static-site agent-readiness discovery signals.</summary>
+public static class WebAgentReadiness
+{
+    private const string AgentBlockStart = "# BEGIN PowerForge Agent Readiness";
+    private const string AgentBlockEnd = "# END PowerForge Agent Readiness";
+    private const string HeadersBlockStart = "# BEGIN PowerForge Agent Readiness";
+    private const string HeadersBlockEnd = "# END PowerForge Agent Readiness";
+    private const string AgentSkillsSchema = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+    private static readonly Regex GeneratedBlockRegex = new(
+        @"(?ms)^\s*# BEGIN PowerForge Agent Readiness\s*$.*?^\s*# END PowerForge Agent Readiness\s*$\r?\n?",
+        RegexOptions.Compiled);
+
+    /// <summary>Writes configured agent-readiness files under the site root.</summary>
+    public static WebAgentReadinessResult Prepare(WebAgentReadinessPrepareOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        if (string.IsNullOrWhiteSpace(options.SiteRoot))
+            throw new ArgumentException("SiteRoot is required.", nameof(options));
+
+        var siteRoot = Path.GetFullPath(options.SiteRoot.Trim().Trim('"'));
+        Directory.CreateDirectory(siteRoot);
+
+        var spec = ResolveSpec(options.AgentReadiness);
+        var baseUrl = NormalizeBaseUrl(options.BaseUrl);
+        var siteName = string.IsNullOrWhiteSpace(options.SiteName) ? "Site" : options.SiteName!.Trim();
+        var written = new List<string>();
+        var warnings = new List<string>();
+        var linkTargets = new List<HeaderLinkTarget>();
+
+        if (!spec.Enabled)
+        {
+            return new WebAgentReadinessResult
+            {
+                Operation = "prepare",
+                SiteRoot = siteRoot,
+                BaseUrl = baseUrl,
+                Success = true,
+                Warnings = new[] { "AgentReadiness is disabled." }
+            };
+        }
+
+        if (spec.Robots)
+            written.Add(UpdateRobots(siteRoot, baseUrl, spec));
+
+        if (spec.ApiCatalog?.Enabled == true)
+        {
+            var apiCatalogPath = WriteApiCatalog(siteRoot, baseUrl, spec.ApiCatalog, warnings);
+            if (!string.IsNullOrWhiteSpace(apiCatalogPath))
+            {
+                written.Add(apiCatalogPath!);
+                linkTargets.Add(new HeaderLinkTarget("/.well-known/api-catalog", "api-catalog", "application/linkset+json"));
+            }
+        }
+
+        if (spec.AgentSkills?.Enabled == true)
+        {
+            var agentSkillsPath = WriteAgentSkills(siteRoot, baseUrl, siteName, spec.AgentSkills, warnings);
+            if (!string.IsNullOrWhiteSpace(agentSkillsPath))
+            {
+                written.Add(agentSkillsPath!);
+                linkTargets.Add(new HeaderLinkTarget("/.well-known/agent-skills/index.json", "describedby", "application/json"));
+            }
+        }
+
+        if (spec.AgentsJson?.Enabled == true)
+        {
+            var agentsPaths = WriteAgentsJson(siteRoot, baseUrl, siteName, spec, warnings);
+            written.AddRange(agentsPaths);
+            if (agentsPaths.Length > 0)
+                linkTargets.Add(new HeaderLinkTarget("/agents.json", "describedby", "application/json"));
+        }
+
+        if (spec.A2AAgentCard?.Enabled == true)
+        {
+            var agentCardPath = WriteA2AAgentCard(siteRoot, baseUrl, siteName, spec.A2AAgentCard, warnings);
+            if (!string.IsNullOrWhiteSpace(agentCardPath))
+            {
+                written.Add(agentCardPath!);
+                linkTargets.Add(new HeaderLinkTarget("/.well-known/agent-card.json", "service-desc", "application/json"));
+            }
+        }
+
+        if (spec.McpServerCard?.Enabled == true)
+        {
+            var serverCardPath = WriteMcpServerCard(siteRoot, baseUrl, siteName, spec.McpServerCard, warnings);
+            if (!string.IsNullOrWhiteSpace(serverCardPath))
+            {
+                written.Add(serverCardPath!);
+                linkTargets.Add(new HeaderLinkTarget("/.well-known/mcp/server-card.json", "service-desc", "application/json"));
+            }
+        }
+
+        if (File.Exists(Path.Combine(siteRoot, "llms.txt")))
+            linkTargets.Add(new HeaderLinkTarget("/llms.txt", "service-doc", "text/plain"));
+
+        var openApiPath = ResolveOpenApiRoute(siteRoot, spec.OpenApi);
+        if (!string.IsNullOrWhiteSpace(openApiPath))
+            linkTargets.Add(new HeaderLinkTarget(openApiPath!, "service-desc", "application/openapi+json"));
+
+        if (spec.LinkHeaders)
+            written.Add(UpdateHeaders(siteRoot, spec, linkTargets));
+
+        var verify = Verify(new WebAgentReadinessVerifyOptions
+        {
+            SiteRoot = siteRoot,
+            BaseUrl = baseUrl,
+            AgentReadiness = spec
+        });
+
+        return new WebAgentReadinessResult
+        {
+            Operation = "prepare",
+            SiteRoot = siteRoot,
+            BaseUrl = baseUrl,
+            Success = verify.Success,
+            WrittenFiles = written
+                .Where(static path => !string.IsNullOrWhiteSpace(path))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            Checks = verify.Checks,
+            Warnings = warnings.Concat(verify.Warnings).Distinct(StringComparer.OrdinalIgnoreCase).ToArray()
+        };
+    }
+
+    /// <summary>Verifies agent-readiness files in a local static site output.</summary>
+    public static WebAgentReadinessResult Verify(WebAgentReadinessVerifyOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        if (string.IsNullOrWhiteSpace(options.SiteRoot))
+            throw new ArgumentException("SiteRoot is required.", nameof(options));
+
+        var siteRoot = Path.GetFullPath(options.SiteRoot.Trim().Trim('"'));
+        var spec = ResolveSpec(options.AgentReadiness);
+        var checks = new List<WebAgentReadinessCheck>();
+        var warnings = new List<string>();
+
+        var robotsPath = Path.Combine(siteRoot, "robots.txt");
+        var robotsText = File.Exists(robotsPath) ? File.ReadAllText(robotsPath) : null;
+        AddCheck(checks, "robots-txt", "discoverability", "robots.txt", File.Exists(robotsPath) ? "pass" : "fail",
+            File.Exists(robotsPath) ? "robots.txt exists." : "robots.txt is missing.", robotsPath);
+        if (!string.IsNullOrWhiteSpace(robotsText))
+        {
+            AddCheck(checks, "ai-bot-rules", "bot-access-control", "AI bot rules in robots.txt",
+                HasRobotsUserAgent(robotsText!) ? "pass" : "fail",
+                HasRobotsUserAgent(robotsText!) ? "robots.txt declares crawler rules." : "robots.txt has no User-agent rules.",
+                robotsPath);
+            AddCheck(checks, "content-signals", "bot-access-control", "Content Signals in robots.txt",
+                HasContentSignals(robotsText!) ? "pass" : "fail",
+                HasContentSignals(robotsText!) ? "robots.txt declares Content-Signal preferences." : "No Content-Signal directive found.",
+                robotsPath);
+        }
+
+        var sitemapPath = Path.Combine(siteRoot, "sitemap.xml");
+        AddCheck(checks, "sitemap", "discoverability", "sitemap.xml", ValidateSitemap(sitemapPath, out var sitemapMessage) ? "pass" : "fail",
+            sitemapMessage, sitemapPath);
+
+        var headersPath = Path.Combine(siteRoot, string.IsNullOrWhiteSpace(spec.HeadersPath) ? "_headers" : spec.HeadersPath!.TrimStart('/', '\\'));
+        var headersText = File.Exists(headersPath) ? File.ReadAllText(headersPath) : string.Empty;
+        AddCheck(checks, "link-headers", "discoverability", "Link headers (RFC 8288)",
+            File.Exists(headersPath) && headersText.Contains("Link:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            File.Exists(headersPath) && headersText.Contains("Link:", StringComparison.OrdinalIgnoreCase)
+                ? "Static host headers include Link discovery hints."
+                : "No static host Link headers found. Add _headers output or configure host-level response headers.",
+            headersPath);
+
+        AddSecurityHeaderChecks(checks, headersText, headersPath);
+
+        var rootHtml = ReadFirstHtml(siteRoot);
+        AddHtmlSemanticsChecks(checks, rootHtml.Text, rootHtml.Path);
+
+        var apiCatalogPath = Path.Combine(siteRoot, ".well-known", "api-catalog");
+        AddCheck(checks, "api-catalog", "api-auth-mcp-skill-discovery", "API Catalog (RFC 9727)",
+            ValidateApiCatalog(apiCatalogPath, out var apiCatalogMessage) ? "pass" : "fail",
+            apiCatalogMessage, apiCatalogPath);
+
+        var openApi = ResolveOpenApiRoute(siteRoot, spec.OpenApi);
+        AddCheck(checks, "openapi", "agent-protocols", "OpenAPI",
+            !string.IsNullOrWhiteSpace(openApi) ? "pass" : (spec.OpenApi?.Enabled == true ? "fail" : "info"),
+            !string.IsNullOrWhiteSpace(openApi)
+                ? $"OpenAPI document detected at {openApi}."
+                : "No OpenAPI document configured or detected. Skip this for pure documentation sites.",
+            siteRoot);
+
+        var skillsIndexPath = Path.Combine(siteRoot, ".well-known", "agent-skills", "index.json");
+        AddCheck(checks, "agent-skills", "api-auth-mcp-skill-discovery", "Agent Skills index",
+            ValidateAgentSkillsIndex(skillsIndexPath, siteRoot, out var skillsMessage) ? "pass" : "fail",
+            skillsMessage, skillsIndexPath);
+
+        var agentsJsonPath = Path.Combine(siteRoot, "agents.json");
+        AddCheck(checks, "agents-json", "agent-protocols", "agents.json",
+            ValidateAgentsJson(agentsJsonPath, out var agentsMessage) ? "pass" : "fail",
+            agentsMessage, agentsJsonPath);
+
+        var a2aPath = Path.Combine(siteRoot, ".well-known", "agent-card.json");
+        var a2aExpected = spec.A2AAgentCard?.Enabled == true;
+        var a2aStatus = ValidateA2AAgentCard(a2aPath, out var a2aMessage) ? "pass" : (a2aExpected ? "fail" : "info");
+        AddCheck(checks, "a2a-agent-card", "agent-protocols", "A2A Agent Card", a2aStatus, a2aMessage, a2aPath);
+
+        var mcpCardPath = Path.Combine(siteRoot, ".well-known", "mcp", "server-card.json");
+        var mcpExpected = spec.McpServerCard?.Enabled == true;
+        var mcpStatus = ValidateMcpServerCard(mcpCardPath, out var mcpMessage) ? "pass" : (mcpExpected ? "fail" : "info");
+        AddCheck(checks, "mcp-server-card", "api-auth-mcp-skill-discovery", "MCP Server Card", mcpStatus, mcpMessage, mcpCardPath);
+
+        AddCheck(checks, "markdown-negotiation", "content", "Markdown for Agents",
+            spec.MarkdownNegotiation ? "warn" : "info",
+            spec.MarkdownNegotiation
+                ? "Local static output cannot prove Accept: text/markdown negotiation. Use remote scan or Cloudflare Markdown for Agents."
+                : "Markdown negotiation is not expected for this site.",
+            options.BaseUrl);
+
+        if (spec.WebMcp)
+        {
+            var hasWebMcp = Directory.Exists(siteRoot) &&
+                            Directory.EnumerateFiles(siteRoot, "*.html", SearchOption.AllDirectories)
+                                .Take(500)
+                                .Any(file => File.ReadAllText(file).Contains("navigator.modelContext.provideContext", StringComparison.Ordinal));
+            AddCheck(checks, "webmcp", "api-auth-mcp-skill-discovery", "WebMCP", hasWebMcp ? "pass" : "fail",
+                hasWebMcp ? "Rendered HTML includes WebMCP registration." : "No WebMCP browser tool registration found.",
+                siteRoot);
+        }
+
+        return new WebAgentReadinessResult
+        {
+            Operation = "verify",
+            SiteRoot = siteRoot,
+            BaseUrl = options.BaseUrl,
+            Success = checks.All(static c => !string.Equals(c.Status, "fail", StringComparison.OrdinalIgnoreCase)),
+            Checks = checks.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+    }
+
+    /// <summary>Scans a live URL for the same agent-readiness signals PowerForge can prepare locally.</summary>
+    public static async Task<WebAgentReadinessResult> ScanAsync(WebAgentReadinessScanOptions options, CancellationToken cancellationToken = default)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        if (string.IsNullOrWhiteSpace(options.BaseUrl))
+            throw new ArgumentException("BaseUrl is required.", nameof(options));
+
+        var baseUrl = NormalizeBaseUrl(options.BaseUrl);
+        var checks = new List<WebAgentReadinessCheck>();
+        var warnings = new List<string>();
+        using var http = new HttpClient { Timeout = TimeSpan.FromMilliseconds(options.TimeoutMs <= 0 ? 15000 : options.TimeoutMs) };
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("PowerForge.Web.AgentReady/1.0");
+
+        var root = await TrySendAsync(http, HttpMethod.Get, baseUrl, null, cancellationToken).ConfigureAwait(false);
+        var linkHeader = root.Response?.Headers.TryGetValues("Link", out var links) == true ? string.Join(", ", links) : string.Empty;
+        AddCheck(checks, "link-headers", "discoverability", "Link headers (RFC 8288)",
+            root.Success && linkHeader.Contains("api-catalog", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            root.Success && linkHeader.Contains("api-catalog", StringComparison.OrdinalIgnoreCase)
+                ? "Homepage response includes agent discovery Link headers."
+                : "Homepage response does not include Link headers pointing to agent discovery resources.",
+            baseUrl);
+        AddRemoteSecurityHeaderChecks(checks, root.Response, baseUrl);
+
+        var rootText = await TryGetTextAsync(http, baseUrl, null, cancellationToken).ConfigureAwait(false);
+        if (rootText.Success)
+            AddHtmlSemanticsChecks(checks, rootText.Text, baseUrl);
+
+        var robots = await TryGetTextAsync(http, CombineUrl(baseUrl, "/robots.txt"), null, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "robots-txt", "discoverability", "robots.txt", robots.Success ? "pass" : "fail", robots.Message, CombineUrl(baseUrl, "/robots.txt"));
+        if (robots.Success)
+        {
+            AddCheck(checks, "ai-bot-rules", "bot-access-control", "AI bot rules in robots.txt",
+                HasRobotsUserAgent(robots.Text) ? "pass" : "fail",
+                HasRobotsUserAgent(robots.Text) ? "robots.txt declares crawler rules." : "robots.txt has no User-agent rules.",
+                CombineUrl(baseUrl, "/robots.txt"));
+            AddCheck(checks, "content-signals", "bot-access-control", "Content Signals in robots.txt",
+                HasContentSignals(robots.Text) ? "pass" : "fail",
+                HasContentSignals(robots.Text) ? "robots.txt declares Content-Signal preferences." : "No Content-Signal directive found.",
+                CombineUrl(baseUrl, "/robots.txt"));
+        }
+
+        var sitemap = await TryGetTextAsync(http, CombineUrl(baseUrl, "/sitemap.xml"), null, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "sitemap", "discoverability", "sitemap.xml", sitemap.Success && LooksLikeSitemap(sitemap.Text) ? "pass" : "fail",
+            sitemap.Success && LooksLikeSitemap(sitemap.Text) ? "sitemap.xml exists with valid structure." : sitemap.Message,
+            CombineUrl(baseUrl, "/sitemap.xml"));
+
+        var markdown = await TryGetTextAsync(http, baseUrl, "text/markdown", cancellationToken).ConfigureAwait(false);
+        var markdownContentType = markdown.Response?.Content.Headers.ContentType?.MediaType ?? string.Empty;
+        AddCheck(checks, "markdown-negotiation", "content", "Markdown for Agents",
+            markdown.Success && markdownContentType.Contains("markdown", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            markdown.Success && markdownContentType.Contains("markdown", StringComparison.OrdinalIgnoreCase)
+                ? "Accept: text/markdown returned markdown content."
+                : "Accept: text/markdown did not return Content-Type text/markdown.",
+            baseUrl);
+
+        var apiCatalog = await TryGetTextAsync(http, CombineUrl(baseUrl, "/.well-known/api-catalog"), null, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "api-catalog", "api-auth-mcp-skill-discovery", "API Catalog (RFC 9727)",
+            apiCatalog.Success && ValidateApiCatalogText(apiCatalog.Text) ? "pass" : "fail",
+            apiCatalog.Success && ValidateApiCatalogText(apiCatalog.Text) ? "API catalog returned a Linkset document." : apiCatalog.Message,
+            CombineUrl(baseUrl, "/.well-known/api-catalog"));
+
+        var openApi = await TryFindOpenApiAsync(http, baseUrl, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "openapi", "agent-protocols", "OpenAPI",
+            openApi.Success ? "pass" : "info",
+            openApi.Success ? $"OpenAPI document detected at {openApi.Url}." : "No OpenAPI document found at common static paths.",
+            openApi.Url ?? baseUrl);
+
+        var agentSkills = await TryGetTextAsync(http, CombineUrl(baseUrl, "/.well-known/agent-skills/index.json"), null, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "agent-skills", "api-auth-mcp-skill-discovery", "Agent Skills index",
+            agentSkills.Success && ValidateAgentSkillsIndexText(agentSkills.Text) ? "pass" : "fail",
+            agentSkills.Success && ValidateAgentSkillsIndexText(agentSkills.Text) ? "Agent Skills discovery index is valid." : agentSkills.Message,
+            CombineUrl(baseUrl, "/.well-known/agent-skills/index.json"));
+
+        var agentsJson = await TryGetTextAsync(http, CombineUrl(baseUrl, "/agents.json"), null, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "agents-json", "agent-protocols", "agents.json",
+            agentsJson.Success && ValidateAgentsJsonText(agentsJson.Text) ? "pass" : "fail",
+            agentsJson.Success && ValidateAgentsJsonText(agentsJson.Text) ? "agents.json discovery document is valid." : agentsJson.Message,
+            CombineUrl(baseUrl, "/agents.json"));
+
+        var a2a = await TryGetTextAsync(http, CombineUrl(baseUrl, "/.well-known/agent-card.json"), null, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "a2a-agent-card", "agent-protocols", "A2A Agent Card",
+            a2a.Success && ValidateA2AAgentCardText(a2a.Text) ? "pass" : "info",
+            a2a.Success && ValidateA2AAgentCardText(a2a.Text) ? "A2A Agent Card is valid." : "A2A Agent Card was not found or is not valid.",
+            CombineUrl(baseUrl, "/.well-known/agent-card.json"));
+
+        var mcp = await TryGetTextAsync(http, CombineUrl(baseUrl, "/.well-known/mcp/server-card.json"), null, cancellationToken).ConfigureAwait(false);
+        AddCheck(checks, "mcp-server-card", "api-auth-mcp-skill-discovery", "MCP Server Card",
+            mcp.Success && ValidateMcpServerCardText(mcp.Text) ? "pass" : "info",
+            mcp.Success && ValidateMcpServerCardText(mcp.Text) ? "MCP Server Card is valid." : "MCP Server Card was not found or is not valid.",
+            CombineUrl(baseUrl, "/.well-known/mcp/server-card.json"));
+
+        return new WebAgentReadinessResult
+        {
+            Operation = "scan",
+            BaseUrl = baseUrl,
+            Success = checks.All(static c => !string.Equals(c.Status, "fail", StringComparison.OrdinalIgnoreCase)),
+            Checks = checks.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+    }
+
+    private static AgentReadinessSpec ResolveSpec(AgentReadinessSpec? spec)
+    {
+        if (spec is not null)
+        {
+            if (spec.Enabled)
+            {
+                spec.SecurityHeaders ??= new AgentSecurityHeadersSpec();
+                spec.ContentSignals ??= new AgentContentSignalsSpec();
+                spec.ApiCatalog ??= new AgentApiCatalogSpec();
+                spec.AgentSkills ??= new AgentSkillsDiscoverySpec();
+                spec.AgentsJson ??= new AgentDiscoveryDocumentSpec();
+            }
+
+            return spec;
+        }
+
+        return new AgentReadinessSpec
+        {
+            Enabled = true,
+            SecurityHeaders = new AgentSecurityHeadersSpec(),
+            ContentSignals = new AgentContentSignalsSpec(),
+            ApiCatalog = new AgentApiCatalogSpec(),
+            AgentSkills = new AgentSkillsDiscoverySpec(),
+            AgentsJson = new AgentDiscoveryDocumentSpec()
+        };
+    }
+
+    private static string UpdateRobots(string siteRoot, string? baseUrl, AgentReadinessSpec spec)
+    {
+        var path = Path.Combine(siteRoot, "robots.txt");
+        var existing = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        var cleaned = RemoveGeneratedBlock(existing).TrimEnd();
+        var block = BuildRobotsBlock(siteRoot, baseUrl, spec);
+        var next = string.IsNullOrWhiteSpace(cleaned)
+            ? block
+            : cleaned + Environment.NewLine + Environment.NewLine + block;
+        File.WriteAllText(path, next);
+        return path;
+    }
+
+    private static string BuildRobotsBlock(string siteRoot, string? baseUrl, AgentReadinessSpec spec)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(AgentBlockStart);
+        sb.AppendLine("User-agent: *");
+        var signals = spec.ContentSignals ?? new AgentContentSignalsSpec();
+        if (signals.Enabled)
+        {
+            sb.Append("Content-Signal: ");
+            sb.Append("search=").Append(signals.Search ? "yes" : "no");
+            sb.Append(", ai-input=").Append(signals.AiInput ? "yes" : "no");
+            sb.Append(", ai-train=").Append(signals.AiTrain ? "yes" : "no");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("Allow: /");
+        if (!string.IsNullOrWhiteSpace(baseUrl) && File.Exists(Path.Combine(siteRoot, "sitemap.xml")))
+            sb.Append("Sitemap: ").Append(CombineUrl(baseUrl!, "/sitemap.xml")).AppendLine();
+
+        foreach (var rule in spec.BotRules.Where(static r => !string.IsNullOrWhiteSpace(r.UserAgent)))
+        {
+            sb.AppendLine();
+            sb.Append("User-agent: ").Append(rule.UserAgent.Trim()).AppendLine();
+            if (!string.IsNullOrWhiteSpace(rule.Disallow))
+                sb.Append("Disallow: ").Append(NormalizeRoute(rule.Disallow!)).AppendLine();
+            else
+                sb.Append("Allow: ").Append(NormalizeRoute(rule.Allow ?? "/")).AppendLine();
+        }
+
+        sb.AppendLine(AgentBlockEnd);
+        return sb.ToString();
+    }
+
+    private static string? WriteApiCatalog(string siteRoot, string? baseUrl, AgentApiCatalogSpec spec, List<string> warnings)
+    {
+        var output = string.IsNullOrWhiteSpace(spec.OutputPath) ? ".well-known/api-catalog" : spec.OutputPath!;
+        var outputPath = ResolveSitePath(siteRoot, output);
+        var entries = spec.Entries?.Where(static e => !string.IsNullOrWhiteSpace(e.Anchor)).ToList() ?? new List<AgentApiCatalogEntrySpec>();
+        if (entries.Count == 0)
+        {
+            var apiIndex = Path.Combine(siteRoot, "api", "index.json");
+            if (File.Exists(apiIndex))
+            {
+                entries.Add(new AgentApiCatalogEntrySpec
+                {
+                    Anchor = "/api/",
+                    ServiceDesc = "/api/index.json",
+                    ServiceDoc = "/api/",
+                    Title = "API Reference"
+                });
+            }
+        }
+
+        if (entries.Count == 0)
+        {
+            warnings.Add("API catalog enabled but no entries were configured or inferred.");
+            return null;
+        }
+
+        var linkset = new JsonArray();
+        foreach (var entry in entries)
+        {
+            var item = new JsonObject
+            {
+                ["anchor"] = ToAbsoluteUrl(baseUrl, entry.Anchor)
+            };
+            AddLinkArray(item, "service-desc", baseUrl, entry.ServiceDesc, "application/json", entry.Title);
+            AddLinkArray(item, "service-doc", baseUrl, entry.ServiceDoc, "text/html", entry.Title);
+            AddLinkArray(item, "status", baseUrl, entry.Status, "application/json", "Status");
+            linkset.Add(item);
+        }
+
+        var root = new JsonObject { ["linkset"] = linkset };
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        File.WriteAllText(outputPath, root.ToJsonString(WebJson.Options));
+        return outputPath;
+    }
+
+    private static string? WriteAgentSkills(string siteRoot, string? baseUrl, string siteName, AgentSkillsDiscoverySpec spec, List<string> warnings)
+    {
+        var indexPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.IndexPath) ? ".well-known/agent-skills/index.json" : spec.IndexPath!);
+        var skillSpecs = spec.Skills?.ToList() ?? new List<AgentSkillSpec>();
+        if (skillSpecs.Count == 0)
+        {
+            skillSpecs.Add(new AgentSkillSpec
+            {
+                Name = "site-assistant",
+                Type = "skill-md",
+                Description = $"Use {siteName} documentation and API discovery resources.",
+                Content = BuildDefaultSkill(siteName, baseUrl)
+            });
+        }
+
+        var skills = new JsonArray();
+        foreach (var skill in skillSpecs)
+        {
+            var name = Slugify(string.IsNullOrWhiteSpace(skill.Name) ? "site-assistant" : skill.Name);
+            var content = ResolveSkillContent(skill);
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                warnings.Add($"Agent skill '{name}' has no content or source file.");
+                continue;
+            }
+
+            var url = string.IsNullOrWhiteSpace(skill.Url)
+                ? $"/.well-known/agent-skills/{name}/SKILL.md"
+                : skill.Url!.Trim();
+
+            if (url.StartsWith("/", StringComparison.Ordinal))
+            {
+                var skillPath = ResolveSitePath(siteRoot, url);
+                Directory.CreateDirectory(Path.GetDirectoryName(skillPath)!);
+                File.WriteAllText(skillPath, content);
+            }
+
+            skills.Add(new JsonObject
+            {
+                ["name"] = name,
+                ["type"] = string.IsNullOrWhiteSpace(skill.Type) ? "skill-md" : skill.Type.Trim(),
+                ["description"] = string.IsNullOrWhiteSpace(skill.Description) ? $"Use {siteName}." : skill.Description.Trim(),
+                ["url"] = url,
+                ["digest"] = "sha256:" + Sha256Hex(content)
+            });
+        }
+
+        var root = new JsonObject
+        {
+            ["$schema"] = AgentSkillsSchema,
+            ["skills"] = skills
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(indexPath)!);
+        File.WriteAllText(indexPath, root.ToJsonString(WebJson.Options));
+        return indexPath;
+    }
+
+    private static string[] WriteAgentsJson(string siteRoot, string? baseUrl, string siteName, AgentReadinessSpec spec, List<string> warnings)
+    {
+        var config = spec.AgentsJson ?? new AgentDiscoveryDocumentSpec();
+        var output = string.IsNullOrWhiteSpace(config.OutputPath) ? "agents.json" : config.OutputPath!;
+        var wellKnown = string.IsNullOrWhiteSpace(config.WellKnownOutputPath) ? ".well-known/agents.json" : config.WellKnownOutputPath!;
+        var paths = new[] { output, wellKnown }
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var resources = new JsonObject
+        {
+            ["robots"] = ToAbsoluteUrl(baseUrl, "/robots.txt"),
+            ["sitemap"] = ToAbsoluteUrl(baseUrl, "/sitemap.xml"),
+            ["llms"] = File.Exists(Path.Combine(siteRoot, "llms.txt")) ? ToAbsoluteUrl(baseUrl, "/llms.txt") : null,
+            ["apiCatalog"] = spec.ApiCatalog?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/api-catalog") : null,
+            ["agentSkills"] = spec.AgentSkills?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/agent-skills/index.json") : null,
+            ["mcpServerCard"] = spec.McpServerCard?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/mcp/server-card.json") : null,
+            ["a2aAgentCard"] = spec.A2AAgentCard?.Enabled == true ? ToAbsoluteUrl(baseUrl, "/.well-known/agent-card.json") : null
+        };
+
+        var root = new JsonObject
+        {
+            ["name"] = siteName,
+            ["description"] = string.IsNullOrWhiteSpace(config.Description)
+                ? $"Agent-facing discovery metadata for {siteName}."
+                : config.Description!.Trim(),
+            ["url"] = string.IsNullOrWhiteSpace(baseUrl) ? null : baseUrl,
+            ["resources"] = resources,
+            ["capabilities"] = new JsonObject
+            {
+                ["contentNegotiation"] = spec.MarkdownNegotiation ? "text/markdown" : null,
+                ["contentSignals"] = spec.ContentSignals?.Enabled == true,
+                ["webMcp"] = spec.WebMcp
+            }
+        };
+
+        var written = new List<string>();
+        foreach (var path in paths)
+        {
+            var outputPath = ResolveSitePath(siteRoot, path);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            File.WriteAllText(outputPath, root.ToJsonString(WebJson.Options));
+            written.Add(outputPath);
+        }
+
+        if (written.Count == 0)
+            warnings.Add("agents.json enabled but no output paths were configured.");
+
+        return written.ToArray();
+    }
+
+    private static string? WriteA2AAgentCard(string siteRoot, string? baseUrl, string siteName, AgentA2ACardSpec spec, List<string> warnings)
+    {
+        var outputPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.OutputPath) ? ".well-known/agent-card.json" : spec.OutputPath!);
+        var skills = new JsonArray();
+        var skillSpecs = spec.Skills?.Where(static skill => !string.IsNullOrWhiteSpace(skill.Name) || !string.IsNullOrWhiteSpace(skill.Id)).ToArray() ?? Array.Empty<AgentA2ASkillSpec>();
+        if (skillSpecs.Length == 0)
+        {
+            warnings.Add("A2A Agent Card enabled without explicit skills; writing a documentation discovery skill.");
+            skillSpecs = new[]
+            {
+                new AgentA2ASkillSpec
+                {
+                    Id = "documentation-discovery",
+                    Name = "Documentation discovery",
+                    Description = $"Find public documentation, sitemap, llms.txt, and API reference resources for {siteName}.",
+                    Tags = new[] { "documentation", "discovery" }
+                }
+            };
+        }
+
+        foreach (var skill in skillSpecs)
+        {
+            skills.Add(new JsonObject
+            {
+                ["id"] = Slugify(string.IsNullOrWhiteSpace(skill.Id) ? skill.Name : skill.Id),
+                ["name"] = string.IsNullOrWhiteSpace(skill.Name) ? "Documentation discovery" : skill.Name.Trim(),
+                ["description"] = string.IsNullOrWhiteSpace(skill.Description) ? $"Use {siteName} public documentation." : skill.Description.Trim(),
+                ["tags"] = new JsonArray((skill.Tags ?? Array.Empty<string>()).Select(tag => JsonValue.Create(tag)).ToArray())
+            });
+        }
+
+        var root = new JsonObject
+        {
+            ["name"] = string.IsNullOrWhiteSpace(spec.Name) ? siteName : spec.Name!.Trim(),
+            ["description"] = string.IsNullOrWhiteSpace(spec.Description)
+                ? $"Public documentation and discovery surface for {siteName}."
+                : spec.Description!.Trim(),
+            ["url"] = ToAbsoluteUrl(baseUrl, string.IsNullOrWhiteSpace(spec.Url) ? "/" : spec.Url!),
+            ["version"] = string.IsNullOrWhiteSpace(spec.Version) ? "1.0.0" : spec.Version!.Trim(),
+            ["documentationUrl"] = string.IsNullOrWhiteSpace(spec.DocumentationUrl) ? ToAbsoluteUrl(baseUrl, "/docs/") : ToAbsoluteUrl(baseUrl, spec.DocumentationUrl!),
+            ["capabilities"] = new JsonObject
+            {
+                ["streaming"] = false,
+                ["pushNotifications"] = false
+            },
+            ["defaultInputModes"] = new JsonArray((spec.DefaultInputModes ?? Array.Empty<string>()).Select(mode => JsonValue.Create(mode)).ToArray()),
+            ["defaultOutputModes"] = new JsonArray((spec.DefaultOutputModes ?? Array.Empty<string>()).Select(mode => JsonValue.Create(mode)).ToArray()),
+            ["skills"] = skills
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        File.WriteAllText(outputPath, root.ToJsonString(WebJson.Options));
+        return outputPath;
+    }
+
+    private static string? WriteMcpServerCard(string siteRoot, string? baseUrl, string siteName, AgentMcpServerCardSpec spec, List<string> warnings)
+    {
+        if (string.IsNullOrWhiteSpace(spec.Endpoint))
+        {
+            warnings.Add("MCP Server Card enabled but no endpoint was configured.");
+            return null;
+        }
+
+        var outputPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.OutputPath) ? ".well-known/mcp/server-card.json" : spec.OutputPath!);
+        var root = new JsonObject
+        {
+            ["serverInfo"] = new JsonObject
+            {
+                ["name"] = string.IsNullOrWhiteSpace(spec.Name) ? siteName : spec.Name!.Trim(),
+                ["version"] = string.IsNullOrWhiteSpace(spec.Version) ? "1.0.0" : spec.Version!.Trim()
+            },
+            ["transport"] = new JsonObject
+            {
+                ["type"] = string.IsNullOrWhiteSpace(spec.Transport) ? "streamable-http" : spec.Transport!.Trim(),
+                ["endpoint"] = ToAbsoluteUrl(baseUrl, spec.Endpoint!)
+            },
+            ["capabilities"] = new JsonObject
+            {
+                ["tools"] = spec.Tools,
+                ["resources"] = spec.Resources,
+                ["prompts"] = spec.Prompts
+            }
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        File.WriteAllText(outputPath, root.ToJsonString(WebJson.Options));
+        return outputPath;
+    }
+
+    private static string UpdateHeaders(string siteRoot, AgentReadinessSpec spec, List<HeaderLinkTarget> linkTargets)
+    {
+        var headersPath = spec.HeadersPath;
+        var path = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(headersPath) ? "_headers" : headersPath!);
+        var existing = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        var cleaned = RemoveGeneratedBlock(existing).TrimEnd();
+        var sb = new StringBuilder();
+        sb.AppendLine(HeadersBlockStart);
+        var security = spec.SecurityHeaders ?? new AgentSecurityHeadersSpec();
+        if (linkTargets.Count > 0)
+        {
+            sb.AppendLine("/");
+            AppendSecurityHeaders(sb, security);
+            foreach (var target in linkTargets.DistinctBy(static t => t.Href, StringComparer.OrdinalIgnoreCase))
+            {
+                sb.Append("  Link: <").Append(target.Href).Append(">; rel=\"").Append(target.Rel).Append("\"");
+                if (!string.IsNullOrWhiteSpace(target.Type))
+                    sb.Append("; type=\"").Append(target.Type).Append("\"");
+                sb.AppendLine();
+            }
+        }
+
+        sb.AppendLine("/.well-known/api-catalog");
+        sb.AppendLine("  Content-Type: application/linkset+json; profile=\"https://www.rfc-editor.org/info/rfc9727\"");
+        AppendCorsHeaders(sb, security);
+        sb.AppendLine("/.well-known/agent-skills/index.json");
+        sb.AppendLine("  Content-Type: application/json");
+        AppendCorsHeaders(sb, security);
+        sb.AppendLine("/agents.json");
+        sb.AppendLine("  Content-Type: application/json");
+        AppendCorsHeaders(sb, security);
+        sb.AppendLine("/.well-known/agents.json");
+        sb.AppendLine("  Content-Type: application/json");
+        AppendCorsHeaders(sb, security);
+        sb.AppendLine("/.well-known/agent-card.json");
+        sb.AppendLine("  Content-Type: application/json");
+        AppendCorsHeaders(sb, security);
+        sb.AppendLine("/.well-known/mcp/server-card.json");
+        sb.AppendLine("  Content-Type: application/json");
+        AppendCorsHeaders(sb, security);
+        sb.AppendLine(HeadersBlockEnd);
+
+        var next = string.IsNullOrWhiteSpace(cleaned)
+            ? sb.ToString()
+            : cleaned + Environment.NewLine + Environment.NewLine + sb;
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, next);
+        return path;
+    }
+
+    private static void AppendSecurityHeaders(StringBuilder sb, AgentSecurityHeadersSpec security)
+    {
+        if (!security.Enabled)
+            return;
+
+        if (security.Hsts && !string.IsNullOrWhiteSpace(security.HstsValue))
+            sb.Append("  Strict-Transport-Security: ").Append(security.HstsValue!.Trim()).AppendLine();
+        if (security.ContentSecurityPolicy && !string.IsNullOrWhiteSpace(security.ContentSecurityPolicyValue))
+            sb.Append("  Content-Security-Policy: ").Append(security.ContentSecurityPolicyValue!.Trim()).AppendLine();
+        if (security.XContentTypeOptions)
+            sb.AppendLine("  X-Content-Type-Options: nosniff");
+        if (security.XFrameOptions)
+            sb.AppendLine("  X-Frame-Options: DENY");
+        if (security.ReferrerPolicy)
+            sb.Append("  Referrer-Policy: ").Append(string.IsNullOrWhiteSpace(security.ReferrerPolicyValue) ? "strict-origin-when-cross-origin" : security.ReferrerPolicyValue!.Trim()).AppendLine();
+    }
+
+    private static void AppendCorsHeaders(StringBuilder sb, AgentSecurityHeadersSpec security)
+    {
+        if (security.Enabled && security.CorsForWellKnown && !string.IsNullOrWhiteSpace(security.CorsAllowOrigin))
+            sb.Append("  Access-Control-Allow-Origin: ").Append(security.CorsAllowOrigin!.Trim()).AppendLine();
+    }
+
+    private static string RemoveGeneratedBlock(string text)
+        => string.IsNullOrWhiteSpace(text) ? string.Empty : GeneratedBlockRegex.Replace(text, string.Empty);
+
+    private static bool ValidateSitemap(string path, out string message)
+    {
+        if (!File.Exists(path))
+        {
+            message = "sitemap.xml is missing.";
+            return false;
+        }
+
+        try
+        {
+            var doc = XDocument.Load(path);
+            var hasLoc = doc.Descendants().Any(static element => element.Name.LocalName.Equals("loc", StringComparison.OrdinalIgnoreCase));
+            message = hasLoc ? "sitemap.xml exists with URL entries." : "sitemap.xml has no loc entries.";
+            return hasLoc;
+        }
+        catch (Exception ex)
+        {
+            message = $"sitemap.xml could not be parsed: {ex.Message}";
+            return false;
+        }
+    }
+
+    private static bool ValidateApiCatalog(string path, out string message)
+    {
+        if (!File.Exists(path))
+        {
+            message = "API catalog not found.";
+            return false;
+        }
+
+        var valid = ValidateApiCatalogText(File.ReadAllText(path));
+        message = valid ? "API catalog contains a linkset array." : "API catalog must contain a linkset array.";
+        return valid;
+    }
+
+    private static bool ValidateApiCatalogText(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return doc.RootElement.TryGetProperty("linkset", out var linkset) &&
+                   linkset.ValueKind == JsonValueKind.Array &&
+                   linkset.GetArrayLength() > 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool ValidateAgentSkillsIndex(string path, string siteRoot, out string message)
+    {
+        if (!File.Exists(path))
+        {
+            message = "Agent Skills discovery index not found.";
+            return false;
+        }
+
+        var text = File.ReadAllText(path);
+        if (!ValidateAgentSkillsIndexText(text))
+        {
+            message = "Agent Skills index must include schema and skills array.";
+            return false;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            var checkedDigest = false;
+            foreach (var skill in doc.RootElement.GetProperty("skills").EnumerateArray())
+            {
+                var url = skill.TryGetProperty("url", out var urlElement) ? urlElement.GetString() : null;
+                var digest = skill.TryGetProperty("digest", out var digestElement) ? digestElement.GetString() : null;
+                if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(digest) || !url.StartsWith("/", StringComparison.Ordinal))
+                    continue;
+
+                var skillPath = ResolveSitePath(siteRoot, url);
+                if (!File.Exists(skillPath))
+                    continue;
+
+                checkedDigest = true;
+                var actual = "sha256:" + Sha256Hex(File.ReadAllText(skillPath));
+                if (!string.Equals(actual, digest, StringComparison.OrdinalIgnoreCase))
+                {
+                    message = $"Agent skill digest mismatch for {url}.";
+                    return false;
+                }
+            }
+
+            message = checkedDigest
+                ? "Agent Skills index is valid and local digests match."
+                : "Agent Skills index is valid.";
+            return true;
+        }
+        catch
+        {
+            message = "Agent Skills index could not be parsed.";
+            return false;
+        }
+    }
+
+    private static bool ValidateAgentSkillsIndexText(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return doc.RootElement.TryGetProperty("$schema", out var schema) &&
+                   string.Equals(schema.GetString(), AgentSkillsSchema, StringComparison.OrdinalIgnoreCase) &&
+                   doc.RootElement.TryGetProperty("skills", out var skills) &&
+                   skills.ValueKind == JsonValueKind.Array &&
+                   skills.GetArrayLength() > 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool ValidateAgentsJson(string path, out string message)
+    {
+        if (!File.Exists(path))
+        {
+            message = "agents.json not found.";
+            return false;
+        }
+
+        var valid = ValidateAgentsJsonText(File.ReadAllText(path));
+        message = valid ? "agents.json includes name and resources." : "agents.json must include name and resources.";
+        return valid;
+    }
+
+    private static bool ValidateAgentsJsonText(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return JsonLdObjectHasNonEmptyValue(doc.RootElement, "name") &&
+                   doc.RootElement.TryGetProperty("resources", out var resources) &&
+                   resources.ValueKind == JsonValueKind.Object;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool ValidateA2AAgentCard(string path, out string message)
+    {
+        if (!File.Exists(path))
+        {
+            message = "A2A Agent Card not found.";
+            return false;
+        }
+
+        var valid = ValidateA2AAgentCardText(File.ReadAllText(path));
+        message = valid ? "A2A Agent Card includes name, description, url, version, and skills." : "A2A Agent Card is missing required fields.";
+        return valid;
+    }
+
+    private static bool ValidateA2AAgentCardText(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return JsonLdObjectHasNonEmptyValue(doc.RootElement, "name") &&
+                   JsonLdObjectHasNonEmptyValue(doc.RootElement, "description") &&
+                   JsonLdObjectHasNonEmptyValue(doc.RootElement, "url") &&
+                   JsonLdObjectHasNonEmptyValue(doc.RootElement, "version") &&
+                   doc.RootElement.TryGetProperty("skills", out var skills) &&
+                   skills.ValueKind == JsonValueKind.Array;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool ValidateMcpServerCard(string path, out string message)
+    {
+        if (!File.Exists(path))
+        {
+            message = "MCP Server Card not found.";
+            return false;
+        }
+
+        var valid = ValidateMcpServerCardText(File.ReadAllText(path));
+        message = valid ? "MCP Server Card includes serverInfo and transport endpoint." : "MCP Server Card must include serverInfo and transport.endpoint.";
+        return valid;
+    }
+
+    private static bool ValidateMcpServerCardText(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return doc.RootElement.TryGetProperty("serverInfo", out var serverInfo) &&
+                   serverInfo.ValueKind == JsonValueKind.Object &&
+                   doc.RootElement.TryGetProperty("transport", out var transport) &&
+                   transport.ValueKind == JsonValueKind.Object &&
+                   transport.TryGetProperty("endpoint", out var endpoint) &&
+                   !string.IsNullOrWhiteSpace(endpoint.GetString());
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool HasRobotsUserAgent(string text)
+        => text.Contains("User-agent:", StringComparison.OrdinalIgnoreCase) ||
+           text.Contains("User-Agent:", StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasContentSignals(string text)
+        => text.Contains("Content-Signal:", StringComparison.OrdinalIgnoreCase) ||
+           text.Contains("Content-signal:", StringComparison.OrdinalIgnoreCase);
+
+    private static bool LooksLikeSitemap(string text)
+        => text.Contains("<urlset", StringComparison.OrdinalIgnoreCase) ||
+           text.Contains("<sitemapindex", StringComparison.OrdinalIgnoreCase);
+
+    private static void AddSecurityHeaderChecks(List<WebAgentReadinessCheck> checks, string headersText, string target)
+    {
+        AddCheck(checks, "security-hsts", "security-trust", "HSTS",
+            headersText.Contains("Strict-Transport-Security:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            headersText.Contains("Strict-Transport-Security:", StringComparison.OrdinalIgnoreCase)
+                ? "Static host headers include HSTS."
+                : "Static host headers do not include Strict-Transport-Security.",
+            target);
+        AddCheck(checks, "security-csp", "security-trust", "CSP",
+            headersText.Contains("Content-Security-Policy:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            headersText.Contains("Content-Security-Policy:", StringComparison.OrdinalIgnoreCase)
+                ? "Static host headers include Content-Security-Policy."
+                : "Static host headers do not include Content-Security-Policy.",
+            target);
+        AddCheck(checks, "security-xcto", "security-trust", "X-Content-Type-Options",
+            headersText.Contains("X-Content-Type-Options:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            headersText.Contains("X-Content-Type-Options:", StringComparison.OrdinalIgnoreCase)
+                ? "Static host headers include X-Content-Type-Options."
+                : "Static host headers do not include X-Content-Type-Options.",
+            target);
+        AddCheck(checks, "security-xfo", "security-trust", "X-Frame-Options",
+            headersText.Contains("X-Frame-Options:", StringComparison.OrdinalIgnoreCase) ||
+            headersText.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            headersText.Contains("X-Frame-Options:", StringComparison.OrdinalIgnoreCase) ||
+            headersText.Contains("frame-ancestors", StringComparison.OrdinalIgnoreCase)
+                ? "Static host headers include clickjacking protection."
+                : "Static host headers do not include X-Frame-Options or CSP frame-ancestors.",
+            target);
+        AddCheck(checks, "security-referrer-policy", "security-trust", "Referrer-Policy",
+            headersText.Contains("Referrer-Policy:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            headersText.Contains("Referrer-Policy:", StringComparison.OrdinalIgnoreCase)
+                ? "Static host headers include Referrer-Policy."
+                : "Static host headers do not include Referrer-Policy.",
+            target);
+        AddCheck(checks, "security-cors", "security-trust", "CORS",
+            headersText.Contains("Access-Control-Allow-Origin:", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
+            headersText.Contains("Access-Control-Allow-Origin:", StringComparison.OrdinalIgnoreCase)
+                ? "Agent discovery resources include CORS headers."
+                : "No Access-Control-Allow-Origin header configured for agent discovery resources.",
+            target);
+    }
+
+    private static void AddRemoteSecurityHeaderChecks(List<WebAgentReadinessCheck> checks, HttpResponseMessage? response, string target)
+    {
+        AddCheck(checks, "security-hsts", "security-trust", "HSTS",
+            HeaderExists(response, "Strict-Transport-Security") ? "pass" : "fail",
+            HeaderExists(response, "Strict-Transport-Security") ? "Homepage response includes HSTS." : "Homepage response does not include HSTS.",
+            target);
+        AddCheck(checks, "security-csp", "security-trust", "CSP",
+            HeaderExists(response, "Content-Security-Policy") ? "pass" : "fail",
+            HeaderExists(response, "Content-Security-Policy") ? "Homepage response includes CSP." : "Homepage response does not include CSP.",
+            target);
+        AddCheck(checks, "security-xcto", "security-trust", "X-Content-Type-Options",
+            HeaderExists(response, "X-Content-Type-Options") ? "pass" : "fail",
+            HeaderExists(response, "X-Content-Type-Options") ? "Homepage response includes X-Content-Type-Options." : "Homepage response does not include X-Content-Type-Options.",
+            target);
+        AddCheck(checks, "security-xfo", "security-trust", "X-Frame-Options",
+            HeaderExists(response, "X-Frame-Options") || HeaderContains(response, "Content-Security-Policy", "frame-ancestors") ? "pass" : "fail",
+            HeaderExists(response, "X-Frame-Options") || HeaderContains(response, "Content-Security-Policy", "frame-ancestors") ? "Homepage response includes clickjacking protection." : "Homepage response does not include X-Frame-Options or CSP frame-ancestors.",
+            target);
+        AddCheck(checks, "security-referrer-policy", "security-trust", "Referrer-Policy",
+            HeaderExists(response, "Referrer-Policy") ? "pass" : "fail",
+            HeaderExists(response, "Referrer-Policy") ? "Homepage response includes Referrer-Policy." : "Homepage response does not include Referrer-Policy.",
+            target);
+        AddCheck(checks, "security-cors", "security-trust", "CORS",
+            HeaderExists(response, "Access-Control-Allow-Origin") ? "pass" : "warn",
+            HeaderExists(response, "Access-Control-Allow-Origin") ? "Homepage response includes CORS." : "Homepage response does not include CORS; this is usually only required on API or discovery resources.",
+            target);
+    }
+
+    private static void AddHtmlSemanticsChecks(List<WebAgentReadinessCheck> checks, string html, string? target)
+    {
+        var hasHtml = !string.IsNullOrWhiteSpace(html);
+        AddCheck(checks, "ssr-detection", "content-semantics", "SSR Detection",
+            hasHtml && Regex.IsMatch(html, @"<body\b[^>]*>[\s\S]*\w", RegexOptions.IgnoreCase) ? "pass" : "fail",
+            hasHtml ? "Rendered HTML contains body content." : "No rendered HTML content was available.",
+            target);
+        AddCheck(checks, "language", "content-semantics", "Language",
+            hasHtml && Regex.IsMatch(html, @"<html\b[^>]*\blang\s*=", RegexOptions.IgnoreCase) ? "pass" : "fail",
+            "HTML document should declare a lang attribute.",
+            target);
+        AddCheck(checks, "meta-robots", "ai-content-discovery", "Meta Robots",
+            hasHtml && Regex.IsMatch(html, @"<meta\b[^>]*name\s*=\s*([""']?)robots\1(?:\s|/|>)", RegexOptions.IgnoreCase) ? "pass" : "warn",
+            hasHtml && Regex.IsMatch(html, @"<meta\b[^>]*name\s*=\s*([""']?)robots\1(?:\s|/|>)", RegexOptions.IgnoreCase)
+                ? "HTML includes a meta robots directive."
+                : "No meta robots directive found on the homepage.",
+            target);
+        AddCheck(checks, "semantic-html", "content-semantics", "Semantic HTML",
+            hasHtml && Regex.IsMatch(html, @"<(main|article|section|header|footer|nav)\b", RegexOptions.IgnoreCase) ? "pass" : "fail",
+            "HTML should expose semantic landmarks for agents and accessibility trees.",
+            target);
+        AddCheck(checks, "aria-landmarks", "content-semantics", "ARIA Landmarks",
+            hasHtml && (Regex.IsMatch(html, @"<(main|nav|header|footer)\b", RegexOptions.IgnoreCase) ||
+                        Regex.IsMatch(html, @"\brole\s*=\s*[""'](main|navigation|banner|contentinfo)[""']", RegexOptions.IgnoreCase)) ? "pass" : "fail",
+            "HTML should expose navigation/main/footer landmarks.",
+            target);
+        AddCheck(checks, "heading-hierarchy", "content-semantics", "Heading Hierarchy",
+            HasReasonableHeadingHierarchy(html) ? "pass" : "warn",
+            HasReasonableHeadingHierarchy(html) ? "Headings include an h1 and do not skip the first level." : "Could not confirm a clean heading hierarchy from homepage HTML.",
+            target);
+        AddCheck(checks, "link-text", "content-semantics", "Link Text",
+            hasHtml && !Regex.IsMatch(html, @"<a\b(?:(?!</a>).)*>\s*(click here|read more|more)\s*</a>", RegexOptions.IgnoreCase | RegexOptions.Singleline) ? "pass" : "warn",
+            "Avoid generic link text so agents can infer navigation intent.",
+            target);
+        AddCheck(checks, "alt-text", "content-semantics", "Alt Text",
+            hasHtml && !Regex.IsMatch(html, @"<img\b(?![^>]*\balt\s*=)", RegexOptions.IgnoreCase) ? "pass" : "warn",
+            "Images should include alt text or an explicit empty alt.",
+            target);
+        AddCheck(checks, "question-headings", "content-semantics", "Question Headings",
+            hasHtml && Regex.IsMatch(html, @"<h[1-6]\b[^>]*>[^<]*\?", RegexOptions.IgnoreCase) ? "pass" : "info",
+            "Question-style headings are useful for AI answer extraction when the page has FAQ content.",
+            target);
+        AddStructuredDataChecks(checks, html, target);
+    }
+
+    private static void AddStructuredDataChecks(List<WebAgentReadinessCheck> checks, string html, string? target)
+    {
+        var jsonLd = ExtractJsonLd(html).ToArray();
+        AddCheck(checks, "json-ld", "ai-search-signals", "JSON-LD",
+            jsonLd.Length > 0 ? "pass" : "fail",
+            jsonLd.Length > 0 ? "HTML includes JSON-LD." : "No JSON-LD structured data found.",
+            target);
+        AddCheck(checks, "schema-types", "ai-search-signals", "Schema.org Types",
+            jsonLd.Any(static item => item.Contains("\"@type\"", StringComparison.OrdinalIgnoreCase)) ? "pass" : "fail",
+            "JSON-LD should include Schema.org @type values.",
+            target);
+        AddCheck(checks, "entity-linking", "ai-search-signals", "Entity Linking",
+            jsonLd.Any(static item => item.Contains("\"sameAs\"", StringComparison.OrdinalIgnoreCase) ||
+                                      item.Contains("\"@id\"", StringComparison.OrdinalIgnoreCase)) ||
+            html.Contains("sameAs", StringComparison.OrdinalIgnoreCase) ||
+            html.Contains("\"@id\"", StringComparison.OrdinalIgnoreCase) ? "pass" : "warn",
+            "Organization/content entities should include sameAs or @id links where possible.",
+            target);
+        AddCheck(checks, "breadcrumb-list", "ai-search-signals", "BreadcrumbList",
+            jsonLd.Any(static item => item.Contains("BreadcrumbList", StringComparison.OrdinalIgnoreCase)) ||
+            html.Contains("BreadcrumbList", StringComparison.OrdinalIgnoreCase) ? "pass" : "warn",
+            "BreadcrumbList structured data helps agents resolve page context.",
+            target);
+        AddCheck(checks, "organization-schema", "ai-search-signals", "Organization Schema",
+            jsonLd.Any(static item => item.Contains("Organization", StringComparison.OrdinalIgnoreCase)) ? "pass" : "warn",
+            "Organization schema helps identify the publisher.",
+            target);
+        AddCheck(checks, "faqpage-schema", "ai-search-signals", "FAQPage Schema",
+            jsonLd.Any(static item => item.Contains("FAQPage", StringComparison.OrdinalIgnoreCase)) ? "pass" : "info",
+            "FAQPage schema is useful when a page contains FAQ content.",
+            target);
+        AddCheck(checks, "author-attribution", "ai-search-signals", "Author Attribution",
+            jsonLd.Any(static item => item.Contains("\"author\"", StringComparison.OrdinalIgnoreCase) ||
+                                      item.Contains("\"publisher\"", StringComparison.OrdinalIgnoreCase) ||
+                                      item.Contains("Organization", StringComparison.OrdinalIgnoreCase)) ? "pass" : "warn",
+            "Content should expose author or publisher attribution.",
+            target);
+        AddCheck(checks, "content-freshness", "ai-content-discovery", "Content Freshness",
+            jsonLd.Any(static item => item.Contains("dateModified", StringComparison.OrdinalIgnoreCase) ||
+                                      item.Contains("datePublished", StringComparison.OrdinalIgnoreCase)) ||
+            Regex.IsMatch(html, @"<time\b[^>]*datetime\s*=", RegexOptions.IgnoreCase) ? "pass" : "warn",
+            "dateModified, datePublished, or time[datetime] helps agents judge freshness.",
+            target);
+    }
+
+    private static HtmlReadResult ReadFirstHtml(string siteRoot)
+    {
+        var preferred = new[] { Path.Combine(siteRoot, "index.html"), Path.Combine(siteRoot, "index.htm") };
+        var path = preferred.FirstOrDefault(File.Exists) ??
+                   (Directory.Exists(siteRoot)
+                       ? Directory.EnumerateFiles(siteRoot, "*.html", SearchOption.AllDirectories).FirstOrDefault()
+                       : null);
+        return string.IsNullOrWhiteSpace(path)
+            ? new HtmlReadResult(string.Empty, siteRoot)
+            : new HtmlReadResult(File.ReadAllText(path), path);
+    }
+
+    private static IEnumerable<string> ExtractJsonLd(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            yield break;
+
+        foreach (Match match in Regex.Matches(html, @"<script\b[^>]*type\s*=\s*([""']?)application/ld\+json\1(?:\s[^>]*)?>(?<json>[\s\S]*?)</script>", RegexOptions.IgnoreCase))
+            yield return match.Groups["json"].Value;
+    }
+
+    private static bool HasReasonableHeadingHierarchy(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return false;
+
+        var levels = Regex.Matches(html, @"<h(?<level>[1-6])\b", RegexOptions.IgnoreCase)
+            .Select(match => int.TryParse(match.Groups["level"].Value, out var level) ? level : 0)
+            .Where(static level => level > 0)
+            .ToArray();
+        return levels.Length > 0 && levels[0] == 1 && levels.Contains(1);
+    }
+
+    private static bool JsonLdObjectHasNonEmptyValue(JsonElement obj, string propertyName)
+        => obj.ValueKind == JsonValueKind.Object &&
+           obj.TryGetProperty(propertyName, out var value) &&
+           value.ValueKind != JsonValueKind.Null &&
+           value.ValueKind != JsonValueKind.Undefined &&
+           !string.IsNullOrWhiteSpace(value.ToString());
+
+    private static bool HeaderExists(HttpResponseMessage? response, string name)
+        => response?.Headers.Contains(name) == true || response?.Content.Headers.Contains(name) == true;
+
+    private static bool HeaderContains(HttpResponseMessage? response, string name, string value)
+        => response?.Headers.TryGetValues(name, out var values) == true &&
+           values.Any(header => header.Contains(value, StringComparison.OrdinalIgnoreCase));
+
+    private static string? ResolveOpenApiRoute(string siteRoot, AgentOpenApiSpec? spec)
+    {
+        if (!string.IsNullOrWhiteSpace(spec?.Path))
+        {
+            var configured = spec.Path!.Trim();
+            if (Uri.TryCreate(configured, UriKind.Absolute, out _))
+                return configured;
+            return File.Exists(ResolveSitePath(siteRoot, configured)) ? NormalizeRoute(configured) : null;
+        }
+
+        foreach (var candidate in new[] { "/openapi.json", "/api/openapi.json", "/swagger.json", "/api/swagger.json", "/.well-known/openapi.json" })
+        {
+            if (File.Exists(ResolveSitePath(siteRoot, candidate)))
+                return candidate;
+        }
+
+        return null;
+    }
+
+    private static async Task<OpenApiScanResult> TryFindOpenApiAsync(HttpClient http, string baseUrl, CancellationToken cancellationToken)
+    {
+        foreach (var candidate in new[] { "/openapi.json", "/api/openapi.json", "/swagger.json", "/api/swagger.json", "/.well-known/openapi.json" })
+        {
+            var url = CombineUrl(baseUrl, candidate);
+            var result = await TryGetTextAsync(http, url, null, cancellationToken).ConfigureAwait(false);
+            if (result.Success && LooksLikeOpenApi(result.Text))
+                return new OpenApiScanResult(true, url);
+        }
+
+        return new OpenApiScanResult(false, null);
+    }
+
+    private static bool LooksLikeOpenApi(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return doc.RootElement.TryGetProperty("openapi", out _) ||
+                   doc.RootElement.TryGetProperty("swagger", out _);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void AddCheck(List<WebAgentReadinessCheck> checks, string id, string category, string name, string status, string message, string? target)
+        => checks.Add(new WebAgentReadinessCheck
+        {
+            Id = id,
+            Category = category,
+            Name = name,
+            Status = status,
+            Message = message,
+            Target = target
+        });
+
+    private static void AddLinkArray(JsonObject item, string rel, string? baseUrl, string? href, string type, string? title)
+    {
+        if (string.IsNullOrWhiteSpace(href))
+            return;
+
+        var link = new JsonObject
+        {
+            ["href"] = ToAbsoluteUrl(baseUrl, href),
+            ["type"] = type
+        };
+        if (!string.IsNullOrWhiteSpace(title))
+            link["title"] = title.Trim();
+        item[rel] = new JsonArray(link);
+    }
+
+    private static string? ResolveSkillContent(AgentSkillSpec skill)
+    {
+        if (!string.IsNullOrWhiteSpace(skill.SourcePath))
+        {
+            var sourcePath = Path.GetFullPath(skill.SourcePath.Trim().Trim('"'));
+            if (File.Exists(sourcePath))
+                return File.ReadAllText(sourcePath);
+        }
+
+        return skill.Content;
+    }
+
+    private static string BuildDefaultSkill(string siteName, string? baseUrl)
+    {
+        var url = string.IsNullOrWhiteSpace(baseUrl) ? "the site" : baseUrl!.TrimEnd('/');
+        return $"""
+        ---
+        name: site-assistant
+        description: Use {siteName} documentation, API catalog, sitemap, and llms resources.
+        ---
+
+        # {siteName} Site Assistant
+
+        Use this skill when answering questions about {siteName}.
+
+        - Prefer canonical pages from {url}.
+        - Check `/sitemap.xml` for public routes.
+        - Check `/llms.txt`, `/llms.json`, and `/llms-full.txt` when present for agent-readable summaries.
+        - Check `/.well-known/api-catalog` before assuming API documentation paths.
+        - Respect the site's `robots.txt` and Content-Signal preferences.
+        """;
+    }
+
+    private static async Task<HttpTextResult> TryGetTextAsync(HttpClient http, string url, string? accept, CancellationToken cancellationToken)
+    {
+        var result = await TrySendAsync(http, HttpMethod.Get, url, accept, cancellationToken).ConfigureAwait(false);
+        if (result.Response is null)
+            return new HttpTextResult(false, result.Message, string.Empty, null);
+
+        var text = string.Empty;
+        try
+        {
+            text = await result.Response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return new HttpTextResult(false, ex.Message, string.Empty, result.Response);
+        }
+
+        var success = (int)result.Response.StatusCode >= 200 && (int)result.Response.StatusCode < 300;
+        return new HttpTextResult(success, success ? $"HTTP {(int)result.Response.StatusCode}" : $"HTTP {(int)result.Response.StatusCode}", text, result.Response);
+    }
+
+    private static async Task<HttpResponseResult> TrySendAsync(HttpClient http, HttpMethod method, string url, string? accept, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(method, url);
+            if (!string.IsNullOrWhiteSpace(accept))
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+            var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var success = (int)response.StatusCode >= 200 && (int)response.StatusCode < 400;
+            return new HttpResponseResult(success, $"HTTP {(int)response.StatusCode}", response);
+        }
+        catch (Exception ex)
+        {
+            return new HttpResponseResult(false, ex.Message, null);
+        }
+    }
+
+    private static string NormalizeBaseUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        return value.Trim().TrimEnd('/');
+    }
+
+    private static string CombineUrl(string baseUrl, string route)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            return NormalizeRoute(route);
+        return baseUrl.TrimEnd('/') + "/" + NormalizeRoute(route).TrimStart('/');
+    }
+
+    private static string ToAbsoluteUrl(string? baseUrl, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+        if (Uri.TryCreate(value, UriKind.Absolute, out _))
+            return value.Trim();
+        return string.IsNullOrWhiteSpace(baseUrl) ? NormalizeRoute(value) : CombineUrl(baseUrl!, value);
+    }
+
+    private static string NormalizeRoute(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "/";
+        var trimmed = value.Trim().Replace('\\', '/');
+        return trimmed.StartsWith("/", StringComparison.Ordinal) ? trimmed : "/" + trimmed;
+    }
+
+    private static string ResolveSitePath(string siteRoot, string path)
+    {
+        var normalized = path.Trim().Trim('"').Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar);
+        return Path.GetFullPath(Path.Combine(siteRoot, normalized));
+    }
+
+    private static string Slugify(string value)
+    {
+        var sb = new StringBuilder();
+        foreach (var ch in value.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+                sb.Append(ch);
+            else if (ch == '-' || ch == '_' || char.IsWhiteSpace(ch))
+                sb.Append('-');
+        }
+
+        var slug = Regex.Replace(sb.ToString(), "-{2,}", "-").Trim('-');
+        return string.IsNullOrWhiteSpace(slug) ? "site-assistant" : slug;
+    }
+
+    private static string Sha256Hex(string content)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private sealed record HeaderLinkTarget(string Href, string Rel, string Type);
+    private sealed record HtmlReadResult(string Text, string Path);
+    private sealed record OpenApiScanResult(bool Success, string? Url);
+    private sealed record HttpTextResult(bool Success, string Message, string Text, HttpResponseMessage? Response);
+    private sealed record HttpResponseResult(bool Success, string Message, HttpResponseMessage? Response);
+}
+
+/// <summary>Options for preparing local agent-readiness artifacts.</summary>
+public sealed class WebAgentReadinessPrepareOptions
+{
+    /// <summary>Static site output directory.</summary>
+    public string SiteRoot { get; set; } = string.Empty;
+    /// <summary>Public base URL.</summary>
+    public string? BaseUrl { get; set; }
+    /// <summary>Site name.</summary>
+    public string? SiteName { get; set; }
+    /// <summary>Agent-readiness settings.</summary>
+    public AgentReadinessSpec? AgentReadiness { get; set; }
+}
+
+/// <summary>Options for verifying local agent-readiness artifacts.</summary>
+public sealed class WebAgentReadinessVerifyOptions
+{
+    /// <summary>Static site output directory.</summary>
+    public string SiteRoot { get; set; } = string.Empty;
+    /// <summary>Public base URL.</summary>
+    public string? BaseUrl { get; set; }
+    /// <summary>Agent-readiness settings.</summary>
+    public AgentReadinessSpec? AgentReadiness { get; set; }
+}
+
+/// <summary>Options for scanning a live site.</summary>
+public sealed class WebAgentReadinessScanOptions
+{
+    /// <summary>Public base URL to scan.</summary>
+    public string BaseUrl { get; set; } = string.Empty;
+    /// <summary>HTTP timeout in milliseconds.</summary>
+    public int TimeoutMs { get; set; } = 15000;
+}

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -2966,7 +2966,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "task": { "const": "agent-ready" },
+        "task": { "enum": ["agent-ready", "agentready"] },
         "id": { "type": "string" },
         "dependsOn": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
         "mode": { "type": "string" },

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -54,6 +54,7 @@
         { "$ref": "#/$defs/LlmsStep" },
         { "$ref": "#/$defs/CompatMatrixStep" },
         { "$ref": "#/$defs/SitemapStep" },
+        { "$ref": "#/$defs/AgentReadyStep" },
         { "$ref": "#/$defs/OptimizeStep" },
         { "$ref": "#/$defs/AuditStep" },
         { "$ref": "#/$defs/SeoDoctorStep" },
@@ -2960,6 +2961,37 @@
           ]
         }
       ]
+    },
+    "AgentReadyStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "task": { "const": "agent-ready" },
+        "id": { "type": "string" },
+        "dependsOn": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+        "mode": { "type": "string" },
+        "modes": { "type": "array", "items": { "type": "string" } },
+        "onlyModes": { "type": "array", "items": { "type": "string" } },
+        "only-modes": { "type": "array", "items": { "type": "string" } },
+        "skipModes": { "type": "array", "items": { "type": "string" } },
+        "skip-modes": { "type": "array", "items": { "type": "string" } },
+        "operation": { "type": "string", "enum": ["prepare", "verify", "scan"] },
+        "config": { "type": "string" },
+        "siteRoot": { "type": "string" },
+        "site-root": { "type": "string" },
+        "out": { "type": "string" },
+        "output": { "type": "string" },
+        "baseUrl": { "type": "string" },
+        "base-url": { "type": "string" },
+        "url": { "type": "string" },
+        "timeoutMs": { "type": "integer", "minimum": 1 },
+        "timeout-ms": { "type": "integer", "minimum": 1 },
+        "failOnFailures": { "type": "boolean" },
+        "fail-on-failures": { "type": "boolean" },
+        "headersPath": { "type": "string" },
+        "headers-path": { "type": "string" }
+      },
+      "required": ["task"]
     },
     "OptimizeStep": {
       "type": "object",

--- a/Schemas/powerforge.web.sitespec.schema.json
+++ b/Schemas/powerforge.web.sitespec.schema.json
@@ -85,6 +85,8 @@
     "LinkCheck": { "$ref": "#/$defs/LinkCheckSpec" },
     "Xref": { "$ref": "#/$defs/XrefSpec" },
     "Verify": { "$ref": "#/$defs/VerifyPolicySpec" },
+    "AgentReadiness": { "$ref": "#/$defs/AgentReadinessSpec" },
+    "agentReadiness": { "$ref": "#/$defs/AgentReadinessSpec" },
     "Features": {
       "type": "array",
       "items": {
@@ -748,6 +750,246 @@
         "FailOnNavLint": { "type": "boolean" },
         "FailOnThemeContract": { "type": "boolean" },
         "SuppressWarnings": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "AgentReadinessSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "HeadersPath": { "type": "string" },
+        "headersPath": { "type": "string" },
+        "LinkHeaders": { "type": "boolean" },
+        "linkHeaders": { "type": "boolean" },
+        "SecurityHeaders": { "$ref": "#/$defs/AgentSecurityHeadersSpec" },
+        "securityHeaders": { "$ref": "#/$defs/AgentSecurityHeadersSpec" },
+        "Robots": { "type": "boolean" },
+        "robots": { "type": "boolean" },
+        "ContentSignals": { "$ref": "#/$defs/AgentContentSignalsSpec" },
+        "contentSignals": { "$ref": "#/$defs/AgentContentSignalsSpec" },
+        "BotRules": { "type": "array", "items": { "$ref": "#/$defs/AgentBotRuleSpec" } },
+        "botRules": { "type": "array", "items": { "$ref": "#/$defs/AgentBotRuleSpec" } },
+        "ApiCatalog": { "$ref": "#/$defs/AgentApiCatalogSpec" },
+        "apiCatalog": { "$ref": "#/$defs/AgentApiCatalogSpec" },
+        "AgentSkills": { "$ref": "#/$defs/AgentSkillsDiscoverySpec" },
+        "agentSkills": { "$ref": "#/$defs/AgentSkillsDiscoverySpec" },
+        "AgentsJson": { "$ref": "#/$defs/AgentDiscoveryDocumentSpec" },
+        "agentsJson": { "$ref": "#/$defs/AgentDiscoveryDocumentSpec" },
+        "A2AAgentCard": { "$ref": "#/$defs/AgentA2ACardSpec" },
+        "a2aAgentCard": { "$ref": "#/$defs/AgentA2ACardSpec" },
+        "McpServerCard": { "$ref": "#/$defs/AgentMcpServerCardSpec" },
+        "mcpServerCard": { "$ref": "#/$defs/AgentMcpServerCardSpec" },
+        "OpenApi": { "$ref": "#/$defs/AgentOpenApiSpec" },
+        "openApi": { "$ref": "#/$defs/AgentOpenApiSpec" },
+        "WebMcp": { "type": "boolean" },
+        "webMcp": { "type": "boolean" },
+        "MarkdownNegotiation": { "type": "boolean" },
+        "markdownNegotiation": { "type": "boolean" }
+      }
+    },
+    "AgentSecurityHeadersSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "Hsts": { "type": "boolean" },
+        "hsts": { "type": "boolean" },
+        "HstsValue": { "type": "string" },
+        "hstsValue": { "type": "string" },
+        "ContentSecurityPolicy": { "type": "boolean" },
+        "contentSecurityPolicy": { "type": "boolean" },
+        "ContentSecurityPolicyValue": { "type": "string" },
+        "contentSecurityPolicyValue": { "type": "string" },
+        "XContentTypeOptions": { "type": "boolean" },
+        "xContentTypeOptions": { "type": "boolean" },
+        "XFrameOptions": { "type": "boolean" },
+        "xFrameOptions": { "type": "boolean" },
+        "ReferrerPolicy": { "type": "boolean" },
+        "referrerPolicy": { "type": "boolean" },
+        "ReferrerPolicyValue": { "type": "string" },
+        "referrerPolicyValue": { "type": "string" },
+        "CorsForWellKnown": { "type": "boolean" },
+        "corsForWellKnown": { "type": "boolean" },
+        "CorsAllowOrigin": { "type": "string" },
+        "corsAllowOrigin": { "type": "string" }
+      }
+    },
+    "AgentContentSignalsSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "Search": { "type": "boolean" },
+        "search": { "type": "boolean" },
+        "AiInput": { "type": "boolean" },
+        "aiInput": { "type": "boolean" },
+        "AiTrain": { "type": "boolean" },
+        "aiTrain": { "type": "boolean" }
+      }
+    },
+    "AgentBotRuleSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "UserAgent": { "type": "string" },
+        "userAgent": { "type": "string" },
+        "Allow": { "type": "string" },
+        "allow": { "type": "string" },
+        "Disallow": { "type": "string" },
+        "disallow": { "type": "string" }
+      },
+      "anyOf": [
+        { "required": ["UserAgent"] },
+        { "required": ["userAgent"] }
+      ]
+    },
+    "AgentApiCatalogSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "OutputPath": { "type": "string" },
+        "outputPath": { "type": "string" },
+        "Entries": { "type": "array", "items": { "$ref": "#/$defs/AgentApiCatalogEntrySpec" } },
+        "entries": { "type": "array", "items": { "$ref": "#/$defs/AgentApiCatalogEntrySpec" } }
+      }
+    },
+    "AgentApiCatalogEntrySpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Anchor": { "type": "string" },
+        "anchor": { "type": "string" },
+        "ServiceDesc": { "type": "string" },
+        "serviceDesc": { "type": "string" },
+        "ServiceDoc": { "type": "string" },
+        "serviceDoc": { "type": "string" },
+        "Status": { "type": "string" },
+        "status": { "type": "string" },
+        "Title": { "type": "string" },
+        "title": { "type": "string" }
+      }
+    },
+    "AgentSkillsDiscoverySpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "IndexPath": { "type": "string" },
+        "indexPath": { "type": "string" },
+        "Skills": { "type": "array", "items": { "$ref": "#/$defs/AgentSkillSpec" } },
+        "skills": { "type": "array", "items": { "$ref": "#/$defs/AgentSkillSpec" } }
+      }
+    },
+    "AgentDiscoveryDocumentSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "OutputPath": { "type": "string" },
+        "outputPath": { "type": "string" },
+        "WellKnownOutputPath": { "type": "string" },
+        "wellKnownOutputPath": { "type": "string" },
+        "Description": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "AgentA2ACardSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "OutputPath": { "type": "string" },
+        "outputPath": { "type": "string" },
+        "Name": { "type": "string" },
+        "name": { "type": "string" },
+        "Description": { "type": "string" },
+        "description": { "type": "string" },
+        "Url": { "type": "string" },
+        "url": { "type": "string" },
+        "Version": { "type": "string" },
+        "version": { "type": "string" },
+        "DocumentationUrl": { "type": "string" },
+        "documentationUrl": { "type": "string" },
+        "DefaultInputModes": { "type": "array", "items": { "type": "string" } },
+        "defaultInputModes": { "type": "array", "items": { "type": "string" } },
+        "DefaultOutputModes": { "type": "array", "items": { "type": "string" } },
+        "defaultOutputModes": { "type": "array", "items": { "type": "string" } },
+        "Skills": { "type": "array", "items": { "$ref": "#/$defs/AgentA2ASkillSpec" } },
+        "skills": { "type": "array", "items": { "$ref": "#/$defs/AgentA2ASkillSpec" } }
+      }
+    },
+    "AgentA2ASkillSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Id": { "type": "string" },
+        "id": { "type": "string" },
+        "Name": { "type": "string" },
+        "name": { "type": "string" },
+        "Description": { "type": "string" },
+        "description": { "type": "string" },
+        "Tags": { "type": "array", "items": { "type": "string" } },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "AgentSkillSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Name": { "type": "string" },
+        "name": { "type": "string" },
+        "Type": { "type": "string" },
+        "type": { "type": "string" },
+        "Description": { "type": "string" },
+        "description": { "type": "string" },
+        "Url": { "type": "string" },
+        "url": { "type": "string" },
+        "SourcePath": { "type": "string" },
+        "sourcePath": { "type": "string" },
+        "Content": { "type": "string" },
+        "content": { "type": "string" }
+      }
+    },
+    "AgentOpenApiSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "Path": { "type": "string" },
+        "path": { "type": "string" }
+      }
+    },
+    "AgentMcpServerCardSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "OutputPath": { "type": "string" },
+        "outputPath": { "type": "string" },
+        "Name": { "type": "string" },
+        "name": { "type": "string" },
+        "Version": { "type": "string" },
+        "version": { "type": "string" },
+        "Endpoint": { "type": "string" },
+        "endpoint": { "type": "string" },
+        "Transport": { "type": "string" },
+        "transport": { "type": "string" },
+        "Tools": { "type": "boolean" },
+        "tools": { "type": "boolean" },
+        "Resources": { "type": "boolean" },
+        "resources": { "type": "boolean" },
+        "Prompts": { "type": "boolean" },
+        "prompts": { "type": "boolean" }
       }
     },
     "NavigationSpec": {


### PR DESCRIPTION
## Summary
- Add a PowerForge.Web agent readiness engine with prepare, verify, and scan operations plus an agent-ready pipeline task.
- Generate and validate agent-facing assets for Cloudflare/isagentready scanners: robots content signals, Link headers, security headers, API catalog, Agent Skills index, agents.json, A2A card, MCP card metadata, OpenAPI discovery, and markdown/WebMCP checks.
- Add site/pipeline schema coverage, docs, regression tests, and a direct System.Security.Cryptography.Xml 10.0.6 override to clear NU1903.

## Validation
- dotnet build .\PowerForge.Web.Cli\PowerForge.Web.Cli.csproj -c Release --no-restore
- dotnet restore .\PowerForge.Tests\PowerForge.Tests.csproj --force-evaluate
- dotnet list PowerForge.PowerShell\PowerForge.PowerShell.csproj package --include-transitive --vulnerable
- dotnet list PSPublishModule\PSPublishModule.csproj package --include-transitive --vulnerable
- dotnet list PowerForge.Tests\PowerForge.Tests.csproj package --include-transitive --vulnerable
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter WebAgentReadinessTests

Full solution test note: dotnet test .\PSPublishModule.sln -c Release --no-restore is no longer blocked by NU1903, but it hit pre-existing unrelated failures and then hung, so I stopped dotnet/vstest.