### PR TITLE
Fix audit required static file routes

### DIFF
--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2.cs
@@ -635,6 +635,43 @@ public partial class WebSiteAuditOptimizeBuildTests
     }
 
     [Fact]
+    public void Audit_AcceptsRequiredStaticFileRoute()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-audit-required-static-route-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><header><nav><a href="/">Home</a></nav></header></body>
+                </html>
+                """);
+            File.WriteAllBytes(Path.Combine(root, "favicon.ico"), new byte[] { 0, 0, 1, 0, 0, 0 });
+
+            var result = WebSiteAuditor.Audit(new WebAuditOptions
+            {
+                SiteRoot = root,
+                RequiredRoutes = new[] { "/", "/favicon.ico" },
+                CheckLinks = false,
+                CheckAssets = false
+            });
+
+            Assert.True(result.Success);
+            Assert.Equal(2, result.RequiredRouteCount);
+            Assert.Equal(0, result.MissingRequiredRouteCount);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Audit_FailsWhenForbiddenRouteExists()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-audit-forbidden-routes-" + Guid.NewGuid().ToString("N"));
@@ -672,6 +709,44 @@ public partial class WebSiteAuditOptimizeBuildTests
             Assert.Equal(1, result.ForbiddenRouteCount);
             Assert.Equal(1, result.PresentForbiddenRouteCount);
             Assert.Contains(result.Errors, error => error.Contains("forbidden route '/pl/kontakt/' exists", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Audit_FailsWhenForbiddenStaticFileRouteExists()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-audit-forbidden-static-route-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head><title>Home</title></head>
+                <body><header><nav><a href="/">Home</a></nav></header></body>
+                </html>
+                """);
+            File.WriteAllBytes(Path.Combine(root, "favicon.ico"), new byte[] { 0, 0, 1, 0, 0, 0 });
+
+            var result = WebSiteAuditor.Audit(new WebAuditOptions
+            {
+                SiteRoot = root,
+                ForbiddenRoutes = new[] { "/favicon.ico" },
+                CheckLinks = false,
+                CheckAssets = false
+            });
+
+            Assert.False(result.Success);
+            Assert.Equal(1, result.ForbiddenRouteCount);
+            Assert.Equal(1, result.PresentForbiddenRouteCount);
+            Assert.Contains(result.Errors, error => error.Contains("forbidden route '/favicon.ico' exists", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
@@ -81,6 +81,18 @@ public static partial class WebSiteAuditor
         }
     }
 
+    private static IEnumerable<string> EnumerateRouteFiles(string root, string[] excludePatterns, bool useDefaultExcludes)
+    {
+        var excludes = BuildExcludePatterns(excludePatterns, useDefaultExcludes);
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(root, file).Replace('\\', '/');
+            if (excludes.Length > 0 && MatchesAny(excludes, relative))
+                continue;
+            yield return file;
+        }
+    }
+
     private static string[] NormalizePatterns(string[] patterns)
     {
         return patterns

--- a/PowerForge.Web/Services/WebSiteAuditor.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.cs
@@ -215,19 +215,26 @@ public static partial class WebSiteAuditor
             .Select(route => route.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        var htmlSet = new HashSet<string>(
-            htmlFiles.Select(path => Path.GetRelativePath(siteRoot, path).Replace('\\', '/')),
-            StringComparer.OrdinalIgnoreCase);
+        HashSet<string>? routeFileSet = null;
+        HashSet<string> GetRouteFileSet()
+        {
+            return routeFileSet ??= new HashSet<string>(
+                EnumerateRouteFiles(siteRoot, options.Exclude, options.UseDefaultExcludes)
+                    .Select(path => Path.GetRelativePath(siteRoot, path).Replace('\\', '/')),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
         requiredRouteCount = requiredRoutes.Length;
         if (requiredRoutes.Length > 0)
         {
+            var generatedRoutes = GetRouteFileSet();
             foreach (var requiredRoute in requiredRoutes)
             {
                 var candidates = ResolveRequiredRouteCandidates(requiredRoute);
                 if (candidates.Length == 0)
                     continue;
 
-                var exists = candidates.Any(candidate => htmlSet.Contains(candidate));
+                var exists = candidates.Any(candidate => generatedRoutes.Contains(candidate));
                 if (exists)
                     continue;
 
@@ -247,6 +254,7 @@ public static partial class WebSiteAuditor
         forbiddenRouteCount = forbiddenRoutes.Length;
         if (forbiddenRoutes.Length > 0)
         {
+            var generatedRoutes = GetRouteFileSet();
             foreach (var forbiddenRoute in forbiddenRoutes)
             {
                 var candidates = ResolveRequiredRouteCandidates(forbiddenRoute);
@@ -254,7 +262,7 @@ public static partial class WebSiteAuditor
                     continue;
 
                 var matches = candidates
-                    .Where(candidate => htmlSet.Contains(candidate))
+                    .Where(candidate => generatedRoutes.Contains(candidate))
                     .ToArray();
                 if (matches.Length == 0)
                     continue;


### PR DESCRIPTION
## Summary
- include generated static files when validating required/forbidden audit routes
- allow required routes such as `/favicon.ico` to be enforced
- add regression coverage for required static file routes

## Tests
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSiteAuditOptimizeBuildTests" --no-restore`
- Website `.xyz` deploy slice: `build-evotec-xyz`, `project-apidocs-evotec-xyz`, `audit-evotec-xyz`
- Website `.pl` deploy slice: `build-evotec-pl`, `project-apidocs-evotec-pl`, `audit-evotec-pl`
