### PR TITLE
Improve incremental website content validation

### DIFF
--- a/PowerForge.Tests/WebContributionProcessorTests.cs
+++ b/PowerForge.Tests/WebContributionProcessorTests.cs
@@ -1,4 +1,5 @@
 using PowerForge.Web;
+using PowerForge.Web.Cli;
 
 namespace PowerForge.Tests;
 
@@ -389,6 +390,191 @@ public class WebContributionProcessorTests
 
             Assert.False(result.Success);
             Assert.Contains(result.Errors, error => error.Contains("PostsPath must stay inside the configured root", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public void Validate_ReportsPublishReadinessWarnings()
+    {
+        var root = CreateTempRoot("pf-web-contributions-editorial-");
+
+        try
+        {
+            var sourceRoot = Path.Combine(root, "contributions");
+            WriteAuthor(sourceRoot, "jane-doe");
+            WritePost(sourceRoot, "editorial-post",
+                """
+                ---
+                title: "Editorial Post"
+                description: "A practical sample contribution."
+                date: "2026-04-29"
+                language: "en"
+                authors:
+                  - jane-doe
+                image: "./cover.webp"
+                image_alt: "Screenshot showing a configured workflow"
+                draft: true
+                ---
+
+                PowerApps and PowerAutomate save files into Sharepoint.
+
+                yaml
+                ```text
+                sample: true
+                ```
+
+                • File Name
+                ________________________________________
+                """);
+
+            var result = WebContributionProcessor.Process(new WebContributionOptions
+            {
+                SourceRoot = sourceRoot
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors));
+            Assert.Contains(result.Warnings, warning => warning.Contains("decorative separator lines", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Warnings, warning => warning.Contains("standalone 'yaml'", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Warnings, warning => warning.Contains("bullet characters", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Warnings, warning => warning.Contains("PowerApps", StringComparison.Ordinal));
+            Assert.Contains(result.Warnings, warning => warning.Contains("PowerAutomate", StringComparison.Ordinal));
+            Assert.Contains(result.Warnings, warning => warning.Contains("Sharepoint", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public void Validate_AllowsSetextHeadings()
+    {
+        var root = CreateTempRoot("pf-web-contributions-setext-");
+
+        try
+        {
+            var sourceRoot = Path.Combine(root, "contributions");
+            WriteAuthor(sourceRoot, "jane-doe");
+            WritePost(sourceRoot, "setext-post",
+                """
+                ---
+                title: "Setext Post"
+                description: "A practical sample contribution."
+                date: "2026-04-29"
+                language: "en"
+                authors:
+                  - jane-doe
+                image: "./cover.webp"
+                image_alt: "Screenshot showing a configured workflow"
+                draft: true
+                ---
+
+                Main Section
+                ============
+
+                Secondary Section
+                -----------------
+                """);
+
+            var result = WebContributionProcessor.Process(new WebContributionOptions
+            {
+                SourceRoot = sourceRoot
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors));
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("decorative separator lines", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public void Validate_RejectsSlugLikeFeaturedImageAlt()
+    {
+        var root = CreateTempRoot("pf-web-contributions-alt-");
+
+        try
+        {
+            var sourceRoot = Path.Combine(root, "contributions");
+            WriteAuthor(sourceRoot, "jane-doe");
+            WritePost(sourceRoot, "bad-alt-post",
+                """
+                ---
+                title: "Bad Alt Post"
+                description: "A practical sample contribution."
+                date: "2026-04-29"
+                language: "en"
+                authors:
+                  - jane-doe
+                image: "./cover.webp"
+                image_alt: "powerplatform-save-files-issue"
+                draft: true
+                ---
+
+                Body.
+                """);
+
+            var result = WebContributionProcessor.Process(new WebContributionOptions
+            {
+                SourceRoot = sourceRoot
+            });
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Errors, error => error.Contains("image_alt looks like a slug", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            DeleteTempRoot(root);
+        }
+    }
+
+    [Fact]
+    public void ContributionsCli_FailOnWarningsReturnsNonZeroForEditorialWarnings()
+    {
+        var root = CreateTempRoot("pf-web-contributions-cli-warnings-");
+
+        try
+        {
+            var sourceRoot = Path.Combine(root, "contributions");
+            WriteAuthor(sourceRoot, "jane-doe");
+            WritePost(sourceRoot, "warning-post",
+                """
+                ---
+                title: "Warning Post"
+                description: "A practical sample contribution."
+                date: "2026-04-29"
+                language: "en"
+                authors:
+                  - jane-doe
+                image: "./cover.webp"
+                image_alt: "Screenshot showing a workflow"
+                draft: true
+                ---
+
+                ________________________________________
+                """);
+
+            var relaxed = WebCliCommandHandlers.HandleSubCommand(
+                "contributions",
+                new[] { "validate", "--root", sourceRoot },
+                outputJson: true,
+                logger: new WebConsoleLogger(),
+                outputSchemaVersion: 1);
+            var strict = WebCliCommandHandlers.HandleSubCommand(
+                "contributions",
+                new[] { "validate", "--root", sourceRoot, "--fail-on-warnings" },
+                outputJson: true,
+                logger: new WebConsoleLogger(),
+                outputSchemaVersion: 1);
+
+            Assert.Equal(0, relaxed);
+            Assert.Equal(1, strict);
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectDocsSyncTests.cs
@@ -97,6 +97,69 @@ public sealed class WebPipelineRunnerProjectDocsSyncTests
     }
 
     [Fact]
+    public void RunPipeline_ProjectDocsSync_FiltersProjectsWhenConfigured()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-sync-filter-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var catalogPath = Path.Combine(root, "data", "projects", "catalog.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(catalogPath)!);
+            File.WriteAllText(catalogPath,
+                """
+                {
+                  "projects": [
+                    { "slug": "alpha", "surfaces": { "docs": true } },
+                    { "slug": "beta", "surfaces": { "docs": true } }
+                  ]
+                }
+                """);
+
+            var alphaDocs = Path.Combine(root, "projects-sources", "alpha", "Docs");
+            Directory.CreateDirectory(alphaDocs);
+            File.WriteAllText(Path.Combine(alphaDocs, "index.md"), "# Alpha");
+
+            var betaDocs = Path.Combine(root, "projects-sources", "beta", "Docs");
+            Directory.CreateDirectory(betaDocs);
+            File.WriteAllText(Path.Combine(betaDocs, "index.md"), "# Beta");
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "project-docs-sync",
+                      "catalog": "./data/projects/catalog.json",
+                      "projects": ["beta"],
+                      "sourcesRoot": "./projects-sources",
+                      "contentRoot": "./content/docs",
+                      "summaryPath": "./Build/sync-project-docs-summary.json"
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+
+            Assert.True(result.Success);
+            Assert.True(File.Exists(Path.Combine(root, "content", "docs", "beta", "index.md")));
+            Assert.False(File.Exists(Path.Combine(root, "content", "docs", "alpha", "index.md")));
+
+            using var summaryDoc = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "Build", "sync-project-docs-summary.json")));
+            Assert.Equal(1, summaryDoc.RootElement.GetProperty("totalProjects").GetInt32());
+            Assert.Equal(1, summaryDoc.RootElement.GetProperty("docsProjects").GetInt32());
+            Assert.Equal(1, summaryDoc.RootElement.GetProperty("synced").GetInt32());
+            Assert.Equal(0, summaryDoc.RootElement.GetProperty("skipped").GetInt32());
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void RunPipeline_ProjectDocsSync_FailsWhenMissingDocsSourceAndFailOnMissingSourceEnabled()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-project-docs-sync-fail-missing-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebPipelineRunnerSourcesSyncTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerSourcesSyncTests.cs
@@ -234,6 +234,138 @@ public class WebPipelineRunnerSourcesSyncTests
         }
     }
 
+    [Fact]
+    public void RunPipeline_SourcesSync_FiltersSourcesWhenProjectsConfigured()
+    {
+        if (!IsGitAvailable())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-sources-sync-filter-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var alphaSource = CreateGitSource(root, "alpha-source", "README.md", "alpha source");
+            var betaSource = CreateGitSource(root, "beta-source", "README.md", "beta source");
+
+            Directory.CreateDirectory(Path.Combine(root, "content", "pages"));
+            File.WriteAllText(Path.Combine(root, "content", "pages", "index.md"),
+                """
+                ---
+                title: Home
+                slug: /
+                ---
+
+                # Home
+                """);
+
+            File.WriteAllText(Path.Combine(root, "site.json"),
+                $$"""
+                {
+                  "Name": "Pipeline Sources Sync Filter Test",
+                  "BaseUrl": "https://example.test",
+                  "ContentRoot": "content",
+                  "ProjectsRoot": "projects",
+                  "Collections": [
+                    { "Name": "pages", "Input": "content/pages", "Output": "/" }
+                  ],
+                  "Sources": [
+                    { "Repo": "{{EscapeJson(alphaSource)}}", "Slug": "alpha" },
+                    { "Repo": "{{EscapeJson(betaSource)}}", "Slug": "beta" }
+                  ]
+                }
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    { "task": "sources-sync", "config": "./site.json", "projects": ["beta"] }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.True(result.Success);
+            Assert.True(File.Exists(Path.Combine(root, "projects", "beta", "README.md")));
+            Assert.False(Directory.Exists(Path.Combine(root, "projects", "alpha")));
+            Assert.Equal("beta source", File.ReadAllText(Path.Combine(root, "projects", "beta", "README.md")));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void RunPipeline_SourcesSync_RejectsFilteredLockUpdate()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-sources-sync-filter-update-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "content", "pages"));
+            File.WriteAllText(Path.Combine(root, "content", "pages", "index.md"),
+                """
+                ---
+                title: Home
+                slug: /
+                ---
+
+                # Home
+                """);
+
+            File.WriteAllText(Path.Combine(root, "site.json"),
+                """
+                {
+                  "Name": "Pipeline Sources Sync Filter Update Test",
+                  "BaseUrl": "https://example.test",
+                  "ContentRoot": "content",
+                  "ProjectsRoot": "projects",
+                  "Collections": [
+                    { "Name": "pages", "Input": "content/pages", "Output": "/" }
+                  ],
+                  "Sources": [
+                    { "Repo": "https://example.test/alpha.git", "Slug": "alpha" }
+                  ]
+                }
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    { "task": "sources-sync", "config": "./site.json", "projects": "alpha", "lockMode": "update" }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.False(result.Success);
+            Assert.Contains("filtered lock update", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static string CreateGitSource(string root, string name, string fileName, string content)
+    {
+        var source = Path.Combine(root, name);
+        Directory.CreateDirectory(source);
+        File.WriteAllText(Path.Combine(source, fileName), content);
+        RunGit(source, "init");
+        RunGit(source, "config", "user.email", "pf-tests@example.local");
+        RunGit(source, "config", "user.name", "PowerForge Tests");
+        RunGit(source, "add", ".");
+        RunGit(source, "commit", "-m", "init", "--quiet");
+        return source;
+    }
+
     private static bool IsGitAvailable()
     {
         try

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Contributions.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Contributions.cs
@@ -23,6 +23,8 @@ internal static partial class WebCliCommandHandlers
                        TryGetOptionValue(effectiveArgs, "--site");
         var force = HasOption(effectiveArgs, "--force");
         var publish = HasOption(effectiveArgs, "--publish");
+        var failOnWarnings = HasOption(effectiveArgs, "--fail-on-warnings") ||
+                             HasOption(effectiveArgs, "--strict");
 
         WebContributionResult result;
         try
@@ -41,18 +43,20 @@ internal static partial class WebCliCommandHandlers
             return Fail(ex.ToString(), outputJson, logger, "web.contributions");
         }
 
+        var success = result.Success && (!failOnWarnings || result.Warnings.Length == 0);
+
         if (outputJson)
         {
             WebCliJsonWriter.Write(new WebCliJsonEnvelope
             {
                 SchemaVersion = outputSchemaVersion,
                 Command = "web.contributions",
-                Success = result.Success,
-                ExitCode = result.Success ? 0 : 1,
+                Success = success,
+                ExitCode = success ? 0 : 1,
                 Result = WebCliJson.SerializeToElement(result, WebCliJson.Context.WebContributionResult),
-                Error = result.Success ? null : string.Join(" | ", result.Errors)
+                Error = success ? null : string.Join(" | ", failOnWarnings && result.Warnings.Length > 0 ? result.Warnings : result.Errors)
             });
-            return result.Success ? 0 : 1;
+            return success ? 0 : 1;
         }
 
         foreach (var warning in result.Warnings)
@@ -71,6 +75,8 @@ internal static partial class WebCliCommandHandlers
         }
 
         if (!result.Success)
+            return 1;
+        if (failOnWarnings && result.Warnings.Length > 0)
             return 1;
 
         logger.Success(isImport ? "Contribution import passed." : "Contribution validation passed.");

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -121,6 +121,7 @@ internal static class WebCliHelpers
         Console.WriteLine("  powerforge-web links report-404 --site-root <dir> [--source <access.log|observations.csv>] [--out <report.json>] [--review-csv <file>] [--output json]");
         Console.WriteLine("  powerforge-web links promote-404 --source <404-suggestions.json> --config <site.json> [--out <redirects.json>] [--review-csv <file>] [--enable] [--output json]");
         Console.WriteLine("  powerforge-web links ignore-404 --source <404-suggestions.json> --config <site.json> (--path <url>|--without-suggestions|--all) [--reason <text>] [--review-csv <file>] [--output json]");
+        Console.WriteLine("  powerforge-web contributions validate --root <dir> [--fail-on-warnings|--strict] [--output json]");
         Console.WriteLine("  powerforge-web llms --site-root <dir> [--project <path>] [--api-index <path>] [--api-base /api]");
         Console.WriteLine("                     [--name <Name>] [--package <Id>] [--version <X.Y.Z>] [--quickstart <file>]");
         Console.WriteLine("                     [--overview <text>] [--license <text>] [--targets <text>] [--extra <file>]");

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectDocsSync.cs
@@ -79,6 +79,7 @@ internal static partial class WebPipelineRunner
             arrayKeys: new[] { "sourceExamplesPaths", "source-examples-paths" },
             scalarKeys: new[] { "sourceExamplesPath", "source-examples-path", "sourceExamplesFolder", "source-examples-folder" },
             defaults: new[] { "Website/content/examples", "content/examples" });
+        var selectedProjectSlugs = ResolveProjectDocsProjectFilter(step);
 
         var apiRoot = ResolvePath(baseDir,
             GetString(step, "apiRoot") ??
@@ -175,6 +176,12 @@ internal static partial class WebPipelineRunner
         }
 
         var projects = ReadProjectDocsCatalog(catalogPath, onlyLocalLinks);
+        if (selectedProjectSlugs.Count > 0)
+        {
+            projects = projects
+                .Where(project => selectedProjectSlugs.Contains(NormalizeSlug(project.Slug)))
+                .ToList();
+        }
         var docsProjects = syncDocs
             ? projects.Where(p => p.HasDocsSurface && (includeDedicatedExternal || !p.ContentMode.Equals("external", StringComparison.OrdinalIgnoreCase))).ToList()
             : new List<ProjectDocsCatalogItem>();
@@ -1666,6 +1673,36 @@ internal static partial class WebPipelineRunner
         return values
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private static HashSet<string> ResolveProjectDocsProjectFilter(JsonElement step)
+    {
+        var selected = ParseTokenSet(
+            GetString(step, "projects") ??
+            GetString(step, "project") ??
+            GetString(step, "projectSlugs") ??
+            GetString(step, "project-slugs"));
+
+        foreach (var key in new[] { "projects", "projectSlugs", "project-slugs" })
+        {
+            var values = GetArrayOfStrings(step, key);
+            if (values is null)
+                continue;
+
+            foreach (var value in values)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                    selected.Add(value.Trim());
+            }
+        }
+
+        if (selected.Count == 0)
+            return selected;
+
+        return selected
+            .Select(NormalizeSlug)
+            .Where(static slug => !string.IsNullOrWhiteSpace(slug))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private static void AddPathCandidate(ICollection<string> values, string? value)

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.SourcesSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.SourcesSync.cs
@@ -23,6 +23,11 @@ internal static partial class WebPipelineRunner
 
         var repos = new List<Dictionary<string, object?>>();
         var cleanDefault = GetBool(step, "clean") ?? GetBool(step, "clean-target");
+        var selectedSourceSlugs = ResolveSourcesSyncSourceFilter(step);
+        var lockModeText = GetString(step, "lockMode") ?? GetString(step, "lock-mode");
+        if (selectedSourceSlugs.Count > 0 && string.Equals(lockModeText?.Trim(), "update", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("sources-sync project filters cannot be used with lockMode=update because a filtered lock update would drop unrelated source entries. Use lockMode=verify/off for project-scoped source hydration, or run an unfiltered update to advance the lock.");
+
         var destinationComparer = FileSystemPathComparison == StringComparison.OrdinalIgnoreCase
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
@@ -35,6 +40,10 @@ internal static partial class WebPipelineRunner
             var slug = !string.IsNullOrWhiteSpace(source.Slug) ? source.Slug!.Trim() : InferRepoSlug(source.Repo);
             if (string.IsNullOrWhiteSpace(slug))
                 slug = "repo";
+
+            var normalizedSlug = NormalizeSlug(slug);
+            if (selectedSourceSlugs.Count > 0 && !selectedSourceSlugs.Contains(normalizedSlug))
+                continue;
 
             var destinationValue = string.IsNullOrWhiteSpace(source.Destination)
                 ? null
@@ -76,7 +85,12 @@ internal static partial class WebPipelineRunner
         }
 
         if (repos.Count == 0)
+        {
+            if (selectedSourceSlugs.Count > 0)
+                throw new InvalidOperationException($"sources-sync: no Sources entries matched requested projects: {string.Join(", ", selectedSourceSlugs.OrderBy(static value => value, StringComparer.OrdinalIgnoreCase))}.");
+
             throw new InvalidOperationException("sources-sync: Sources entries are empty.");
+        }
 
         var gitSyncStep = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
         {
@@ -94,7 +108,7 @@ internal static partial class WebPipelineRunner
             ["submodules"] = GetBool(step, "submodules") ?? GetBool(step, "submodule"),
             ["submodulesRecursive"] = GetBool(step, "submodulesRecursive") ?? GetBool(step, "submodules-recursive") ?? GetBool(step, "recursiveSubmodules") ?? GetBool(step, "recursive-submodules"),
             ["submoduleDepth"] = GetInt(step, "submoduleDepth") ?? GetInt(step, "submodule-depth"),
-            ["lockMode"] = GetString(step, "lockMode") ?? GetString(step, "lock-mode"),
+            ["lockMode"] = lockModeText,
             ["lockPath"] = GetString(step, "lockPath") ?? GetString(step, "lock-path") ?? GetString(step, "lock"),
             ["writeManifest"] = GetBool(step, "writeManifest") ?? GetBool(step, "write-manifest"),
             ["manifestPath"] = GetString(step, "manifestPath") ?? GetString(step, "manifest-path") ?? GetString(step, "manifest")
@@ -105,6 +119,37 @@ internal static partial class WebPipelineRunner
 
         ExecuteGitSync(doc.RootElement, plan.RootPath, logger, stepResult);
         stepResult.Task = "sources-sync";
+    }
+
+    private static HashSet<string> ResolveSourcesSyncSourceFilter(JsonElement step)
+    {
+        var selected = ParseTokenSet(
+            GetString(step, "projects") ??
+            GetString(step, "project") ??
+            GetString(step, "sourceSlugs") ??
+            GetString(step, "source-slugs") ??
+            GetString(step, "sources"));
+
+        foreach (var key in new[] { "projects", "sourceSlugs", "source-slugs", "sources" })
+        {
+            var values = GetArrayOfStrings(step, key);
+            if (values is null)
+                continue;
+
+            foreach (var value in values)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                    selected.Add(value.Trim());
+            }
+        }
+
+        if (selected.Count == 0)
+            return selected;
+
+        return selected
+            .Select(NormalizeSlug)
+            .Where(static slug => !string.IsNullOrWhiteSpace(slug))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private static string InferRepoSlug(string repo)

--- a/PowerForge.Web/Services/WebContributionProcessor.Validation.cs
+++ b/PowerForge.Web/Services/WebContributionProcessor.Validation.cs
@@ -209,6 +209,7 @@ public static partial class WebContributionProcessor
 
         ValidateFeaturedImage(indexPath, relative, bundleRoot, matter, errors);
         ValidateMarkdownImages(relative, bundleRoot, body, errors, warnings);
+        ValidateMarkdownEditorialHygiene(relative, body, warnings);
         return result;
     }
 
@@ -240,6 +241,10 @@ public static partial class WebContributionProcessor
         {
             errors.Add($"{relative}: featured image_alt is empty.");
         }
+        else if (LooksLikeSlugOrFileName(alt))
+        {
+            errors.Add($"{relative}: featured image_alt looks like a slug or file name. Describe what the image shows.");
+        }
     }
 
     private static void ValidateMarkdownImages(
@@ -268,5 +273,104 @@ public static partial class WebContributionProcessor
 
         if (scannableBody.Contains("<img", StringComparison.OrdinalIgnoreCase))
             warnings.Add($"{relative}: contains raw <img> HTML. Prefer Markdown image syntax so validation can check alt text and local files.");
+    }
+
+    private static void ValidateMarkdownEditorialHygiene(
+        string relative,
+        string body,
+        List<string> warnings)
+    {
+        var scannableBody = MaskFencedCodeBlocks(body);
+        if (ContainsDecorativeSeparator(scannableBody))
+            warnings.Add($"{relative}: contains decorative separator lines. Prefer headings, paragraphs, or Markdown lists.");
+
+        // Use the unmasked body here because the anti-pattern is the label immediately before a fence.
+        var bareFenceLabelMatch = BareFenceLanguageLabelRegex.Match(body);
+        if (bareFenceLabelMatch.Success)
+        {
+            var label = bareFenceLabelMatch.Groups["label"].Value;
+            warnings.Add($"{relative}: contains standalone '{label}' before a fenced code block. Put the language on the opening fence, for example ```{label}.");
+        }
+
+        if (scannableBody.Contains('•'))
+            warnings.Add($"{relative}: contains bullet characters. Prefer Markdown list markers such as '-'.");
+
+        WarnIfContains(scannableBody, "PowerApps", "Power Apps", relative, warnings);
+        WarnIfContains(scannableBody, "PowerAutomate", "Power Automate", relative, warnings);
+        WarnIfContains(scannableBody, "Sharepoint", "SharePoint", relative, warnings);
+    }
+
+    private static bool ContainsDecorativeSeparator(string body)
+    {
+        foreach (Match match in DecorativeSeparatorRegex.Matches(body))
+        {
+            if (!IsLikelySetextHeadingUnderline(body, match))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsLikelySetextHeadingUnderline(string body, Match separatorMatch)
+    {
+        var markerGroup = separatorMatch.Groups["marker"];
+        if (!markerGroup.Success)
+            return false;
+
+        var marker = markerGroup.Value;
+        if (string.IsNullOrWhiteSpace(marker) || marker[0] == '_')
+            return false;
+
+        var previousLineEnd = separatorMatch.Index - 1;
+        while (previousLineEnd >= 0 && (body[previousLineEnd] == '\r' || body[previousLineEnd] == '\n'))
+            previousLineEnd--;
+        if (previousLineEnd < 0)
+            return false;
+
+        var previousLineStart = body.LastIndexOf('\n', previousLineEnd);
+        previousLineStart = previousLineStart < 0 ? 0 : previousLineStart + 1;
+        var previousLine = body.Substring(previousLineStart, previousLineEnd - previousLineStart + 1).Trim();
+        if (previousLine.Length == 0)
+            return false;
+
+        if (previousLine.StartsWith("#", StringComparison.Ordinal) ||
+            previousLine.StartsWith(">", StringComparison.Ordinal) ||
+            previousLine.StartsWith("|", StringComparison.Ordinal) ||
+            previousLine.StartsWith("-", StringComparison.Ordinal) ||
+            previousLine.StartsWith("*", StringComparison.Ordinal) ||
+            previousLine.StartsWith("+", StringComparison.Ordinal) ||
+            previousLine.StartsWith("`", StringComparison.Ordinal) ||
+            previousLine.StartsWith("~", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool LooksLikeSlugOrFileName(string value)
+    {
+        var text = value.Trim();
+        if (text.Length < 8)
+            return false;
+
+        if (text.Contains(' ', StringComparison.Ordinal))
+            return false;
+
+        if (Path.HasExtension(text))
+            return true;
+
+        return SlugLikeAltTextRegex.IsMatch(text);
+    }
+
+    private static void WarnIfContains(
+        string body,
+        string current,
+        string preferred,
+        string relative,
+        List<string> warnings)
+    {
+        if (body.Contains(current, StringComparison.Ordinal))
+            warnings.Add($"{relative}: contains '{current}'. Prefer '{preferred}' in visible article copy.");
     }
 }

--- a/PowerForge.Web/Services/WebContributionProcessor.cs
+++ b/PowerForge.Web/Services/WebContributionProcessor.cs
@@ -32,6 +32,18 @@ public static partial class WebContributionProcessor
         @"(?m)^---\s*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
         RegexTimeout);
+    private static readonly Regex DecorativeSeparatorRegex = new(
+        @"(?m)^[ \t]*(?<marker>_{5,}|-{5,}|={5,})[ \t]*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexTimeout);
+    private static readonly Regex BareFenceLanguageLabelRegex = new(
+        @"(?im)^[ \t]*(?<label>bash|csharp|html|json|powershell|ps1|text|xml|yaml|yml)[ \t]*\r?\n[ \t]*(```|~~~)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexTimeout);
+    private static readonly Regex SlugLikeAltTextRegex = new(
+        @"^[a-z0-9]+(?:[-_][a-z0-9]+)+$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        RegexTimeout);
     private static readonly Regex SlugRegex = new(
         "^[a-z0-9]+(?:-[a-z0-9]+)*$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -1487,6 +1487,11 @@
         "skip-modes": { "type": "array", "items": { "type": "string" } },
 
         "config": { "type": "string", "description": "Path to site.json containing Sources entries." },
+        "projects": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }], "description": "Optional source/project slugs to sync from site.json Sources." },
+        "project": { "type": "string", "description": "Alias for projects when syncing one source/project slug." },
+        "sourceSlugs": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }], "description": "Alias for projects." },
+        "source-slugs": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }], "description": "Alias for projects." },
+        "sources": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }], "description": "Alias for projects." },
 
         "lockMode": { "type": "string", "description": "Passed through to git-sync lockMode (off|verify|update)." },
         "lock-mode": { "type": "string", "description": "Alias for lockMode." },
@@ -1599,6 +1604,10 @@
         "catalog": { "type": "string" },
         "catalogPath": { "type": "string" },
         "catalog-path": { "type": "string" },
+        "projects": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }], "description": "Optional project slugs to sync from the project catalog." },
+        "project": { "type": "string", "description": "Alias for projects when syncing one project slug." },
+        "projectSlugs": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }], "description": "Alias for projects." },
+        "project-slugs": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }], "description": "Alias for projects." },
         "sourcesRoot": { "type": "string" },
         "sources-root": { "type": "string" },
         "contentRoot": { "type": "string" },


### PR DESCRIPTION
## Summary
- add project filters to reusable sources-sync and project-docs-sync pipeline tasks
- make contribution validation catch low-value image alt text, separator noise, loose language markers, bullet characters, and product casing issues
- add strict/fail-on-warnings validation support for contribution automation

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "WebContributionProcessorTests|WebPipelineRunnerSourcesSyncTests|WebPipelineRunnerProjectDocsSyncTests"
- git diff --check