### PR TITLE
Polish web asset strategy and Linux deployment guidance

### DIFF
--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -1,0 +1,123 @@
+# PowerForge.Web Linux Deployment Pattern
+
+Last updated: 2026-05-02
+
+This pattern is the reusable baseline for static PowerForge.Web sites hosted on Linux with Apache or another file-based web server.
+
+## Goals
+
+- Build deploy artifacts from a clean checkout.
+- Publish each deploy into a timestamped release directory.
+- Promote the release by moving a `current` symlink.
+- Keep generated web-server redirect artifacts in sync.
+- Run cheap hourly change checks without rebuilding when nothing changed.
+- Keep provider-specific cache purges in environment variables, not in repo files.
+
+## Repository Flow
+
+Use one website checkout and, when developing against a local engine checkout, one engine checkout:
+
+```text
+/srv/example/Website
+/srv/example/PSPublishModule
+```
+
+The deploy script should fetch both repositories, reset them to configured branches, and compare the current commits with the last successful deploy metadata. If both commits are unchanged and `DEPLOY_ONLY_ON_CHANGE=1`, exit successfully without running the pipeline.
+
+Recommended environment variables:
+
+```bash
+WEBSITE_ROOT=/srv/example/Website
+ENGINE_ROOT=/srv/example/PSPublishModule
+WEBSITE_BRANCH=main
+ENGINE_BRANCH=main
+PIPELINE_CONFIG=pipeline.deploy.json
+DEPLOY_ONLY_ON_CHANGE=0
+DEPLOY_STATE_ROOT=/srv/example/deploy-state/website
+```
+
+## Timers
+
+Use two timers:
+
+- Daily full rebuild: catches generated content, external data, feeds, and slow-moving maintenance work.
+- Hourly change rebuild: fetches repositories and deploys only when `Website` or the engine commit changed.
+
+Example change-check service:
+
+```ini
+[Unit]
+Description=Example website rebuild and deploy when repository revisions changed
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/srv/example/Website/deploy/linux/example-website.env
+Environment=DEPLOY_ONLY_ON_CHANGE=1
+WorkingDirectory=/srv/example/Website
+ExecStart=/usr/bin/env bash /srv/example/Website/deploy/linux/deploy-website.sh
+```
+
+Example hourly timer:
+
+```ini
+[Unit]
+Description=Check example website repositories for deployable changes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1h
+AccuracySec=1min
+Persistent=false
+Unit=example-website-change-rebuild.service
+
+[Install]
+WantedBy=timers.target
+```
+
+## External Content
+
+Do not make the Linux host poll every contribution or project repository directly unless the site really needs that. Prefer this pattern:
+
+1. GitHub Actions or another CI runner imports external content into the website repository.
+2. The import commit becomes the reviewable source of truth.
+3. The Linux host only watches `Website` and the engine commits.
+
+This keeps the deploy host simple and makes rebuild decisions reproducible from Git history.
+
+## Cache Purge
+
+Cache purge settings should live in the server environment file or CI secrets:
+
+```bash
+CLOUDFLARE_PURGE_ENABLED=0
+CLOUDFLARE_PURGE_HOSTS=example.com,www.example.com
+CLOUDFLARE_PURGE_EVERYTHING=0
+CLOUDFLARE_PURGE_PATHS=/,/blog/,/sitemap.xml,/sitemap-index.xml
+# CLOUDFLARE_API_TOKEN=...
+```
+
+The deploy script may also keep a scheduled CI purge as a fallback, but the server-side purge is the fastest path after a successful deploy.
+
+## What Belongs In PowerForge
+
+Reusable:
+
+- pipeline execution
+- `sources-sync` and lock verification
+- generated project/catalog/docs content
+- contribution imports
+- redirect generation
+- sitemap/feed/IndexNow outputs
+- deploy metadata shape and change-detection rules
+
+Site-local:
+
+- host names
+- release root paths
+- Apache service names
+- cache purge hosts
+- contact relay or other site-specific services
+
+When a site-local script becomes useful for more than one site, lift the convention into this pattern first, then into a scaffold/install command.

