### PR TITLE
Add PowerForge Web agent readiness

### DIFF
--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -69,6 +69,7 @@ PowerForge.Web can prepare and verify the common static-site subset:
 - static host `_headers` with Link headers and well-known content types
 - static security headers for HSTS, CSP, X-Content-Type-Options,
   X-Frame-Options, Referrer-Policy, and discovery-resource CORS
+- optional static Markdown artifacts generated from rendered HTML
 - API catalog Linkset generation
 - Agent Skills index + default SKILL.md generation
 - agents.json generation
@@ -82,6 +83,11 @@ PowerForge.Web can prepare and verify the common static-site subset:
 Cloudflare Markdown for Agents is a host-level feature. PowerForge verifies it
 with a live scan, but static output cannot prove that `Accept: text/markdown`
 will be negotiated by the deployed edge or origin.
+
+PowerForge can also generate Markdown artifacts itself. This is separate from
+live HTTP negotiation: the static site can contain `/index.md` and
+`/docs/index.md`, but the deployed host or edge still needs a rule if the same
+HTML route should return Markdown for `Accept: text/markdown`.
 
 ## Site Configuration
 
@@ -117,6 +123,12 @@ Add an `agentReadiness` block to `site.json`:
     "agentsJson": {
       "enabled": true
     },
+    "markdownArtifacts": {
+      "enabled": true,
+      "extension": ".md",
+      "maxPages": 0,
+      "includeTitle": true
+    },
     "a2aAgentCard": {
       "enabled": false
     },
@@ -138,6 +150,12 @@ Skills Discovery index.
 If `apiCatalog.entries` is empty but `_site/api/index.json` exists, PowerForge
 infers a basic API documentation entry. For public programmable APIs, prefer
 explicit entries that point `serviceDesc` at an OpenAPI document.
+
+If `markdownArtifacts.enabled` is true, `agent-ready prepare` converts rendered
+HTML pages to sibling Markdown files such as `index.md` and `docs/index.md`.
+These files are useful directly and can be served by host-level rules for
+`Accept: text/markdown`. Keep this disabled on very large sites unless the
+extra files are expected; use `maxPages` for staged rollouts.
 
 Do not enable MCP, WebMCP, OAuth, OpenAPI, A2A, or commerce settings just to
 make a scanner green. These discovery files are contracts. Publish them only

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -160,7 +160,7 @@ public class WebAgentReadinessTests
                 """
                 <!doctype html>
                 <html lang="en">
-                <head><title>Example Home</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <head><title>Example Home</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2020-01-01"}</script></head>
                 <body><main><h1>Welcome</h1><p>Hello <strong>agents</strong>.</p><p><a href="/docs/">Read docs</a></p></main></body>
                 </html>
                 """);
