### PR TITLE
Infer hosted project API references for agent readiness

### DIFF
--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -113,6 +113,7 @@ Add an `agentReadiness` block to `site.json`:
     },
     "apiCatalog": {
       "enabled": true,
+      "includeProjectApiReferences": true,
       "entries": [
         {
           "anchor": "/api/",
@@ -166,6 +167,14 @@ the matching generator is enabled in `site.json`.
 If `apiCatalog.entries` is empty but `_site/api/index.json` exists, PowerForge
 infers a basic API documentation entry. For public programmable APIs, prefer
 explicit entries that point `serviceDesc` at an OpenAPI document.
+
+If `apiCatalog.includeProjectApiReferences` is true, PowerForge also scans the
+rendered site for local `/projects/{slug}/api/index.html` pages and adds those
+hosted API reference surfaces to the linkset. It uses
+`data/projects/catalog.json` only to improve titles and classify local
+PowerShell API references; external project sites must publish their own API
+catalogs instead of being claimed by the hub. A generated
+`/projects/{slug}/api/index.json` is used as `service-desc` when present.
 
 If `markdownArtifacts.enabled` is true, `agent-ready prepare` converts rendered
 HTML pages to sibling Markdown files such as `index.md` and `docs/index.md`.

--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -172,8 +172,10 @@ If `apiCatalog.includeProjectApiReferences` is true, PowerForge also scans the
 rendered site for local `/projects/{slug}/api/index.html` pages and adds those
 hosted API reference surfaces to the linkset. It uses
 `data/projects/catalog.json` only to improve titles and classify local
-PowerShell API references; external project sites must publish their own API
-catalogs instead of being claimed by the hub. A generated
+PowerShell API references; set `projectCatalogPath` to a different relative
+site-root path when needed, or leave it blank to use the default catalog.
+External project sites must publish their own API catalogs instead of being
+claimed by the hub. A generated
 `/projects/{slug}/api/index.json` is used as `service-desc` when present.
 
 If `markdownArtifacts.enabled` is true, `agent-ready prepare` converts rendered

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -348,6 +348,77 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void Prepare_DoesNotInferHostedProjectApiReferencesWhenDisabled()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-project-api-disabled-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var apiRoot = Path.Combine(root, "projects", "disabled-module", "api");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "index.html"), "<!doctype html><title>Disabled API</title>");
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec
+                    {
+                        Enabled = true,
+                        IncludeProjectApiReferences = false,
+                        Entries = new[]
+                        {
+                            new AgentApiCatalogEntrySpec
+                            {
+                                Anchor = "/api/",
+                                ServiceDoc = "/api/",
+                                Title = "Explicit API"
+                            }
+                        }
+                    },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
+            var anchors = apiCatalog.RootElement.GetProperty("linkset").EnumerateArray()
+                .Select(static item => item.GetProperty("anchor").GetString())
+                .ToArray();
+            Assert.Contains("https://example.test/api/", anchors);
+            Assert.DoesNotContain("https://example.test/projects/disabled-module/api/", anchors);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Prepare_WritesSecurityHeadersWhenLinkHeadersAreDisabled()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-security-headers-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -127,6 +127,14 @@ public class WebAgentReadinessTests
             Directory.CreateDirectory(unknownApiRoot);
             File.WriteAllText(Path.Combine(unknownApiRoot, "index.html"), "<!doctype html><title>Unknown API</title>");
 
+            var numericApiRoot = Path.Combine(root, "projects", "123-module", "api");
+            Directory.CreateDirectory(numericApiRoot);
+            File.WriteAllText(Path.Combine(numericApiRoot, "index.html"), "<!doctype html><title>Numeric API</title>");
+
+            var duplicateApiRoot = Path.Combine(root, "projects", "duplicate-project", "api");
+            Directory.CreateDirectory(duplicateApiRoot);
+            File.WriteAllText(Path.Combine(duplicateApiRoot, "index.html"), "<!doctype html><title>Duplicate API</title>");
+
             var catalogRoot = Path.Combine(root, "data", "projects");
             Directory.CreateDirectory(catalogRoot);
             File.WriteAllText(Path.Combine(catalogRoot, "catalog.json"),
@@ -162,6 +170,12 @@ public class WebAgentReadinessTests
                                 Anchor = "/projects/api-suite/",
                                 ServiceDoc = "/projects/api-suite/",
                                 Title = "API suite"
+                            },
+                            new AgentApiCatalogEntrySpec
+                            {
+                                Anchor = "/projects/duplicate-project/api/",
+                                ServiceDoc = "/projects/duplicate-project/api/custom/",
+                                Title = "Explicit duplicate API"
                             }
                         }
                     },
@@ -179,7 +193,9 @@ public class WebAgentReadinessTests
             Assert.Contains("https://example.test/projects/gpozaurr/api/", anchors);
             Assert.Contains("https://example.test/projects/plain-project/api/", anchors);
             Assert.Contains("https://example.test/projects/unknown-module/api/", anchors);
+            Assert.Contains("https://example.test/projects/123-module/api/", anchors);
             Assert.DoesNotContain("https://officeimo.com/api/powershell/", anchors);
+            Assert.Single(anchors, static anchor => anchor == "https://example.test/projects/duplicate-project/api/");
 
             var gpo = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/gpozaurr/api/");
             Assert.Equal("https://example.test/projects/gpozaurr/api/index.json", gpo.GetProperty("service-desc")[0].GetProperty("href").GetString());
@@ -190,6 +206,75 @@ public class WebAgentReadinessTests
 
             var unknown = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/unknown-module/api/");
             Assert.Equal("Unknown Module API reference", unknown.GetProperty("service-doc")[0].GetProperty("title").GetString());
