### PR TITLE
Add SEO doctor page assertions and social card safeguards

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerSeoDoctorTests.cs
@@ -464,6 +464,86 @@ public class WebPipelineRunnerSeoDoctorTests
         }
     }
 
+    [Fact]
+    public void RunPipeline_SeoDoctor_PageAssertions_FailOnLocalizedLeakAndMissingText()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-seo-doctor-page-assertions-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var siteRoot = Path.Combine(root, "_site");
+            Directory.CreateDirectory(Path.Combine(siteRoot, "fr", "contact"));
+
+            File.WriteAllText(Path.Combine(siteRoot, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><h1>Home</h1></body>
+                </html>
+                """);
+
+            File.WriteAllText(Path.Combine(siteRoot, "fr", "contact", "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Contact</title></head>
+                <body>
+                  <main>
+                    <article>
+                      <h1>Contact</h1>
+                      <p>translation_key: "contact" meta.raw_html: true</p>
+                    </article>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "seo-doctor",
+                      "siteRoot": "./_site",
+                      "maxHtmlFiles": 1,
+                      "checkTitleLength": false,
+                      "checkDescriptionLength": false,
+                      "checkH1": false,
+                      "checkImageAlt": false,
+                      "checkDuplicateTitles": false,
+                      "checkOrphanPages": false,
+                      "checkCanonical": false,
+                      "checkHreflang": false,
+                      "checkStructuredData": false,
+                      "checkContentLeaks": false,
+                      "pageAssertions": [
+                        {
+                          "path": "/fr/contact/",
+                          "label": "French contact",
+                          "contains": ["Contactez-nous"],
+                          "notContains": ["translation_key:", "meta.raw_html: true"]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.False(result.Success);
+            Assert.Single(result.Steps);
+            Assert.False(result.Steps[0].Success);
+            Assert.Contains("errors", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -1244,6 +1244,70 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_PageAssertions_TreatsDottedRouteSegmentsAsDirectories()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-dotted-route-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><h1>Home</h1></body>
+                </html>
+                """);
+
+            var dottedRoute = Path.Combine(root, "docs", "v1.0");
+            Directory.CreateDirectory(dottedRoute);
+            File.WriteAllText(Path.Combine(dottedRoute, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Versioned docs</title></head>
+                <body><h1>Documentation v1.0</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                MaxHtmlFiles = 1,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = false,
+                PageAssertions = new[]
+                {
+                    new WebSeoDoctorPageAssertion
+                    {
+                        Path = "/docs/v1.0",
+                        Label = "Versioned docs route",
+                        Contains = new[] { "Documentation v1.0" }
+                    }
+                }
+            });
+
+            Assert.DoesNotContain(result.Issues, issue =>
+                issue.Hint == "page-assertion-missing-page" ||
+                issue.Hint == "page-assertion-contains");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_PageAssertions_DoNotResolveSiblingPathsThatOnlyShareTheRootPrefix()
     {
         var parentRoot = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-prefix-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -1140,6 +1140,110 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_PageAssertions_RenderedScopeAliasesToBody()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-rendered-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><h1>Contactez-nous</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = false,
+                PageAssertions = new[]
+                {
+                    new WebSeoDoctorPageAssertion
+                    {
+                        Path = "/",
+                        Label = "Home rendered alias",
+                        Scope = "rendered",
+                        Contains = new[] { "Contactez-nous" }
+                    }
+                }
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Category == "page-assertion");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_PageAssertions_MissingInRootPathReportsRelativeIndex()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-missing-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><h1>Home</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                MaxHtmlFiles = 1,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = false,
+                PageAssertions = new[]
+                {
+                    new WebSeoDoctorPageAssertion
+                    {
+                        Path = "/fr/contact/",
+                        Label = "French contact must exist"
+                    }
+                }
+            });
+
+            Assert.Contains(result.Issues, issue =>
+                issue.Hint == "page-assertion-missing-page" &&
+                issue.Path == "fr/contact/index.html" &&
+                issue.Message.Contains("French contact must exist", StringComparison.OrdinalIgnoreCase));
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_PageAssertions_DoNotResolveSiblingPathsThatOnlyShareTheRootPrefix()
     {
         var parentRoot = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-prefix-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -1032,6 +1032,181 @@ public class WebSeoDoctorTests
         }
     }
 
