### PR TITLE
Write root-relative sitemap stylesheet files

### DIFF
--- a/PowerForge.Web/Services/WebSitemapGenerator.cs
+++ b/PowerForge.Web/Services/WebSitemapGenerator.cs
@@ -516,7 +516,8 @@ public static partial class WebSitemapGenerator
             return false;
 
         var trimmed = href.Trim();
-        if (Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+        if (!trimmed.StartsWith("/", StringComparison.Ordinal) &&
+            Uri.TryCreate(trimmed, UriKind.Absolute, out _))
             return false;
 
         var pathOnly = trimmed.Split('?', '#')[0].TrimStart('/');


### PR DESCRIPTION
## Summary
- allow root-relative sitemap browser stylesheet hrefs to resolve to files under the site root on Linux
- keeps absolute CDN stylesheet hrefs from writing local files

## Validation
- dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSitemapGeneratorCanonicalizationTests" --no-restore
- git diff --check