### PR TITLE
Support contributor author avatars

### DIFF
--- a/PowerForge.Tests/WebContributionProcessorTests.cs
+++ b/PowerForge.Tests/WebContributionProcessorTests.cs
@@ -180,6 +180,41 @@ public class WebContributionProcessorTests
     }
 
     [Fact]
+    public void Import_CopiesLocalAuthorAvatarIntoWebsiteAssets()
+    {
+        var root = CreateTempRoot("pf-web-contributions-author-avatar-");
+
+        try
+        {
+            var sourceRoot = Path.Combine(root, "contributions");
+            var siteRoot = Path.Combine(root, "site");
+            WriteAuthor(sourceRoot, "jane-doe", avatar: "./images/jane-doe.webp");
+            var authorImagesRoot = Path.Combine(sourceRoot, "authors", "images");
+            Directory.CreateDirectory(authorImagesRoot);
+            File.WriteAllBytes(Path.Combine(authorImagesRoot, "jane-doe.webp"), [0, 1, 2, 3]);
+            WritePost(sourceRoot, "sample-post");
+            Directory.CreateDirectory(siteRoot);
+
+            var result = WebContributionProcessor.Process(new WebContributionOptions
+            {
+                SourceRoot = sourceRoot,
+                SiteRoot = siteRoot,
+                Import = true,
+                Force = true
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors));
+            Assert.True(File.Exists(Path.Combine(siteRoot, "static", "assets", "authors", "jane-doe", "jane-doe.webp")));
+            var catalog = File.ReadAllText(Path.Combine(siteRoot, "data", "authors", "catalog.json"));
+            Assert.Contains("\"avatar\": \"/assets/authors/jane-doe/jane-doe.webp\"", catalog);
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
     public void Validate_RejectsImageReferencesThatEscapePostBundle()
     {
         var root = CreateTempRoot("pf-web-contributions-traversal-");
@@ -212,6 +247,31 @@ public class WebContributionProcessorTests
 
             Assert.False(result.Success);
             Assert.Contains(result.Errors, error => error.Contains("markdown image target '../secret.png' must stay inside the post bundle", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public void Validate_RejectsAuthorAvatarThatEscapesAuthorsFolder()
+    {
+        var root = CreateTempRoot("pf-web-contributions-avatar-traversal-");
+
+        try
+        {
+            var sourceRoot = Path.Combine(root, "contributions");
+            WriteAuthor(sourceRoot, "jane-doe", avatar: "../jane-doe.webp");
+            WritePost(sourceRoot, "sample-post");
+
+            var result = WebContributionProcessor.Process(new WebContributionOptions
+            {
+                SourceRoot = sourceRoot
+            });
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Errors, error => error.Contains("avatar '../jane-doe.webp' must stay inside authors", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {
@@ -341,15 +401,17 @@ public class WebContributionProcessorTests
         string slug,
         string x = "JaneDoe",
         string name = "Jane Doe",
-        string linkedin = "https://www.linkedin.com/in/janedoe")
+        string linkedin = "https://www.linkedin.com/in/janedoe",
+        string? avatar = null)
     {
         var authorsRoot = Path.Combine(sourceRoot, "authors");
         Directory.CreateDirectory(authorsRoot);
+        var avatarLine = string.IsNullOrWhiteSpace(avatar) ? string.Empty : $"avatar: {avatar}\n";
         File.WriteAllText(Path.Combine(authorsRoot, slug + ".yml"),
             $$"""
             name: {{name}}
             slug: {{slug}}
-            linkedin: {{linkedin}}
+            {{avatarLine}}linkedin: {{linkedin}}
             x: {{x}}
             """);
     }

--- a/PowerForge.Tests/WebPipelineRunnerBuildStepTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerBuildStepTests.cs
@@ -1,0 +1,98 @@
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public class WebPipelineRunnerBuildStepTests
+{
+    [Fact]
+    public void RunPipeline_BuildStep_CanDisableGeneratedSocialCards()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-build-social-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var contentRoot = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(contentRoot);
+            File.WriteAllText(Path.Combine(contentRoot, "index.md"),
+                """
+                ---
+                title: Home
+                description: Home description used for generated metadata.
+                ---
+
+                Hello from the build override test.
+                """);
+
+            var themeRoot = Path.Combine(root, "themes", "base", "layouts");
+            Directory.CreateDirectory(themeRoot);
+            File.WriteAllText(Path.Combine(themeRoot, "page.html"),
+                """
+                <!doctype html><html lang="en"><head><title>{{TITLE}}</title>{{HEAD_HTML}}</head><body><main>{{CONTENT}}</main></body></html>
+                """);
+
+            File.WriteAllText(Path.Combine(root, "site.json"),
+                """
+                {
+                  "name": "Build Step Social Test",
+                  "baseUrl": "https://example.test",
+                  "contentRoot": "content",
+                  "themesRoot": "themes",
+                  "defaultTheme": "base",
+                  "social": {
+                    "enabled": true,
+                    "image": "/social/default.png",
+                    "autoGenerateCards": true,
+                    "generatedCardsPath": "/assets/social/generated"
+                  },
+                  "collections": [
+                    { "name": "pages", "input": "content/pages", "output": "/", "defaultLayout": "page" }
+                  ]
+                }
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "build",
+                      "config": "./site.json",
+                      "out": "./site",
+                      "clean": true,
+                      "socialAutoGenerate": false
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+
+            Assert.True(result.Success);
+            Assert.Single(result.Steps);
+            Assert.True(result.Steps[0].Success, result.Steps[0].Message);
+
+            var html = File.ReadAllText(Path.Combine(root, "site", "index.html"));
+            Assert.DoesNotContain("/assets/social/generated/", html);
+            Assert.False(Directory.Exists(Path.Combine(root, "site", "assets", "social", "generated")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup for Windows test runners that may still hold file handles briefly.
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.BuildVerify.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.BuildVerify.cs
@@ -23,11 +23,13 @@ internal static partial class WebPipelineRunner
         var language = GetString(step, "language") ?? GetString(step, "lang");
         var languages = GetArrayOfStrings(step, "languages") ?? GetArrayOfStrings(step, "langs");
         var languageAsRoot = GetBool(step, "languageAsRoot") ?? GetBool(step, "language-as-root") ?? false;
+        var socialAutoGenerate = GetBool(step, "socialAutoGenerate") ?? GetBool(step, "social-auto-generate");
         var cleanOutput = GetBool(step, "clean") ?? false;
         if (string.IsNullOrWhiteSpace(config) || string.IsNullOrWhiteSpace(outPath))
             throw new InvalidOperationException("build requires config and out.");
 
         var (spec, specPath) = WebSiteSpecLoader.LoadWithPath(config, WebCliJson.Options);
+        ApplyBuildStepOverrides(spec, socialAutoGenerate);
         var plan = WebSitePlanner.Plan(spec, specPath, WebCliJson.Options);
         if (cleanOutput)
             WebCliFileSystem.CleanOutputDirectory(outPath);
@@ -50,6 +52,15 @@ internal static partial class WebPipelineRunner
                 ? $"Built {build.OutputPath} (languages={string.Join(",", languages)})"
                 : $"Built {build.OutputPath}"
             : $"Built {build.OutputPath} (language={language}, as-root={languageAsRoot.ToString().ToLowerInvariant()})";
+    }
+
+    private static void ApplyBuildStepOverrides(SiteSpec spec, bool? socialAutoGenerate)
+    {
+        if (socialAutoGenerate is null)
+            return;
+
+        spec.Social ??= new SocialSpec();
+        spec.Social.AutoGenerateCards = socialAutoGenerate.Value;
     }
 
     private static void ExecuteVerify(JsonElement step, string baseDir, bool fast, string effectiveMode, WebPipelineStepResult stepResult)

--- a/PowerForge.Web/Models/WebContributionModels.cs
+++ b/PowerForge.Web/Models/WebContributionModels.cs
@@ -25,6 +25,8 @@ public sealed class WebContributionOptions
     public string StaticBlogAssetsPath { get; set; } = "static/assets/blog";
     /// <summary>Relative destination authors root inside the website repository.</summary>
     public string TargetAuthorsPath { get; set; } = "data/authors";
+    /// <summary>Relative destination author image root inside the website repository.</summary>
+    public string TargetAuthorAssetsPath { get; set; } = "static/assets/authors";
     /// <summary>Maximum allowed size for a single contributed asset.</summary>
     public long MaxAssetBytes { get; set; } = 5 * 1024 * 1024;
     /// <summary>Maximum total size for all assets in one post bundle.</summary>
@@ -49,6 +51,12 @@ public sealed class WebContributionAuthorProfile
     /// <summary>Avatar URL or site-rooted avatar path.</summary>
     [JsonPropertyName("avatar")]
     public string? Avatar { get; set; }
+    /// <summary>Source YAML path; used internally for resolving local avatar paths.</summary>
+    [JsonIgnore]
+    public string? SourcePath { get; set; }
+    /// <summary>Resolved local avatar path; used internally during import.</summary>
+    [JsonIgnore]
+    public string? AvatarSourcePath { get; set; }
     /// <summary>X/Twitter profile URL or handle.</summary>
     [JsonPropertyName("x")]
     public string? X { get; set; }

--- a/PowerForge.Web/Services/WebContributionProcessor.Validation.cs
+++ b/PowerForge.Web/Services/WebContributionProcessor.Validation.cs
@@ -25,7 +25,7 @@ public static partial class WebContributionProcessor
                 if (map is null)
                     continue;
 
-                var profile = MapAuthorProfile(map, slug);
+                var profile = MapAuthorProfile(map, slug, path);
                 if (!string.IsNullOrWhiteSpace(profile.Slug))
                     authors[profile.Slug] = profile;
             }
@@ -38,7 +38,7 @@ public static partial class WebContributionProcessor
         return authors;
     }
 
-    private static WebContributionAuthorProfile MapAuthorProfile(Dictionary<string, object?> map, string fallbackSlug)
+    private static WebContributionAuthorProfile MapAuthorProfile(Dictionary<string, object?> map, string fallbackSlug, string sourcePath)
     {
         return new WebContributionAuthorProfile
         {
@@ -50,12 +50,14 @@ public static partial class WebContributionProcessor
             X = NullIfWhiteSpace(ReadMapString(map, "x", "twitter")),
             LinkedIn = NullIfWhiteSpace(ReadMapString(map, "linkedin", "linkedIn")),
             GitHub = NullIfWhiteSpace(ReadMapString(map, "github", "gitHub")),
-            Website = NullIfWhiteSpace(ReadMapString(map, "website", "url"))
+            Website = NullIfWhiteSpace(ReadMapString(map, "website", "url")),
+            SourcePath = sourcePath
         };
     }
 
     private static void ValidateAuthorProfiles(
         IReadOnlyDictionary<string, WebContributionAuthorProfile> authors,
+        WebContributionOptions options,
         List<string> errors)
     {
         foreach (var profile in authors.Values)
@@ -69,13 +71,54 @@ public static partial class WebContributionProcessor
                 errors.Add($"{label}: linkedin must be a valid linkedin.com URL.");
             if (!IsEmptyOrValidHttpUrl(profile.Website))
                 errors.Add($"{label}: website must be a valid URL.");
-            if (!IsEmptyOrValidHttpUrl(profile.Avatar) && !IsRootedWebPath(profile.Avatar))
-                errors.Add($"{label}: avatar must be a valid URL or site-rooted path.");
+            ValidateAuthorAvatar(profile, options, label, errors);
             if (!IsEmptyOrValidSocialValue(profile.X, allowUnderscoreHandle: true, "x.com", "twitter.com"))
                 errors.Add($"{label}: x must be an X/Twitter URL or handle.");
             if (!IsEmptyOrValidSocialValue(profile.GitHub, allowUnderscoreHandle: false, "github.com"))
                 errors.Add($"{label}: github must be a GitHub URL or username.");
         }
+    }
+
+    private static void ValidateAuthorAvatar(
+        WebContributionAuthorProfile profile,
+        WebContributionOptions options,
+        string label,
+        List<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(profile.Avatar))
+            return;
+
+        var avatar = profile.Avatar.Trim();
+        if (IsEmptyOrValidHttpUrl(avatar) || IsRootedWebPath(avatar))
+            return;
+
+        if (string.IsNullOrWhiteSpace(profile.SourcePath))
+        {
+            errors.Add($"{label}: local avatar could not be resolved.");
+            return;
+        }
+
+        var authorRoot = Path.GetDirectoryName(profile.SourcePath) ?? ".";
+        if (!TryResolveAuthorAsset(authorRoot, avatar, out var fullPath))
+        {
+            errors.Add($"{label}: avatar '{avatar}' must stay inside authors/.");
+            return;
+        }
+
+        profile.AvatarSourcePath = fullPath;
+        if (!File.Exists(fullPath))
+        {
+            errors.Add($"{label}: avatar '{avatar}' does not exist.");
+            return;
+        }
+
+        var extension = Path.GetExtension(fullPath);
+        if (!AllowedAssetExtensions.Contains(extension))
+            errors.Add($"{label}: avatar '{avatar}' has unsupported extension '{extension}'. Use PNG, JPG, JPEG, WEBP, or GIF.");
+
+        var length = new FileInfo(fullPath).Length;
+        if (options.MaxAssetBytes > 0 && length > options.MaxAssetBytes)
+            errors.Add($"{label}: avatar '{avatar}' is larger than {options.MaxAssetBytes} bytes.");
     }
 
     private static WebContributionPostResult ValidatePost(

--- a/PowerForge.Web/Services/WebContributionProcessor.cs
+++ b/PowerForge.Web/Services/WebContributionProcessor.cs
@@ -88,7 +88,7 @@ public static partial class WebContributionProcessor
 
         var authors = LoadAuthors(authorsRoot, warnings);
         result.AuthorCount = authors.Count;
-        ValidateAuthorProfiles(authors, errors);
+        ValidateAuthorProfiles(authors, options, errors);
 
         if (!Directory.Exists(postsRoot))
             errors.Add($"Posts directory does not exist: {postsRoot}");
@@ -114,6 +114,7 @@ public static partial class WebContributionProcessor
             else
             {
                 TryResolveInside(result.SiteRoot, options.TargetAuthorsPath, "TargetAuthorsPath", errors, out _);
+                TryResolveInside(result.SiteRoot, options.TargetAuthorAssetsPath, "TargetAuthorAssetsPath", errors, out _);
                 TryResolveInside(result.SiteRoot, options.ContentBlogPath, "ContentBlogPath", errors, out _);
                 TryResolveInside(result.SiteRoot, options.StaticBlogAssetsPath, "StaticBlogAssetsPath", errors, out _);
             }
@@ -147,7 +148,11 @@ public static partial class WebContributionProcessor
                 var profiles = authors.Values
                     .OrderBy(static profile => profile.Name, StringComparer.OrdinalIgnoreCase)
                     .ThenBy(static profile => profile.Slug, StringComparer.OrdinalIgnoreCase)
+                    .Select(profile => PrepareAuthorProfileForImport(profile, options, siteRoot, errors, result))
                     .ToArray();
+                if (errors.Count > 0)
+                    return;
+
                 var catalog = new WebContributionAuthorCatalog { Authors = profiles };
                 var catalogPath = Path.Combine(targetAuthorsRoot, "catalog.json");
                 var json = JsonSerializer.Serialize(catalog, WebContributionJsonContext.Default.WebContributionAuthorCatalog);
@@ -216,6 +221,48 @@ public static partial class WebContributionProcessor
 
         if (errors.Count == 0 && result.ImportedPostCount == 0 && posts.Length > 0)
             warnings.Add("No posts were imported.");
+    }
+
+    private static WebContributionAuthorProfile PrepareAuthorProfileForImport(
+        WebContributionAuthorProfile profile,
+        WebContributionOptions options,
+        string siteRoot,
+        List<string> errors,
+        WebContributionResult result)
+    {
+        var imported = new WebContributionAuthorProfile
+        {
+            Name = profile.Name,
+            Slug = profile.Slug,
+            Title = profile.Title,
+            Bio = profile.Bio,
+            Avatar = profile.Avatar,
+            X = profile.X,
+            LinkedIn = profile.LinkedIn,
+            GitHub = profile.GitHub,
+            Website = profile.Website
+        };
+
+        if (string.IsNullOrWhiteSpace(profile.Avatar) ||
+            IsExternalOrRootedWebPath(profile.Avatar) ||
+            string.IsNullOrWhiteSpace(profile.AvatarSourcePath))
+        {
+            return imported;
+        }
+
+        var avatarFileName = Path.GetFileName(profile.AvatarSourcePath);
+        var targetRoot = ResolveInside(siteRoot, Path.Combine(options.TargetAuthorAssetsPath, profile.Slug));
+        var target = Path.Combine(targetRoot, avatarFileName);
+        if (CopyFile(profile.AvatarSourcePath, target, options.Force, errors))
+        {
+            result.CopiedAssetCount++;
+            var publicRoot = options.TargetAuthorAssetsPath.Replace('\\', '/').Trim('/');
+            if (publicRoot.StartsWith("static/", StringComparison.OrdinalIgnoreCase))
+                publicRoot = publicRoot["static/".Length..];
+            imported.Avatar = "/" + ToSlash(Path.Combine(publicRoot, profile.Slug, avatarFileName));
+        }
+
+        return imported;
     }
 
     private static string RewritePostMarkdown(
@@ -424,6 +471,21 @@ public static partial class WebContributionProcessor
 
         var candidate = Path.GetFullPath(Path.Combine(bundleRoot, FromSlash(normalized)));
         var rootPrefix = Path.GetFullPath(bundleRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(rootPrefix, PathComparison))
+            return false;
+
+        fullPath = candidate;
+        return true;
+    }
+
+    private static bool TryResolveAuthorAsset(string authorsRoot, string target, out string fullPath)
+    {
+        fullPath = string.Empty;
+        if (!TryNormalizeRelativeAssetPath(target, out var normalized))
+            return false;
+
+        var candidate = Path.GetFullPath(Path.Combine(authorsRoot, FromSlash(normalized)));
+        var rootPrefix = Path.GetFullPath(authorsRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
         if (!candidate.StartsWith(rootPrefix, PathComparison))
             return false;
 

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -138,6 +138,14 @@
         "clean": {
           "type": "boolean",
           "description": "When true, delete existing output contents before writing new build artifacts."
+        },
+        "socialAutoGenerate": {
+          "type": "boolean",
+          "description": "Override site social.autoGenerateCards for this build step."
+        },
+        "social-auto-generate": {
+          "type": "boolean",
+          "description": "Alias for socialAutoGenerate."
         }
       },
       "required": ["task", "config", "out"]


### PR DESCRIPTION
## Summary
- allow contribution author profiles to reference local avatar images
- validate avatar paths, supported extensions, and file size limits
- copy local avatars into website author assets during import and rewrite catalog paths
- add regression coverage for avatar import and path traversal rejection

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --filter WebContributionProcessorTests
- dotnet C:\\Support\\GitHub\\PSPublishModule\\PowerForge.Web.Cli\\bin\\Release\\net10.0\\PowerForge.Web.Cli.dll contributions validate --root C:\\Support\\GitHub\\Website.Contributions