+    [Fact]
+    public void Analyze_PageAssertions_DoesNotReportMissingPageWhenMustExistIsFalse()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-optional-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><h1>Home</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                MaxHtmlFiles = 1,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = false,
+                PageAssertions = new[]
+                {
+                    new WebSeoDoctorPageAssertion
+                    {
+                        Path = "/fr/contact/",
+                        Label = "Optional French contact",
+                        MustExist = false,
+                        Contains = new[] { "Contactez-nous" }
+                    }
+                }
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "page-assertion-missing-page");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_PageAssertions_HtmlScopeInspectsRawMarkup()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-html-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Home</title>
+                  <script type="application/ld+json">{"@type":"Organization"}</script>
+                </head>
+                <body><h1>Home</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = false,
+                PageAssertions = new[]
+                {
+                    new WebSeoDoctorPageAssertion
+                    {
+                        Path = "/",
+                        Label = "Home raw html",
+                        Scope = "html",
+                        Contains = new[] { "application/ld+json" },
+                        NotContains = new[] { "meta.raw_html: true" }
+                    }
+                }
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint is "page-assertion-contains" or "page-assertion-not-contains");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_PageAssertions_DoNotResolveSiblingPathsThatOnlyShareTheRootPrefix()
+    {
+        var parentRoot = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-prefix-" + Guid.NewGuid().ToString("N"));
+        var root = Path.Combine(parentRoot, "site");
+        var sibling = Path.Combine(parentRoot, "site-copy");
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(sibling);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><h1>Home</h1></body>
+                </html>
+                """);
+
+            Directory.CreateDirectory(Path.Combine(sibling, "fr", "contact"));
+            File.WriteAllText(Path.Combine(sibling, "fr", "contact", "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Leaked sibling</title></head>
+                <body><p>Contactez-nous</p></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                MaxHtmlFiles = 1,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = false,
+                PageAssertions = new[]
+                {
+                    new WebSeoDoctorPageAssertion
+                    {
+                        Path = "../site-copy/fr/contact/",
+                        Label = "Sibling path traversal"
+                    }
+                }
+            });
+
+            Assert.Contains(result.Issues, issue =>
+                issue.Hint == "page-assertion-missing-page" &&
+                issue.Path == "../site-copy/fr/contact/index.html");
+            Assert.DoesNotContain(result.Issues, issue =>
+                issue.Hint == "page-assertion-contains" ||
+                issue.Hint == "page-assertion-not-contains" ||
+                issue.Message.Contains("Contactez-nous", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(parentRoot);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -952,6 +952,86 @@ public class WebSeoDoctorTests
         }
     }
 
+    [Fact]
+    public void Analyze_PageAssertions_ValidateRepresentativeLocalizedPageOutsideScannedSubset()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "fr", "contact"));
+
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><h1>Home</h1></body>
+                </html>
+                """);
+
+            File.WriteAllText(Path.Combine(root, "fr", "contact", "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Contact</title></head>
+                <body>
+                  <main>
+                    <article>
+                      <h1>Contact</h1>
+                      <p>translation_key: "contact" meta.raw_html: true</p>
+                    </article>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                MaxHtmlFiles = 1,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = false,
+                PageAssertions = new[]
+                {
+                    new WebSeoDoctorPageAssertion
+                    {
+                        Path = "/fr/contact/",
+                        Label = "French contact",
+                        Contains = new[] { "Contactez-nous" },
+                        NotContains = new[] { "translation_key:", "meta.raw_html: true" }
+                    }
+                }
+            });
+
+            Assert.Contains(result.Issues, issue =>
+                issue.Hint == "page-assertion-contains" &&
+                issue.Path == "fr/contact/index.html" &&
+                issue.Severity.Equals("error", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Issues, issue =>
+                issue.Hint == "page-assertion-not-contains" &&
+                issue.Path == "fr/contact/index.html" &&
+                issue.Message.Contains("translation_key:", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Issues, issue =>
+                issue.Hint == "page-assertion-not-contains" &&
+                issue.Path == "fr/contact/index.html" &&
+                issue.Message.Contains("meta.raw_html: true", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try

--- a/PowerForge.Tests/WebSiteSocialCardsTests.cs
+++ b/PowerForge.Tests/WebSiteSocialCardsTests.cs
@@ -358,7 +358,7 @@ public class WebSiteSocialCardsTests
     }
 
     [Fact]
-    public void Build_UsesFirstMarkdownImage_ForBlogSocialPreview_WhenNoExplicitSocialImage()
+    public void Build_UsesGeneratedCard_ForBlogSocialPreview_WhenAutoGenerateCardsEnabled_EvenWithBodyImage()
     {
         var root = CreateTempRoot("pf-web-social-blog-first-image-");
         try
@@ -400,8 +400,59 @@ public class WebSiteSocialCardsTests
             };
 
             var html = BuildAndRead(root, spec, Path.Combine("blog", "multilanguage-support-in-action", "index.html"));
-            Assert.Contains("property=\"og:image\" content=\"https://example.test/assets/screenshots/multilang-01.png\"", html, StringComparison.Ordinal);
-            Assert.Contains("name=\"twitter:image\" content=\"https://example.test/assets/screenshots/multilang-01.png\"", html, StringComparison.Ordinal);
+            Assert.Contains("property=\"og:image\" content=\"https://example.test/assets/social/generated/blog-multilanguage-support-in-action-", html, StringComparison.Ordinal);
+            Assert.Contains("name=\"twitter:image\" content=\"https://example.test/assets/social/generated/blog-multilanguage-support-in-action-", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("https://example.test/assets/screenshots/multilang-01.png", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_UsesFirstMarkdownImage_ForBlogSocialPreview_WhenNoSiteImageOrGeneratedCardExists()
+    {
+        var root = CreateTempRoot("pf-web-social-blog-inline-fallback-");
+        try
+        {
+            var blogPath = Path.Combine(root, "content", "blog");
+            Directory.CreateDirectory(blogPath);
+            File.WriteAllText(Path.Combine(blogPath, "inline-image-fallback.md"),
+                """
+                ---
+                title: Inline Image Fallback
+                description: Blog fallback image selection test.
+                slug: inline-image-fallback
+                ---
+
+                Intro text.
+
+                ![Primary screenshot](/assets/screenshots/fallback-01.png)
+
+                More text.
+                """);
+
+            var spec = BuildPagesSpec();
+            spec.Social = new SocialSpec
+            {
+                Enabled = true,
+                SiteName = "Example Site",
+                AutoGenerateCards = false
+            };
+            spec.Collections = new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "blog",
+                    Input = "content/blog",
+                    Output = "/blog"
+                }
+            };
+
+            var html = BuildAndRead(root, spec, Path.Combine("blog", "inline-image-fallback", "index.html"));
+            Assert.Contains("property=\"og:image\" content=\"https://example.test/assets/screenshots/fallback-01.png\"", html, StringComparison.Ordinal);
+            Assert.Contains("name=\"twitter:image\" content=\"https://example.test/assets/screenshots/fallback-01.png\"", html, StringComparison.Ordinal);
             Assert.DoesNotContain("/assets/social/generated/", html, StringComparison.Ordinal);
         }
         finally

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.SeoDoctor.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.SeoDoctor.cs
@@ -62,6 +62,7 @@ internal static partial class WebPipelineRunner
             UseDefaultExcludes = useDefaultExclude,
             MaxHtmlFiles = Math.Max(0, maxHtmlFiles),
             IncludeNoIndexPages = GetBool(step, "includeNoIndexPages") ?? false,
+            PageAssertions = ResolvePageAssertions(step),
             CheckTitleLength = GetBool(step, "checkTitleLength") ?? true,
             CheckDescriptionLength = GetBool(step, "checkDescriptionLength") ?? true,
             CheckH1 = GetBool(step, "checkH1") ?? GetBool(step, "checkHeading") ?? true,
@@ -283,6 +284,58 @@ internal static partial class WebPipelineRunner
         }
 
         return sb.ToString().Trim('-');
+    }
+
+    private static WebSeoDoctorPageAssertion[] ResolvePageAssertions(JsonElement step)
+    {
+        var items = GetArrayOfObjects(step, "pageAssertions") ??
+                    GetArrayOfObjects(step, "page-assertions");
+        if (items is not { Length: > 0 })
+            return Array.Empty<WebSeoDoctorPageAssertion>();
+
+        var assertions = new List<WebSeoDoctorPageAssertion>();
+        foreach (var item in items)
+        {
+            var path = GetString(item, "path") ??
+                       GetString(item, "page") ??
+                       GetString(item, "route");
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+
+            assertions.Add(new WebSeoDoctorPageAssertion
+            {
+                Path = path,
+                Label = GetString(item, "label") ?? string.Empty,
+                MustExist = GetBool(item, "mustExist") ?? GetBool(item, "must-exist") ?? true,
+                Contains = ResolveStringArrayOrSingle(item, "contains"),
+                NotContains = ResolveStringArrayOrSingle(item, "notContains", "not-contains"),
+                Scope = GetString(item, "scope") ??
+                        GetString(item, "matchIn") ??
+                        GetString(item, "match-in") ??
+                        "body"
+            });
+        }
+
+        return assertions.ToArray();
+    }
+
+    private static string[] ResolveStringArrayOrSingle(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var values = GetArrayOfStrings(element, name);
+            if (values is { Length: > 0 })
+                return values;
+
+            var single = GetString(element, name);
+            if (!string.IsNullOrWhiteSpace(single))
+                return new[] { single };
+        }
+
+        return Array.Empty<string>();
     }
 
     private static string[] ResolveFocusKeyphraseMetaNames(JsonElement step)

--- a/PowerForge.Web/Models/WebSeoDoctorOptions.cs
+++ b/PowerForge.Web/Models/WebSeoDoctorOptions.cs
@@ -17,6 +17,8 @@ public sealed class WebSeoDoctorOptions
     public int MaxHtmlFiles { get; set; }
     /// <summary>When false, pages declaring robots noindex are skipped.</summary>
     public bool IncludeNoIndexPages { get; set; }
+    /// <summary>Representative page assertions evaluated independently from the scanned page subset.</summary>
+    public WebSeoDoctorPageAssertion[] PageAssertions { get; set; } = Array.Empty<WebSeoDoctorPageAssertion>();
 
     /// <summary>When true, run title length checks.</summary>
     public bool CheckTitleLength { get; set; } = true;

--- a/PowerForge.Web/Models/WebSeoDoctorPageAssertion.cs
+++ b/PowerForge.Web/Models/WebSeoDoctorPageAssertion.cs
@@ -15,7 +15,8 @@ public sealed class WebSeoDoctorPageAssertion
     public string[] NotContains { get; set; } = Array.Empty<string>();
     /// <summary>
     /// Content scope to inspect. Supported values are <c>body</c>, <c>rendered</c>, and <c>html</c>.
-    /// Unknown values fall back to <c>body</c>.
+    /// <c>rendered</c> is accepted as an alias of <c>body</c>, and diagnostics report the canonical
+    /// <c>body</c> scope name. Unknown values also fall back to <c>body</c>.
     /// </summary>
     public string Scope { get; set; } = "body";
 }

