### PR TITLE
Add module-scoped ALC bootstrapper generation

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 ﻿# PSPublishModule Changelog
 
+## Unreleased
+### What's Changed
+- Added opt-in module-scoped `UseAssemblyLoadContext` / `NETAssemblyLoadContext` loading for binary modules. The PowerShell Core export bridge uses the private `PSModuleInfo.AddExportedCmdlet` method when available and falls back to a warning if a future PowerShell version removes it.
+
 ## 2.0.19 - 2025.06.17
 ### What's Changed
 * Improve error handling in release utilities by @PrzemyslawKlys in https://github.com/EvotecIT/PSPublishModule/pull/32

--- a/PSPublishModule/Cmdlets/NewConfigurationBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationBuildCommand.cs
@@ -266,6 +266,11 @@ public sealed class NewConfigurationBuildCommand : PSCmdlet
     /// <summary>Handle runtimes folder when copying libraries.</summary>
     [Parameter] public SwitchParameter NETHandleRuntimes { get; set; }
 
+    /// <summary>Load the binary module through a custom AssemblyLoadContext on PowerShell Core.</summary>
+    [Parameter]
+    [Alias("UseAssemblyLoadContext")]
+    public SwitchParameter NETAssemblyLoadContext { get; set; }
+
     /// <summary>Kill locking processes before install.</summary>
     [Parameter] public SwitchParameter KillLockersBeforeInstall { get; set; }
 
@@ -379,6 +384,8 @@ public sealed class NewConfigurationBuildCommand : PSCmdlet
             NETSearchClass = NETSearchClass,
             NETHandleRuntimesSpecified = bound.ContainsKey(nameof(NETHandleRuntimes)),
             NETHandleRuntimes = NETHandleRuntimes.IsPresent,
+            NETAssemblyLoadContextSpecified = bound.ContainsKey(nameof(NETAssemblyLoadContext)),
+            NETAssemblyLoadContext = NETAssemblyLoadContext.IsPresent,
             KillLockersBeforeInstallSpecified = bound.ContainsKey(nameof(KillLockersBeforeInstall)),
             KillLockersBeforeInstall = KillLockersBeforeInstall.IsPresent,
             KillLockersForceSpecified = bound.ContainsKey(nameof(KillLockersForce)),

--- a/PowerForge.PowerShell/Models/BuildConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/BuildConfigurationRequest.cs
@@ -100,6 +100,8 @@ internal sealed class BuildConfigurationRequest
     public string? NETSearchClass { get; set; }
     public bool NETHandleRuntimesSpecified { get; set; }
     public bool NETHandleRuntimes { get; set; }
+    public bool NETAssemblyLoadContextSpecified { get; set; }
+    public bool NETAssemblyLoadContext { get; set; }
     public bool KillLockersBeforeInstallSpecified { get; set; }
     public bool KillLockersBeforeInstall { get; set; }
     public bool KillLockersForceSpecified { get; set; }

--- a/PowerForge.PowerShell/Services/BuildConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/BuildConfigurationFactory.cs
@@ -177,6 +177,7 @@ internal sealed class BuildConfigurationFactory
         if (request.NETSearchClassSpecified) { EnsureBuildLibraries(); buildLibraries!.SearchClass = request.NETSearchClass; }
         if (request.NETBinaryModuleDocumentationSpecified) { EnsureBuildLibraries(); buildLibraries!.NETBinaryModuleDocumentation = request.NETBinaryModuleDocumentation; }
         if (request.NETHandleRuntimesSpecified) { EnsureBuildLibraries(); buildLibraries!.HandleRuntimes = request.NETHandleRuntimes; }
+        if (request.NETAssemblyLoadContextSpecified) { EnsureBuildLibraries(); buildLibraries!.UseAssemblyLoadContext = request.NETAssemblyLoadContext; }
         if (request.NETDoNotCopyLibrariesRecursivelySpecified) { EnsureBuildLibraries(); buildLibraries!.NETDoNotCopyLibrariesRecursively = request.NETDoNotCopyLibrariesRecursively; }
 
         if (buildLibraries is null)

--- a/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
+++ b/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
@@ -126,6 +126,11 @@ public static class LegacySegmentAdapter
                         NETProjectPath = GetString(buildLibraries, "NETProjectPath"),
                         ExcludeLibraryFilter = GetStringArray(buildLibraries, "ExcludeLibraryFilter") ?? GetStringArray(buildLibraries, "NETExcludeLibraryFilter"),
                         IgnoreLibraryOnLoad = GetStringArray(buildLibraries, "IgnoreLibraryOnLoad") ?? GetStringArray(buildLibraries, "NETIgnoreLibraryOnLoad"),
+                        UseAssemblyLoadContext = HasKey(buildLibraries, "UseAssemblyLoadContext")
+                            ? GetBool(buildLibraries, "UseAssemblyLoadContext")
+                            : HasKey(buildLibraries, "NETAssemblyLoadContext")
+                                ? GetBool(buildLibraries, "NETAssemblyLoadContext")
+                                : null,
                         NETDoNotCopyLibrariesRecursively = HasKey(buildLibraries, "NETDoNotCopyLibrariesRecursively")
                             ? GetBool(buildLibraries, "NETDoNotCopyLibrariesRecursively")
                             : null
@@ -198,6 +203,11 @@ public static class LegacySegmentAdapter
                     NETProjectPath = GetString(conf, "NETProjectPath"),
                     ExcludeLibraryFilter = GetStringArray(conf, "ExcludeLibraryFilter") ?? GetStringArray(conf, "NETExcludeLibraryFilter"),
                     IgnoreLibraryOnLoad = GetStringArray(conf, "IgnoreLibraryOnLoad") ?? GetStringArray(conf, "NETIgnoreLibraryOnLoad"),
+                    UseAssemblyLoadContext = HasKey(conf, "UseAssemblyLoadContext")
+                        ? GetBool(conf, "UseAssemblyLoadContext")
+                        : HasKey(conf, "NETAssemblyLoadContext")
+                            ? GetBool(conf, "NETAssemblyLoadContext")
+                            : null,
                     NETDoNotCopyLibrariesRecursively = HasKey(conf, "NETDoNotCopyLibrariesRecursively")
                         ? GetBool(conf, "NETDoNotCopyLibrariesRecursively")
                         : null

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
@@ -368,6 +368,7 @@ public sealed partial class ModulePipelineRunner
                 exports,
                 exportAssemblies,
                 handleRuntimes,
+                plan?.BuildSpec.UseAssemblyLoadContext ?? false,
                 conditionalExportDependencies);
         }
         catch (Exception ex)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
@@ -368,8 +368,10 @@ public sealed partial class ModulePipelineRunner
                 exports,
                 exportAssemblies,
                 handleRuntimes,
-                plan?.BuildSpec.UseAssemblyLoadContext ?? false,
-                conditionalExportDependencies);
+                useAssemblyLoadContext: plan?.BuildSpec.UseAssemblyLoadContext ?? false,
+                conditionalFunctionDependencies: conditionalExportDependencies,
+                targetFrameworks: plan?.BuildSpec.Frameworks,
+                log: message => _logger.Info(message));
         }
         catch (Exception ex)
         {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -265,7 +265,10 @@ public sealed partial class ModulePipelineRunner
                     if (bl.ExcludeLibraryFilter is { Length: > 0 }) excludeLibraryFilterFromSegments = bl.ExcludeLibraryFilter;
                     if (bl.NETDoNotCopyLibrariesRecursively.HasValue) doNotCopyLibrariesRecursivelyFromSegments = bl.NETDoNotCopyLibrariesRecursively.Value;
                     if (bl.HandleRuntimes.HasValue) handleRuntimesFromSegments = bl.HandleRuntimes.Value;
-                    if (bl.UseAssemblyLoadContext.HasValue) useAssemblyLoadContextFromSegments = bl.UseAssemblyLoadContext.Value;
+                    if (bl.UseAssemblyLoadContext.HasValue)
+                        useAssemblyLoadContextFromSegments = bl.UseAssemblyLoadContext.Value;
+                    else if (bl.NETAssemblyLoadContext.HasValue)
+                        useAssemblyLoadContextFromSegments = bl.NETAssemblyLoadContext.Value;
                     if (bl.BinaryModuleCmdletScanDisabled.HasValue) disableBinaryCmdletScanFromSegments = bl.BinaryModuleCmdletScanDisabled.Value;
                     if (bl.NETBinaryModuleDocumentation.HasValue) binaryModuleDocumentationRequested = bl.NETBinaryModuleDocumentation.Value;
                     break;

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -843,7 +843,7 @@ public sealed partial class ModulePipelineRunner
             reasons.Add("NETHandleRuntimes");
 
         if (effectiveUseAssemblyLoadContext)
-            reasons.Add("NETAssemblyLoadContext");
+            reasons.Add("UseAssemblyLoadContext");
 
         if (binaryModuleDocumentationRequested)
             reasons.Add("NETBinaryModuleDocumentation");

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -518,6 +518,7 @@ public sealed partial class ModulePipelineRunner
                 excludeLibraryFilterFromSegments,
                 doNotCopyLibrariesRecursivelyFromSegments,
                 handleRuntimesFromSegments,
+                useAssemblyLoadContextFromSegments,
                 resolveBinaryConflictsProjectName,
                 binaryModuleDocumentationRequested == true);
 
