### PR TITLE
Improve module failure summaries

### DIFF
--- a/PowerForge.Tests/ModuleImportFailureFormatterTests.cs
+++ b/PowerForge.Tests/ModuleImportFailureFormatterTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -25,6 +26,7 @@ public sealed class ModuleImportFailureFormatterTests
         Assert.Contains("Cause: The manifest contains one or more members that are not valid ('Prerelease').", message);
         Assert.Contains("PowerShell: 7.5.4 (Core)", message);
         Assert.Contains(@"Manifest: C:\Temp\TestModule\TestModule.psd1", message);
+        Assert.Contains("Detail: Import-Module: some long stack trace line" + Environment.NewLine + "At line:1 char:1", message);
         Assert.DoesNotContain("PFIMPORT::ERROR::", message);
         Assert.DoesNotContain("StdOut:", message);
     }

--- a/PowerForge.Tests/SpectrePipelineSummaryWriterTests.cs
+++ b/PowerForge.Tests/SpectrePipelineSummaryWriterTests.cs
@@ -38,6 +38,129 @@ public sealed class SpectrePipelineSummaryWriterTests
     }
 
     [Fact]
+    public void NormalizeFailureMessage_PreservesStructuredContinuationLines()
+    {
+        var message = string.Join(Environment.NewLine, new[]
+        {
+            "Import-Module failed during PowerShell/Core validation (exit 1).",
+            "Cause: Could not load file or assembly 'Microsoft.Win32.SystemEvents.dll'.",
+            "Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7",
+            "Line |",
+            " 128 | Import-Module -Name $ModulePath -Force -ErrorAction Stop",
+            "     | Could not load file or assembly 'Microsoft.Win32.SystemEvents.dll'.",
+            "PowerShell: 7.5.5 (Core)",
+            "Manifest: C:\\Temp\\ADPlayground\\ADPlayground.psd1"
+        });
+
+        var normalized = SpectrePipelineSummaryWriter.NormalizeFailureMessage(new InvalidOperationException(message));
+
+        Assert.Contains("Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7", normalized);
+        Assert.Contains("Line |", normalized);
+        Assert.Contains("128 | Import-Module -Name $ModulePath -Force -ErrorAction Stop", normalized);
+        Assert.Contains("PowerShell: 7.5.5 (Core)", normalized);
+    }
+
+    [Fact]
+    public void BuildFailureDetailRows_SplitsStructuredFieldsForReadableSummary()
+    {
+        var message = string.Join(Environment.NewLine, new[]
+        {
+            "Import-Module failed during PowerShell/Core validation (exit 1).",
+            "Cause: Could not load file or assembly 'Microsoft.Win32.SystemEvents.dll'.",
+            "PowerShell: 7.5.5 (Core)",
+            "Manifest: C:\\Temp\\ADPlayground\\ADPlayground.psd1"
+        });
+
+        var rows = SpectrePipelineSummaryWriter.BuildFailureDetailRows(message);
+
+        Assert.Collection(
+            rows,
+            row =>
+            {
+                Assert.Equal("Failure", row.Field);
+                Assert.Contains("PowerShell/Core", row.Detail);
+            },
+            row =>
+            {
+                Assert.Equal("Cause", row.Field);
+                Assert.Contains("Microsoft.Win32.SystemEvents.dll", row.Detail);
+            },
+            row => Assert.Equal(("PowerShell", "7.5.5 (Core)"), row),
+            row => Assert.Equal(("Manifest", "C:\\Temp\\ADPlayground\\ADPlayground.psd1"), row));
+    }
+
+    [Fact]
+    public void BuildFailureDetailRows_AppendsContinuationLinesToStructuredDetail()
+    {
+        var message = string.Join(Environment.NewLine, new[]
+        {
+            "Import-Module failed during PowerShell/Core validation (exit 1).",
+            "Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7",
+            "Line |",
+            " 128 | Import-Module -Name $ModulePath -Force -ErrorAction Stop"
+        });
+
+        var rows = SpectrePipelineSummaryWriter.BuildFailureDetailRows(message);
+
+        Assert.Collection(
+            rows,
+            row => Assert.Equal("Failure", row.Field),
+            row =>
+            {
+                Assert.Equal("Detail", row.Field);
+                Assert.Contains("Import-Module: C:\\Temp\\modulepipeline.ps1:128:7", row.Detail);
+                Assert.Contains("Line |", row.Detail);
+                Assert.Contains("128 | Import-Module -Name $ModulePath -Force -ErrorAction Stop", row.Detail);
+            });
+    }
+
+    [Fact]
+    public void BuildFailureDetailRows_LabelsUnstructuredFirstLineAsMessage()
+    {
+        var rows = SpectrePipelineSummaryWriter.BuildFailureDetailRows("plain failure");
+
+        Assert.Collection(
+            rows,
+            row => Assert.Equal(("Message", "plain failure"), row));
+    }
+
+    [Fact]
+    public void NormalizeFailureMessage_DeduplicatesStructuredLinesAfterContinuation()
+    {
+        var message = string.Join(Environment.NewLine, new[]
+        {
+            "Import-Module failed during PowerShell/Core validation (exit 1).",
+            "Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7",
+            "Line |",
+            "Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7"
+        });
+
+        var normalized = SpectrePipelineSummaryWriter.NormalizeFailureMessage(new InvalidOperationException(message));
+
+        Assert.Equal(1, normalized.Split("Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7").Length - 1);
+        Assert.Contains("Line |", normalized);
+    }
+
+    [Fact]
+    public void NormalizeFailureMessage_SkipsContinuationLinesAfterDuplicateStructuredHeader()
+    {
+        var message = string.Join(Environment.NewLine, new[]
+        {
+            "Import-Module failed during PowerShell/Core validation (exit 1).",
+            "Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7",
+            "Line |",
+            "Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7",
+            " 128 | duplicate code"
+        });
+
+        var normalized = SpectrePipelineSummaryWriter.NormalizeFailureMessage(new InvalidOperationException(message));
+
+        Assert.Equal(1, normalized.Split("Detail: Import-Module: C:\\Temp\\modulepipeline.ps1:128:7").Length - 1);
+        Assert.Contains("Line |", normalized);
+        Assert.DoesNotContain("duplicate code", normalized);
+    }
+
+    [Fact]
     public void NormalizeFailureMessage_TruncatesLongUnstructuredMessagesByDefault()
     {
         var message = new string('x', 2105);

--- a/PowerForge/Services/ModuleImportFailureFormatter.cs
+++ b/PowerForge/Services/ModuleImportFailureFormatter.cs
@@ -7,6 +7,8 @@ namespace PowerForge;
 
 internal static class ModuleImportFailureFormatter
 {
+    internal const string FailureMessagePrefix = "Import-Module failed";
+
     internal static string BuildFailureMessage(PowerShellRunResult result, string? modulePath = null, string? validationTarget = null)
     {
         if (result is null) throw new ArgumentNullException(nameof(result));
@@ -19,7 +21,7 @@ internal static class ModuleImportFailureFormatter
             diagnostics.StdoutSummary);
 
         var sb = new StringBuilder();
-        sb.Append("Import-Module failed");
+        sb.Append(FailureMessagePrefix);
         if (!string.IsNullOrWhiteSpace(validationTarget))
             sb.Append(" during ").Append(validationTarget!.Trim()).Append(" validation");
         sb.Append($" (exit {result.ExitCode}).");
@@ -64,13 +66,13 @@ internal static class ModuleImportFailureFormatter
         if (string.IsNullOrWhiteSpace(cause) &&
             !string.IsNullOrWhiteSpace(result.StdOut))
         {
-            sb.AppendLine().Append("StdOut: ").Append(Normalize(result.StdOut));
+            sb.AppendLine().Append("StdOut: ").Append(NormalizeMultiline(result.StdOut));
         }
 
         if (string.IsNullOrWhiteSpace(cause) &&
             !string.IsNullOrWhiteSpace(result.StdErr))
         {
-            sb.AppendLine().Append("StdErr: ").Append(Normalize(result.StdErr));
+            sb.AppendLine().Append("StdErr: ").Append(NormalizeMultiline(result.StdErr));
         }
 
         return sb.ToString();
@@ -166,7 +168,7 @@ internal static class ModuleImportFailureFormatter
             importError,
             psModulePathEntries.ToArray(),
             loaderErrors.ToArray(),
-            Normalize(stderr),
+            NormalizeMultiline(stderr),
             stdoutSummary);
     }
 
