### PR TITLE
Fix API docs index canonical URLs

### DIFF
--- a/PowerForge.Tests/WebApiDocsSocialMetaTests.cs
+++ b/PowerForge.Tests/WebApiDocsSocialMetaTests.cs
@@ -55,7 +55,7 @@ public class WebApiDocsSocialMetaTests
             Assert.True(File.Exists(htmlIndexPath));
             var html = File.ReadAllText(htmlIndexPath);
             Assert.Contains("property=\"og:title\"", html, StringComparison.Ordinal);
-            Assert.Contains("property=\"og:url\" content=\"https://example.test/api\"", html, StringComparison.Ordinal);
+            Assert.Contains("property=\"og:url\" content=\"https://example.test/api/\"", html, StringComparison.Ordinal);
             Assert.Contains("property=\"og:image\" content=\"https://example.test/assets/social/share-card.png\"", html, StringComparison.Ordinal);
             Assert.Contains("property=\"og:image:alt\" content=\"Sample API Reference\"", html, StringComparison.Ordinal);
             Assert.Contains("property=\"og:image:width\" content=\"1200\"", html, StringComparison.Ordinal);
@@ -65,7 +65,7 @@ public class WebApiDocsSocialMetaTests
             Assert.Contains("name=\"twitter:creator\" content=\"@apiAuthor\"", html, StringComparison.Ordinal);
             Assert.Contains("name=\"twitter:image\" content=\"https://example.test/assets/social/share-card.png\"", html, StringComparison.Ordinal);
             Assert.Contains("name=\"twitter:image:alt\" content=\"Sample API Reference\"", html, StringComparison.Ordinal);
-            Assert.Contains("<link rel=\"canonical\" href=\"https://example.test/api\"", html, StringComparison.Ordinal);
+            Assert.Contains("<link rel=\"canonical\" href=\"https://example.test/api/\"", html, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
@@ -43,7 +43,7 @@ public static partial class WebApiDocsGenerator
         var fallbackCss = LoadAsset(options, "fallback.css", null);
         var cssBlock = BuildCssBlockWithFallback(fallbackCss, cssLinks, prismCss);
         var social = ResolveApiSocialProfile(options);
-        var indexRoute = NormalizeApiRoute(options.BaseUrl);
+        var indexRoute = NormalizeApiIndexRoute(options.BaseUrl);
 
         var indexTemplate = LoadTemplate(options, "index.html", options.IndexTemplatePath);
         var searchScript = JoinHtmlFragments(
@@ -141,7 +141,7 @@ public static partial class WebApiDocsGenerator
         {
             ["TITLE"] = System.Web.HttpUtility.HtmlEncode(options.Title),
             ["DESCRIPTION_META"] = BuildDescriptionMetaTag($"API reference for {options.Title}."),
-            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, options.Title, $"API reference for {options.Title}.", NormalizeApiRoute(baseUrl)),
+            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, options.Title, $"API reference for {options.Title}.", NormalizeApiIndexRoute(baseUrl)),
             ["HEAD_HTML"] = head,
             ["CRITICAL_CSS"] = criticalCss,
             ["CSS"] = cssBlock,
@@ -568,6 +568,25 @@ $@"<!doctype html>
         if (!trimmed.StartsWith("/"))
             trimmed = "/" + trimmed;
         return trimmed;
+    }
+
+    private static string NormalizeApiIndexRoute(string? route)
+    {
+        var normalized = NormalizeApiRoute(route);
+        if (string.IsNullOrWhiteSpace(normalized) ||
+            normalized.EndsWith("/", StringComparison.Ordinal))
+            return normalized;
+
+        var path = normalized;
+        var queryIndex = path.IndexOfAny(new[] { '?', '#' });
+        if (queryIndex >= 0)
+            path = path[..queryIndex];
+        if (Uri.TryCreate(normalized, UriKind.Absolute, out var absolute))
+            path = absolute.AbsolutePath;
+
+        return string.IsNullOrWhiteSpace(Path.GetExtension(path))
+            ? normalized + "/"
+            : normalized;
     }
 
     private static string ResolveApiAbsoluteUrl(string? siteBaseUrl, string? routeOrUrl)


### PR DESCRIPTION
## Summary
- canonicalize generated API docs landing pages as directory URLs
- keep API docs index Open Graph/Twitter URLs aligned with sitemap folder routes
- update focused social metadata coverage

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebApiDocsSocialMetaTests" --no-restore
- C:\Support\GitHub\PSPublishModule\PowerForge.Web.Cli\bin\Debug\net10.0\PowerForge.Web.Cli.exe pipeline --config .\pipeline.deploy.json --mode dev --only build-evotec-xyz,project-apidocs-evotec-xyz,sitemap-evotec-xyz,agent-ready-evotec-xyz,audit-evotec-xyz