--- a/PowerForge.Web/Models/WebSeoDoctorPageAssertion.cs
+++ b/PowerForge.Web/Models/WebSeoDoctorPageAssertion.cs
@@ -13,6 +13,9 @@ public sealed class WebSeoDoctorPageAssertion
     public string[] Contains { get; set; } = Array.Empty<string>();
     /// <summary>Text snippets that must not appear in the selected page scope.</summary>
     public string[] NotContains { get; set; } = Array.Empty<string>();
-    /// <summary>Content scope to inspect. Supported values are <c>body</c>, <c>rendered</c>, and <c>html</c>.</summary>
+    /// <summary>
+    /// Content scope to inspect. Supported values are <c>body</c>, <c>rendered</c>, and <c>html</c>.
+    /// Unknown values fall back to <c>body</c>.
+    /// </summary>
     public string Scope { get; set; } = "body";
 }

--- a/PowerForge.Web/Models/WebSeoDoctorPageAssertion.cs
+++ b/PowerForge.Web/Models/WebSeoDoctorPageAssertion.cs
@@ -1,0 +1,18 @@
+namespace PowerForge.Web;
+
+/// <summary>Represents an opt-in rendered page assertion for SEO doctor checks.</summary>
+public sealed class WebSeoDoctorPageAssertion
+{
+    /// <summary>Relative output path or route-like page path to validate.</summary>
+    public string Path { get; set; } = string.Empty;
+    /// <summary>Optional friendly label used in diagnostics.</summary>
+    public string Label { get; set; } = string.Empty;
+    /// <summary>When true, the asserted page must exist.</summary>
+    public bool MustExist { get; set; } = true;
+    /// <summary>Text snippets that must appear in the selected page scope.</summary>
+    public string[] Contains { get; set; } = Array.Empty<string>();
+    /// <summary>Text snippets that must not appear in the selected page scope.</summary>
+    public string[] NotContains { get; set; } = Array.Empty<string>();
+    /// <summary>Content scope to inspect. Supported values are <c>body</c>, <c>rendered</c>, and <c>html</c>.</summary>
+    public string Scope { get; set; } = "body";
+}

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -324,6 +324,8 @@ public static class WebSeoDoctor
             }
         }
 
