### PR TITLE
Harden module install and pipeline test coverage

### DIFF
--- a/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
@@ -11,10 +11,15 @@ public sealed class GitHubRunnerHousekeepingWorkflowTests
         Assert.True(File.Exists(workflowPath), $"Runner housekeeping workflow not found: {workflowPath}");
 
         var workflowYaml = File.ReadAllText(workflowPath);
+        var runsOnLine = File.ReadLines(workflowPath)
+            .Single(line => line.TrimStart().StartsWith("runs-on:", StringComparison.Ordinal));
+
         Assert.Contains("PowerForge GitHub Runner Housekeeping", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner-labels", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("fromJson(", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("inputs['runner-labels']", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("fromJson(", runsOnLine, StringComparison.Ordinal);
+        Assert.Contains("inputs.runner_labels_json != '' && inputs.runner_labels_json", runsOnLine, StringComparison.Ordinal);
+        Assert.Contains("inputs['runner-labels'] != '' && inputs['runner-labels']", runsOnLine, StringComparison.Ordinal);
+        Assert.Contains("'[\"self-hosted\",\"ubuntu\"]'", runsOnLine, StringComparison.Ordinal);
         Assert.Contains("./.powerforge/pspublishmodule/.github/actions/github-housekeeping", workflowYaml, StringComparison.Ordinal);
         Assert.Contains(".powerforge/runner-housekeeping.json", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner-min-free-gb", workflowYaml, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
@@ -13,7 +13,8 @@ public sealed class GitHubRunnerHousekeepingWorkflowTests
         var workflowYaml = File.ReadAllText(workflowPath);
         Assert.Contains("PowerForge GitHub Runner Housekeeping", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner-labels", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("fromJson(inputs['runner-labels'])", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("fromJson(", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("inputs['runner-labels']", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("./.powerforge/pspublishmodule/.github/actions/github-housekeeping", workflowYaml, StringComparison.Ordinal);
         Assert.Contains(".powerforge/runner-housekeeping.json", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner-min-free-gb", workflowYaml, StringComparison.Ordinal);

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -54,6 +54,28 @@ public sealed class ModuleBuildHostServiceTests
         Assert.True(result.Succeeded);
     }
 
+    [Fact]
+    public async Task ExecuteBuildAsync_DoesNotForwardSigningFlags_WhenUnset()
+    {
+        PowerShellRunRequest? captured = null;
+        var runner = new StubPowerShellRunner(request => {
+            captured = request;
+            return new PowerShellRunResult(0, "ok", string.Empty, "pwsh");
+        });
+        var service = new ModuleBuildHostService(runner);
+
+        var result = await service.ExecuteBuildAsync(new ModuleBuildHostBuildRequest {
+            RepositoryRoot = @"C:\repo",
+            ScriptPath = @"C:\repo\Build\Build-Module.ps1",
+            ModulePath = @"C:\repo\Module\PSPublishModule.psd1"
+        });
+
+        Assert.NotNull(captured);
+        Assert.DoesNotContain("-NoSign", captured!.CommandText!, StringComparison.Ordinal);
+        Assert.DoesNotContain("-SignModule", captured.CommandText!, StringComparison.Ordinal);
+        Assert.True(result.Succeeded);
+    }
+
     private sealed class StubPowerShellRunner : IPowerShellRunner
     {
         private readonly Func<PowerShellRunRequest, PowerShellRunResult> _execute;

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -31,7 +31,7 @@ public sealed class ModuleBuildHostServiceTests
     }
 
     [Fact]
-    public async Task ExecuteBuildAsync_UsesSharedSigningOverrideWrapper()
+    public async Task ExecuteBuildAsync_ForwardsSigningFlags()
     {
         PowerShellRunRequest? captured = null;
         var runner = new StubPowerShellRunner(request => {
@@ -43,14 +43,14 @@ public sealed class ModuleBuildHostServiceTests
         var result = await service.ExecuteBuildAsync(new ModuleBuildHostBuildRequest {
             RepositoryRoot = @"C:\repo",
             ScriptPath = @"C:\repo\Build\Build-Module.ps1",
-            ModulePath = @"C:\repo\Module\PSPublishModule.psd1"
+            ModulePath = @"C:\repo\Module\PSPublishModule.psd1",
+            NoSign = true
         });
 
         Assert.NotNull(captured);
         Assert.Equal(PowerShellInvocationMode.Command, captured!.InvocationMode);
-        Assert.Contains("function New-ConfigurationBuild", captured.CommandText!, StringComparison.Ordinal);
-        Assert.Contains("$params['SignModule'] = $false", captured.CommandText!, StringComparison.Ordinal);
-        Assert.Contains("-SignModule:$false", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains(@". 'C:\repo\Build\Build-Module.ps1'", captured.CommandText!, StringComparison.Ordinal);
+        Assert.Contains("-NoSign", captured.CommandText!, StringComparison.Ordinal);
         Assert.True(result.Succeeded);
     }
 

--- a/PowerForge.Tests/ModuleInstallerLegacyFlatHandlingTests.cs
+++ b/PowerForge.Tests/ModuleInstallerLegacyFlatHandlingTests.cs
@@ -122,8 +122,54 @@ public sealed class ModuleInstallerLegacyFlatHandlingTests
             _ = installer.InstallFromStaging(staging, moduleName, "3.0.0", opts);
 
             Assert.False(File.Exists(Path.Combine(moduleRoot, $"{moduleName}.psd1")));
-            Assert.True(Directory.Exists(Path.Combine(moduleRoot, "_legacy_flat")));
-            Assert.NotEmpty(Directory.GetDirectories(Path.Combine(moduleRoot, "_legacy_flat")));
+            Assert.True(Directory.Exists(Path.Combine(moduleRoot, "3.0.0")));
+            var quarantineRoot = Path.Combine(moduleRoot, "_legacy_flat");
+            Assert.True(Directory.Exists(quarantineRoot));
+            var quarantine = Assert.Single(Directory.GetDirectories(quarantineRoot));
+            Assert.StartsWith("unknown_", Path.GetFileName(quarantine), StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(quarantine, $"{moduleName}.psd1")));
+            Assert.True(Directory.Exists(Path.Combine(quarantine, "Public")));
+        }
+        finally
+        {
+            try { temp.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void InstallFromStaging_ConvertQuarantinesFlatItems_WhenManifestCannotBeDecoded()
+    {
+        var temp = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var staging = Path.Combine(temp.FullName, "staging");
+            var roots = Path.Combine(temp.FullName, "roots");
+            Directory.CreateDirectory(staging);
+            Directory.CreateDirectory(roots);
+
+            const string moduleName = "Foo";
+            WriteMinimalModule(staging, moduleName, "3.0.0");
+
+            var moduleRoot = Path.Combine(roots, moduleName);
+            Directory.CreateDirectory(moduleRoot);
+            File.WriteAllText(Path.Combine(moduleRoot, $"{moduleName}.psm1"), string.Empty);
+            File.WriteAllBytes(Path.Combine(moduleRoot, $"{moduleName}.psd1"), new byte[] { 0x80, 0x80, 0x80 });
+
+            var installer = new ModuleInstaller(new NullLogger());
+            var opts = new ModuleInstallerOptions(
+                destinationRoots: new[] { roots },
+                strategy: InstallationStrategy.Exact,
+                keepVersions: 1,
+                legacyFlatHandling: LegacyFlatModuleHandling.Convert,
+                preserveVersions: null);
+
+            _ = installer.InstallFromStaging(staging, moduleName, "3.0.0", opts);
+
+            var quarantineRoot = Path.Combine(moduleRoot, "_legacy_flat");
+            var quarantine = Assert.Single(Directory.GetDirectories(quarantineRoot));
+            Assert.StartsWith("unknown_", Path.GetFileName(quarantine), StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(quarantine, $"{moduleName}.psd1")));
+            Assert.True(Directory.Exists(Path.Combine(moduleRoot, "3.0.0")));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineApprovedModulesTests.cs
+++ b/PowerForge.Tests/ModulePipelineApprovedModulesTests.cs
@@ -147,7 +147,7 @@ public sealed class ModulePipelineApprovedModulesTests
             var requiredNames = ReadRequiredModuleNames(result.BuildResult.ManifestPath);
 
             Assert.Contains("LegacyOnly", requiredNames, StringComparer.OrdinalIgnoreCase);
-            Assert.Contains("Microsoft.PowerShell.Utility", requiredNames, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Microsoft.PowerShell.Utility", requiredNames, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain("Graphimo", requiredNames, StringComparer.OrdinalIgnoreCase);
         }
         finally
@@ -198,12 +198,12 @@ public sealed class ModulePipelineApprovedModulesTests
 
             var requiredNames = ReadRequiredModuleNames(result.BuildResult.ManifestPath);
             Assert.Contains("LegacyOnly", requiredNames, StringComparer.OrdinalIgnoreCase);
-            Assert.Contains("Microsoft.PowerShell.Utility", requiredNames, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Microsoft.PowerShell.Utility", requiredNames, StringComparer.OrdinalIgnoreCase);
 
             Assert.True(ManifestEditor.TryGetPsDataStringArray(result.BuildResult.ManifestPath, "ExternalModuleDependencies", out var externalDeps));
             Assert.NotNull(externalDeps);
-            Assert.Contains("Microsoft.PowerShell.Utility", externalDeps!, StringComparer.OrdinalIgnoreCase);
-            Assert.Contains("Microsoft.PowerShell.Management", externalDeps!, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Microsoft.PowerShell.Utility", externalDeps!, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Microsoft.PowerShell.Management", externalDeps!, StringComparer.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineApprovedModulesTests.cs
+++ b/PowerForge.Tests/ModulePipelineApprovedModulesTests.cs
@@ -147,6 +147,7 @@ public sealed class ModulePipelineApprovedModulesTests
             var requiredNames = ReadRequiredModuleNames(result.BuildResult.ManifestPath);
 
             Assert.Contains("LegacyOnly", requiredNames, StringComparer.OrdinalIgnoreCase);
+            // Inbox modules are filtered out of generated RequiredModules metadata.
             Assert.DoesNotContain("Microsoft.PowerShell.Utility", requiredNames, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain("Graphimo", requiredNames, StringComparer.OrdinalIgnoreCase);
         }
@@ -198,6 +199,7 @@ public sealed class ModulePipelineApprovedModulesTests
 
             var requiredNames = ReadRequiredModuleNames(result.BuildResult.ManifestPath);
             Assert.Contains("LegacyOnly", requiredNames, StringComparer.OrdinalIgnoreCase);
+            // Inbox modules are filtered out of generated RequiredModules and ExternalModuleDependencies metadata.
             Assert.DoesNotContain("Microsoft.PowerShell.Utility", requiredNames, StringComparer.OrdinalIgnoreCase);
 
             Assert.True(ManifestEditor.TryGetPsDataStringArray(result.BuildResult.ManifestPath, "ExternalModuleDependencies", out var externalDeps));

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -382,10 +382,10 @@ public sealed class ModulePipelineManifestRefreshTests
 
             Assert.True(ManifestEditor.TryGetRequiredModules(manifestPath, out RequiredModuleReference[]? requiredModules));
             Assert.NotNull(requiredModules);
-            Assert.Equal(2, requiredModules!.Length);
+            Assert.Single(requiredModules!);
             Assert.Contains(requiredModules, module => string.Equals(module.ModuleName, "LegacyOnly", StringComparison.OrdinalIgnoreCase));
-            Assert.Contains(requiredModules, module => string.Equals(module.ModuleName, "Az.Accounts", StringComparison.OrdinalIgnoreCase));
             Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "Microsoft.PowerShell.Utility", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "Az.Accounts", StringComparison.OrdinalIgnoreCase));
 
             Assert.True(ManifestEditor.TryGetPsDataStringArray(manifestPath, "ExternalModuleDependencies", out var externalModules));
             Assert.Equal(new[] { "Az.Accounts" }, externalModules);

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -384,6 +384,7 @@ public sealed class ModulePipelineManifestRefreshTests
             Assert.NotNull(requiredModules);
             Assert.Single(requiredModules!);
             Assert.Contains(requiredModules, module => string.Equals(module.ModuleName, "LegacyOnly", StringComparison.OrdinalIgnoreCase));
+            // Inbox and externally-classified modules are filtered out of generated RequiredModules metadata.
             Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "Microsoft.PowerShell.Utility", StringComparison.OrdinalIgnoreCase));
             Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "Az.Accounts", StringComparison.OrdinalIgnoreCase));
 

--- a/PowerForge.Tests/PowerForgeCliProjectReleaseTests.cs
+++ b/PowerForge.Tests/PowerForgeCliProjectReleaseTests.cs
@@ -6,7 +6,7 @@ namespace PowerForge.Tests;
 public sealed class PowerForgeCliProjectReleaseTests
 {
     [Fact]
-    public void ProjectRelease_CliPreservesProjectDefaultsFromConfig()
+    public async Task ProjectRelease_CliPreservesProjectDefaultsFromConfig()
     {
         var repoRoot = FindRepositoryRoot();
         var tempRoot = CreateTempDirectory();
@@ -61,9 +61,16 @@ public sealed class PowerForgeCliProjectReleaseTests
             };
 
             process.Start();
-            var stdout = process.StandardOutput.ReadToEnd();
-            var stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(120_000))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+                throw new TimeoutException("PowerForge CLI project release plan test timed out.");
+            }
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
 
             Assert.True(process.ExitCode == 0, $"CLI exit code {process.ExitCode}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
 

--- a/PowerForge.Tests/PowerForgeCliProjectReleaseTests.cs
+++ b/PowerForge.Tests/PowerForgeCliProjectReleaseTests.cs
@@ -69,6 +69,10 @@ public sealed class PowerForgeCliProjectReleaseTests
                 throw new TimeoutException("PowerForge CLI project release plan test timed out.");
             }
 
+            var drainTask = Task.WhenAll(stdoutTask, stderrTask);
+            if (await Task.WhenAny(drainTask, Task.Delay(TimeSpan.FromSeconds(10))) != drainTask)
+                throw new TimeoutException("PowerForge CLI project release plan output drain timed out.");
+
             var stdout = await stdoutTask;
             var stderr = await stderrTask;
 

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -3609,9 +3609,24 @@ public sealed class PowerForgeReleaseServiceTests
 
     private static void TryDelete(string path)
     {
-        if (Directory.Exists(path))
-            Directory.Delete(path, recursive: true);
-        else if (File.Exists(path))
-            File.Delete(path);
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                    Directory.Delete(path, recursive: true);
+                else if (File.Exists(path))
+                    File.Delete(path);
+                return;
+            }
+            catch (IOException) when (attempt < 9)
+            {
+                Thread.Sleep(50);
+            }
+            catch (UnauthorizedAccessException) when (attempt < 9)
+            {
+                Thread.Sleep(50);
+            }
+        }
     }
 }

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -3623,9 +3623,17 @@ public sealed class PowerForgeReleaseServiceTests
             {
                 Thread.Sleep(50);
             }
+            catch (IOException)
+            {
+                return;
+            }
             catch (UnauthorizedAccessException) when (attempt < 9)
             {
                 Thread.Sleep(50);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return;
             }
         }
     }

