### PR TITLE
Allow root-relative sitemap stylesheet hrefs

### DIFF
--- a/PowerForge.Web/Services/WebSitemapGenerator.cs
+++ b/PowerForge.Web/Services/WebSitemapGenerator.cs
@@ -418,6 +418,9 @@ public static partial class WebSitemapGenerator
         if (href.Contains('"') || href.Contains("?>", StringComparison.Ordinal))
             throw new ArgumentException("BrowserStylesheetHref cannot contain double quotes or processing instruction terminators.", nameof(options));
 
+        if (href.StartsWith("/", StringComparison.Ordinal))
+            return href;
+
         if (Uri.TryCreate(href, UriKind.Absolute, out var absoluteUri))
         {
             if (absoluteUri.Scheme != Uri.UriSchemeHttp && absoluteUri.Scheme != Uri.UriSchemeHttps)


### PR DESCRIPTION
## Summary
- allow root-relative sitemap browser stylesheet hrefs before absolute URI scheme validation
- keeps http/https absolute stylesheet URLs validated for CDN use

## Validation
- dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSitemapGeneratorCanonicalizationTests" --no-restore
- git diff --check