+
+            var numeric = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/123-module/api/");
+            Assert.Equal("123 Module API reference", numeric.GetProperty("service-doc")[0].GetProperty("title").GetString());
+
+            var duplicate = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/duplicate-project/api/");
+            Assert.Equal("Explicit duplicate API", duplicate.GetProperty("service-doc")[0].GetProperty("title").GetString());
+            Assert.Contains(result.Warnings, warning => warning.Contains("duplicate-project", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Prepare_WithProjectCatalogPathOutsideSiteRoot_WarnsAndStillInfersProjectApi()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-project-api-catalog-path-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var apiRoot = Path.Combine(root, "projects", "safe-module", "api");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "index.html"), "<!doctype html><title>Safe API</title>");
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec
+                    {
+                        Enabled = true,
+                        IncludeProjectApiReferences = true,
+                        ProjectCatalogPath = Path.Combine(Path.GetTempPath(), "outside-project-catalog.json")
+                    },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            Assert.Contains(result.Warnings, warning => warning.Contains("resolves outside the site root", StringComparison.OrdinalIgnoreCase));
+            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
+            var linkset = apiCatalog.RootElement.GetProperty("linkset").EnumerateArray().ToArray();
+            var entry = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/safe-module/api/");
+            Assert.Equal("Safe Module API reference", entry.GetProperty("service-doc")[0].GetProperty("title").GetString());
         }
         finally
         {

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -123,6 +123,10 @@ public class WebAgentReadinessTests
             Directory.CreateDirectory(plainApiRoot);
             File.WriteAllText(Path.Combine(plainApiRoot, "index.html"), "<!doctype html><title>Plain API</title>");
 
+            var unknownApiRoot = Path.Combine(root, "projects", "unknown-module", "api");
+            Directory.CreateDirectory(unknownApiRoot);
+            File.WriteAllText(Path.Combine(unknownApiRoot, "index.html"), "<!doctype html><title>Unknown API</title>");
+
             var catalogRoot = Path.Combine(root, "data", "projects");
             Directory.CreateDirectory(catalogRoot);
             File.WriteAllText(Path.Combine(catalogRoot, "catalog.json"),
@@ -174,6 +178,7 @@ public class WebAgentReadinessTests
             Assert.Contains("https://example.test/projects/api-suite/", anchors);
             Assert.Contains("https://example.test/projects/gpozaurr/api/", anchors);
             Assert.Contains("https://example.test/projects/plain-project/api/", anchors);
+            Assert.Contains("https://example.test/projects/unknown-module/api/", anchors);
             Assert.DoesNotContain("https://officeimo.com/api/powershell/", anchors);
 
             var gpo = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/gpozaurr/api/");
@@ -182,6 +187,9 @@ public class WebAgentReadinessTests
 
             var plain = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/plain-project/api/");
             Assert.False(plain.TryGetProperty("service-desc", out _));
+
+            var unknown = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/unknown-module/api/");
+            Assert.Equal("Unknown Module API reference", unknown.GetProperty("service-doc")[0].GetProperty("title").GetString());
         }
         finally
         {

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -348,6 +348,68 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void Prepare_WithProjectCatalogTraversalPath_WarnsAndStillInfersProjectApi()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-project-api-traversal-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var apiRoot = Path.Combine(root, "projects", "traversal-module", "api");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "index.html"), "<!doctype html><title>Traversal API</title>");
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec
+                    {
+                        Enabled = true,
+                        IncludeProjectApiReferences = true,
+                        ProjectCatalogPath = "../outside-project-catalog.json"
+                    },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            Assert.Contains(result.Warnings, warning => warning.Contains("resolves outside the site root", StringComparison.OrdinalIgnoreCase));
+            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
+            var linkset = apiCatalog.RootElement.GetProperty("linkset").EnumerateArray().ToArray();
+            var entry = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/traversal-module/api/");
+            Assert.Equal("Traversal Module API reference", entry.GetProperty("service-doc")[0].GetProperty("title").GetString());
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Prepare_DoesNotInferHostedProjectApiReferencesWhenDisabled()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-project-api-disabled-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -221,7 +221,7 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
-    public void Prepare_WithProjectCatalogPathOutsideSiteRoot_WarnsAndStillInfersProjectApi()
+    public void Prepare_WithAbsoluteProjectCatalogPath_WarnsAndStillInfersProjectApi()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-project-api-catalog-path-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -270,7 +270,7 @@ public class WebAgentReadinessTests
             });
 
             Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