@@ -794,6 +795,7 @@ public sealed partial class ModulePipelineRunner
         string[]? excludeLibraryFilterFromSegments,
         bool? doNotCopyLibrariesRecursivelyFromSegments,
         bool? handleRuntimesFromSegments,
+        bool? useAssemblyLoadContextFromSegments,
         string? resolveBinaryConflictsProjectName,
         bool binaryModuleDocumentationRequested)
     {
@@ -806,6 +808,8 @@ public sealed partial class ModulePipelineRunner
             doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively;
         var effectiveHandleRuntimes =
             handleRuntimesFromSegments ?? spec.Build.HandleRuntimes;
+        var effectiveUseAssemblyLoadContext =
+            useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext;
         var hasExplicitBinaryIntentBeyondFramework =
             syncNETProjectVersion
             || hasBinaryModules
@@ -814,6 +818,7 @@ public sealed partial class ModulePipelineRunner
             || HasAnyConfiguredValues(spec.Build.ExcludeLibraryFilter)
             || effectiveDoNotCopyLibrariesRecursively
             || effectiveHandleRuntimes
+            || effectiveUseAssemblyLoadContext
             || binaryModuleDocumentationRequested;
 
         if (syncNETProjectVersion)
@@ -836,6 +841,9 @@ public sealed partial class ModulePipelineRunner
 
         if (effectiveHandleRuntimes)
             reasons.Add("NETHandleRuntimes");
+
+        if (effectiveUseAssemblyLoadContext)
+            reasons.Add("NETAssemblyLoadContext");
 
         if (binaryModuleDocumentationRequested)
             reasons.Add("NETBinaryModuleDocumentation");

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -71,6 +71,7 @@ public sealed partial class ModulePipelineRunner
         string[]? excludeLibraryFilterFromSegments = null;
         bool? doNotCopyLibrariesRecursivelyFromSegments = null;
         bool? handleRuntimesFromSegments = null;
+        bool? useAssemblyLoadContextFromSegments = null;
         bool? disableBinaryCmdletScanFromSegments = null;
         string? resolveBinaryConflictsProjectName = null;
         bool? binaryModuleDocumentationRequested = null;
@@ -264,6 +265,7 @@ public sealed partial class ModulePipelineRunner
                     if (bl.ExcludeLibraryFilter is { Length: > 0 }) excludeLibraryFilterFromSegments = bl.ExcludeLibraryFilter;
                     if (bl.NETDoNotCopyLibrariesRecursively.HasValue) doNotCopyLibrariesRecursivelyFromSegments = bl.NETDoNotCopyLibrariesRecursively.Value;
                     if (bl.HandleRuntimes.HasValue) handleRuntimesFromSegments = bl.HandleRuntimes.Value;
+                    if (bl.UseAssemblyLoadContext.HasValue) useAssemblyLoadContextFromSegments = bl.UseAssemblyLoadContext.Value;
                     if (bl.BinaryModuleCmdletScanDisabled.HasValue) disableBinaryCmdletScanFromSegments = bl.BinaryModuleCmdletScanDisabled.Value;
                     if (bl.NETBinaryModuleDocumentation.HasValue) binaryModuleDocumentationRequested = bl.NETBinaryModuleDocumentation.Value;
                     break;
@@ -537,6 +539,7 @@ public sealed partial class ModulePipelineRunner
             ExcludeLibraryFilter = excludeLibraryFilterFromSegments ?? spec.Build.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively,
             HandleRuntimes = handleRuntimesFromSegments ?? spec.Build.HandleRuntimes,
+            UseAssemblyLoadContext = useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext,
             DisableBinaryCmdletScan = disableBinaryCmdletScanFromSegments ?? spec.Build.DisableBinaryCmdletScan,
             CsprojRequiredReasons = string.IsNullOrWhiteSpace(csproj) ? csprojRequiredReasons : Array.Empty<string>(),
             BinaryConflictPriorityModuleNames = requiredModulesDraft

--- a/PowerForge.Tests/BuildConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/BuildConfigurationFactoryTests.cs
@@ -27,6 +27,8 @@ public sealed class BuildConfigurationFactoryTests
             NETConfiguration = "Release",
             NETProjectPathSpecified = true,
             NETProjectPath = "src/Sample.csproj",
+            NETAssemblyLoadContextSpecified = true,
+            NETAssemblyLoadContext = true,
             SkipBuiltinReplacementsSpecified = true,
             SkipBuiltinReplacements = true
         });
@@ -48,6 +50,7 @@ public sealed class BuildConfigurationFactoryTests
         Assert.True(libraries.BuildLibraries.Enable);
         Assert.Equal("Release", libraries.BuildLibraries.Configuration);
         Assert.Equal("src/Sample.csproj", libraries.BuildLibraries.NETProjectPath);
