### PR TITLE
Add PowerForge server recovery CLI

### DIFF
--- a/Docs/PowerForge.Web.Backlog.md
+++ b/Docs/PowerForge.Web.Backlog.md
@@ -9,7 +9,7 @@ Short, high-signal list to keep parity and stability work visible.
 - Audit: heading-order check and link-purpose consistency check (same label -> multiple URLs).
 - Audit: navRequired / navIgnorePrefixes options (CLI + pipeline).
 - Prism: auto-init highlight + local asset warnings.
-- CodeGlyphX sample: apply Prism highlighting and unified code-block styling to docs pages.
+- Sample docs site: apply Prism highlighting and unified code-block styling to docs pages.
 - Auto-generate `data/site-nav.json` when missing (navigation export).
 - Normalize Markdown code blocks to add `.code-block` on `<pre>` for consistent styling.
 - Verify: warn when custom `site-nav.json` drifts from Navigation menus.
@@ -18,7 +18,7 @@ Short, high-signal list to keep parity and stability work visible.
 - Crawl policy: route-scoped robots + bot directives + `_powerforge/crawl-policy.json` diagnostics.
 
 ## Engine parity & quality
-- CodeGlyphX 1:1 coverage checklist (home, docs, benchmarks, pricing, showcase, playground, API docs).
+- Interactive docs site coverage checklist (home, docs, benchmarks, pricing, showcase, playground, API docs).
 - Docs API parity: namespace/type filters, search UX, member grouping (methods/properties/fields/events).
 - Fix markdown parser precedence: `## Heading: Text` should be heading, not definition list.
 - Syntax highlighting: verify Prism injection for all markdown code blocks and API pages.
@@ -50,10 +50,11 @@ Short, high-signal list to keep parity and stability work visible.
 - Optional Playwright smoke checks (config‑driven, no custom tests required).
 - Configured audit step in sample pipelines (docs + scaffolder defaults).
 - Content diagnostics: warn on missing syntax highlighter assets, missing theme files, or invalid pipeline entries.
+- Server recovery: implement `powerforge-web server inspect/capture/bootstrap/restore-secrets/deploy/verify` from `powerforge.web.serverrecovery.schema.json`.
 
 ## Documentation
 - “Theme anatomy” doc: where assets live, how `extra_css_html`/`extra_scripts_html` are used.
-- Content spec examples for multi‑site reuse and CodeGlyphX migration steps.
+- Content spec examples for multi-site reuse and project migration steps.
 - Prism local asset expectations + troubleshooting (docs/assets).
 - Docs nav rules (auto + manual), sidebar placement options, and relative link resolution.
 - Sitemap behavior (auto + manual entries) with examples.

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -111,6 +111,7 @@ Reusable:
 - redirect generation
 - sitemap/feed/IndexNow outputs
 - deploy metadata shape and change-detection rules
+- server recovery manifest schema, inspection, capture, bootstrap, restore, deploy, and verification workflow
 
 Site-local:
 
@@ -119,5 +120,33 @@ Site-local:
 - Apache service names
 - cache purge hosts
 - contact relay or other site-specific services
+- concrete recovery manifests that name site domains, secrets, services, and server paths
 
 When a site-local script becomes useful for more than one site, lift the convention into this pattern first, then into a scaffold/install command.
+
+## Server Recovery
+
+Linux deployment scripts handle the normal happy path on an already prepared host. Server recovery covers the bigger case: a fresh Ubuntu server needs to be made production-ready and then redeployed from source control.
+
+Use a site-local manifest such as:
+
+```text
+deploy/linux/example.serverrecovery.json
+```
+
+The manifest should point at the reusable schema:
+
+```text
+Schemas/powerforge.web.serverrecovery.schema.json
+```
+
+PowerForge should use that manifest to support these stages:
+
+1. inspect the existing host for drift
+2. capture plain configuration and encrypted secrets
+3. bootstrap a new host
+4. restore or prompt for required secrets
+5. run the normal deploy script
+6. verify services, certificates, origin behavior, and public URLs
+
+Generated site output and timestamped release folders are not primary backup state. They are rebuildable from Git, lock files, and the deployment pipeline. Private keys, API tokens, SMTP credentials, and environment files must only enter GitHub backup storage as encrypted bundles.

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -48,6 +48,7 @@ Current implemented slices:
 powerforge-web server inspect --manifest deploy/linux/example.serverrecovery.json
 powerforge-web server plan --manifest deploy/linux/example.serverrecovery.json
 powerforge-web server capture --manifest deploy/linux/example.serverrecovery.json --out ./_server-state/example
+powerforge-web server capture --manifest deploy/linux/example.serverrecovery.json --out ./_server-state/example --fail-on-failure
 powerforge-web server capture --manifest deploy/linux/example.serverrecovery.json --out ./_server-state/example --encrypt-remote
 powerforge-web server deploy --manifest deploy/linux/example.serverrecovery.json --dry-run
 powerforge-web server verify --manifest deploy/linux/example.serverrecovery.json --fail-on-failure
@@ -57,9 +58,9 @@ powerforge-web server restore-secrets-plan --manifest deploy/linux/example.serve
 
 `server inspect` runs read-only SSH checks against the target host and compares live state with the manifest: OS, SSH posture, packages, Apache modules/config, managed paths, systemd units, UFW policy, Certbot renewal config, required secret-path presence, and release symlinks. Pass `--fail-on-drift` when CI or automation should exit non-zero on drift.
 
-`server plan` loads the manifest, summarizes recovery coverage, emits the planned stages, and warns when encrypted capture is configured but no encryption recipient environment variable is available.
+`server plan` loads the manifest, summarizes recovery coverage, emits the planned stages, and warns when encrypted capture is configured but no encryption recipient environment variable is available. `server validate` is currently an alias for `server plan`; it does not run a schema-only validation pass.
 
-`server capture` uses SSH to collect manifest-defined command outputs, streams the plain capture file set into `plain-files.tar.gz`, writes `capture-summary.json`, and creates a restore checklist. Encrypted files are skipped unless `backupTarget.recipient` is set or the configured `backupTarget.recipientEnv` environment variable is present. By default, the secret tar stream is encrypted by local `age`; with `--encrypt-remote`, the target host runs `tar | age` and only the encrypted `.age` blob is streamed back to the workstation.
+`server capture` uses SSH to collect manifest-defined command outputs, streams the plain capture file set into `plain-files.tar.gz`, writes `capture-summary.json`, and creates a restore checklist. Encrypted files are skipped unless `backupTarget.recipient` is set or the configured `backupTarget.recipientEnv` environment variable is present. By default, the secret tar stream is encrypted by local `age`; with `--encrypt-remote`, the target host runs `tar | age` and only the encrypted `.age` blob is streamed back to the workstation. Capture warnings remain non-fatal for interactive use unless `--fail-on-failure` is passed, which exits non-zero when required command captures, archive capture, or encrypted capture reports warnings.
 
 `server deploy` runs the manifest's deploy commands over SSH. Use `--dry-run` to print the resolved remote commands without executing them, and `--fail-on-failure` when automation should exit non-zero if a required deploy command fails.
 

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -1,0 +1,190 @@
+# PowerForge.Web Server Recovery
+
+Last updated: 2026-05-03
+
+This document defines the reusable PowerForge pattern for rebuilding a Linux-hosted static website from source control, encrypted secrets, and a site-owned recovery manifest.
+
+The goal is not only to back up a VPS. The goal is to make a fresh server boring to rebuild.
+
+## Goals
+
+- Recreate a production host from a clean Ubuntu installation.
+- Keep rebuildable assets in Git and generated web output out of backup history.
+- Capture enough runtime state to compare a live server against a manifest.
+- Keep raw secrets out of source repositories.
+- Support site-specific wrappers without hardcoding Evotec-only behavior into the engine.
+- Preserve the existing PowerForge deploy model: clean checkout, pipeline build, timestamped releases, symlink promotion, and verification.
+
+## Recovery Model
+
+```text
+Git repositories + recovery manifest + encrypted secrets + deploy pipeline
+  -> bootstrap host
+  -> restore configuration
+  -> deploy site
+  -> verify runtime
+```
+
+PowerForge owns the generic workflow. Each website owns a small manifest that names hosts, paths, services, packages, domains, and secrets.
+
+## Engine Commands
+
+The first implementation should expose the same workflow through the CLI and PowerShell module.
+
+Proposed CLI shape:
+
+```bash
+powerforge-web server inspect --manifest deploy/linux/example.serverrecovery.json
+powerforge-web server capture --manifest deploy/linux/example.serverrecovery.json --out ./_server-state
+powerforge-web server bootstrap --manifest deploy/linux/example.serverrecovery.json --host new-host
+powerforge-web server restore-secrets --manifest deploy/linux/example.serverrecovery.json
+powerforge-web server deploy --manifest deploy/linux/example.serverrecovery.json
+powerforge-web server verify --manifest deploy/linux/example.serverrecovery.json
+```
+
+Current implemented slices:
+
+```bash
+powerforge-web server inspect --manifest deploy/linux/example.serverrecovery.json
+powerforge-web server plan --manifest deploy/linux/example.serverrecovery.json
+powerforge-web server capture --manifest deploy/linux/example.serverrecovery.json --out ./_server-state/example
+powerforge-web server capture --manifest deploy/linux/example.serverrecovery.json --out ./_server-state/example --encrypt-remote
+powerforge-web server deploy --manifest deploy/linux/example.serverrecovery.json --dry-run
+powerforge-web server verify --manifest deploy/linux/example.serverrecovery.json --fail-on-failure
+powerforge-web server bootstrap-plan --manifest deploy/linux/example.serverrecovery.json --out ./_server-state/bootstrap-plan
+powerforge-web server restore-secrets-plan --manifest deploy/linux/example.serverrecovery.json --out ./_server-state/restore-secrets-plan --archive encrypted-secrets.tar.gz.age
+```
+
+`server inspect` runs read-only SSH checks against the target host and compares live state with the manifest: OS, SSH posture, packages, Apache modules/config, managed paths, systemd units, UFW policy, Certbot renewal config, required secret-path presence, and release symlinks. Pass `--fail-on-drift` when CI or automation should exit non-zero on drift.
+
+`server plan` loads the manifest, summarizes recovery coverage, emits the planned stages, and warns when encrypted capture is configured but no encryption recipient environment variable is available.
+
+`server capture` uses SSH to collect manifest-defined command outputs, streams the plain capture file set into `plain-files.tar.gz`, writes `capture-summary.json`, and creates a restore checklist. Encrypted files are skipped unless `backupTarget.recipient` is set or the configured `backupTarget.recipientEnv` environment variable is present. By default, the secret tar stream is encrypted by local `age`; with `--encrypt-remote`, the target host runs `tar | age` and only the encrypted `.age` blob is streamed back to the workstation.
+
+`server deploy` runs the manifest's deploy commands over SSH. Use `--dry-run` to print the resolved remote commands without executing them, and `--fail-on-failure` when automation should exit non-zero if a required deploy command fails.
+
+`server verify` runs the manifest's operational health checks, such as Apache config validation, local service health checks, Certbot dry-runs, Cloudflare origin sync, and public URL checks. Pass `--fail-on-failure` when the command should exit non-zero if a required command or URL check fails.
+
+`server bootstrap-plan` generates a reviewable markdown plan, JSON plan, and LF-normalized shell script draft for rebuilding a fresh host. Manual and sensitive steps are left as blocking TODOs in the script so it cannot silently deploy without restored secrets.
+
+`server restore-secrets-plan` generates a markdown plan, JSON plan, and LF-normalized `restore-secrets.sh` draft for an encrypted secret bundle. The script requires `age`, decrypts to a temporary directory, lists archive contents, and refuses to extract into `/` unless `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES` is set.
+
+Proposed PowerShell shape:
+
+```powershell
+Test-PowerForgeServerRecovery -Manifest .\deploy\linux\example.serverrecovery.json
+Backup-PowerForgeServerState -Manifest .\deploy\linux\example.serverrecovery.json
+Initialize-PowerForgeServer -Manifest .\deploy\linux\example.serverrecovery.json -ComputerName new-host
+Restore-PowerForgeServerSecret -Manifest .\deploy\linux\example.serverrecovery.json
+Invoke-PowerForgeServerDeploy -Manifest .\deploy\linux\example.serverrecovery.json
+```
+
+The PowerShell cmdlets should stay thin. Manifest parsing, planning, redaction, command generation, and report shaping belong in shared PowerForge services so the CLI, module, and future UI can reuse them.
+
+## Manifest Responsibilities
+
+A recovery manifest should describe:
+
+- target host and SSH connection defaults
+- expected operating system family and version
+- package prerequisites
+- repository checkouts and branches
+- filesystem layout
+- Apache modules, vhosts, and managed includes
+- systemd services and timers
+- firewall policy, including Cloudflare-origin locking when used
+- Certbot certificates and renewal validation commands
+- capture sets for plain configuration and encrypted secrets
+- bootstrap, deploy, and verification commands
+- Cloudflare DNS/cache expectations when a site uses Cloudflare
+
+The manifest must not contain secret values. It may contain secret paths and secret environment variable names.
+
+## Capture Sets
+
+Recovery uses two capture sets.
+
+Plain capture:
+
+- Apache vhosts and managed includes
+- systemd unit files and drop-ins
+- UFW status
+- package list
+- current release symlink targets
+- Certbot renewal config without private keys
+- deploy metadata and current Git commits
+
+Encrypted capture:
+
+- deployment environment files
+- Cloudflare API token credentials
+- contact relay SMTP/API secrets
+- certificate private keys, if the site chooses to make certificate-key recovery possible
+
+Encrypted capture requires an explicit recipient such as an age or GPG public key. If no recipient is configured, PowerForge should skip encrypted capture and report the missing secret recovery coverage.
+
+## Bootstrap Stages
+
+The engine should plan and run these stages:
+
+1. Connect to the host and confirm OS support.
+2. Install packages and language runtimes.
+3. Create service users, directories, and permissions.
+4. Configure SSH, UFW, and base security posture.
+5. Install Apache modules, vhosts, and managed includes.
+6. Install systemd services and timers.
+7. Clone or update website and engine repositories.
+8. Restore or prompt for secrets.
+9. Run the site deploy script.
+10. Verify local services, origin behavior, public URLs, and certificate renewal.
+
+Stages must be resumable. A failed stage should leave a report that tells the operator what already happened and what remains.
+
+## What Not To Back Up As Primary State
+
+Do not treat these as the primary recovery source:
+
+- generated `_site-*` outputs
+- timestamped release directories
+- pipeline temp folders
+- downloaded project-source working trees when they are reproducible from lock files
+- package caches
+
+Those are rebuildable. Capture them only when diagnosing an incident, not as the normal recovery path.
+
+## Drift Detection
+
+`server inspect` should compare live state against the manifest and report:
+
+- missing packages
+- disabled or failed services
+- unmanaged Apache includes
+- SSH port/authentication drift
+- UFW rules outside the expected policy
+- Certbot certificates that cannot renew
+- release symlink targets that do not match deploy metadata
+- secrets that are required but not restorable
+
+The default result should be a human-readable table plus a JSON report for CI or scheduled checks.
+
+## GitHub Backup Target
+
+PowerForge may publish capture artifacts to a private GitHub repository, but only with this split:
+
+- plain config snapshots may be committed directly
+- secret bundles must be encrypted before commit
+- raw tokens, private keys, and env files must never be committed
+
+For most sites, a separate private backup repository is cleaner than storing generated backup artifacts in the engine source repository.
+
+`backupTarget.retention.keepLatest` can define how many timestamped captures should remain in the backup repository working tree. This is a publication policy for wrappers or future publish commands; Git history still preserves older committed captures unless repository history is rewritten.
+
+## Evotec Reference
+
+Evotec uses this pattern with a site-local manifest under the Website repository:
+
+```text
+deploy/linux/evotec.serverrecovery.json
+```
+
+The manifest names the OVH host, Apache/Cloudflare/certbot/contact-relay runtime, and recovery capture policy. The reusable behavior belongs here in PowerForge; the Evotec-specific paths and domains belong in the Website repo.

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -67,7 +67,7 @@ powerforge-web server restore-secrets-plan --manifest deploy/linux/example.serve
 
 `server bootstrap-plan` generates a reviewable markdown plan, JSON plan, and LF-normalized shell script draft for rebuilding a fresh host. Manual and sensitive steps are left as blocking TODOs in the script so it cannot silently deploy without restored secrets.
 
-`server restore-secrets-plan` generates a markdown plan, JSON plan, and LF-normalized `restore-secrets.sh` draft for an encrypted secret bundle. The script requires `age`, decrypts to a temporary directory, lists archive contents, and refuses to extract into `/` unless `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES` is set.
+`server restore-secrets-plan` generates a markdown plan, JSON plan, and LF-normalized `restore-secrets.sh` draft for an encrypted secret bundle. The script requires `age`, decrypts to a temporary directory, lists archive contents, rejects absolute or path-traversal archive entries, and refuses to extract into `/` unless `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES` is set.
 
 Proposed PowerShell shape:
 