@@ -204,6 +204,65 @@ public class WebAgentReadinessTests
             Assert.Contains("/docs/index.md" + Environment.NewLine + "  Content-Type: text/markdown; charset=utf-8", headers, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(result.Checks, check => check.Id == "markdown-artifacts" && check.Status == "pass");
             Assert.Contains(result.Checks, check => check.Id == "markdown-root-artifact" && check.Status == "pass");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Prepare_HonorsMarkdownArtifactExtensionAndSkipsApiFragments()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-markdown-extension-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "api-fragments"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example Home</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2020-01-01"}</script></head>
+                <body><main><h1>Welcome</h1><p>Hello agents.</p></main></body>
+                </html>
+                """);
+            File.WriteAllText(Path.Combine(root, "api-fragments", "index.html"),
+                """
+                <!doctype html>
+                <html><body><main><h1>Fragment</h1></main></body></html>
+                """);
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    MarkdownArtifacts = new AgentMarkdownArtifactsSpec { Enabled = true, Extension = ".markdown" },
+                    MarkdownNegotiation = false,
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            Assert.True(File.Exists(Path.Combine(root, "index.markdown")));
+            Assert.False(File.Exists(Path.Combine(root, "api-fragments", "index.markdown")));
+
+            var headers = File.ReadAllText(Path.Combine(root, "_headers"));
+            Assert.Contains("</index.markdown>; rel=\"alternate\"; type=\"text/markdown\"", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("/index.markdown" + Environment.NewLine + "  Content-Type: text/markdown; charset=utf-8", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/api-fragments/index.markdown", headers, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -408,7 +467,9 @@ public class WebAgentReadinessTests
         {
             var siteRoot = Path.Combine(root, "site");
             Directory.CreateDirectory(siteRoot);
+            Directory.CreateDirectory(Path.Combine(siteRoot, "api-fragments"));
             File.WriteAllText(Path.Combine(siteRoot, "index.html"), "<!doctype html><html><body><main><h1>Home</h1></main></body></html>");
+            File.WriteAllText(Path.Combine(siteRoot, "api-fragments", "index.html"), "<!doctype html><html><body><main><h1>Fragment</h1></main></body></html>");
             File.WriteAllText(Path.Combine(root, "site.json"),
                 """
                 {
@@ -434,6 +495,7 @@ public class WebAgentReadinessTests
             Assert.Contains(Path.Combine(siteRoot, "robots.txt"), outputs);
             Assert.Contains(Path.Combine(siteRoot, ".well-known", "skills.json"), outputs);
             Assert.Contains(Path.Combine(siteRoot, "index.md"), outputs);
+            Assert.DoesNotContain(Path.Combine(siteRoot, "api-fragments", "index.md"), outputs);
             Assert.Contains(Path.Combine(siteRoot, "_headers"), outputs);
             Assert.DoesNotContain(Path.Combine(siteRoot, ".well-known", "api-catalog"), outputs);
             Assert.DoesNotContain(Path.Combine(siteRoot, ".well-known", "mcp", "server-card.json"), outputs);

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -143,6 +143,75 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void Prepare_GeneratesMarkdownArtifactsWhenEnabled()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-markdown-artifacts-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "docs"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example Home</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><main><h1>Welcome</h1><p>Hello <strong>agents</strong>.</p><p><a href="/docs/">Read docs</a></p></main></body>
+                </html>
+                """);
+            File.WriteAllText(Path.Combine(root, "docs", "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Docs</title></head>
+                <body><main><h1>Docs</h1><ul><li>Install</li><li>Configure</li></ul></main></body>
+                </html>
+                """);
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    MarkdownArtifacts = new AgentMarkdownArtifactsSpec { Enabled = true },
+                    MarkdownNegotiation = true,
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = true }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            Assert.True(File.Exists(Path.Combine(root, "index.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", "index.md")));
+
+            var markdown = File.ReadAllText(Path.Combine(root, "index.md"));
+            Assert.Contains("# Example Home", markdown, StringComparison.Ordinal);
+            Assert.Contains("Hello **agents**.", markdown, StringComparison.Ordinal);
+            Assert.Contains("[Read docs](/docs/)", markdown, StringComparison.Ordinal);
+
+            var headers = File.ReadAllText(Path.Combine(root, "_headers"));
+            Assert.Contains("</index.md>; rel=\"alternate\"; type=\"text/markdown\"", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("/index.md" + Environment.NewLine + "  Content-Type: text/markdown; charset=utf-8", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("/docs/index.md" + Environment.NewLine + "  Content-Type: text/markdown; charset=utf-8", headers, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(result.Checks, check => check.Id == "markdown-artifacts" && check.Status == "pass");
+            Assert.Contains(result.Checks, check => check.Id == "markdown-root-artifact" && check.Status == "pass");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Verify_DisabledAgentReadinessShortCircuits()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-disabled-all-" + Guid.NewGuid().ToString("N"));
@@ -339,6 +408,7 @@ public class WebAgentReadinessTests
         {
             var siteRoot = Path.Combine(root, "site");
             Directory.CreateDirectory(siteRoot);
+            File.WriteAllText(Path.Combine(siteRoot, "index.html"), "<!doctype html><html><body><main><h1>Home</h1></main></body></html>");
             File.WriteAllText(Path.Combine(root, "site.json"),
                 """
                 {
@@ -349,7 +419,8 @@ public class WebAgentReadinessTests
                     "agentSkills": { "enabled": true, "indexPath": ".well-known/skills.json" },
                     "agentsJson": { "enabled": false },
                     "a2aAgentCard": { "enabled": false },
-                    "mcpServerCard": { "enabled": false }
+                    "mcpServerCard": { "enabled": false },
+                    "markdownArtifacts": { "enabled": true }
                   }
                 }
                 """);
@@ -362,6 +433,7 @@ public class WebAgentReadinessTests
 
             Assert.Contains(Path.Combine(siteRoot, "robots.txt"), outputs);
             Assert.Contains(Path.Combine(siteRoot, ".well-known", "skills.json"), outputs);
+            Assert.Contains(Path.Combine(siteRoot, "index.md"), outputs);
             Assert.Contains(Path.Combine(siteRoot, "_headers"), outputs);
             Assert.DoesNotContain(Path.Combine(siteRoot, ".well-known", "api-catalog"), outputs);
             Assert.DoesNotContain(Path.Combine(siteRoot, ".well-known", "mcp", "server-card.json"), outputs);

--- a/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
@@ -1034,6 +1034,12 @@ internal static partial class WebPipelineRunner
                 ? Directory.EnumerateFiles(siteRoot, "*.html", SearchOption.AllDirectories)
                     .Where(path => !Path.GetFileName(path).EndsWith(".head.html", StringComparison.OrdinalIgnoreCase))
                     .Where(path => !Path.GetFileName(path).EndsWith(".scripts.html", StringComparison.OrdinalIgnoreCase))
+                    .Where(path =>
+                    {
+                        var relative = Path.GetRelativePath(siteRoot, path).Replace('\\', '/');
+                        return !relative.StartsWith("api-fragments/", StringComparison.OrdinalIgnoreCase) &&
+                               !relative.Contains("/api-fragments/", StringComparison.OrdinalIgnoreCase);
+                    })
                     .Select(path => Path.ChangeExtension(path, extension))
                 : new[] { ResolveAgentReadySiteOutputPath(siteRoot, "index" + extension) });
         }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Cache.cs
@@ -1024,6 +1024,20 @@ internal static partial class WebPipelineRunner
         if (spec.McpServerCard?.Enabled == true && !string.IsNullOrWhiteSpace(spec.McpServerCard.Endpoint))
             outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, string.IsNullOrWhiteSpace(spec.McpServerCard.OutputPath) ? ".well-known/mcp/server-card.json" : spec.McpServerCard.OutputPath!));
 
