### PR TITLE
Add sitemap SEO consistency guards

### DIFF
--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2b.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2b.cs
@@ -134,6 +134,9 @@ public partial class WebSiteAuditOptimizeBuildTests
 
             Assert.True(File.Exists(Path.Combine(outputRoot, "404.html")));
             Assert.False(File.Exists(Path.Combine(outputRoot, "404", "index.html")));
+            var html = File.ReadAllText(Path.Combine(outputRoot, "404.html"));
+            Assert.Contains("<link rel=\"canonical\" href=\"https://example.test/404.html\" />", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("href=\"/404/\"", html, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.cs
@@ -565,6 +565,87 @@ public partial class WebSiteAuditOptimizeBuildTests
     }
 
     [Fact]
+    public void Build_SkipsAliasRedirects_ThatResolveToCanonicalRoute()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-self-alias-redirects-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "allianz.md"),
+                """
+                ---
+                title: Allianz
+                slug: allianz
+                aliases:
+                  - /allianz/
+                  - /?page_id=8328
+                ---
+
+                Allianz
+                """);
+
+            var themeRoot = Path.Combine(root, "themes", "self-alias-test");
+            Directory.CreateDirectory(Path.Combine(themeRoot, "layouts"));
+            File.WriteAllText(Path.Combine(themeRoot, "layouts", "page.html"),
+                """
+                <!doctype html>
+                <html><body>{{ content }}</body></html>
+                """);
+
+            var spec = new SiteSpec
+            {
+                Name = "Self Alias Redirect Test",
+                BaseUrl = "https://example.test",
+                ContentRoot = "content",
+                DefaultTheme = "self-alias-test",
+                ThemesRoot = "themes",
+                Collections = new[]
+                {
+                    new CollectionSpec
+                    {
+                        Name = "pages",
+                        Input = "content/pages",
+                        Output = "/",
+                        DefaultLayout = "page"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+            var outPath = Path.Combine(root, "_site");
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var result = WebSiteBuilder.Build(spec, plan, outPath);
+
+            var metadataPath = Path.Combine(result.OutputPath, "_powerforge", "redirects.json");
+            using var metadata = JsonDocument.Parse(File.ReadAllText(metadataPath));
+            var redirects = metadata.RootElement.GetProperty("redirects")
+                .EnumerateArray()
+                .Select(static entry => new
+                {
+                    From = entry.GetProperty("from").GetString(),
+                    To = entry.GetProperty("to").GetString()
+                })
+                .ToArray();
+
+            Assert.DoesNotContain(redirects, static entry =>
+                string.Equals(entry.From, "/allianz", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(entry.From, "/allianz/", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(redirects, static entry =>
+                string.Equals(entry.From, "/?page_id=8328", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(entry.To, "/allianz", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_FeedOptions_LimitItems_IncludeContent_AndRespectTaxonomyOutputs()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-feed-options-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSiteAuditSeoMetaTests.cs
+++ b/PowerForge.Tests/WebSiteAuditSeoMetaTests.cs
@@ -80,11 +80,118 @@ public class WebSiteAuditSeoMetaTests
                 </urlset>
                 """);
 
-            var result = WebSiteAuditor.Audit(CreateSeoOnlyOptions(root));
+            var options = CreateSeoOnlyOptions(root);
+            options.Include = new[] { "index.html" };
+
+            var result = WebSiteAuditor.Audit(options);
 
             Assert.Contains(result.Issues, issue => issue.Category == "seo" &&
                                                    issue.Path == "sitemap.xml" &&
                                                    issue.Hint.StartsWith("seo-sitemap-noindex", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Audit_FlagsSitemapCanonicalMismatch_WhenSitemapLocDiffersFromPageCanonical()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-audit-seo-sitemap-canonical-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "blog", "network-tools"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "blog", "network-tools", "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Network Tools</title>
+                  <link rel="canonical" href="https://example.test/blog/network-tools" />
+                  <meta property="og:title" content="Network Tools" />
+                  <meta property="og:description" content="Network diagnostics." />
+                  <meta property="og:url" content="https://example.test/blog/network-tools" />
+                  <meta property="og:image" content="https://example.test/assets/card.png" />
+                  <meta name="twitter:card" content="summary_large_image" />
+                  <meta name="twitter:title" content="Network Tools" />
+                  <meta name="twitter:description" content="Network diagnostics." />
+                  <meta name="twitter:url" content="https://example.test/blog/network-tools" />
+                  <meta name="twitter:image" content="https://example.test/assets/card.png" />
+                </head>
+                <body>Network Tools</body>
+                </html>
+                """);
+
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/blog/network-tools/</loc></url>
+                </urlset>
+                """);
+
+            var options = CreateSeoOnlyOptions(root);
+            options.Include = new[] { "index.html" };
+
+            var result = WebSiteAuditor.Audit(options);
+
+            Assert.Contains(result.Issues, issue => issue.Category == "seo" &&
+                                                   issue.Path == "sitemap.xml" &&
+                                                   issue.Hint.StartsWith("seo-sitemap-canonical-mismatch", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Audit_FlagsDuplicateSitemapLocs_WhenSameUrlAppearsMoreThanOnce()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-audit-seo-sitemap-duplicate-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "blog", "network-tools"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "blog", "network-tools", "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Network Tools</title>
+                  <link rel="canonical" href="https://example.test/blog/network-tools/" />
+                  <meta property="og:title" content="Network Tools" />
+                  <meta property="og:description" content="Network diagnostics." />
+                  <meta property="og:url" content="https://example.test/blog/network-tools/" />
+                  <meta property="og:image" content="https://example.test/assets/card.png" />
+                  <meta name="twitter:card" content="summary_large_image" />
+                  <meta name="twitter:title" content="Network Tools" />
+                  <meta name="twitter:description" content="Network diagnostics." />
+                  <meta name="twitter:url" content="https://example.test/blog/network-tools/" />
+                  <meta name="twitter:image" content="https://example.test/assets/card.png" />
+                </head>
+                <body>Network Tools</body>
+                </html>
+                """);
+
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/blog/network-tools/</loc></url>
+                  <url><loc>https://example.test/blog/network-tools/</loc></url>
+                </urlset>
+                """);
+
+            var result = WebSiteAuditor.Audit(CreateSeoOnlyOptions(root));
+
+            Assert.Contains(result.Issues, issue => issue.Category == "seo" &&
+                                                   issue.Path == "sitemap.xml" &&
+                                                   issue.Hint.StartsWith("seo-sitemap-duplicate-loc", StringComparison.Ordinal));
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteAuditSeoMetaTests.cs
+++ b/PowerForge.Tests/WebSiteAuditSeoMetaTests.cs
@@ -81,6 +81,7 @@ public class WebSiteAuditSeoMetaTests
                 """);
 
             var options = CreateSeoOnlyOptions(root);
+            // The sitemap SEO pass stays global even when the normal audit is scoped to a page sample.
             options.Include = new[] { "index.html" };
 
             var result = WebSiteAuditor.Audit(options);
@@ -134,6 +135,7 @@ public class WebSiteAuditSeoMetaTests
                 """);
 
             var options = CreateSeoOnlyOptions(root);
+            // The sitemap SEO pass stays global even when the normal audit is scoped to a page sample.
             options.Include = new[] { "index.html" };
 
             var result = WebSiteAuditor.Audit(options);

--- a/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
@@ -684,8 +684,7 @@ public static partial class WebSiteAuditor
     private static string[] BuildRouteCandidatesForSeoChecks(string relativePath, string routePath, AngleSharp.Dom.IDocument doc)
     {
         var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        AddRouteCandidates(candidates, routePath);
-        AddRouteCandidates(candidates, "/" + relativePath.Replace('\\', '/').TrimStart('/'));
+        AddGeneratedPageRouteCandidates(candidates, relativePath, routePath);
 
         if (doc.Head is not null)
         {
@@ -698,6 +697,19 @@ public static partial class WebSiteAuditor
         }
 
         return candidates.ToArray();
+    }
+
+    private static string[] BuildGeneratedPageRouteCandidates(string relativePath, string routePath)
+    {
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddGeneratedPageRouteCandidates(candidates, relativePath, routePath);
+        return candidates.ToArray();
+    }
+
+    private static void AddGeneratedPageRouteCandidates(HashSet<string> candidates, string relativePath, string routePath)
+    {
+        AddRouteCandidates(candidates, routePath);
+        AddRouteCandidates(candidates, "/" + relativePath.Replace('\\', '/').TrimStart('/'));
     }
 
     private static void AddRouteCandidates(HashSet<string> routes, string? value)
@@ -747,12 +759,74 @@ public static partial class WebSiteAuditor
         return raw;
     }
 
-    private static void ValidateSitemapNoIndexConsistency(
+    private static SitemapSeoScan CollectSitemapSeoMetadata(string siteRoot, IReadOnlyCollection<string> htmlFiles)
+    {
+        var noIndexRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var pagesByRoute = new Dictionary<string, SitemapPageSeoMetadata>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in htmlFiles)
+        {
+            string html;
+            try
+            {
+                html = File.ReadAllText(file);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(html))
+                continue;
+
+            AngleSharp.Dom.IDocument doc;
+            try
+            {
+                doc = HtmlParser.ParseWithAngleSharp(html);
+            }
+            catch
+            {
+                continue;
+            }
+
+            var relativePath = Path.GetRelativePath(siteRoot, file).Replace('\\', '/');
+            var routePath = ToRoutePath(relativePath);
+            if (doc.Head is not null)
+            {
+                var canonicalLinks = GetHeadLinkValues(doc, "canonical", html);
+                var canonicalHref = canonicalLinks.Length == 1 && IsAbsoluteHttpUrl(canonicalLinks[0])
+                    ? canonicalLinks[0]
+                    : string.Empty;
+                if (!string.IsNullOrWhiteSpace(canonicalHref))
+                {
+                    var metadata = new SitemapPageSeoMetadata(relativePath, canonicalHref);
+                    foreach (var candidate in BuildGeneratedPageRouteCandidates(relativePath, routePath))
+                    {
+                        if (!string.IsNullOrWhiteSpace(candidate))
+                            pagesByRoute[candidate] = metadata;
+                    }
+                }
+            }
+
+            if (!HasNoIndexRobots(doc, html))
+                continue;
+
+            foreach (var candidate in BuildRouteCandidatesForSeoChecks(relativePath, routePath, doc))
+            {
+                if (!string.IsNullOrWhiteSpace(candidate))
+                    noIndexRoutes.Add(candidate);
+            }
+        }
+
+        return new SitemapSeoScan(noIndexRoutes, pagesByRoute);
+    }
+
+    private static void ValidateSitemapSeoConsistency(
         string siteRoot,
         HashSet<string> noIndexRoutes,
+        Dictionary<string, SitemapPageSeoMetadata> pageMetadataByRoute,
         Action<string, string, string?, string, string?> addIssue)
     {
-        if (noIndexRoutes.Count == 0)
+        if (noIndexRoutes.Count == 0 && pageMetadataByRoute.Count == 0)
             return;
 
         var sitemapPath = Path.Combine(siteRoot, "sitemap.xml");
@@ -765,35 +839,98 @@ public static partial class WebSiteAuditor
             var locs = doc
                 .Descendants()
                 .Where(node => node.Name.LocalName.Equals("loc", StringComparison.OrdinalIgnoreCase))
-                .Select(node => NormalizeRouteLikeValue(node.Value))
-                .Where(path => !string.IsNullOrWhiteSpace(path))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(node => (Url: (node.Value ?? string.Empty).Trim(), ComparableUrl: NormalizeExactSeoUrl(node.Value), Route: NormalizeRouteLikeValue(node.Value)))
+                .Where(loc => !string.IsNullOrWhiteSpace(loc.Url))
                 .ToArray();
 
-            var noIndexInSitemap = new List<string>();
-            foreach (var loc in locs)
-            {
-                var matches = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                AddRouteCandidates(matches, loc);
-                if (matches.Any(candidate => noIndexRoutes.Contains(candidate)))
-                    noIndexInSitemap.Add(loc);
-            }
-
-            foreach (var route in noIndexInSitemap
-                         .Distinct(StringComparer.OrdinalIgnoreCase)
-                         .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            var duplicateLocs = locs
+                .Where(loc => !string.IsNullOrWhiteSpace(loc.ComparableUrl))
+                .GroupBy(loc => loc.ComparableUrl, StringComparer.OrdinalIgnoreCase)
+                .Where(group => group.Count() > 1)
+                .ToArray();
+            foreach (var duplicate in duplicateLocs
+                         .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
                          .Take(50))
             {
                 addIssue("warning", "seo", "sitemap.xml",
-                    $"sitemap includes noindex route '{route}'.",
-                    $"seo-sitemap-noindex:{route}");
+                    $"sitemap includes duplicate URL '{duplicate.First().Url}' ({duplicate.Count()} entries).",
+                    $"seo-sitemap-duplicate-loc:{duplicate.First().Route}");
             }
-
-            if (noIndexInSitemap.Count > 50)
+            if (duplicateLocs.Length > 50)
             {
                 addIssue("warning", "seo", "sitemap.xml",
-                    $"sitemap includes additional noindex routes ({noIndexInSitemap.Count - 50} more).",
-                    "seo-sitemap-noindex-more");
+                    $"sitemap includes additional duplicate URL groups ({duplicateLocs.Length - 50} more).",
+                    "seo-sitemap-duplicate-loc-more");
+            }
+
+            if (noIndexRoutes.Count > 0)
+            {
+                var noIndexInSitemap = new List<string>();
+                foreach (var loc in locs.Where(loc => !string.IsNullOrWhiteSpace(loc.Route)))
+                {
+                    var matches = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    AddRouteCandidates(matches, loc.Route);
+                    if (matches.Any(candidate => noIndexRoutes.Contains(candidate)))
+                        noIndexInSitemap.Add(loc.Route);
+                }
+
+                foreach (var route in noIndexInSitemap
+                             .Distinct(StringComparer.OrdinalIgnoreCase)
+                             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                             .Take(50))
+                {
+                    addIssue("warning", "seo", "sitemap.xml",
+                        $"sitemap includes noindex route '{route}'.",
+                        $"seo-sitemap-noindex:{route}");
+                }
+
+                if (noIndexInSitemap.Count > 50)
+                {
+                    addIssue("warning", "seo", "sitemap.xml",
+                        $"sitemap includes additional noindex routes ({noIndexInSitemap.Count - 50} more).",
+                        "seo-sitemap-noindex-more");
+                }
+            }
+
+            if (pageMetadataByRoute.Count > 0)
+            {
+                var canonicalMismatches = new List<(string Url, string Route, SitemapPageSeoMetadata Metadata)>();
+                foreach (var loc in locs
+                             .Where(loc => !string.IsNullOrWhiteSpace(loc.Route) && !string.IsNullOrWhiteSpace(loc.ComparableUrl))
+                             .GroupBy(loc => loc.ComparableUrl, StringComparer.OrdinalIgnoreCase)
+                             .Select(group => group.First()))
+                {
+                    var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    AddRouteCandidates(candidates, loc.Route);
+                    var metadata = candidates
+                        .Select(candidate => pageMetadataByRoute.TryGetValue(candidate, out var value) ? value : null)
+                        .FirstOrDefault(value => value is not null);
+                    if (metadata is null)
+                        continue;
+
+                    var canonicalUrl = NormalizeExactSeoUrl(metadata.CanonicalUrl);
+                    if (string.IsNullOrWhiteSpace(canonicalUrl))
+                        continue;
+
+                    if (!string.Equals(loc.ComparableUrl, canonicalUrl, StringComparison.OrdinalIgnoreCase))
+                        canonicalMismatches.Add((loc.Url, loc.Route, metadata));
+                }
+
+                foreach (var mismatch in canonicalMismatches
+                             .OrderBy(item => item.Route, StringComparer.OrdinalIgnoreCase)
+                             .Take(50))
+                {
+                    addIssue("warning", "seo", "sitemap.xml",
+                        $"sitemap URL '{mismatch.Url}' points to generated page '{mismatch.Metadata.RelativePath}' whose canonical is '{mismatch.Metadata.CanonicalUrl}'.",
+                        $"seo-sitemap-canonical-mismatch:{mismatch.Route}");
+                }
+
+                if (canonicalMismatches.Count > 50)
+                {
+                    addIssue("warning", "seo", "sitemap.xml",
+                        $"sitemap includes additional URLs whose page canonical points elsewhere ({canonicalMismatches.Count - 50} more).",
+                        "seo-sitemap-canonical-mismatch-more");
+                }
             }
         }
         catch (Exception ex)
@@ -803,6 +940,28 @@ public static partial class WebSiteAuditor
                 "seo-sitemap-parse");
         }
     }
+
+    private static string NormalizeExactSeoUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) ||
+            !Uri.TryCreate(value.Trim(), UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return string.Empty;
+        }
+
+        var path = string.IsNullOrWhiteSpace(uri.AbsolutePath) ? "/" : uri.AbsolutePath;
+        var authority = uri.IsDefaultPort
+            ? uri.IdnHost.ToLowerInvariant()
+            : uri.IdnHost.ToLowerInvariant() + ":" + uri.Port.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return $"{uri.Scheme.ToLowerInvariant()}://{authority}{path}{uri.Query}";
+    }
+
+    private sealed record SitemapPageSeoMetadata(string RelativePath, string CanonicalUrl);
+
+    private sealed record SitemapSeoScan(
+        HashSet<string> NoIndexRoutes,
+        Dictionary<string, SitemapPageSeoMetadata> PagesByRoute);
 
     private static string[] GetMetaPropertyValues(AngleSharp.Dom.IDocument doc, string propertyName, string? rawHtml = null)
     {

--- a/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
@@ -797,7 +797,7 @@ public static partial class WebSiteAuditor
             {
                 doc = HtmlParser.ParseWithAngleSharp(html);
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
             {
                 parseErrorCount++;
                 AddSample(parseErrorSamples, relativePath, sampleLimit);

--- a/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
@@ -782,7 +782,7 @@ public static partial class WebSiteAuditor
             {
                 html = File.ReadAllText(file);
             }
-            catch
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {
                 readErrorCount++;
                 AddSample(readErrorSamples, relativePath, sampleLimit);
@@ -797,7 +797,7 @@ public static partial class WebSiteAuditor
             {
                 doc = HtmlParser.ParseWithAngleSharp(html);
             }
-            catch
+            catch (Exception)
             {
                 parseErrorCount++;
                 AddSample(parseErrorSamples, relativePath, sampleLimit);
@@ -814,6 +814,7 @@ public static partial class WebSiteAuditor
                 if (!string.IsNullOrWhiteSpace(canonicalHref))
                 {
                     var metadata = new SitemapPageSeoMetadata(relativePath, canonicalHref);
+                    var routeCollisionRecordedForPage = false;
                     foreach (var candidate in BuildGeneratedPageRouteCandidates(relativePath, routePath))
                     {
                         if (!string.IsNullOrWhiteSpace(candidate))
@@ -822,8 +823,13 @@ public static partial class WebSiteAuditor
                                 (!string.Equals(existing.RelativePath, metadata.RelativePath, StringComparison.OrdinalIgnoreCase) ||
                                  !string.Equals(existing.CanonicalUrl, metadata.CanonicalUrl, StringComparison.OrdinalIgnoreCase)))
                             {
-                                routeCollisionCount++;
-                                AddSample(routeCollisionSamples, $"{candidate} ({existing.RelativePath}, {metadata.RelativePath})", sampleLimit);
+                                // Keep first-registered route metadata deterministic while reporting the colliding page once.
+                                if (!routeCollisionRecordedForPage)
+                                {
+                                    routeCollisionCount++;
+                                    AddSample(routeCollisionSamples, $"{candidate} ({existing.RelativePath}, {metadata.RelativePath})", sampleLimit);
+                                    routeCollisionRecordedForPage = true;
+                                }
                                 continue;
                             }
 

--- a/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
@@ -759,12 +759,24 @@ public static partial class WebSiteAuditor
         return raw;
     }
 
-    private static SitemapSeoScan CollectSitemapSeoMetadata(string siteRoot, IReadOnlyCollection<string> htmlFiles)
+    private static SitemapSeoScan CollectSitemapSeoMetadata(
+        string siteRoot,
+        IReadOnlyCollection<string> htmlFiles,
+        Action<string, string, string?, string, string?> addIssue)
     {
+        const int sampleLimit = 5;
         var noIndexRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var pagesByRoute = new Dictionary<string, SitemapPageSeoMetadata>(StringComparer.OrdinalIgnoreCase);
+        var readErrorSamples = new List<string>(sampleLimit);
+        var parseErrorSamples = new List<string>(sampleLimit);
+        var routeCollisionSamples = new List<string>(sampleLimit);
+        var readErrorCount = 0;
+        var parseErrorCount = 0;
+        var routeCollisionCount = 0;
+
         foreach (var file in htmlFiles)
         {
+            var relativePath = Path.GetRelativePath(siteRoot, file).Replace('\\', '/');
             string html;
             try
             {
@@ -772,6 +784,8 @@ public static partial class WebSiteAuditor
             }
             catch
             {
+                readErrorCount++;
+                AddSample(readErrorSamples, relativePath, sampleLimit);
                 continue;
             }
 
@@ -785,10 +799,11 @@ public static partial class WebSiteAuditor
             }
             catch
             {
+                parseErrorCount++;
+                AddSample(parseErrorSamples, relativePath, sampleLimit);
                 continue;
             }
 
-            var relativePath = Path.GetRelativePath(siteRoot, file).Replace('\\', '/');
             var routePath = ToRoutePath(relativePath);
             if (doc.Head is not null)
             {
@@ -802,7 +817,18 @@ public static partial class WebSiteAuditor
                     foreach (var candidate in BuildGeneratedPageRouteCandidates(relativePath, routePath))
                     {
                         if (!string.IsNullOrWhiteSpace(candidate))
+                        {
+                            if (pagesByRoute.TryGetValue(candidate, out var existing) &&
+                                (!string.Equals(existing.RelativePath, metadata.RelativePath, StringComparison.OrdinalIgnoreCase) ||
+                                 !string.Equals(existing.CanonicalUrl, metadata.CanonicalUrl, StringComparison.OrdinalIgnoreCase)))
+                            {
+                                routeCollisionCount++;
+                                AddSample(routeCollisionSamples, $"{candidate} ({existing.RelativePath}, {metadata.RelativePath})", sampleLimit);
+                                continue;
+                            }
+
                             pagesByRoute[candidate] = metadata;
+                        }
                     }
                 }
             }
@@ -817,7 +843,39 @@ public static partial class WebSiteAuditor
             }
         }
 
+        AddSitemapSeoScanSummaryIssue(addIssue, "seo-sitemap-metadata-read-error",
+            "sitemap SEO metadata scan skipped {0} HTML file(s) that could not be read.",
+            readErrorCount, readErrorSamples);
+        AddSitemapSeoScanSummaryIssue(addIssue, "seo-sitemap-metadata-parse-error",
+            "sitemap SEO metadata scan skipped {0} HTML file(s) that could not be parsed.",
+            parseErrorCount, parseErrorSamples);
+        AddSitemapSeoScanSummaryIssue(addIssue, "seo-sitemap-route-collision",
+            "sitemap SEO metadata scan found {0} generated route candidate collision(s).",
+            routeCollisionCount, routeCollisionSamples);
+
         return new SitemapSeoScan(noIndexRoutes, pagesByRoute);
+    }
+
+    private static void AddSample(List<string> samples, string value, int sampleLimit)
+    {
+        if (samples.Count < sampleLimit && !string.IsNullOrWhiteSpace(value))
+            samples.Add(value);
+    }
+
+    private static void AddSitemapSeoScanSummaryIssue(
+        Action<string, string, string?, string, string?> addIssue,
+        string hint,
+        string messageFormat,
+        int count,
+        List<string> samples)
+    {
+        if (count <= 0)
+            return;
+
+        var sampleText = samples.Count > 0 ? $" Sample: {string.Join(", ", samples)}." : string.Empty;
+        addIssue("warning", "seo", "sitemap.xml",
+            string.Format(System.Globalization.CultureInfo.InvariantCulture, messageFormat, count) + sampleText,
+            hint);
     }
 
     private static void ValidateSitemapSeoConsistency(
@@ -954,6 +1012,7 @@ public static partial class WebSiteAuditor
         var authority = uri.IsDefaultPort
             ? uri.IdnHost.ToLowerInvariant()
             : uri.IdnHost.ToLowerInvariant() + ":" + uri.Port.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        // Fragments are intentionally omitted because sitemap and canonical URLs identify documents, not anchors.
         return $"{uri.Scheme.ToLowerInvariant()}://{authority}{path}{uri.Query}";
     }
 

--- a/PowerForge.Web/Services/WebSiteAuditor.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.cs
@@ -42,7 +42,7 @@ public static partial class WebSiteAuditor
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToList();
         // Sitemap-wide SEO checks must still inspect every generated page when the main
-        // audit is narrowed with Include for a fast page sample.
+        // audit is narrowed with Include/MaxHtmlFiles for a fast page sample.
         var sitemapSeoHtmlFiles = options.CheckSeoMeta
             ? EnumerateHtmlFiles(siteRoot, Array.Empty<string>(), options.Exclude, options.UseDefaultExcludes)
                 .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)

--- a/PowerForge.Web/Services/WebSiteAuditor.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.cs
@@ -41,6 +41,11 @@ public static partial class WebSiteAuditor
         var allHtmlFiles = EnumerateHtmlFiles(siteRoot, options.Include, options.Exclude, options.UseDefaultExcludes)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var sitemapSeoHtmlFiles = options.CheckSeoMeta
+            ? EnumerateHtmlFiles(siteRoot, Array.Empty<string>(), options.Exclude, options.UseDefaultExcludes)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+            : new List<string>();
         var htmlFiles = allHtmlFiles;
         if (options.MaxHtmlFiles > 0 && htmlFiles.Count > options.MaxHtmlFiles)
             htmlFiles = htmlFiles.Take(options.MaxHtmlFiles).ToList();
@@ -118,7 +123,6 @@ public static partial class WebSiteAuditor
         var navMismatchCount = 0;
         var navCheckedCount = 0;
         var navIgnoredCount = 0;
-        var noIndexRoutes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var navMissing = new Dictionary<string, (int Count, List<string> Samples)>(StringComparer.OrdinalIgnoreCase);
         var duplicateIdCount = 0;
         var requiredRouteCount = 0;
@@ -326,14 +330,6 @@ public static partial class WebSiteAuditor
                 AddIssue("warning", "utf8", relativePath, "contains replacement characters (�).", "replacement-char");
 
             var routePath = ToRoutePath(relativePath);
-            if (HasNoIndexRobots(doc, html))
-            {
-                foreach (var candidate in BuildRouteCandidatesForSeoChecks(relativePath, routePath, doc))
-                {
-                    if (!string.IsNullOrWhiteSpace(candidate))
-                        noIndexRoutes.Add(candidate);
-                }
-            }
 
             if (options.CheckUtf8 && options.CheckMetaCharset && !HasUtf8Meta(doc))
                 AddIssue("warning", "utf8", relativePath, "missing UTF-8 meta charset declaration.", "meta-charset");
@@ -531,7 +527,10 @@ public static partial class WebSiteAuditor
         }
 
         if (options.CheckSeoMeta)
-            ValidateSitemapNoIndexConsistency(siteRoot, noIndexRoutes, AddIssue);
+        {
+            var sitemapSeoScan = CollectSitemapSeoMetadata(siteRoot, sitemapSeoHtmlFiles);
+            ValidateSitemapSeoConsistency(siteRoot, sitemapSeoScan.NoIndexRoutes, sitemapSeoScan.PagesByRoute, AddIssue);
+        }
 
         if (options.CheckRendered && htmlFiles.Count > 0)
         {

--- a/PowerForge.Web/Services/WebSiteAuditor.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.cs
@@ -41,6 +41,8 @@ public static partial class WebSiteAuditor
         var allHtmlFiles = EnumerateHtmlFiles(siteRoot, options.Include, options.Exclude, options.UseDefaultExcludes)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        // Sitemap-wide SEO checks must still inspect every generated page when the main
+        // audit is narrowed with Include for a fast page sample.
         var sitemapSeoHtmlFiles = options.CheckSeoMeta
             ? EnumerateHtmlFiles(siteRoot, Array.Empty<string>(), options.Exclude, options.UseDefaultExcludes)
                 .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
@@ -528,7 +530,7 @@ public static partial class WebSiteAuditor
 
         if (options.CheckSeoMeta)
         {
-            var sitemapSeoScan = CollectSitemapSeoMetadata(siteRoot, sitemapSeoHtmlFiles);
+            var sitemapSeoScan = CollectSitemapSeoMetadata(siteRoot, sitemapSeoHtmlFiles, AddIssue);
             ValidateSitemapSeoConsistency(siteRoot, sitemapSeoScan.NoIndexRoutes, sitemapSeoScan.PagesByRoute, AddIssue);
         }
 

--- a/PowerForge.Web/Services/WebSiteAuditor.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.cs
@@ -41,12 +41,15 @@ public static partial class WebSiteAuditor
         var allHtmlFiles = EnumerateHtmlFiles(siteRoot, options.Include, options.Exclude, options.UseDefaultExcludes)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var hasHtmlIncludeScope = options.Include.Any(pattern => !string.IsNullOrWhiteSpace(pattern));
         // Sitemap-wide SEO checks must still inspect every generated page when the main
         // audit is narrowed with Include/MaxHtmlFiles for a fast page sample.
         var sitemapSeoHtmlFiles = options.CheckSeoMeta
-            ? EnumerateHtmlFiles(siteRoot, Array.Empty<string>(), options.Exclude, options.UseDefaultExcludes)
-                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-                .ToList()
+            ? hasHtmlIncludeScope
+                ? EnumerateHtmlFiles(siteRoot, Array.Empty<string>(), options.Exclude, options.UseDefaultExcludes)
+                    .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                    .ToList()
+                : allHtmlFiles
             : new List<string>();
         var htmlFiles = allHtmlFiles;
         if (options.MaxHtmlFiles > 0 && htmlFiles.Count > options.MaxHtmlFiles)

--- a/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
@@ -168,6 +168,8 @@ public static partial class WebSiteBuilder
                         {
                             if (!seenAliasSources.Add(aliasSource))
                                 continue;
+                            if (IsAliasRedirectSourceEquivalentToRoute(aliasSource, route))
+                                continue;
                             redirects.Add(new RedirectSpec
                             {
                                 From = aliasSource,

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
@@ -608,21 +608,6 @@ public static partial class WebSiteBuilder
         return EnsureTrailingSlash(publicRoute, spec.TrailingSlash);
     }
 
-    private static string NormalizeRootNotFoundPublicRoute(string route)
-    {
-        if (string.IsNullOrWhiteSpace(route))
-            return route;
-
-        var suffixIndex = route.IndexOfAny(new[] { '?', '#' });
-        var path = suffixIndex >= 0 ? route.Substring(0, suffixIndex) : route;
-        var suffix = suffixIndex >= 0 ? route.Substring(suffixIndex) : string.Empty;
-        var normalizedPath = NormalizePath(path);
-        return normalizedPath.Equals("404", StringComparison.OrdinalIgnoreCase) ||
-               normalizedPath.Equals("404.html", StringComparison.OrdinalIgnoreCase)
-            ? "/404.html" + suffix
-            : route;
-    }
-
     private static string RebaseRouteForSelectedLanguageRootBuild(
         SiteSpec spec,
         string route)

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
@@ -15,13 +15,17 @@ public static partial class WebSiteBuilder
     {
         var localization = ResolveLocalizationConfig(spec);
         var currentCode = ResolveEffectiveLanguageCode(localization, page.Language);
-        var currentPath = string.IsNullOrWhiteSpace(page.OutputPath) ? "/" : page.OutputPath;
+        var currentPath = string.IsNullOrWhiteSpace(page.OutputPath)
+            ? "/"
+            : ResolvePublicRouteForLanguage(spec, localization, page.OutputPath, currentCode);
 
         var languages = new List<LocalizationLanguageRuntime>();
         foreach (var language in localization.Languages)
         {
             var route = ResolveLocalizedPageUrl(spec, localization, page, allItems, language.Code, currentCode);
-            var localRoute = string.IsNullOrWhiteSpace(route) ? currentPath : route;
+            var localRoute = string.IsNullOrWhiteSpace(route)
+                ? currentPath
+                : ResolvePublicRouteForLanguage(spec, localization, route, language.Code);
             var publicRoute = route;
             if (!string.IsNullOrWhiteSpace(route) &&
                 !route.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
@@ -597,7 +601,26 @@ public static partial class WebSiteBuilder
             return EnsureTrailingSlash(normalizedRoute, spec.TrailingSlash);
 
         var stripped = StripLanguagePrefix(localization, normalizedRoute);
-        return EnsureTrailingSlash(stripped, spec.TrailingSlash);
+        var publicRoute = NormalizeRootNotFoundPublicRoute(stripped);
+        if (publicRoute.StartsWith("/404.html", StringComparison.OrdinalIgnoreCase))
+            return publicRoute;
+
+        return EnsureTrailingSlash(publicRoute, spec.TrailingSlash);
+    }
+
+    private static string NormalizeRootNotFoundPublicRoute(string route)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return route;
+
+        var suffixIndex = route.IndexOfAny(new[] { '?', '#' });
+        var path = suffixIndex >= 0 ? route.Substring(0, suffixIndex) : route;
+        var suffix = suffixIndex >= 0 ? route.Substring(suffixIndex) : string.Empty;
+        var normalizedPath = NormalizePath(path);
+        return normalizedPath.Equals("404", StringComparison.OrdinalIgnoreCase) ||
+               normalizedPath.Equals("404.html", StringComparison.OrdinalIgnoreCase)
+            ? "/404.html" + suffix
+            : route;
     }
 
     private static string RebaseRouteForSelectedLanguageRootBuild(

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -1177,6 +1177,33 @@ public static partial class WebSiteBuilder
             .ToArray();
     }
 
+    private static bool IsAliasRedirectSourceEquivalentToRoute(string aliasSource, string route)
+    {
+        var source = NormalizeRedirectComparisonPath(aliasSource);
+        var target = NormalizeRedirectComparisonPath(route);
+        return !string.IsNullOrWhiteSpace(source) &&
+               source.Equals(target, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeRedirectComparisonPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        var normalized = NormalizeAlias(path).Trim();
+        var queryIndex = normalized.IndexOf('?', StringComparison.Ordinal);
+        var query = queryIndex >= 0 ? normalized[queryIndex..] : string.Empty;
+        var pathOnly = queryIndex >= 0 ? normalized[..queryIndex] : normalized;
+        if (!pathOnly.StartsWith("/", StringComparison.Ordinal))
+            pathOnly = "/" + pathOnly.TrimStart('/');
+
+        var route = "/" + NormalizePath(pathOnly).Trim('/');
+        if (route.Length > 1)
+            route = route.TrimEnd('/');
+
+        return route + query;
+    }
+
     private static string Slugify(string input)
     {
         if (string.IsNullOrWhiteSpace(input)) return string.Empty;

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -1101,6 +1101,7 @@ public static partial class WebSiteBuilder
         if (string.IsNullOrWhiteSpace(route))
             return route;
 
+        // Root 404 content is written as /404.html, so public metadata must not advertise /404/.
         var suffixIndex = route.IndexOfAny(new[] { '?', '#' });
         var path = suffixIndex >= 0 ? route.Substring(0, suffixIndex) : route;
         var suffix = suffixIndex >= 0 ? route.Substring(suffixIndex) : string.Empty;
@@ -1209,7 +1210,7 @@ public static partial class WebSiteBuilder
         var queryIndex = normalized.IndexOf('?', StringComparison.Ordinal);
         var query = queryIndex >= 0 ? normalized[queryIndex..] : string.Empty;
         var pathOnly = queryIndex >= 0 ? normalized[..queryIndex] : normalized;
-        // Query-bearing aliases can never equal a canonical route, but the path segment still needs route normalization.
+        // Query-bearing aliases are intentionally preserved as redirects, while their path segment still gets route normalization.
         if (!pathOnly.StartsWith("/", StringComparison.Ordinal))
             pathOnly = "/" + pathOnly.TrimStart('/');
 

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -1096,6 +1096,21 @@ public static partial class WebSiteBuilder
         return path;
     }
 
+    private static string NormalizeRootNotFoundPublicRoute(string route)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return route;
+
+        var suffixIndex = route.IndexOfAny(new[] { '?', '#' });
+        var path = suffixIndex >= 0 ? route.Substring(0, suffixIndex) : route;
+        var suffix = suffixIndex >= 0 ? route.Substring(suffixIndex) : string.Empty;
+        var normalizedPath = NormalizePath(path);
+        return normalizedPath.Equals("404", StringComparison.OrdinalIgnoreCase) ||
+               normalizedPath.Equals("404.html", StringComparison.OrdinalIgnoreCase)
+            ? "/404.html" + suffix
+            : route;
+    }
+
     private static string NormalizePath(string? path)
     {
         if (string.IsNullOrWhiteSpace(path)) return string.Empty;
@@ -1194,6 +1209,7 @@ public static partial class WebSiteBuilder
         var queryIndex = normalized.IndexOf('?', StringComparison.Ordinal);
         var query = queryIndex >= 0 ? normalized[queryIndex..] : string.Empty;
         var pathOnly = queryIndex >= 0 ? normalized[..queryIndex] : normalized;
+        // Query-bearing aliases can never equal a canonical route, but the path segment still needs route normalization.
         if (!pathOnly.StartsWith("/", StringComparison.Ordinal))
             pathOnly = "/" + pathOnly.TrimStart('/');
 


### PR DESCRIPTION
## Summary
- add PowerForge audit checks that compare sitemap URLs with generated page canonicals
- flag duplicate sitemap `<loc>` entries and keep the existing noindex-in-sitemap validation in the same SEO pass
- skip self-equivalent alias redirects while preserving query-based legacy redirects
- add regression coverage for sitemap/canonical drift and redirect alias handling

## Why
Google Search Console showed slash URL pages being treated as alternate canonicals because rendered pages declared a different canonical than the sitemap/runtime URL. This turns that class of SEO drift into an engine-level audit warning so PowerForge-built sites catch it before deploy.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSiteAuditSeoMetaTests|FullyQualifiedName~Build_SkipsAliasRedirects_ThatResolveToCanonicalRoute|FullyQualifiedName~Build_ExpandsAliasRedirects_ForSlashVariants" --no-restore`
- `git diff --check`

Note: the focused test run passed; it emitted transient copy retry warnings because another local PowerForge CLI audit was running at the same time.