+        ValidatePageAssertions(siteRoot, options.PageAssertions, AddIssue);
+
         if (pages.Count == 0)
             AddIssue("warning", "general", null, "No HTML pages selected for SEO doctor checks.", "no-pages");
 
@@ -785,6 +787,210 @@ public static class WebSeoDoctor
                 "content-markdown-leak",
                 sample);
         }
+    }
+
+    private static void ValidatePageAssertions(
+        string siteRoot,
+        IReadOnlyList<WebSeoDoctorPageAssertion>? assertions,
+        Action<string, string, string?, string, string?, string?> addIssue)
+    {
+        if (assertions is null || assertions.Count == 0)
+            return;
+
+        foreach (var assertion in assertions)
+        {
+            if (assertion is null || string.IsNullOrWhiteSpace(assertion.Path))
+                continue;
+
+            var displayName = GetPageAssertionDisplayName(assertion);
+            if (!TryResolvePageAssertionPath(siteRoot, assertion.Path, out var assertedFile, out var relativePath))
+            {
+                if (assertion.MustExist)
+                {
+                    AddPageAssertionIssue(
+                        addIssue,
+                        relativePath,
+                        displayName,
+                        NormalizePageAssertionScope(assertion.Scope),
+                        "page-assertion-missing-page",
+                        "asserted page is missing.",
+                        assertion.Path);
+                }
+
+                continue;
+            }
+
+            string html;
+            try
+            {
+                html = File.ReadAllText(assertedFile);
+            }
+            catch (Exception ex)
+            {
+                AddPageAssertionIssue(
+                    addIssue,
+                    relativePath,
+                    displayName,
+                    NormalizePageAssertionScope(assertion.Scope),
+                    "page-assertion-read",
+                    $"failed to read asserted page ({ex.Message}).",
+                    ex.GetType().Name);
+                continue;
+            }
+
+            string inspectedText;
+            var scope = NormalizePageAssertionScope(assertion.Scope);
+            if (scope.Equals("html", StringComparison.OrdinalIgnoreCase))
+            {
+                inspectedText = NormalizeWhitespace(html);
+            }
+            else
+            {
+                AngleSharp.Dom.IDocument doc;
+                try
+                {
+                    doc = HtmlParser.ParseWithAngleSharp(html);
+                }
+                catch (Exception ex)
+                {
+                    AddPageAssertionIssue(
+                        addIssue,
+                        relativePath,
+                        displayName,
+                        scope,
+                        "page-assertion-parse",
+                        $"failed to parse asserted page ({ex.Message}).",
+                        ex.GetType().Name);
+                    continue;
+                }
+
+                inspectedText = GetVisibleBodyText(doc.Body);
+            }
+
+            foreach (var expected in NormalizePageAssertionValues(assertion.Contains))
+            {
+                if (inspectedText.IndexOf(expected, StringComparison.OrdinalIgnoreCase) >= 0)
+                    continue;
+
+                AddPageAssertionIssue(
+                    addIssue,
+                    relativePath,
+                    displayName,
+                    scope,
+                    "page-assertion-contains",
+                    $"missing expected {scope} text '{expected}'.",
+                    expected);
+            }
+
+            foreach (var forbidden in NormalizePageAssertionValues(assertion.NotContains))
+            {
+                if (inspectedText.IndexOf(forbidden, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                AddPageAssertionIssue(
+                    addIssue,
+                    relativePath,
+                    displayName,
+                    scope,
+                    "page-assertion-not-contains",
+                    $"contains forbidden {scope} text '{forbidden}'.",
+                    forbidden);
+            }
+        }
+    }
+
+    private static void AddPageAssertionIssue(
+        Action<string, string, string?, string, string?, string?> addIssue,
+        string relativePath,
+        string displayName,
+        string scope,
+        string hint,
+        string detail,
+        string? keyHint)
+    {
+        addIssue(
+            "error",
+            "page-assertion",
+            relativePath,
+            $"page assertion '{displayName}' failed: {detail}",
+            hint,
+            $"{scope}|{keyHint}");
+    }
+
+    private static string[] NormalizePageAssertionValues(string[]? values)
+    {
+        return (values ?? Array.Empty<string>())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(NormalizeWhitespace)
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string NormalizePageAssertionScope(string? scope)
+    {
+        var normalized = NormalizeWhitespace(scope);
+        if (normalized.Equals("html", StringComparison.OrdinalIgnoreCase))
+            return "html";
+        if (normalized.Equals("rendered", StringComparison.OrdinalIgnoreCase))
+            return "body";
+        return "body";
+    }
+
+    private static string GetPageAssertionDisplayName(WebSeoDoctorPageAssertion assertion)
+    {
+        var label = NormalizeWhitespace(assertion.Label);
+        if (!string.IsNullOrWhiteSpace(label))
+            return label;
+
+        var normalizedPath = NormalizeAssertionRelativePath(assertion.Path);
+        return string.IsNullOrWhiteSpace(normalizedPath) ? assertion.Path.Trim() : normalizedPath;
+    }
+
+    private static bool TryResolvePageAssertionPath(
+        string siteRoot,
+        string assertionPath,
+        out string resolvedPath,
+        out string relativePath)
+    {
+        resolvedPath = string.Empty;
+        relativePath = NormalizeAssertionRelativePath(assertionPath);
+        if (string.IsNullOrWhiteSpace(relativePath))
+            return false;
+
+        var candidate = Path.GetFullPath(Path.Combine(siteRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!candidate.StartsWith(siteRoot, FileSystemPathComparison))
+            return false;
+
+        resolvedPath = candidate;
+        relativePath = Path.GetRelativePath(siteRoot, candidate).Replace('\\', '/');
+        return File.Exists(candidate);
+    }
+
+    private static string NormalizeAssertionRelativePath(string? assertionPath)
+    {
+        var normalized = StripQueryAndFragment(assertionPath ?? string.Empty)
+            .Replace('\\', '/')
+            .Trim();
+        if (string.IsNullOrWhiteSpace(normalized) || normalized.Equals("/", StringComparison.Ordinal))
+            return "index.html";
+
+        normalized = normalized.TrimStart('/');
+        if (string.IsNullOrWhiteSpace(normalized))
+            return "index.html";
+
+        var explicitDirectory = normalized.EndsWith("/", StringComparison.Ordinal);
+        normalized = normalized.TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(normalized))
+            return "index.html";
+
+        if (explicitDirectory)
+            return normalized + "/index.html";
+
+        if (Path.HasExtension(normalized))
+            return normalized;
+
+        return normalized + "/index.html";
     }
 
     private static void ValidateStructuredData(

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -987,7 +987,9 @@ public static class WebSeoDoctor
         if (explicitDirectory)
             return normalized + "/index.html";
 
-        if (Path.HasExtension(normalized))
+        var extension = Path.GetExtension(normalized);
+        if (!string.IsNullOrWhiteSpace(extension) &&
+            DefaultHtmlExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
             return normalized;
 
         return normalized + "/index.html";

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -959,7 +959,7 @@ public static class WebSeoDoctor
             return false;
 
         var candidate = Path.GetFullPath(Path.Combine(siteRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
-        if (!candidate.StartsWith(siteRoot, FileSystemPathComparison))
+        if (!IsPathWithinRoot(NormalizeRootPath(siteRoot), candidate))
             return false;
 
         resolvedPath = candidate;
@@ -1790,6 +1790,18 @@ public static class WebSeoDoctor
         return href.TrimEnd('/');
     }
 
+    private static string NormalizeRootPath(string rootPath)
+    {
+        var full = Path.GetFullPath(rootPath);
+        return full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+    }
+
+    private static bool IsPathWithinRoot(string normalizedRoot, string candidatePath)
+    {
+        var full = Path.GetFullPath(candidatePath);
+        return full.StartsWith(normalizedRoot, FileSystemPathComparison);
+    }
+
     private static bool TryResolveLocalTarget(string siteRoot, string baseDir, string href, out string resolvedPath)
     {
         resolvedPath = string.Empty;
@@ -1805,7 +1817,7 @@ public static class WebSeoDoctor
 
         var candidateBase = isRooted ? siteRoot : baseDir;
         var candidate = Path.GetFullPath(Path.Combine(candidateBase, relative));
-        if (!candidate.StartsWith(siteRoot, FileSystemPathComparison))
+        if (!IsPathWithinRoot(NormalizeRootPath(siteRoot), candidate))
             return false;
 
         if (isExplicitDir)

--- a/PowerForge.Web/Services/WebSiteBuilder.SocialCards.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.SocialCards.cs
@@ -34,10 +34,7 @@ public static partial class WebSiteBuilder
         if (!string.IsNullOrWhiteSpace(explicitMetaImage))
             return explicitMetaImage!;
 
-        if (!string.Equals(item.Collection, "blog", StringComparison.OrdinalIgnoreCase))
-            return string.Empty;
-
-        return TryExtractFirstBodyImage(item.SourcePath);
+        return string.Empty;
     }
 
     private static string ResolveSocialImagePath(
@@ -59,7 +56,13 @@ public static partial class WebSiteBuilder
                 return generated;
         }
 
-        return spec.Social?.Image ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(spec.Social?.Image))
+            return spec.Social.Image!;
+
+        if (string.Equals(item.Collection, "blog", StringComparison.OrdinalIgnoreCase))
+            return TryExtractFirstBodyImage(item.SourcePath);
+
+        return string.Empty;
     }
 
     private static string TryGenerateSocialCardPath(


### PR DESCRIPTION
## Summary
- add representative page assertions to SEO doctor so specific routes can be validated outside the scanned subset
- tighten social card resolution so generated cards win before inline body-image fallback
- cover the new SEO doctor and social card behavior with targeted tests

## Verification
- `dotnet test .\\PSPublishModule.sln -c Release --filter ""FullyQualifiedName~WebSeoDoctorTests|FullyQualifiedName~WebPipelineRunnerSeoDoctorTests|FullyQualifiedName~WebSiteSocialCardsTests""`