### PR TITLE
Fix localized API docs SEO URLs

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerProjectApiDocsTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectApiDocsTests.cs
@@ -773,7 +773,7 @@ public class WebPipelineRunnerProjectApiDocsTests
                       {
                         "code": "fr",
                         "label": "Français",
-                        "baseUrl": "https://example.test"
+                        "baseUrl": "https://fr.example.test"
                       }
                     ]
                   },
@@ -842,6 +842,7 @@ public class WebPipelineRunnerProjectApiDocsTests
 
             Assert.True(result.Success);
             var html = File.ReadAllText(Path.Combine(root, "_site-fr", "projects", "alpha", "api", "index.html"));
+            Assert.Contains("<link rel=\"canonical\" href=\"https://fr.example.test/fr/projects/alpha/api/\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("id=\"overview\" href=\"/fr/projects/alpha/\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("id=\"api\" href=\"/fr/projects/alpha/api/\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("id=\"docs\" href=\"https://example.test/projects/alpha/docs/\"", html, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2b.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2b.cs
@@ -144,4 +144,112 @@ public partial class WebSiteAuditOptimizeBuildTests
                 Directory.Delete(root, true);
         }
     }
+
+    [Fact]
+    public void Build_LanguageRootRebase_PreservesFileAssetUrls()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-build-language-root-assets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var contentRoot = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(contentRoot);
+            File.WriteAllText(Path.Combine(contentRoot, "index.md"),
+                """
+                ---
+                title: Home
+                ---
+
+            # Home
+
+            <img src="/assets/logo.png" alt="Logo" />
+            """);
+            var localizedContentRoot = Path.Combine(contentRoot, "pl");
+            Directory.CreateDirectory(localizedContentRoot);
+            File.WriteAllText(Path.Combine(localizedContentRoot, "index.md"),
+                """
+                ---
+                title: Start
+                ---
+
+                # Start
+
+                <img src="/assets/logo.png" alt="Logo" />
+                """);
+
+            var spec = new SiteSpec
+            {
+                Name = "Test",
+                BaseUrl = "https://example.test",
+                ContentRoot = "content",
+                TrailingSlash = TrailingSlashMode.Always,
+                Localization = new LocalizationSpec
+                {
+                    Enabled = true,
+                    DefaultLanguage = "en",
+                    Languages = new[]
+                    {
+                        new LanguageSpec { Code = "en", Default = true, BaseUrl = "https://example.test" },
+                        new LanguageSpec { Code = "pl", BaseUrl = "https://pl.example.test", RenderAtRoot = true }
+                    }
+                },
+                Collections = new[]
+                {
+                    new CollectionSpec
+                    {
+                        Name = "pages",
+                        Input = "content/pages",
+                        Output = "/"
+                    }
+                },
+                AssetRegistry = new AssetRegistrySpec
+                {
+                    Bundles = new[]
+                    {
+                        new AssetBundleSpec
+                        {
+                            Name = "main",
+                            Css = new[] { "/assets/app.css" },
+                            Js = new[] { "/assets/app.js" }
+                        }
+                    },
+                    RouteBundles = new[]
+                    {
+                        new RouteBundleSpec { Match = "**", Bundles = new[] { "main" } }
+                    },
+                    Preloads = new[]
+                    {
+                        new PreloadSpec { Href = "/assets/font.woff2", As = "font", Type = "font/woff2" }
+                    }
+                },
+                Feed = new FeedSpec
+                {
+                    Enabled = true
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var outputRoot = Path.Combine(root, "_site");
+
+            WebSiteBuilder.Build(spec, plan, outputRoot, language: "pl", languageAsRoot: true);
+
+            var html = File.ReadAllText(Path.Combine(outputRoot, "index.html"));
+            Assert.Contains("href=\"/assets/app.css\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("src=\"/assets/app.js\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"/assets/font.woff2\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("src=\"/assets/logo.png\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/app.css/", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/app.js/", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/font.woff2/", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/assets/logo.png/", html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
 }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectApiDocs.cs
@@ -181,6 +181,7 @@ internal static partial class WebPipelineRunner
             WriteIndented = true
         };
         var siteSpec = TryLoadProjectApiSiteSpec(siteConfigPath, logger);
+        var apiSiteBaseUrl = ResolveProjectApiSiteBaseUrl(siteSpec, apiLanguage);
 
         var catalog = JsonSerializer.Deserialize<ProjectCatalogDocument>(File.ReadAllText(catalogPath), serializerOptions)
                       ?? new ProjectCatalogDocument();
@@ -247,6 +248,7 @@ internal static partial class WebPipelineRunner
                 siteSpec,
                 apiLanguage,
                 navSurfaceName,
+                apiSiteBaseUrl,
                 GetProjectApiDocsOverrides(project, baseDir)));
         }
 
@@ -343,6 +345,7 @@ internal static partial class WebPipelineRunner
                     suiteEntries,
                     defaultCssHref,
                     siteConfigPath,
+                    apiSiteBaseUrl,
                     suiteArtifacts?.SearchOutputPath,
                     suiteArtifacts?.XrefMapOutputPath,
                     suiteArtifacts?.CoverageOutputPath,