-            Assert.Contains(result.Warnings, warning => warning.Contains("resolves outside the site root", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result.Warnings, warning => warning.Contains("relative to the site root", StringComparison.OrdinalIgnoreCase));
             using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
             var linkset = apiCatalog.RootElement.GetProperty("linkset").EnumerateArray().ToArray();
             var entry = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/safe-module/api/");

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -92,6 +92,104 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void Prepare_IncludesHostedProjectApiReferencesWhenEnabled()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-project-api-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var gpoApiRoot = Path.Combine(root, "projects", "gpozaurr", "api");
+            Directory.CreateDirectory(gpoApiRoot);
+            File.WriteAllText(Path.Combine(gpoApiRoot, "index.html"), "<!doctype html><title>GPOZaurr API</title>");
+            File.WriteAllText(Path.Combine(gpoApiRoot, "index.json"), "{}");
+
+            var plainApiRoot = Path.Combine(root, "projects", "plain-project", "api");
+            Directory.CreateDirectory(plainApiRoot);
+            File.WriteAllText(Path.Combine(plainApiRoot, "index.html"), "<!doctype html><title>Plain API</title>");
+
+            var catalogRoot = Path.Combine(root, "data", "projects");
+            Directory.CreateDirectory(catalogRoot);
+            File.WriteAllText(Path.Combine(catalogRoot, "catalog.json"),
+                """
+                {
+                  "projects": [
+                    { "slug": "gpozaurr", "name": "GPOZaurr", "links": { "apiPowerShell": "/projects/gpozaurr/api/" } },
+                    { "slug": "plain-project", "name": "Plain Project", "links": { "apiPowerShell": null } },
+                    { "slug": "officeimo", "name": "OfficeIMO", "links": { "apiPowerShell": "https://officeimo.com/api/powershell/" } }
+                  ]
+                }
+                """);
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec
+                    {
+                        Enabled = true,
+                        IncludeProjectApiReferences = true,
+                        Entries = new[]
+                        {
+                            new AgentApiCatalogEntrySpec
+                            {
+                                Anchor = "/projects/api-suite/",
+                                ServiceDoc = "/projects/api-suite/",
+                                Title = "API suite"
+                            }
+                        }
+                    },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
+            var linkset = apiCatalog.RootElement.GetProperty("linkset").EnumerateArray().ToArray();
+            var anchors = linkset.Select(static item => item.GetProperty("anchor").GetString()).ToArray();
+
+            Assert.Contains("https://example.test/projects/api-suite/", anchors);
+            Assert.Contains("https://example.test/projects/gpozaurr/api/", anchors);
+            Assert.Contains("https://example.test/projects/plain-project/api/", anchors);
+            Assert.DoesNotContain("https://officeimo.com/api/powershell/", anchors);
+
+            var gpo = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/gpozaurr/api/");
+            Assert.Equal("https://example.test/projects/gpozaurr/api/index.json", gpo.GetProperty("service-desc")[0].GetProperty("href").GetString());
+            Assert.Equal("GPOZaurr PowerShell API reference", gpo.GetProperty("service-doc")[0].GetProperty("title").GetString());
+
+            var plain = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/plain-project/api/");
+            Assert.False(plain.TryGetProperty("service-desc", out _));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Prepare_WritesSecurityHeadersWhenLinkHeadersAreDisabled()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-security-headers-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -283,6 +283,71 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void Prepare_WithMalformedProjectCatalog_WarnsAndStillInfersProjectApi()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-project-api-bad-catalog-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":["WebSite","Organization"],"name":"Example","sameAs":["https://example.test"],"publisher":{"@type":"Organization","name":"Example"},"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example?</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var apiRoot = Path.Combine(root, "projects", "bad-catalog-module", "api");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "index.html"), "<!doctype html><title>Bad Catalog API</title>");
+
+            var catalogRoot = Path.Combine(root, "data", "projects");
+            Directory.CreateDirectory(catalogRoot);
+            File.WriteAllText(Path.Combine(catalogRoot, "catalog.json"), "{ this is not json");
+
+            var result = WebAgentReadiness.Prepare(new WebAgentReadinessPrepareOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                SiteName = "Example",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec
+                    {
+                        Enabled = true,
+                        IncludeProjectApiReferences = true
+                    },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false }
+                }
+            });
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            Assert.Contains(result.Warnings, warning => warning.Contains("Could not read project catalog", StringComparison.OrdinalIgnoreCase));
+            using var apiCatalog = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, ".well-known", "api-catalog")));
+            var linkset = apiCatalog.RootElement.GetProperty("linkset").EnumerateArray().ToArray();
+            var entry = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/bad-catalog-module/api/");
+            Assert.Equal("Bad Catalog Module API reference", entry.GetProperty("service-doc")[0].GetProperty("title").GetString());
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Prepare_WritesSecurityHeadersWhenLinkHeadersAreDisabled()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-security-headers-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -131,6 +131,10 @@ public class WebAgentReadinessTests
             Directory.CreateDirectory(numericApiRoot);
             File.WriteAllText(Path.Combine(numericApiRoot, "index.html"), "<!doctype html><title>Numeric API</title>");
 
+            var encodedApiRoot = Path.Combine(root, "projects", "space module", "api");
+            Directory.CreateDirectory(encodedApiRoot);
+            File.WriteAllText(Path.Combine(encodedApiRoot, "index.html"), "<!doctype html><title>Encoded API</title>");
+
             var duplicateApiRoot = Path.Combine(root, "projects", "duplicate-project", "api");
             Directory.CreateDirectory(duplicateApiRoot);
             File.WriteAllText(Path.Combine(duplicateApiRoot, "index.html"), "<!doctype html><title>Duplicate API</title>");
@@ -194,6 +198,7 @@ public class WebAgentReadinessTests
             Assert.Contains("https://example.test/projects/plain-project/api/", anchors);
             Assert.Contains("https://example.test/projects/unknown-module/api/", anchors);
             Assert.Contains("https://example.test/projects/123-module/api/", anchors);
+            Assert.Contains("https://example.test/projects/space%20module/api/", anchors);
             Assert.DoesNotContain("https://officeimo.com/api/powershell/", anchors);
             Assert.Single(anchors, static anchor => anchor == "https://example.test/projects/duplicate-project/api/");
 
@@ -209,6 +214,9 @@ public class WebAgentReadinessTests
 
             var numeric = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/123-module/api/");
             Assert.Equal("123 Module API reference", numeric.GetProperty("service-doc")[0].GetProperty("title").GetString());
+
+            var encoded = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/space%20module/api/");
+            Assert.Equal("Space Module API reference", encoded.GetProperty("service-doc")[0].GetProperty("title").GetString());
 
             var duplicate = linkset.Single(static item => item.GetProperty("anchor").GetString() == "https://example.test/projects/duplicate-project/api/");
             Assert.Equal("Explicit duplicate API", duplicate.GetProperty("service-doc")[0].GetProperty("title").GetString());

--- a/PowerForge.Web/Models/AgentReadinessSpec.cs
+++ b/PowerForge.Web/Models/AgentReadinessSpec.cs
@@ -133,6 +133,10 @@ public sealed class AgentApiCatalogSpec
     public bool Enabled { get; set; } = true;
     /// <summary>Output path relative to site root.</summary>
     public string? OutputPath { get; set; }
+    /// <summary>When true, infer entries from generated /projects/{slug}/api/ pages hosted by this site.</summary>
+    public bool IncludeProjectApiReferences { get; set; }
+    /// <summary>Optional project catalog path relative to site root. Used for inferred project API entry titles.</summary>
+    public string? ProjectCatalogPath { get; set; } = "data/projects/catalog.json";
     /// <summary>API catalog entries.</summary>
     public AgentApiCatalogEntrySpec[] Entries { get; set; } = Array.Empty<AgentApiCatalogEntrySpec>();
 }