+        Assert.True(libraries.BuildLibraries.UseAssemblyLoadContext);
 
         var placeholder = Assert.IsType<ConfigurationPlaceHolderOptionSegment>(segments[3]);
         Assert.True(placeholder.PlaceHolderOption.SkipBuiltinReplacements);

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -66,6 +66,22 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void ResolveAssemblyLoadContextTargetFramework_UsesLowestModernModuleFramework()
+    {
+        var framework = ModuleBootstrapperGenerator.ResolveAssemblyLoadContextTargetFramework(new[] { "net472", "net8.0", "net6.0-windows" });
+
+        Assert.Equal("net6.0", framework);
+    }
+
+    [Fact]
+    public void ResolveAssemblyLoadContextTargetFramework_DefaultsToNet8WhenNoModernFrameworkIsKnown()
+    {
+        var framework = ModuleBootstrapperGenerator.ResolveAssemblyLoadContextTargetFramework(new[] { "net472", "netstandard2.0" });
+
+        Assert.Equal("net8.0", framework);
+    }
+
+    [Fact]
     [Trait("Category", "Integration")]
     public void Generate_WithAssemblyLoadContext_WritesAlcBootstrapperAndKeepsDesktopLibrariesScript()
     {
@@ -91,6 +107,7 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", bootstrapper);
             Assert.Contains("DemoModule.ModuleLoadContext.dll", bootstrapper);
             Assert.Contains("LoadModule($ModuleAssemblyPath, 'DemoModule')", bootstrapper);
+            Assert.Contains("-PassThru -ErrorAction Stop", bootstrapper);
             Assert.Contains("AddExportedCmdlet", bootstrapper);
             Assert.Contains("$PSEdition -ne 'Core'", bootstrapper);
             Assert.Contains("$LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'DemoModule.Libraries.ps1')", bootstrapper);

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -66,6 +66,45 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void Generate_WithAssemblyLoadContext_WritesAlcBootstrapperAndSkipsLibrariesScript()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
+        Directory.CreateDirectory(Path.Combine(root, "Lib", "Default"));
+        File.WriteAllText(Path.Combine(root, "Lib", "Core", "DemoModule.dll"), string.Empty);
+        File.WriteAllText(Path.Combine(root, "Lib", "Core", "Dependency.dll"), string.Empty);
+        File.WriteAllText(Path.Combine(root, "Lib", "Default", "DemoModule.dll"), string.Empty);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true);
+
+            var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
+            Assert.Contains("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", bootstrapper);
+            Assert.Contains("DemoModule.ModuleLoadContext.dll", bootstrapper);
+            Assert.Contains("LoadModule($ModuleAssemblyPath, 'DemoModule')", bootstrapper);
+            Assert.Contains("AddExportedCmdlet", bootstrapper);
+            Assert.DoesNotContain("$LibrariesScript =", bootstrapper);
+
+            Assert.True(File.Exists(Path.Combine(root, "Lib", "Core", "DemoModule.ModuleLoadContext.dll")));
+            Assert.False(File.Exists(Path.Combine(root, "Lib", "Default", "DemoModule.ModuleLoadContext.dll")));
+            Assert.False(File.Exists(Path.Combine(root, "DemoModule.Libraries.ps1")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Generate_WithScriptLayoutOnly_WritesScriptLoaderWithoutBinaryLoader()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-script-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -131,8 +131,8 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("LoadModule($ModuleAssemblyPath, 'DemoModule')", bootstrapper);
             Assert.Contains("-PassThru -ErrorAction Stop", bootstrapper);
             Assert.Contains("AddExportedCmdlet", bootstrapper);
-            Assert.Contains("NotSupportedException", bootstrapper);
-            Assert.Contains("cannot be exported from the ALC-loaded module", bootstrapper);
+            Assert.Contains("Falling back to direct Import-Module", bootstrapper);
+            Assert.Contains("will load from the default context", bootstrapper);
             Assert.Contains("$PSEdition -ne 'Core'", bootstrapper);
             Assert.Contains("$LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'DemoModule.Libraries.ps1')", bootstrapper);
 

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -82,6 +82,28 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void ResolveAssemblyLoadContextTargetDirectories_PrefersStandardWhenAllLibLayoutsExist()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-layout-" + Guid.NewGuid().ToString("N"));
+        var libRoot = Path.Combine(root, "Lib");
+        Directory.CreateDirectory(Path.Combine(libRoot, "Standard"));
+        Directory.CreateDirectory(Path.Combine(libRoot, "Core"));
+        Directory.CreateDirectory(Path.Combine(libRoot, "Default"));
+
+        try
+        {
+            var directories = ModuleBootstrapperGenerator.ResolveAssemblyLoadContextTargetDirectories(libRoot);
+
+            Assert.Equal(new[] { Path.Combine(libRoot, "Standard") }, directories);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     [Trait("Category", "Integration")]
     public void Generate_WithAssemblyLoadContext_WritesAlcBootstrapperAndKeepsDesktopLibrariesScript()
     {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -66,7 +66,8 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
-    public void Generate_WithAssemblyLoadContext_WritesAlcBootstrapperAndSkipsLibrariesScript()
+    [Trait("Category", "Integration")]
+    public void Generate_WithAssemblyLoadContext_WritesAlcBootstrapperAndKeepsDesktopLibrariesScript()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
@@ -91,11 +92,12 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("DemoModule.ModuleLoadContext.dll", bootstrapper);
             Assert.Contains("LoadModule($ModuleAssemblyPath, 'DemoModule')", bootstrapper);
             Assert.Contains("AddExportedCmdlet", bootstrapper);
-            Assert.DoesNotContain("$LibrariesScript =", bootstrapper);
+            Assert.Contains("$PSEdition -ne 'Core'", bootstrapper);
+            Assert.Contains("$LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'DemoModule.Libraries.ps1')", bootstrapper);
 
             Assert.True(File.Exists(Path.Combine(root, "Lib", "Core", "DemoModule.ModuleLoadContext.dll")));
             Assert.False(File.Exists(Path.Combine(root, "Lib", "Default", "DemoModule.ModuleLoadContext.dll")));
-            Assert.False(File.Exists(Path.Combine(root, "DemoModule.Libraries.ps1")));
+            Assert.True(File.Exists(Path.Combine(root, "DemoModule.Libraries.ps1")));
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -115,6 +115,42 @@ public class ModuleBootstrapperGeneratorTests
             Assert.True(File.Exists(Path.Combine(root, "Lib", "Core", "DemoModule.ModuleLoadContext.dll")));
             Assert.False(File.Exists(Path.Combine(root, "Lib", "Default", "DemoModule.ModuleLoadContext.dll")));
             Assert.True(File.Exists(Path.Combine(root, "DemoModule.Libraries.ps1")));
+
+            var libraries = File.ReadAllText(Path.Combine(root, "DemoModule.Libraries.ps1"));
+            Assert.DoesNotContain("DemoModule.ModuleLoadContext.dll", libraries);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Generate_WithAssemblyLoadContextAndDefaultOnlyLib_WritesLoaderBesideDefaultAssembly()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-default-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Lib", "Default"));
+        File.WriteAllText(Path.Combine(root, "Lib", "Default", "DemoModule.dll"), string.Empty);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true);
+
+            var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
+            Assert.Contains("$Framework = 'Default'", bootstrapper);
+            Assert.True(File.Exists(Path.Combine(root, "Lib", "Default", "DemoModule.ModuleLoadContext.dll")));
+
+            var libraries = File.ReadAllText(Path.Combine(root, "DemoModule.Libraries.ps1"));
+            Assert.DoesNotContain("DemoModule.ModuleLoadContext.dll", libraries);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -131,6 +131,8 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("LoadModule($ModuleAssemblyPath, 'DemoModule')", bootstrapper);
             Assert.Contains("-PassThru -ErrorAction Stop", bootstrapper);
             Assert.Contains("AddExportedCmdlet", bootstrapper);
+            Assert.Contains("NotSupportedException", bootstrapper);
+            Assert.Contains("cannot be exported from the ALC-loaded module", bootstrapper);
             Assert.Contains("$PSEdition -ne 'Core'", bootstrapper);
             Assert.Contains("$LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'DemoModule.Libraries.ps1')", bootstrapper);
 

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -447,6 +447,7 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
             var plan = runner.Plan(spec!);
 
             Assert.True(plan.BuildSpec.UseAssemblyLoadContext);
+            Assert.Equal(new[] { "NETAssemblyLoadContext" }, plan.BuildSpec.CsprojRequiredReasons);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -447,7 +447,7 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
             var plan = runner.Plan(spec!);
 
             Assert.True(plan.BuildSpec.UseAssemblyLoadContext);
-            Assert.Equal(new[] { "NETAssemblyLoadContext" }, plan.BuildSpec.CsprojRequiredReasons);
+            Assert.Equal(new[] { "UseAssemblyLoadContext" }, plan.BuildSpec.CsprojRequiredReasons);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -399,6 +401,52 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
             var plan = runner.Plan(spec);
 
             Assert.Equal(new[] { "NETFramework", "NETBinaryModule" }, plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_DeserializesLegacyNetAssemblyLoadContextAlias_IntoBuildSpec()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+            var json = $$"""
+            {
+              "Build": {
+                "Name": "PSParseHTML",
+                "SourcePath": "{{projectRoot.FullName.Replace("\\", "\\\\")}}",
+                "Version": "1.0.0"
+              },
+              "Segments": [
+                {
+                  "Type": "BuildLibraries",
+                  "BuildLibraries": {
+                    "NETAssemblyLoadContext": true
+                  }
+                }
+              ],
+              "Install": {
+                "Enabled": false
+              }
+            }
+            """;
+
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            options.Converters.Add(new JsonStringEnumConverter());
+            options.Converters.Add(new ConfigurationSegmentJsonConverter());
+
+            var spec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, options);
+            Assert.NotNull(spec);
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec!);
+
+            Assert.True(plan.BuildSpec.UseAssemblyLoadContext);
         }
         finally
         {

--- a/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
@@ -67,6 +67,9 @@ public sealed class BuildLibrariesConfiguration
     /// <summary>Load the binary module and its dependencies through a custom AssemblyLoadContext on PowerShell Core.</summary>
     public bool? UseAssemblyLoadContext { get; set; }
 
+    /// <summary>Legacy alias for <see cref="UseAssemblyLoadContext"/>.</summary>
+    public bool? NETAssemblyLoadContext { get; set; }
+
     /// <summary>Do not copy libraries recursively (legacy).</summary>
     public bool? NETDoNotCopyLibrariesRecursively { get; set; }
 }

--- a/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
@@ -64,6 +64,9 @@ public sealed class BuildLibrariesConfiguration
     /// <summary>Handle runtimes folder when copying libraries.</summary>
     public bool? HandleRuntimes { get; set; }
 
+    /// <summary>Load the binary module and its dependencies through a custom AssemblyLoadContext on PowerShell Core.</summary>
+    public bool? UseAssemblyLoadContext { get; set; }
+
     /// <summary>Do not copy libraries recursively (legacy).</summary>
     public bool? NETDoNotCopyLibrariesRecursively { get; set; }
 }

--- a/PowerForge/Models/ModuleBuildSpec.cs
+++ b/PowerForge/Models/ModuleBuildSpec.cs
@@ -106,6 +106,12 @@ public sealed class ModuleBuildSpec
     public bool HandleRuntimes { get; set; }
 
     /// <summary>