@@ -793,6 +796,7 @@ internal static partial class WebPipelineRunner
         SiteSpec? siteSpec,
         string language,
         string navSurfaceName,
+        string? siteBaseUrl,
         ProjectApiDocsCatalogOverrides? apiDocsOverrides)
     {
         var name = NormalizeOptionalString(project.Name) ?? slug;
@@ -815,6 +819,7 @@ internal static partial class WebPipelineRunner
             ["title"] = $"{name} API Reference",
             ["out"] = outputPath,
             ["baseUrl"] = apiBaseUrl,
+            ["siteBaseUrl"] = siteBaseUrl,
             ["language"] = string.IsNullOrWhiteSpace(language) ? "en" : language,
             ["docsHome"] = docsHomeUrl,
             ["navContextPath"] = "/",
@@ -1218,6 +1223,7 @@ internal static partial class WebPipelineRunner
         IReadOnlyList<WebApiDocsSuiteEntry> suiteEntries,
         string? cssHref,
         string? siteConfigPath,
+        string? siteBaseUrl,
         string? suiteSearchPath,
         string? suiteXrefMapPath,
         string? suiteCoveragePath,
@@ -1257,6 +1263,7 @@ internal static partial class WebPipelineRunner
                 DocsScriptPath = ResolvePath(baseDir, GetString(step, "docsScript") ?? GetString(step, "docs-script")),
                 NavJsonPath = siteConfigPath,
                 SiteConfigPath = siteConfigPath,
+                SiteBaseUrl = siteBaseUrl,
                 NavContextPath = GetString(step, "navContextPath") ?? GetString(step, "nav-context-path") ?? "/",
                 NavContextCollection = GetString(step, "navContextCollection") ?? GetString(step, "nav-context-collection"),
                 NavContextLayout = GetString(step, "navContextLayout") ?? GetString(step, "nav-context-layout"),
@@ -2496,6 +2503,15 @@ internal static partial class WebPipelineRunner
         var normalizedBaseUrl = baseUrl.TrimEnd('/') + "/";
         var normalizedRoute = EnsureProjectRouteTrailingSlash(route).TrimStart('/');
         return new Uri(new Uri(normalizedBaseUrl, UriKind.Absolute), normalizedRoute).ToString();
+    }
+
+    private static string? ResolveProjectApiSiteBaseUrl(SiteSpec? siteSpec, string? targetLanguage)
+    {
+        if (siteSpec is null)
+            return null;
+
+        return NormalizeOptionalString(ResolveProjectApiLanguageSpec(siteSpec, targetLanguage)?.BaseUrl) ??
+               NormalizeOptionalString(siteSpec.BaseUrl);
     }
 
     private static bool ProjectApiCollectionSupportsLanguage(SiteSpec siteSpec, string? collectionName, string? languageCode)

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
@@ -598,14 +598,34 @@ public static partial class WebSiteBuilder
             : route.StartsWith("/", StringComparison.Ordinal) ? route : "/" + route.TrimStart('/');
 
         if (!ShouldRenderLanguageAtRoot(localization, languageCode))
+        {
+            if (LooksLikeFileRoute(normalizedRoute))
+                return normalizedRoute;
+
             return EnsureTrailingSlash(normalizedRoute, spec.TrailingSlash);
+        }
 
         var stripped = StripLanguagePrefix(localization, normalizedRoute);
         var publicRoute = NormalizeRootNotFoundPublicRoute(stripped);
         if (publicRoute.StartsWith("/404.html", StringComparison.OrdinalIgnoreCase))
             return publicRoute;
+        if (LooksLikeFileRoute(publicRoute))
+            return publicRoute;
 
         return EnsureTrailingSlash(publicRoute, spec.TrailingSlash);
+    }
+
+    private static bool LooksLikeFileRoute(string? route)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return false;
+
+        var path = route.Trim();
+        var queryIndex = path.IndexOfAny(new[] { '?', '#' });
+        if (queryIndex >= 0)
+            path = path[..queryIndex];
+
+        return !string.IsNullOrWhiteSpace(Path.GetExtension(path));
     }
 
     private static string RebaseRouteForSelectedLanguageRootBuild(


### PR DESCRIPTION
## Summary
- pass language-specific site base URLs into generated project API docs and suite landing pages
- preserve file asset/feed URLs when rebasing selected languages to a root host
- add focused coverage for localized API docs canonicals and language-root file URL rebasing

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~Build_LanguageRootRebase_PreservesFileAssetUrls|FullyQualifiedName~Build_WritesRoot404HtmlForNotFoundSlug|FullyQualifiedName~RunPipeline_ProjectApiDocs_LocalizesProjectTabsAndFallsBackToDefaultLanguageForUnsupportedCollections" --no-restore
- C:\Support\GitHub\PSPublishModule\PowerForge.Web.Cli\bin\Debug\net10.0\PowerForge.Web.Cli.exe pipeline --config .\pipeline.deploy.json --mode dev --only build-evotec-pl,project-apidocs-evotec-pl,seo-smoke-evotec-pl,sitemap-evotec-pl,indexnow-evotec-pl,search-index-compat-evotec-pl,llms-evotec-pl,optimize-evotec-pl,hosting-evotec-pl,agent-ready-evotec-pl,audit-evotec-pl