@@ -99,6 +99,8 @@ A recovery manifest should describe:
 - Cloudflare DNS/cache expectations when a site uses Cloudflare
 
 The manifest must not contain secret values. It may contain secret paths and secret environment variable names.
+
+Manifest files are trusted operator input. Command fields are executed on the target host through SSH, so review changes to bootstrap, deploy, verify, and capture command entries with the same care as shell scripts.
 
 ## Capture Sets
 

--- a/PowerForge.Web.Cli/PowerForgeWebCliJsonContext.cs
+++ b/PowerForge.Web.Cli/PowerForgeWebCliJsonContext.cs
@@ -64,6 +64,22 @@ namespace PowerForge.Web.Cli;
 [JsonSerializable(typeof(WebLegacyAmpRedirectResult))]
 [JsonSerializable(typeof(WebSitemapMigrationResult))]
 [JsonSerializable(typeof(WebLinkCommandSummary))]
+[JsonSerializable(typeof(PowerForgeServerRecoveryManifest))]
+[JsonSerializable(typeof(PowerForgeServerBackupRetention))]
+[JsonSerializable(typeof(PowerForgeServerRecoveryPlanResult))]
+[JsonSerializable(typeof(PowerForgeServerCaptureResult))]
+[JsonSerializable(typeof(PowerForgeServerCaptureCommandResult))]
+[JsonSerializable(typeof(PowerForgeServerInspectResult))]
+[JsonSerializable(typeof(PowerForgeServerInspectCheck))]
+[JsonSerializable(typeof(PowerForgeServerVerifyResult))]
+[JsonSerializable(typeof(PowerForgeServerVerifyCommandResult))]
+[JsonSerializable(typeof(PowerForgeServerVerifyUrlResult))]
+[JsonSerializable(typeof(PowerForgeServerDeployResult))]
+[JsonSerializable(typeof(PowerForgeServerDeployCommandResult))]
+[JsonSerializable(typeof(PowerForgeServerBootstrapPlanResult))]
+[JsonSerializable(typeof(PowerForgeServerBootstrapPlanStep))]
+[JsonSerializable(typeof(PowerForgeServerRestoreSecretsPlanResult))]
+[JsonSerializable(typeof(PowerForgeServerRestoreSecretEntry))]
 internal partial class PowerForgeWebCliJsonContext : JsonSerializerContext
 {
 }

--- a/PowerForge.Web.Cli/ServerRecoveryModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryModels.cs
@@ -1,0 +1,343 @@
+namespace PowerForge.Web.Cli;
+
+internal sealed class PowerForgeServerRecoveryManifest
+{
+    public int SchemaVersion { get; set; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public PowerForgeServerTarget? Target { get; set; }
+    public PowerForgeServerRepository[]? Repositories { get; set; }
+    public PowerForgeServerPackages? Packages { get; set; }
+    public PowerForgeServerPath[]? Paths { get; set; }
+    public PowerForgeServerApache? Apache { get; set; }
+    public PowerForgeServerFirewall? Firewall { get; set; }
+    public PowerForgeServerSystemd? Systemd { get; set; }
+    public PowerForgeServerCertificate[]? Certificates { get; set; }
+    public PowerForgeServerSecret[]? Secrets { get; set; }
+    public PowerForgeServerCapture? Capture { get; set; }
+    public PowerForgeServerCommandGroup? Bootstrap { get; set; }
+    public PowerForgeServerCommandGroup? Deploy { get; set; }
+    public PowerForgeServerVerify? Verify { get; set; }
+    public PowerForgeServerBackupTarget? BackupTarget { get; set; }
+}
+
+internal sealed class PowerForgeServerTarget
+{
+    public string? SshAlias { get; set; }
+    public string? Host { get; set; }
+    public string? User { get; set; }
+    public int? SshPort { get; set; }
+    public string? Os { get; set; }
+}
+
+internal sealed class PowerForgeServerRepository
+{
+    public string? Role { get; set; }
+    public string? Url { get; set; }
+    public string? Path { get; set; }
+    public string? Branch { get; set; }
+    public bool Required { get; set; }
+}
+
+internal sealed class PowerForgeServerPackages
+{
+    public string[]? Apt { get; set; }
+    public string[]? ApacheModules { get; set; }
+    public string[]? DotnetSdks { get; set; }
+    public bool Powershell { get; set; }
+}
+
+internal sealed class PowerForgeServerPath
+{
+    public string? Id { get; set; }
+    public string? Path { get; set; }
+    public string? Owner { get; set; }
+    public string? Group { get; set; }
+    public string? Mode { get; set; }
+    public string? Kind { get; set; }
+}
+
+internal sealed class PowerForgeServerApache
+{
+    public string? Service { get; set; }
+    public string[]? Modules { get; set; }
+    public PowerForgeServerManagedFile[]? Sites { get; set; }
+    public PowerForgeServerManagedFile[]? Conf { get; set; }
+    public string? ValidateCommand { get; set; }
+    public string? ReloadCommand { get; set; }
+}
+
+internal sealed class PowerForgeServerFirewall
+{
+    public string? Provider { get; set; }
+    public string? DefaultIncoming { get; set; }
+    public string? DefaultOutgoing { get; set; }
+    public int[]? SshPorts { get; set; }
+    public string? WebOriginPolicy { get; set; }
+    public string? SyncCommand { get; set; }
+}
+
+internal sealed class PowerForgeServerSystemd
+{
+    public PowerForgeServerSystemdUnit[]? Services { get; set; }
+    public PowerForgeServerSystemdUnit[]? Timers { get; set; }
+}
+
+internal sealed class PowerForgeServerSystemdUnit
+{
+    public string? Name { get; set; }
+    public string? Source { get; set; }
+    public string? Target { get; set; }
+    public bool Enabled { get; set; }
+    public bool Required { get; set; }
+}
+
+internal sealed class PowerForgeServerCertificate
+{
+    public string? Name { get; set; }
+    public string[]? Domains { get; set; }
+    public string? Authenticator { get; set; }
+    public string? CredentialsPath { get; set; }
+    public string? RenewalConfigPath { get; set; }
+    public string? DryRunCommand { get; set; }
+    public string[]? SecretRefs { get; set; }
+}
+
+internal sealed class PowerForgeServerSecret
+{
+    public string Id { get; set; } = string.Empty;
+    public string? Path { get; set; }
+    public string? Env { get; set; }
+    public string[]? RequiredFor { get; set; }
+    public string Capture { get; set; } = string.Empty;
+    public string? RestoreMode { get; set; }
+}
+
+internal sealed class PowerForgeServerCapture
+{
+    public PowerForgeServerManagedFile[]? PlainFiles { get; set; }
+    public PowerForgeServerManagedFile[]? EncryptedFiles { get; set; }
+    public PowerForgeServerNamedCommand[]? Commands { get; set; }
+    public string[]? Exclude { get; set; }
+}
+
+internal sealed class PowerForgeServerManagedFile
+{
+    public string? Source { get; set; }
+    public string? Target { get; set; }
+    public bool Required { get; set; }
+    public bool Sensitive { get; set; }
+}
+
+internal sealed class PowerForgeServerCommandGroup
+{
+    public PowerForgeServerNamedCommand[]? Commands { get; set; }
+}
+
+internal sealed class PowerForgeServerNamedCommand
+{
+    public string? Id { get; set; }
+    public string? Command { get; set; }
+    public string? WorkingDirectory { get; set; }
+    public bool Sensitive { get; set; }
+    public bool Required { get; set; }
+}
+
+internal sealed class PowerForgeServerVerify
+{
+    public PowerForgeServerNamedCommand[]? Commands { get; set; }
+    public PowerForgeServerVerifyUrl[]? Urls { get; set; }
+}
+
+internal sealed class PowerForgeServerVerifyUrl
+{
+    public string? Url { get; set; }
+    public int? ExpectedStatus { get; set; }
+    public string? Via { get; set; }
+}
+
+internal sealed class PowerForgeServerBackupTarget
+{
+    public string? Type { get; set; }
+    public string? Repository { get; set; }
+    public string? Branch { get; set; }
+    public string? Path { get; set; }
+    public string? Encryption { get; set; }
+    public string? Recipient { get; set; }
+    public string? RecipientEnv { get; set; }
+    public PowerForgeServerBackupRetention? Retention { get; set; }
+}
+
+internal sealed class PowerForgeServerBackupRetention
+{
+    public int? KeepLatest { get; set; }
+    public int? KeepDays { get; set; }
+}
+
+internal sealed class PowerForgeServerRecoveryPlanResult
+{
+    public string? ManifestPath { get; set; }
+    public string? Name { get; set; }
+    public string? TargetHost { get; set; }
+    public string? SshAlias { get; set; }
+    public int? SshPort { get; set; }
+    public int RepositoryCount { get; set; }
+    public int PackageCount { get; set; }
+    public int ApacheModuleCount { get; set; }
+    public int SystemdServiceCount { get; set; }
+    public int SystemdTimerCount { get; set; }
+    public int CertificateCount { get; set; }
+    public int PlainCaptureCount { get; set; }
+    public int EncryptedCaptureCount { get; set; }
+    public int SecretCount { get; set; }
+    public string? BackupTarget { get; set; }
+    public string? BackupEncryption { get; set; }
+    public string[]? Stages { get; set; }
+    public string[]? Warnings { get; set; }
+}
+
+internal sealed class PowerForgeServerCaptureResult
+{
+    public string? ManifestPath { get; set; }
+    public string? OutputPath { get; set; }
+    public string? PlainArchivePath { get; set; }
+    public string? EncryptedArchivePath { get; set; }
+    public string? RestoreChecklistPath { get; set; }
+    public PowerForgeServerCaptureCommandResult[]? CommandResults { get; set; }
+    public string[]? Warnings { get; set; }
+}
+
+internal sealed class PowerForgeServerCaptureCommandResult
+{
+    public string? Id { get; set; }
+    public string? Command { get; set; }
+    public int ExitCode { get; set; }
+    public bool Success { get; set; }
+    public string? StdoutPath { get; set; }
+    public string? StderrPath { get; set; }
+}
+
+internal sealed class PowerForgeServerInspectResult
+{
+    public string? ManifestPath { get; set; }
+    public string? Target { get; set; }
+    public bool Success { get; set; }
+    public PowerForgeServerInspectCheck[]? Checks { get; set; }
+    public string[]? Warnings { get; set; }
+}
+
+internal sealed class PowerForgeServerInspectCheck
+{
+    public string Id { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public bool Success { get; set; }
+    public string? Expected { get; set; }
+    public string? Actual { get; set; }
+}
+
+internal sealed class PowerForgeServerVerifyResult
+{
+    public string? ManifestPath { get; set; }
+    public string? Target { get; set; }
+    public bool Success { get; set; }
+    public PowerForgeServerVerifyCommandResult[]? Commands { get; set; }
+    public PowerForgeServerVerifyUrlResult[]? Urls { get; set; }
+    public string[]? Warnings { get; set; }
+}
+
+internal sealed class PowerForgeServerVerifyCommandResult
+{
+    public string? Id { get; set; }
+    public string? Command { get; set; }
+    public bool Required { get; set; }
+    public int ExitCode { get; set; }
+    public bool Success { get; set; }
+    public string? OutputPreview { get; set; }
+    public string? ErrorPreview { get; set; }
+}
+
+internal sealed class PowerForgeServerVerifyUrlResult
+{
+    public string? Url { get; set; }
+    public int? ExpectedStatus { get; set; }
+    public int? ActualStatus { get; set; }
+    public string? Via { get; set; }
+    public bool Success { get; set; }
+    public string? ServerHeader { get; set; }
+    public string? Error { get; set; }
+}
+
+internal sealed class PowerForgeServerDeployResult
+{
+    public string? ManifestPath { get; set; }
+    public string? Target { get; set; }
+    public bool DryRun { get; set; }
+    public bool Success { get; set; }
+    public PowerForgeServerDeployCommandResult[]? Commands { get; set; }
+    public string[]? Warnings { get; set; }
+}
+
+internal sealed class PowerForgeServerDeployCommandResult
+{
+    public string? Id { get; set; }
+    public string? Command { get; set; }
+    public string? WorkingDirectory { get; set; }
+    public bool Required { get; set; }
+    public bool Sensitive { get; set; }
+    public int ExitCode { get; set; }
+    public bool Success { get; set; }
+    public bool Skipped { get; set; }
+    public string? OutputPreview { get; set; }
+    public string? ErrorPreview { get; set; }
+}
+
+internal sealed class PowerForgeServerBootstrapPlanResult
+{
+    public string? ManifestPath { get; set; }
+    public string? OutputPath { get; set; }
+    public string? MarkdownPath { get; set; }
+    public string? ScriptPath { get; set; }
+    public PowerForgeServerBootstrapPlanStep[]? Steps { get; set; }
+    public string[]? Warnings { get; set; }
+}
+
+internal sealed class PowerForgeServerBootstrapPlanStep
+{
+    public int Order { get; set; }
+    public string Category { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string? Command { get; set; }
+    public bool Manual { get; set; }
+    public bool Sensitive { get; set; }
+}
+
+internal sealed class PowerForgeServerRestoreSecretsPlanResult
+{
+    public string? ManifestPath { get; set; }
+    public string? OutputPath { get; set; }
+    public string? MarkdownPath { get; set; }
+    public string? ScriptPath { get; set; }
+    public string? ArchivePath { get; set; }
+    public string? Encryption { get; set; }
+    public string? RecipientEnv { get; set; }
+    public PowerForgeServerRestoreSecretEntry[]? Secrets { get; set; }
+    public string[]? Warnings { get; set; }
+}
+
+internal sealed class PowerForgeServerRestoreSecretEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string? Path { get; set; }
+    public string? Env { get; set; }
+    public string? RestoreMode { get; set; }
+    public string? RequiredFor { get; set; }
+}
+
+internal sealed class ProcessResult
+{
+    public int ExitCode { get; set; }
+    public string Stdout { get; set; } = string.Empty;
+    public string Stderr { get; set; } = string.Empty;
+    public bool Success => ExitCode == 0;
+}

--- a/PowerForge.Web.Cli/ServerRecoveryModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryModels.cs
@@ -111,7 +111,7 @@ internal sealed class PowerForgeServerSecret
     public string? Path { get; set; }
     public string? Env { get; set; }
     public string[]? RequiredFor { get; set; }
-    public string Capture { get; set; } = string.Empty;
+    public string Capture { get; set; } = "exclude";
     public string? RestoreMode { get; set; }
 }
 
@@ -138,7 +138,7 @@ internal sealed class PowerForgeServerCommandGroup
 
 internal sealed class PowerForgeServerNamedCommand
 {
-    public string? Id { get; set; }
+    public string Id { get; set; } = string.Empty;
     public string? Command { get; set; }
     public string? WorkingDirectory { get; set; }
     public bool Sensitive { get; set; }

--- a/PowerForge.Web.Cli/ServerRecoveryModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryModels.cs
@@ -19,6 +19,7 @@ internal sealed class PowerForgeServerRecoveryManifest
     public PowerForgeServerCommandGroup? Deploy { get; set; }
     public PowerForgeServerVerify? Verify { get; set; }
     public PowerForgeServerBackupTarget? BackupTarget { get; set; }
+    public string[]? Notes { get; set; }
 }
 
 internal sealed class PowerForgeServerTarget
@@ -28,6 +29,7 @@ internal sealed class PowerForgeServerTarget
     public string? User { get; set; }
     public int? SshPort { get; set; }
     public string? Os { get; set; }
+    public string? Architecture { get; set; }
 }
 
 internal sealed class PowerForgeServerRepository
@@ -265,6 +267,7 @@ internal sealed class PowerForgeServerVerifyUrlResult
     public string? Via { get; set; }
     public bool Success { get; set; }
     public string? ServerHeader { get; set; }
+    public string? CloudflareRay { get; set; }
     public string? Error { get; set; }
 }
 

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Dispatch.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Dispatch.cs
@@ -55,6 +55,7 @@ collection: {{collection}}
             "agent-ready" => HandleAgentReady(subArgs, outputJson, logger, outputSchemaVersion),
             "agentready" => HandleAgentReady(subArgs, outputJson, logger, outputSchemaVersion),
             "xref-merge" => HandleXrefMerge(subArgs, outputJson, logger, outputSchemaVersion),