+    /// When true, the generated binary bootstrapper loads the binary module through a custom AssemblyLoadContext on
+    /// PowerShell Core, isolating the module's managed dependency graph from other modules in the session.
+    /// </summary>
+    public bool UseAssemblyLoadContext { get; set; }
+
+    /// <summary>
     /// When true, keeps the staging directory after a successful build.
     /// </summary>
     public bool KeepStaging { get; set; }

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -37,7 +37,7 @@ if ($Standard -and $Core -and $Default) {
     $Framework = 'Core'
     $FrameworkNet = ''
 } elseif ($Default) {
-    $Framework = ''
+    $Framework = 'Default'
     $FrameworkNet = 'Default'
 } else {
     Write-Error -Message 'No assemblies found'

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -64,6 +64,9 @@ if ($PSEdition -eq 'Core') {
         $InnerModule = & $ImportModule -Assembly $ModuleAssembly -Force -PassThru:$IsReload -ErrorAction Stop
 
         if ($InnerModule) {
+            # Import-Module -Assembly loads the inner binary module into its own module object. PowerShell has no
+            # public API to copy those exported cmdlets back to the script-module wrapper, so this uses the same
+            # private PSModuleInfo hook used by community ALC loaders. Keep this isolated to Core ALC imports.
             $AddExportedCmdlet = [System.Management.Automation.PSModuleInfo].GetMethod(
                 'AddExportedCmdlet',
                 [System.Reflection.BindingFlags]'Instance, NonPublic'
@@ -83,5 +86,12 @@ if ($PSEdition -eq 'Core') {
         throw
     } else {
         Write-Warning -Message "Importing module $Library failed. Fix errors before continuing. Error: $($_.Exception.Message)"
+    }
+}
+
+if ($PSEdition -ne 'Core') {
+    $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, '{{ModuleName}}.Libraries.ps1')
+    if (Test-Path -LiteralPath $LibrariesScript) {
+        . $LibrariesScript
     }
 }

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -1,0 +1,87 @@
+# Get library name, from the PSM1 file name
+$LibraryName = '{{LibraryName}}'
+$Library = "$LibraryName.dll"
+$Class = "$LibraryName.Initialize"
+
+$AssemblyFolders = Get-ChildItem -Path $PSScriptRoot\Lib -Directory -ErrorAction SilentlyContinue
+
+$Default = $false
+$Core = $false
+$Standard = $false
+foreach ($A in $AssemblyFolders.Name) {
+    if ($A -eq 'Default') {
+        $Default = $true
+    } elseif ($A -eq 'Core') {
+        $Core = $true
+    } elseif ($A -eq 'Standard') {
+        $Standard = $true
+    }
+}
+if ($Standard -and $Core -and $Default) {
+    $FrameworkNet = 'Default'
+    $Framework = 'Standard'
+} elseif ($Standard -and $Core) {
+    $Framework = 'Standard'
+    $FrameworkNet = 'Standard'
+} elseif ($Core -and $Default) {
+    $Framework = 'Core'
+    $FrameworkNet = 'Default'
+} elseif ($Standard -and $Default) {
+    $Framework = 'Standard'
+    $FrameworkNet = 'Default'
+} elseif ($Standard) {
+    $Framework = 'Standard'
+    $FrameworkNet = 'Standard'
+} elseif ($Core) {
+    $Framework = 'Core'
+    $FrameworkNet = ''
+} elseif ($Default) {
+    $Framework = ''
+    $FrameworkNet = 'Default'
+} else {
+    Write-Error -Message 'No assemblies found'
+}
+
+if ($PSEdition -eq 'Core') {
+    $LibFolder = $Framework
+} else {
+    $LibFolder = $FrameworkNet
+}
+
+{{RuntimeHandlerBlock}}try {
+    $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
+    $ModuleAssemblyPath = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder, $Library)
+
+    if ($PSEdition -eq 'Core') {
+        $LoaderAssemblyPath = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder, '{{LoaderAssemblyName}}.dll')
+        $IsReload = $true
+        if (-not ('{{LoaderTypeName}}' -as [type])) {
+            $IsReload = $false
+            Add-Type -Path $LoaderAssemblyPath -ErrorAction Stop
+        }
+
+        $ModuleAssembly = [{{LoaderTypeName}}]::LoadModule($ModuleAssemblyPath, '{{ModuleName}}')
+        $InnerModule = & $ImportModule -Assembly $ModuleAssembly -Force -PassThru:$IsReload -ErrorAction Stop
+
+        if ($InnerModule) {
+            $AddExportedCmdlet = [System.Management.Automation.PSModuleInfo].GetMethod(
+                'AddExportedCmdlet',
+                [System.Reflection.BindingFlags]'Instance, NonPublic'
+            )
+            foreach ($Cmd in $InnerModule.ExportedCmdlets.Values) {
+                $AddExportedCmdlet.Invoke($ExecutionContext.SessionState.Module, @(, $Cmd)) | Out-Null
+            }
+        }
+    } elseif (-not ($Class -as [type])) {
+        & $ImportModule $ModuleAssemblyPath -ErrorAction Stop
+    } else {
+        $Type = "$Class" -as [Type]
+        & $ImportModule -Force -Assembly ($Type.Assembly)
+    }
+} catch {
+    if ($ErrorActionPreference -eq 'Stop') {
+        throw
+    } else {
+        Write-Warning -Message "Importing module $Library failed. Fix errors before continuing. Error: $($_.Exception.Message)"
+    }
+}

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -3,7 +3,8 @@ $LibraryName = '{{LibraryName}}'
 $Library = "$LibraryName.dll"
 $Class = "$LibraryName.Initialize"
 
-$AssemblyFolders = Get-ChildItem -Path $PSScriptRoot\Lib -Directory -ErrorAction SilentlyContinue
+$LibRoot = [IO.Path]::Combine($PSScriptRoot, 'Lib')
+$AssemblyFolders = Get-ChildItem -LiteralPath $LibRoot -Directory -ErrorAction SilentlyContinue
 
 $Default = $false
 $Core = $false