@@ -203,6 +205,18 @@ internal static class ModuleImportFailureFormatter
 
         return string.Join(
             " ",
+            SplitLines(text)
+                .Select(static line => line.Trim())
+                .Where(static line => !string.IsNullOrWhiteSpace(line)));
+    }
+
+    private static string NormalizeMultiline(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return string.Empty;
+
+        // Keep raw PowerShell context here; the summary renderer applies display-time noise filtering.
+        return string.Join(
+            Environment.NewLine,
             SplitLines(text)
                 .Select(static line => line.Trim())
                 .Where(static line => !string.IsNullOrWhiteSpace(line)));

--- a/Shared/SpectrePipelineSummaryWriter.cs
+++ b/Shared/SpectrePipelineSummaryWriter.cs
@@ -392,13 +392,14 @@ internal static class SpectrePipelineSummaryWriter
 
         var message = NormalizeFailureMessage(error);
         if (!string.IsNullOrWhiteSpace(message))
-            table.AddRow($"{(unicode ? "💥" : "*")} Error", Esc(message));
+            table.AddRow($"{(unicode ? "💥" : "*")} Error", Esc(GetFailureHeadline(message)));
 
         var hint = BuildHint(message);
         if (!string.IsNullOrWhiteSpace(hint))
             table.AddRow($"{(unicode ? "💡" : "*")} Hint", Esc(hint));
 
         AnsiConsole.Write(table);
+        WriteFailureDetails(message, border);
     }
 
     private static string BuildPublishTarget(ModulePublishResult publish)