+            "server" => HandleServer(subArgs, outputJson, logger, outputSchemaVersion),
             "cloudflare" => HandleCloudflare(subArgs, outputJson, logger, outputSchemaVersion),
             _ => HandleUnknownCommand()
         };

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
@@ -1,0 +1,313 @@
+using System.Text;
+using System.Text.Json;
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static int HandleServerBootstrapPlan(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var loaded = LoadServerRecoveryManifest(subArgs, outputJson, logger, "web.server.bootstrap-plan");
+        if (loaded.Manifest is null)
+            return loaded.ExitCode;
+
+        var manifest = loaded.Manifest;
+        var manifestPath = loaded.ManifestPath!;
+        var outPathArg = TryGetOptionValue(subArgs, "--out") ??
+                         TryGetOptionValue(subArgs, "--output") ??
+                         TryGetOptionValue(subArgs, "--output-dir");
+        var outputRoot = ResolveBootstrapPlanOutputPath(outPathArg, manifest);
+        Directory.CreateDirectory(outputRoot);
+
+        var warnings = new List<string>();
+        var steps = BuildBootstrapPlanSteps(manifest, warnings);
+        var markdownPath = Path.Combine(outputRoot, "bootstrap-plan.md");
+        var scriptPath = Path.Combine(outputRoot, "bootstrap-plan.sh");
+        WriteBootstrapPlanMarkdown(markdownPath, manifest, steps, warnings);
+        WriteBootstrapPlanScript(scriptPath, steps);
+
+        var result = new PowerForgeServerBootstrapPlanResult
+        {
+            ManifestPath = manifestPath,
+            OutputPath = outputRoot,
+            MarkdownPath = markdownPath,
+            ScriptPath = scriptPath,
+            Steps = steps.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+
+        File.WriteAllText(
+            Path.Combine(outputRoot, "bootstrap-plan.json"),
+            JsonSerializer.Serialize(result, WebCliJson.Context.PowerForgeServerBootstrapPlanResult));
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.server.bootstrap-plan",
+                Success = true,
+                ExitCode = 0,
+                Config = "web.serverrecovery",
+                ConfigPath = manifestPath,
+                Result = WebCliJson.SerializeToElement(result, WebCliJson.Context.PowerForgeServerBootstrapPlanResult),
+                Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
+            });
+            return 0;
+        }
+
+        logger.Success("Server bootstrap plan generated.");
+        logger.Info($"Output: {outputRoot}");
+        logger.Info($"Markdown: {markdownPath}");
+        logger.Info($"Script draft: {scriptPath}");
+        logger.Info($"Steps: {steps.Count}");
+        foreach (var warning in warnings)
+            logger.Warn(warning);
+
+        return 0;
+    }
+
+    private static string ResolveBootstrapPlanOutputPath(string? outPathArg, PowerForgeServerRecoveryManifest manifest)
+    {
+        if (!string.IsNullOrWhiteSpace(outPathArg))
+            return Path.GetFullPath(outPathArg);
+
+        var name = SanitizeFileName(string.IsNullOrWhiteSpace(manifest.Name) ? "server" : manifest.Name);
+        return Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "_server-state", name, "bootstrap-plan"));
+    }
+
+    private static List<PowerForgeServerBootstrapPlanStep> BuildBootstrapPlanSteps(
+        PowerForgeServerRecoveryManifest manifest,
+        ICollection<string> warnings)
+    {
+        var steps = new List<PowerForgeServerBootstrapPlanStep>();
+        var plannedCommands = new HashSet<string>(StringComparer.Ordinal);
+        var order = 1;
+
+        AddStep(steps, ref order, "preflight", "Confirm supported host",
+            $"test -f /etc/os-release && grep -q {ShellQuote((manifest.Target?.Os ?? "ubuntu").Replace("ubuntu-", string.Empty, StringComparison.OrdinalIgnoreCase))} /etc/os-release || true",
+            plannedCommands: plannedCommands);
+
+        if (manifest.Packages?.Apt?.Length > 0)
+        {
+            AddStep(steps, ref order, "packages", "Install apt prerequisites",
+                "apt-get update && apt-get install -y " + string.Join(' ', manifest.Packages.Apt),
+                plannedCommands: plannedCommands);
+        }
+
+        foreach (var path in manifest.Paths ?? Array.Empty<PowerForgeServerPath>())
+        {
+            if (string.IsNullOrWhiteSpace(path.Path)) continue;
+            var owner = string.IsNullOrWhiteSpace(path.Owner) ? "root" : path.Owner;
+            var group = string.IsNullOrWhiteSpace(path.Group) ? "root" : path.Group;
+            var mode = string.IsNullOrWhiteSpace(path.Mode) ? "755" : path.Mode;
+            if (path.Kind?.Equals("directory", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                AddStep(steps, ref order, "filesystem", $"Create directory {path.Path}",
+                    $"install -d -o {owner} -g {group} -m {mode} {ShellQuote(path.Path)}",
+                    plannedCommands: plannedCommands);
+            }
+        }
+
+        foreach (var repository in manifest.Repositories ?? Array.Empty<PowerForgeServerRepository>())
+        {
+            if (string.IsNullOrWhiteSpace(repository.Path)) continue;
+            if (string.IsNullOrWhiteSpace(repository.Url))
+            {
+                warnings.Add($"Repository URL is missing for role '{repository.Role}'. Bootstrap script leaves a manual clone step.");
+                AddStep(steps, ref order, "repositories", $"Clone {repository.Role} repository", $"# TODO: git clone <{repository.Role}-repo-url> {ShellQuote(repository.Path)}", manual: true, plannedCommands: plannedCommands);
+            }
+            else
+            {
+                var branchArg = string.IsNullOrWhiteSpace(repository.Branch) ? string.Empty : $" --branch {ShellQuote(repository.Branch)}";
+                var gitDirectory = repository.Path.TrimEnd('/') + "/.git";
+                AddStep(steps, ref order, "repositories", $"Clone or update {repository.Role} repository",
+                    $"if [ -d {ShellQuote(gitDirectory)} ]; then git -C {ShellQuote(repository.Path)} fetch --all --prune; else git clone{branchArg} {ShellQuote(repository.Url)} {ShellQuote(repository.Path)}; fi",
+                    plannedCommands: plannedCommands);
+            }
+        }
+
+        foreach (var command in manifest.Bootstrap?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>())
+        {
+            if (string.IsNullOrWhiteSpace(command.Command)) continue;
+            AddStep(steps, ref order, "bootstrap", command.Id ?? "bootstrap command", command.Command, command.Sensitive, plannedCommands: plannedCommands);
+        }
+
+        var apacheModules = manifest.Packages?.ApacheModules ?? manifest.Apache?.Modules ?? Array.Empty<string>();
+        if (apacheModules.Length > 0)
+            AddStep(steps, ref order, "apache", "Enable Apache modules", "a2enmod " + string.Join(' ', apacheModules), plannedCommands: plannedCommands);
+
+        foreach (var file in (manifest.Apache?.Sites ?? Array.Empty<PowerForgeServerManagedFile>())
+                 .Concat(manifest.Apache?.Conf ?? Array.Empty<PowerForgeServerManagedFile>()))
+        {
+            if (string.IsNullOrWhiteSpace(file.Source) || string.IsNullOrWhiteSpace(file.Target)) continue;
+            AddStep(steps, ref order, "apache", $"Install Apache file {file.Target}",
+                $"install -m 0644 {ShellQuote(file.Source)} {ShellQuote(file.Target)}",
+                plannedCommands: plannedCommands);
+        }
+
+        foreach (var unit in (manifest.Systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
+                 .Concat(manifest.Systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>()))
+        {
+            if (!string.IsNullOrWhiteSpace(unit.Source) && !string.IsNullOrWhiteSpace(unit.Target))
+            {
+                AddStep(steps, ref order, "systemd", $"Install systemd unit {unit.Name}",
+                    $"install -m 0644 {ShellQuote(unit.Source)} {ShellQuote(unit.Target)}",
+                    plannedCommands: plannedCommands);
+            }
+        }
+
+        AddStep(steps, ref order, "systemd", "Reload systemd units", "systemctl daemon-reload", plannedCommands: plannedCommands);
+
+        foreach (var unit in (manifest.Systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
+                 .Concat(manifest.Systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>())
+                 .Where(static unit => unit.Enabled && !string.IsNullOrWhiteSpace(unit.Name)))
+        {
+            AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+        }
+
+        foreach (var port in manifest.Firewall?.SshPorts ?? Array.Empty<int>())
+            AddStep(steps, ref order, "firewall", $"Allow SSH port {port}", $"ufw allow {port}/tcp", plannedCommands: plannedCommands);
+
+        if (!string.IsNullOrWhiteSpace(manifest.Firewall?.SyncCommand))
+            AddStep(steps, ref order, "firewall", "Apply origin firewall sync", manifest.Firewall.SyncCommand, plannedCommands: plannedCommands);
+
+        AddStep(steps, ref order, "firewall", "Enable UFW", "ufw --force enable", plannedCommands: plannedCommands);
+
+        foreach (var secret in manifest.Secrets ?? Array.Empty<PowerForgeServerSecret>())
+        {
+            AddStep(steps, ref order, "secrets", $"Restore secret {secret.Id}",
+                $"# TODO: restore encrypted secret to {secret.Path ?? secret.Env ?? secret.Id}", manual: true, sensitive: true, plannedCommands: plannedCommands);
+        }
+
+        foreach (var command in manifest.Deploy?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>())
+        {
+            if (string.IsNullOrWhiteSpace(command.Command)) continue;
+            var shell = string.IsNullOrWhiteSpace(command.WorkingDirectory)
+                ? command.Command
+                : $"cd {ShellQuote(command.WorkingDirectory)} && {command.Command}";
+            AddStep(steps, ref order, "deploy", command.Id ?? "deploy command", shell, command.Sensitive, plannedCommands: plannedCommands);
+        }
+
+        AddStep(steps, ref order, "verify", "Run PowerForge server verify", "# Run from an operator workstation: powerforge-web server verify --manifest <manifest> --fail-on-failure", manual: true, plannedCommands: plannedCommands);
+        return steps;
+    }
+
+    private static void AddStep(
+        ICollection<PowerForgeServerBootstrapPlanStep> steps,
+        ref int order,
+        string category,
+        string title,
+        string? command,
+        bool sensitive = false,
+        bool manual = false,
+        ISet<string>? plannedCommands = null)
+    {
+        if (!string.IsNullOrWhiteSpace(command) &&
+            plannedCommands is not null &&
+            !command.TrimStart().StartsWith("#", StringComparison.Ordinal) &&
+            !plannedCommands.Add(command))
+        {
+            return;
+        }
+
+        steps.Add(new PowerForgeServerBootstrapPlanStep
+        {
+            Order = order++,
+            Category = category,
+            Title = title,
+            Command = command,
+            Sensitive = sensitive,
+            Manual = manual
+        });
+    }
+
+    private static void WriteBootstrapPlanMarkdown(
+        string path,
+        PowerForgeServerRecoveryManifest manifest,
+        IReadOnlyList<PowerForgeServerBootstrapPlanStep> steps,
+        IReadOnlyList<string> warnings)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# PowerForge Server Bootstrap Plan");
+        builder.AppendLine();
+        builder.AppendLine($"Manifest: `{manifest.Name}`");
+        builder.AppendLine($"Target: `{manifest.Target?.SshAlias ?? manifest.Target?.Host ?? "new host"}`");
+        builder.AppendLine();
+        builder.AppendLine("This is a review artifact. It is safe to commit the plan, but not generated secret bundles.");
+        builder.AppendLine();
+
+        foreach (var group in steps.GroupBy(static step => step.Category))
+        {
+            builder.AppendLine($"## {group.Key}");
+            builder.AppendLine();
+            foreach (var step in group)
+            {
+                builder.AppendLine($"{step.Order}. {step.Title}");
+                if (step.Manual) builder.AppendLine("   - Manual review/action required.");
+                if (step.Sensitive) builder.AppendLine("   - Sensitive step; do not paste secret values into Git.");
+                if (!string.IsNullOrWhiteSpace(step.Command))
+                {
+                    builder.AppendLine();
+                    builder.AppendLine("```bash");
+                    builder.AppendLine(step.Command);
+                    builder.AppendLine("```");
+                }
+                builder.AppendLine();
+            }
+        }
+
+        if (warnings.Count > 0)
+        {
+            builder.AppendLine("## Warnings");
+            builder.AppendLine();
+            foreach (var warning in warnings)
+                builder.AppendLine($"- {warning}");
+        }
+
+        File.WriteAllText(path, builder.ToString());
+    }
+
+    private static void WriteBootstrapPlanScript(
+        string path,
+        IReadOnlyList<PowerForgeServerBootstrapPlanStep> steps)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("#!/usr/bin/env bash");
+        builder.AppendLine("set -Eeuo pipefail");
+        builder.AppendLine();
+        builder.AppendLine("# Generated by powerforge-web server bootstrap-plan.");
+        builder.AppendLine("# Review before running. Manual/TODO steps intentionally remain comments.");
+        builder.AppendLine();
+
+        foreach (var step in steps)
+        {
+            builder.AppendLine($"# {step.Order}. [{step.Category}] {step.Title}");
+            if (string.IsNullOrWhiteSpace(step.Command))
+            {
+                builder.AppendLine();
+                continue;
+            }
+
+            if (step.Manual || step.Sensitive || step.Command.TrimStart().StartsWith("#", StringComparison.Ordinal))
+            {
+                foreach (var line in step.Command.Split(new[] { '\r', '\n' }, StringSplitOptions.None))
+                    builder.AppendLine("# " + line);
+                if (step.Manual)
+                {
+                    builder.AppendLine($"echo {ShellQuote($"Manual bootstrap step required: {step.Title}")} >&2");
+                    builder.AppendLine("exit 3");
+                }
+            }
+            else
+            {
+                builder.AppendLine(step.Command);
+            }
+
+            builder.AppendLine();
+        }
+
+        File.WriteAllText(path, builder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Deploy.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Deploy.cs
@@ -1,0 +1,137 @@
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static int HandleServerDeploy(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var loaded = LoadServerRecoveryManifest(subArgs, outputJson, logger, "web.server.deploy");
+        if (loaded.Manifest is null)
+            return loaded.ExitCode;
+
+        var manifest = loaded.Manifest;
+        var manifestPath = loaded.ManifestPath!;
+        var sshCommand = TryGetOptionValue(subArgs, "--ssh") ?? "ssh";
+        var dryRun = HasOption(subArgs, "--dry-run");
+        var failOnFailure = HasOption(subArgs, "--fail-on-failure");
+        var target = BuildServerSshTarget(manifest.Target);
+        var commandResults = new List<PowerForgeServerDeployCommandResult>();
+        var warnings = new List<string>();
+
+        var deployCommands = manifest.Deploy?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>();
+        if (deployCommands.Length == 0)
+            warnings.Add("No deploy commands are defined in the manifest.");
+
+        foreach (var command in deployCommands)
+        {
+            var commandText = BuildDeployCommand(command);
+            if (string.IsNullOrWhiteSpace(commandText))
+            {
+                warnings.Add($"Skipping deploy command '{command.Id}' because command text is empty.");
+                continue;
+            }
+
+            if (command.Sensitive)
+            {
+                warnings.Add($"Skipping sensitive deploy command '{command.Id}'.");
+                commandResults.Add(new PowerForgeServerDeployCommandResult
+                {
+                    Id = command.Id,
+                    Command = command.Command,
+                    WorkingDirectory = command.WorkingDirectory,
+                    Required = command.Required,
+                    Sensitive = command.Sensitive,
+                    Skipped = true,
+                    Success = !command.Required,
+                    ErrorPreview = "Sensitive command skipped."
+                });
+                continue;
+            }
+
+            if (dryRun)
+            {
+                commandResults.Add(new PowerForgeServerDeployCommandResult
+                {
+                    Id = command.Id,
+                    Command = command.Command,
+                    WorkingDirectory = command.WorkingDirectory,
+                    Required = command.Required,
+                    Sensitive = command.Sensitive,
+                    Skipped = true,
+                    Success = true,
+                    OutputPreview = commandText
+                });
+                continue;
+            }
+
+            var result = ExecuteRemote(sshCommand, target, commandText);
+            commandResults.Add(new PowerForgeServerDeployCommandResult
+            {
+                Id = command.Id,
+                Command = command.Command,
+                WorkingDirectory = command.WorkingDirectory,
+                Required = command.Required,
+                Sensitive = command.Sensitive,
+                ExitCode = result.ExitCode,
+                Success = result.Success,
+                OutputPreview = Preview(result.Stdout),
+                ErrorPreview = Preview(result.Stderr)
+            });
+        }
+
+        var failedCommands = commandResults
+            .Where(static result => result.Required && !result.Success)
+            .ToArray();
+        if (failedCommands.Length > 0)
+            warnings.Add($"{failedCommands.Length} required deploy command(s) failed.");
+
+        var success = failedCommands.Length == 0;
+        var resultSummary = new PowerForgeServerDeployResult
+        {
+            ManifestPath = manifestPath,
+            Target = target,
+            DryRun = dryRun,
+            Success = success,
+            Commands = commandResults.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.server.deploy",
+                Success = success || !failOnFailure,
+                ExitCode = success || !failOnFailure ? 0 : 1,
+                Config = "web.serverrecovery",
+                ConfigPath = manifestPath,
+                Result = WebCliJson.SerializeToElement(resultSummary, WebCliJson.Context.PowerForgeServerDeployResult),
+                Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
+            });
+            return success || !failOnFailure ? 0 : 1;
+        }
+
+        logger.Success(success ? (dryRun ? "Server deploy dry run completed." : "Server deploy completed.") : "Server deploy completed with failures.");
+        logger.Info($"Target: {target}");
+        logger.Info($"Commands: {commandResults.Count}");
+        foreach (var result in commandResults.Where(static result => result.Skipped && !string.IsNullOrWhiteSpace(result.OutputPreview)))
+            logger.Info($"dry-run {result.Id}: {result.OutputPreview}");
+        foreach (var failure in failedCommands)
+            logger.Warn($"command {failure.Id}: exit={failure.ExitCode}; error={failure.ErrorPreview}");
+        foreach (var warning in warnings)
+            logger.Warn(warning);
+
+        return success || !failOnFailure ? 0 : 1;
+    }
+
+    private static string? BuildDeployCommand(PowerForgeServerNamedCommand command)
+    {
+        if (string.IsNullOrWhiteSpace(command.Command))
+            return null;
+        return string.IsNullOrWhiteSpace(command.WorkingDirectory)
+            ? command.Command
+            : $"cd {ShellQuote(command.WorkingDirectory)} && {command.Command}";
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
@@ -1,0 +1,258 @@
+using System.Text.Json;
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static int HandleServerInspect(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var loaded = LoadServerRecoveryManifest(subArgs, outputJson, logger, "web.server.inspect");
+        if (loaded.Manifest is null)
+            return loaded.ExitCode;
+
+        var manifest = loaded.Manifest;
+        var manifestPath = loaded.ManifestPath!;
+        var sshCommand = TryGetOptionValue(subArgs, "--ssh") ?? "ssh";
+        var failOnDrift = HasOption(subArgs, "--fail-on-drift");
+        var target = BuildServerSshTarget(manifest.Target);
+        var checks = new List<PowerForgeServerInspectCheck>();
+        var warnings = new List<string>();
+
+        AddCommandCheck(checks, "ssh.connect", "connectivity", "SSH target is reachable",
+            ExecuteRemote(sshCommand, target, "printf ok"), "ok");
+
+        var os = ExecuteRemote(sshCommand, target, "cat /etc/os-release");
+        if (os.Success && !string.IsNullOrWhiteSpace(manifest.Target?.Os))
+        {
+            var expectedVersion = manifest.Target.Os.Replace("ubuntu-", string.Empty, StringComparison.OrdinalIgnoreCase);
+            AddBooleanCheck(checks, "os.version", "os", "OS version matches manifest",
+                os.Stdout.Contains(expectedVersion, StringComparison.OrdinalIgnoreCase),
+                manifest.Target.Os,
+                FirstMatchingLine(os.Stdout, "VERSION_ID") ?? "unknown");
+        }
+        else
+        {
+            AddCommandCheck(checks, "os.release", "os", "OS release can be read", os, "success");
+        }
+
+        var sshd = ExecuteRemote(sshCommand, target, "sudo -n /usr/sbin/sshd -T 2>/dev/null | awk '/^(port|passwordauthentication|permitrootlogin|x11forwarding|maxauthtries|logingracetime) / { print }'");
+        if (sshd.Success && manifest.Target?.SshPort is not null)
+        {
+            AddBooleanCheck(checks, "ssh.port", "ssh", "SSH port matches manifest",
+                HasLine(sshd.Stdout, $"port {manifest.Target.SshPort.Value}"),
+                manifest.Target.SshPort.Value.ToString(),
+                FirstMatchingLine(sshd.Stdout, "port ") ?? "unknown");
+            AddBooleanCheck(checks, "ssh.root-login", "ssh", "Root SSH login is disabled",
+                HasLine(sshd.Stdout, "permitrootlogin no"),
+                "permitrootlogin no",
+                FirstMatchingLine(sshd.Stdout, "permitrootlogin") ?? "unknown");
+        }
+        else
+        {
+            AddCommandCheck(checks, "ssh.effective-config", "ssh", "SSH effective config can be read", sshd, "success");
+        }
+
+        var packages = ExecuteRemote(sshCommand, target, "dpkg-query -W -f='${binary:Package}\\n'");
+        foreach (var package in manifest.Packages?.Apt ?? Array.Empty<string>())
+        {
+            AddBooleanCheck(checks, $"package.{package}", "packages", $"Package is installed: {package}",
+                HasExactLine(packages.Stdout, package),
+                package,
+                packages.Success ? "installed/missing from dpkg-query" : packages.Stderr.Trim());
+        }
+
+        var apacheModules = ExecuteRemote(sshCommand, target, "apache2ctl -M 2>/dev/null || apachectl -M 2>/dev/null");
+        foreach (var module in manifest.Packages?.ApacheModules ?? manifest.Apache?.Modules ?? Array.Empty<string>())
+        {
+            AddBooleanCheck(checks, $"apache.module.{module}", "apache", $"Apache module is enabled: {module}",
+                apacheModules.Stdout.Contains($"{module}_module", StringComparison.OrdinalIgnoreCase),
+                $"{module}_module",
+                apacheModules.Success ? "enabled/missing from apache -M" : apacheModules.Stderr.Trim());
+        }
+
+        AddCommandCheck(checks, "apache.configtest", "apache", "Apache configtest succeeds",
+            ExecuteRemote(sshCommand, target, manifest.Apache?.ValidateCommand ?? "apachectl configtest"), "Syntax OK");
+
+        foreach (var path in manifest.Paths ?? Array.Empty<PowerForgeServerPath>())
+        {
+            if (string.IsNullOrWhiteSpace(path.Path)) continue;
+            var test = path.Kind?.Equals("directory", StringComparison.OrdinalIgnoreCase) == true
+                ? $"test -d {ShellQuote(path.Path)}"
+                : $"test -e {ShellQuote(path.Path)}";
+            AddBooleanCheck(checks, $"path.{path.Id ?? path.Path}", "paths", $"Managed path exists: {path.Path}",
+                ExecuteRemote(sshCommand, target, test).Success,
+                path.Kind ?? "exists",
+                path.Path);
+        }
+
+        InspectSystemdUnits(sshCommand, target, manifest.Systemd?.Services, "service", checks);
+        InspectSystemdUnits(sshCommand, target, manifest.Systemd?.Timers, "timer", checks);
+
+        var ufw = ExecuteRemote(sshCommand, target, "sudo -n ufw status numbered");
+        AddBooleanCheck(checks, "ufw.active", "firewall", "UFW is active",
+            ufw.Stdout.Contains("Status: active", StringComparison.OrdinalIgnoreCase),
+            "active",
+            FirstMatchingLine(ufw.Stdout, "Status:") ?? ufw.Stderr.Trim());
+        foreach (var port in manifest.Firewall?.SshPorts ?? Array.Empty<int>())
+        {
+            AddBooleanCheck(checks, $"ufw.ssh.{port}", "firewall", $"UFW allows SSH port {port}",
+                ufw.Stdout.Contains($"{port}/tcp", StringComparison.OrdinalIgnoreCase),
+                $"{port}/tcp allowed",
+                "ufw status numbered");
+        }
+        if (manifest.Firewall?.WebOriginPolicy?.Equals("cloudflare-only", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            AddBooleanCheck(checks, "ufw.cloudflare-only", "firewall", "HTTP/HTTPS are not open to Anywhere",
+                !ufw.Stdout.Contains("80/tcp                     ALLOW IN    Anywhere", StringComparison.OrdinalIgnoreCase) &&
+                !ufw.Stdout.Contains("443/tcp                    ALLOW IN    Anywhere", StringComparison.OrdinalIgnoreCase),
+                "Cloudflare ranges only",
+                "ufw status numbered");
+        }
+
+        foreach (var cert in manifest.Certificates ?? Array.Empty<PowerForgeServerCertificate>())
+        {
+            if (!string.IsNullOrWhiteSpace(cert.RenewalConfigPath))
+            {
+                AddBooleanCheck(checks, $"cert.{cert.Name}.renewal", "certbot", $"Certbot renewal config exists: {cert.Name}",
+                    ExecuteRemote(sshCommand, target, $"test -f {ShellQuote(cert.RenewalConfigPath)}").Success,
+                    cert.RenewalConfigPath,
+                    cert.RenewalConfigPath);
+            }
+        }
+
+        foreach (var secret in manifest.Secrets ?? Array.Empty<PowerForgeServerSecret>())
+        {
+            if (string.IsNullOrWhiteSpace(secret.Path)) continue;
+            var command = secret.RestoreMode?.Equals("directory", StringComparison.OrdinalIgnoreCase) == true
+                ? $"test -d {ShellQuote(secret.Path)}"
+                : $"test -e {ShellQuote(secret.Path)}";
+            AddBooleanCheck(checks, $"secret.{secret.Id}.exists", "secrets", $"Required secret path exists: {secret.Id}",
+                ExecuteRemote(sshCommand, target, "sudo -n " + command).Success,
+                secret.Path,
+                "exists/missing");
+        }
+
+        AddCommandCheck(checks, "release.links", "deploy", "Current release symlinks resolve",
+            ExecuteRemote(sshCommand, target, "readlink -f /var/www/evotec/xyz/current && readlink -f /var/www/evotec/pl/current"), "/var/www/evotec");
+
+        var failed = checks.Where(static check => !check.Success).ToArray();
+        if (failed.Length > 0)
+            warnings.Add($"{failed.Length} inspect check(s) reported drift or failure.");
+
+        var result = new PowerForgeServerInspectResult
+        {
+            ManifestPath = manifestPath,
+            Target = target,
+            Success = failed.Length == 0,
+            Checks = checks.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.server.inspect",
+                Success = result.Success || !failOnDrift,
+                ExitCode = result.Success || !failOnDrift ? 0 : 1,
+                Config = "web.serverrecovery",
+                ConfigPath = manifestPath,
+                Result = WebCliJson.SerializeToElement(result, WebCliJson.Context.PowerForgeServerInspectResult),
+                Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
+            });
+            return result.Success || !failOnDrift ? 0 : 1;
+        }
+
+        logger.Success(result.Success ? "Server inspect completed without drift." : "Server inspect completed with drift.");
+        logger.Info($"Target: {target}");
+        logger.Info($"Checks: {checks.Count}; failures: {failed.Length}");
+        foreach (var failure in failed.Take(20))
+            logger.Warn($"{failure.Id}: {failure.Message} (expected: {failure.Expected}; actual: {failure.Actual})");
+        if (failed.Length > 20)
+            logger.Warn($"Additional failures omitted: {failed.Length - 20}");
+
+        return result.Success || !failOnDrift ? 0 : 1;
+    }
+
+    private static ProcessResult ExecuteRemote(string sshCommand, string target, string command)
+        => RunProcessCaptureText(sshCommand, new[] { target, $"sh -lc {ShellQuote(command)}" });
+
+    private static void InspectSystemdUnits(
+        string sshCommand,
+        string target,
+        PowerForgeServerSystemdUnit[]? units,
+        string kind,
+        ICollection<PowerForgeServerInspectCheck> checks)
+    {
+        foreach (var unit in units ?? Array.Empty<PowerForgeServerSystemdUnit>())
+        {
+            if (string.IsNullOrWhiteSpace(unit.Name)) continue;
+            var exists = ExecuteRemote(sshCommand, target, $"systemctl cat {ShellQuote(unit.Name)} >/dev/null");
+            AddBooleanCheck(checks, $"systemd.{kind}.{unit.Name}.exists", "systemd", $"systemd {kind} exists: {unit.Name}",
+                exists.Success,
+                "unit exists",
+                exists.Success ? "unit exists" : exists.Stderr.Trim());
+
+            if (!unit.Enabled) continue;
+            var enabled = ExecuteRemote(sshCommand, target, $"systemctl is-enabled {ShellQuote(unit.Name)}");
+            AddBooleanCheck(checks, $"systemd.{kind}.{unit.Name}.enabled", "systemd", $"systemd {kind} is enabled: {unit.Name}",
+                enabled.Stdout.Trim().Equals("enabled", StringComparison.OrdinalIgnoreCase),
+                "enabled",
+                enabled.Stdout.Trim());
+        }
+    }
+
+    private static void AddCommandCheck(
+        ICollection<PowerForgeServerInspectCheck> checks,
+        string id,
+        string category,
+        string message,
+        ProcessResult result,
+        string expected)
+    {
+        checks.Add(new PowerForgeServerInspectCheck
+        {
+            Id = id,
+            Category = category,
+            Message = message,
+            Success = result.Success,
+            Expected = expected,
+            Actual = result.Success ? result.Stdout.Trim() : result.Stderr.Trim()
+        });
+    }
+
+    private static void AddBooleanCheck(
+        ICollection<PowerForgeServerInspectCheck> checks,
+        string id,
+        string category,
+        string message,
+        bool success,
+        string? expected,
+        string? actual)
+    {
+        checks.Add(new PowerForgeServerInspectCheck
+        {
+            Id = id,
+            Category = category,
+            Message = message,
+            Success = success,
+            Expected = expected,
+            Actual = actual
+        });
+    }
+
+    private static bool HasExactLine(string text, string expected)
+        => text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(line => line.Trim().Equals(expected, StringComparison.OrdinalIgnoreCase));
+
+    private static bool HasLine(string text, string expected)
+        => text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(line => line.Trim().Equals(expected, StringComparison.OrdinalIgnoreCase));
+
+    private static string? FirstMatchingLine(string text, string prefix)
+        => text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(line => line.TrimStart().StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            ?.Trim();
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
@@ -86,6 +86,13 @@ internal static partial class WebCliCommandHandlers
                 path.Path);
         }
 