--- a/PowerForge/Services/ModuleInstaller.cs
+++ b/PowerForge/Services/ModuleInstaller.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace PowerForge;
@@ -9,7 +10,7 @@ public sealed class ModuleInstaller
 {
     private readonly ILogger _logger;
     private static readonly char[] PathSeparators = { '/', '\\' };
-    private static readonly ModuleManifestMetadataReader ManifestMetadataReader = new();
+    private static readonly Encoding StrictUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     /// <summary>
     /// Creates a new installer.
@@ -172,7 +173,8 @@ public sealed class ModuleInstaller
         if (handling != LegacyFlatModuleHandling.Convert)
             return;
 
-        if (!LegacyFlatManifestHasModuleVersion(flatManifest))
+        if (!TryReadLegacyFlatManifestVersion(flatManifest, out var legacyVersion) ||
+            string.IsNullOrWhiteSpace(legacyVersion))
         {
             var target = EnsureLegacyFlatQuarantineFolder(moduleRoot, "unknown");
             _logger.Warn($"Legacy flat install detected but ModuleVersion could not be read. Quarantining to '{target}'.");
@@ -180,18 +182,9 @@ public sealed class ModuleInstaller
             return;
         }
 
-        var metadata = TryReadManifestMetadata(flatManifest);
-        if (string.IsNullOrWhiteSpace(metadata?.ModuleVersion))
-        {
-            var target = EnsureLegacyFlatQuarantineFolder(moduleRoot, "unknown");
-            _logger.Warn($"Legacy flat install detected but ModuleVersion could not be read. Quarantining to '{target}'.");
-            MoveLegacyFlatItems(moduleRoot, target);
-            return;
-        }
-
-        var legacyVersion = metadata!.ModuleVersion.Trim();
+        legacyVersion = (legacyVersion ?? string.Empty).Trim();
         try { ValidatePathSegment(legacyVersion, nameof(legacyVersion)); }
-        catch
+        catch (ArgumentException)
         {
             var target = EnsureLegacyFlatQuarantineFolder(moduleRoot, "invalidversion");
             _logger.Warn($"Legacy flat install detected but ModuleVersion '{legacyVersion}' is not a safe folder name. Quarantining to '{target}'.");
@@ -280,29 +273,29 @@ public sealed class ModuleInstaller
         return Version.TryParse(basePart, out _);
     }
 
-    private ModuleManifestMetadata? TryReadManifestMetadata(string manifestPath)
+    private bool TryReadLegacyFlatManifestVersion(string manifestPath, out string? version)
     {
-        try
-        {
-            return ManifestMetadataReader.Read(manifestPath);
-        }
-        catch (Exception ex)
-        {
-            _logger.Warn($"Failed to read manifest metadata from '{manifestPath}': {ex.Message}");
-            return null;
-        }
-    }
+        version = null;
 
-    private static bool LegacyFlatManifestHasModuleVersion(string manifestPath)
-    {
         try
         {
-            var content = File.ReadAllText(manifestPath);
-            return ModuleManifestTextParser.TryGetQuotedStringValue(content, "ModuleVersion", out var version) &&
+            var content = File.ReadAllText(manifestPath, StrictUtf8);
+            return ModuleManifestTextParser.TryGetQuotedStringValue(content, "ModuleVersion", out version) &&
                    !string.IsNullOrWhiteSpace(version);
         }
-        catch
+        catch (IOException ex)
         {
+            _logger.Verbose($"Failed to read legacy flat manifest '{manifestPath}': {ex.Message}");
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.Verbose($"Failed to read legacy flat manifest '{manifestPath}': {ex.Message}");
+            return false;
+        }
+        catch (System.Text.DecoderFallbackException ex)
+        {
+            _logger.Verbose($"Failed to decode legacy flat manifest '{manifestPath}': {ex.Message}");
             return false;
         }
     }

--- a/PowerForge/Services/ModuleInstaller.cs
+++ b/PowerForge/Services/ModuleInstaller.cs
@@ -172,6 +172,14 @@ public sealed class ModuleInstaller
         if (handling != LegacyFlatModuleHandling.Convert)
             return;
 
+        if (!LegacyFlatManifestHasModuleVersion(flatManifest))
+        {
+            var target = EnsureLegacyFlatQuarantineFolder(moduleRoot, "unknown");
+            _logger.Warn($"Legacy flat install detected but ModuleVersion could not be read. Quarantining to '{target}'.");
+            MoveLegacyFlatItems(moduleRoot, target);
+            return;
+        }
+
         var metadata = TryReadManifestMetadata(flatManifest);
         if (string.IsNullOrWhiteSpace(metadata?.ModuleVersion))
         {
@@ -282,6 +290,20 @@ public sealed class ModuleInstaller
         {
             _logger.Warn($"Failed to read manifest metadata from '{manifestPath}': {ex.Message}");
             return null;
+        }
+    }
+
+    private static bool LegacyFlatManifestHasModuleVersion(string manifestPath)
+    {
+        try
+        {
+            var content = File.ReadAllText(manifestPath);
+            return ModuleManifestTextParser.TryGetQuotedStringValue(content, "ModuleVersion", out var version) &&
+                   !string.IsNullOrWhiteSpace(version);
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/PowerForge/Services/StoreSubmissionService.cs
+++ b/PowerForge/Services/StoreSubmissionService.cs
@@ -255,6 +255,8 @@ internal sealed class StoreSubmissionService : IDisposable
         if (authentication is null)
             throw new InvalidOperationException("Store submission authentication settings are required.");
 
+        _ = NormalizeAuthorityHost(authentication.AuthorityHost);
+
         var accessToken = ResolveCredential(authentication.AccessToken, authentication.AccessTokenEnvVar);
         if (!string.IsNullOrWhiteSpace(accessToken))
             return;

--- a/PowerForge/Services/StoreSubmissionService.cs
+++ b/PowerForge/Services/StoreSubmissionService.cs
@@ -255,7 +255,7 @@ internal sealed class StoreSubmissionService : IDisposable
         if (authentication is null)
             throw new InvalidOperationException("Store submission authentication settings are required.");
 
-        _ = NormalizeAuthorityHost(authentication.AuthorityHost);
+        ValidateAuthorityHost(authentication.AuthorityHost);
 
         var accessToken = ResolveCredential(authentication.AccessToken, authentication.AccessTokenEnvVar);
         if (!string.IsNullOrWhiteSpace(accessToken))
@@ -684,6 +684,16 @@ internal sealed class StoreSubmissionService : IDisposable
             : authorityHost.Trim();
         var uri = ValidateHttpsUrl(normalized, nameof(authorityHost));
         return uri.GetLeftPart(UriPartial.Authority).TrimEnd('/');
+    }
+
+    private static void ValidateAuthorityHost(string authorityHost)
+    {
+        // Blank authority host values intentionally use the same Microsoft Entra default as token resolution.
+        var normalized = string.IsNullOrWhiteSpace(authorityHost)
+            ? "https://login.microsoftonline.com"
+            : authorityHost.Trim();
+
+        ValidateHttpsUrl(normalized, nameof(authorityHost));
     }
 
     private static Uri ValidateHttpsUrl(string value, string parameterName)


### PR DESCRIPTION
## Summary
- quarantine legacy flat module installs when ModuleVersion cannot be read before conversion
- validate store submission authority hosts earlier during authentication checks
- align module pipeline and build-host tests with current dependency and signing behavior
- harden CLI/release tests against hangs and transient file cleanup races

## Validation
- dotnet test .\\PowerForge.Tests\\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~GitHubRunnerHousekeepingWorkflowTests|FullyQualifiedName~ModuleBuildHostServiceTests|FullyQualifiedName~ModulePipelineApprovedModulesTests|FullyQualifiedName~ModulePipelineManifestRefreshTests"
- dotnet test .\\PowerForge.Tests\\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeCliProjectReleaseTests|FullyQualifiedName~PowerForgeReleaseServiceTests"