+        if (spec.MarkdownArtifacts?.Enabled == true)
+        {
+            var extension = string.IsNullOrWhiteSpace(spec.MarkdownArtifacts.Extension) ? ".md" : spec.MarkdownArtifacts.Extension!.Trim();
+            if (!extension.StartsWith(".", StringComparison.Ordinal))
+                extension = "." + extension;
+
+            outputs.AddRange(Directory.Exists(siteRoot)
+                ? Directory.EnumerateFiles(siteRoot, "*.html", SearchOption.AllDirectories)
+                    .Where(path => !Path.GetFileName(path).EndsWith(".head.html", StringComparison.OrdinalIgnoreCase))
+                    .Where(path => !Path.GetFileName(path).EndsWith(".scripts.html", StringComparison.OrdinalIgnoreCase))
+                    .Select(path => Path.ChangeExtension(path, extension))
+                : new[] { ResolveAgentReadySiteOutputPath(siteRoot, "index" + extension) });
+        }
+
         if (ShouldExpectAgentReadyHeaders(siteRoot, spec))
             outputs.Add(ResolveAgentReadySiteOutputPath(siteRoot, string.IsNullOrWhiteSpace(spec.HeadersPath) ? "_headers" : spec.HeadersPath!));
 
@@ -1075,6 +1089,7 @@ internal static partial class WebPipelineRunner
             McpServerCard = spec.McpServerCard,
             OpenApi = spec.OpenApi,
             WebMcp = spec.WebMcp,
+            MarkdownArtifacts = spec.MarkdownArtifacts,
             MarkdownNegotiation = spec.MarkdownNegotiation
         };
 
@@ -1106,7 +1121,8 @@ internal static partial class WebPipelineRunner
            spec.AgentSkills?.Enabled == true ||
            spec.AgentsJson?.Enabled == true ||
            spec.A2AAgentCard?.Enabled == true ||
-           spec.McpServerCard?.Enabled == true;
+           spec.McpServerCard?.Enabled == true ||
+           spec.MarkdownArtifacts?.Enabled == true;
 
     private static bool AgentReadyOpenApiRouteExists(string siteRoot, AgentOpenApiSpec? spec)
     {

--- a/PowerForge.Web/Models/AgentReadinessSpec.cs
+++ b/PowerForge.Web/Models/AgentReadinessSpec.cs
@@ -31,8 +31,23 @@ public sealed class AgentReadinessSpec
     public AgentOpenApiSpec? OpenApi { get; set; }
     /// <summary>When true, verify that rendered HTML exposes WebMCP browser tools.</summary>
     public bool WebMcp { get; set; }
+    /// <summary>Optional static markdown artifacts generated from rendered HTML.</summary>
+    public AgentMarkdownArtifactsSpec? MarkdownArtifacts { get; set; }
     /// <summary>When true, treat markdown negotiation as expected during remote scans.</summary>
     public bool MarkdownNegotiation { get; set; } = true;
+}
+
+/// <summary>Static markdown artifacts generated from rendered HTML for agent readers and edge negotiation.</summary>
+public sealed class AgentMarkdownArtifactsSpec
+{
+    /// <summary>Enable markdown artifact generation during agent-ready prepare.</summary>
+    public bool Enabled { get; set; }
+    /// <summary>Markdown file extension. Defaults to .md.</summary>
+    public string? Extension { get; set; } = ".md";
+    /// <summary>Maximum number of HTML pages to convert. Zero means no explicit limit.</summary>
+    public int MaxPages { get; set; }
+    /// <summary>When true, prepend the page title as a top-level heading when one can be resolved.</summary>
+    public bool IncludeTitle { get; set; } = true;
 }
 
 /// <summary>Security headers that agent and AI-readiness scanners commonly expect.</summary>

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -16,9 +16,16 @@ public static class WebAgentReadiness
     private const string AgentBlockStart = "# BEGIN PowerForge Agent Readiness";
     private const string AgentBlockEnd = "# END PowerForge Agent Readiness";
     private const string AgentSkillsSchema = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+    private static readonly StringComparison FileSystemPathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
     private static readonly Regex GeneratedBlockRegex = new(
         @"(?ms)^\s*# BEGIN PowerForge Agent Readiness\s*$.*?^\s*# END PowerForge Agent Readiness\s*$\r?\n?",
         RegexOptions.Compiled);
+    private static readonly Regex MarkdownWhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+    private static readonly Regex MarkdownTrailingWhitespaceRegex = new(@"[ \t]+\n", RegexOptions.Compiled);
+    private static readonly Regex MarkdownBlankLinesRegex = new(@"\n{3,}", RegexOptions.Compiled);
+    private static readonly Regex MarkdownRepeatedSpacesRegex = new(@"[ \t]{2,}", RegexOptions.Compiled);
 
     /// <summary>Writes configured agent-readiness files under the site root.</summary>
     public static WebAgentReadinessResult Prepare(WebAgentReadinessPrepareOptions options)