--- a/PowerForge.Web/Models/AgentReadinessSpec.cs
+++ b/PowerForge.Web/Models/AgentReadinessSpec.cs
@@ -129,6 +129,8 @@ public sealed class AgentBotRuleSpec
 /// <summary>API catalog output settings.</summary>
 public sealed class AgentApiCatalogSpec
 {
+    internal const string DefaultProjectCatalogPath = "data/projects/catalog.json";
+
     /// <summary>Enable /.well-known/api-catalog generation.</summary>
     public bool Enabled { get; set; } = true;
     /// <summary>Output path relative to site root.</summary>
@@ -136,7 +138,7 @@ public sealed class AgentApiCatalogSpec
     /// <summary>When true, infer entries from generated /projects/{slug}/api/ pages hosted by this site.</summary>
     public bool IncludeProjectApiReferences { get; set; }
     /// <summary>Optional project catalog path relative to site root. Used for inferred project API entry titles.</summary>
-    public string? ProjectCatalogPath { get; set; } = "data/projects/catalog.json";
+    public string? ProjectCatalogPath { get; set; } = DefaultProjectCatalogPath;
     /// <summary>API catalog entries.</summary>
     public AgentApiCatalogEntrySpec[] Entries { get; set; } = Array.Empty<AgentApiCatalogEntrySpec>();
 }

--- a/PowerForge.Web/Models/AgentReadinessSpec.cs
+++ b/PowerForge.Web/Models/AgentReadinessSpec.cs
@@ -136,7 +136,7 @@ public sealed class AgentApiCatalogSpec
     /// <summary>When true, infer entries from generated /projects/{slug}/api/ pages hosted by this site.</summary>
     public bool IncludeProjectApiReferences { get; set; }
     /// <summary>Optional project catalog path relative to site root. Null or blank uses the default project catalog path.</summary>
-    public string? ProjectCatalogPath { get; set; } = WebAgentReadiness.DefaultProjectCatalogPath;
+    public string? ProjectCatalogPath { get; set; }
     /// <summary>API catalog entries.</summary>
     public AgentApiCatalogEntrySpec[] Entries { get; set; } = Array.Empty<AgentApiCatalogEntrySpec>();
 }

--- a/PowerForge.Web/Models/AgentReadinessSpec.cs
+++ b/PowerForge.Web/Models/AgentReadinessSpec.cs
@@ -129,16 +129,14 @@ public sealed class AgentBotRuleSpec
 /// <summary>API catalog output settings.</summary>
 public sealed class AgentApiCatalogSpec
 {
-    private const string DefaultProjectCatalogPath = "data/projects/catalog.json";
-
     /// <summary>Enable /.well-known/api-catalog generation.</summary>
     public bool Enabled { get; set; } = true;
     /// <summary>Output path relative to site root.</summary>
     public string? OutputPath { get; set; }
     /// <summary>When true, infer entries from generated /projects/{slug}/api/ pages hosted by this site.</summary>
     public bool IncludeProjectApiReferences { get; set; }
-    /// <summary>Optional project catalog path relative to site root. Used for inferred project API entry titles.</summary>
-    public string? ProjectCatalogPath { get; set; } = DefaultProjectCatalogPath;
+    /// <summary>Optional project catalog path relative to site root. Null or blank uses the default project catalog path.</summary>
+    public string? ProjectCatalogPath { get; set; } = WebAgentReadiness.DefaultProjectCatalogPath;
     /// <summary>API catalog entries.</summary>
     public AgentApiCatalogEntrySpec[] Entries { get; set; } = Array.Empty<AgentApiCatalogEntrySpec>();
 }

--- a/PowerForge.Web/Models/AgentReadinessSpec.cs
+++ b/PowerForge.Web/Models/AgentReadinessSpec.cs
@@ -129,7 +129,7 @@ public sealed class AgentBotRuleSpec
 /// <summary>API catalog output settings.</summary>
 public sealed class AgentApiCatalogSpec
 {
-    internal const string DefaultProjectCatalogPath = "data/projects/catalog.json";
+    private const string DefaultProjectCatalogPath = "data/projects/catalog.json";
 
     /// <summary>Enable /.well-known/api-catalog generation.</summary>
     public bool Enabled { get; set; } = true;

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -16,7 +16,7 @@ public static class WebAgentReadiness
     private const string AgentBlockStart = "# BEGIN PowerForge Agent Readiness";
     private const string AgentBlockEnd = "# END PowerForge Agent Readiness";
     private const string AgentSkillsSchema = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
-    private const string DefaultProjectCatalogPath = "data/projects/catalog.json";
+    internal const string DefaultProjectCatalogPath = "data/projects/catalog.json";
     private static readonly StringComparison FileSystemPathComparison = OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
@@ -626,9 +626,8 @@ public static class WebAgentReadiness
 
                 var name = GetJsonString(project, "name");
                 var apiPowerShell = project.TryGetProperty("links", out var links) ? GetJsonString(links, "apiPowerShell") : null;
-                var slugKey = slug;
-                catalog[slugKey] = new ProjectApiCatalogInfo(
-                    string.IsNullOrWhiteSpace(name) ? ToDisplayNameFromSlug(slugKey) : name!,
+                catalog[slug] = new ProjectApiCatalogInfo(
+                    string.IsNullOrWhiteSpace(name) ? ToDisplayNameFromSlug(slug) : name!,
                     IsLocalProjectApiRoute(apiPowerShell));
             }
         }
@@ -653,17 +652,19 @@ public static class WebAgentReadiness
         var normalized = Uri.TryCreate(value, UriKind.Absolute, out var uri)
             ? uri.AbsoluteUri
             : NormalizeRoute(value);