+        foreach (var path in manifest.Paths?.Where(static path => path.Kind?.Equals("symlink", StringComparison.OrdinalIgnoreCase) == true) ?? Array.Empty<PowerForgeServerPath>())
+        {
+            if (string.IsNullOrWhiteSpace(path.Path)) continue;
+            AddCommandCheck(checks, $"path.{path.Id ?? path.Path}.target", "paths", $"Managed symlink resolves: {path.Path}",
+                ExecuteRemote(sshCommand, target, $"readlink -f {ShellQuote(path.Path)}"), "symlink target");
+        }
+
         InspectSystemdUnits(sshCommand, target, manifest.Systemd?.Services, "service", checks);
         InspectSystemdUnits(sshCommand, target, manifest.Systemd?.Timers, "timer", checks);
 
@@ -133,9 +140,6 @@ internal static partial class WebCliCommandHandlers
                 "exists/missing");
         }
 
-        AddCommandCheck(checks, "release.links", "deploy", "Current release symlinks resolve",
-            ExecuteRemote(sshCommand, target, "readlink -f /var/www/evotec/xyz/current && readlink -f /var/www/evotec/pl/current"), "/var/www/evotec");
-
         var failed = checks.Where(static check => !check.Success).ToArray();
         if (failed.Length > 0)
             warnings.Add($"{failed.Length} inspect check(s) reported drift or failure.");
@@ -177,7 +181,7 @@ internal static partial class WebCliCommandHandlers
     }
 
     private static ProcessResult ExecuteRemote(string sshCommand, string target, string command)