@@ -733,12 +740,12 @@ public static class WebAgentReadiness
         var written = new List<string>();
         foreach (var htmlPath in candidates)
         {
-            var markdown = ConvertHtmlDocumentToMarkdown(File.ReadAllText(htmlPath), spec);
+            var markdown = ConvertHtmlDocumentToMarkdown(File.ReadAllText(htmlPath, Encoding.UTF8), spec);
             if (string.IsNullOrWhiteSpace(markdown))
                 continue;
 
             var outputPath = Path.ChangeExtension(htmlPath, extension);
-            File.WriteAllText(outputPath, markdown);
+            File.WriteAllText(outputPath, markdown, Encoding.UTF8);
             written.Add(outputPath);
         }
 
@@ -910,10 +917,10 @@ public static class WebAgentReadiness
             "footer" or "form" or "header" or "main" or "nav" or "section" or "table";
 
     private static string NormalizeInlineWhitespace(string text)
-        => string.IsNullOrWhiteSpace(text) ? string.Empty : Regex.Replace(text, @"\s+", " ");
+        => string.IsNullOrWhiteSpace(text) ? string.Empty : MarkdownWhitespaceRegex.Replace(text, " ");
 
     private static string CollapseMarkdownInline(string text)
-        => Regex.Replace(NormalizeMarkdownDocument(text).Replace(Environment.NewLine, " ", StringComparison.Ordinal), @"\s+", " ").Trim();
+        => MarkdownWhitespaceRegex.Replace(NormalizeMarkdownDocument(text).Replace(Environment.NewLine, " ", StringComparison.Ordinal), " ").Trim();
 
     private static string NormalizeMarkdownDocument(string text)
     {
@@ -921,9 +928,9 @@ public static class WebAgentReadiness
             return string.Empty;
 
         var normalized = text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
-        normalized = Regex.Replace(normalized, @"[ \t]+\n", "\n");
-        normalized = Regex.Replace(normalized, @"\n{3,}", "\n\n");
-        normalized = Regex.Replace(normalized, @"[ \t]{2,}", " ");
+        normalized = MarkdownTrailingWhitespaceRegex.Replace(normalized, "\n");
+        normalized = MarkdownBlankLinesRegex.Replace(normalized, "\n\n");
+        normalized = MarkdownRepeatedSpacesRegex.Replace(normalized, " ");
         return normalized.Replace("\n", Environment.NewLine, StringComparison.Ordinal).Trim();
     }
 
