### PR TITLE
Add MSBuild batch pack strategy

### DIFF
--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -306,7 +306,7 @@ Versioning
 - When both `VersionTracks` and `ExpectedVersionMap` are present, the explicit map wins for matching projects.
 - `UpdateVersions`: when false, csproj files are not updated.
 - Version source resolution can use `NugetSource` (v3 index URL or local folder) with optional credentials.
-- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`. The batch target runs `Restore;Pack`, so private feed credentials must already be available to `dotnet`/MSBuild restore. Batch mode stops on the first project failure and skips projects that do not have a resolved version.
+- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`. The batch target runs `Restore;Pack`, so private feed credentials must already be available to `dotnet`/MSBuild restore. Batch mode stops on the first project failure and reports projects without a resolved version as failed skipped projects.
 
 Staging and outputs
 - `StagingPath`: root directory for pipeline outputs (recommended).

--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -306,7 +306,7 @@ Versioning
 - When both `VersionTracks` and `ExpectedVersionMap` are present, the explicit map wins for matching projects.
 - `UpdateVersions`: when false, csproj files are not updated.
 - Version source resolution can use `NugetSource` (v3 index URL or local folder) with optional credentials.
-- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`.
+- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`. The batch target runs `Restore;Pack`, so private feed credentials must already be available to `dotnet`/MSBuild restore.
 
 Staging and outputs
 - `StagingPath`: root directory for pipeline outputs (recommended).

--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -306,7 +306,7 @@ Versioning
 - When both `VersionTracks` and `ExpectedVersionMap` are present, the explicit map wins for matching projects.
 - `UpdateVersions`: when false, csproj files are not updated.
 - Version source resolution can use `NugetSource` (v3 index URL or local folder) with optional credentials.
-- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) generates a temporary traversal project and packs selected projects in one parallel MSBuild invocation, which is usually faster for multi-project repositories with shared project references.
+- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`.
 
 Staging and outputs
 - `StagingPath`: root directory for pipeline outputs (recommended).

--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -306,7 +306,7 @@ Versioning
 - When both `VersionTracks` and `ExpectedVersionMap` are present, the explicit map wins for matching projects.
 - `UpdateVersions`: when false, csproj files are not updated.
 - Version source resolution can use `NugetSource` (v3 index URL or local folder) with optional credentials.
-- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`. The batch target runs `Restore;Pack`, so private feed credentials must already be available to `dotnet`/MSBuild restore. Batch mode stops on the first project failure and reports projects without a resolved version as failed skipped projects.
+- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`. The batch target runs `Restore;Pack`, so private feed credentials must already be available to `dotnet`/MSBuild restore. Batch mode stops on the first project failure and treats the whole failed batch as failed, so already-produced packages from that batch are not signed or published. Projects without a resolved version are reported as failed skipped projects.
 
 Staging and outputs
 - `StagingPath`: root directory for pipeline outputs (recommended).

--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -306,7 +306,7 @@ Versioning
 - When both `VersionTracks` and `ExpectedVersionMap` are present, the explicit map wins for matching projects.
 - `UpdateVersions`: when false, csproj files are not updated.
 - Version source resolution can use `NugetSource` (v3 index URL or local folder) with optional credentials.
-- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`. The batch target runs `Restore;Pack`, so private feed credentials must already be available to `dotnet`/MSBuild restore.
+- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and packs selected projects in one parallel MSBuild invocation. If no package output path is available, it logs a warning and falls back to `PerProject`. The batch target runs `Restore;Pack`, so private feed credentials must already be available to `dotnet`/MSBuild restore. Batch mode stops on the first project failure and skips projects that do not have a resolved version.
 
 Staging and outputs
 - `StagingPath`: root directory for pipeline outputs (recommended).

--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -266,6 +266,7 @@ Example configuration
   "PlanOutputPath": "Artefacts/ProjectBuild/project.build.plan.json",
   "UpdateVersions": true,
   "Build": true,
+  "PackStrategy": "MSBuild",
   "PublishNuget": true,
   "PublishGitHub": true,
   "CreateReleaseZip": true,
@@ -305,6 +306,7 @@ Versioning
 - When both `VersionTracks` and `ExpectedVersionMap` are present, the explicit map wins for matching projects.
 - `UpdateVersions`: when false, csproj files are not updated.
 - Version source resolution can use `NugetSource` (v3 index URL or local folder) with optional credentials.
+- `PackStrategy`: optional packing strategy. `PerProject` runs the legacy `dotnet pack` loop. `MSBuild` (alias `Batch`) generates a temporary traversal project and packs selected projects in one parallel MSBuild invocation, which is usually faster for multi-project repositories with shared project references.
 
 Staging and outputs
 - `StagingPath`: root directory for pipeline outputs (recommended).

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 using Xunit;
 
@@ -237,5 +238,17 @@ public sealed class DotNetRepositoryReleaseServiceTests
         {
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
+    }
+
+    [Fact]
+    public void FormatDuration_UsesHoursForLongRuns()
+    {
+        var method = typeof(DotNetRepositoryReleaseService).GetMethod(
+            "FormatDuration",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        var formatted = Assert.IsType<string>(method!.Invoke(null, new object[] { TimeSpan.FromMinutes(90) }));
+
+        Assert.Equal("1h 30.0m", formatted);
     }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -200,7 +200,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
             var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
             var csprojPath = Path.Combine(projectDir.FullName, "Sample.Package.csproj");
             var traversalPath = Path.Combine(root.FullName, "pack.proj");
-            var outputPath = Path.Combine(root.FullName, "packages;with%value");
+            var outputPath = Path.Combine(root.FullName, "packages;with%value=2");
             var project = new DotNetRepositoryProjectResult
             {
                 ProjectName = "Sample.Package",
@@ -229,7 +229,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.Equal("Restore;Pack", msbuild.Attribute("Targets")?.Value);
             Assert.Equal("true", msbuild.Attribute("BuildInParallel")?.Value);
             Assert.Equal(
-                $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B")}",
+                $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D")}",
                 msbuild.Attribute("Properties")?.Value);
         }
         finally

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Xml.Linq;
 using Xunit;
 
@@ -222,11 +221,10 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 outputPath);
 
             var document = XDocument.Load(traversalPath);
-            XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
-            var packProject = Assert.Single(document.Descendants(ns + "PackProject"));
+            var packProject = Assert.Single(document.Descendants("PackProject"));
             Assert.Equal(Path.GetFullPath(csprojPath), packProject.Attribute("Include")?.Value);
 
-            var msbuild = Assert.Single(document.Descendants(ns + "MSBuild"));
+            var msbuild = Assert.Single(document.Descendants("MSBuild"));
             Assert.Equal("@(PackProject)", msbuild.Attribute("Projects")?.Value);
             Assert.Equal("Restore;Pack", msbuild.Attribute("Targets")?.Value);
             Assert.Equal("true", msbuild.Attribute("BuildInParallel")?.Value);
@@ -243,12 +241,37 @@ public sealed class DotNetRepositoryReleaseServiceTests
     [Fact]
     public void FormatDuration_UsesHoursForLongRuns()
     {
-        var method = typeof(DotNetRepositoryReleaseService).GetMethod(
-            "FormatDuration",
-            BindingFlags.Static | BindingFlags.NonPublic);
-
-        var formatted = Assert.IsType<string>(method!.Invoke(null, new object[] { TimeSpan.FromMinutes(90) }));
+        var formatted = DotNetRepositoryReleaseService.FormatDuration(TimeSpan.FromMinutes(90));
 
         Assert.Equal("1h 30.0m", formatted);
+    }
+
+    [Fact]
+    public void PackageSnapshot_DetectsNewAndChangedPackages()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var existing = Path.Combine(root.FullName, "Sample.Package.1.0.0.nupkg");
+            var symbols = Path.Combine(root.FullName, "Sample.Package.1.0.0.symbols.nupkg");
+            File.WriteAllText(existing, "old");
+            File.WriteAllText(symbols, "symbols");
+
+            var snapshot = DotNetRepositoryReleaseService.SnapshotPackages(root.FullName);
+
+            Assert.False(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, existing));
+
+            File.WriteAllText(existing, "changed package");
+            var created = Path.Combine(root.FullName, "Sample.Package.1.0.1.nupkg");
+            File.WriteAllText(created, "new");
+
+            Assert.True(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, existing));
+            Assert.True(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, created));
+            Assert.DoesNotContain(symbols, snapshot.Keys, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
     }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -271,11 +271,19 @@ public sealed class DotNetRepositoryReleaseServiceTests
         var summary = DotNetRepositoryReleaseService.SummarizeProcessOutputLines(string.Join(Environment.NewLine, lines));
 
         Assert.Contains("line 1", summary);
-        Assert.Contains("... omitted 30 line(s) ...", summary);
+        Assert.Contains("... omitted 30 line(s); diagnostic lines from that range are shown below when detected ...", summary);
         Assert.Contains("diagnostic lines:", summary);
         Assert.Contains("Project.csproj : error NU1301: Unable to load service index", summary);
         Assert.Contains("last 40 line(s):", summary);
         Assert.Contains("line 80", summary);
