### PR TITLE
Harden git-sync abbreviated commit verification

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerGitSyncTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerGitSyncTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Text.Json;
 using PowerForge.Web.Cli;
 using Xunit;
@@ -894,6 +895,32 @@ public class WebPipelineRunnerGitSyncTests
         {
             TryDeleteDirectory(root);
         }
+    }
+
+    [Fact]
+    public void RunPipeline_GitSync_LockModeVerify_AcceptsAbbreviatedResolvedCommit()
+    {
+        const string lockedCommit = "e8fa9063d718d13f50ce8a03142c1746d036c723";
+        var method = typeof(WebPipelineRunner).GetMethod("CommitMatchesLockedCommit", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var matches = (bool)method!.Invoke(null, new object?[] { lockedCommit[..16], lockedCommit })!;
+        var mismatch = (bool)method.Invoke(null, new object?[] { "ffffffffffffffff", lockedCommit })!;
+
+        Assert.True(matches);
+        Assert.False(mismatch);
+    }
+
+    [Fact]
+    public void RunPipeline_GitSync_PrefersCheckedOutFullCommitWhenHeadIsAbbreviated()
+    {
+        const string checkedOutCommit = "e8fa9063d718d13f50ce8a03142c1746d036c723";
+        var method = typeof(WebPipelineRunner).GetMethod("SelectResolvedCommit", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var selected = (string?)method!.Invoke(null, new object?[] { checkedOutCommit[..16], checkedOutCommit });
+
+        Assert.Equal(checkedOutCommit, selected);
     }
 
     [Fact]

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.GitSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.GitSync.cs
@@ -109,7 +109,7 @@ internal static partial class WebPipelineRunner
             {
                 var resolvedCommit = execution.Commit?.Trim();
                 if (string.IsNullOrWhiteSpace(resolvedCommit) ||
-                    !string.Equals(resolvedCommit, lockedCommit, StringComparison.OrdinalIgnoreCase))
+                    !CommitMatchesLockedCommit(resolvedCommit, lockedCommit))
                 {
                     throw new InvalidOperationException($"git-sync verify mode: repos[{i}] resolved commit '{resolvedCommit ?? "unknown"}' does not match lock commit '{lockedCommit}'.");
                 }
@@ -356,11 +356,42 @@ internal static partial class WebPipelineRunner
         if (request.Submodules)
             UpdateSubmodules(request.DestinationFull, request.SubmodulesRecursive, request.SubmoduleDepth, request.AuthHeader, request.TimeoutSeconds, request.Retry, request.RetryDelayMs);
 
+        var resolvedHeadCommit = ResolveHeadCommit(request.DestinationFull, request.AuthHeader, request.TimeoutSeconds, request.Retry, request.RetryDelayMs);
         return new GitSyncExecutionResult
         {
             DisplayReference = ResolveHeadReference(request.DestinationFull, request.AuthHeader, request.TimeoutSeconds, request.Retry, request.RetryDelayMs),
-            Commit = ResolveHeadCommit(request.DestinationFull, request.AuthHeader, request.TimeoutSeconds, request.Retry, request.RetryDelayMs) ?? checkedOutCommit
+            Commit = SelectResolvedCommit(resolvedHeadCommit, checkedOutCommit)
         };
+    }
+
+    private static string? SelectResolvedCommit(string? resolvedHeadCommit, string? checkedOutCommit)
+    {
+        if (IsFullGitCommitSha(resolvedHeadCommit))
+            return resolvedHeadCommit!.Trim();
+
+        if (IsFullGitCommitSha(checkedOutCommit))
+            return checkedOutCommit!.Trim();
+
+        return string.IsNullOrWhiteSpace(resolvedHeadCommit)
+            ? checkedOutCommit?.Trim()
+            : resolvedHeadCommit.Trim();
+    }
+
+    private static bool CommitMatchesLockedCommit(string resolvedCommit, string? lockedCommit)
+    {
+        if (string.IsNullOrWhiteSpace(resolvedCommit) || string.IsNullOrWhiteSpace(lockedCommit))
+            return false;
+
+        var resolved = resolvedCommit.Trim();
+        var locked = lockedCommit.Trim();
+        if (string.Equals(resolved, locked, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return resolved.Length >= 12 &&
+               resolved.Length < locked.Length &&
+               IsHexString(resolved) &&
+               IsHexString(locked) &&
+               locked.StartsWith(resolved, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsFullGitCommitSha(string? value)
@@ -372,7 +403,12 @@ internal static partial class WebPipelineRunner
         if (text.Length != 40)
             return false;
 
-        foreach (var ch in text)
+        return IsHexString(text);
+    }
+
+    private static bool IsHexString(string value)
+    {
+        foreach (var ch in value)
         {
             var isHex = ch is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F';
             if (!isHex)


### PR DESCRIPTION
## Summary
- Accept unambiguous abbreviated resolved HEAD commits when verifying against a full lock SHA
- Prefer the exact checked-out lock SHA when HEAD resolution returns an abbreviated value
- Add focused git-sync tests for abbreviated commit handling

## Tests
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebPipelineRunnerGitSyncTests" --framework net10.0 --logger "console;verbosity=minimal"