@@ -55,19 +56,18 @@ if ($PSEdition -eq 'Core') {
 
     if ($PSEdition -eq 'Core') {
         $LoaderAssemblyPath = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder, '{{LoaderAssemblyName}}.dll')
-        $IsReload = $true
         if (-not ('{{LoaderTypeName}}' -as [type])) {
-            $IsReload = $false
             Add-Type -Path $LoaderAssemblyPath -ErrorAction Stop
         }
 
         $ModuleAssembly = [{{LoaderTypeName}}]::LoadModule($ModuleAssemblyPath, '{{ModuleName}}')
-        $InnerModule = & $ImportModule -Assembly $ModuleAssembly -Force -PassThru:$IsReload -ErrorAction Stop
+        $InnerModule = & $ImportModule -Assembly $ModuleAssembly -Force -PassThru -ErrorAction Stop
 
         if ($InnerModule) {
             # Import-Module -Assembly loads the inner binary module into its own module object. PowerShell has no
             # public API to copy those exported cmdlets back to the script-module wrapper, so this uses the same
-            # private PSModuleInfo hook used by community ALC loaders. Keep this isolated to Core ALC imports.
+            # private PSModuleInfo hook used by community ALC loaders. This runs on first load and reloads so the
+            # outer script module always re-exports cmdlets from the ALC-loaded binary module.
             $AddExportedCmdlet = [System.Management.Automation.PSModuleInfo].GetMethod(
                 'AddExportedCmdlet',
                 [System.Reflection.BindingFlags]'Instance, NonPublic'

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -40,6 +40,7 @@ if ($Standard -and $Core -and $Default) {
     $FrameworkNet = 'Default'
 } else {
     Write-Error -Message 'No assemblies found'
+    return
 }
 
 if ($PSEdition -eq 'Core') {
@@ -71,8 +72,12 @@ if ($PSEdition -eq 'Core') {
                 'AddExportedCmdlet',
                 [System.Reflection.BindingFlags]'Instance, NonPublic'
             )
-            foreach ($Cmd in $InnerModule.ExportedCmdlets.Values) {
-                $AddExportedCmdlet.Invoke($ExecutionContext.SessionState.Module, @(, $Cmd)) | Out-Null
+            if ($null -ne $AddExportedCmdlet) {
+                foreach ($Cmd in $InnerModule.ExportedCmdlets.Values) {
+                    $AddExportedCmdlet.Invoke($ExecutionContext.SessionState.Module, @(, $Cmd)) | Out-Null
+                }
+            } else {
+                Write-Warning -Message "AddExportedCmdlet is not available on this PowerShell version; cmdlets from $LibraryName may not be exported."
             }
         }
     } elseif (-not ($Class -as [type])) {
@@ -90,6 +95,8 @@ if ($PSEdition -eq 'Core') {
 }
 
 if ($PSEdition -ne 'Core') {
+    # Core loads dependencies through the module-scoped AssemblyLoadContext above. Dot-sourcing the libraries script
+    # there would load dependency DLLs into the default context and undo the isolation this template exists to provide.
     $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, '{{ModuleName}}.Libraries.ps1')
     if (Test-Path -LiteralPath $LibrariesScript) {
         . $LibrariesScript

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -77,7 +77,8 @@ if ($PSEdition -eq 'Core') {
                     $AddExportedCmdlet.Invoke($ExecutionContext.SessionState.Module, @(, $Cmd)) | Out-Null
                 }
             } else {
-                throw [System.NotSupportedException]::new("AddExportedCmdlet is not available on this PowerShell version; cmdlets from $LibraryName cannot be exported from the ALC-loaded module.")
+                Write-Warning -Message "AddExportedCmdlet is not available on this PowerShell version. Falling back to direct Import-Module; cmdlets from $LibraryName will load from the default context."
+                & $ImportModule $ModuleAssemblyPath -ErrorAction Stop
             }
         }
     } elseif (-not ($Class -as [type])) {
@@ -88,8 +89,6 @@ if ($PSEdition -eq 'Core') {
     }
 } catch {
     if ($ErrorActionPreference -eq 'Stop') {
-        throw
-    } elseif ($_.Exception -is [System.NotSupportedException]) {
         throw
     } else {
         Write-Warning -Message "Importing module $Library failed. Fix errors before continuing. Error: $($_.Exception.Message)"

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -77,7 +77,7 @@ if ($PSEdition -eq 'Core') {
                     $AddExportedCmdlet.Invoke($ExecutionContext.SessionState.Module, @(, $Cmd)) | Out-Null
                 }
             } else {
-                Write-Warning -Message "AddExportedCmdlet is not available on this PowerShell version; cmdlets from $LibraryName may not be exported."
+                throw [System.NotSupportedException]::new("AddExportedCmdlet is not available on this PowerShell version; cmdlets from $LibraryName cannot be exported from the ALC-loaded module.")
             }
         }
     } elseif (-not ($Class -as [type])) {
@@ -88,6 +88,8 @@ if ($PSEdition -eq 'Core') {
     }
 } catch {
     if ($ErrorActionPreference -eq 'Stop') {
+        throw
+    } elseif ($_.Exception -is [System.NotSupportedException]) {
         throw
     } else {
         Write-Warning -Message "Importing module $Library failed. Fix errors before continuing. Error: $($_.Exception.Message)"

--- a/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
@@ -40,6 +40,7 @@ if ($Standard -and $Core -and $Default) {
     $FrameworkNet = 'Default'
 } else {
     Write-Error -Message 'No assemblies found'
+    return
 }
 
 if ($PSEdition -eq 'Core') {

--- a/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
@@ -3,7 +3,8 @@ $LibraryName = '{{LibraryName}}'
 $Library = "$LibraryName.dll"
 $Class = "$LibraryName.Initialize"
 
-$AssemblyFolders = Get-ChildItem -Path $PSScriptRoot\Lib -Directory -ErrorAction SilentlyContinue
+$LibRoot = [IO.Path]::Combine($PSScriptRoot, 'Lib')
+$AssemblyFolders = Get-ChildItem -LiteralPath $LibRoot -Directory -ErrorAction SilentlyContinue
 
 $Default = $false
 $Core = $false

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -375,7 +375,7 @@ internal static class ModuleBootstrapperGenerator
         }
     }
 
-    private static string[] ResolveAssemblyLoadContextTargetDirectories(string libRoot)
+    internal static string[] ResolveAssemblyLoadContextTargetDirectories(string libRoot)
     {
         var byName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var directory in Directory.EnumerateDirectories(libRoot))

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -376,13 +376,14 @@ internal static class ModuleBootstrapperGenerator
 
     private static string? NormalizeAssemblyLoadContextTargetFramework(string? framework)
     {
+        framework ??= string.Empty;
         if (string.IsNullOrWhiteSpace(framework))
             return null;
 
         var normalized = framework.Trim();
-        var platformIndex = normalized.IndexOf('-', StringComparison.Ordinal);
+        var platformIndex = normalized.IndexOf('-');
         if (platformIndex >= 0)
-            normalized = normalized[..platformIndex];
+            normalized = normalized.Substring(0, platformIndex);
 
         return TryGetNetTfmVersion(normalized, out _) ? normalized : null;
     }
@@ -402,7 +403,7 @@ internal static class ModuleBootstrapperGenerator
             return false;
         }
 
-        if (!Version.TryParse(framework[3..], out var parsed))
+        if (!Version.TryParse(framework.Substring(3), out var parsed))
             return false;
 
         version = parsed;

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -8,6 +8,8 @@ namespace PowerForge;
 
 internal static class ModuleBootstrapperGenerator
 {
+    // net8.0 is the default modern PowerShell LTS baseline when the module build does not declare a Core TFM.
+    private const string DefaultAssemblyLoadContextTargetFramework = "net8.0";
     private static readonly UTF8Encoding Utf8Bom = new(encoderShouldEmitUTF8Identifier: true);
     private static readonly TimeSpan AssemblyLoadContextLoaderBuildTimeout = TimeSpan.FromMinutes(5);
 
@@ -41,13 +43,17 @@ internal static class ModuleBootstrapperGenerator
         var primaryLibraryName = Path.GetFileNameWithoutExtension(primaryAssemblyName);
         if (string.IsNullOrWhiteSpace(primaryLibraryName)) primaryLibraryName = moduleName;
 
-        if (hasLib && useAssemblyLoadContext)
-            BuildAssemblyLoadContextLoader(root, moduleName, ResolveAssemblyLoadContextTargetFramework(targetFrameworks), log);
+        var assemblyLoadContextLoaderIdentity = useAssemblyLoadContext
+            ? CreateAssemblyLoadContextLoaderIdentity(moduleName)
+            : null;
+
+        if (hasLib && useAssemblyLoadContext && assemblyLoadContextLoaderIdentity is not null)
+            BuildAssemblyLoadContextLoader(root, assemblyLoadContextLoaderIdentity, ResolveAssemblyLoadContextTargetFramework(targetFrameworks), log);
 
         if (hasLib)
         {
             var librariesPath = Path.Combine(root, $"{moduleName}.Libraries.ps1");
-            var librariesContent = BuildLibrariesScript(root, moduleName, exportAssemblyFileNames);
+            var librariesContent = BuildLibrariesScript(root, moduleName, exportAssemblyFileNames, assemblyLoadContextLoaderIdentity?.AssemblyName);
             WritePowerShellFile(librariesPath, librariesContent);
         }
 
@@ -106,15 +112,19 @@ internal static class ModuleBootstrapperGenerator
         return text.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", "\r\n");
     }
 
-    private static string BuildLibrariesScript(string moduleRoot, string moduleName, IReadOnlyList<string> exportAssemblyFileNames)
+    private static string BuildLibrariesScript(
+        string moduleRoot,
+        string moduleName,
+        IReadOnlyList<string> exportAssemblyFileNames,
+        string? assemblyLoadContextLoaderAssemblyName)
     {
         // Generate a deterministic list of DLLs to Add-Type for each Lib/<Folder>.
         var libRoot = Path.Combine(moduleRoot, "Lib");
         var byFolder = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-        byFolder["Core"] = EnumerateDllRelativePaths(libRoot, "Core", exportAssemblyFileNames);
-        byFolder["Default"] = EnumerateDllRelativePaths(libRoot, "Default", exportAssemblyFileNames);
-        byFolder["Standard"] = EnumerateDllRelativePaths(libRoot, "Standard", exportAssemblyFileNames);
-        byFolder[""] = EnumerateDllRelativePaths(libRoot, null, exportAssemblyFileNames);
+        byFolder["Core"] = EnumerateDllRelativePaths(libRoot, "Core", exportAssemblyFileNames, assemblyLoadContextLoaderAssemblyName);
+        byFolder["Default"] = EnumerateDllRelativePaths(libRoot, "Default", exportAssemblyFileNames, assemblyLoadContextLoaderAssemblyName);
+        byFolder["Standard"] = EnumerateDllRelativePaths(libRoot, "Standard", exportAssemblyFileNames, assemblyLoadContextLoaderAssemblyName);
+        byFolder[""] = EnumerateDllRelativePaths(libRoot, null, exportAssemblyFileNames, assemblyLoadContextLoaderAssemblyName);
 
         var map = BuildLibrariesByFolderMap(byFolder);
         var template = EmbeddedScripts.Load("Scripts/ModuleBootstrapper/Libraries.Template.ps1");
@@ -162,7 +172,11 @@ internal static class ModuleBootstrapperGenerator
         return sb.ToString();
     }
 
-    private static List<string> EnumerateDllRelativePaths(string libRoot, string? folderName, IReadOnlyList<string> exportAssemblyFileNames)
+    private static List<string> EnumerateDllRelativePaths(
+        string libRoot,
+        string? folderName,
+        IReadOnlyList<string> exportAssemblyFileNames,
+        string? assemblyLoadContextLoaderAssemblyName)
     {
         var list = new List<string>();
 
@@ -183,16 +197,22 @@ internal static class ModuleBootstrapperGenerator
             return list;
         }
 
+        var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(assemblyLoadContextLoaderAssemblyName))
+            excluded.Add(assemblyLoadContextLoaderAssemblyName + ".dll");
+
         var exportFirst = new HashSet<string>(exportAssemblyFileNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
         foreach (var name in exportAssemblyFileNames ?? Array.Empty<string>())
         {
             if (string.IsNullOrWhiteSpace(name)) continue;
+            if (excluded.Contains(name)) continue;
             if (!dllFiles.Contains(name, StringComparer.OrdinalIgnoreCase)) continue;
             list.Add(RelativeLibPath(folderName, name));
         }
 
         foreach (var name in dllFiles.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
         {
+            if (excluded.Contains(name)) continue;
             if (exportFirst.Contains(name)) continue;
             list.Add(RelativeLibPath(folderName, name));
         }
@@ -263,17 +283,26 @@ internal static class ModuleBootstrapperGenerator
         return ScriptTemplateRenderer.Render("ModuleBootstrapper.Bootstrapper", template, tokens);
     }
 
-    private static void BuildAssemblyLoadContextLoader(string moduleRoot, string moduleName, string targetFramework, Action<string>? log)
+    private static void BuildAssemblyLoadContextLoader(
+        string moduleRoot,
+        AssemblyLoadContextLoaderIdentity identity,
+        string targetFramework,
+        Action<string>? log)
     {
         var libRoot = Path.Combine(moduleRoot, "Lib");
-        if (!Directory.Exists(libRoot)) return;
+        if (!Directory.Exists(libRoot))
+        {
+            log?.Invoke("UseAssemblyLoadContext is set but no Lib directory was found; skipping ALC loader generation.");
+            return;
+        }
 
-        var targetDirectories = Directory.EnumerateDirectories(libRoot)
-            .Where(directory => !string.Equals(Path.GetFileName(directory), "Default", StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-        if (targetDirectories.Length == 0) return;
+        var targetDirectories = ResolveAssemblyLoadContextTargetDirectories(libRoot);
+        if (targetDirectories.Length == 0)
+        {
+            log?.Invoke("UseAssemblyLoadContext is set but no compatible Lib directory was found; skipping ALC loader generation.");
+            return;
+        }
 
-        var identity = CreateAssemblyLoadContextLoaderIdentity(moduleName);
         var buildRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "module-load-context", identity.AssemblyName + "_" + Guid.NewGuid().ToString("N"));
         var outputRoot = Path.Combine(buildRoot, "out");
 
@@ -286,6 +315,7 @@ internal static class ModuleBootstrapperGenerator
             File.WriteAllText(projectPath, BuildAssemblyLoadContextProject(identity, targetFramework), Encoding.UTF8);
             File.WriteAllText(Path.Combine(buildRoot, "ModuleAssemblyLoadContext.cs"), BuildAssemblyLoadContextSource(identity), Encoding.UTF8);
 
+            EnsureDotNetSdkAvailable(buildRoot);
             log?.Invoke($"Building module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' for {targetFramework}.");
             var result = RunProcess(
                 "dotnet",
@@ -317,6 +347,54 @@ internal static class ModuleBootstrapperGenerator
             try { if (Directory.Exists(buildRoot)) Directory.Delete(buildRoot, recursive: true); }
             catch { /* best effort */ }
         }
+    }
+
+    private static void EnsureDotNetSdkAvailable(string workingDirectory)
+    {
+        ProcessRunResult result;
+        try
+        {
+            result = RunProcess("dotnet", workingDirectory, new[] { "--version" }, TimeSpan.FromSeconds(30));
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("UseAssemblyLoadContext requires the .NET SDK to be installed and 'dotnet' to be available on PATH.", ex);
+        }
+
+        if (result.ExitCode != 0)
+        {
+            var message = string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    "UseAssemblyLoadContext requires the .NET SDK to be installed and 'dotnet' to be available on PATH.",
+                    result.StdOut,
+                    result.StdErr
+                }.Where(static line => !string.IsNullOrWhiteSpace(line)));
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private static string[] ResolveAssemblyLoadContextTargetDirectories(string libRoot)
+    {
+        var byName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in Directory.EnumerateDirectories(libRoot))
+        {
+            var name = Path.GetFileName(directory);
+            if (!string.IsNullOrWhiteSpace(name))
+                byName[name] = directory;
+        }
+
+        if (byName.TryGetValue("Standard", out var standard))
+            return new[] { standard };
+
+        if (byName.TryGetValue("Core", out var core))
+            return new[] { core };
+
+        if (byName.TryGetValue("Default", out var @default))
+            return new[] { @default };
+
+        return Array.Empty<string>();
     }
 
     private static AssemblyLoadContextLoaderIdentity CreateAssemblyLoadContextLoaderIdentity(string moduleName)
@@ -371,7 +449,7 @@ internal static class ModuleBootstrapperGenerator
             .OrderBy(static framework => GetNetTfmVersion(framework!), Comparer<Version>.Create(static (left, right) => left.CompareTo(right)))
             .ToArray();
 
-        return candidates.FirstOrDefault() ?? "net8.0";
+        return candidates.FirstOrDefault() ?? DefaultAssemblyLoadContextTargetFramework;
     }
 
     private static string? NormalizeAssemblyLoadContextTargetFramework(string? framework)
