### PR TITLE
Style generated XML sitemaps

### DIFF
--- a/PowerForge.Tests/WebSitemapGeneratorCanonicalizationTests.cs
+++ b/PowerForge.Tests/WebSitemapGeneratorCanonicalizationTests.cs
@@ -50,6 +50,163 @@ public class WebSitemapGeneratorCanonicalizationTests
     }
 
     [Fact]
+    public void Generate_WritesSitemapCss_AndEmitsProcessingInstruction()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-browser-style-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"), "<!doctype html><title>home</title>");
+
+            var result = WebSitemapGenerator.Generate(new WebSitemapOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                IncludeTextFiles = false
+            });
+
+            Assert.True(File.Exists(Path.Combine(root, "sitemap.css")));
+            var doc = XDocument.Load(result.OutputPath);
+            var stylesheet = doc.Nodes().OfType<XProcessingInstruction>().FirstOrDefault(node => node.Target == "xml-stylesheet");
+            Assert.NotNull(stylesheet);
+            Assert.Contains("href=\"/sitemap.css\"", stylesheet!.Data, StringComparison.OrdinalIgnoreCase);
+
+            var css = File.ReadAllText(Path.Combine(root, "sitemap.css"));
+            Assert.Contains("urlset::before", css, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_CanDisableBrowserStylesheet()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-browser-style-off-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"), "<!doctype html><title>home</title>");
+
+            var result = WebSitemapGenerator.Generate(new WebSitemapOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                IncludeTextFiles = false,
+                GenerateBrowserStylesheet = false
+            });
+
+            Assert.False(File.Exists(Path.Combine(root, "sitemap.css")));
+            var doc = XDocument.Load(result.OutputPath);
+            Assert.DoesNotContain(doc.Nodes().OfType<XProcessingInstruction>(), node => node.Target == "xml-stylesheet");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_CanUseCustomBrowserStylesheetHref()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-browser-style-custom-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"), "<!doctype html><title>home</title>");
+
+            var result = WebSitemapGenerator.Generate(new WebSitemapOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                IncludeTextFiles = false,
+                BrowserStylesheetHref = "assets/sitemap-view.css"
+            });
+
+            Assert.True(File.Exists(Path.Combine(root, "assets", "sitemap-view.css")));
+            var doc = XDocument.Load(result.OutputPath);
+            var stylesheet = doc.Nodes().OfType<XProcessingInstruction>().FirstOrDefault(node => node.Target == "xml-stylesheet");
+            Assert.NotNull(stylesheet);
+            Assert.Contains("href=\"/assets/sitemap-view.css\"", stylesheet!.Data, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_CanUseAbsoluteBrowserStylesheetHref()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-browser-style-absolute-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"), "<!doctype html><title>home</title>");
+
+            var result = WebSitemapGenerator.Generate(new WebSitemapOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                IncludeTextFiles = false,
+                BrowserStylesheetHref = "https://cdn.example.test/sitemap.css"
+            });
+
+            Assert.False(File.Exists(Path.Combine(root, "sitemap.css")));
+            var doc = XDocument.Load(result.OutputPath);
+            var stylesheet = doc.Nodes().OfType<XProcessingInstruction>().FirstOrDefault(node => node.Target == "xml-stylesheet");
+            Assert.NotNull(stylesheet);
+            Assert.Contains("href=\"https://cdn.example.test/sitemap.css\"", stylesheet!.Data, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_RejectsUnsafeBrowserStylesheetHref()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-browser-style-unsafe-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"), "<!doctype html><title>home</title>");
+
+            Assert.Throws<ArgumentException>(() => WebSitemapGenerator.Generate(new WebSitemapOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                IncludeTextFiles = false,
+                BrowserStylesheetHref = "/sitemap.css\" type=\"text/xsl"
+            }));
+
+            Assert.Throws<ArgumentException>(() => WebSitemapGenerator.Generate(new WebSitemapOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                IncludeTextFiles = false,
+                BrowserStylesheetHref = "javascript:alert(1)"
+            }));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Generate_CollapsesLegacyApiHtmlAliases_FromMergedApiSitemap()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-api-merge-alias-" + Guid.NewGuid().ToString("N"));
@@ -301,10 +458,15 @@ public class WebSitemapGeneratorCanonicalizationTests
             Assert.True(File.Exists(result.OutputPath));
             Assert.True(File.Exists(result.NewsOutputPath));
             Assert.True(File.Exists(result.IndexOutputPath));