+        // Treat /api and /api/ as the same catalog anchor for explicit-vs-inferred de-duplication.
         return normalized.EndsWith("/", StringComparison.Ordinal) ? normalized : normalized + "/";
     }
 
     private static string ToDisplayNameFromSlug(string slug)
     {
-        return string.Join(
+        var displayName = string.Join(
             " ",
             SlugSeparatorRegex
                 .Split(slug.Trim())
                 .Where(static part => !string.IsNullOrWhiteSpace(part))
                 .Select(static part => char.ToUpperInvariant(part[0]) + part.Substring(1)));
+        return string.IsNullOrWhiteSpace(displayName) ? slug.Trim() : displayName;
     }
 
     private static bool IsLocalProjectApiRoute(string? value)

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -493,7 +493,23 @@ public static class WebAgentReadiness
     {
         var output = string.IsNullOrWhiteSpace(spec.OutputPath) ? ".well-known/api-catalog" : spec.OutputPath!;
         var outputPath = ResolveSitePath(siteRoot, output);
-        var entries = spec.Entries?.Where(static e => !string.IsNullOrWhiteSpace(e.Anchor)).ToList() ?? new List<AgentApiCatalogEntrySpec>();
+        var entries = new List<AgentApiCatalogEntrySpec>();
+        var anchors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in spec.Entries?.Where(static e => !string.IsNullOrWhiteSpace(e.Anchor)) ?? Array.Empty<AgentApiCatalogEntrySpec>())
+        {
+            if (anchors.Add(NormalizeApiCatalogAnchorKey(entry.Anchor)))
+                entries.Add(entry);
+        }
+
+        if (spec.IncludeProjectApiReferences)
+        {
+            foreach (var entry in InferProjectApiReferenceEntries(siteRoot, spec, warnings))
+            {
+                if (anchors.Add(NormalizeApiCatalogAnchorKey(entry.Anchor)))
+                    entries.Add(entry);
+            }
+        }
+
         if (entries.Count == 0)
         {
             var apiIndex = Path.Combine(siteRoot, "api", "index.json");
@@ -533,6 +549,109 @@ public static class WebAgentReadiness
         File.WriteAllText(outputPath, root.ToJsonString(WebJson.Options));
         return outputPath;
     }
+
+    private static IEnumerable<AgentApiCatalogEntrySpec> InferProjectApiReferenceEntries(string siteRoot, AgentApiCatalogSpec spec, List<string> warnings)
+    {
+        var projectsRoot = Path.Combine(siteRoot, "projects");
+        if (!Directory.Exists(projectsRoot))
+            yield break;
+
+        var catalog = ReadProjectApiCatalogInfo(siteRoot, spec.ProjectCatalogPath, warnings);
+        foreach (var apiIndexPath in Directory.EnumerateFiles(projectsRoot, "index.html", SearchOption.AllDirectories).OrderBy(static path => path, StringComparer.OrdinalIgnoreCase))
+        {
+            var apiDirectory = Directory.GetParent(apiIndexPath);
+            var projectDirectory = apiDirectory?.Parent;
+            if (apiDirectory is null ||
+                projectDirectory is null ||
+                !apiDirectory.Name.Equals("api", StringComparison.OrdinalIgnoreCase) ||
+                !Path.GetFullPath(projectDirectory.Parent?.FullName ?? string.Empty).Equals(Path.GetFullPath(projectsRoot), FileSystemPathComparison))
+            {
+                continue;
+            }
+
+            var slug = projectDirectory.Name;
+            var route = $"/projects/{slug}/api/";
+            var title = BuildProjectApiTitle(slug, catalog.TryGetValue(slug, out var info) ? info : null);
+            var descriptorRoute = File.Exists(Path.Combine(apiDirectory.FullName, "index.json"))
+                ? $"{route}index.json"
+                : null;
+
+            yield return new AgentApiCatalogEntrySpec
+            {
+                Anchor = route,
+                ServiceDesc = descriptorRoute,
+                ServiceDoc = route,
+                Title = title
+            };
+        }
+    }
+
+    private static Dictionary<string, ProjectApiCatalogInfo> ReadProjectApiCatalogInfo(string siteRoot, string? projectCatalogPath, List<string> warnings)
+    {
+        var catalog = new Dictionary<string, ProjectApiCatalogInfo>(StringComparer.OrdinalIgnoreCase);
+        var configuredPath = string.IsNullOrWhiteSpace(projectCatalogPath) ? "data/projects/catalog.json" : projectCatalogPath!;
+        var catalogPath = ResolveSitePath(siteRoot, configuredPath);
+        if (!File.Exists(catalogPath))
+            return catalog;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(catalogPath));
+            if (!doc.RootElement.TryGetProperty("projects", out var projects) || projects.ValueKind != JsonValueKind.Array)
+                return catalog;
+
+            foreach (var project in projects.EnumerateArray())
+            {
+                var slug = GetJsonString(project, "slug");
+                if (string.IsNullOrWhiteSpace(slug))
+                    continue;
+
+                var name = GetJsonString(project, "name");
+                var apiPowerShell = project.TryGetProperty("links", out var links) ? GetJsonString(links, "apiPowerShell") : null;
+                catalog[slug!] = new ProjectApiCatalogInfo(
+                    string.IsNullOrWhiteSpace(name) ? ToDisplayNameFromSlug(slug!) : name!,
+                    IsLocalProjectApiRoute(apiPowerShell));
+            }
+        }
+        catch (Exception ex)
+        {
+            warnings.Add($"Could not read project catalog '{configuredPath}' for API catalog titles: {ex.Message}");
+        }
+
+        return catalog;
+    }
+
+    private static string BuildProjectApiTitle(string slug, ProjectApiCatalogInfo? info)
+    {
+        var name = string.IsNullOrWhiteSpace(info?.Name) ? ToDisplayNameFromSlug(slug) : info!.Name;
+        return info?.IsPowerShellApi == true
+            ? $"{name} PowerShell API reference"
+            : $"{name} API reference";
+    }
+
+    private static string NormalizeApiCatalogAnchorKey(string value)
+    {
+        var normalized = Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            ? uri.AbsoluteUri
+            : NormalizeRoute(value);
+        return normalized.EndsWith("/", StringComparison.Ordinal) ? normalized : normalized + "/";
+    }
+
+    private static string ToDisplayNameFromSlug(string slug)
+    {
+        var normalized = Regex.Replace(slug.Trim(), @"[-_]+", " ");
+        return Regex.Replace(normalized, @"\b\p{Ll}", static match => match.Value.ToUpperInvariant());
+    }
+
+    private static bool IsLocalProjectApiRoute(string? value)
+        => !string.IsNullOrWhiteSpace(value) &&
+           !Uri.TryCreate(value, UriKind.Absolute, out _) &&
+           NormalizeRoute(value!).StartsWith("/projects/", StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetJsonString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
 
     private static string? WriteAgentSkills(string siteRoot, string? baseUrl, string siteName, AgentSkillsDiscoverySpec spec, List<string> warnings)
     {
@@ -2093,6 +2212,7 @@ public static class WebAgentReadiness
     private sealed record OpenApiScanResult(bool Success, string? Url);
     private sealed record HttpTextResult(bool Success, string Message, string Text, HttpResponseMessage? Response);
     private sealed record HttpResponseResult(bool Success, string Message, HttpResponseMessage? Response);
+    private sealed record ProjectApiCatalogInfo(string Name, bool IsPowerShellApi);
 }
 
 /// <summary>Options for preparing local agent-readiness artifacts.</summary>

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -27,7 +27,7 @@ public static class WebAgentReadiness
     private static readonly Regex MarkdownTrailingWhitespaceRegex = new(@"[ \t]+\n", RegexOptions.Compiled);
     private static readonly Regex MarkdownBlankLinesRegex = new(@"\n{3,}", RegexOptions.Compiled);
     private static readonly Regex MarkdownRepeatedSpacesRegex = new(@"[ \t]{2,}", RegexOptions.Compiled);
-    private static readonly Regex SlugSeparatorRegex = new(@"[-_]+", RegexOptions.Compiled);
+    private static readonly Regex SlugSeparatorRegex = new(@"[-_\s]+", RegexOptions.Compiled);
 
     /// <summary>Writes configured agent-readiness files under the site root.</summary>
     public static WebAgentReadinessResult Prepare(WebAgentReadinessPrepareOptions options)
@@ -582,7 +582,7 @@ public static class WebAgentReadiness
             if (!File.Exists(apiIndexPath))
                 continue;
 
-            var route = $"/projects/{slug}/api/";
+            var route = $"/projects/{Uri.EscapeDataString(slug)}/api/";
             var title = BuildProjectApiTitle(slug, catalog.TryGetValue(slug, out var info) ? info : null);
             var descriptorRoute = File.Exists(Path.Combine(apiDirectory, "index.json"))
                 ? $"{route}index.json"
@@ -610,11 +610,15 @@ public static class WebAgentReadiness
 
         try
         {
-            var catalogPath = ResolveSitePath(siteRoot, configuredPath);
+            var catalogPath = ResolveProjectCatalogPath(siteRoot, configuredPath, warnings);
+            if (catalogPath is null)
+                return catalog;
+
             if (!File.Exists(catalogPath))
                 return catalog;
 
-            using var doc = JsonDocument.Parse(File.ReadAllText(catalogPath));
+            using var stream = File.OpenRead(catalogPath);
+            using var doc = JsonDocument.Parse(stream);
             if (!doc.RootElement.TryGetProperty("projects", out var projects) || projects.ValueKind != JsonValueKind.Array)
                 return catalog;
 
@@ -637,6 +641,29 @@ public static class WebAgentReadiness
         }
 
         return catalog;
+    }
+
+    private static string? ResolveProjectCatalogPath(string siteRoot, string configuredPath, List<string> warnings)
+    {
+        var root = Path.GetFullPath(siteRoot.Trim().Trim('"'));
+        var normalized = configuredPath.Trim().Trim('"').Replace('/', Path.DirectorySeparatorChar).TrimStart(Path.DirectorySeparatorChar);
+        var resolved = Path.GetFullPath(Path.Combine(root, normalized));
+        if (!IsPathInsideRoot(root, resolved))
+        {
+            warnings.Add($"Could not read project catalog '{configuredPath}' for API catalog titles: path resolves outside the site root.");
+            return null;
+        }
+
+        return resolved;
+    }
+
+    private static bool IsPathInsideRoot(string root, string resolvedPath)
+    {
+        var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+        return resolvedPath.Equals(root, FileSystemPathComparison) ||
+               resolvedPath.StartsWith(rootWithSeparator, FileSystemPathComparison);
     }
 
     private static string BuildProjectApiTitle(string slug, ProjectApiCatalogInfo? info)