@@ -1018,9 +1025,10 @@ public static class WebAgentReadiness
 
         if (spec.MarkdownArtifacts?.Enabled == true)
         {
+            var extension = NormalizeMarkdownExtension(spec.MarkdownArtifacts.Extension);
             foreach (var route in markdownArtifactPaths
                          .Select(path => ToSiteRoute(siteRoot, path))
-                         .Where(static route => route.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+                         .Where(route => route.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
                          .Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 AppendResourceHeaders(sb, route, "text/markdown; charset=utf-8", security);
@@ -1459,6 +1467,7 @@ public static class WebAgentReadiness
                 .Take(2)
                 .ToArray()
             : Array.Empty<string>();
+        var rootMarkdownExists = File.Exists(rootMarkdown);
 
         AddCheck(checks, "markdown-artifacts", "content", "Markdown artifacts",
             markdownFiles.Length > 0 ? "pass" : (expected ? "fail" : "info"),
@@ -1468,8 +1477,8 @@ public static class WebAgentReadiness
             siteRoot);
 
         AddCheck(checks, "markdown-root-artifact", "content", "Root markdown artifact",
-            File.Exists(rootMarkdown) ? "pass" : (expected ? "fail" : "info"),
-            File.Exists(rootMarkdown)
+            rootMarkdownExists ? "pass" : (expected ? "fail" : "info"),
+            rootMarkdownExists
                 ? "Root page has a markdown artifact for host-level Accept negotiation."
                 : (expected ? "Root markdown artifact is missing." : "Root markdown artifact generation is disabled."),
             rootMarkdown);
@@ -1696,8 +1705,8 @@ public static class WebAgentReadiness
             ? root
             : root + Path.DirectorySeparatorChar;
 
-        if (!resolved.Equals(root, StringComparison.OrdinalIgnoreCase) &&
-            !resolved.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+        if (!resolved.Equals(root, FileSystemPathComparison) &&
+            !resolved.StartsWith(rootWithSeparator, FileSystemPathComparison))
         {
             throw new ArgumentException($"Path '{path}' resolves outside the site root.", nameof(path));
         }
@@ -1716,8 +1725,8 @@ public static class WebAgentReadiness
             ? root
             : root + Path.DirectorySeparatorChar;
 
-        if (!resolved.Equals(root, StringComparison.OrdinalIgnoreCase) &&
-            !resolved.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase))
+        if (!resolved.Equals(root, FileSystemPathComparison) &&
+            !resolved.StartsWith(rootWithSeparator, FileSystemPathComparison))
         {
             throw new ArgumentException($"Path '{path}' resolves outside the site root.", nameof(path));
         }

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using AngleSharp.Dom;
+using HtmlTinkerX;
 
 namespace PowerForge.Web;
 
@@ -34,6 +36,7 @@ public static class WebAgentReadiness
         var written = new List<string>();
         var warnings = new List<string>();
         var linkTargets = new List<HeaderLinkTarget>();
+        var markdownArtifactPaths = Array.Empty<string>();
 
         if (!spec.Enabled)
         {
@@ -98,6 +101,15 @@ public static class WebAgentReadiness
             }
         }
 
+        if (spec.MarkdownArtifacts?.Enabled == true)
+        {
+            var markdownArtifacts = WriteMarkdownArtifacts(siteRoot, spec.MarkdownArtifacts, warnings);
+            markdownArtifactPaths = markdownArtifacts.Paths;
+            written.AddRange(markdownArtifacts.Paths);
+            if (!string.IsNullOrWhiteSpace(markdownArtifacts.RootRoute))
+                linkTargets.Add(new HeaderLinkTarget(markdownArtifacts.RootRoute!, "alternate", "text/markdown"));
+        }
+
         if (File.Exists(Path.Combine(siteRoot, "llms.txt")))
             linkTargets.Add(new HeaderLinkTarget("/llms.txt", "service-doc", "text/plain"));
 
@@ -106,7 +118,7 @@ public static class WebAgentReadiness
             linkTargets.Add(new HeaderLinkTarget(openApiPath!, "service-desc", "application/openapi+json"));
 
         if (ShouldWriteHeaders(spec, linkTargets))
-            written.Add(UpdateHeaders(siteRoot, spec, linkTargets));
+            written.Add(UpdateHeaders(siteRoot, spec, linkTargets, markdownArtifactPaths));
 
         var verify = Verify(new WebAgentReadinessVerifyOptions
         {
@@ -191,6 +203,7 @@ public static class WebAgentReadiness
 
         var rootHtml = ReadFirstHtml(siteRoot);
         AddHtmlSemanticsChecks(checks, rootHtml.Text, rootHtml.Path);
+        AddMarkdownArtifactChecks(checks, siteRoot, spec.MarkdownArtifacts);
 
         var apiCatalogPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.ApiCatalog?.OutputPath) ? ".well-known/api-catalog" : spec.ApiCatalog!.OutputPath!);
         var apiCatalogValid = ValidateApiCatalog(apiCatalogPath, out var apiCatalogMessage);
@@ -237,7 +250,7 @@ public static class WebAgentReadiness
         AddCheck(checks, "markdown-negotiation", "content", "Markdown for Agents",
             spec.MarkdownNegotiation ? "warn" : "info",
             spec.MarkdownNegotiation
-                ? "Local static output cannot prove Accept: text/markdown negotiation. Use remote scan or Cloudflare Markdown for Agents."
+                ? "Local static output cannot prove Accept: text/markdown negotiation. Use remote scan or host-level rules that serve markdown artifacts for markdown requests."
                 : "Markdown negotiation is not expected for this site.",
             options.BaseUrl);
 
@@ -384,6 +397,7 @@ public static class WebAgentReadiness
                 McpServerCard = spec.McpServerCard,
                 OpenApi = spec.OpenApi,
                 WebMcp = spec.WebMcp,
+                MarkdownArtifacts = spec.MarkdownArtifacts,
                 MarkdownNegotiation = spec.MarkdownNegotiation
             };
 
@@ -590,6 +604,7 @@ public static class WebAgentReadiness
             ["capabilities"] = new JsonObject
             {
                 ["contentNegotiation"] = spec.MarkdownNegotiation ? "text/markdown" : null,
+                ["markdownArtifacts"] = spec.MarkdownArtifacts?.Enabled == true,
                 ["contentSignals"] = spec.ContentSignals?.Enabled == true,
                 ["webMcp"] = spec.WebMcp
             }
@@ -697,6 +712,224 @@ public static class WebAgentReadiness
         return outputPath;
     }
 
+    private static MarkdownArtifactWriteResult WriteMarkdownArtifacts(string siteRoot, AgentMarkdownArtifactsSpec spec, List<string> warnings)
+    {
+        if (!Directory.Exists(siteRoot))
+            return new MarkdownArtifactWriteResult(Array.Empty<string>(), null);
+
+        var extension = NormalizeMarkdownExtension(spec.Extension);
+        var candidates = Directory.EnumerateFiles(siteRoot, "*.html", SearchOption.AllDirectories)
+            .Where(path => !ShouldSkipMarkdownArtifactCandidate(siteRoot, path))
+            .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var maxPages = spec.MaxPages;
+        if (maxPages > 0 && candidates.Length > maxPages)
+        {
+            warnings.Add($"Markdown artifact generation limited to {maxPages} of {candidates.Length} HTML pages.");
+            candidates = candidates.Take(maxPages).ToArray();
+        }
+
+        var written = new List<string>();
+        foreach (var htmlPath in candidates)
+        {
+            var markdown = ConvertHtmlDocumentToMarkdown(File.ReadAllText(htmlPath), spec);
+            if (string.IsNullOrWhiteSpace(markdown))
+                continue;
+
+            var outputPath = Path.ChangeExtension(htmlPath, extension);
+            File.WriteAllText(outputPath, markdown);
+            written.Add(outputPath);
+        }
+
+        var rootMarkdown = Path.Combine(siteRoot, "index" + extension);
+        var rootRoute = File.Exists(rootMarkdown) ? ToSiteRoute(siteRoot, rootMarkdown) : null;
+        return new MarkdownArtifactWriteResult(written.ToArray(), rootRoute);
+    }
+
+    private static bool ShouldSkipMarkdownArtifactCandidate(string siteRoot, string path)
+    {
+        var relative = Path.GetRelativePath(siteRoot, path).Replace('\\', '/');
+        return relative.EndsWith(".head.html", StringComparison.OrdinalIgnoreCase) ||
+               relative.EndsWith(".scripts.html", StringComparison.OrdinalIgnoreCase) ||
+               relative.Contains("/api-fragments/", StringComparison.OrdinalIgnoreCase) ||
+               relative.StartsWith("api-fragments/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeMarkdownExtension(string? extension)
+    {
+        var value = string.IsNullOrWhiteSpace(extension) ? ".md" : extension!.Trim();
+        if (!value.StartsWith(".", StringComparison.Ordinal))
+            value = "." + value;
+        return value.Equals(".", StringComparison.Ordinal) ? ".md" : value;
+    }
+
+    private static string ConvertHtmlDocumentToMarkdown(string html, AgentMarkdownArtifactsSpec spec)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return string.Empty;
+
+        var doc = HtmlParser.ParseWithAngleSharp(html);
+        var contentRoot = doc.QuerySelector("main,[role='main'],article") ?? doc.Body ?? doc.DocumentElement;
+        if (contentRoot is null)
+            return string.Empty;
+
+        var body = NormalizeMarkdownDocument(RenderMarkdownChildren(contentRoot));
+        var title = doc.Title?.Trim();
+        if (spec.IncludeTitle &&
+            !string.IsNullOrWhiteSpace(title) &&
+            !body.StartsWith("# " + title, StringComparison.OrdinalIgnoreCase))
+        {
+            body = "# " + title + Environment.NewLine + Environment.NewLine + body.TrimStart();
+        }
+
+        return body.Trim() + Environment.NewLine;
+    }
+
+    private static string RenderMarkdownChildren(INode node)
+    {
+        var sb = new StringBuilder();
+        foreach (var child in node.ChildNodes)
+            sb.Append(RenderMarkdownNode(child));
+        return sb.ToString();
+    }
+
+    private static string RenderMarkdownNode(INode node)
+    {
+        if (node.NodeType == NodeType.Text)
+            return NormalizeInlineWhitespace(node.TextContent);
+
+        if (node is not IElement element)
+            return string.Empty;
+
+        var tag = element.TagName.ToLowerInvariant();
+        return tag switch
+        {
+            "h1" => RenderHeading(element, 1),
+            "h2" => RenderHeading(element, 2),
+            "h3" => RenderHeading(element, 3),
+            "h4" => RenderHeading(element, 4),
+            "h5" => RenderHeading(element, 5),
+            "h6" => RenderHeading(element, 6),
+            "p" => Block(RenderMarkdownChildren(element)),
+            "br" => Environment.NewLine,
+            "strong" or "b" => WrapInline("**", RenderMarkdownChildren(element)),
+            "em" or "i" => WrapInline("*", RenderMarkdownChildren(element)),
+            "code" when !string.Equals(element.ParentElement?.TagName, "pre", StringComparison.OrdinalIgnoreCase) => "`" + element.TextContent.Trim() + "`",
+            "pre" => RenderCodeBlock(element),
+            "a" => RenderLink(element),
+            "img" => RenderImage(element),
+            "ul" => RenderList(element, ordered: false),
+            "ol" => RenderList(element, ordered: true),
+            "li" => RenderMarkdownChildren(element),
+            "blockquote" => RenderBlockquote(element),
+            "hr" => Environment.NewLine + Environment.NewLine + "---" + Environment.NewLine + Environment.NewLine,
+            "script" or "style" or "noscript" or "svg" => string.Empty,
+            _ => IsMarkdownBlockElement(tag) ? Block(RenderMarkdownChildren(element)) : RenderMarkdownChildren(element)
+        };
+    }
+
+    private static string RenderHeading(IElement element, int level)
+    {
+        var text = CollapseMarkdownInline(RenderMarkdownChildren(element));
+        return string.IsNullOrWhiteSpace(text)
+            ? string.Empty
+            : Environment.NewLine + Environment.NewLine + new string('#', level) + " " + text + Environment.NewLine + Environment.NewLine;
+    }
+
+    private static string RenderCodeBlock(IElement element)
+    {
+        var text = element.TextContent.Trim('\r', '\n');
+        return string.IsNullOrWhiteSpace(text)
+            ? string.Empty
+            : Environment.NewLine + Environment.NewLine + "```" + Environment.NewLine + text + Environment.NewLine + "```" + Environment.NewLine + Environment.NewLine;
+    }
+
+    private static string RenderLink(IElement element)
+    {
+        var text = CollapseMarkdownInline(RenderMarkdownChildren(element));
+        var href = element.GetAttribute("href")?.Trim();
+        if (string.IsNullOrWhiteSpace(text))
+            text = href ?? string.Empty;
+        return string.IsNullOrWhiteSpace(href) ? text : $"[{EscapeMarkdownLinkText(text)}]({href})";
+    }
+
+    private static string RenderImage(IElement element)
+    {
+        var src = element.GetAttribute("src")?.Trim();
+        if (string.IsNullOrWhiteSpace(src))
+            return string.Empty;
+        var alt = element.GetAttribute("alt")?.Trim() ?? string.Empty;
+        return $"![{EscapeMarkdownLinkText(alt)}]({src})";
+    }
+
+    private static string RenderList(IElement element, bool ordered)
+    {
+        var index = 1;
+        var lines = new List<string>();
+        foreach (var item in element.Children.Where(static child => child.TagName.Equals("li", StringComparison.OrdinalIgnoreCase)))
+        {
+            var text = NormalizeMarkdownDocument(RenderMarkdownChildren(item)).Trim();
+            if (string.IsNullOrWhiteSpace(text))
+                continue;
+            var prefix = ordered ? $"{index}. " : "- ";
+            lines.Add(prefix + text.Replace(Environment.NewLine, Environment.NewLine + "  ", StringComparison.Ordinal));
+            index++;
+        }
+
+        return lines.Count == 0
+            ? string.Empty
+            : Environment.NewLine + Environment.NewLine + string.Join(Environment.NewLine, lines) + Environment.NewLine + Environment.NewLine;
+    }
+
+    private static string RenderBlockquote(IElement element)
+    {
+        var text = NormalizeMarkdownDocument(RenderMarkdownChildren(element)).Trim();
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+        var quoted = string.Join(Environment.NewLine, text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None).Select(line => "> " + line));
+        return Environment.NewLine + Environment.NewLine + quoted + Environment.NewLine + Environment.NewLine;
+    }
+
+    private static string Block(string text)
+    {
+        var normalized = NormalizeMarkdownDocument(text).Trim();
+        return string.IsNullOrWhiteSpace(normalized)
+            ? string.Empty
+            : Environment.NewLine + Environment.NewLine + normalized + Environment.NewLine + Environment.NewLine;
+    }
+
+    private static string WrapInline(string marker, string text)
+    {
+        var normalized = CollapseMarkdownInline(text);
+        return string.IsNullOrWhiteSpace(normalized) ? string.Empty : marker + normalized + marker;
+    }
+
+    private static bool IsMarkdownBlockElement(string tag)
+        => tag is "address" or "article" or "aside" or "div" or "dl" or "fieldset" or "figcaption" or "figure" or
+            "footer" or "form" or "header" or "main" or "nav" or "section" or "table";
+
+    private static string NormalizeInlineWhitespace(string text)
+        => string.IsNullOrWhiteSpace(text) ? string.Empty : Regex.Replace(text, @"\s+", " ");
+
+    private static string CollapseMarkdownInline(string text)
+        => Regex.Replace(NormalizeMarkdownDocument(text).Replace(Environment.NewLine, " ", StringComparison.Ordinal), @"\s+", " ").Trim();
+
+    private static string NormalizeMarkdownDocument(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+
+        var normalized = text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        normalized = Regex.Replace(normalized, @"[ \t]+\n", "\n");
+        normalized = Regex.Replace(normalized, @"\n{3,}", "\n\n");
+        normalized = Regex.Replace(normalized, @"[ \t]{2,}", " ");
+        return normalized.Replace("\n", Environment.NewLine, StringComparison.Ordinal).Trim();
+    }
+
+    private static string EscapeMarkdownLinkText(string text)
+        => text.Replace("[", "\\[", StringComparison.Ordinal).Replace("]", "\\]", StringComparison.Ordinal);
+
     private static bool ShouldWriteHeaders(AgentReadinessSpec spec, List<HeaderLinkTarget> linkTargets)
         => spec.SecurityHeaders?.Enabled == true ||
            (spec.LinkHeaders && linkTargets.Count > 0) ||
@@ -704,9 +937,10 @@ public static class WebAgentReadiness
            spec.AgentSkills?.Enabled == true ||
            spec.AgentsJson?.Enabled == true ||
            spec.A2AAgentCard?.Enabled == true ||
-           spec.McpServerCard?.Enabled == true;
+           spec.McpServerCard?.Enabled == true ||
+           spec.MarkdownArtifacts?.Enabled == true;
 
-    private static string UpdateHeaders(string siteRoot, AgentReadinessSpec spec, List<HeaderLinkTarget> linkTargets)
+    private static string UpdateHeaders(string siteRoot, AgentReadinessSpec spec, List<HeaderLinkTarget> linkTargets, IReadOnlyList<string> markdownArtifactPaths)
     {
         var headersPath = spec.HeadersPath;
         var path = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(headersPath) ? "_headers" : headersPath!);
@@ -732,7 +966,7 @@ public static class WebAgentReadiness
             }
         }
 