--- a/Docs/PowerForge.Web.WebsiteStarter.md
+++ b/Docs/PowerForge.Web.WebsiteStarter.md
@@ -18,6 +18,7 @@ This is compatible with both "standalone themes" and "themes that extend a vendo
 - Always run with two modes:
   - dev: warn, summarize, stay fast
   - ci/release: fail on new issues, enforce budgets
+- For Linux-hosted static sites, follow `Docs\PowerForge.Web.LinuxDeployment.md` so hourly deploy checks are commit-driven and reusable across sites.
 - Always make the performance path explicit:
   - add `optimize` to CI/release pipelines with explicit `minifyHtml`, `minifyCss`, and `minifyJs`
   - choose `assetRegistry.cssStrategy` intentionally:

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -249,6 +249,84 @@ public class WebSiteBuilderSafetyAndParityTests
     }
 
     [Fact]
+    public void Build_DoesNotWarn_WhenCssStrategyIsExplicitBlocking()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-css-strategy-blocking-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        var writer = new StringWriter();
+        var listener = new TextWriterTraceListener(writer);
+        var listeners = Trace.Listeners.Cast<TraceListener>().ToArray();
+        var previousAutoFlush = Trace.AutoFlush;
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.AssetRegistry = new AssetRegistrySpec
+            {
+                CssStrategy = "blocking",
+                Bundles = new[]
+                {
+                    new AssetBundleSpec
+                    {
+                        Name = "global",
+                        Css = new[] { "/assets/app.css" }
+                    }
+                },
+                RouteBundles = new[]
+                {
+                    new RouteBundleSpec
+                    {
+                        Match = "/**",
+                        Bundles = new[] { "global" }
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(listener);
+            Trace.AutoFlush = true;
+
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            listener.Flush();
+            var traceOutput = writer.ToString();
+            Assert.Contains("<link rel=\"stylesheet\" href=\"/assets/app.css\" />", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("Unknown CssStrategy", traceOutput, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            listener.Flush();
+            listener.Close();
+            Trace.Listeners.Clear();
+            foreach (var existing in listeners)
+                Trace.Listeners.Add(existing);
+            Trace.AutoFlush = previousAutoFlush;
+
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_EmitsTraceWarning_WhenHeadFileCannotBeResolved()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-headfile-warning-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web/Services/WebAssetCssStrategy.cs
+++ b/PowerForge.Web/Services/WebAssetCssStrategy.cs
@@ -12,6 +12,8 @@ internal static class WebAssetCssStrategy
         var original = cssStrategy.Trim();
         return original.ToLowerInvariant() switch
         {
+            "blocking" => "blocking",
+            "standard" => "blocking",
             "sync" => "blocking",
             "inline" => "blocking",
             "render-blocking" => "blocking",

--- a/Schemas/powerforge.web.sitespec.schema.json
+++ b/Schemas/powerforge.web.sitespec.schema.json
@@ -336,7 +336,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/CriticalCssSpec" }
         },
-        "CssStrategy": { "type": "string", "enum": ["standard", "async"] }
+        "CssStrategy": { "type": "string", "enum": ["blocking", "standard", "sync", "inline", "render-blocking", "renderblocking", "preload", "async", "async-print", "print"] }
       }
     },
     "AssetPolicySpec": {


### PR DESCRIPTION
## Summary
- accept explicit blocking CSS strategy without noisy fallback warnings
- update the site schema to match documented CSS strategy values
- add reusable Linux deployment guidance for commit-driven hourly rebuilds and cache purges

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSiteBuilderSafetyAndParityTests.Build_DoesNotWarn_WhenCssStrategyIsExplicitBlocking" --framework net10.0 --logger "console;verbosity=minimal"
- Website deploy pipeline build/optimize smoke with the local engine branch