@@ -663,7 +690,7 @@ public static class WebAgentReadiness
             SlugSeparatorRegex
                 .Split(slug.Trim())
                 .Where(static part => !string.IsNullOrWhiteSpace(part))
-                .Select(static part => char.ToUpperInvariant(part[0]) + part.Substring(1)));
+                .Select(static part => char.ToUpperInvariant(part[0]) + part[1..]));
         return string.IsNullOrWhiteSpace(displayName) ? slug.Trim() : displayName;
     }
 

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -16,6 +16,7 @@ public static class WebAgentReadiness
     private const string AgentBlockStart = "# BEGIN PowerForge Agent Readiness";
     private const string AgentBlockEnd = "# END PowerForge Agent Readiness";
     private const string AgentSkillsSchema = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+    private const string DefaultProjectCatalogPath = "data/projects/catalog.json";
     private static readonly StringComparison FileSystemPathComparison = OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
@@ -518,7 +519,7 @@ public static class WebAgentReadiness
                 }
                 else
                 {
-                    warnings.Add($"Inferred project API catalog anchor '{entry.Anchor}' was ignored because an explicit entry already exists.");
+                    warnings.Add($"Inferred project API catalog anchor '{entry.Anchor}' was ignored because a duplicate entry already exists.");
                 }
             }
         }
