### PR TITLE
Serialize isolated dotnet publishes

### DIFF
--- a/PowerForge/Services/DotnetPublisher.cs
+++ b/PowerForge/Services/DotnetPublisher.cs
@@ -84,12 +84,13 @@ public sealed class DotnetPublisher
         if (requestedFrameworks.Count == 0)
             throw new InvalidOperationException("No supported frameworks were provided for dotnet publish.");
 
+        var maxCpuCountArgument = isWindows ? "/m:1" : "-m:1";
+
         foreach (var tfm in requestedFrameworks)
         {
             var publishDir = useIsolatedArtifacts
                 ? Path.Combine(artifacts!, "publish", tfm)
                 : Path.Combine(projDir, "bin", configuration, tfm, "publish");
-            var maxCpuCountArgument = isWindows ? "/m:1" : "-m:1";
 
             var psi = new ProcessStartInfo
             {
@@ -120,6 +121,7 @@ public sealed class DotnetPublisher
                 args.Add("-p:UseArtifactsOutput=true");
                 args.Add($"-p:ArtifactsPath={artifacts}");
                 // Centralized artifacts output can make parallel project-reference builds race on generated files.
+                // Serializing MSBuild trades speed for deterministic module binary publishes.
                 args.Add(maxCpuCountArgument);
                 args.Add("--output");
                 args.Add(publishDir);
@@ -144,6 +146,7 @@ public sealed class DotnetPublisher
                 psi.ArgumentList.Add("-p:UseArtifactsOutput=true");
                 psi.ArgumentList.Add($"-p:ArtifactsPath={artifacts}");
                 // Centralized artifacts output can make parallel project-reference builds race on generated files.
+                // Serializing MSBuild trades speed for deterministic module binary publishes.
                 psi.ArgumentList.Add(maxCpuCountArgument);
                 psi.ArgumentList.Add("--output");
                 psi.ArgumentList.Add(publishDir);

--- a/PowerForge/Services/DotnetPublisher.cs
+++ b/PowerForge/Services/DotnetPublisher.cs
@@ -118,6 +118,7 @@ public sealed class DotnetPublisher
             {
                 args.Add("-p:UseArtifactsOutput=true");
                 args.Add($"-p:ArtifactsPath={artifacts}");
+                args.Add("/m:1");
                 args.Add("--output");
                 args.Add(publishDir);
             }
@@ -140,6 +141,7 @@ public sealed class DotnetPublisher
             {
                 psi.ArgumentList.Add("-p:UseArtifactsOutput=true");
                 psi.ArgumentList.Add($"-p:ArtifactsPath={artifacts}");
+                psi.ArgumentList.Add("/m:1");
                 psi.ArgumentList.Add("--output");
                 psi.ArgumentList.Add(publishDir);
             }

--- a/PowerForge/Services/DotnetPublisher.cs
+++ b/PowerForge/Services/DotnetPublisher.cs
@@ -89,6 +89,7 @@ public sealed class DotnetPublisher
             var publishDir = useIsolatedArtifacts
                 ? Path.Combine(artifacts!, "publish", tfm)
                 : Path.Combine(projDir, "bin", configuration, tfm, "publish");
+            var maxCpuCountArgument = isWindows ? "/m:1" : "-m:1";
 
             var psi = new ProcessStartInfo
             {
@@ -118,7 +119,8 @@ public sealed class DotnetPublisher
             {
                 args.Add("-p:UseArtifactsOutput=true");
                 args.Add($"-p:ArtifactsPath={artifacts}");
-                args.Add("/m:1");
+                // Centralized artifacts output can make parallel project-reference builds race on generated files.
+                args.Add(maxCpuCountArgument);
                 args.Add("--output");
                 args.Add(publishDir);
             }
@@ -141,7 +143,8 @@ public sealed class DotnetPublisher
             {
                 psi.ArgumentList.Add("-p:UseArtifactsOutput=true");
                 psi.ArgumentList.Add($"-p:ArtifactsPath={artifacts}");
-                psi.ArgumentList.Add("/m:1");
+                // Centralized artifacts output can make parallel project-reference builds race on generated files.
+                psi.ArgumentList.Add(maxCpuCountArgument);
                 psi.ArgumentList.Add("--output");
                 psi.ArgumentList.Add(publishDir);
             }


### PR DESCRIPTION
## Summary
- Serialize isolated PowerForge dotnet publishes with `/m:1` to avoid MSBuild file-lock races in shared temp artifacts output.
- Keeps existing isolated `ArtifactsPath` behavior while preventing parallel project-reference writers from colliding on generated `obj` and `bin` files.

## Root cause
Module binary builds publish into `%TEMP%\PowerForge\dotnet\...` with centralized artifacts output. Complex project-reference graphs can build the same referenced project through multiple paths, and MSBuild parallelism can cause concurrent writes to the same generated files.

## Validation
- `dotnet build C:\Support\GitHub\PSPublishModule\PowerForge\PowerForge.csproj -c Release -nologo`
- `dotnet test C:\Support\GitHub\PSPublishModule\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ModuleBuilder" -nologo`
- Reproduced ADPlayground.PowerShell publish flow with isolated artifacts for `net472` and `net8.0-windows` after the paired TestimoX dependency fix.