-        => RunProcessCaptureText(sshCommand, new[] { target, $"sh -lc {ShellQuote(command)}" });
+        => RunProcessCaptureText(sshCommand, BuildSshArguments(target, command));
 
     private static void InspectSystemdUnits(
         string sshCommand,
@@ -249,7 +253,7 @@ internal static partial class WebCliCommandHandlers
 
     private static bool HasLine(string text, string expected)
         => text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-            .Any(line => line.Trim().Equals(expected, StringComparison.OrdinalIgnoreCase));
+            .Any(line => line.Contains(expected, StringComparison.OrdinalIgnoreCase));
 
     private static string? FirstMatchingLine(string text, string prefix)
         => text.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.RestoreSecretsPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.RestoreSecretsPlan.cs
@@ -22,7 +22,7 @@ internal static partial class WebCliCommandHandlers
         Directory.CreateDirectory(outputRoot);
 
         var warnings = new List<string>();
-        if (!manifest.BackupTarget?.Encryption?.Equals("age", StringComparison.OrdinalIgnoreCase) == true)
+        if (!string.Equals(manifest.BackupTarget?.Encryption, "age", StringComparison.OrdinalIgnoreCase))
             warnings.Add("Restore script currently assumes age encryption.");
         if (manifest.Secrets?.Length is null or 0)
             warnings.Add("Manifest does not define any secrets.");
@@ -113,7 +113,7 @@ internal static partial class WebCliCommandHandlers
         builder.AppendLine($"Archive: `{archivePath}`");
         builder.AppendLine($"Encryption: `{manifest.BackupTarget?.Encryption ?? "unknown"}`");
         builder.AppendLine();
-        builder.AppendLine("The generated script decrypts into a temporary directory, lists archive contents, and refuses to restore unless `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES` is set.");
+        builder.AppendLine("The generated script decrypts into a temporary directory, lists archive contents, rejects unsafe archive paths, and refuses to restore unless `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES` is set.");
         builder.AppendLine();
         builder.AppendLine("## Secrets");
         builder.AppendLine();
@@ -153,6 +153,11 @@ internal static partial class WebCliCommandHandlers
         builder.AppendLine("age -d -o \"$tmp_dir/secrets.tar.gz\" \"$archive\"");
         builder.AppendLine("echo 'Encrypted secret archive contents:'");
         builder.AppendLine("tar -tzf \"$tmp_dir/secrets.tar.gz\"");
+        builder.AppendLine();
+        builder.AppendLine("if tar -tzf \"$tmp_dir/secrets.tar.gz\" | grep -E '(^/|(^|/)\\.\\.(/|$))' >/dev/null; then");
+        builder.AppendLine("  echo 'Unsafe secret archive path detected; refusing to extract.' >&2");
+        builder.AppendLine("  exit 4");
+        builder.AppendLine("fi");
         builder.AppendLine();
         builder.AppendLine("if [ \"${POWERFORGE_RESTORE_SECRETS_CONFIRM:-}\" != \"YES\" ]; then");
         builder.AppendLine("  echo 'Set POWERFORGE_RESTORE_SECRETS_CONFIRM=YES to extract secrets to /.' >&2");

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.RestoreSecretsPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.RestoreSecretsPlan.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using System.Text.Json;
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static int HandleServerRestoreSecretsPlan(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var loaded = LoadServerRecoveryManifest(subArgs, outputJson, logger, "web.server.restore-secrets-plan");
+        if (loaded.Manifest is null)
+            return loaded.ExitCode;
+
+        var manifest = loaded.Manifest;
+        var manifestPath = loaded.ManifestPath!;
+        var outPathArg = TryGetOptionValue(subArgs, "--out") ??
+                         TryGetOptionValue(subArgs, "--output") ??
+                         TryGetOptionValue(subArgs, "--output-dir");
+        var archivePath = TryGetOptionValue(subArgs, "--archive") ?? "encrypted-secrets.tar.gz.age";
+        var outputRoot = ResolveRestoreSecretsPlanOutputPath(outPathArg, manifest);
+        Directory.CreateDirectory(outputRoot);
+
+        var warnings = new List<string>();
+        if (!manifest.BackupTarget?.Encryption?.Equals("age", StringComparison.OrdinalIgnoreCase) == true)
+            warnings.Add("Restore script currently assumes age encryption.");
+        if (manifest.Secrets?.Length is null or 0)
+            warnings.Add("Manifest does not define any secrets.");
+        if (string.IsNullOrWhiteSpace(manifest.BackupTarget?.RecipientEnv) &&
+            string.IsNullOrWhiteSpace(manifest.BackupTarget?.Recipient))
+            warnings.Add("backupTarget.recipient and backupTarget.recipientEnv are not configured.");
+
+        var secrets = (manifest.Secrets ?? Array.Empty<PowerForgeServerSecret>())
+            .Select(static secret => new PowerForgeServerRestoreSecretEntry
+            {
+                Id = secret.Id,
+                Path = secret.Path,
+                Env = secret.Env,
+                RestoreMode = secret.RestoreMode,
+                RequiredFor = secret.RequiredFor is { Length: > 0 } ? string.Join(", ", secret.RequiredFor) : null
+            })
+            .ToArray();
+
+        var markdownPath = Path.Combine(outputRoot, "restore-secrets-plan.md");
+        var scriptPath = Path.Combine(outputRoot, "restore-secrets.sh");
+        WriteRestoreSecretsMarkdown(markdownPath, manifest, archivePath, secrets, warnings);
+        WriteRestoreSecretsScript(scriptPath, archivePath, secrets);
+
+        var result = new PowerForgeServerRestoreSecretsPlanResult
+        {
+            ManifestPath = manifestPath,
+            OutputPath = outputRoot,
+            MarkdownPath = markdownPath,
+            ScriptPath = scriptPath,
+            ArchivePath = archivePath,
+            Encryption = manifest.BackupTarget?.Encryption,
+            RecipientEnv = manifest.BackupTarget?.RecipientEnv,
+            Secrets = secrets,
+            Warnings = warnings.ToArray()
+        };
+
+        File.WriteAllText(
+            Path.Combine(outputRoot, "restore-secrets-plan.json"),
+            JsonSerializer.Serialize(result, WebCliJson.Context.PowerForgeServerRestoreSecretsPlanResult));
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.server.restore-secrets-plan",
+                Success = true,
+                ExitCode = 0,
+                Config = "web.serverrecovery",
+                ConfigPath = manifestPath,
+                Result = WebCliJson.SerializeToElement(result, WebCliJson.Context.PowerForgeServerRestoreSecretsPlanResult),
+                Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
+            });
+            return 0;
+        }
+
+        logger.Success("Server secret restore plan generated.");
+        logger.Info($"Output: {outputRoot}");
+        logger.Info($"Markdown: {markdownPath}");
+        logger.Info($"Script draft: {scriptPath}");
+        logger.Info($"Secrets: {secrets.Length}");
+        foreach (var warning in warnings)
+            logger.Warn(warning);
+
+        return 0;
+    }
+
+    private static string ResolveRestoreSecretsPlanOutputPath(string? outPathArg, PowerForgeServerRecoveryManifest manifest)
+    {
+        if (!string.IsNullOrWhiteSpace(outPathArg))
+            return Path.GetFullPath(outPathArg);
+
+        var name = SanitizeFileName(string.IsNullOrWhiteSpace(manifest.Name) ? "server" : manifest.Name);
+        return Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "_server-state", name, "restore-secrets-plan"));
+    }
+
+    private static void WriteRestoreSecretsMarkdown(
+        string path,
+        PowerForgeServerRecoveryManifest manifest,
+        string archivePath,
+        IReadOnlyList<PowerForgeServerRestoreSecretEntry> secrets,
+        IReadOnlyList<string> warnings)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# PowerForge Secret Restore Plan");
+        builder.AppendLine();
+        builder.AppendLine($"Manifest: `{manifest.Name}`");
+        builder.AppendLine($"Archive: `{archivePath}`");
+        builder.AppendLine($"Encryption: `{manifest.BackupTarget?.Encryption ?? "unknown"}`");
+        builder.AppendLine();
+        builder.AppendLine("The generated script decrypts into a temporary directory, lists archive contents, and refuses to restore unless `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES` is set.");
+        builder.AppendLine();
+        builder.AppendLine("## Secrets");
+        builder.AppendLine();
+        foreach (var secret in secrets)
+            builder.AppendLine($"- `{secret.Id}` -> `{secret.Path ?? secret.Env ?? "manual"}` ({secret.RestoreMode ?? "file"})");
+
+        if (warnings.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("## Warnings");
+            builder.AppendLine();
+            foreach (var warning in warnings)
+                builder.AppendLine($"- {warning}");
+        }
+
+        File.WriteAllText(path, builder.ToString());
+    }
+
+    private static void WriteRestoreSecretsScript(
+        string path,
+        string archivePath,
+        IReadOnlyList<PowerForgeServerRestoreSecretEntry> secrets)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("#!/usr/bin/env bash");
+        builder.AppendLine("set -Eeuo pipefail");
+        builder.AppendLine();
+        builder.AppendLine("# Generated by powerforge-web server restore-secrets-plan.");
+        builder.AppendLine("# Run on the target host after copying the encrypted archive there.");
+        builder.AppendLine();
+        builder.AppendLine($"archive=\"${{1:-{archivePath}}}\"");
+        builder.AppendLine("tmp_dir=\"$(mktemp -d)\"");
+        builder.AppendLine("trap 'rm -rf \"$tmp_dir\"' EXIT");
+        builder.AppendLine();
+        builder.AppendLine("command -v age >/dev/null || { echo 'age is required to decrypt secrets' >&2; exit 2; }");
+        builder.AppendLine("test -f \"$archive\" || { echo \"encrypted archive not found: $archive\" >&2; exit 2; }");
+        builder.AppendLine("age -d -o \"$tmp_dir/secrets.tar.gz\" \"$archive\"");
+        builder.AppendLine("echo 'Encrypted secret archive contents:'");
+        builder.AppendLine("tar -tzf \"$tmp_dir/secrets.tar.gz\"");
+        builder.AppendLine();
+        builder.AppendLine("if [ \"${POWERFORGE_RESTORE_SECRETS_CONFIRM:-}\" != \"YES\" ]; then");
+        builder.AppendLine("  echo 'Set POWERFORGE_RESTORE_SECRETS_CONFIRM=YES to extract secrets to /.' >&2");
+        builder.AppendLine("  exit 3");
+        builder.AppendLine("fi");
+        builder.AppendLine();
+        builder.AppendLine("tar -xzf \"$tmp_dir/secrets.tar.gz\" -C /");
+        foreach (var secret in secrets.Where(static secret => !string.IsNullOrWhiteSpace(secret.Path)))
+        {
+            if (secret.RestoreMode?.Equals("directory", StringComparison.OrdinalIgnoreCase) == true)
+                continue;
+            var mode = secret.Path!.Contains("letsencrypt/credentials", StringComparison.OrdinalIgnoreCase) ||
+                       secret.Path.Contains(".env", StringComparison.OrdinalIgnoreCase)
+                ? "600"
+                : "640";
+            builder.AppendLine($"if [ -e {ShellQuote(secret.Path)} ]; then chmod {mode} {ShellQuote(secret.Path)}; fi");
+        }
+        builder.AppendLine("echo 'Secrets restored. Run server verify next.'");
+
+        File.WriteAllText(path, builder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal));
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Verify.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Verify.cs
@@ -121,9 +121,13 @@ internal static partial class WebCliCommandHandlers
             var status = (int)response.StatusCode;
             var expected = verifyUrl.ExpectedStatus ?? 200;
             var serverHeader = response.Headers.Server.ToString();
+            var cloudflareRay = response.Headers.TryGetValues("CF-Ray", out var cloudflareRayValues)
+                ? cloudflareRayValues.FirstOrDefault()
+                : null;
             var success = status == expected;
             if (verifyUrl.Via?.Equals("cloudflare", StringComparison.OrdinalIgnoreCase) == true)
-                success = success && serverHeader.Contains("cloudflare", StringComparison.OrdinalIgnoreCase);
+                success = success && (!string.IsNullOrWhiteSpace(cloudflareRay) ||
+                                      serverHeader.Contains("cloudflare", StringComparison.OrdinalIgnoreCase));
 
             return new PowerForgeServerVerifyUrlResult
             {
@@ -133,6 +137,7 @@ internal static partial class WebCliCommandHandlers
                 Via = verifyUrl.Via,
                 Success = success,
                 ServerHeader = serverHeader,
+                CloudflareRay = cloudflareRay,
                 Error = success ? null : "Unexpected status or missing expected proxy header."
             };
         }

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Verify.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Verify.cs
@@ -1,0 +1,160 @@
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static int HandleServerVerify(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var loaded = LoadServerRecoveryManifest(subArgs, outputJson, logger, "web.server.verify");
+        if (loaded.Manifest is null)
+            return loaded.ExitCode;
+
+        var manifest = loaded.Manifest;
+        var manifestPath = loaded.ManifestPath!;
+        var sshCommand = TryGetOptionValue(subArgs, "--ssh") ?? "ssh";
+        var failOnFailure = HasOption(subArgs, "--fail-on-failure");
+        var urlTimeoutSeconds = ParseIntOption(TryGetOptionValue(subArgs, "--url-timeout-seconds"), 30);
+        var target = BuildServerSshTarget(manifest.Target);
+        var commandResults = new List<PowerForgeServerVerifyCommandResult>();
+        var urlResults = new List<PowerForgeServerVerifyUrlResult>();
+        var warnings = new List<string>();
+
+        foreach (var command in manifest.Verify?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>())
+        {
+            if (command.Sensitive)
+            {
+                warnings.Add($"Skipping sensitive verify command '{command.Id}'.");
+                continue;
+            }
+
+            var result = ExecuteRemote(sshCommand, target, command.Command ?? string.Empty);
+            commandResults.Add(new PowerForgeServerVerifyCommandResult
+            {
+                Id = command.Id,
+                Command = command.Command,
+                Required = command.Required,
+                ExitCode = result.ExitCode,
+                Success = result.Success,
+                OutputPreview = Preview(result.Stdout),
+                ErrorPreview = Preview(result.Stderr)
+            });
+        }
+
+        foreach (var url in manifest.Verify?.Urls ?? Array.Empty<PowerForgeServerVerifyUrl>())
+            urlResults.Add(VerifyUrl(url, urlTimeoutSeconds));
+
+        var failedCommands = commandResults
+            .Where(static result => result.Required && !result.Success)
+            .ToArray();
+        var failedUrls = urlResults
+            .Where(static result => !result.Success)
+            .ToArray();
+
+        if (failedCommands.Length > 0)
+            warnings.Add($"{failedCommands.Length} required verify command(s) failed.");
+        if (failedUrls.Length > 0)
+            warnings.Add($"{failedUrls.Length} URL check(s) failed.");
+
+        var success = failedCommands.Length == 0 && failedUrls.Length == 0;
+        var resultSummary = new PowerForgeServerVerifyResult
+        {
+            ManifestPath = manifestPath,
+            Target = target,
+            Success = success,
+            Commands = commandResults.ToArray(),
+            Urls = urlResults.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.server.verify",
+                Success = success || !failOnFailure,
+                ExitCode = success || !failOnFailure ? 0 : 1,
+                Config = "web.serverrecovery",
+                ConfigPath = manifestPath,
+                Result = WebCliJson.SerializeToElement(resultSummary, WebCliJson.Context.PowerForgeServerVerifyResult),
+                Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
+            });
+            return success || !failOnFailure ? 0 : 1;
+        }
+
+        logger.Success(success ? "Server verify completed successfully." : "Server verify completed with failures.");
+        logger.Info($"Target: {target}");
+        logger.Info($"Commands: {commandResults.Count}; URLs: {urlResults.Count}");
+        foreach (var failure in failedCommands)
+            logger.Warn($"command {failure.Id}: exit={failure.ExitCode}; error={failure.ErrorPreview}");
+        foreach (var failure in failedUrls)
+            logger.Warn($"url {failure.Url}: expected={failure.ExpectedStatus}; actual={failure.ActualStatus}; error={failure.Error}");
+
+        return success || !failOnFailure ? 0 : 1;
+    }
+
+    private static PowerForgeServerVerifyUrlResult VerifyUrl(PowerForgeServerVerifyUrl verifyUrl, int timeoutSeconds)
+    {
+        if (string.IsNullOrWhiteSpace(verifyUrl.Url))
+        {
+            return new PowerForgeServerVerifyUrlResult
+            {
+                Url = verifyUrl.Url,
+                ExpectedStatus = verifyUrl.ExpectedStatus,
+                Via = verifyUrl.Via,
+                Success = false,
+                Error = "URL is missing."
+            };
+        }
+
+        try
+        {
+            using var httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(Math.Max(1, timeoutSeconds))
+            };
+            using var request = new HttpRequestMessage(HttpMethod.Get, verifyUrl.Url);
+            request.Headers.UserAgent.ParseAdd("PowerForge-Web-ServerRecovery/1.0");
+            using var response = httpClient.Send(request);
+
+            var status = (int)response.StatusCode;
+            var expected = verifyUrl.ExpectedStatus ?? 200;
+            var serverHeader = response.Headers.Server.ToString();
+            var success = status == expected;
+            if (verifyUrl.Via?.Equals("cloudflare", StringComparison.OrdinalIgnoreCase) == true)
+                success = success && serverHeader.Contains("cloudflare", StringComparison.OrdinalIgnoreCase);
+
+            return new PowerForgeServerVerifyUrlResult
+            {
+                Url = verifyUrl.Url,
+                ExpectedStatus = expected,
+                ActualStatus = status,
+                Via = verifyUrl.Via,
+                Success = success,
+                ServerHeader = serverHeader,
+                Error = success ? null : "Unexpected status or missing expected proxy header."
+            };
+        }
+        catch (Exception ex)
+        {
+            return new PowerForgeServerVerifyUrlResult
+            {
+                Url = verifyUrl.Url,
+                ExpectedStatus = verifyUrl.ExpectedStatus,
+                Via = verifyUrl.Via,
+                Success = false,
+                Error = ex.Message
+            };
+        }
+    }
+
+    private static string? Preview(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var normalized = text.Trim();
+        return normalized.Length <= 500 ? normalized : normalized[..500];
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -7,10 +7,12 @@ namespace PowerForge.Web.Cli;
 
 internal static partial class WebCliCommandHandlers
 {
+    private const string SupportedServerActions = "inspect, plan, capture, deploy, verify, bootstrap-plan, restore-secrets-plan";
+
     internal static int HandleServer(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
     {
         if (subArgs.Length == 0)
-            return Fail("Missing server action. Supported action: plan.", outputJson, logger, "web.server");
+            return Fail($"Missing server action. Supported actions: {SupportedServerActions}.", outputJson, logger, "web.server");
 
         var action = subArgs[0].ToLowerInvariant();
         var actionArgs = subArgs.Skip(1).ToArray();
@@ -25,7 +27,7 @@ internal static partial class WebCliCommandHandlers
             "deploy" => HandleServerDeploy(actionArgs, outputJson, logger, outputSchemaVersion),
             "bootstrap-plan" => HandleServerBootstrapPlan(actionArgs, outputJson, logger, outputSchemaVersion),
             "restore-secrets-plan" => HandleServerRestoreSecretsPlan(actionArgs, outputJson, logger, outputSchemaVersion),
-            _ => Fail($"Unknown server action '{subArgs[0]}'. Supported actions: inspect, plan, capture, deploy, verify, bootstrap-plan, restore-secrets-plan.", outputJson, logger, "web.server")
+            _ => Fail($"Unknown server action '{subArgs[0]}'. Supported actions: {SupportedServerActions}.", outputJson, logger, "web.server")
         };
     }
 
@@ -282,13 +284,20 @@ internal static partial class WebCliCommandHandlers
         if (string.IsNullOrWhiteSpace(manifestPath))
             return (null, null, Fail("Missing required --manifest.", outputJson, logger, commandName));
 
-        var fullManifestPath = ResolveExistingFilePath(manifestPath);
-        var manifest = JsonSerializer.Deserialize<PowerForgeServerRecoveryManifest>(
-            File.ReadAllText(fullManifestPath), WebCliJson.Options);
-        if (manifest is null)
-            return (null, null, Fail("Invalid server recovery manifest.", outputJson, logger, commandName));
+        try
+        {
+            var fullManifestPath = ResolveExistingFilePath(manifestPath);
+            var manifest = JsonSerializer.Deserialize<PowerForgeServerRecoveryManifest>(
+                File.ReadAllText(fullManifestPath), WebCliJson.Options);
+            if (manifest is null)
+                return (null, null, Fail("Invalid server recovery manifest.", outputJson, logger, commandName));
 
-        return (manifest, fullManifestPath, 0);
+            return (manifest, fullManifestPath, 0);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException)
+        {
+            return (null, null, Fail($"Failed to load server recovery manifest: {ex.Message}", outputJson, logger, commandName));
+        }
     }
 
     private static string? ResolveBackupRecipient(PowerForgeServerRecoveryManifest manifest)
@@ -328,7 +337,7 @@ internal static partial class WebCliCommandHandlers
         var id = SanitizeFileName(string.IsNullOrWhiteSpace(command.Id) ? "command" : command.Id);
         var stdoutPath = Path.Combine(commandOutputDirectory, $"{id}.out.txt");
         var stderrPath = Path.Combine(commandOutputDirectory, $"{id}.err.txt");
-        var execution = RunProcessCaptureText(sshCommand, new[] { target, command.Command ?? string.Empty });
+        var execution = RunProcessCaptureText(sshCommand, BuildSshArguments(target, command.Command ?? string.Empty));
 
         File.WriteAllText(stdoutPath, execution.Stdout);
         File.WriteAllText(stderrPath, execution.Stderr);
@@ -351,7 +360,7 @@ internal static partial class WebCliCommandHandlers
         string outputPath)
     {
         var script = BuildRemoteTarScript(files);
-        return RunProcessCaptureBinary(sshCommand, new[] { target, $"sh -lc {ShellQuote(script)}" }, outputPath);
+        return RunProcessCaptureBinary(sshCommand, BuildSshArguments(target, script), outputPath);
     }
 
     private static ProcessResult CaptureEncryptedRemoteTarArchive(
@@ -363,7 +372,7 @@ internal static partial class WebCliCommandHandlers
         string recipient)
     {
         var script = BuildRemoteTarScript(files);
-        using var ssh = CreateProcess(sshCommand, new[] { target, $"sh -lc {ShellQuote(script)}" });
+        using var ssh = CreateProcess(sshCommand, BuildSshArguments(target, script));
         using var age = CreateProcess(ageCommand, new[] { "-r", recipient, "-o", outputPath });
         ssh.StartInfo.RedirectStandardOutput = true;
         ssh.StartInfo.RedirectStandardError = true;
@@ -406,7 +415,7 @@ internal static partial class WebCliCommandHandlers
         string recipient)
     {
         var script = BuildRemoteEncryptedTarScript(files, recipient);
-        return RunProcessCaptureBinary(sshCommand, new[] { target, $"sh -lc {ShellQuote(script)}" }, outputPath);
+        return RunProcessCaptureBinary(sshCommand, BuildSshArguments(target, script), outputPath);
     }
 
     private static string BuildRemoteTarScript(PowerForgeServerManagedFile[] files)