+    }
+
+    [Fact]
+    public void SummarizeProcessOutputLines_returns_short_output_verbatim()
+    {
+        var output = string.Join(Environment.NewLine, new[] { "first", "second", "third" });
+
+        Assert.Equal(output, DotNetRepositoryReleaseService.SummarizeProcessOutputLines(output));
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -200,7 +200,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
             var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
             var csprojPath = Path.Combine(projectDir.FullName, "Sample.Package.csproj");
             var traversalPath = Path.Combine(root.FullName, "pack.proj");
-            var outputPath = Path.Combine(root.FullName, "packages;with%value=2");
+            var outputPath = Path.Combine(root.FullName, "packages;with%value=2$build@local");
             var project = new DotNetRepositoryProjectResult
             {
                 ProjectName = "Sample.Package",
@@ -229,7 +229,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.Equal("Restore;Pack", msbuild.Attribute("Targets")?.Value);
             Assert.Equal("true", msbuild.Attribute("BuildInParallel")?.Value);
             Assert.Equal(
-                $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D")}",
+                $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D").Replace("$", "%24").Replace("@", "%40")}",
                 msbuild.Attribute("Properties")?.Value);
         }
         finally

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -262,6 +262,23 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
+    public void SummarizeProcessOutputLines_includes_first_last_and_diagnostic_lines()
+    {
+        var lines = Enumerable.Range(1, 80)
+            .Select(i => i == 31 ? "Project.csproj : error NU1301: Unable to load service index" : $"line {i}")
+            .ToArray();
+
+        var summary = DotNetRepositoryReleaseService.SummarizeProcessOutputLines(string.Join(Environment.NewLine, lines));
+
+        Assert.Contains("line 1", summary);
+        Assert.Contains("... omitted 30 line(s) ...", summary);
+        Assert.Contains("diagnostic lines:", summary);
+        Assert.Contains("Project.csproj : error NU1301: Unable to load service index", summary);
+        Assert.Contains("last 40 line(s):", summary);
+        Assert.Contains("line 80", summary);
+    }
+
+    [Fact]
     public void PackageSnapshot_DetectsNewAndChangedPackages()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -228,6 +228,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.Equal("@(PackProject)", msbuild.Attribute("Projects")?.Value);
             Assert.Equal("Restore;Pack", msbuild.Attribute("Targets")?.Value);
             Assert.Equal("true", msbuild.Attribute("BuildInParallel")?.Value);
+            Assert.Equal("true", msbuild.Attribute("StopOnFirstFailure")?.Value);
             Assert.Equal(
                 $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D").Replace("$", "%24").Replace("@", "%40")}",
                 msbuild.Attribute("Properties")?.Value);

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -238,12 +238,26 @@ public sealed class DotNetRepositoryReleaseServiceTests
         }
     }
 
-    [Fact]
-    public void FormatDuration_UsesHoursForLongRuns()
+    [Theory]
+    [InlineData(5_400_000, "1h 30.0m")]
+    [InlineData(65_000, "1.1m")]
+    [InlineData(1_500, "1.5s")]
+    [InlineData(12, "12ms")]
+    public void FormatDuration_returns_human_readable_output(int milliseconds, string expected)
     {
-        var formatted = DotNetRepositoryReleaseService.FormatDuration(TimeSpan.FromMinutes(90));
+        var formatted = DotNetRepositoryReleaseService.FormatDuration(TimeSpan.FromMilliseconds(milliseconds));
 
-        Assert.Equal("1h 30.0m", formatted);
+        Assert.Equal(expected, formatted);
+    }
+
+    [Theory]
+    [InlineData(1023, "1023 B")]
+    [InlineData(1024, "1 KB")]
+    [InlineData(1048576, "1 MB")]
+    [InlineData(1073741824, "1 GB")]
+    public void FormatBytes_returns_human_readable_output(long bytes, string expected)
+    {
+        Assert.Equal(expected, DotNetRepositoryReleaseService.FormatBytes(bytes));
     }
 
     [Fact]
@@ -267,6 +281,9 @@ public sealed class DotNetRepositoryReleaseServiceTests
 
             Assert.True(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, existing));
             Assert.True(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, created));
+
+            File.Delete(existing);
+            Assert.False(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, existing));
             Assert.DoesNotContain(symbols, snapshot.Keys, StringComparer.OrdinalIgnoreCase);
         }
         finally

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -187,5 +189,53 @@ public sealed class DotNetRepositoryReleaseServiceTests
             stdOut: "Your package was pushed.");
 
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, result.Outcome);
+    }
+
+    [Fact]
+    public void WritePackTraversalProject_EmitsBatchPackProjectWithEscapedProperties()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            var csprojPath = Path.Combine(projectDir.FullName, "Sample.Package.csproj");
+            var traversalPath = Path.Combine(root.FullName, "pack.proj");
+            var outputPath = Path.Combine(root.FullName, "packages;with%value");
+            var project = new DotNetRepositoryProjectResult
+            {
+                ProjectName = "Sample.Package",
+                CsprojPath = csprojPath,
+                PackageId = "Sample.Package",
+                IsPackable = true
+            };
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release"
+            };
+
+            DotNetRepositoryReleaseService.WritePackTraversalProject(
+                traversalPath,
+                new[] { project },
+                spec,
+                outputPath);
+
+            var document = XDocument.Load(traversalPath);
+            XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+            var packProject = Assert.Single(document.Descendants(ns + "PackProject"));
+            Assert.Equal(Path.GetFullPath(csprojPath), packProject.Attribute("Include")?.Value);
+
+            var msbuild = Assert.Single(document.Descendants(ns + "MSBuild"));
+            Assert.Equal("@(PackProject)", msbuild.Attribute("Projects")?.Value);
+            Assert.Equal("Restore;Pack", msbuild.Attribute("Targets")?.Value);
+            Assert.Equal("true", msbuild.Attribute("BuildInParallel")?.Value);
+            Assert.Equal(
+                $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B")}",
+                msbuild.Attribute("Properties")?.Value);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
     }
 }

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -122,6 +122,8 @@ public sealed class ProjectBuildPreparationServiceTests
     [InlineData(null, DotNetRepositoryPackStrategy.PerProject)]
     [InlineData("", DotNetRepositoryPackStrategy.PerProject)]
     [InlineData("   ", DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData("PerProject", DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData("perproject", DotNetRepositoryPackStrategy.PerProject)]
     [InlineData("MSBuild", DotNetRepositoryPackStrategy.MSBuild)]
     [InlineData("msbuild", DotNetRepositoryPackStrategy.MSBuild)]
     [InlineData("Batch", DotNetRepositoryPackStrategy.MSBuild)]

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -89,6 +89,7 @@ public sealed class ProjectBuildPreparationServiceTests
                 GitHubAccessTokenEnvName = gitHubEnv,
                 CertificateStore = "LocalMachine",
                 Configuration = "Debug",
+                PackStrategy = "MSBuild",
                 PublishNuget = true,
                 PublishGitHub = true
             };
@@ -107,6 +108,7 @@ public sealed class ProjectBuildPreparationServiceTests
             Assert.Equal("secret-from-file", context.Spec.VersionSourceCredential.Secret);
             Assert.Equal(CertificateStoreLocation.LocalMachine, context.Spec.CertificateStore);
             Assert.Equal("Debug", context.Spec.Configuration);
+            Assert.Equal(DotNetRepositoryPackStrategy.MSBuild, context.Spec.PackStrategy);
         }
         finally
         {

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -118,6 +118,19 @@ public sealed class ProjectBuildPreparationServiceTests
         }
     }
 