+            Assert.True(File.Exists(Path.Combine(root, "sitemap.css")));
 
             var newsNs = XNamespace.Get("http://www.google.com/schemas/sitemap-news/0.9");
             var sitemapNs = XNamespace.Get("http://www.sitemaps.org/schemas/sitemap/0.9");
             var newsDoc = XDocument.Load(result.NewsOutputPath!);
+            var newsStylesheet = newsDoc.Nodes().OfType<XProcessingInstruction>().FirstOrDefault(node => node.Target == "xml-stylesheet");
+            Assert.NotNull(newsStylesheet);
+            Assert.Contains("href=\"/sitemap.css\"", newsStylesheet!.Data, StringComparison.OrdinalIgnoreCase);
+
             var newsUrls = newsDoc.Descendants(sitemapNs + "url").ToArray();
             Assert.Single(newsUrls);
             Assert.Contains("https://example.test/news/launch/",
@@ -319,6 +481,10 @@ public class WebSitemapGeneratorCanonicalizationTests
                     .Value);
 
             var indexDoc = XDocument.Load(result.IndexOutputPath!);
+            var stylesheet = indexDoc.Nodes().OfType<XProcessingInstruction>().FirstOrDefault(node => node.Target == "xml-stylesheet");
+            Assert.NotNull(stylesheet);
+            Assert.Contains("href=\"/sitemap.css\"", stylesheet!.Data, StringComparison.OrdinalIgnoreCase);
+
             var indexedLocs = indexDoc
                 .Descendants(sitemapNs + "sitemap")
                 .Select(node => node.Element(sitemapNs + "loc")?.Value)
@@ -419,12 +585,20 @@ public class WebSitemapGeneratorCanonicalizationTests
             var videoNs = XNamespace.Get("http://www.google.com/schemas/sitemap-video/1.1");
 
             var imageDoc = XDocument.Load(result.ImageOutputPath!);
+            var imageStylesheet = imageDoc.Nodes().OfType<XProcessingInstruction>().FirstOrDefault(node => node.Target == "xml-stylesheet");
+            Assert.NotNull(imageStylesheet);
+            Assert.Contains("href=\"/sitemap.css\"", imageStylesheet!.Data, StringComparison.OrdinalIgnoreCase);
+
             Assert.Contains(
                 "https://example.test/assets/hero.png",
                 imageDoc.Descendants(imageNs + "loc").Select(node => node.Value),
                 StringComparer.OrdinalIgnoreCase);
 
             var videoDoc = XDocument.Load(result.VideoOutputPath!);