@@ -437,16 +446,24 @@ internal static partial class WebCliCommandHandlers
     private static string ShellQuote(string value)
         => "'" + value.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";
 
+    private static string[] BuildSshArguments(string target, string command)
+        => new[] { "-o", "ConnectTimeout=30", target, $"sh -lc {ShellQuote(command)}" };
+
     private static ProcessResult RunProcessCaptureText(string fileName, IReadOnlyList<string> args)
     {
         using var process = CreateProcess(fileName, args);
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
         process.Start();
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
         process.WaitForExit();
-        return new ProcessResult { ExitCode = process.ExitCode, Stdout = stdout, Stderr = stderr };
+        return new ProcessResult
+        {
+            ExitCode = process.ExitCode,
+            Stdout = stdoutTask.GetAwaiter().GetResult(),
+            Stderr = stderrTask.GetAwaiter().GetResult()
+        };
     }
 
     private static ProcessResult RunProcessCaptureBinary(string fileName, IReadOnlyList<string> args, string stdoutPath)
@@ -455,11 +472,12 @@ internal static partial class WebCliCommandHandlers
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
         process.Start();
-        using (var output = File.Create(stdoutPath))
-            process.StandardOutput.BaseStream.CopyTo(output);
-        var stderr = process.StandardError.ReadToEnd();
+        using var output = File.Create(stdoutPath);
+        var copyTask = process.StandardOutput.BaseStream.CopyToAsync(output);
+        var stderrTask = process.StandardError.ReadToEndAsync();
         process.WaitForExit();
-        return new ProcessResult { ExitCode = process.ExitCode, Stdout = string.Empty, Stderr = stderr };
+        copyTask.GetAwaiter().GetResult();
+        return new ProcessResult { ExitCode = process.ExitCode, Stdout = string.Empty, Stderr = stderrTask.GetAwaiter().GetResult() };
     }
 
     private static Process CreateProcess(string fileName, IReadOnlyList<string> args)
@@ -497,9 +515,14 @@ internal static partial class WebCliCommandHandlers
         builder.AppendLine("1. Bootstrap Ubuntu and install prerequisite packages.");
         builder.AppendLine("2. Restore plain configuration files from the plain archive.");
         builder.AppendLine("3. Restore encrypted secrets only after decrypting them on a trusted machine.");
-        builder.AppendLine("4. Clone or update the Website and PSPublishModule repositories.");
+        builder.AppendLine("4. Clone or update the manifest repositories.");
         builder.AppendLine("5. Run the deployment command from the manifest.");
         builder.AppendLine("6. Run the verification commands and public URL checks from the manifest.");
+        builder.AppendLine();
+        builder.AppendLine("## Required Repositories");
+        builder.AppendLine();
+        foreach (var repository in manifest.Repositories ?? Array.Empty<PowerForgeServerRepository>())
+            builder.AppendLine($"- `{repository.Role ?? "repository"}`: `{repository.Path ?? repository.Url ?? "manual"}`");
         builder.AppendLine();
         builder.AppendLine("## Required Secrets");
         builder.AppendLine();
@@ -523,7 +546,7 @@ internal static partial class WebCliCommandHandlers
         var invalid = Path.GetInvalidFileNameChars();
         var builder = new StringBuilder(value.Length);
         foreach (var c in value)
-            builder.Append(invalid.Contains(c) ? '-' : c);
+            builder.Append(invalid.Contains(c) || c is '/' or '\\' ? '-' : c);
         return builder.ToString();
     }
 

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -144,6 +144,7 @@ internal static partial class WebCliCommandHandlers
         var failOnFailure = HasOption(subArgs, "--fail-on-failure");
         var sshCommand = TryGetOptionValue(subArgs, "--ssh") ?? "ssh";
         var ageCommand = TryGetOptionValue(subArgs, "--age") ?? "age";
+        var target = BuildServerSshTarget(manifest.Target);
 
         var outputRoot = ResolveCaptureOutputPath(outPathArg, manifest);
         Directory.CreateDirectory(outputRoot);
@@ -157,7 +158,6 @@ internal static partial class WebCliCommandHandlers
         var commandList = manifest.Capture?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>();
         var plainFiles = manifest.Capture?.PlainFiles ?? Array.Empty<PowerForgeServerManagedFile>();
         var encryptedFiles = manifest.Capture?.EncryptedFiles ?? Array.Empty<PowerForgeServerManagedFile>();
