### PR TITLE
Fix Apache link service vhost patterns

### DIFF
--- a/PowerForge.Tests/WebCliLinksTests.cs
+++ b/PowerForge.Tests/WebCliLinksTests.cs
@@ -75,8 +75,8 @@ public sealed class WebCliLinksTests
             Assert.True(File.Exists(outputPath));
             var apache = File.ReadAllText(outputPath);
             Assert.Contains("ErrorDocument 404 /404.html", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteRule ^old/?$ /new/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteRule ^discord/?$ https://discord.gg/example [R=302,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?old/?$ /new/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?discord/?$ https://discord.gg/example [R=302,L,QSD]", apache, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebLinkServiceTests.cs
+++ b/PowerForge.Tests/WebLinkServiceTests.cs
@@ -574,11 +574,11 @@ public sealed class WebLinkServiceTests
             Assert.Equal(3, result.RuleCount);
             var apache = File.ReadAllText(outPath);
             Assert.Contains("ErrorDocument 404 /404.html", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteCond %{HTTP_HOST} ^(.+\\.)?evotec\\.pl$ [NC]", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteRule ^stary/?$ /nowy/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteCond %{HTTP_HOST} ^(www\\.)?evotec\\.pl$ [NC]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?stary/?$ /nowy/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
             Assert.Contains("RewriteCond %{QUERY_STRING} (^|&)p=123(&|$)", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteCond %{HTTP_HOST} ^(.+\\.)?evo\\.yt$ [NC]", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteRule ^discord/?$ https://discord.gg/example [R=302,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteCond %{HTTP_HOST} ^(www\\.)?evo\\.yt$ [NC]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?discord/?$ https://discord.gg/example [R=302,L,QSD]", apache, StringComparison.Ordinal);
         }
         finally
         {
@@ -615,7 +615,7 @@ public sealed class WebLinkServiceTests
             });
 
             var apache = File.ReadAllText(outPath);
-            Assert.Contains(@"RewriteRule ^foo\.bar/?$ /new/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains(@"RewriteRule ^/?foo\.bar/?$ /new/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
         }
         finally
         {
@@ -649,6 +649,13 @@ public sealed class WebLinkServiceTests
                         SourcePath = "/legacy/.*",
                         MatchType = LinkRedirectMatchType.Regex,
                         Status = 410
+                    },
+                    new LinkRedirectRule
+                    {
+                        Id = "gone-bare-regex",
+                        SourcePath = "download\\/.*\\/feed\\/",
+                        MatchType = LinkRedirectMatchType.Regex,
+                        Status = 410
                     }
                 }
             };
@@ -659,9 +666,10 @@ public sealed class WebLinkServiceTests
             });
 
             var apache = File.ReadAllText(outPath);
-            Assert.Contains("RewriteRule ^gone", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteRule ^legacy/.* - [G,L]", apache, StringComparison.Ordinal);
-            Assert.Equal(2, CountOccurrences(apache, "[G,L]"));
+            Assert.Contains("RewriteRule ^/?gone", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?legacy/.* - [G,L]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?download\\/.*\\/feed\\/ - [G,L]", apache, StringComparison.Ordinal);
+            Assert.Equal(3, CountOccurrences(apache, "[G,L]"));
         }
         finally
         {
@@ -699,7 +707,7 @@ public sealed class WebLinkServiceTests
             });
 
             var apache = File.ReadAllText(outPath);
-            Assert.Contains("RewriteRule ^legacy/(.*)$ /archive/$1 [R=301,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?legacy/(.*)$ /archive/$1 [R=301,L,QSD]", apache, StringComparison.Ordinal);
             Assert.DoesNotContain("RewriteRule ^/legacy", apache, StringComparison.Ordinal);
         }
         finally
@@ -1461,7 +1469,7 @@ public sealed class WebLinkServiceTests
             });
 
             var apache = File.ReadAllText(outPath);
-            Assert.Contains("RewriteRule ^stary/?$ /blog/current/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?stary/?$ /blog/current/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
             Assert.DoesNotContain("/pl/blog/current/", apache, StringComparison.Ordinal);
         }
         finally

--- a/PowerForge.Tests/WebPipelineRunnerLinksTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerLinksTests.cs
@@ -83,8 +83,8 @@ public sealed class WebPipelineRunnerLinksTests
             var outputPath = Path.Combine(root, "deploy", "apache", "link-service-redirects.conf");
             Assert.True(File.Exists(outputPath));
             var apache = File.ReadAllText(outputPath);
