### PR TITLE
Respect rendered noindex in sitemap metadata

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerSitemapTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerSitemapTests.cs
@@ -24,12 +24,27 @@ public class WebPipelineRunnerSitemapTests
 
                 Hello
                 """);
+            File.WriteAllText(Path.Combine(contentRoot, "search.md"),
+                """
+                ---
+                title: Search
+                slug: search
+                layout: search
+                date: 2020-01-03
+                ---
+
+                Search page
+                """);
 
             var themeRoot = Path.Combine(root, "themes", "base", "layouts");
             Directory.CreateDirectory(themeRoot);
             File.WriteAllText(Path.Combine(themeRoot, "page.html"),
                 """
                 <!doctype html><html><head><title>{{TITLE}}</title></head><body>{{CONTENT}}</body></html>
+                """);
+            File.WriteAllText(Path.Combine(themeRoot, "search.html"),
+                """
+                <!doctype html><html><head><title>{{TITLE}}</title><meta name="robots" content="noindex,follow" /></head><body>{{CONTENT}}</body></html>
                 """);
 
             File.WriteAllText(Path.Combine(root, "site.json"),
@@ -66,10 +81,14 @@ public class WebPipelineRunnerSitemapTests
             var content = File.ReadAllText(sitemapPath);
             Assert.Contains("https://example.test/", content, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<lastmod>2020-01-02T00:00:00.000Z</lastmod>", content, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("https://example.test/search", content, StringComparison.OrdinalIgnoreCase);
 
             var metadataPath = Path.Combine(root, "site", "_powerforge", "sitemap-entries.json");
             Assert.True(File.Exists(metadataPath));
-            Assert.Contains("2020-01-02T00:00:00.000Z", File.ReadAllText(metadataPath), StringComparison.OrdinalIgnoreCase);
+            var metadata = File.ReadAllText(metadataPath);
+            Assert.Contains("2020-01-02T00:00:00.000Z", metadata, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"path\": \"/search\"", metadata, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"noIndex\": true", metadata, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Web/Services/WebSiteBuilder.Sitemap.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Sitemap.cs
@@ -1,15 +1,22 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace PowerForge.Web;
 
 /// <summary>Exports trusted builder sitemap metadata under _powerforge/sitemap-entries.json.</summary>
 public static partial class WebSiteBuilder
 {
+    private static readonly TimeSpan SitemapRenderedHtmlRegexTimeout = TimeSpan.FromSeconds(1);
+    private static readonly Regex SitemapMetaTagRegex = new("<meta\\b[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, SitemapRenderedHtmlRegexTimeout);
+    private static readonly Regex SitemapHtmlAttributeRegex = new("(?<name>[a-zA-Z_:][\\w:.-]*)\\s*=\\s*(?<q>['\"])(?<value>.*?)\\k<q>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.CultureInvariant, SitemapRenderedHtmlRegexTimeout);
+    private static readonly string[] SitemapNoIndexMetaNames = { "robots", "googlebot", "bingbot", "slurp" };
+
     private static void WriteSitemapEntriesReport(
         SiteSpec spec,
         IReadOnlyList<ContentItem> items,
-        string metaDir)
+        string metaDir,
+        string outputRoot)
     {
         var entries = items
             .Where(static item => item is not null && !item.Draft && !string.IsNullOrWhiteSpace(item.OutputPath))
@@ -23,7 +30,7 @@ public static partial class WebSiteBuilder
                 Description = item.Description,
                 Section = item.Collection,
                 LastModified = FormatSitemapLastModified(item.LastModifiedUtc),
-                NoIndex = ItemDeclaresNoIndex(spec, item)
+                NoIndex = ItemDeclaresNoIndex(spec, item, outputRoot)
             })
             .ToArray();
 
@@ -60,7 +67,7 @@ public static partial class WebSiteBuilder
              string.Equals(format.Suffix, "html", StringComparison.OrdinalIgnoreCase)));
     }
 
-    private static bool ItemDeclaresNoIndex(SiteSpec spec, ContentItem item)
+    private static bool ItemDeclaresNoIndex(SiteSpec spec, ContentItem item, string outputRoot)
     {
         var forceFallbackNoIndex = IsLocalizedFallbackCopy(item) && !HasExplicitRobotsOverride(item);
         var resolved = ResolveCrawlPolicy(spec, item);
@@ -69,11 +76,94 @@ public static partial class WebSiteBuilder
             : resolved.Robots;
 
         return ContainsNoIndexDirective(robots) ||
-               resolved.Bots.Values.Any(ContainsNoIndexDirective);
+               resolved.Bots.Values.Any(ContainsNoIndexDirective) ||
+               RenderedHtmlDeclaresNoIndex(spec, item, outputRoot);
     }
 
     private static bool ContainsNoIndexDirective(string? directives)
         => !string.IsNullOrWhiteSpace(directives) &&
            directives.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
                .Any(static directive => directive.Equals("noindex", StringComparison.OrdinalIgnoreCase));
+
+    private static bool RenderedHtmlDeclaresNoIndex(SiteSpec spec, ContentItem item, string outputRoot)
+    {
+        if (string.IsNullOrWhiteSpace(outputRoot))
+            return false;
+
+        foreach (var format in ResolveOutputFormats(spec, item))
+        {
+            if (format is null ||
+                (!string.Equals(format.Name, "html", StringComparison.OrdinalIgnoreCase) &&
+                 !string.IsNullOrWhiteSpace(format.Suffix) &&
+                 !string.Equals(format.Suffix, "html", StringComparison.OrdinalIgnoreCase) &&
+                 !string.Equals(format.Suffix, "htm", StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            var route = ResolveOutputRoute(item.OutputPath, format);
+            var path = ResolveRenderedHtmlPath(outputRoot, route, format);
+            if (!string.IsNullOrWhiteSpace(path) &&
+                File.Exists(path) &&
+                HasNoIndexRobotsMeta(File.ReadAllText(path)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ResolveRenderedHtmlPath(string outputRoot, string route, OutputFormatSpec format)
+    {
+        var normalizedRoute = NormalizeRouteForMatch(route).Trim('/');
+        var fileName = ResolveOutputFileName(format);
+        var relative = string.IsNullOrWhiteSpace(normalizedRoute)
+            ? fileName
+            : normalizedRoute.EndsWith(".html", StringComparison.OrdinalIgnoreCase) ||
+              normalizedRoute.EndsWith(".htm", StringComparison.OrdinalIgnoreCase)
+                ? normalizedRoute
+                : Path.Combine(normalizedRoute.Replace('/', Path.DirectorySeparatorChar), fileName);
+
+        return Path.GetFullPath(Path.Combine(outputRoot, relative));
+    }
+
+    private static bool HasNoIndexRobotsMeta(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return false;
+
+        foreach (Match tagMatch in SitemapMetaTagRegex.Matches(html))
+        {
+            var tag = tagMatch.Value;
+            var name = ReadSitemapHtmlAttribute(tag, "name");
+            if (string.IsNullOrWhiteSpace(name) ||
+                !SitemapNoIndexMetaNames.Any(known => known.Equals(name, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            var content = ReadSitemapHtmlAttribute(tag, "content");
+            if (ContainsNoIndexDirective(content))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string? ReadSitemapHtmlAttribute(string tag, string attrName)
+    {
+        if (string.IsNullOrWhiteSpace(tag) || string.IsNullOrWhiteSpace(attrName))
+            return null;
+
+        foreach (Match attrMatch in SitemapHtmlAttributeRegex.Matches(tag))
+        {
+            var name = attrMatch.Groups["name"].Value;
+            if (!name.Equals(attrName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            return System.Net.WebUtility.HtmlDecode(attrMatch.Groups["value"].Value).Trim();
+        }
+
+        return null;
+    }
 }

--- a/PowerForge.Web/Services/WebSiteBuilder.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.cs
@@ -212,7 +212,7 @@ public static partial class WebSiteBuilder
             WriteSearchIndex(spec, outDir, renderItems);
             WriteLinkCheckReport(spec, renderItems, metaDir);
             WriteSeoPreviewReport(spec, renderItems, metaDir);
-            WriteSitemapEntriesReport(spec, renderItems, metaDir);
+            WriteSitemapEntriesReport(spec, renderItems, metaDir, outDir);
             WriteCrawlPolicyReport(spec, renderItems, metaDir);
 
             var redirectsPayload = new


### PR DESCRIPTION
## Summary
- mark generated sitemap metadata noIndex when rendered HTML declares robots noindex
- keep trusted generated metadata safe for layout-level noindex pages such as search
- add a pipeline regression test that verifies rendered noindex metadata is excluded from sitemap output

## Validation
- dotnet build PSPublishModule.sln --no-restore
- dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebPipelineRunnerSitemapTests|FullyQualifiedName~WebSitemapGeneratorCanonicalizationTests" --no-restore