@@ -437,6 +515,7 @@ namespace {identity.Namespace};
 public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 {{
     private static readonly object Sync = new();
+    // Module contexts are intentionally non-collectible. A process restart is required to load a replaced DLL at the same path.
     private static readonly Dictionary<string, ModuleAssemblyLoadContext> Contexts = new(StringComparer.OrdinalIgnoreCase);
 
     private readonly string _assemblyDirectory;
@@ -461,6 +540,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         if (!File.Exists(fullPath))
             throw new FileNotFoundException(""Module assembly was not found."", fullPath);
 
+        // The global lock keeps context creation and the first main assembly load single-shot for each module path.
         lock (Sync)
         {{
             if (!Contexts.TryGetValue(fullPath, out var context))

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -11,7 +11,7 @@ internal static class ModuleBootstrapperGenerator
     // net8.0 is the default modern PowerShell LTS baseline when the module build does not declare a Core TFM.
     private const string DefaultAssemblyLoadContextTargetFramework = "net8.0";
     private static readonly UTF8Encoding Utf8Bom = new(encoderShouldEmitUTF8Identifier: true);
-    private static readonly TimeSpan AssemblyLoadContextLoaderBuildTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan AssemblyLoadContextLoaderBuildTimeout = TimeSpan.FromMinutes(10);
 
     internal static void Generate(
         string moduleRoot,
@@ -303,6 +303,8 @@ internal static class ModuleBootstrapperGenerator
             return;
         }
 
+        EnsureDotNetSdkAvailable(moduleRoot);
+
         var buildRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "module-load-context", identity.AssemblyName + "_" + Guid.NewGuid().ToString("N"));
         var outputRoot = Path.Combine(buildRoot, "out");
 
@@ -315,7 +317,6 @@ internal static class ModuleBootstrapperGenerator
             File.WriteAllText(projectPath, BuildAssemblyLoadContextProject(identity, targetFramework), Encoding.UTF8);
             File.WriteAllText(Path.Combine(buildRoot, "ModuleAssemblyLoadContext.cs"), BuildAssemblyLoadContextSource(identity), Encoding.UTF8);
 
-            EnsureDotNetSdkAvailable(buildRoot);
             log?.Invoke($"Building module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' for {targetFramework}.");
             var result = RunProcess(
                 "dotnet",
@@ -580,6 +581,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 
     private Assembly LoadMainModule()
     {{
+        // Called only while LoadModule holds Sync; keep the one-time main assembly load under that lock.
         _moduleAssembly ??= LoadFromAssemblyPath(_moduleAssemblyPath);
         return _moduleAssembly;
     }}

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -16,6 +16,7 @@ internal static class ModuleBootstrapperGenerator
         ExportSet exports,
         IReadOnlyList<string>? exportAssemblies,
         bool handleRuntimes,
+        bool useAssemblyLoadContext = false,
         IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies = null)
     {
         if (string.IsNullOrWhiteSpace(moduleRoot)) throw new ArgumentException("Module root is required.", nameof(moduleRoot));
@@ -37,7 +38,11 @@ internal static class ModuleBootstrapperGenerator
         var primaryLibraryName = Path.GetFileNameWithoutExtension(primaryAssemblyName);
         if (string.IsNullOrWhiteSpace(primaryLibraryName)) primaryLibraryName = moduleName;
 
-        if (hasLib)
+        if (hasLib && useAssemblyLoadContext)
+        {
+            BuildAssemblyLoadContextLoader(root, moduleName);
+        }
+        else if (hasLib)
         {
             var librariesPath = Path.Combine(root, $"{moduleName}.Libraries.ps1");
             var librariesContent = BuildLibrariesScript(root, moduleName, exportAssemblyFileNames);
@@ -52,6 +57,7 @@ internal static class ModuleBootstrapperGenerator
             includeBinaryLoader: hasLib,
             includeScriptLoader: hasScriptFolders,
             handleRuntimes: handleRuntimes,
+            useAssemblyLoadContext: useAssemblyLoadContext,
             conditionalFunctionDependencies: conditionalFunctionDependencies);
         WritePowerShellFile(psm1Path, psm1Content);
     }
@@ -210,16 +216,21 @@ internal static class ModuleBootstrapperGenerator
         bool includeBinaryLoader,
         bool includeScriptLoader,
         bool handleRuntimes,
+        bool useAssemblyLoadContext,
         IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies)
     {
         var binaryLoaderBlock = includeBinaryLoader
             ? RenderModuleBootstrapperTemplate(
-                "BinaryLoader",
-                "Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1",
+                useAssemblyLoadContext ? "AssemblyLoadContextBinaryLoader" : "BinaryLoader",
+                useAssemblyLoadContext
+                    ? "Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1"
+                    : "Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1",
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
                     ["LibraryName"] = EscapePsSingleQuoted(libraryName),
                     ["ModuleName"] = EscapePsSingleQuoted(moduleName),
+                    ["LoaderAssemblyName"] = EscapePsSingleQuoted(CreateAssemblyLoadContextLoaderIdentity(moduleName).AssemblyName),
+                    ["LoaderTypeName"] = CreateAssemblyLoadContextLoaderIdentity(moduleName).TypeName,
                     ["RuntimeHandlerBlock"] = handleRuntimes ? BuildRuntimeHandlerBlock() : string.Empty
                 })
             : string.Empty;
@@ -244,6 +255,226 @@ internal static class ModuleBootstrapperGenerator
 
         var template = EmbeddedScripts.Load("Scripts/ModuleBootstrapper/Bootstrapper.Template.ps1");
         return ScriptTemplateRenderer.Render("ModuleBootstrapper.Bootstrapper", template, tokens);
+    }
+
+    private static void BuildAssemblyLoadContextLoader(string moduleRoot, string moduleName)
+    {
+        var libRoot = Path.Combine(moduleRoot, "Lib");
+        if (!Directory.Exists(libRoot)) return;
+
+        var targetDirectories = Directory.EnumerateDirectories(libRoot)
+            .Where(directory => !string.Equals(Path.GetFileName(directory), "Default", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (targetDirectories.Length == 0) return;
+
+        var identity = CreateAssemblyLoadContextLoaderIdentity(moduleName);
+        var buildRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "module-load-context", identity.AssemblyName + "_" + Guid.NewGuid().ToString("N"));
+        var outputRoot = Path.Combine(buildRoot, "out");
+
+        try
+        {
+            Directory.CreateDirectory(buildRoot);
+            Directory.CreateDirectory(outputRoot);
+
+            var projectPath = Path.Combine(buildRoot, identity.AssemblyName + ".csproj");
+            File.WriteAllText(projectPath, BuildAssemblyLoadContextProject(identity), Encoding.UTF8);
+            File.WriteAllText(Path.Combine(buildRoot, "ModuleAssemblyLoadContext.cs"), BuildAssemblyLoadContextSource(identity), Encoding.UTF8);
+
+            var result = RunProcess(
+                "dotnet",
+                buildRoot,
+                new[] { "build", projectPath, "-c", "Release", "-o", outputRoot, "-nologo", "-v:minimal" },
+                TimeSpan.FromMinutes(2));
+            if (result.ExitCode != 0)
+            {
+                var message = string.Join(
+                    Environment.NewLine,
+                    new[]
+                    {
+                        $"Failed to build module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' (exit {result.ExitCode}).",
+                        result.StdOut,
+                        result.StdErr
+                    }.Where(static line => !string.IsNullOrWhiteSpace(line)));
+                throw new InvalidOperationException(message);
+            }
+
+            var loaderPath = Path.Combine(outputRoot, identity.AssemblyName + ".dll");
+            if (!File.Exists(loaderPath))
+                throw new FileNotFoundException("Module-scoped AssemblyLoadContext loader build did not produce the expected DLL.", loaderPath);
+
+            foreach (var directory in targetDirectories)
+                File.Copy(loaderPath, Path.Combine(directory, identity.AssemblyName + ".dll"), overwrite: true);
+        }
+        finally
+        {
+            try { if (Directory.Exists(buildRoot)) Directory.Delete(buildRoot, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    private static AssemblyLoadContextLoaderIdentity CreateAssemblyLoadContextLoaderIdentity(string moduleName)
+    {
+        var safeNamespaceRoot = ToCSharpIdentifierPath(moduleName);
+        var assemblyName = SanitizeAssemblyName(moduleName) + ".ModuleLoadContext";
+        var ns = safeNamespaceRoot + ".ModuleLoadContext";
+        return new AssemblyLoadContextLoaderIdentity(assemblyName, ns, ns + ".ModuleAssemblyLoadContext");
+    }
+
+    private static string SanitizeAssemblyName(string value)
+    {
+        var chars = (value ?? string.Empty).Select(ch => char.IsLetterOrDigit(ch) || ch is '.' or '_' or '-' ? ch : '_').ToArray();
+        var sanitized = new string(chars).Trim('.', '-', '_');
+        return string.IsNullOrWhiteSpace(sanitized) ? "Module" : sanitized;
+    }
+
+    private static string ToCSharpIdentifierPath(string value)
+    {
+        var parts = (value ?? string.Empty)
+            .Split(new[] { '.', '-' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(ToCSharpIdentifier)
+            .Where(static part => !string.IsNullOrWhiteSpace(part))
+            .ToArray();
+
+        return parts.Length == 0 ? "Module" : string.Join(".", parts);
+    }
+
+    private static string ToCSharpIdentifier(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+
+        var sb = new StringBuilder(value.Length + 1);
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+            var valid = i == 0
+                ? char.IsLetter(ch) || ch == '_'
+                : char.IsLetterOrDigit(ch) || ch == '_';
+            sb.Append(valid ? ch : '_');
+        }
+
+        if (sb.Length == 0 || !(char.IsLetter(sb[0]) || sb[0] == '_'))
+            sb.Insert(0, '_');
+
+        return sb.ToString();
+    }
+
+    private static string BuildAssemblyLoadContextProject(AssemblyLoadContextLoaderIdentity identity)
+        => $@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>{EscapeXml(identity.AssemblyName)}</AssemblyName>
+    <RootNamespace>{EscapeXml(identity.Namespace)}</RootNamespace>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <InformationalVersion>1.0.0</InformationalVersion>
+  </PropertyGroup>
+</Project>
+";
+
+    private static string BuildAssemblyLoadContextSource(AssemblyLoadContextLoaderIdentity identity)
+        => $@"using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace {identity.Namespace};
+
+public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
+{{
+    private static readonly object Sync = new();
+    private static readonly Dictionary<string, ModuleAssemblyLoadContext> Contexts = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly string _assemblyDirectory;
+    private readonly string _moduleAssemblyPath;
+    private readonly AssemblyDependencyResolver _resolver;
+    private Assembly? _moduleAssembly;
+
+    private ModuleAssemblyLoadContext(string moduleAssemblyPath, string contextName)
+        : base(contextName, isCollectible: false)
+    {{
+        _moduleAssemblyPath = Path.GetFullPath(moduleAssemblyPath);
+        _assemblyDirectory = Path.GetDirectoryName(_moduleAssemblyPath) ?? string.Empty;
+        _resolver = new AssemblyDependencyResolver(_moduleAssemblyPath);
+    }}
+
+    public static Assembly LoadModule(string moduleAssemblyPath, string? contextName)
+    {{
+        if (string.IsNullOrWhiteSpace(moduleAssemblyPath))
+            throw new ArgumentException(""Module assembly path is required."", nameof(moduleAssemblyPath));
+
+        var fullPath = Path.GetFullPath(moduleAssemblyPath);
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException(""Module assembly was not found."", fullPath);
+
+        lock (Sync)
+        {{
+            if (!Contexts.TryGetValue(fullPath, out var context))
+            {{
+                context = new ModuleAssemblyLoadContext(fullPath, string.IsNullOrWhiteSpace(contextName) ? Path.GetFileNameWithoutExtension(fullPath) : contextName);
+                Contexts[fullPath] = context;
+            }}
+
+            return context.LoadMainModule();
+        }}
+    }}
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {{
+        if (assemblyName is null || string.IsNullOrWhiteSpace(assemblyName.Name))
+            return null;
+
+        var loaderAssembly = typeof(ModuleAssemblyLoadContext).Assembly.GetName();
+        if (AssemblyName.ReferenceMatchesDefinition(loaderAssembly, assemblyName))
+            return typeof(ModuleAssemblyLoadContext).Assembly;
+
+        var resolvedPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
+            return LoadFromAssemblyPath(resolvedPath);
+
+        var assemblyPath = Path.Combine(_assemblyDirectory, assemblyName.Name + "".dll"");
+        return File.Exists(assemblyPath) ? LoadFromAssemblyPath(assemblyPath) : null;
+    }}
+
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {{
+        var resolvedPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        return !string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath)
+            ? LoadUnmanagedDllFromPath(resolvedPath)
+            : IntPtr.Zero;
+    }}
+
+    private Assembly LoadMainModule()
+    {{
+        _moduleAssembly ??= LoadFromAssemblyPath(_moduleAssemblyPath);
+        return _moduleAssembly;
+    }}
+}}
+";
+
+    private static string EscapeXml(string value)
+        => System.Security.SecurityElement.Escape(value) ?? string.Empty;
+
+    private static ProcessRunResult RunProcess(string fileName, string workingDirectory, IReadOnlyList<string> arguments, TimeSpan timeout)
+        => new ProcessRunner()
+            .RunAsync(new ProcessRunRequest(fileName, workingDirectory, arguments, timeout))
+            .GetAwaiter()
+            .GetResult();
+
+    private sealed class AssemblyLoadContextLoaderIdentity
+    {
+        public AssemblyLoadContextLoaderIdentity(string assemblyName, string ns, string typeName)
+        {
+            AssemblyName = assemblyName;
+            Namespace = ns;
+            TypeName = typeName;
+        }
+
+        public string AssemblyName { get; }
+        public string Namespace { get; }
+        public string TypeName { get; }
     }
 
     private static string BuildRuntimeHandlerBlock()

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -592,8 +592,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         => System.Security.SecurityElement.Escape(value) ?? string.Empty;
 
     private static ProcessRunResult RunProcess(string fileName, string workingDirectory, IReadOnlyList<string> arguments, TimeSpan timeout)
-        => new ProcessRunner()
-            .RunAsync(new ProcessRunRequest(fileName, workingDirectory, arguments, timeout))
+        => Task.Run(() => new ProcessRunner().RunAsync(new ProcessRunRequest(fileName, workingDirectory, arguments, timeout)))
             .GetAwaiter()
             .GetResult();
 

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -18,7 +18,9 @@ internal static class ModuleBootstrapperGenerator
         IReadOnlyList<string>? exportAssemblies,
         bool handleRuntimes,
         bool useAssemblyLoadContext = false,
-        IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies = null)
+        IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies = null,
+        IReadOnlyList<string>? targetFrameworks = null,
+        Action<string>? log = null)
     {
         if (string.IsNullOrWhiteSpace(moduleRoot)) throw new ArgumentException("Module root is required.", nameof(moduleRoot));
         if (string.IsNullOrWhiteSpace(moduleName)) throw new ArgumentException("Module name is required.", nameof(moduleName));
@@ -40,7 +42,7 @@ internal static class ModuleBootstrapperGenerator
         if (string.IsNullOrWhiteSpace(primaryLibraryName)) primaryLibraryName = moduleName;
 
         if (hasLib && useAssemblyLoadContext)
-            BuildAssemblyLoadContextLoader(root, moduleName);
+            BuildAssemblyLoadContextLoader(root, moduleName, ResolveAssemblyLoadContextTargetFramework(targetFrameworks), log);
 
         if (hasLib)
         {
@@ -261,7 +263,7 @@ internal static class ModuleBootstrapperGenerator
         return ScriptTemplateRenderer.Render("ModuleBootstrapper.Bootstrapper", template, tokens);
     }
 
-    private static void BuildAssemblyLoadContextLoader(string moduleRoot, string moduleName)
+    private static void BuildAssemblyLoadContextLoader(string moduleRoot, string moduleName, string targetFramework, Action<string>? log)
     {
         var libRoot = Path.Combine(moduleRoot, "Lib");
         if (!Directory.Exists(libRoot)) return;
@@ -281,9 +283,10 @@ internal static class ModuleBootstrapperGenerator
             Directory.CreateDirectory(outputRoot);
 
             var projectPath = Path.Combine(buildRoot, identity.AssemblyName + ".csproj");
-            File.WriteAllText(projectPath, BuildAssemblyLoadContextProject(identity), Encoding.UTF8);
+            File.WriteAllText(projectPath, BuildAssemblyLoadContextProject(identity, targetFramework), Encoding.UTF8);
             File.WriteAllText(Path.Combine(buildRoot, "ModuleAssemblyLoadContext.cs"), BuildAssemblyLoadContextSource(identity), Encoding.UTF8);
 
+            log?.Invoke($"Building module-scoped AssemblyLoadContext loader '{identity.AssemblyName}' for {targetFramework}.");
             var result = RunProcess(
                 "dotnet",
                 buildRoot,
@@ -359,10 +362,57 @@ internal static class ModuleBootstrapperGenerator
         return sb.ToString();
     }
 
-    private static string BuildAssemblyLoadContextProject(AssemblyLoadContextLoaderIdentity identity)
+    internal static string ResolveAssemblyLoadContextTargetFramework(IReadOnlyList<string>? targetFrameworks)
+    {
+        var candidates = (targetFrameworks ?? Array.Empty<string>())
+            .Select(static framework => NormalizeAssemblyLoadContextTargetFramework(framework))
+            .Where(static framework => !string.IsNullOrWhiteSpace(framework))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static framework => GetNetTfmVersion(framework!), Comparer<Version>.Create(static (left, right) => left.CompareTo(right)))
+            .ToArray();
+
+        return candidates.FirstOrDefault() ?? "net8.0";
+    }
+
+    private static string? NormalizeAssemblyLoadContextTargetFramework(string? framework)
+    {
+        if (string.IsNullOrWhiteSpace(framework))
+            return null;
+
+        var normalized = framework.Trim();
+        var platformIndex = normalized.IndexOf('-', StringComparison.Ordinal);
+        if (platformIndex >= 0)
+            normalized = normalized[..platformIndex];
+
+        return TryGetNetTfmVersion(normalized, out _) ? normalized : null;
+    }
+
+    private static Version GetNetTfmVersion(string framework)
+        => TryGetNetTfmVersion(framework, out var version) ? version : new Version(int.MaxValue, 0);
+
+    private static bool TryGetNetTfmVersion(string framework, out Version version)
+    {
+        version = new Version(0, 0);
+        if (string.IsNullOrWhiteSpace(framework) ||
+            !framework.StartsWith("net", StringComparison.OrdinalIgnoreCase) ||
+            framework.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) ||
+            framework.Length < 5 ||
+            !char.IsDigit(framework[3]))
+        {
+            return false;
+        }
+
+        if (!Version.TryParse(framework[3..], out var parsed))
+            return false;
+
+        version = parsed;
+        return true;
+    }
+
+    private static string BuildAssemblyLoadContextProject(AssemblyLoadContextLoaderIdentity identity, string targetFramework)
         => $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>{EscapeXml(targetFramework)}</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>{EscapeXml(identity.AssemblyName)}</AssemblyName>

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -9,6 +9,7 @@ namespace PowerForge;
 internal static class ModuleBootstrapperGenerator
 {
     private static readonly UTF8Encoding Utf8Bom = new(encoderShouldEmitUTF8Identifier: true);
+    private static readonly TimeSpan AssemblyLoadContextLoaderBuildTimeout = TimeSpan.FromMinutes(5);
 
     internal static void Generate(
         string moduleRoot,
@@ -39,10 +40,9 @@ internal static class ModuleBootstrapperGenerator
         if (string.IsNullOrWhiteSpace(primaryLibraryName)) primaryLibraryName = moduleName;
 
         if (hasLib && useAssemblyLoadContext)
-        {
             BuildAssemblyLoadContextLoader(root, moduleName);
-        }
-        else if (hasLib)
+
+        if (hasLib)
         {
             var librariesPath = Path.Combine(root, $"{moduleName}.Libraries.ps1");
             var librariesContent = BuildLibrariesScript(root, moduleName, exportAssemblyFileNames);
@@ -219,6 +219,10 @@ internal static class ModuleBootstrapperGenerator
         bool useAssemblyLoadContext,
         IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies)
     {
+        var loaderIdentity = useAssemblyLoadContext
+            ? CreateAssemblyLoadContextLoaderIdentity(moduleName)
+            : null;
+
         var binaryLoaderBlock = includeBinaryLoader
             ? RenderModuleBootstrapperTemplate(
                 useAssemblyLoadContext ? "AssemblyLoadContextBinaryLoader" : "BinaryLoader",
@@ -229,8 +233,8 @@ internal static class ModuleBootstrapperGenerator
                 {
                     ["LibraryName"] = EscapePsSingleQuoted(libraryName),
                     ["ModuleName"] = EscapePsSingleQuoted(moduleName),
-                    ["LoaderAssemblyName"] = EscapePsSingleQuoted(CreateAssemblyLoadContextLoaderIdentity(moduleName).AssemblyName),
-                    ["LoaderTypeName"] = CreateAssemblyLoadContextLoaderIdentity(moduleName).TypeName,
+                    ["LoaderAssemblyName"] = EscapePsSingleQuoted(loaderIdentity?.AssemblyName ?? string.Empty),
+                    ["LoaderTypeName"] = loaderIdentity?.TypeName ?? string.Empty,
                     ["RuntimeHandlerBlock"] = handleRuntimes ? BuildRuntimeHandlerBlock() : string.Empty
                 })
             : string.Empty;
@@ -284,7 +288,7 @@ internal static class ModuleBootstrapperGenerator
                 "dotnet",
                 buildRoot,
                 new[] { "build", projectPath, "-c", "Release", "-o", outputRoot, "-nologo", "-v:minimal" },
-                TimeSpan.FromMinutes(2));
+                AssemblyLoadContextLoaderBuildTimeout);
             if (result.ExitCode != 0)
             {
                 var message = string.Join(
@@ -352,16 +356,13 @@ internal static class ModuleBootstrapperGenerator
             sb.Append(valid ? ch : '_');
         }
 
-        if (sb.Length == 0 || !(char.IsLetter(sb[0]) || sb[0] == '_'))
-            sb.Insert(0, '_');
-
         return sb.ToString();
     }
 
     private static string BuildAssemblyLoadContextProject(AssemblyLoadContextLoaderIdentity identity)
         => $@"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>{EscapeXml(identity.AssemblyName)}</AssemblyName>

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -155,7 +155,13 @@ public sealed class ModuleBuildPipeline
         // This keeps artefacts and installs aligned with historical PSPublishModule behavior for binary/mixed modules.
         if (!spec.RefreshManifestOnly)
         {
-            ModuleBootstrapperGenerator.Generate(staging, spec.Name, exports, spec.ExportAssemblies, spec.HandleRuntimes);
+            ModuleBootstrapperGenerator.Generate(
+                staging,
+                spec.Name,
+                exports,
+                spec.ExportAssemblies,
+                spec.HandleRuntimes,
+                spec.UseAssemblyLoadContext);
         }
         else
         {

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -161,7 +161,9 @@ public sealed class ModuleBuildPipeline
                 exports,
                 spec.ExportAssemblies,
                 spec.HandleRuntimes,
-                spec.UseAssemblyLoadContext);
+                spec.UseAssemblyLoadContext,
+                targetFrameworks: spec.Frameworks,
+                log: message => _logger.Info(message));
         }
         else
         {

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -91,6 +91,8 @@
         "SearchClass": { "type": ["string", "null"] },
         "NETBinaryModuleDocumentation": { "type": ["boolean", "null"] },
         "HandleRuntimes": { "type": ["boolean", "null"] },
+        "UseAssemblyLoadContext": { "type": ["boolean", "null"] },
+        "NETAssemblyLoadContext": { "type": ["boolean", "null"] },
         "NETDoNotCopyLibrariesRecursively": { "type": ["boolean", "null"] }
       }
     },


### PR DESCRIPTION
## Summary
- adds an opt-in `NETAssemblyLoadContext` / `UseAssemblyLoadContext` build setting for binary modules
- generates a module-scoped AssemblyLoadContext loader DLL, for example `PSParseHTML.ModuleLoadContext.dll`, instead of sharing a common loader assembly across modules
- updates the generated Core bootstrapper to load binary modules through the module-scoped loader while keeping Desktop behavior on the normal import path

## Validation
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0`
- `dotnet build .\PowerForge.Tests\PowerForge.Tests.csproj -c Debug`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~BuildConfigurationFactoryTests|FullyQualifiedName~ModulePipelineExportAssemblyInferenceTests|FullyQualifiedName~ModuleBootstrapperGeneratorTests"`
- `git diff --check`