-            Assert.Contains("RewriteRule ^old/?$ /new/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
-            Assert.Contains("RewriteRule ^discord/?$ https://discord.gg/example [R=302,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?old/?$ /new/ [R=301,L,QSD]", apache, StringComparison.Ordinal);
+            Assert.Contains("RewriteRule ^/?discord/?$ https://discord.gg/example [R=302,L,QSD]", apache, StringComparison.Ordinal);
 
             using var summary = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "Build", "links-summary.json")));
             Assert.Equal(1, summary.RootElement.GetProperty("redirects").GetInt32());

--- a/PowerForge.Web/Services/WebLinkService.ExportApache.cs
+++ b/PowerForge.Web/Services/WebLinkService.ExportApache.cs
@@ -185,18 +185,25 @@ public static partial class WebLinkService
                     prefix = prefix.Substring(0, starIndex);
                 prefix = prefix.Trim('/');
                 pattern = string.IsNullOrWhiteSpace(prefix)
-                    ? "^(.*)$"
-                    : $"^{Regex.Escape(prefix)}(?:/(.*))?$";
+                    ? "^/?(.*)$"
+                    : $"^/?{Regex.Escape(prefix)}(?:/(.*))?$";
                 destination = NormalizeDestination(rule.TargetUrl).Replace("{path}", "$1", StringComparison.OrdinalIgnoreCase);
                 return rule.Status == 410 || !string.IsNullOrWhiteSpace(destination);
             }
             case LinkRedirectMatchType.Regex:
             {
                 var regex = rule.SourcePath.Trim();
-                if (regex.StartsWith("^/", StringComparison.Ordinal))
-                    regex = "^" + regex[2..].TrimStart('/');
-                else if (regex.StartsWith("/", StringComparison.Ordinal))
-                    regex = regex.TrimStart('/');
+                if (!regex.StartsWith("^/?", StringComparison.Ordinal))
+                {
+                    if (regex.StartsWith("^/", StringComparison.Ordinal))
+                        regex = "^/?" + regex[2..].TrimStart('/');
+                    else if (regex.StartsWith("^", StringComparison.Ordinal))
+                        regex = "^/?" + regex[1..].TrimStart('/');
+                    else if (regex.StartsWith("/", StringComparison.Ordinal))
+                        regex = "/?" + regex.TrimStart('/');
+                    else
+                        regex = "/?" + regex;
+                }
                 pattern = regex.StartsWith("^", StringComparison.Ordinal) ? regex : "^" + regex;
                 destination = NormalizeDestination(rule.TargetUrl).Replace("{path}", "$1", StringComparison.OrdinalIgnoreCase);
                 return rule.Status == 410 || !string.IsNullOrWhiteSpace(destination);
@@ -206,7 +213,7 @@ public static partial class WebLinkService
             default:
             {
                 var exact = NormalizeSourcePath(rule.SourcePath).Trim('/');
-                pattern = string.IsNullOrWhiteSpace(exact) ? "^$" : $"^{Regex.Escape(exact)}/?$";
+                pattern = string.IsNullOrWhiteSpace(exact) ? "^/?$" : $"^/?{Regex.Escape(exact)}/?$";
                 destination = NormalizeDestination(rule.TargetUrl);
                 return rule.Status == 410 || !string.IsNullOrWhiteSpace(destination);
             }
@@ -218,7 +225,9 @@ public static partial class WebLinkService
         if (string.IsNullOrWhiteSpace(host) || host.Trim().Equals("*", StringComparison.Ordinal))
             return;
 
-        lines.Add($"RewriteCond %{{HTTP_HOST}} ^(.+\\.)?{Regex.Escape(host.Trim())}$ [NC]");
+        var trimmed = host.Trim();
+        var prefix = trimmed.StartsWith("www.", StringComparison.OrdinalIgnoreCase) ? string.Empty : "(www\\.)?";
+        lines.Add($"RewriteCond %{{HTTP_HOST}} ^{prefix}{Regex.Escape(trimmed)}$ [NC]");
     }
 
     private static void AppendQueryCondition(List<string> lines, string? query)


### PR DESCRIPTION
## Summary
- emit Apache link-service rewrite patterns that match both vhost and .htaccess contexts
- cover exact, prefix, and regex redirects with optional leading slash
- update link-service exporter tests

## Tests
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~WebLinkServiceTests|FullyQualifiedName~WebCliLinksTests|FullyQualifiedName~WebPipelineRunnerLinksTests"