@@ -600,7 +601,7 @@ public static class WebAgentReadiness
     private static Dictionary<string, ProjectApiCatalogInfo> ReadProjectApiCatalogInfo(string siteRoot, string? projectCatalogPath, List<string> warnings)
     {
         var catalog = new Dictionary<string, ProjectApiCatalogInfo>(StringComparer.OrdinalIgnoreCase);
-        var configuredPath = string.IsNullOrWhiteSpace(projectCatalogPath) ? AgentApiCatalogSpec.DefaultProjectCatalogPath : projectCatalogPath!;
+        var configuredPath = string.IsNullOrWhiteSpace(projectCatalogPath) ? DefaultProjectCatalogPath : projectCatalogPath!;
         if (Path.IsPathFullyQualified(configuredPath))
         {
             warnings.Add($"Could not read project catalog '{configuredPath}' for API catalog titles: path must be relative to the site root.");
@@ -625,8 +626,9 @@ public static class WebAgentReadiness
 
                 var name = GetJsonString(project, "name");
                 var apiPowerShell = project.TryGetProperty("links", out var links) ? GetJsonString(links, "apiPowerShell") : null;
-                catalog[slug!] = new ProjectApiCatalogInfo(
-                    string.IsNullOrWhiteSpace(name) ? ToDisplayNameFromSlug(slug!) : name!,
+                var slugKey = slug;
+                catalog[slugKey] = new ProjectApiCatalogInfo(
+                    string.IsNullOrWhiteSpace(name) ? ToDisplayNameFromSlug(slugKey) : name!,
                     IsLocalProjectApiRoute(apiPowerShell));
             }
         }

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -600,7 +600,12 @@ public static class WebAgentReadiness
     private static Dictionary<string, ProjectApiCatalogInfo> ReadProjectApiCatalogInfo(string siteRoot, string? projectCatalogPath, List<string> warnings)
     {
         var catalog = new Dictionary<string, ProjectApiCatalogInfo>(StringComparer.OrdinalIgnoreCase);
-        var configuredPath = string.IsNullOrWhiteSpace(projectCatalogPath) ? "data/projects/catalog.json" : projectCatalogPath!;
+        var configuredPath = string.IsNullOrWhiteSpace(projectCatalogPath) ? AgentApiCatalogSpec.DefaultProjectCatalogPath : projectCatalogPath!;
+        if (Path.IsPathFullyQualified(configuredPath))
+        {
+            warnings.Add($"Could not read project catalog '{configuredPath}' for API catalog titles: path must be relative to the site root.");
+            return catalog;
+        }
 
         try
         {

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -27,7 +27,6 @@ public static class WebAgentReadiness
     private static readonly Regex MarkdownBlankLinesRegex = new(@"\n{3,}", RegexOptions.Compiled);
     private static readonly Regex MarkdownRepeatedSpacesRegex = new(@"[ \t]{2,}", RegexOptions.Compiled);
     private static readonly Regex SlugSeparatorRegex = new(@"[-_]+", RegexOptions.Compiled);
-    private static readonly Regex SlugWordBoundaryRegex = new(@"\b\p{Ll}", RegexOptions.Compiled);
 
     /// <summary>Writes configured agent-readiness files under the site root.</summary>
     public static WebAgentReadinessResult Prepare(WebAgentReadinessPrepareOptions options)
@@ -500,7 +499,13 @@ public static class WebAgentReadiness
         foreach (var entry in spec.Entries?.Where(static e => !string.IsNullOrWhiteSpace(e.Anchor)) ?? Array.Empty<AgentApiCatalogEntrySpec>())
         {
             if (anchors.Add(NormalizeApiCatalogAnchorKey(entry.Anchor)))
+            {
                 entries.Add(entry);
+            }
+            else
+            {
+                warnings.Add($"Duplicate API catalog anchor '{entry.Anchor}' was ignored.");
+            }
         }
 
         if (spec.IncludeProjectApiReferences)
@@ -508,7 +513,13 @@ public static class WebAgentReadiness
             foreach (var entry in InferProjectApiReferenceEntries(siteRoot, spec, warnings))
             {
                 if (anchors.Add(NormalizeApiCatalogAnchorKey(entry.Anchor)))
+                {
                     entries.Add(entry);
+                }
+                else
+                {
+                    warnings.Add($"Inferred project API catalog anchor '{entry.Anchor}' was ignored because an explicit entry already exists.");
+                }
             }
         }
 
@@ -590,12 +601,13 @@ public static class WebAgentReadiness
     {
         var catalog = new Dictionary<string, ProjectApiCatalogInfo>(StringComparer.OrdinalIgnoreCase);
         var configuredPath = string.IsNullOrWhiteSpace(projectCatalogPath) ? "data/projects/catalog.json" : projectCatalogPath!;
-        var catalogPath = ResolveSitePath(siteRoot, configuredPath);
-        if (!File.Exists(catalogPath))
-            return catalog;
 
         try
         {
+            var catalogPath = ResolveSitePath(siteRoot, configuredPath);
+            if (!File.Exists(catalogPath))
+                return catalog;
+
             using var doc = JsonDocument.Parse(File.ReadAllText(catalogPath));
             if (!doc.RootElement.TryGetProperty("projects", out var projects) || projects.ValueKind != JsonValueKind.Array)
                 return catalog;
@@ -639,8 +651,12 @@ public static class WebAgentReadiness
 
     private static string ToDisplayNameFromSlug(string slug)
     {
-        var normalized = SlugSeparatorRegex.Replace(slug.Trim(), " ");
-        return SlugWordBoundaryRegex.Replace(normalized, static match => match.Value.ToUpperInvariant());
+        return string.Join(
+            " ",
+            SlugSeparatorRegex
+                .Split(slug.Trim())
+                .Where(static part => !string.IsNullOrWhiteSpace(part))
+                .Select(static part => char.ToUpperInvariant(part[0]) + part.Substring(1)));
     }
 
     private static bool IsLocalProjectApiRoute(string? value)

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -26,6 +26,8 @@ public static class WebAgentReadiness
     private static readonly Regex MarkdownTrailingWhitespaceRegex = new(@"[ \t]+\n", RegexOptions.Compiled);
     private static readonly Regex MarkdownBlankLinesRegex = new(@"\n{3,}", RegexOptions.Compiled);
     private static readonly Regex MarkdownRepeatedSpacesRegex = new(@"[ \t]{2,}", RegexOptions.Compiled);
+    private static readonly Regex SlugSeparatorRegex = new(@"[-_]+", RegexOptions.Compiled);
+    private static readonly Regex SlugWordBoundaryRegex = new(@"\b\p{Ll}", RegexOptions.Compiled);
 
     /// <summary>Writes configured agent-readiness files under the site root.</summary>
     public static WebAgentReadinessResult Prepare(WebAgentReadinessPrepareOptions options)
@@ -557,22 +559,20 @@ public static class WebAgentReadiness
             yield break;
 
         var catalog = ReadProjectApiCatalogInfo(siteRoot, spec.ProjectCatalogPath, warnings);
-        foreach (var apiIndexPath in Directory.EnumerateFiles(projectsRoot, "index.html", SearchOption.AllDirectories).OrderBy(static path => path, StringComparer.OrdinalIgnoreCase))
+        foreach (var projectDirectory in Directory.EnumerateDirectories(projectsRoot).OrderBy(static path => path, StringComparer.OrdinalIgnoreCase))
         {
-            var apiDirectory = Directory.GetParent(apiIndexPath);
-            var projectDirectory = apiDirectory?.Parent;
-            if (apiDirectory is null ||
-                projectDirectory is null ||
-                !apiDirectory.Name.Equals("api", StringComparison.OrdinalIgnoreCase) ||
-                !Path.GetFullPath(projectDirectory.Parent?.FullName ?? string.Empty).Equals(Path.GetFullPath(projectsRoot), FileSystemPathComparison))
-            {
+            var slug = Path.GetFileName(projectDirectory);
+            if (string.IsNullOrWhiteSpace(slug))
                 continue;
-            }
 
-            var slug = projectDirectory.Name;
+            var apiDirectory = Path.Combine(projectDirectory, "api");
+            var apiIndexPath = Path.Combine(apiDirectory, "index.html");
+            if (!File.Exists(apiIndexPath))
+                continue;
+
             var route = $"/projects/{slug}/api/";
             var title = BuildProjectApiTitle(slug, catalog.TryGetValue(slug, out var info) ? info : null);
-            var descriptorRoute = File.Exists(Path.Combine(apiDirectory.FullName, "index.json"))
+            var descriptorRoute = File.Exists(Path.Combine(apiDirectory, "index.json"))
                 ? $"{route}index.json"
                 : null;
 
@@ -639,8 +639,8 @@ public static class WebAgentReadiness
 
     private static string ToDisplayNameFromSlug(string slug)
     {
-        var normalized = Regex.Replace(slug.Trim(), @"[-_]+", " ");
-        return Regex.Replace(normalized, @"\b\p{Ll}", static match => match.Value.ToUpperInvariant());
+        var normalized = SlugSeparatorRegex.Replace(slug.Trim(), " ");
+        return SlugWordBoundaryRegex.Replace(normalized, static match => match.Value.ToUpperInvariant());
     }
 
     private static bool IsLocalProjectApiRoute(string? value)

--- a/Schemas/powerforge.web.sitespec.schema.json
+++ b/Schemas/powerforge.web.sitespec.schema.json
@@ -947,6 +947,10 @@
         "enabled": { "type": "boolean" },
         "OutputPath": { "type": "string" },
         "outputPath": { "type": "string" },
+        "IncludeProjectApiReferences": { "type": "boolean" },
+        "includeProjectApiReferences": { "type": "boolean" },
+        "ProjectCatalogPath": { "type": "string" },
+        "projectCatalogPath": { "type": "string" },
         "Entries": { "type": "array", "items": { "$ref": "#/$defs/AgentApiCatalogEntrySpec" } },
         "entries": { "type": "array", "items": { "$ref": "#/$defs/AgentApiCatalogEntrySpec" } }
       }


### PR DESCRIPTION
## Summary
- add `agentReadiness.apiCatalog.includeProjectApiReferences` and `projectCatalogPath`
- infer local `/projects/{slug}/api/` pages into RFC 9727 API catalog output
- use the generated project catalog for better titles while leaving external dedicated project sites to publish their own metadata
- add schema, docs, and WebAgentReadiness coverage for the generated entries
- de-duplicate explicit and inferred API catalog anchors by normalized URL, preserving the first explicit entry and warning on duplicates

## Validation
- `git diff --check -- Docs/PowerForge.Web.AgentReadiness.md PowerForge.Tests/WebAgentReadinessTests.cs PowerForge.Web/Models/AgentReadinessSpec.cs PowerForge.Web/Services/WebAgentReadiness.cs Schemas/powerforge.web.sitespec.schema.json`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter WebAgentReadinessTests --no-restore --nologo`
- `dotnet build .\PowerForge.Web\PowerForge.Web.csproj -c Release --nologo`
- `dotnet build .\PowerForge.Web.Cli\PowerForge.Web.Cli.csproj -c Release --no-restore --nologo`
- `PowerForge.Web.Cli.exe pipeline --config C:\Support\GitHub\Website\pipeline.json --mode dev --skip sources-sync`
- `PowerForge.Web.Cli.exe agent-ready prepare --site-root C:\Support\GitHub\Website\_site --config C:\Support\GitHub\Website\site.json --base-url https://evotec.xyz --fail-on-failures --output json`

## Notes
The website consumer changes in `C:\Support\GitHub\Website` are intentionally not included here. This PR keeps the reusable engine behavior isolated so the hub can opt in cleanly after the engine change lands.