### PR TITLE
Ignore code examples in SEO leak checks

### DIFF
--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -1143,6 +1143,64 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_DoesNotFlagContentLeak_ForFrontMatterExampleInCodeBlock()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-frontmatter-code-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Contribution Guide</title></head>
+                <body>
+                  <main>
+                    <article>
+                      <p>Here is a beginner-friendly starter template:</p>
+                      <pre><code class="language-markdown">---
+                title: "Your Article Title"
+                description: "A short summary of what the article explains."
+                date: "2026-04-29"
+                language: "en"
+                authors:
+                  - your-name
+                draft: true
+                ---
+
+                Start with a short introduction.
+                </code></pre>
+                    </article>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                CheckTitleLength = false,
+                CheckDescriptionLength = false,
+                CheckH1 = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                CheckHreflang = false,
+                CheckStructuredData = false,
+                CheckContentLeaks = true
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "content-frontmatter-leak");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_FlagsRenderedMarkdownLeakWhenEscapedHtmlAndMarkdownAreVisible()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-markdown-leak-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -190,7 +190,8 @@ public static class WebSeoDoctor
 
             if (options.CheckContentLeaks)
             {
-                ValidateContentLeaks(relativePath, bodyText, AddIssue);
+                var leakCheckText = GetVisibleBodyText(doc.Body, excludeCodeBlocks: true);
+                ValidateContentLeaks(relativePath, leakCheckText, AddIssue);
             }
 
             var page = new PageScan
@@ -1958,7 +1959,7 @@ public static class WebSeoDoctor
         return string.Empty;
     }
 
-    private static string GetVisibleBodyText(AngleSharp.Dom.IElement? body)
+    private static string GetVisibleBodyText(AngleSharp.Dom.IElement? body, bool excludeCodeBlocks = false)
     {
         if (body is null)
             return string.Empty;
@@ -1967,7 +1968,10 @@ public static class WebSeoDoctor
         if (clone is null)
             return NormalizeWhitespace(body.TextContent);
 
-        foreach (var element in clone.QuerySelectorAll("script,style,template,noscript"))
+        var ignoredSelectors = excludeCodeBlocks
+            ? "script,style,template,noscript,pre,code,kbd,samp"
+            : "script,style,template,noscript";
+        foreach (var element in clone.QuerySelectorAll(ignoredSelectors))
             element.Remove();
 
         return NormalizeWhitespace(clone.TextContent);


### PR DESCRIPTION
## Summary
- keep SEO content-leak detection enabled while ignoring fenced/inline code content for the leak heuristic
- add a regression test for article front matter examples rendered inside code blocks

## Validation
- dotnet test PowerForge.Tests\PowerForge.Tests.csproj --configuration Release --filter "FullyQualifiedName~WebSeoDoctorTests"