-        var target = BuildServerSshTarget(manifest.Target);
         var plainArchivePath = dryRun || skipFiles || plainFiles.Length == 0
             ? null
             : Path.Combine(outputRoot, "plain-files.tar.gz");

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -1,0 +1,546 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    internal static int HandleServer(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        if (subArgs.Length == 0)
+            return Fail("Missing server action. Supported action: plan.", outputJson, logger, "web.server");
+
+        var action = subArgs[0].ToLowerInvariant();
+        var actionArgs = subArgs.Skip(1).ToArray();
+
+        return action switch
+        {
+            "inspect" => HandleServerInspect(actionArgs, outputJson, logger, outputSchemaVersion),
+            "plan" => HandleServerPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+            "validate" => HandleServerPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+            "capture" => HandleServerCapture(actionArgs, outputJson, logger, outputSchemaVersion),
+            "verify" => HandleServerVerify(actionArgs, outputJson, logger, outputSchemaVersion),
+            "deploy" => HandleServerDeploy(actionArgs, outputJson, logger, outputSchemaVersion),
+            "bootstrap-plan" => HandleServerBootstrapPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+            "restore-secrets-plan" => HandleServerRestoreSecretsPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+            _ => Fail($"Unknown server action '{subArgs[0]}'. Supported actions: inspect, plan, capture, deploy, verify, bootstrap-plan, restore-secrets-plan.", outputJson, logger, "web.server")
+        };
+    }
+
+    private static int HandleServerPlan(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var loaded = LoadServerRecoveryManifest(subArgs, outputJson, logger, "web.server.plan");
+        if (loaded.Manifest is null)
+            return loaded.ExitCode;
+
+        var fullManifestPath = loaded.ManifestPath!;
+        var manifest = loaded.Manifest;
+
+        var warnings = new List<string>();
+        if (manifest.SchemaVersion <= 0)
+            warnings.Add("schemaVersion should be greater than zero.");
+        if (string.IsNullOrWhiteSpace(manifest.Name))
+            warnings.Add("name is missing.");
+        if (manifest.Target is null)
+            warnings.Add("target is missing.");
+        if (manifest.Repositories is null || manifest.Repositories.Length == 0)
+            warnings.Add("No repositories are defined.");
+        if (manifest.Secrets?.Any(secret => secret.Capture.Equals("encrypted", StringComparison.OrdinalIgnoreCase)) == true &&
+            string.IsNullOrWhiteSpace(manifest.BackupTarget?.RecipientEnv) &&
+            string.IsNullOrWhiteSpace(manifest.BackupTarget?.Recipient))
+        {
+            warnings.Add("Encrypted secret capture is configured but backupTarget.recipient and backupTarget.recipientEnv are missing.");
+        }
+        else if (string.IsNullOrWhiteSpace(manifest.BackupTarget?.Recipient) &&
+                 !string.IsNullOrWhiteSpace(manifest.BackupTarget?.RecipientEnv) &&
+                 string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(manifest.BackupTarget.RecipientEnv)))
+        {
+            warnings.Add($"Encryption recipient environment variable '{manifest.BackupTarget.RecipientEnv}' is not set.");
+        }
+
+        var stages = BuildServerRecoveryStages(manifest);
+        var result = new PowerForgeServerRecoveryPlanResult
+        {
+            ManifestPath = fullManifestPath,
+            Name = manifest.Name,
+            TargetHost = manifest.Target?.Host,
+            SshAlias = manifest.Target?.SshAlias,
+            SshPort = manifest.Target?.SshPort,
+            RepositoryCount = manifest.Repositories?.Length ?? 0,
+            PackageCount = manifest.Packages?.Apt?.Length ?? 0,
+            ApacheModuleCount = manifest.Packages?.ApacheModules?.Length ?? manifest.Apache?.Modules?.Length ?? 0,
+            SystemdServiceCount = manifest.Systemd?.Services?.Length ?? 0,
+            SystemdTimerCount = manifest.Systemd?.Timers?.Length ?? 0,
+            CertificateCount = manifest.Certificates?.Length ?? 0,
+            PlainCaptureCount = manifest.Capture?.PlainFiles?.Length ?? 0,
+            EncryptedCaptureCount = manifest.Capture?.EncryptedFiles?.Length ?? 0,
+            SecretCount = manifest.Secrets?.Length ?? 0,
+            BackupTarget = manifest.BackupTarget?.Repository,
+            BackupEncryption = manifest.BackupTarget?.Encryption,
+            Stages = stages,
+            Warnings = warnings.ToArray()
+        };
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.server.plan",
+                Success = true,
+                ExitCode = 0,
+                Config = "web.serverrecovery",
+                ConfigPath = fullManifestPath,
+                Spec = WebCliJson.SerializeToElement(manifest, WebCliJson.Context.PowerForgeServerRecoveryManifest),
+                Result = WebCliJson.SerializeToElement(result, WebCliJson.Context.PowerForgeServerRecoveryPlanResult),
+                Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
+            });
+            return 0;
+        }
+
+        logger.Success("Server recovery manifest loaded.");
+        logger.Info($"Manifest: {fullManifestPath}");
+        logger.Info($"Target: {manifest.Target?.SshAlias ?? manifest.Target?.Host ?? "(unknown)"} port {manifest.Target?.SshPort?.ToString() ?? "(default)"}");
+        logger.Info($"Repositories: {result.RepositoryCount}; packages: {result.PackageCount}; services: {result.SystemdServiceCount}; timers: {result.SystemdTimerCount}");
+        logger.Info($"Certificates: {result.CertificateCount}; plain captures: {result.PlainCaptureCount}; encrypted captures: {result.EncryptedCaptureCount}; secrets: {result.SecretCount}");
+        if (!string.IsNullOrWhiteSpace(result.BackupTarget))
+            logger.Info($"Backup target: {result.BackupTarget} ({result.BackupEncryption ?? "no encryption configured"})");
+
+        logger.Info("Recovery stages:");
+        foreach (var stage in stages)
+            logger.Info($"- {stage}");
+
+        foreach (var warning in warnings)
+            logger.Warn(warning);
+
+        return 0;
+    }
+
+    private static int HandleServerCapture(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var loaded = LoadServerRecoveryManifest(subArgs, outputJson, logger, "web.server.capture");
+        if (loaded.Manifest is null)
+            return loaded.ExitCode;
+
+        var manifest = loaded.Manifest;
+        var manifestPath = loaded.ManifestPath!;
+        var outPathArg = TryGetOptionValue(subArgs, "--out") ??
+                         TryGetOptionValue(subArgs, "--output") ??
+                         TryGetOptionValue(subArgs, "--output-dir");
+        var dryRun = HasOption(subArgs, "--dry-run");
+        var skipFiles = HasOption(subArgs, "--skip-files");
+        var skipEncrypted = HasOption(subArgs, "--skip-encrypted");
+        var encryptRemote = HasOption(subArgs, "--encrypt-remote") || HasOption(subArgs, "--remote-encryption");
+        var sshCommand = TryGetOptionValue(subArgs, "--ssh") ?? "ssh";
+        var ageCommand = TryGetOptionValue(subArgs, "--age") ?? "age";
+
+        var outputRoot = ResolveCaptureOutputPath(outPathArg, manifest);
+        Directory.CreateDirectory(outputRoot);
+        Directory.CreateDirectory(Path.Combine(outputRoot, "commands"));
+
+        var warnings = new List<string>();
+        var commandResults = new List<PowerForgeServerCaptureCommandResult>();
+        var copiedManifestPath = Path.Combine(outputRoot, "manifest.json");
+        File.Copy(manifestPath, copiedManifestPath, overwrite: true);
+
+        var commandList = manifest.Capture?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>();
+        var plainFiles = manifest.Capture?.PlainFiles ?? Array.Empty<PowerForgeServerManagedFile>();
+        var encryptedFiles = manifest.Capture?.EncryptedFiles ?? Array.Empty<PowerForgeServerManagedFile>();
+        var target = BuildServerSshTarget(manifest.Target);
+        var plainArchivePath = dryRun || skipFiles || plainFiles.Length == 0
+            ? null
+            : Path.Combine(outputRoot, "plain-files.tar.gz");
+        string? encryptedArchivePath = null;
+
+        if (dryRun)
+        {
+            warnings.Add("Dry run requested; no SSH commands were executed.");
+        }
+        else
+        {
+            foreach (var command in commandList.Where(static command => !command.Sensitive))
+            {
+                var result = CaptureRemoteCommand(
+                    sshCommand,
+                    target,
+                    command,
+                    Path.Combine(outputRoot, "commands"));
+                commandResults.Add(result);
+                if (!result.Success && command.Required)
+                    warnings.Add($"Required capture command '{result.Id}' failed with exit code {result.ExitCode}.");
+            }
+
+            if (!skipFiles && plainFiles.Length > 0 && plainArchivePath is not null)
+            {
+                var archiveResult = CaptureRemoteTarArchive(sshCommand, target, plainFiles, plainArchivePath);
+                if (!archiveResult.Success)
+                {
+                    warnings.Add($"Plain file archive failed with exit code {archiveResult.ExitCode}.");
+                    if (!string.IsNullOrWhiteSpace(archiveResult.Stderr))
+                        File.WriteAllText(Path.Combine(outputRoot, "plain-files.stderr.txt"), archiveResult.Stderr);
+                }
+            }
+
+            if (!skipEncrypted && encryptedFiles.Length > 0)
+            {
+                var recipientEnv = manifest.BackupTarget?.RecipientEnv;
+                var recipient = ResolveBackupRecipient(manifest);
+
+                if (string.IsNullOrWhiteSpace(recipientEnv) && string.IsNullOrWhiteSpace(manifest.BackupTarget?.Recipient))
+                {
+                    warnings.Add("Encrypted capture skipped: backupTarget.recipient and backupTarget.recipientEnv are not configured.");
+                }
+                else if (string.IsNullOrWhiteSpace(recipient))
+                {
+                    warnings.Add($"Encrypted capture skipped: environment variable '{recipientEnv}' is not set.");
+                }
+                else
+                {
+                    encryptedArchivePath = Path.Combine(outputRoot, "encrypted-secrets.tar.gz.age");
+                    var encryptedResult = encryptRemote
+                        ? CaptureRemoteEncryptedTarArchive(
+                            sshCommand,
+                            target,
+                            encryptedFiles,
+                            encryptedArchivePath,
+                            recipient)
+                        : CaptureEncryptedRemoteTarArchive(
+                            sshCommand,
+                            ageCommand,
+                            target,
+                            encryptedFiles,
+                            encryptedArchivePath,
+                            recipient);
+                    if (!encryptedResult.Success)
+                    {
+                        warnings.Add($"Encrypted capture failed with exit code {encryptedResult.ExitCode}.");
+                        if (!string.IsNullOrWhiteSpace(encryptedResult.Stderr))
+                            File.WriteAllText(Path.Combine(outputRoot, "encrypted-secrets.stderr.txt"), encryptedResult.Stderr);
+                    }
+                }
+            }
+        }
+
+        var checklistPath = Path.Combine(outputRoot, "restore-checklist.md");
+        WriteRestoreChecklist(checklistPath, manifest, plainArchivePath, encryptedArchivePath, warnings);
+
+        var resultSummary = new PowerForgeServerCaptureResult
+        {
+            ManifestPath = manifestPath,
+            OutputPath = outputRoot,
+            PlainArchivePath = plainArchivePath,
+            EncryptedArchivePath = encryptedArchivePath,
+            RestoreChecklistPath = checklistPath,
+            CommandResults = commandResults.ToArray(),
+            Warnings = warnings.ToArray()
+        };
+
+        File.WriteAllText(
+            Path.Combine(outputRoot, "capture-summary.json"),
+            JsonSerializer.Serialize(resultSummary, WebCliJson.Context.PowerForgeServerCaptureResult));
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.server.capture",
+                Success = true,
+                ExitCode = 0,
+                Config = "web.serverrecovery",
+                ConfigPath = manifestPath,
+                Result = WebCliJson.SerializeToElement(resultSummary, WebCliJson.Context.PowerForgeServerCaptureResult),
+                Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
+            });
+            return 0;
+        }
+
+        logger.Success(dryRun ? "Server capture dry run completed." : "Server capture completed.");
+        logger.Info($"Output: {outputRoot}");
+        logger.Info($"Command captures: {commandResults.Count}");
+        if (!string.IsNullOrWhiteSpace(plainArchivePath))
+            logger.Info($"Plain archive: {plainArchivePath}");
+        if (!string.IsNullOrWhiteSpace(encryptedArchivePath))
+            logger.Info($"Encrypted archive: {encryptedArchivePath}");
+        logger.Info($"Restore checklist: {checklistPath}");
+        foreach (var warning in warnings)
+            logger.Warn(warning);
+
+        return 0;
+    }
+
+    private static (PowerForgeServerRecoveryManifest? Manifest, string? ManifestPath, int ExitCode) LoadServerRecoveryManifest(
+        string[] subArgs,
+        bool outputJson,
+        WebConsoleLogger logger,
+        string commandName)
+    {
+        var manifestPath = TryGetOptionValue(subArgs, "--manifest") ??
+                           TryGetOptionValue(subArgs, "--config");
+        if (string.IsNullOrWhiteSpace(manifestPath))
+            return (null, null, Fail("Missing required --manifest.", outputJson, logger, commandName));
+
+        var fullManifestPath = ResolveExistingFilePath(manifestPath);
+        var manifest = JsonSerializer.Deserialize<PowerForgeServerRecoveryManifest>(
+            File.ReadAllText(fullManifestPath), WebCliJson.Options);
+        if (manifest is null)
+            return (null, null, Fail("Invalid server recovery manifest.", outputJson, logger, commandName));
+
+        return (manifest, fullManifestPath, 0);
+    }
+
+    private static string? ResolveBackupRecipient(PowerForgeServerRecoveryManifest manifest)
+    {
+        if (!string.IsNullOrWhiteSpace(manifest.BackupTarget?.Recipient))
+            return manifest.BackupTarget.Recipient;
+        return string.IsNullOrWhiteSpace(manifest.BackupTarget?.RecipientEnv)
+            ? null
+            : Environment.GetEnvironmentVariable(manifest.BackupTarget.RecipientEnv);
+    }
+
+    private static string ResolveCaptureOutputPath(string? outPathArg, PowerForgeServerRecoveryManifest manifest)
+    {
+        if (!string.IsNullOrWhiteSpace(outPathArg))
+            return Path.GetFullPath(outPathArg);
+
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+        var name = SanitizeFileName(string.IsNullOrWhiteSpace(manifest.Name) ? "server" : manifest.Name);
+        return Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "_server-state", name, timestamp));
+    }
+
+    private static string BuildServerSshTarget(PowerForgeServerTarget? target)
+    {
+        if (!string.IsNullOrWhiteSpace(target?.SshAlias))
+            return target.SshAlias!;
+        if (string.IsNullOrWhiteSpace(target?.Host))
+            throw new InvalidOperationException("Server recovery target requires target.sshAlias or target.host.");
+        return string.IsNullOrWhiteSpace(target.User) ? target.Host! : $"{target.User}@{target.Host}";
+    }
+
+    private static PowerForgeServerCaptureCommandResult CaptureRemoteCommand(
+        string sshCommand,
+        string target,
+        PowerForgeServerNamedCommand command,
+        string commandOutputDirectory)
+    {
+        var id = SanitizeFileName(string.IsNullOrWhiteSpace(command.Id) ? "command" : command.Id);
+        var stdoutPath = Path.Combine(commandOutputDirectory, $"{id}.out.txt");
+        var stderrPath = Path.Combine(commandOutputDirectory, $"{id}.err.txt");
+        var execution = RunProcessCaptureText(sshCommand, new[] { target, command.Command ?? string.Empty });
+
+        File.WriteAllText(stdoutPath, execution.Stdout);
+        File.WriteAllText(stderrPath, execution.Stderr);
+
+        return new PowerForgeServerCaptureCommandResult
+        {
+            Id = command.Id,
+            Command = command.Command,
+            ExitCode = execution.ExitCode,
+            Success = execution.ExitCode == 0,
+            StdoutPath = stdoutPath,
+            StderrPath = stderrPath
+        };
+    }
+
+    private static ProcessResult CaptureRemoteTarArchive(
+        string sshCommand,
+        string target,
+        PowerForgeServerManagedFile[] files,
+        string outputPath)
+    {
+        var script = BuildRemoteTarScript(files);
+        return RunProcessCaptureBinary(sshCommand, new[] { target, $"sh -lc {ShellQuote(script)}" }, outputPath);
+    }
+
+    private static ProcessResult CaptureEncryptedRemoteTarArchive(
+        string sshCommand,
+        string ageCommand,
+        string target,
+        PowerForgeServerManagedFile[] files,
+        string outputPath,
+        string recipient)
+    {
+        var script = BuildRemoteTarScript(files);
+        using var ssh = CreateProcess(sshCommand, new[] { target, $"sh -lc {ShellQuote(script)}" });
+        using var age = CreateProcess(ageCommand, new[] { "-r", recipient, "-o", outputPath });
+        ssh.StartInfo.RedirectStandardOutput = true;
+        ssh.StartInfo.RedirectStandardError = true;
+        age.StartInfo.RedirectStandardInput = true;
+        age.StartInfo.RedirectStandardError = true;
+
+        if (!ssh.Start())
+            throw new InvalidOperationException("Failed to start ssh.");
+        if (!age.Start())
+            throw new InvalidOperationException("Failed to start age.");
+
+        var copyTask = ssh.StandardOutput.BaseStream.CopyToAsync(age.StandardInput.BaseStream)
+            .ContinueWith(task =>
+            {
+                age.StandardInput.Close();
+                if (task.IsFaulted && task.Exception is not null)
+                    throw task.Exception;
+            });
+        var sshErrTask = ssh.StandardError.ReadToEndAsync();
+        var ageErrTask = age.StandardError.ReadToEndAsync();
+
+        ssh.WaitForExit();
+        copyTask.GetAwaiter().GetResult();
+        age.WaitForExit();
+
+        var stderr = string.Concat(sshErrTask.GetAwaiter().GetResult(), ageErrTask.GetAwaiter().GetResult());
+        return new ProcessResult
+        {
+            ExitCode = ssh.ExitCode == 0 ? age.ExitCode : ssh.ExitCode,
+            Stdout = string.Empty,
+            Stderr = stderr
+        };
+    }
+
+    private static ProcessResult CaptureRemoteEncryptedTarArchive(
+        string sshCommand,
+        string target,
+        PowerForgeServerManagedFile[] files,
+        string outputPath,
+        string recipient)
+    {
+        var script = BuildRemoteEncryptedTarScript(files, recipient);
+        return RunProcessCaptureBinary(sshCommand, new[] { target, $"sh -lc {ShellQuote(script)}" }, outputPath);
+    }
+
+    private static string BuildRemoteTarScript(PowerForgeServerManagedFile[] files)
+    {
+        var paths = files
+            .Select(static file => file.Target)
+            .Where(static target => !string.IsNullOrWhiteSpace(target))
+            .Select(static target => target!)
+            .ToArray();
+        if (paths.Length == 0)
+            throw new InvalidOperationException("No target paths are defined for capture.");
+
+        foreach (var path in paths)
+        {
+            if (path.Any(static c => !(char.IsLetterOrDigit(c) || c is '/' or '.' or '_' or '-' or '*' or '?' or '[' or ']')))
+                throw new InvalidOperationException($"Capture path contains unsupported characters: {path}");
+        }
+
+        return "set -e; sudo -n tar -czf - --ignore-failed-read " + string.Join(' ', paths);
+    }
+
+    private static string BuildRemoteEncryptedTarScript(PowerForgeServerManagedFile[] files, string recipient)
+    {
+        var tarScript = BuildRemoteTarScript(files);
+        return $"{tarScript} | age -r {ShellQuote(recipient)} -o -";
+    }
+
+    private static string ShellQuote(string value)
+        => "'" + value.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";
+
+    private static ProcessResult RunProcessCaptureText(string fileName, IReadOnlyList<string> args)
+    {
+        using var process = CreateProcess(fileName, args);
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.Start();
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return new ProcessResult { ExitCode = process.ExitCode, Stdout = stdout, Stderr = stderr };
+    }
+
+    private static ProcessResult RunProcessCaptureBinary(string fileName, IReadOnlyList<string> args, string stdoutPath)
+    {
+        using var process = CreateProcess(fileName, args);
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.Start();
+        using (var output = File.Create(stdoutPath))
+            process.StandardOutput.BaseStream.CopyTo(output);
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return new ProcessResult { ExitCode = process.ExitCode, Stdout = string.Empty, Stderr = stderr };
+    }
+
+    private static Process CreateProcess(string fileName, IReadOnlyList<string> args)
+    {
+        var startInfo = new ProcessStartInfo(fileName)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var arg in args)
+            startInfo.ArgumentList.Add(arg);
+        return new Process { StartInfo = startInfo };
+    }
+
+    private static void WriteRestoreChecklist(
+        string path,
+        PowerForgeServerRecoveryManifest manifest,
+        string? plainArchivePath,
+        string? encryptedArchivePath,
+        IReadOnlyList<string> warnings)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# PowerForge Server Restore Checklist");
+        builder.AppendLine();
+        builder.AppendLine($"Manifest: `{manifest.Name}`");
+        builder.AppendLine($"Target: `{manifest.Target?.SshAlias ?? manifest.Target?.Host ?? "unknown"}`");
+        builder.AppendLine();
+        builder.AppendLine("## Artifacts");
+        builder.AppendLine();
+        builder.AppendLine($"- Plain config archive: `{plainArchivePath ?? "not captured"}`");
+        builder.AppendLine($"- Encrypted secret archive: `{encryptedArchivePath ?? "not captured"}`");
+        builder.AppendLine();
+        builder.AppendLine("## Restore Order");
+        builder.AppendLine();
+        builder.AppendLine("1. Bootstrap Ubuntu and install prerequisite packages.");
+        builder.AppendLine("2. Restore plain configuration files from the plain archive.");
+        builder.AppendLine("3. Restore encrypted secrets only after decrypting them on a trusted machine.");
+        builder.AppendLine("4. Clone or update the Website and PSPublishModule repositories.");
+        builder.AppendLine("5. Run the deployment command from the manifest.");
+        builder.AppendLine("6. Run the verification commands and public URL checks from the manifest.");
+        builder.AppendLine();
+        builder.AppendLine("## Required Secrets");
+        builder.AppendLine();
+        foreach (var secret in manifest.Secrets ?? Array.Empty<PowerForgeServerSecret>())
+            builder.AppendLine($"- `{secret.Id}`: `{secret.Path ?? secret.Env ?? "manual"}` ({secret.Capture})");
+
+        if (warnings.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("## Warnings");
+            builder.AppendLine();
+            foreach (var warning in warnings)
+                builder.AppendLine($"- {warning}");
+        }
+
+        File.WriteAllText(path, builder.ToString());
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(value.Length);
+        foreach (var c in value)
+            builder.Append(invalid.Contains(c) ? '-' : c);
+        return builder.ToString();
+    }
+
+    private static string[] BuildServerRecoveryStages(PowerForgeServerRecoveryManifest manifest)
+    {
+        var stages = new List<string> { "inspect" };
+        if (manifest.Capture is not null)
+            stages.Add("capture");
+        if (manifest.Bootstrap?.Commands?.Length > 0)
+            stages.Add("bootstrap");
+        if (manifest.Secrets?.Length > 0)
+            stages.Add("restore-secrets");
+        if (manifest.Deploy?.Commands?.Length > 0)
+            stages.Add("deploy");
+        if (manifest.Verify?.Commands?.Length > 0 || manifest.Verify?.Urls?.Length > 0)
+            stages.Add("verify");
+
+        return stages.ToArray();
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -7,7 +7,7 @@ namespace PowerForge.Web.Cli;
 
 internal static partial class WebCliCommandHandlers
 {
-    private const string SupportedServerActions = "inspect, plan, capture, deploy, verify, bootstrap-plan, restore-secrets-plan";
+    private const string SupportedServerActions = "inspect, plan, validate, capture, deploy, verify, bootstrap-plan, restore-secrets-plan";
 
     internal static int HandleServer(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
     {
@@ -17,18 +17,25 @@ internal static partial class WebCliCommandHandlers
         var action = subArgs[0].ToLowerInvariant();
         var actionArgs = subArgs.Skip(1).ToArray();
 
-        return action switch
+        try
         {
-            "inspect" => HandleServerInspect(actionArgs, outputJson, logger, outputSchemaVersion),
-            "plan" => HandleServerPlan(actionArgs, outputJson, logger, outputSchemaVersion),
-            "validate" => HandleServerPlan(actionArgs, outputJson, logger, outputSchemaVersion),
-            "capture" => HandleServerCapture(actionArgs, outputJson, logger, outputSchemaVersion),
-            "verify" => HandleServerVerify(actionArgs, outputJson, logger, outputSchemaVersion),
-            "deploy" => HandleServerDeploy(actionArgs, outputJson, logger, outputSchemaVersion),
-            "bootstrap-plan" => HandleServerBootstrapPlan(actionArgs, outputJson, logger, outputSchemaVersion),
-            "restore-secrets-plan" => HandleServerRestoreSecretsPlan(actionArgs, outputJson, logger, outputSchemaVersion),
-            _ => Fail($"Unknown server action '{subArgs[0]}'. Supported actions: {SupportedServerActions}.", outputJson, logger, "web.server")
-        };
+            return action switch
+            {
+                "inspect" => HandleServerInspect(actionArgs, outputJson, logger, outputSchemaVersion),
+                "plan" => HandleServerPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+                "validate" => HandleServerPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+                "capture" => HandleServerCapture(actionArgs, outputJson, logger, outputSchemaVersion),
+                "verify" => HandleServerVerify(actionArgs, outputJson, logger, outputSchemaVersion),
+                "deploy" => HandleServerDeploy(actionArgs, outputJson, logger, outputSchemaVersion),
+                "bootstrap-plan" => HandleServerBootstrapPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+                "restore-secrets-plan" => HandleServerRestoreSecretsPlan(actionArgs, outputJson, logger, outputSchemaVersion),
+                _ => Fail($"Unknown server action '{subArgs[0]}'. Supported actions: {SupportedServerActions}.", outputJson, logger, "web.server")
+            };
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Fail($"Server action failed: {ex.Message}", outputJson, logger, "web.server");
+        }
     }
 
     private static int HandleServerPlan(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
@@ -129,12 +136,12 @@ internal static partial class WebCliCommandHandlers
         var manifest = loaded.Manifest;
         var manifestPath = loaded.ManifestPath!;
         var outPathArg = TryGetOptionValue(subArgs, "--out") ??
-                         TryGetOptionValue(subArgs, "--output") ??
                          TryGetOptionValue(subArgs, "--output-dir");
         var dryRun = HasOption(subArgs, "--dry-run");
         var skipFiles = HasOption(subArgs, "--skip-files");
         var skipEncrypted = HasOption(subArgs, "--skip-encrypted");
         var encryptRemote = HasOption(subArgs, "--encrypt-remote") || HasOption(subArgs, "--remote-encryption");
+        var failOnFailure = HasOption(subArgs, "--fail-on-failure");
         var sshCommand = TryGetOptionValue(subArgs, "--ssh") ?? "ssh";
         var ageCommand = TryGetOptionValue(subArgs, "--age") ?? "age";
 
@@ -225,6 +232,8 @@ internal static partial class WebCliCommandHandlers
             }
         }
 
+        var success = dryRun || warnings.Count == 0;
+        var exitCode = success || !failOnFailure ? 0 : 1;
         var checklistPath = Path.Combine(outputRoot, "restore-checklist.md");
         WriteRestoreChecklist(checklistPath, manifest, plainArchivePath, encryptedArchivePath, warnings);
 
@@ -249,17 +258,19 @@ internal static partial class WebCliCommandHandlers
             {
                 SchemaVersion = outputSchemaVersion,
                 Command = "web.server.capture",
-                Success = true,
-                ExitCode = 0,
+                Success = success || !failOnFailure,
+                ExitCode = exitCode,
                 Config = "web.serverrecovery",
                 ConfigPath = manifestPath,
                 Result = WebCliJson.SerializeToElement(resultSummary, WebCliJson.Context.PowerForgeServerCaptureResult),
                 Error = warnings.Count == 0 ? null : string.Join(" | ", warnings)
             });