@@ -940,6 +941,96 @@ internal static class SpectrePipelineSummaryWriter
         return reasons;
     }
 
+    private static string GetFailureHeadline(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return string.Empty;
+
+        return message.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static line => line.Trim())
+            .FirstOrDefault(static line => !string.IsNullOrWhiteSpace(line))
+            ?? string.Empty;
+    }
+
+    private static void WriteFailureDetails(string message, TableBorder border)
+    {
+        var rows = BuildFailureDetailRows(message);
+        // A single row would only repeat the headline already shown in the summary table.
+        if (rows.Count <= 1)
+            return;
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(new Rule("[grey]Error details[/]").LeftJustified());
+
+        var table = new Table()
+            .Border(border)
+            .AddColumn(new TableColumn("Field").NoWrap())
+            .AddColumn(new TableColumn("Detail"));
+
+        foreach (var row in rows)
+            table.AddRow(Markup.Escape(row.Field), Markup.Escape(row.Detail));
+
+        AnsiConsole.Write(table);
+    }
+
+    internal static IReadOnlyList<(string Field, string Detail)> BuildFailureDetailRows(string message)
+    {
+        var rows = new List<(string Field, string Detail)>();
+        if (string.IsNullOrWhiteSpace(message))
+            return rows;
+
+        foreach (var rawLine in message.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var line = rawLine.Trim();
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var (field, detail) = SplitFailureDetailLine(line);
+            if (string.IsNullOrWhiteSpace(field) && rows.Count > 0)
+            {
+                var previousIndex = rows.Count - 1;
+                var previous = rows[previousIndex];
+                rows[previousIndex] = (previous.Field, previous.Detail + Environment.NewLine + line);
+                continue;
+            }
+
+            rows.Add((
+                string.IsNullOrWhiteSpace(field) ? "Message" : field,
+                string.IsNullOrWhiteSpace(detail) ? line : detail));
+        }
+
+        return rows;
+    }
+
+    private static (string Field, string Detail) SplitFailureDetailLine(string line)
+    {
+        if (line.StartsWith(ModuleImportFailureFormatter.FailureMessagePrefix, StringComparison.OrdinalIgnoreCase))
+            return ("Failure", line);
+
+        var separator = line.IndexOf(':');
+        if (separator <= 0)
+            return (string.Empty, line);
+
+        var field = line.Substring(0, separator).Trim();
+        if (!IsKnownFailureDetailField(field))
+            return (string.Empty, line);
+
+        return (field, line.Substring(separator + 1).Trim());
+    }
+
+    private static bool IsKnownFailureDetailField(string field)
+        => field.Equals("Cause", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("Detail", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("Loader", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("PowerShell", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("PSModulePath", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("Manifest", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("Executable", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("Hint", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("Payload", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("StdOut", StringComparison.OrdinalIgnoreCase)
+           || field.Equals("StdErr", StringComparison.OrdinalIgnoreCase);
+
     internal static string NormalizeFailureMessage(Exception error, int maxLength = 0)
     {
         const int DefaultUnstructuredFailureMessageMaxLength = 2000;
@@ -964,18 +1055,14 @@ internal static class SpectrePipelineSummaryWriter
             "PowerShell:",
             "PSModulePath:",
             "Manifest:",
-            "Executable:"
+            "Executable:",
+            "Hint:",
+            "Payload:",
+            "StdOut:",
+            "StdErr:"
         };
 
-        var structuredLines = new List<string>();
-        foreach (var prefix in preferredPrefixes)
-        {
-            foreach (var line in lines.Where(line => line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
-            {
-                if (!structuredLines.Contains(line, StringComparer.OrdinalIgnoreCase))
-                    structuredLines.Add(line);
-            }
-        }
+        var structuredLines = ExtractStructuredFailureLines(lines, preferredPrefixes);
 
         if (structuredLines.Count == 0)
         {
@@ -1003,6 +1090,38 @@ internal static class SpectrePipelineSummaryWriter
             return msg.Substring(0, effectiveMaxLength - 1) + "…";
 
         return msg;
+    }
+
+    private static List<string> ExtractStructuredFailureLines(string[] lines, string[] preferredPrefixes)
+    {
+        var structuredLines = new List<string>();
+        var seenStructuredHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var currentStructuredLine = -1;
+
+        foreach (var line in lines)
+        {
+            if (preferredPrefixes.Any(prefix => line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+            {
+                if (seenStructuredHeaders.Add(line))
+                {
+                    structuredLines.Add(line);
+                    currentStructuredLine = structuredLines.Count - 1;
+                }
+                else
+                {
+                    currentStructuredLine = -1;
+                }
+
+                continue;
+            }
+
+            if (currentStructuredLine < 0 || PowerShellFailureLineFilter.ShouldSkip(line))
+                continue;
+
+            structuredLines[currentStructuredLine] = structuredLines[currentStructuredLine] + Environment.NewLine + line;
+        }
+
+        return structuredLines;
     }
 
     private static string BuildHint(string message)


### PR DESCRIPTION
## Summary
- show a short failure headline in the module build summary table
- render structured failure details in a separate table for readability
- preserve multiline PowerShell import diagnostics instead of flattening stderr

## Verification
- dotnet test PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~SpectrePipelineSummaryWriterTests|FullyQualifiedName~ModuleImportFailureFormatterTests"
- dotnet build PowerForge\PowerForge.csproj -c Release