+    [Theory]
+    [InlineData(null, DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData("", DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData("   ", DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData("MSBuild", DotNetRepositoryPackStrategy.MSBuild)]
+    [InlineData("msbuild", DotNetRepositoryPackStrategy.MSBuild)]
+    [InlineData("Batch", DotNetRepositoryPackStrategy.MSBuild)]
+    [InlineData("Other", DotNetRepositoryPackStrategy.PerProject)]
+    public void ParsePackStrategy_maps_known_values(string? value, DotNetRepositoryPackStrategy expected)
+    {
+        Assert.Equal(expected, ProjectBuildSupportService.ParsePackStrategy(value));
+    }
+
     [Fact]
     public void Prepare_can_resolve_to_no_work_when_all_actions_are_disabled()
     {

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -134,6 +134,27 @@ public sealed class ProjectBuildPreparationServiceTests
     }
 
     [Fact]
+    public void Prepare_warns_when_pack_strategy_is_unknown()
+    {
+        var logger = new BufferedLogger();
+        var service = new ProjectBuildPreparationService(logger);
+
+        var context = service.Prepare(
+            new ProjectBuildConfiguration
+            {
+                PackStrategy = "MSBuild2"
+            },
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions());
+
+        Assert.Equal(DotNetRepositoryPackStrategy.PerProject, context.Spec.PackStrategy);
+        Assert.Contains(logger.Entries, entry =>
+            entry.Level == "warn" &&
+            entry.Message.Contains("Unknown PackStrategy 'MSBuild2'", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Prepare_can_resolve_to_no_work_when_all_actions_are_disabled()
     {
         var service = new ProjectBuildPreparationService();

--- a/PowerForge/Models/DotNetRepositoryPackStrategy.cs
+++ b/PowerForge/Models/DotNetRepositoryPackStrategy.cs
@@ -1,0 +1,13 @@
+namespace PowerForge;
+
+/// <summary>
+/// Strategy used to pack selected .NET repository projects.
+/// </summary>
+public enum DotNetRepositoryPackStrategy
+{
+    /// <summary>Run <c>dotnet pack</c> once per selected project.</summary>
+    PerProject,
+
+    /// <summary>Generate a temporary MSBuild traversal project and pack selected projects in one invocation.</summary>
+    MSBuild
+}

--- a/PowerForge/Models/DotNetRepositoryPackStrategy.cs
+++ b/PowerForge/Models/DotNetRepositoryPackStrategy.cs
@@ -8,6 +8,9 @@ public enum DotNetRepositoryPackStrategy
     /// <summary>Run <c>dotnet pack</c> once per selected project.</summary>
     PerProject,
 
-    /// <summary>Generate a temporary MSBuild traversal project and pack selected projects in one invocation.</summary>
+    /// <summary>
+    /// Generate a temporary MSBuild traversal project and pack selected projects in one invocation.
+    /// Also accepted from configuration as the string alias <c>Batch</c>.
+    /// </summary>
     MSBuild
 }

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -59,6 +59,9 @@ public sealed class DotNetRepositoryReleaseSpec
     /// <summary>When true, runs dotnet pack.</summary>
     public bool Pack { get; set; } = true;
 
+    /// <summary>Strategy used for packing selected projects.</summary>
+    public DotNetRepositoryPackStrategy PackStrategy { get; set; } = DotNetRepositoryPackStrategy.PerProject;
+
     /// <summary>When true, create a release zip from the build output.</summary>
     public bool CreateReleaseZip { get; set; }
 

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -27,6 +27,7 @@ internal sealed class ProjectBuildConfiguration
     public string? PlanOutputPath { get; set; }
     public bool? UpdateVersions { get; set; }
     public bool? Build { get; set; }
+    public string? PackStrategy { get; set; }
     public bool? PublishNuget { get; set; }
     public bool? PublishGitHub { get; set; }
     public bool? CreateReleaseZip { get; set; }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -276,7 +276,18 @@ public sealed partial class DotNetRepositoryReleaseService
                             string.IsNullOrWhiteSpace(project.ErrorMessage) &&
                             !string.IsNullOrWhiteSpace(project.NewVersion))
                         .ToArray();
+                    var missingVersionCandidates = packable
+                        .Where(project =>
+                            string.IsNullOrWhiteSpace(project.ErrorMessage) &&
+                            string.IsNullOrWhiteSpace(project.NewVersion))
+                        .ToArray();
                     batchCandidateSet = new HashSet<DotNetRepositoryProjectResult>(batchCandidates);
+
+                    if (missingVersionCandidates.Length > 0)
+                    {
+                        var names = string.Join(", ", missingVersionCandidates.Select(project => project.ProjectName));
+                        _logger.Warn($"MSBuild batch pack excluded {missingVersionCandidates.Length} project(s) without a resolved version; they will be skipped during pack: {names}");
+                    }
 
                     if (string.IsNullOrWhiteSpace(spec.OutputPath))
                     {
@@ -344,6 +355,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         continue;
                     }
 
+                    // A successful batch result contains all produced packages; narrow it to this project/version.
                     var filtered = FilterPackages(packResult.Packages, project.PackageId, project.NewVersion!);
                     if (filtered.Count == 0)
                     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -336,7 +336,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         _logger.Info($"Packing {project.ProjectName}...");
 
                     var packResult = useBatchPackResult ? batchPackResult! : PackProject(project, spec, _logger);
-                    if (!packResult.Success)
+                    if (!useBatchPackResult && !packResult.Success)
                     {
                         project.ErrorMessage = packResult.ErrorMessage;
                         _logger.Warn($"{project.ProjectName}: pack failed. {packResult.ErrorMessage}");

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -301,7 +301,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         batchPackResult = PackProjectsWithMsBuild(batchCandidates, spec, _logger);
                         if (!batchPackResult.Success)
                         {
-                            var batchError = $"{batchPackResult.ErrorMessage ?? "MSBuild batch pack failed."} (MSBuild batch failed; see batch output for per-project details.)";
+                            var batchError = $"{batchPackResult.ErrorMessage ?? "MSBuild batch pack failed."} (MSBuild batch failed; enable verbose logging to see per-project MSBuild output.)";
                             foreach (var project in batchCandidates)
                                 project.ErrorMessage = batchError;
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -267,6 +267,7 @@ public sealed partial class DotNetRepositoryReleaseService
             if (spec.Pack)
             {
                 DotNetPackResult? batchPackResult = null;
+                HashSet<DotNetRepositoryProjectResult>? batchCandidateSet = null;
                 var batchPackRequested = spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf;
                 if (batchPackRequested)
                 {
@@ -275,6 +276,7 @@ public sealed partial class DotNetRepositoryReleaseService
                             string.IsNullOrWhiteSpace(project.ErrorMessage) &&
                             !string.IsNullOrWhiteSpace(project.NewVersion))
                         .ToArray();
+                    batchCandidateSet = new HashSet<DotNetRepositoryProjectResult>(batchCandidates);
 
                     if (string.IsNullOrWhiteSpace(spec.OutputPath))
                     {
@@ -326,12 +328,14 @@ public sealed partial class DotNetRepositoryReleaseService
                         continue;
                     }
 
-                    if (batchPackResult is not null)
+                    var useBatchPackResult = batchPackResult is not null && batchCandidateSet?.Contains(project) == true;
+
+                    if (useBatchPackResult)
                         _logger.Info($"Collecting {project.ProjectName} package(s) from MSBuild batch...");
                     else
                         _logger.Info($"Packing {project.ProjectName}...");
 
-                    var packResult = batchPackResult ?? PackProject(project, spec, _logger);
+                    var packResult = useBatchPackResult ? batchPackResult! : PackProject(project, spec, _logger);
                     if (!packResult.Success)
                     {
                         project.ErrorMessage = packResult.ErrorMessage;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -287,6 +287,8 @@ public sealed partial class DotNetRepositoryReleaseService
                     {
                         var names = string.Join(", ", missingVersionCandidates.Select(project => project.ProjectName));
                         _logger.Warn($"MSBuild batch pack excluded {missingVersionCandidates.Length} project(s) without a resolved version; they will be skipped during pack: {names}");
+                        foreach (var project in missingVersionCandidates)
+                            project.ErrorMessage = "No resolved version; skipping pack.";
                     }
 
                     if (string.IsNullOrWhiteSpace(spec.OutputPath))

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -299,7 +299,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         batchPackResult = PackProjectsWithMsBuild(batchCandidates, spec, _logger);
                         if (!batchPackResult.Success)
                         {
-                            var batchError = batchPackResult.ErrorMessage ?? "MSBuild batch pack failed.";
+                            var batchError = $"{batchPackResult.ErrorMessage ?? "MSBuild batch pack failed."} (MSBuild batch failed; see batch output for per-project details.)";
                             foreach (var project in batchCandidates)
                                 project.ErrorMessage = batchError;
 
@@ -371,6 +371,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         project.Packages.Add(pkg);
 
                     var ignored = packResult.Packages.Except(filtered, StringComparer.OrdinalIgnoreCase).ToArray();
+                    // In batch mode, ignored packages are normally packages for other batched projects.
                     if (ignored.Length > 0 && batchPackResult is null)
                         _logger.Verbose($"{project.ProjectName}: ignored {ignored.Length} package(s) from other versions.");
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -266,6 +266,42 @@ public sealed partial class DotNetRepositoryReleaseService
 
             if (spec.Pack)
             {
+                DotNetPackResult? batchPackResult = null;
+                var batchPackRequested = spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf;
+                if (batchPackRequested)
+                {
+                    var batchCandidates = packable
+                        .Where(project =>
+                            string.IsNullOrWhiteSpace(project.ErrorMessage) &&
+                            !string.IsNullOrWhiteSpace(project.NewVersion))
+                        .ToArray();
+
+                    if (string.IsNullOrWhiteSpace(spec.OutputPath))
+                    {
+                        _logger.Warn("MSBuild pack strategy requires OutputPath/StagingPath; falling back to per-project dotnet pack.");
+                    }
+                    else if (batchCandidates.Length > 0)
+                    {
+                        _logger.Info($"Packing {batchCandidates.Length} project(s) with MSBuild batch strategy...");
+                        batchPackResult = PackProjectsWithMsBuild(batchCandidates, spec, _logger);
+                        if (!batchPackResult.Success)
+                        {
+                            var batchError = batchPackResult.ErrorMessage ?? "MSBuild batch pack failed.";
+                            foreach (var project in batchCandidates)
+                                project.ErrorMessage = batchError;
+
+                            result.Success = false;
+                            _logger.Warn(batchError);
+                            if (spec.PublishFailFast)
+                                return result;
+                        }
+                        else
+                        {
+                            _logger.Success($"MSBuild batch pack produced {batchPackResult.Packages.Count} package(s) in {FormatDuration(batchPackResult.Duration)}.");
+                        }
+                    }
+                }
+
                 foreach (var project in packable)
                 {
                     if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
@@ -290,8 +326,12 @@ public sealed partial class DotNetRepositoryReleaseService
                         continue;
                     }
 
-                    _logger.Info($"Packing {project.ProjectName}...");
-                    var packResult = PackProject(project, spec);
+                    if (batchPackResult is not null)
+                        _logger.Info($"Collecting {project.ProjectName} package(s) from MSBuild batch...");
+                    else
+                        _logger.Info($"Packing {project.ProjectName}...");
+
+                    var packResult = batchPackResult ?? PackProject(project, spec, _logger);
                     if (!packResult.Success)
                     {
                         project.ErrorMessage = packResult.ErrorMessage;
@@ -315,11 +355,16 @@ public sealed partial class DotNetRepositoryReleaseService
                         project.Packages.Add(pkg);
 
                     var ignored = packResult.Packages.Except(filtered, StringComparer.OrdinalIgnoreCase).ToArray();
-                    if (ignored.Length > 0)
+                    if (ignored.Length > 0 && batchPackResult is null)
                         _logger.Verbose($"{project.ProjectName}: ignored {ignored.Length} package(s) from other versions.");
 
                     if (filtered.Count > 0)
-                        _logger.Success($"{project.ProjectName}: packed {filtered.Count} package(s).");
+                    {
+                        var packTiming = batchPackResult is null
+                            ? $" in {FormatDuration(packResult.Duration)}"
+                            : " from MSBuild batch";
+                        _logger.Success($"{project.ProjectName}: packed {filtered.Count} package(s){packTiming}.");
+                    }
 
                     if (signingSha256 is not null)
                     {
@@ -334,8 +379,10 @@ public sealed partial class DotNetRepositoryReleaseService
                         }
 
                         _logger.Info($"Signing {project.ProjectName} package(s)...");
+                        var signingWatch = Stopwatch.StartNew();
                         if (!SignPackages(project.Packages, spec, signingSha256, out var signError))
                         {
+                            signingWatch.Stop();
                             project.ErrorMessage = signError;
                             _logger.Warn($"{project.ProjectName}: {signError}");
                             result.Success = false;
@@ -344,7 +391,8 @@ public sealed partial class DotNetRepositoryReleaseService
                         }
                         else
                         {
-                            _logger.Success($"{project.ProjectName}: signed {project.Packages.Count} package(s).");
+                            signingWatch.Stop();
+                            _logger.Success($"{project.ProjectName}: signed {project.Packages.Count} package(s) in {FormatDuration(signingWatch.Elapsed)}.");
                         }
                     }
 
@@ -354,8 +402,11 @@ public sealed partial class DotNetRepositoryReleaseService
                         project.ReleaseZipPath = zipPath;
                         if (!spec.WhatIf)
                         {
-                            if (!TryCreateReleaseZip(project, spec.Configuration, zipPath, out var zipError))
+                            _logger.Info($"Creating {project.ProjectName} release zip...");
+                            var zipWatch = Stopwatch.StartNew();
+                            if (!TryCreateReleaseZip(project, spec.Configuration, zipPath, out var zipError, out var zippedFiles, out var zippedBytes))
                             {
+                                zipWatch.Stop();
                                 project.ErrorMessage = zipError;
                                 _logger.Warn($"{project.ProjectName}: {zipError}");
                                 result.Success = false;
@@ -364,7 +415,9 @@ public sealed partial class DotNetRepositoryReleaseService
                             }
                             else
                             {
-                                _logger.Success($"{project.ProjectName}: release zip created.");
+                                zipWatch.Stop();
+                                var zipSize = File.Exists(zipPath) ? new FileInfo(zipPath).Length : 0;
+                                _logger.Success($"{project.ProjectName}: release zip created in {FormatDuration(zipWatch.Elapsed)} ({zippedFiles} file(s), {FormatBytes(zippedBytes)} input, {FormatBytes(zipSize)} zip).");
                             }
                         }
                     }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ExpectedAndZip.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ExpectedAndZip.cs
@@ -80,9 +80,13 @@ public sealed partial class DotNetRepositoryReleaseService
         DotNetRepositoryProjectResult project,
         string configuration,
         string zipPath,
-        out string error)
+        out string error,
+        out int fileCount,
+        out long inputBytes)
     {
         error = string.Empty;
+        fileCount = 0;
+        inputBytes = 0;
         var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
         var cfg = string.IsNullOrWhiteSpace(configuration) ? "Release" : configuration.Trim();
         var releasePath = Path.Combine(csprojDir, "bin", cfg);
@@ -122,6 +126,8 @@ public sealed partial class DotNetRepositoryReleaseService
                 var entry = archive.CreateEntry(rel, System.IO.Compression.CompressionLevel.Optimal);
                 using var entryStream = entry.Open();
                 using var fileStream = File.OpenRead(file);
+                fileCount++;
+                inputBytes += fileStream.Length;
                 fileStream.CopyTo(entryStream);
             }
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -38,7 +38,7 @@ public sealed partial class DotNetRepositoryReleaseService
         return $"{duration.TotalMilliseconds:0}ms";
     }
 
-    private static string FormatBytes(long bytes)
+    internal static string FormatBytes(long bytes)
     {
         const double kb = 1024d;
         const double mb = kb * 1024d;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -12,6 +12,8 @@ namespace PowerForge;
 
 public sealed partial class DotNetRepositoryReleaseService
 {
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(15);
+
     private sealed class DotNetPackResult
     {
         public bool Success { get; set; }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -16,7 +16,50 @@ public sealed partial class DotNetRepositoryReleaseService
     {
         public bool Success { get; set; }
         public string? ErrorMessage { get; set; }
+        public TimeSpan Duration { get; set; }
         public List<string> Packages { get; } = new();
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalMinutes >= 1)
+            return $"{duration.TotalMinutes:0.0}m";
+
+        if (duration.TotalSeconds >= 1)
+            return $"{duration.TotalSeconds:0.0}s";
+
+        return $"{duration.TotalMilliseconds:0}ms";
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        const double kb = 1024d;
+        const double mb = kb * 1024d;
+        const double gb = mb * 1024d;
+
+        if (bytes >= gb)
+            return $"{bytes / gb:0.##} GB";
+
+        if (bytes >= mb)
+            return $"{bytes / mb:0.##} MB";
+
+        if (bytes >= kb)
+            return $"{bytes / kb:0.##} KB";
+
+        return $"{bytes} B";
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
     }
 
 #if NET472

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -20,7 +20,7 @@ public sealed partial class DotNetRepositoryReleaseService
         public List<string> Packages { get; } = new();
     }
 
-    private static string FormatDuration(TimeSpan duration)
+    internal static string FormatDuration(TimeSpan duration)
     {
         if (duration.TotalHours >= 1)
         {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -56,16 +56,17 @@ public sealed partial class DotNetRepositoryReleaseService
         return $"{bytes} B";
     }
 
-    private static void TryDeleteDirectory(string path)
+    private static void TryDeleteDirectory(string path, ILogger? logger = null)
     {
         try
         {
             if (Directory.Exists(path))
                 Directory.Delete(path, recursive: true);
         }
-        catch
+        catch (Exception ex)
         {
-            // Best-effort cleanup only.
+            if (logger?.IsVerbose == true)
+                logger.Verbose($"Failed to delete temporary directory '{path}': {ex.Message}");
         }
     }
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -22,6 +22,13 @@ public sealed partial class DotNetRepositoryReleaseService
 
     private static string FormatDuration(TimeSpan duration)
     {
+        if (duration.TotalHours >= 1)
+        {
+            var hours = (int)duration.TotalHours;
+            var minutes = duration.TotalMinutes - (hours * 60);
+            return $"{hours}h {minutes:0.0}m";
+        }
+
         if (duration.TotalMinutes >= 1)
             return $"{duration.TotalMinutes:0.0}m";
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -436,7 +436,7 @@ public sealed partial class DotNetRepositoryReleaseService
 
         var summary = new List<string>();
         summary.AddRange(lines.Take(firstLines));
-        summary.Add($"... omitted {middle.Length} line(s) ...");
+        summary.Add($"... omitted {middle.Length} line(s); diagnostic lines from that range are shown below when detected ...");
         if (diagnostics.Length > 0)
         {
             summary.Add("diagnostic lines:");
@@ -453,7 +453,8 @@ public sealed partial class DotNetRepositoryReleaseService
         return line.Contains(": error", StringComparison.OrdinalIgnoreCase) ||
                line.StartsWith("error", StringComparison.OrdinalIgnoreCase) ||
                line.Contains("exception", StringComparison.OrdinalIgnoreCase) ||
-               line.Contains("failed", StringComparison.OrdinalIgnoreCase) ||
+               line.StartsWith("failed", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains(": failed", StringComparison.OrdinalIgnoreCase) ||
                line.Contains("unable to", StringComparison.OrdinalIgnoreCase) ||
                line.Contains("not found", StringComparison.OrdinalIgnoreCase);
     }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -456,6 +456,9 @@ public sealed partial class DotNetRepositoryReleaseService
         string path)
     {
         var info = new FileInfo(path);
+        if (!info.Exists)
+            return false;
+
         if (!existingPackages.TryGetValue(path, out var existing))
             return true;
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -173,6 +173,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         // Restore is intentional so project references and package assets resolve inside the batch.
                         new XAttribute("Targets", "Restore;Pack"),
                         new XAttribute("BuildInParallel", "true"),
+                        new XAttribute("StopOnFirstFailure", "true"),
                         new XAttribute("Properties", properties)))));
 
         document.Save(traversalPath);
@@ -438,7 +439,7 @@ public sealed partial class DotNetRepositoryReleaseService
         var stdoutTask = p.StandardOutput.ReadToEndAsync();
         var stderrTask = p.StandardError.ReadToEndAsync();
         var stopwatch = Stopwatch.StartNew();
-        var nextProgress = TimeSpan.FromSeconds(15);
+        var nextProgress = HeartbeatInterval;
 
         while (!p.WaitForExit(1000))
         {
@@ -446,7 +447,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 continue;
 
             logger.Info(heartbeatMessage(stopwatch.Elapsed));
-            nextProgress += TimeSpan.FromSeconds(15);
+            nextProgress += HeartbeatInterval;
         }
 
         // On .NET Framework, WaitForExit(int) returning true does not guarantee async

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -74,7 +74,7 @@ public sealed partial class DotNetRepositoryReleaseService
         result.Duration = duration;
         if (exitCode != 0)
         {
-            result.ErrorMessage = $"dotnet pack failed for {project.ProjectName} (exit {exitCode}). {stdErr}".Trim();
+            result.ErrorMessage = $"dotnet pack failed for {project.ProjectName} (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
             return result;
         }
 
@@ -134,7 +134,7 @@ public sealed partial class DotNetRepositoryReleaseService
 
             if (exitCode != 0)
             {
-                result.ErrorMessage = $"dotnet msbuild batch pack failed (exit {exitCode}). {stdErr}".Trim();
+                result.ErrorMessage = $"dotnet msbuild batch pack failed (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
                 return result;
             }
 
@@ -397,6 +397,23 @@ public sealed partial class DotNetRepositoryReleaseService
             logger.Verbose($"{projectName}: {operation} stderr:{Environment.NewLine}{stdErr.TrimEnd()}");
     }
 
+    private static string SummarizeProcessFailureOutput(string stdErr, string stdOut)
+    {
+        var text = !string.IsNullOrWhiteSpace(stdErr) ? stdErr : stdOut;
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+
+        var lines = text.Replace("\r\n", "\n").Split('\n')
+            .Select(line => line.TrimEnd())
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+        if (lines.Length == 0)
+            return string.Empty;
+
+        const int maxLines = 40;
+        return string.Join(Environment.NewLine, lines.Skip(Math.Max(0, lines.Length - maxLines)));
+    }
+
     private static int RunProcessWithHeartbeat(
         ProcessStartInfo psi,
         ILogger logger,
@@ -426,6 +443,7 @@ public sealed partial class DotNetRepositoryReleaseService
             nextProgress += TimeSpan.FromSeconds(15);
         }
 
+        // Ensures redirected stream callbacks flush before reading async tasks.
         p.WaitForExit();
         stdOut = stdoutTask.GetAwaiter().GetResult();
         stdErr = stderrTask.GetAwaiter().GetResult();

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -412,14 +412,49 @@ public sealed partial class DotNetRepositoryReleaseService
             : string.Join(Environment.NewLine, sections);
     }
 
-    private static string SummarizeProcessOutputLines(string text)
+    internal static string SummarizeProcessOutputLines(string text)
     {
         var lines = text.Replace("\r\n", "\n").Split('\n')
             .Select(line => line.TrimEnd())
             .Where(line => !string.IsNullOrWhiteSpace(line))
             .ToArray();
-        const int maxLines = 40;
-        return string.Join(Environment.NewLine, lines.Skip(Math.Max(0, lines.Length - maxLines)));
+
+        const int firstLines = 10;
+        const int lastLines = 40;
+        const int maxDiagnosticLines = 20;
+        if (lines.Length <= firstLines + lastLines)
+            return string.Join(Environment.NewLine, lines);
+
+        var middle = lines.Skip(firstLines).Take(lines.Length - firstLines - lastLines).ToArray();
+        var diagnostics = middle
+            .Where(IsDiagnosticOutputLine)
+            .Distinct(StringComparer.Ordinal)
+            .Take(maxDiagnosticLines)
+            .ToArray();
+
+        var summary = new List<string>();
+        summary.AddRange(lines.Take(firstLines));
+        summary.Add($"... omitted {middle.Length} line(s) ...");
+        if (diagnostics.Length > 0)
+        {
+            summary.Add("diagnostic lines:");
+            summary.AddRange(diagnostics);
+        }
+
+        summary.Add($"last {lastLines} line(s):");
+        summary.AddRange(lines.Skip(lines.Length - lastLines));
+        return string.Join(Environment.NewLine, summary);
+    }
+
+    private static bool IsDiagnosticOutputLine(string line)
+    {
+        return line.Contains(": error", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains(" error ", StringComparison.OrdinalIgnoreCase) ||
+               line.StartsWith("error", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains("exception", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains("failed", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains("unable to", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains("not found", StringComparison.OrdinalIgnoreCase);
     }
 
     private static int RunProcessWithHeartbeat(

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -67,6 +67,9 @@ public sealed partial class DotNetRepositoryReleaseService
             Directory.CreateDirectory(outputPath);
         }
 
+        var packageRoot = outputPath ?? Path.Combine(csprojDir, "bin", configuration);
+        var existingPackages = SnapshotPackages(packageRoot);
+
         var exitCode = RunDotnetPack(project.CsprojPath, csprojDir, configuration, outputPath, project.ProjectName, logger, out var stdErr, out var stdOut, out var duration);
         result.Duration = duration;
         if (exitCode != 0)
@@ -75,11 +78,11 @@ public sealed partial class DotNetRepositoryReleaseService
             return result;
         }
 
-        var packageRoot = outputPath ?? Path.Combine(csprojDir, "bin", configuration);
         if (Directory.Exists(packageRoot))
         {
             var pkgs = Directory.EnumerateFiles(packageRoot, "*.nupkg", SearchOption.AllDirectories)
                 .Where(p => !p.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
                 .ToArray();
             result.Packages.AddRange(pkgs);
         }
@@ -94,7 +97,7 @@ public sealed partial class DotNetRepositoryReleaseService
         ILogger logger)
     {
         var result = new DotNetPackResult();
-        if (projects is null || projects.Count == 0)
+        if (projects.Count == 0)
         {
             result.Success = true;
             return result;
@@ -110,6 +113,7 @@ public sealed partial class DotNetRepositoryReleaseService
             ? spec.OutputPath!
             : Path.GetFullPath(Path.Combine(spec.RootPath, spec.OutputPath!));
         Directory.CreateDirectory(outputPath);
+        var existingPackages = SnapshotPackages(outputPath);
 
         var tempRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "project-build", $"pack-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempRoot);
@@ -136,6 +140,7 @@ public sealed partial class DotNetRepositoryReleaseService
 
             var pkgs = Directory.EnumerateFiles(outputPath, "*.nupkg", SearchOption.AllDirectories)
                 .Where(p => !p.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
                 .ToArray();
             result.Packages.AddRange(pkgs);
             result.Success = true;
@@ -147,7 +152,7 @@ public sealed partial class DotNetRepositoryReleaseService
         }
     }
 
-    private static void WritePackTraversalProject(
+    internal static void WritePackTraversalProject(
         string traversalPath,
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         DotNetRepositoryReleaseSpec spec,
@@ -155,7 +160,7 @@ public sealed partial class DotNetRepositoryReleaseService
     {
         XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
-        var properties = $"Configuration={configuration};PackageOutputPath={outputPath}";
+        var properties = $"Configuration={EscapeMsBuildPropertyValue(configuration)};PackageOutputPath={EscapeMsBuildPropertyValue(outputPath)}";
 
         var document = new XDocument(
             new XElement(ns + "Project",
@@ -166,6 +171,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     new XAttribute("Name", "PackSelected"),
                     new XElement(ns + "MSBuild",
                         new XAttribute("Projects", "@(PackProject)"),
+                        // Restore is intentional so project references and package assets resolve inside the batch.
                         new XAttribute("Targets", "Restore;Pack"),
                         new XAttribute("BuildInParallel", "true"),
                         new XAttribute("Properties", properties)))));
@@ -233,30 +239,15 @@ public sealed partial class DotNetRepositoryReleaseService
         }
 #endif
 
-        using var p = Process.Start(psi);
-        if (p is null) return 1;
-
-        var stdoutTask = p.StandardOutput.ReadToEndAsync();
-        var stderrTask = p.StandardError.ReadToEndAsync();
-        var stopwatch = Stopwatch.StartNew();
-        var nextProgress = TimeSpan.FromSeconds(15);
-
-        while (!p.WaitForExit(1000))
-        {
-            if (stopwatch.Elapsed < nextProgress)
-                continue;
-
-            logger.Info($"{projectName}: dotnet pack still running ({FormatDuration(stopwatch.Elapsed)} elapsed).");
-            nextProgress += TimeSpan.FromSeconds(15);
-        }
-
-        stdOut = stdoutTask.GetAwaiter().GetResult();
-        stdErr = stderrTask.GetAwaiter().GetResult();
-        stopwatch.Stop();
-        duration = stopwatch.Elapsed;
-
+        var exitCode = RunProcessWithHeartbeat(
+            psi,
+            logger,
+            elapsed => $"{projectName}: dotnet pack still running ({FormatDuration(elapsed)} elapsed).",
+            out stdErr,
+            out stdOut,
+            out duration);
         LogProcessOutput(logger, projectName, "dotnet pack", stdOut, stdErr);
-        return p.ExitCode;
+        return exitCode;
     }
 
     private static int RunDotnetMsBuildPack(
@@ -302,30 +293,15 @@ public sealed partial class DotNetRepositoryReleaseService
         psi.ArgumentList.Add("/v:m");
 #endif
 
-        using var p = Process.Start(psi);
-        if (p is null) return 1;
-
-        var stdoutTask = p.StandardOutput.ReadToEndAsync();
-        var stderrTask = p.StandardError.ReadToEndAsync();
-        var stopwatch = Stopwatch.StartNew();
-        var nextProgress = TimeSpan.FromSeconds(15);
-
-        while (!p.WaitForExit(1000))
-        {
-            if (stopwatch.Elapsed < nextProgress)
-                continue;
-
-            logger.Info($"MSBuild batch pack still running ({projectCount} project(s), {FormatDuration(stopwatch.Elapsed)} elapsed).");
-            nextProgress += TimeSpan.FromSeconds(15);
-        }
-
-        stdOut = stdoutTask.GetAwaiter().GetResult();
-        stdErr = stderrTask.GetAwaiter().GetResult();
-        stopwatch.Stop();
-        duration = stopwatch.Elapsed;
-
+        var exitCode = RunProcessWithHeartbeat(
+            psi,
+            logger,
+            elapsed => $"MSBuild batch pack still running ({projectCount} project(s), {FormatDuration(elapsed)} elapsed).",
+            out stdErr,
+            out stdOut,
+            out duration);
         LogProcessOutput(logger, "MSBuild batch", "dotnet msbuild pack", stdOut, stdErr);
-        return p.ExitCode;
+        return exitCode;
     }
 
     internal static PackagePushResult ClassifyNuGetPushOutcome(int exitCode, bool skipDuplicate, string stdErr, string stdOut)
@@ -420,6 +396,74 @@ public sealed partial class DotNetRepositoryReleaseService
         if (!string.IsNullOrWhiteSpace(stdErr))
             logger.Verbose($"{projectName}: {operation} stderr:{Environment.NewLine}{stdErr.TrimEnd()}");
     }
+
+    private static int RunProcessWithHeartbeat(
+        ProcessStartInfo psi,
+        ILogger logger,
+        Func<TimeSpan, string> heartbeatMessage,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        stdErr = string.Empty;
+        stdOut = string.Empty;
+        duration = TimeSpan.Zero;
+
+        using var p = Process.Start(psi);
+        if (p is null) return 1;
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        var stopwatch = Stopwatch.StartNew();
+        var nextProgress = TimeSpan.FromSeconds(15);
+
+        while (!p.WaitForExit(1000))
+        {
+            if (stopwatch.Elapsed < nextProgress)
+                continue;
+
+            logger.Info(heartbeatMessage(stopwatch.Elapsed));
+            nextProgress += TimeSpan.FromSeconds(15);
+        }
+
+        stdOut = stdoutTask.GetAwaiter().GetResult();
+        stdErr = stderrTask.GetAwaiter().GetResult();
+        stopwatch.Stop();
+        duration = stopwatch.Elapsed;
+        return p.ExitCode;
+    }
+
+    private static Dictionary<string, (DateTime LastWriteUtc, long Length)> SnapshotPackages(string packageRoot)
+    {
+        var snapshot = new Dictionary<string, (DateTime LastWriteUtc, long Length)>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(packageRoot))
+            return snapshot;
+
+        foreach (var path in Directory.EnumerateFiles(packageRoot, "*.nupkg", SearchOption.AllDirectories))
+        {
+            if (path.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var info = new FileInfo(path);
+            snapshot[path] = (info.LastWriteTimeUtc, info.Length);
+        }
+
+        return snapshot;
+    }
+
+    private static bool WasPackageCreatedOrChanged(
+        IReadOnlyDictionary<string, (DateTime LastWriteUtc, long Length)> existingPackages,
+        string path)
+    {
+        var info = new FileInfo(path);
+        if (!existingPackages.TryGetValue(path, out var existing))
+            return true;
+
+        return existing.LastWriteUtc != info.LastWriteTimeUtc || existing.Length != info.Length;
+    }
+
+    private static string EscapeMsBuildPropertyValue(string value)
+        => value.Replace("%", "%25").Replace(";", "%3B");
 
     private static bool LooksLikeSkippedDuplicate(string text)
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -105,6 +105,7 @@ public sealed partial class DotNetRepositoryReleaseService
 
         if (string.IsNullOrWhiteSpace(spec.OutputPath))
         {
+            result.Success = false;
             result.ErrorMessage = "MSBuild batch pack requires OutputPath.";
             return result;
         }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -281,7 +281,7 @@ public sealed partial class DotNetRepositoryReleaseService
             "/t:PackSelected",
             "/m",
             "/nr:false",
-            "/v:m"
+            logger.IsVerbose ? "/v:n" : "/v:m"
         });
 #else
         psi.ArgumentList.Add("msbuild");
@@ -289,7 +289,7 @@ public sealed partial class DotNetRepositoryReleaseService
         psi.ArgumentList.Add("/t:PackSelected");
         psi.ArgumentList.Add("/m");
         psi.ArgumentList.Add("/nr:false");
-        psi.ArgumentList.Add("/v:m");
+        psi.ArgumentList.Add(logger.IsVerbose ? "/v:n" : "/v:m");
 #endif
 
         var exitCode = RunProcessWithHeartbeat(
@@ -376,9 +376,9 @@ public sealed partial class DotNetRepositoryReleaseService
             };
             return false;
         }
+        // Start both stream reads before waiting to avoid pipe-buffer deadlocks.
         var stdoutTask = p.StandardOutput.ReadToEndAsync();
         var stderrTask = p.StandardError.ReadToEndAsync();
-        // Ensures redirected output streams are fully flushed before reading them on .NET Framework.
         p.WaitForExit();
         var stdOut = stdoutTask.GetAwaiter().GetResult();
         var stdErr = stderrTask.GetAwaiter().GetResult();
@@ -399,17 +399,23 @@ public sealed partial class DotNetRepositoryReleaseService
 
     private static string SummarizeProcessFailureOutput(string stdErr, string stdOut)
     {
-        var text = !string.IsNullOrWhiteSpace(stdErr) ? stdErr : stdOut;
-        if (string.IsNullOrWhiteSpace(text))
-            return string.Empty;
+        var sections = new List<string>();
+        if (!string.IsNullOrWhiteSpace(stdErr))
+            sections.Add("stderr:" + Environment.NewLine + SummarizeProcessOutputLines(stdErr));
+        if (!string.IsNullOrWhiteSpace(stdOut))
+            sections.Add("stdout:" + Environment.NewLine + SummarizeProcessOutputLines(stdOut));
 
+        return sections.Count == 0
+            ? string.Empty
+            : string.Join(Environment.NewLine, sections);
+    }
+
+    private static string SummarizeProcessOutputLines(string text)
+    {
         var lines = text.Replace("\r\n", "\n").Split('\n')
             .Select(line => line.TrimEnd())
             .Where(line => !string.IsNullOrWhiteSpace(line))
             .ToArray();
-        if (lines.Length == 0)
-            return string.Empty;
-
         const int maxLines = 40;
         return string.Join(Environment.NewLine, lines.Skip(Math.Max(0, lines.Length - maxLines)));
     }
@@ -486,7 +492,11 @@ public sealed partial class DotNetRepositoryReleaseService
     }
 
     private static string EscapeMsBuildPropertyValue(string value)
-        => value.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D");
+        => value.Replace("%", "%25")
+            .Replace(";", "%3B")
+            .Replace("=", "%3D")
+            .Replace("$", "%24")
+            .Replace("@", "%40");
 
     private static bool LooksLikeSkippedDuplicate(string text)
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -51,7 +51,7 @@ public sealed partial class DotNetRepositoryReleaseService
         return VersionPatternStepper.Step(expectedVersion!, current);
     }
 
-    private static DotNetPackResult PackProject(DotNetRepositoryProjectResult project, DotNetRepositoryReleaseSpec spec)
+    private static DotNetPackResult PackProject(DotNetRepositoryProjectResult project, DotNetRepositoryReleaseSpec spec, ILogger logger)
     {
         var result = new DotNetPackResult();
 
@@ -67,7 +67,8 @@ public sealed partial class DotNetRepositoryReleaseService
             Directory.CreateDirectory(outputPath);
         }
 
-        var exitCode = RunDotnetPack(project.CsprojPath, csprojDir, configuration, outputPath, out var stdErr, out var stdOut);
+        var exitCode = RunDotnetPack(project.CsprojPath, csprojDir, configuration, outputPath, project.ProjectName, logger, out var stdErr, out var stdOut, out var duration);
+        result.Duration = duration;
         if (exitCode != 0)
         {
             result.ErrorMessage = $"dotnet pack failed for {project.ProjectName} (exit {exitCode}). {stdErr}".Trim();
@@ -87,6 +88,91 @@ public sealed partial class DotNetRepositoryReleaseService
         return result;
     }
 
+    private static DotNetPackResult PackProjectsWithMsBuild(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        ILogger logger)
+    {
+        var result = new DotNetPackResult();
+        if (projects is null || projects.Count == 0)
+        {
+            result.Success = true;
+            return result;
+        }
+
+        if (string.IsNullOrWhiteSpace(spec.OutputPath))
+        {
+            result.ErrorMessage = "MSBuild batch pack requires OutputPath.";
+            return result;
+        }
+
+        var outputPath = Path.IsPathRooted(spec.OutputPath!)
+            ? spec.OutputPath!
+            : Path.GetFullPath(Path.Combine(spec.RootPath, spec.OutputPath!));
+        Directory.CreateDirectory(outputPath);
+
+        var tempRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "project-build", $"pack-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        var traversalPath = Path.Combine(tempRoot, "pack.proj");
+        try
+        {
+            WritePackTraversalProject(traversalPath, projects, spec, outputPath);
+
+            var exitCode = RunDotnetMsBuildPack(
+                traversalPath,
+                tempRoot,
+                projects.Count,
+                logger,
+                out var stdErr,
+                out var stdOut,
+                out var duration);
+            result.Duration = duration;
+
+            if (exitCode != 0)
+            {
+                result.ErrorMessage = $"dotnet msbuild batch pack failed (exit {exitCode}). {stdErr}".Trim();
+                return result;
+            }
+
+            var pkgs = Directory.EnumerateFiles(outputPath, "*.nupkg", SearchOption.AllDirectories)
+                .Where(p => !p.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            result.Packages.AddRange(pkgs);
+            result.Success = true;
+            return result;
+        }
+        finally
+        {
+            TryDeleteDirectory(tempRoot);
+        }
+    }
+
+    private static void WritePackTraversalProject(
+        string traversalPath,
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        string outputPath)
+    {
+        XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+        var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
+        var properties = $"Configuration={configuration};PackageOutputPath={outputPath}";
+
+        var document = new XDocument(
+            new XElement(ns + "Project",
+                new XElement(ns + "ItemGroup",
+                    projects.Select(project => new XElement(ns + "PackProject",
+                        new XAttribute("Include", Path.GetFullPath(project.CsprojPath))))),
+                new XElement(ns + "Target",
+                    new XAttribute("Name", "PackSelected"),
+                    new XElement(ns + "MSBuild",
+                        new XAttribute("Projects", "@(PackProject)"),
+                        new XAttribute("Targets", "Restore;Pack"),
+                        new XAttribute("BuildInParallel", "true"),
+                        new XAttribute("Properties", properties)))));
+
+        document.Save(traversalPath);
+    }
+
     private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotNetRepositoryProjectResult project, string version)
     {
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
@@ -101,10 +187,20 @@ public sealed partial class DotNetRepositoryReleaseService
         return Path.Combine(outputPath, $"{packageId}.{version}.nupkg");
     }
 
-    private static int RunDotnetPack(string csproj, string workingDirectory, string configuration, string? outputPath, out string stdErr, out string stdOut)
+    private static int RunDotnetPack(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string? outputPath,
+        string projectName,
+        ILogger logger,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
     {
         stdErr = string.Empty;
         stdOut = string.Empty;
+        duration = TimeSpan.Zero;
 
         var psi = new ProcessStartInfo
         {
@@ -139,9 +235,96 @@ public sealed partial class DotNetRepositoryReleaseService
 
         using var p = Process.Start(psi);
         if (p is null) return 1;
-        stdOut = p.StandardOutput.ReadToEnd();
-        stdErr = p.StandardError.ReadToEnd();
-        p.WaitForExit();
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        var stopwatch = Stopwatch.StartNew();
+        var nextProgress = TimeSpan.FromSeconds(15);
+
+        while (!p.WaitForExit(1000))
+        {
+            if (stopwatch.Elapsed < nextProgress)
+                continue;
+
+            logger.Info($"{projectName}: dotnet pack still running ({FormatDuration(stopwatch.Elapsed)} elapsed).");
+            nextProgress += TimeSpan.FromSeconds(15);
+        }
+
+        stdOut = stdoutTask.GetAwaiter().GetResult();
+        stdErr = stderrTask.GetAwaiter().GetResult();
+        stopwatch.Stop();
+        duration = stopwatch.Elapsed;
+
+        LogProcessOutput(logger, projectName, "dotnet pack", stdOut, stdErr);
+        return p.ExitCode;
+    }
+
+    private static int RunDotnetMsBuildPack(
+        string traversalProject,
+        string workingDirectory,
+        int projectCount,
+        ILogger logger,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        stdErr = string.Empty;
+        stdOut = string.Empty;
+        duration = TimeSpan.Zero;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+#if NET472
+        psi.Arguments = BuildWindowsArgumentString(new[]
+        {
+            "msbuild",
+            traversalProject,
+            "/t:PackSelected",
+            "/m",
+            "/nr:false",
+            "/v:m"
+        });
+#else
+        psi.ArgumentList.Add("msbuild");
+        psi.ArgumentList.Add(traversalProject);
+        psi.ArgumentList.Add("/t:PackSelected");
+        psi.ArgumentList.Add("/m");
+        psi.ArgumentList.Add("/nr:false");
+        psi.ArgumentList.Add("/v:m");
+#endif
+
+        using var p = Process.Start(psi);
+        if (p is null) return 1;
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        var stopwatch = Stopwatch.StartNew();
+        var nextProgress = TimeSpan.FromSeconds(15);
+
+        while (!p.WaitForExit(1000))
+        {
+            if (stopwatch.Elapsed < nextProgress)
+                continue;
+
+            logger.Info($"MSBuild batch pack still running ({projectCount} project(s), {FormatDuration(stopwatch.Elapsed)} elapsed).");
+            nextProgress += TimeSpan.FromSeconds(15);
+        }
+
+        stdOut = stdoutTask.GetAwaiter().GetResult();
+        stdErr = stderrTask.GetAwaiter().GetResult();
+        stopwatch.Stop();
+        duration = stopwatch.Elapsed;
+
+        LogProcessOutput(logger, "MSBuild batch", "dotnet msbuild pack", stdOut, stdErr);
         return p.ExitCode;
     }
 
@@ -218,11 +401,24 @@ public sealed partial class DotNetRepositoryReleaseService
             };
             return false;
         }
-        var stdOut = p.StandardOutput.ReadToEnd();
-        var stdErr = p.StandardError.ReadToEnd();
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
         p.WaitForExit();
+        var stdOut = stdoutTask.GetAwaiter().GetResult();
+        var stdErr = stderrTask.GetAwaiter().GetResult();
         result = ClassifyNuGetPushOutcome(p.ExitCode, skipDuplicate, stdErr, stdOut);
         return result.Outcome != PackagePushOutcome.Failed;
+    }
+
+    private static void LogProcessOutput(ILogger logger, string projectName, string operation, string stdOut, string stdErr)
+    {
+        if (!logger.IsVerbose)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(stdOut))
+            logger.Verbose($"{projectName}: {operation} stdout:{Environment.NewLine}{stdOut.TrimEnd()}");
+        if (!string.IsNullOrWhiteSpace(stdErr))
+            logger.Verbose($"{projectName}: {operation} stderr:{Environment.NewLine}{stdErr.TrimEnd()}");
     }
 
     private static bool LooksLikeSkippedDuplicate(string text)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -443,7 +443,8 @@ public sealed partial class DotNetRepositoryReleaseService
             nextProgress += TimeSpan.FromSeconds(15);
         }
 
-        // Ensures redirected stream callbacks flush before reading async tasks.
+        // On .NET Framework, WaitForExit(int) returning true does not guarantee async
+        // output callbacks have completed; the no-arg overload does.
         p.WaitForExit();
         stdOut = stdoutTask.GetAwaiter().GetResult();
         stdErr = stderrTask.GetAwaiter().GetResult();

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -148,7 +148,7 @@ public sealed partial class DotNetRepositoryReleaseService
         }
         finally
         {
-            TryDeleteDirectory(tempRoot);
+            TryDeleteDirectory(tempRoot, logger);
         }
     }
 