-        AppendDiscoveryResourceHeaders(sb, siteRoot, spec, security);
+        AppendDiscoveryResourceHeaders(sb, siteRoot, spec, security, markdownArtifactPaths);
         sb.AppendLine(AgentBlockEnd);
 
         var next = string.IsNullOrWhiteSpace(cleaned)
@@ -743,7 +977,7 @@ public static class WebAgentReadiness
         return path;
     }
 
-    private static void AppendDiscoveryResourceHeaders(StringBuilder sb, string siteRoot, AgentReadinessSpec spec, AgentSecurityHeadersSpec security)
+    private static void AppendDiscoveryResourceHeaders(StringBuilder sb, string siteRoot, AgentReadinessSpec spec, AgentSecurityHeadersSpec security, IReadOnlyList<string> markdownArtifactPaths)
     {
         if (spec.ApiCatalog?.Enabled == true)
         {
@@ -780,6 +1014,17 @@ public static class WebAgentReadiness
         {
             AppendResourceHeaders(sb, ResolveSiteRoute(siteRoot, spec.McpServerCard.OutputPath, ".well-known/mcp/server-card.json"),
                 "application/json", security);
+        }
+
+        if (spec.MarkdownArtifacts?.Enabled == true)
+        {
+            foreach (var route in markdownArtifactPaths
+                         .Select(path => ToSiteRoute(siteRoot, path))
+                         .Where(static route => route.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+                         .Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                AppendResourceHeaders(sb, route, "text/markdown; charset=utf-8", security);
+            }
         }
     }
 
@@ -1203,6 +1448,33 @@ public static class WebAgentReadiness
             : new HtmlReadResult(File.ReadAllText(path), path);
     }
 
+    private static void AddMarkdownArtifactChecks(List<WebAgentReadinessCheck> checks, string siteRoot, AgentMarkdownArtifactsSpec? spec)
+    {
+        var expected = spec?.Enabled == true;
+        var extension = NormalizeMarkdownExtension(spec?.Extension);
+        var rootMarkdown = Path.Combine(siteRoot, "index" + extension);
+        var markdownFiles = Directory.Exists(siteRoot)
+            ? Directory.EnumerateFiles(siteRoot, "*" + extension, SearchOption.AllDirectories)
+                .Where(path => !ShouldSkipMarkdownArtifactCandidate(siteRoot, path))
+                .Take(2)
+                .ToArray()
+            : Array.Empty<string>();
+
+        AddCheck(checks, "markdown-artifacts", "content", "Markdown artifacts",
+            markdownFiles.Length > 0 ? "pass" : (expected ? "fail" : "info"),
+            markdownFiles.Length > 0
+                ? "Static markdown artifacts exist for agent-readable content."
+                : (expected ? "Markdown artifact generation is enabled, but no markdown artifacts were found." : "Markdown artifact generation is disabled."),
+            siteRoot);
+
+        AddCheck(checks, "markdown-root-artifact", "content", "Root markdown artifact",
+            File.Exists(rootMarkdown) ? "pass" : (expected ? "fail" : "info"),
+            File.Exists(rootMarkdown)
+                ? "Root page has a markdown artifact for host-level Accept negotiation."
+                : (expected ? "Root markdown artifact is missing." : "Root markdown artifact generation is disabled."),
+            rootMarkdown);
+    }
+
     private static IEnumerable<string> ExtractJsonLd(string html)
     {
         if (string.IsNullOrWhiteSpace(html))
@@ -1476,6 +1748,7 @@ public static class WebAgentReadiness
     }
 
     private sealed record HeaderLinkTarget(string Href, string Rel, string Type);
+    private sealed record MarkdownArtifactWriteResult(string[] Paths, string? RootRoute);
     private sealed record HtmlReadResult(string Text, string Path);
     private sealed record OpenApiScanResult(bool Success, string? Url);
     private sealed record HttpTextResult(bool Success, string Message, string Text, HttpResponseMessage? Response);

--- a/Schemas/powerforge.web.sitespec.schema.json
+++ b/Schemas/powerforge.web.sitespec.schema.json
@@ -784,8 +784,24 @@
         "openApi": { "$ref": "#/$defs/AgentOpenApiSpec" },
         "WebMcp": { "type": "boolean" },
         "webMcp": { "type": "boolean" },
+        "MarkdownArtifacts": { "$ref": "#/$defs/AgentMarkdownArtifactsSpec" },
+        "markdownArtifacts": { "$ref": "#/$defs/AgentMarkdownArtifactsSpec" },
         "MarkdownNegotiation": { "type": "boolean" },
         "markdownNegotiation": { "type": "boolean" }
+      }
+    },
+    "AgentMarkdownArtifactsSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "Extension": { "type": "string" },
+        "extension": { "type": "string" },
+        "MaxPages": { "type": "integer", "minimum": 0 },
+        "maxPages": { "type": "integer", "minimum": 0 },
+        "IncludeTitle": { "type": "boolean" },
+        "includeTitle": { "type": "boolean" }
       }
     },
     "AgentSecurityHeadersSpec": {


### PR DESCRIPTION
## Summary

Adds PowerForge.Web agent-readiness preparation and verification for the static-site pieces expected by current AI-agent readiness scanners.

This includes robots and content signals, Link response headers, API catalog and Agent Skills discovery, agents.json, A2A/MCP discovery files, security header helpers, remote scan support, and opt-in Markdown artifact generation from rendered HTML.

## Impact

Sites can enable these features from `site.json` and run the PowerForge agent-ready pipeline without relying on Cloudflare Markdown for Agents or Workers. Markdown artifacts are generated as static sibling files, while live `Accept: text/markdown` negotiation can be handled later by hosting rules.

## Validation

- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter FullyQualifiedName~WebAgentReadinessTests`