+            var videoStylesheet = videoDoc.Nodes().OfType<XProcessingInstruction>().FirstOrDefault(node => node.Target == "xml-stylesheet");
+            Assert.NotNull(videoStylesheet);
+            Assert.Contains("href=\"/sitemap.css\"", videoStylesheet!.Data, StringComparison.OrdinalIgnoreCase);
+
             Assert.Contains(
                 "https://example.test/media/demo.mp4",
                 videoDoc.Descendants(videoNs + "content_loc").Select(node => node.Value),

--- a/PowerForge.Web/Services/WebSitemapGenerator.Specialized.cs
+++ b/PowerForge.Web/Services/WebSitemapGenerator.Specialized.cs
@@ -14,6 +14,7 @@ public static partial class WebSitemapGenerator
         string baseUrl,
         WebSitemapNewsOptions options,
         IReadOnlyList<WebSitemapEntry> entries,
+        string? browserStylesheetHref,
         string defaultLastModified,
         string outputPath)
     {
@@ -30,8 +31,8 @@ public static partial class WebSitemapGenerator
             ? "en"
             : options.PublicationLanguage.Trim();
 
-        var doc = new XDocument(
-            new XDeclaration("1.0", "UTF-8", null),
+        var doc = CreateSitemapDocument(
+            browserStylesheetHref,
             new XElement(
                 sitemapNs + "urlset",
                 new XAttribute(XNamespace.Xmlns + "news", newsNs.NamespaceName),
@@ -73,6 +74,7 @@ public static partial class WebSitemapGenerator
         string siteRoot,
         string baseUrl,
         string outputPath,
+        string? browserStylesheetHref,
         string defaultLastModified,
         params string?[] sitemapPaths)
     {
@@ -84,8 +86,8 @@ public static partial class WebSitemapGenerator
             .ToArray();
 
         var sitemapNs = XNamespace.Get("http://www.sitemaps.org/schemas/sitemap/0.9");
-        var doc = new XDocument(
-            new XDeclaration("1.0", "UTF-8", null),
+        var doc = CreateSitemapDocument(
+            browserStylesheetHref,
             new XElement(
                 sitemapNs + "sitemapindex",
                 normalizedPaths.Select(path =>
@@ -108,6 +110,7 @@ public static partial class WebSitemapGenerator
         string baseUrl,
         WebSitemapImageOptions options,
         IReadOnlyList<WebSitemapEntry> entries,
+        string? browserStylesheetHref,
         string outputPath)
     {
         var patterns = BuildImagePathPatterns(options.PathPatterns);
@@ -119,8 +122,8 @@ public static partial class WebSitemapGenerator
 
         var sitemapNs = XNamespace.Get("http://www.sitemaps.org/schemas/sitemap/0.9");
         var imageNs = XNamespace.Get("http://www.google.com/schemas/sitemap-image/1.1");
-        var doc = new XDocument(
-            new XDeclaration("1.0", "UTF-8", null),
+        var doc = CreateSitemapDocument(
+            browserStylesheetHref,
             new XElement(
                 sitemapNs + "urlset",
                 new XAttribute(XNamespace.Xmlns + "image", imageNs.NamespaceName),
@@ -155,6 +158,7 @@ public static partial class WebSitemapGenerator
         string baseUrl,
         WebSitemapVideoOptions options,
         IReadOnlyList<WebSitemapEntry> entries,
+        string? browserStylesheetHref,
         string outputPath)
     {
         var patterns = BuildVideoPathPatterns(options.PathPatterns);
@@ -166,8 +170,8 @@ public static partial class WebSitemapGenerator
 
         var sitemapNs = XNamespace.Get("http://www.sitemaps.org/schemas/sitemap/0.9");
         var videoNs = XNamespace.Get("http://www.google.com/schemas/sitemap-video/1.1");
-        var doc = new XDocument(
-            new XDeclaration("1.0", "UTF-8", null),
+        var doc = CreateSitemapDocument(
+            browserStylesheetHref,
             new XElement(
                 sitemapNs + "urlset",
                 new XAttribute(XNamespace.Xmlns + "video", videoNs.NamespaceName),

--- a/PowerForge.Web/Services/WebSitemapGenerator.cs
+++ b/PowerForge.Web/Services/WebSitemapGenerator.cs
@@ -54,6 +54,10 @@ public sealed class WebSitemapOptions
     public string? HtmlCssHref { get; set; }
     /// <summary>When true, include the generated HTML sitemap route in sitemap.xml.</summary>
     public bool IncludeGeneratedHtmlRouteInXml { get; set; }
+    /// <summary>When true, write a lightweight browser stylesheet for generated XML sitemaps. The generated stylesheet file is overwritten on each run when the href resolves under the site root.</summary>
+    public bool GenerateBrowserStylesheet { get; set; } = true;
+    /// <summary>Optional href override for the generated XML sitemap browser stylesheet.</summary>
+    public string? BrowserStylesheetHref { get; set; }
     /// <summary>Optional news sitemap generation options.</summary>
     public WebSitemapNewsOptions? NewsSitemap { get; set; }
     /// <summary>Optional image sitemap generation options.</summary>
@@ -142,6 +146,9 @@ public sealed class WebSitemapAlternate
 /// <summary>Generates sitemap.xml for the site output.</summary>
 public static partial class WebSitemapGenerator
 {
+    private const string DefaultSitemapStylesheetHref = "/sitemap.css";
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     private static readonly string[] DefaultExcludedHtmlPatterns =
     {
         "*.scripts.html",
@@ -315,9 +322,10 @@ public static partial class WebSitemapGenerator
         var entriesXml = orderedEntries
             .Select(u => BuildEntry(baseUrl, u, today, ns, xhtmlNs))
             .ToArray();
+        var browserStylesheetHref = ResolveSitemapBrowserStylesheetHref(options);
 
-        var doc = new XDocument(
-            new XDeclaration("1.0", "UTF-8", null),
+        var doc = CreateSitemapDocument(
+            browserStylesheetHref,
             new XElement(
                 ns + "urlset",
                 new XAttribute(XNamespace.Xmlns + "xhtml", xhtmlNs.NamespaceName),
@@ -328,6 +336,7 @@ public static partial class WebSitemapGenerator
         {
             doc.Save(stream);
         }
+        WriteSitemapBrowserStylesheet(siteRoot, browserStylesheetHref);
 
         if (generateNewsSitemap && !string.IsNullOrWhiteSpace(newsOutputPath))
         {
@@ -336,6 +345,7 @@ public static partial class WebSitemapGenerator
                 baseUrl,
                 options.NewsSitemap!,
                 orderedEntries,
+                browserStylesheetHref,
                 today,
                 newsOutputPath);
         }
@@ -346,6 +356,7 @@ public static partial class WebSitemapGenerator
                 baseUrl,
                 options.ImageSitemap!,
                 orderedEntries,
+                browserStylesheetHref,
                 imageOutputPath);
         }
         if (generateVideoSitemap && !string.IsNullOrWhiteSpace(videoOutputPath))
@@ -355,6 +366,7 @@ public static partial class WebSitemapGenerator
                 baseUrl,
                 options.VideoSitemap!,
                 orderedEntries,
+                browserStylesheetHref,
                 videoOutputPath);
         }
 
@@ -364,6 +376,7 @@ public static partial class WebSitemapGenerator
                 siteRoot,
                 baseUrl,
                 indexOutputPath,
+                browserStylesheetHref,
                 today,
                 outputPath,
                 newsOutputPath,
@@ -392,6 +405,127 @@ public static partial class WebSitemapGenerator
             HtmlOutputPath = htmlOutputPath,
             UrlCount = entriesXml.Length
         };
+    }
+
+    private static string? ResolveSitemapBrowserStylesheetHref(WebSitemapOptions options)
+    {
+        if (!options.GenerateBrowserStylesheet)
+            return null;
+
+        var href = string.IsNullOrWhiteSpace(options.BrowserStylesheetHref)
+            ? DefaultSitemapStylesheetHref
+            : options.BrowserStylesheetHref.Trim();
+        if (href.Contains('"') || href.Contains("?>", StringComparison.Ordinal))
+            throw new ArgumentException("BrowserStylesheetHref cannot contain double quotes or processing instruction terminators.", nameof(options));
+
+        if (Uri.TryCreate(href, UriKind.Absolute, out var absoluteUri))
+        {
+            if (absoluteUri.Scheme != Uri.UriSchemeHttp && absoluteUri.Scheme != Uri.UriSchemeHttps)
+                throw new ArgumentException("BrowserStylesheetHref absolute URLs must use http or https.", nameof(options));
+
+            return href;
+        }
+
+        return href.StartsWith("/", StringComparison.Ordinal) ? href : "/" + href;
+    }
+
+    private static XDocument CreateSitemapDocument(string? browserStylesheetHref, XElement root)
+    {
+        return string.IsNullOrWhiteSpace(browserStylesheetHref)
+            ? new XDocument(new XDeclaration("1.0", "UTF-8", null), root)
+            : new XDocument(
+                new XDeclaration("1.0", "UTF-8", null),
+                new XProcessingInstruction(
+                    "xml-stylesheet",
+                    $"type=\"text/css\" href=\"{browserStylesheetHref}\""),
+                root);
+    }
+
+    private static void WriteSitemapBrowserStylesheet(string siteRoot, string? browserStylesheetHref)
+    {
+        if (!TryResolveRootRelativeHref(siteRoot, browserStylesheetHref, out var outputPath))
+            return;
+
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? siteRoot);
+        File.WriteAllText(
+            outputPath,
+            """
+            urlset, sitemapindex {
+              display: block;
+              min-height: 100vh;
+              box-sizing: border-box;
+              padding: 24px;
+              background: #f8fafc;
+              color: #0f172a;
+              font-family: "Segoe UI", Arial, sans-serif;
+            }
+            urlset::before {
+              content: "XML sitemap";
+              display: block;
+              margin: 0 0 16px;
+              font-size: 28px;
+              font-weight: 700;
+            }
+            sitemapindex::before {
+              content: "XML sitemap index";
+              display: block;
+              margin: 0 0 16px;
+              font-size: 28px;
+              font-weight: 700;
+            }
+            url, sitemap {
+              display: block;
+              margin: 0 0 12px;
+              padding: 14px 16px;
+              border: 1px solid #dbe4ef;
+              border-radius: 8px;
+              background: #ffffff;
+              box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+            }
+            loc {
+              display: block;
+              margin: 0 0 8px;
+              color: #075985;
+              font-family: "Cascadia Mono", Consolas, monospace;
+              font-size: 14px;
+              word-break: break-all;
+            }
+            lastmod, changefreq, priority {
+              display: inline-block;
+              margin-right: 16px;
+              color: #475569;
+              font-size: 13px;
+            }
+            lastmod::before { content: "Last modified: "; font-weight: 600; color: #334155; }
+            changefreq::before { content: "Change frequency: "; font-weight: 600; color: #334155; }
+            priority::before { content: "Priority: "; font-weight: 600; color: #334155; }
+            link {
+              display: none;
+            }
+            """,
+            Utf8NoBom);
+    }
+
+    private static bool TryResolveRootRelativeHref(string siteRoot, string? href, out string outputPath)
+    {
+        outputPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(href))
+            return false;
+
+        var trimmed = href.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+            return false;
+
+        var pathOnly = trimmed.Split('?', '#')[0].TrimStart('/');
+        if (string.IsNullOrWhiteSpace(pathOnly))
+            return false;
+
+        var candidate = Path.GetFullPath(Path.Combine(siteRoot, pathOnly.Replace('/', Path.DirectorySeparatorChar)));
+        if (!IsUnderRoot(siteRoot, candidate))
+            return false;
+
+        outputPath = candidate;
+        return true;
     }
 
     private static string NormalizeRoute(string path)


### PR DESCRIPTION
## Summary
- add a generated `/sitemap.css` browser stylesheet for XML sitemap output
- emit an `xml-stylesheet` processing instruction from generated `sitemap.xml`
- keep sitemap XML machine-readable while making browser views readable for hreflang-heavy sitemap files

## Validation
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSitemapGeneratorCanonicalizationTests" --no-restore`
- `./build.ps1 -PipelineConfig .\pipeline.deploy.json -Only build-evotec-xyz,sitemap-evotec-xyz -ExpectedOutputPath _site-xyz -SkipSourcesSync`
- verified `_site-xyz/sitemap.xml` includes `/sitemap.css`, `_site-xyz/sitemap.css` exists, and XML parsing still finds sitemap loc entries