-            return 0;
+            return exitCode;
         }
 
-        logger.Success(dryRun ? "Server capture dry run completed." : "Server capture completed.");
+        logger.Success(success
+            ? (dryRun ? "Server capture dry run completed." : "Server capture completed.")
+            : "Server capture completed with warnings.");
         logger.Info($"Output: {outputRoot}");
         logger.Info($"Command captures: {commandResults.Count}");
         if (!string.IsNullOrWhiteSpace(plainArchivePath))
@@ -270,7 +281,7 @@ internal static partial class WebCliCommandHandlers
         foreach (var warning in warnings)
             logger.Warn(warning);
 
-        return 0;
+        return exitCode;
     }
 
     private static (PowerForgeServerRecoveryManifest? Manifest, string? ManifestPath, int ExitCode) LoadServerRecoveryManifest(
@@ -384,27 +395,44 @@ internal static partial class WebCliCommandHandlers
         if (!age.Start())
             throw new InvalidOperationException("Failed to start age.");
 
-        var copyTask = ssh.StandardOutput.BaseStream.CopyToAsync(age.StandardInput.BaseStream)
-            .ContinueWith(task =>
-            {
-                age.StandardInput.Close();
-                if (task.IsFaulted && task.Exception is not null)
-                    throw task.Exception;
-            });
+        var copyTask = CopyAndCloseAsync(ssh.StandardOutput.BaseStream, age.StandardInput.BaseStream);
         var sshErrTask = ssh.StandardError.ReadToEndAsync();
         var ageErrTask = age.StandardError.ReadToEndAsync();
 
         ssh.WaitForExit();
-        copyTask.GetAwaiter().GetResult();
+        string? copyError = null;
+        try
+        {
+            copyTask.GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            copyError = ex.GetBaseException().Message;
+        }
         age.WaitForExit();
 
-        var stderr = string.Concat(sshErrTask.GetAwaiter().GetResult(), ageErrTask.GetAwaiter().GetResult());
+        var stderr = string.Concat(
+            sshErrTask.GetAwaiter().GetResult(),
+            ageErrTask.GetAwaiter().GetResult(),
+            string.IsNullOrWhiteSpace(copyError) ? string.Empty : $"{Environment.NewLine}stream copy failed: {copyError}");
         return new ProcessResult
         {
-            ExitCode = ssh.ExitCode == 0 ? age.ExitCode : ssh.ExitCode,
+            ExitCode = copyError is null ? (ssh.ExitCode == 0 ? age.ExitCode : ssh.ExitCode) : 1,
             Stdout = string.Empty,
             Stderr = stderr
         };
+    }
+
+    private static async Task CopyAndCloseAsync(Stream input, Stream output)
+    {
+        try
+        {
+            await input.CopyToAsync(output);
+        }
+        finally
+        {
+            output.Close();
+        }
     }
 
     private static ProcessResult CaptureRemoteEncryptedTarArchive(

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -137,7 +137,8 @@ internal static class WebCliHelpers
         Console.WriteLine("                     [--max-reference-growth-count <n>] [--max-reference-growth-percent <n>] [--fail-on-warnings]");
         Console.WriteLine("  powerforge-web server inspect --manifest <serverrecovery.json> [--fail-on-drift] [--output json]");
         Console.WriteLine("  powerforge-web server plan --manifest <serverrecovery.json> [--output json]");
-        Console.WriteLine("  powerforge-web server capture --manifest <serverrecovery.json> [--out <dir>] [--dry-run] [--skip-files] [--skip-encrypted] [--encrypt-remote] [--output json]");
+        Console.WriteLine("  powerforge-web server validate --manifest <serverrecovery.json> [--output json] (alias for plan)");
+        Console.WriteLine("  powerforge-web server capture --manifest <serverrecovery.json> [--out <dir>] [--dry-run] [--skip-files] [--skip-encrypted] [--encrypt-remote] [--fail-on-failure] [--output json]");
         Console.WriteLine("  powerforge-web server deploy --manifest <serverrecovery.json> [--dry-run] [--fail-on-failure] [--output json]");
         Console.WriteLine("  powerforge-web server verify --manifest <serverrecovery.json> [--fail-on-failure] [--url-timeout-seconds <n>] [--output json]");
         Console.WriteLine("  powerforge-web server bootstrap-plan --manifest <serverrecovery.json> [--out <dir>] [--output json]");

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -135,6 +135,13 @@ internal static class WebCliHelpers
         Console.WriteLine("  powerforge-web xref-merge --out <file> --map <file|dir[,file|dir...]> [--pattern *.json] [--top-only]");
         Console.WriteLine("                     [--prefer-last] [--fail-on-duplicates] [--max-references <n>] [--max-duplicates <n>]");
         Console.WriteLine("                     [--max-reference-growth-count <n>] [--max-reference-growth-percent <n>] [--fail-on-warnings]");
+        Console.WriteLine("  powerforge-web server inspect --manifest <serverrecovery.json> [--fail-on-drift] [--output json]");
+        Console.WriteLine("  powerforge-web server plan --manifest <serverrecovery.json> [--output json]");
+        Console.WriteLine("  powerforge-web server capture --manifest <serverrecovery.json> [--out <dir>] [--dry-run] [--skip-files] [--skip-encrypted] [--encrypt-remote] [--output json]");
+        Console.WriteLine("  powerforge-web server deploy --manifest <serverrecovery.json> [--dry-run] [--fail-on-failure] [--output json]");
+        Console.WriteLine("  powerforge-web server verify --manifest <serverrecovery.json> [--fail-on-failure] [--url-timeout-seconds <n>] [--output json]");
+        Console.WriteLine("  powerforge-web server bootstrap-plan --manifest <serverrecovery.json> [--out <dir>] [--output json]");
+        Console.WriteLine("  powerforge-web server restore-secrets-plan --manifest <serverrecovery.json> [--out <dir>] [--archive <encrypted-secrets.tar.gz.age>] [--output json]");
         Console.WriteLine("  powerforge-web cloudflare purge --zone-id <id> [--token <token> | --token-env <env>]");
         Console.WriteLine("                     [--purge-everything] [--site-config <site.json>] [--base-url <url>] [--path <p[,p...]>] [--url <u[,u...]>] [--dry-run]");
         Console.WriteLine("  powerforge-web cloudflare verify [--site-config <site.json>] [--base-url <url>] [--path <p[,p...]>] [--url <u[,u...]>]");

--- a/Schemas/powerforge.web.serverrecovery.schema.json
+++ b/Schemas/powerforge.web.serverrecovery.schema.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "powerforge.web.serverrecovery.schema.json",
+  "title": "PowerForge Web Server Recovery Manifest (schema v1)",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "target": { "$ref": "#/$defs/Target" },
+    "repositories": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Repository" }
+    },
+    "packages": { "$ref": "#/$defs/Packages" },
+    "paths": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ManagedPath" }
+    },
+    "apache": { "$ref": "#/$defs/Apache" },
+    "firewall": { "$ref": "#/$defs/Firewall" },
+    "certificates": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Certificate" }
+    },
+    "systemd": { "$ref": "#/$defs/Systemd" },
+    "secrets": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Secret" }
+    },
+    "capture": { "$ref": "#/$defs/Capture" },
+    "bootstrap": { "$ref": "#/$defs/CommandGroup" },
+    "deploy": { "$ref": "#/$defs/CommandGroup" },
+    "verify": { "$ref": "#/$defs/Verify" },
+    "backupTarget": { "$ref": "#/$defs/BackupTarget" },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["schemaVersion", "name", "target"],
+  "$defs": {
+    "Target": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sshAlias": { "type": "string" },
+        "host": { "type": "string" },
+        "user": { "type": "string" },
+        "sshPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "os": { "type": "string" },
+        "architecture": { "type": "string" }
+      }
+    },
+    "Repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "url": { "type": "string" },
+        "path": { "type": "string" },
+        "branch": { "type": "string" },
+        "required": { "type": "boolean" }
+      },
+      "required": ["role", "path"]
+    },
+    "Packages": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apt": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "apacheModules": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "dotnetSdks": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "powershell": { "type": "boolean" }
+      }
+    },
+    "ManagedPath": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "path": { "type": "string" },
+        "owner": { "type": "string" },
+        "group": { "type": "string" },
+        "mode": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "enum": ["directory", "file", "symlink"]
+        }
+      },
+      "required": ["id", "path"]
+    },
+    "Apache": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "service": { "type": "string" },
+        "modules": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "sites": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ManagedFile" }
+        },
+        "conf": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ManagedFile" }
+        },
+        "validateCommand": { "type": "string" },
+        "reloadCommand": { "type": "string" }
+      }
+    },
+    "ManagedFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": { "type": "string" },
+        "target": { "type": "string" },
+        "required": { "type": "boolean" },
+        "sensitive": { "type": "boolean" }
+      },
+      "required": ["target"]
+    },
+    "Firewall": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": { "type": "string" },
+        "defaultIncoming": { "type": "string" },
+        "defaultOutgoing": { "type": "string" },
+        "sshPorts": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1, "maximum": 65535 }
+        },
+        "webOriginPolicy": { "type": "string" },
+        "syncCommand": { "type": "string" }
+      }
+    },
+    "Certificate": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "domains": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "authenticator": { "type": "string" },
+        "credentialsPath": { "type": "string" },
+        "renewalConfigPath": { "type": "string" },
+        "dryRunCommand": { "type": "string" },
+        "secretRefs": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["name"]
+    },
+    "Systemd": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "services": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SystemdUnit" }
+        },
+        "timers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SystemdUnit" }
+        }
+      }
+    },
+    "SystemdUnit": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "source": { "type": "string" },
+        "target": { "type": "string" },
+        "enabled": { "type": "boolean" },
+        "required": { "type": "boolean" }
+      },
+      "required": ["name"]
+    },
+    "Secret": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "path": { "type": "string" },
+        "env": { "type": "string" },
+        "requiredFor": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "capture": {
+          "type": "string",
+          "enum": ["exclude", "encrypted"]
+        },
+        "restoreMode": { "type": "string" }
+      },
+      "required": ["id", "capture"]
+    },
+    "Capture": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "plainFiles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ManagedFile" }
+        },
+        "encryptedFiles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ManagedFile" }
+        },
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NamedCommand" }
+        },
+        "exclude": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "CommandGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NamedCommand" }
+        }
+      }
+    },
+    "NamedCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "command": { "type": "string", "minLength": 1 },
+        "workingDirectory": { "type": "string" },
+        "sensitive": { "type": "boolean" },
+        "required": { "type": "boolean" }
+      },
+      "required": ["id", "command"]
+    },
+    "Verify": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/NamedCommand" }
+        },
+        "urls": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/VerifyUrl" }
+        }
+      }
+    },
+    "VerifyUrl": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": { "type": "string" },
+        "expectedStatus": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "via": { "type": "string" }
+      },
+      "required": ["url"]
+    },
+    "BackupTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string" },
+        "repository": { "type": "string" },
+        "branch": { "type": "string" },
+        "path": { "type": "string" },
+        "encryption": { "type": "string" },
+        "recipient": { "type": "string" },
+        "recipientEnv": { "type": "string" },
+        "retention": { "$ref": "#/$defs/BackupRetention" }
+      }
+    },
+    "BackupRetention": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "keepLatest": { "type": "integer", "minimum": 0 },
+        "keepDays": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/Schemas/powerforge.web.serverrecovery.schema.json
+++ b/Schemas/powerforge.web.serverrecovery.schema.json
@@ -52,7 +52,11 @@
         "sshPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "os": { "type": "string" },
         "architecture": { "type": "string" }
-      }
+      },
+      "anyOf": [
+        { "required": ["sshAlias"] },
+        { "required": ["host"] }
+      ]
     },
     "Repository": {
       "type": "object",
@@ -275,7 +279,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "url": { "type": "string" },
+        "url": { "type": "string", "format": "uri" },
         "expectedStatus": { "type": "integer", "minimum": 100, "maximum": 599 },
         "via": { "type": "string" }
       },
@@ -285,11 +289,17 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "type": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["github"]
+        },
         "repository": { "type": "string" },
         "branch": { "type": "string" },
         "path": { "type": "string" },
-        "encryption": { "type": "string" },
+        "encryption": {
+          "type": "string",
+          "enum": ["age"]
+        },
         "recipient": { "type": "string" },
         "recipientEnv": { "type": "string" },
         "retention": { "$ref": "#/$defs/BackupRetention" }
@@ -299,8 +309,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "keepLatest": { "type": "integer", "minimum": 0 },
-        "keepDays": { "type": "integer", "minimum": 0 }
+        "keepLatest": { "type": "integer", "minimum": 1 },
+        "keepDays": { "type": "integer", "minimum": 1 }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `powerforge-web server` recovery actions for plan, inspect, capture, deploy dry-run/run, verify, bootstrap-plan, and restore-secrets-plan
- add the server recovery manifest schema and source-generated JSON models
- document the recovery workflow, encrypted capture behavior, GitHub backup target policy, and Evotec reference usage

## Validation
- `dotnet build C:\Support\GitHub\PSPublishModule\PowerForge.Web.Cli\PowerForge.Web.Cli.csproj -c Release --no-restore`
- `Test-Json -Path C:\Support\GitHub\Website\deploy\linux\evotec.serverrecovery.json -SchemaFile C:\Support\GitHub\PSPublishModule\Schemas\powerforge.web.serverrecovery.schema.json`
- `PowerForge.Web.Cli.exe server plan --manifest C:\Support\GitHub\Website\deploy\linux\evotec.serverrecovery.json --output json`
- `PowerForge.Web.Cli.exe server deploy --manifest C:\Support\GitHub\Website\deploy\linux\evotec.serverrecovery.json --dry-run --fail-on-failure --output json`