@@ -378,6 +378,7 @@ public sealed partial class DotNetRepositoryReleaseService
         }
         var stdoutTask = p.StandardOutput.ReadToEndAsync();
         var stderrTask = p.StandardError.ReadToEndAsync();
+        // Ensures redirected output streams are fully flushed before reading them on .NET Framework.
         p.WaitForExit();
         var stdOut = stdoutTask.GetAwaiter().GetResult();
         var stdErr = stderrTask.GetAwaiter().GetResult();
@@ -466,7 +467,7 @@ public sealed partial class DotNetRepositoryReleaseService
     }
 
     private static string EscapeMsBuildPropertyValue(string value)
-        => value.Replace("%", "%25").Replace(";", "%3B");
+        => value.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D");
 
     private static bool LooksLikeSkippedDuplicate(string text)
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -158,18 +158,17 @@ public sealed partial class DotNetRepositoryReleaseService
         DotNetRepositoryReleaseSpec spec,
         string outputPath)
     {
-        XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
         var properties = $"Configuration={EscapeMsBuildPropertyValue(configuration)};PackageOutputPath={EscapeMsBuildPropertyValue(outputPath)}";
 
         var document = new XDocument(
-            new XElement(ns + "Project",
-                new XElement(ns + "ItemGroup",
-                    projects.Select(project => new XElement(ns + "PackProject",
+            new XElement("Project",
+                new XElement("ItemGroup",
+                    projects.Select(project => new XElement("PackProject",
                         new XAttribute("Include", Path.GetFullPath(project.CsprojPath))))),
-                new XElement(ns + "Target",
+                new XElement("Target",
                     new XAttribute("Name", "PackSelected"),
-                    new XElement(ns + "MSBuild",
+                    new XElement("MSBuild",
                         new XAttribute("Projects", "@(PackProject)"),
                         // Restore is intentional so project references and package assets resolve inside the batch.
                         new XAttribute("Targets", "Restore;Pack"),
@@ -426,6 +425,7 @@ public sealed partial class DotNetRepositoryReleaseService
             nextProgress += TimeSpan.FromSeconds(15);
         }
 
+        p.WaitForExit();
         stdOut = stdoutTask.GetAwaiter().GetResult();
         stdErr = stderrTask.GetAwaiter().GetResult();
         stopwatch.Stop();
@@ -433,7 +433,7 @@ public sealed partial class DotNetRepositoryReleaseService
         return p.ExitCode;
     }
 
-    private static Dictionary<string, (DateTime LastWriteUtc, long Length)> SnapshotPackages(string packageRoot)
+    internal static Dictionary<string, (DateTime LastWriteUtc, long Length)> SnapshotPackages(string packageRoot)
     {
         var snapshot = new Dictionary<string, (DateTime LastWriteUtc, long Length)>(StringComparer.OrdinalIgnoreCase);
         if (!Directory.Exists(packageRoot))
@@ -451,7 +451,7 @@ public sealed partial class DotNetRepositoryReleaseService
         return snapshot;
     }
 
-    private static bool WasPackageCreatedOrChanged(
+    internal static bool WasPackageCreatedOrChanged(
         IReadOnlyDictionary<string, (DateTime LastWriteUtc, long Length)> existingPackages,
         string path)
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -162,6 +162,8 @@ public sealed partial class DotNetRepositoryReleaseService
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
         var properties = $"Configuration={EscapeMsBuildPropertyValue(configuration)};PackageOutputPath={EscapeMsBuildPropertyValue(outputPath)}";
 
+        // Keep this a classic MSBuild project: it only fans out to concrete SDK projects
+        // and does not require Microsoft.Build.Traversal to be installed.
         var document = new XDocument(
             new XElement("Project",
                 new XElement("ItemGroup",
@@ -449,7 +451,6 @@ public sealed partial class DotNetRepositoryReleaseService
     private static bool IsDiagnosticOutputLine(string line)
     {
         return line.Contains(": error", StringComparison.OrdinalIgnoreCase) ||
-               line.Contains(" error ", StringComparison.OrdinalIgnoreCase) ||
                line.StartsWith("error", StringComparison.OrdinalIgnoreCase) ||
                line.Contains("exception", StringComparison.OrdinalIgnoreCase) ||
                line.Contains("failed", StringComparison.OrdinalIgnoreCase) ||

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -113,6 +113,7 @@ internal sealed class ProjectBuildPreparationService
             Configuration = string.IsNullOrWhiteSpace(config.Configuration) ? "Release" : config.Configuration!,
             OutputPath = context.OutputPath,
             ReleaseZipOutputPath = context.ReleaseZipOutputPath,
+            PackStrategy = ProjectBuildSupportService.ParsePackStrategy(config.PackStrategy),
             CertificateThumbprint = config.CertificateThumbprint,
             CertificateStore = ProjectBuildSupportService.ParseCertificateStore(config.CertificateStore),
             TimeStampServer = config.TimeStampServer,

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -98,7 +98,7 @@ internal sealed class ProjectBuildPreparationService
             configDir);
 
         var packStrategy = ProjectBuildSupportService.ParsePackStrategy(config.PackStrategy);
-        if (!IsKnownPackStrategy(config.PackStrategy))
+        if (!ProjectBuildSupportService.IsKnownPackStrategy(config.PackStrategy))
             _logger.Warn($"Unknown PackStrategy '{config.PackStrategy!.Trim()}'; using PerProject.");
 
         context.Spec = new DotNetRepositoryReleaseSpec
@@ -132,16 +132,5 @@ internal sealed class ProjectBuildPreparationService
         };
 
         return context;
-    }
-
-    private static bool IsKnownPackStrategy(string? strategy)
-    {
-        var trimmedStrategy = strategy?.Trim();
-        if (string.IsNullOrWhiteSpace(trimmedStrategy))
-            return true;
-
-        return string.Equals(trimmedStrategy, "PerProject", StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(trimmedStrategy, "MSBuild", StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(trimmedStrategy, "Batch", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -97,6 +97,10 @@ internal sealed class ProjectBuildPreparationService
             config.GitHubAccessTokenEnvName,
             configDir);
 
+        var packStrategy = ProjectBuildSupportService.ParsePackStrategy(config.PackStrategy);
+        if (!IsKnownPackStrategy(config.PackStrategy))
+            _logger.Warn($"Unknown PackStrategy '{config.PackStrategy!.Trim()}'; using PerProject.");
+
         context.Spec = new DotNetRepositoryReleaseSpec
         {
             RootPath = context.RootPath,
@@ -113,7 +117,7 @@ internal sealed class ProjectBuildPreparationService
             Configuration = string.IsNullOrWhiteSpace(config.Configuration) ? "Release" : config.Configuration!,
             OutputPath = context.OutputPath,
             ReleaseZipOutputPath = context.ReleaseZipOutputPath,
-            PackStrategy = ProjectBuildSupportService.ParsePackStrategy(config.PackStrategy),
+            PackStrategy = packStrategy,
             CertificateThumbprint = config.CertificateThumbprint,
             CertificateStore = ProjectBuildSupportService.ParseCertificateStore(config.CertificateStore),
             TimeStampServer = config.TimeStampServer,
@@ -128,5 +132,16 @@ internal sealed class ProjectBuildPreparationService
         };
 
         return context;
+    }
+
+    private static bool IsKnownPackStrategy(string? strategy)
+    {
+        var trimmedStrategy = strategy?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedStrategy))
+            return true;
+
+        return string.Equals(trimmedStrategy, "PerProject", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(trimmedStrategy, "MSBuild", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(trimmedStrategy, "Batch", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge/Services/ProjectBuildSupportService.cs
+++ b/PowerForge/Services/ProjectBuildSupportService.cs
@@ -118,13 +118,10 @@ internal sealed class ProjectBuildSupportService
     /// </summary>
     public static DotNetRepositoryPackStrategy ParsePackStrategy(string? strategy)
     {
-        if (strategy is null)
+        var trimmedStrategy = strategy?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedStrategy))
             return DotNetRepositoryPackStrategy.PerProject;
 
-        if (string.IsNullOrWhiteSpace(strategy))
-            return DotNetRepositoryPackStrategy.PerProject;
-
-        var trimmedStrategy = strategy.Trim();
         return string.Equals(trimmedStrategy, "MSBuild", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(trimmedStrategy, "Batch", StringComparison.OrdinalIgnoreCase)
             ? DotNetRepositoryPackStrategy.MSBuild

--- a/PowerForge/Services/ProjectBuildSupportService.cs
+++ b/PowerForge/Services/ProjectBuildSupportService.cs
@@ -121,7 +121,7 @@ internal sealed class ProjectBuildSupportService
         if (string.IsNullOrWhiteSpace(strategy))
             return DotNetRepositoryPackStrategy.PerProject;
 
-        var trimmedStrategy = strategy!.Trim();
+        var trimmedStrategy = (strategy ?? string.Empty).Trim();
         return string.Equals(trimmedStrategy, "MSBuild", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(trimmedStrategy, "Batch", StringComparison.OrdinalIgnoreCase)
             ? DotNetRepositoryPackStrategy.MSBuild

--- a/PowerForge/Services/ProjectBuildSupportService.cs
+++ b/PowerForge/Services/ProjectBuildSupportService.cs
@@ -114,6 +114,21 @@ internal sealed class ProjectBuildSupportService
     }
 
     /// <summary>
+    /// Maps a pack strategy string to the core strategy enum.
+    /// </summary>
+    public static DotNetRepositoryPackStrategy ParsePackStrategy(string? strategy)
+    {
+        if (string.IsNullOrWhiteSpace(strategy))
+            return DotNetRepositoryPackStrategy.PerProject;
+
+        var trimmedStrategy = strategy!.Trim();
+        return string.Equals(trimmedStrategy, "MSBuild", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(trimmedStrategy, "Batch", StringComparison.OrdinalIgnoreCase)
+            ? DotNetRepositoryPackStrategy.MSBuild
+            : DotNetRepositoryPackStrategy.PerProject;
+    }
+
+    /// <summary>
     /// Converts loosely typed bound parameter values to a boolean.
     /// </summary>
     public static bool IsTrue(object? value)

--- a/PowerForge/Services/ProjectBuildSupportService.cs
+++ b/PowerForge/Services/ProjectBuildSupportService.cs
@@ -129,6 +129,20 @@ internal sealed class ProjectBuildSupportService
     }
 
     /// <summary>
+    /// Returns true when the provided pack strategy string maps to a supported value.
+    /// </summary>
+    public static bool IsKnownPackStrategy(string? strategy)
+    {
+        var trimmedStrategy = strategy?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedStrategy))
+            return true;
+
+        return string.Equals(trimmedStrategy, "PerProject", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(trimmedStrategy, "MSBuild", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(trimmedStrategy, "Batch", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Converts loosely typed bound parameter values to a boolean.
     /// </summary>
     public static bool IsTrue(object? value)

--- a/PowerForge/Services/ProjectBuildSupportService.cs
+++ b/PowerForge/Services/ProjectBuildSupportService.cs
@@ -118,10 +118,13 @@ internal sealed class ProjectBuildSupportService
     /// </summary>
     public static DotNetRepositoryPackStrategy ParsePackStrategy(string? strategy)
     {
+        if (strategy is null)
+            return DotNetRepositoryPackStrategy.PerProject;
+
         if (string.IsNullOrWhiteSpace(strategy))
             return DotNetRepositoryPackStrategy.PerProject;
 
-        var trimmedStrategy = (strategy ?? string.Empty).Trim();
+        var trimmedStrategy = strategy.Trim();
         return string.Equals(trimmedStrategy, "MSBuild", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(trimmedStrategy, "Batch", StringComparison.OrdinalIgnoreCase)
             ? DotNetRepositoryPackStrategy.MSBuild

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -117,7 +117,7 @@
         "MSBuild",
         "Batch"
       ],
-      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject. The batch target runs Restore;Pack, so private feed credentials must be available to dotnet/MSBuild restore."
+      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject. The batch target runs Restore;Pack, requires private feed credentials to be available to dotnet/MSBuild restore, stops on the first project failure, and skips projects without a resolved version."
     },
     "PublishNuget": {
       "type": "boolean"

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -117,7 +117,7 @@
         "MSBuild",
         "Batch"
       ],
-      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch generates a temporary MSBuild traversal project and packs selected projects in one invocation."
+      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject."
     },
     "PublishNuget": {
       "type": "boolean"

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -110,6 +110,15 @@
     "Build": {
       "type": "boolean"
     },
+    "PackStrategy": {
+      "type": "string",
+      "enum": [
+        "PerProject",
+        "MSBuild",
+        "Batch"
+      ],
+      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch generates a temporary MSBuild traversal project and packs selected projects in one invocation."
+    },
     "PublishNuget": {
       "type": "boolean"
     },

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -117,7 +117,7 @@
         "MSBuild",
         "Batch"
       ],
-      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject. The batch target runs Restore;Pack, requires private feed credentials to be available to dotnet/MSBuild restore, stops on the first project failure, and skips projects without a resolved version."
+      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject. The batch target runs Restore;Pack, requires private feed credentials to be available to dotnet/MSBuild restore, stops on the first project failure, and reports projects without a resolved version as failed skipped projects."
     },
     "PublishNuget": {
       "type": "boolean"

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -117,7 +117,7 @@
         "MSBuild",
         "Batch"
       ],
-      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject."
+      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject. The batch target runs Restore;Pack, so private feed credentials must be available to dotnet/MSBuild restore."
     },
     "PublishNuget": {
       "type": "boolean"

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -117,7 +117,7 @@
         "MSBuild",
         "Batch"
       ],
-      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject. The batch target runs Restore;Pack, requires private feed credentials to be available to dotnet/MSBuild restore, stops on the first project failure, and reports projects without a resolved version as failed skipped projects."
+      "description": "Controls how selected projects are packed. PerProject runs dotnet pack for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and packs selected projects in one invocation; when no package output path is available it falls back to PerProject. The batch target runs Restore;Pack, requires private feed credentials to be available to dotnet/MSBuild restore, stops on the first project failure, and treats the whole failed batch as failed, so already-produced packages from that batch are not signed or published. Projects without a resolved version are reported as failed skipped projects."
     },
     "PublishNuget": {
       "type": "boolean"


### PR DESCRIPTION
## Summary
- Add `PackStrategy` to project build config with the existing per-project behavior as the default.
- Add an `MSBuild`/`Batch` strategy that writes a temporary traversal project and packs selected projects in one `dotnet msbuild` invocation with `/m /nr:false`.
- Add pack/sign/zip timings, long-running pack heartbeat messages, verbose child-process output capture, schema coverage, docs, and focused test coverage.

## Validation
- `dotnet build C:\Support\GitHub\PSPublishModule\PSPublishModule\PSPublishModule.csproj -c Release -f net8.0 --no-restore`
- `dotnet build C:\Support\GitHub\PSPublishModule\PSPublishModule\PSPublishModule.csproj -c Release -f net472 --no-restore`
- `dotnet test C:\Support\GitHub\PSPublishModule\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~ProjectBuildPreparationServiceTests|FullyQualifiedName~DotNetRepositoryReleaseServiceTests"`
- OfficeIMO local probe: MSBuild batch packed 22 projects in 69.68s with signing/release zips disabled.

## Notes
- Full `PowerForge.Tests` was not clean in this workspace because `PowerForgeCliProjectReleaseTests.ProjectRelease_CliPreservesProjectDefaultsFromConfig` hit an output-drain timeout; the targeted build/release tests above passed.