### PR TITLE
Fix sitemap lastmod policy

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -235,6 +235,7 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("meta.project_link_psgallery: \"https://www.powershellgallery.com/packages/PSWriteHTML/1.40.0\"", projectPage, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("meta.project_github_last_pushed_at_display: \"2026-02-14\"", projectPage, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("meta.project_release_latest_published_at_display: \"2025-12-14\"", projectPage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("sitemap.lastmod: \"2026-02-14T21:19:34.0000000+00:00\"", projectPage, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogTests.cs
@@ -235,7 +235,22 @@ public class WebPipelineRunnerProjectCatalogTests
             Assert.Contains("meta.project_link_psgallery: \"https://www.powershellgallery.com/packages/PSWriteHTML/1.40.0\"", projectPage, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("meta.project_github_last_pushed_at_display: \"2026-02-14\"", projectPage, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("meta.project_release_latest_published_at_display: \"2025-12-14\"", projectPage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("meta.project_sitemap_fingerprint:", projectPage, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("sitemap.lastmod: \"2026-02-14T21:19:34.0000000+00:00\"", projectPage, StringComparison.OrdinalIgnoreCase);
+            var firstLastModified = ReadFrontMatterValue(projectPage, "sitemap.lastmod:");
+            Assert.False(string.IsNullOrWhiteSpace(firstLastModified));
+
+            File.WriteAllText(catalogPath, catalogText
+                .Replace("\"stars\": 987", "\"stars\": 988", StringComparison.Ordinal)
+                .Replace("\"totalDownloads\": 7374604", "\"totalDownloads\": 7374605", StringComparison.Ordinal));
+
+            var counterOnlyResult = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+
+            Assert.True(counterOnlyResult.Success);
+            var counterOnlyProjectPage = File.ReadAllText(projectPagePath);
+            Assert.Contains("meta.project_github_stars: 988", counterOnlyProjectPage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("meta.project_psgallery_downloads: 7374605", counterOnlyProjectPage, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(firstLastModified, ReadFrontMatterValue(counterOnlyProjectPage, "sitemap.lastmod:"));
         }
         finally
         {
@@ -616,5 +631,26 @@ public class WebPipelineRunnerProjectCatalogTests
         {
             // ignore cleanup failures in tests
         }
+    }
+
+    private static string? ReadFrontMatterValue(string markdown, string key)
+    {
+        foreach (var rawLine in markdown.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None))
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith(key, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = line[key.Length..].Trim();
+            if ((value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal)) ||
+                (value.StartsWith("'", StringComparison.Ordinal) && value.EndsWith("'", StringComparison.Ordinal)))
+            {
+                value = value[1..^1];
+            }
+
+            return value;
+        }
+
+        return null;
     }
 }

--- a/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
+++ b/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
@@ -28,6 +28,9 @@ public class WebSiteSitemapFreshnessPolicyTests
 
         Assert.NotNull(spec);
         Assert.Equal(SitemapLastModifiedPolicy.ExplicitOnly, spec!.Collections[0].SitemapLastModified);
+
+        var json = JsonSerializer.Serialize(spec.Collections[0], new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        Assert.Contains("\"sitemapLastModified\":\"explicitOnly\"", json, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -107,6 +110,119 @@ public class WebSiteSitemapFreshnessPolicyTests
     }
 
     [Fact]
+    public void Build_ExplicitOnlySitemapLastmod_LeavesLastmodUnsetWithoutExplicitMetadata()
+    {
+        var root = CreateTempRoot("pf-web-sitemap-explicit-only-");
+        try
+        {
+            WriteMarkdown(root, "content/pages/about.md",
+                """
+                ---
+                title: About
+                slug: about
+                date: 2020-01-02
+                ---
+
+                Reference content.
+                """);
+            CommitAll(root, "2026-01-15T12:34:56Z");
+
+            Build(root, new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "pages",
+                    Preset = "pages",
+                    Input = "content/pages",
+                    Output = "/",
+                    SitemapLastModified = SitemapLastModifiedPolicy.ExplicitOnly
+                }
+            });
+
+            Assert.Null(ReadSitemapMetadataLastModified(root, "/about/"));
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_SourceDateSitemapLastmod_UsesGitDateForEditorialCollections()
+    {
+        var root = CreateTempRoot("pf-web-sitemap-explicit-source-");
+        try
+        {
+            WriteMarkdown(root, "content/blog/ship-log.md",
+                """
+                ---
+                title: Ship Log
+                slug: ship-log
+                date: 2020-01-02
+                ---
+
+                Editorial content.
+                """);
+            CommitAll(root, "2026-01-15T12:34:56Z");
+
+            Build(root, new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "blog",
+                    Preset = "blog",
+                    Input = "content/blog",
+                    Output = "/blog",
+                    SitemapLastModified = SitemapLastModifiedPolicy.SourceDate
+                }
+            });
+
+            Assert.Equal("2026-01-15T12:34:56.000Z", ReadSitemapMetadataLastModified(root, "/blog/ship-log/"));
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_PublishedDateSitemapLastmod_FallsBackToGitWhenDateMissing()
+    {
+        var root = CreateTempRoot("pf-web-sitemap-published-fallback-");
+        try
+        {
+            WriteMarkdown(root, "content/blog/undated.md",
+                """
+                ---
+                title: Undated Post
+                slug: undated
+                ---
+
+                Editorial content without a publish date.
+                """);
+            CommitAll(root, "2026-01-15T12:34:56Z");
+
+            Build(root, new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "blog",
+                    Preset = "blog",
+                    Input = "content/blog",
+                    Output = "/blog",
+                    SitemapLastModified = SitemapLastModifiedPolicy.PublishedDate
+                }
+            });
+
+            Assert.Equal("2026-01-15T12:34:56.000Z", ReadSitemapMetadataLastModified(root, "/blog/undated/"));
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
     public void Build_ExplicitLastmod_DrivesSitemapAndArticleStructuredData()
     {
         var root = CreateTempRoot("pf-web-sitemap-explicit-freshness-");
@@ -156,6 +272,7 @@ public class WebSiteSitemapFreshnessPolicyTests
 
             var html = File.ReadAllText(Path.Combine(root, "_site", "blog", "updated", "index.html"));
             Assert.Contains("\"datePublished\":\"2020-01-02T00:00:00.0000000Z\"", html, StringComparison.Ordinal);
+            // Offset formatting can differ between date parsers; this assertion is about the chosen instant.
             Assert.Contains("\"dateModified\":\"2026-02-03T04:05:06", html, StringComparison.Ordinal);
             Assert.Contains("property=\"article:published_time\" content=\"2020-01-02T00:00:00.0000000Z\"", html, StringComparison.Ordinal);
             Assert.Contains("property=\"article:modified_time\" content=\"2026-02-03T04:05:06", html, StringComparison.Ordinal);
@@ -193,7 +310,9 @@ public class WebSiteSitemapFreshnessPolicyTests
         {
             var entryPath = entry.GetProperty("path").GetString();
             if (entryPath?.TrimEnd('/').Equals(normalizedPath, StringComparison.OrdinalIgnoreCase) == true)
-                return entry.GetProperty("lastModified").GetString();
+                return entry.TryGetProperty("lastModified", out var lastModified)
+                    ? lastModified.GetString()
+                    : null;
         }
 
         return null;

--- a/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
+++ b/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
@@ -34,6 +34,27 @@ public class WebSiteSitemapFreshnessPolicyTests
     }
 
     [Fact]
+    public void CollectionSpec_SitemapLastmodPolicy_RejectsNumericEnumValues()
+    {
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SiteSpec>(
+            """
+            {
+              "name": "Freshness Test",
+              "baseUrl": "https://example.test",
+              "collections": [
+                {
+                  "name": "docs",
+                  "input": "content/docs",
+                  "output": "/docs",
+                  "sitemapLastModified": 2
+                }
+              ]
+            }
+            """,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true }));
+    }
+
+    [Fact]
     public void Build_AutoSitemapLastmod_PreservesEditorialPublishDate()
     {
         var root = CreateTempRoot("pf-web-sitemap-editorial-freshness-");
@@ -102,6 +123,42 @@ public class WebSiteSitemapFreshnessPolicyTests
 
             var lastmod = ReadSitemapMetadataLastModified(root, "/about/");
             Assert.Equal("2026-01-15T12:34:56.000Z", lastmod);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_AutoSitemapLastmod_DoesNotTreatBlogPrefixedReferenceRoutesAsEditorial()
+    {
+        var root = CreateTempRoot("pf-web-sitemap-blog-tools-freshness-");
+        try
+        {
+            WriteMarkdown(root, "content/blog-tools/reference.md",
+                """
+                ---
+                title: Reference Tooling
+                slug: reference
+                date: 2020-01-02
+                ---
+
+                Reference content.
+                """);
+            CommitAll(root, "2026-01-15T12:34:56Z");
+
+            Build(root, new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "tools",
+                    Input = "content/blog-tools",
+                    Output = "/blog-tools"
+                }
+            });
+
+            Assert.Equal("2026-01-15T12:34:56.000Z", ReadSitemapMetadataLastModified(root, "/blog-tools/reference/"));
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
+++ b/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
@@ -1,0 +1,265 @@
+using System.Diagnostics;
+using System.Text.Json;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public class WebSiteSitemapFreshnessPolicyTests
+{
+    [Fact]
+    public void CollectionSpec_SitemapLastmodPolicy_DeserializesCamelCaseValue()
+    {
+        var spec = JsonSerializer.Deserialize<SiteSpec>(
+            """
+            {
+              "name": "Freshness Test",
+              "baseUrl": "https://example.test",
+              "collections": [
+                {
+                  "name": "docs",
+                  "input": "content/docs",
+                  "output": "/docs",
+                  "sitemapLastModified": "explicitOnly"
+                }
+              ]
+            }
+            """,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(spec);
+        Assert.Equal(SitemapLastModifiedPolicy.ExplicitOnly, spec!.Collections[0].SitemapLastModified);
+    }
+
+    [Fact]
+    public void Build_AutoSitemapLastmod_PreservesEditorialPublishDate()
+    {
+        var root = CreateTempRoot("pf-web-sitemap-editorial-freshness-");
+        try
+        {
+            WriteMarkdown(root, "content/blog/ship-log.md",
+                """
+                ---
+                title: Ship Log
+                slug: ship-log
+                date: 2020-01-02
+                ---
+
+                Editorial content.
+                """);
+            CommitAll(root, "2026-01-15T12:34:56Z");
+
+            Build(root, new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "blog",
+                    Preset = "blog",
+                    Input = "content/blog",
+                    Output = "/blog"
+                }
+            });
+
+            var lastmod = ReadSitemapMetadataLastModified(root, "/blog/ship-log/");
+            Assert.Equal("2020-01-02T00:00:00.000Z", lastmod);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_AutoSitemapLastmod_UsesSourceDateForReferencePages()
+    {
+        var root = CreateTempRoot("pf-web-sitemap-source-freshness-");
+        try
+        {
+            WriteMarkdown(root, "content/pages/about.md",
+                """
+                ---
+                title: About
+                slug: about
+                date: 2020-01-02
+                ---
+
+                Reference content.
+                """);
+            CommitAll(root, "2026-01-15T12:34:56Z");
+
+            Build(root, new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "pages",
+                    Preset = "pages",
+                    Input = "content/pages",
+                    Output = "/"
+                }
+            });
+
+            var lastmod = ReadSitemapMetadataLastModified(root, "/about/");
+            Assert.Equal("2026-01-15T12:34:56.000Z", lastmod);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_ExplicitLastmod_DrivesSitemapAndArticleStructuredData()
+    {
+        var root = CreateTempRoot("pf-web-sitemap-explicit-freshness-");
+        try
+        {
+            WriteMarkdown(root, "content/blog/updated.md",
+                """
+                ---
+                title: Updated Post
+                slug: updated
+                date: 2020-01-02
+                lastmod: 2026-02-03T04:05:06Z
+                ---
+
+                Updated editorial content.
+                """);
+
+            var spec = new SiteSpec
+            {
+                Name = "Freshness Test",
+                BaseUrl = "https://example.test",
+                ContentRoot = "content",
+                Collections = new[]
+                {
+                    new CollectionSpec
+                    {
+                        Name = "blog",
+                        Preset = "blog",
+                        Input = "content/blog",
+                        Output = "/blog"
+                    }
+                },
+                StructuredData = new StructuredDataSpec
+                {
+                    Enabled = true,
+                    Article = true
+                },
+                Social = new SocialSpec
+                {
+                    Enabled = true
+                }
+            };
+
+            Build(root, spec);
+
+            Assert.Equal("2026-02-03T04:05:06.000Z", ReadSitemapMetadataLastModified(root, "/blog/updated/"));
+
+            var html = File.ReadAllText(Path.Combine(root, "_site", "blog", "updated", "index.html"));
+            Assert.Contains("\"datePublished\":\"2020-01-02T00:00:00.0000000Z\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"dateModified\":\"2026-02-03T04:05:06", html, StringComparison.Ordinal);
+            Assert.Contains("property=\"article:published_time\" content=\"2020-01-02T00:00:00.0000000Z\"", html, StringComparison.Ordinal);
+            Assert.Contains("property=\"article:modified_time\" content=\"2026-02-03T04:05:06", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    private static void Build(string root, CollectionSpec[] collections)
+    {
+        Build(root, new SiteSpec
+        {
+            Name = "Freshness Test",
+            BaseUrl = "https://example.test",
+            ContentRoot = "content",
+            Collections = collections
+        });
+    }
+
+    private static void Build(string root, SiteSpec spec)
+    {
+        var configPath = Path.Combine(root, "site.json");
+        File.WriteAllText(configPath, "{}");
+        var plan = WebSitePlanner.Plan(spec, configPath);
+        WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+    }
+
+    private static string? ReadSitemapMetadataLastModified(string root, string path)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "_site", "_powerforge", "sitemap-entries.json")));
+        var normalizedPath = path.TrimEnd('/');
+        foreach (var entry in doc.RootElement.GetProperty("entries").EnumerateArray())
+        {
+            var entryPath = entry.GetProperty("path").GetString();
+            if (entryPath?.TrimEnd('/').Equals(normalizedPath, StringComparison.OrdinalIgnoreCase) == true)
+                return entry.GetProperty("lastModified").GetString();
+        }
+
+        return null;
+    }
+
+    private static string CreateTempRoot(string prefix)
+    {
+        var root = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void WriteMarkdown(string root, string relativePath, string content)
+    {
+        var path = Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    private static void CommitAll(string root, string isoDate)
+    {
+        RunGit(root, "init");
+        RunGit(root, "config", "user.email", "tests@example.test");
+        RunGit(root, "config", "user.name", "PowerForge Tests");
+        RunGit(root, "add", ".");
+        RunGitWithDate(root, isoDate, "commit", "-m", "initial");
+    }
+
+    private static void RunGit(string root, params string[] args) =>
+        RunGitCore(root, null, args);
+
+    private static void RunGitWithDate(string root, string isoDate, params string[] args) =>
+        RunGitCore(root, isoDate, args);
+
+    private static void RunGitCore(string root, string? isoDate, params string[] args)
+    {
+        using var process = new Process();
+        process.StartInfo.FileName = "git";
+        process.StartInfo.WorkingDirectory = root;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.CreateNoWindow = true;
+        if (!string.IsNullOrWhiteSpace(isoDate))
+        {
+            process.StartInfo.Environment["GIT_AUTHOR_DATE"] = isoDate;
+            process.StartInfo.Environment["GIT_COMMITTER_DATE"] = isoDate;
+        }
+
+        foreach (var arg in args)
+            process.StartInfo.ArgumentList.Add(arg);
+
+        process.Start();
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"git {string.Join(" ", args)} failed with exit {process.ExitCode}\n{stdout}\n{stderr}");
+    }
+
+    private static void Cleanup(string root)
+    {
+        if (Directory.Exists(root))
+        {
+            foreach (var path in Directory.EnumerateFileSystemEntries(root, "*", SearchOption.AllDirectories))
+                File.SetAttributes(path, FileAttributes.Normal);
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -1573,6 +1574,9 @@ internal static partial class WebPipelineRunner
                 lines.Add($"meta.project_manifest_generated_at: {YamlQuote(project.ManifestGeneratedAt)}");
             if (!string.IsNullOrWhiteSpace(project.ManifestCommit))
                 lines.Add($"meta.project_manifest_commit: {YamlQuote(project.ManifestCommit)}");
+            var projectLastModified = ResolveProjectSitemapLastModified(project);
+            if (!string.IsNullOrWhiteSpace(projectLastModified))
+                lines.Add($"sitemap.lastmod: {YamlQuote(projectLastModified)}");
             AppendProjectFrontMatterExtensions(lines, project);
             lines.Add("meta.generated_by: powerforge.project-catalog");
             lines.Add("---");
@@ -1802,6 +1806,9 @@ internal static partial class WebPipelineRunner
                     lines.Add($"meta.project_github_repo: {YamlQuote(project.GitHubRepo)}");
                 if (!string.IsNullOrWhiteSpace(project.ExternalUrl))
                     lines.Add($"meta.project_external_url: {YamlQuote(project.ExternalUrl)}");
+                var projectLastModified = ResolveProjectSitemapLastModified(project);
+                if (!string.IsNullOrWhiteSpace(projectLastModified))
+                    lines.Add($"sitemap.lastmod: {YamlQuote(projectLastModified)}");
                 AppendProjectFrontMatterExtensions(lines, project);
                 var externalCanonical = contentMode.Equals("external", StringComparison.OrdinalIgnoreCase)
                     ? GetProjectExternalSectionCanonicalLink(project, section)
@@ -2547,6 +2554,29 @@ internal static partial class WebPipelineRunner
         if (DateTimeOffset.TryParse(value, out var parsed))
             return parsed.ToString("yyyy-MM-dd");
         return value.Trim();
+    }
+
+    private static string? ResolveProjectSitemapLastModified(ProjectCatalogEntry project)
+    {
+        DateTimeOffset? latest = null;
+
+        Add(project.Metrics?.GitHub?.LastPushedAt);
+        Add(project.Metrics?.Release?.LatestPublishedAt);
+
+        return latest?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+
+        void Add(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+
+            if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+                return;
+
+            var utc = parsed.ToUniversalTime();
+            if (latest is null || utc > latest.Value)
+                latest = utc;
+        }
     }
 
     private static string? TryGetDictionaryValue(Dictionary<string, string?> dictionary, string key)

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -2573,7 +2573,7 @@ internal static partial class WebPipelineRunner
             if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
                 return;
 
-            var utc = parsed.ToUniversalTime();
+            var utc = parsed;
             if (latest is null || utc > latest.Value)
                 latest = utc;
         }

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -27,6 +28,11 @@ internal static partial class WebPipelineRunner
     private static readonly string[] AllowedProjectStatuses = { "active", "archived", "deprecated", "experimental" };
     private static readonly string[] AllowedProjectSurfaceKeys = { "docs", "apiDotNet", "apiPowerShell", "examples", "changelog", "releases", "downloads" };
     private static readonly string[] AllowedProjectLinkKeys = { "docs", "apiDotNet", "apiPowerShell", "examples", "changelog", "releases", "downloads", "source", "website", "nuget", "powerShellGallery", "blog" };
+    private static readonly JsonSerializerOptions ProjectSitemapFingerprintJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
     private static void ExecuteProjectCatalog(JsonElement step, string baseDir, WebPipelineStepResult stepResult)
     {
@@ -1574,7 +1580,9 @@ internal static partial class WebPipelineRunner
                 lines.Add($"meta.project_manifest_generated_at: {YamlQuote(project.ManifestGeneratedAt)}");
             if (!string.IsNullOrWhiteSpace(project.ManifestCommit))
                 lines.Add($"meta.project_manifest_commit: {YamlQuote(project.ManifestCommit)}");
-            var projectLastModified = ResolveProjectSitemapLastModified(project);
+            var projectFingerprint = ComputeProjectSitemapFingerprint(project, "overview");
+            lines.Add($"meta.project_sitemap_fingerprint: {YamlQuote(projectFingerprint)}");
+            var projectLastModified = ResolveProjectSitemapLastModified(project, outputPath, projectFingerprint);
             if (!string.IsNullOrWhiteSpace(projectLastModified))
                 lines.Add($"sitemap.lastmod: {YamlQuote(projectLastModified)}");
             AppendProjectFrontMatterExtensions(lines, project);
@@ -1806,7 +1814,9 @@ internal static partial class WebPipelineRunner
                     lines.Add($"meta.project_github_repo: {YamlQuote(project.GitHubRepo)}");
                 if (!string.IsNullOrWhiteSpace(project.ExternalUrl))
                     lines.Add($"meta.project_external_url: {YamlQuote(project.ExternalUrl)}");
-                var projectLastModified = ResolveProjectSitemapLastModified(project);
+                var projectFingerprint = ComputeProjectSitemapFingerprint(project, section);
+                lines.Add($"meta.project_sitemap_fingerprint: {YamlQuote(projectFingerprint)}");
+                var projectLastModified = ResolveProjectSitemapLastModified(project, outputPath, projectFingerprint);
                 if (!string.IsNullOrWhiteSpace(projectLastModified))
                     lines.Add($"sitemap.lastmod: {YamlQuote(projectLastModified)}");
                 AppendProjectFrontMatterExtensions(lines, project);
@@ -2556,14 +2566,37 @@ internal static partial class WebPipelineRunner
         return value.Trim();
     }
 
-    private static string? ResolveProjectSitemapLastModified(ProjectCatalogEntry project)
+    private static string? ResolveProjectSitemapLastModified(ProjectCatalogEntry project, string outputPath, string fingerprint)
+    {
+        var activityLastModified = ResolveProjectActivityLastModified(project);
+        var previous = ReadPreviousProjectSitemapState(outputPath);
+        if (previous is not null &&
+            string.Equals(previous.Fingerprint, fingerprint, StringComparison.OrdinalIgnoreCase) &&
+            previous.LastModified.HasValue)
+        {
+            return previous.LastModified.Value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+        }
+
+        if (previous?.Fingerprint is not null &&
+            !string.Equals(previous.Fingerprint, fingerprint, StringComparison.OrdinalIgnoreCase))
+        {
+            var contentChangedAt = DateTimeOffset.UtcNow;
+            if (activityLastModified.HasValue && activityLastModified.Value > contentChangedAt)
+                contentChangedAt = activityLastModified.Value;
+            return contentChangedAt.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+        }
+
+        return activityLastModified?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+    }
+
+    private static DateTimeOffset? ResolveProjectActivityLastModified(ProjectCatalogEntry project)
     {
         DateTimeOffset? latest = null;
 
         Add(project.Metrics?.GitHub?.LastPushedAt);
         Add(project.Metrics?.Release?.LatestPublishedAt);
 
-        return latest?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+        return latest;
 
         void Add(string? value)
         {
@@ -2577,6 +2610,172 @@ internal static partial class WebPipelineRunner
             if (latest is null || utc > latest.Value)
                 latest = utc;
         }
+    }
+
+    private static string ComputeProjectSitemapFingerprint(ProjectCatalogEntry project, string section)
+    {
+        var payload = new
+        {
+            Section = NormalizeOptionalString(section),
+            Slug = NormalizeOptionalString(project.Slug),
+            Name = NormalizeOptionalString(project.Name),
+            Mode = NormalizeOptionalString(project.Mode),
+            ContentMode = NormalizeOptionalString(project.ContentMode),
+            HubPath = NormalizeOptionalString(project.HubPath),
+            GitHubRepo = NormalizeOptionalString(project.GitHubRepo),
+            Description = NormalizeOptionalString(project.Description),
+            Status = NormalizeOptionalString(project.Status),
+            Listed = project.Listed,
+            ExternalUrl = NormalizeOptionalString(project.ExternalUrl),
+            Version = NormalizeOptionalString(project.Version),
+            ManifestCommit = NormalizeOptionalString(project.ManifestCommit),
+            Aliases = NormalizeStringArray(project.Aliases),
+            Links = NormalizeStringDictionary(project.Links),
+            Surfaces = NormalizeBoolDictionary(project.Surfaces),
+            Artifacts = project.Artifacts is null
+                ? null
+                : new
+                {
+                    Docs = NormalizeOptionalString(project.Artifacts.Docs),
+                    Api = NormalizeOptionalString(project.Artifacts.Api),
+                    Examples = NormalizeOptionalString(project.Artifacts.Examples)
+                },
+            Metrics = project.Metrics is null
+                ? null
+                : new
+                {
+                    GitHub = project.Metrics.GitHub is null
+                        ? null
+                        : new
+                        {
+                            Repository = NormalizeOptionalString(project.Metrics.GitHub.Repository),
+                            Url = NormalizeOptionalString(project.Metrics.GitHub.Url),
+                            Language = NormalizeOptionalString(project.Metrics.GitHub.Language),
+                            Archived = project.Metrics.GitHub.Archived,
+                            LastPushedAt = NormalizeOptionalString(project.Metrics.GitHub.LastPushedAt)
+                        },
+                    NuGet = project.Metrics.NuGet is null
+                        ? null
+                        : new
+                        {
+                            Id = NormalizeOptionalString(project.Metrics.NuGet.Id),
+                            Version = NormalizeOptionalString(project.Metrics.NuGet.Version),
+                            PackageUrl = NormalizeOptionalString(project.Metrics.NuGet.PackageUrl),
+                            ProjectUrl = NormalizeOptionalString(project.Metrics.NuGet.ProjectUrl)
+                        },
+                    PowerShellGallery = project.Metrics.PowerShellGallery is null
+                        ? null
+                        : new
+                        {
+                            Id = NormalizeOptionalString(project.Metrics.PowerShellGallery.Id),
+                            Version = NormalizeOptionalString(project.Metrics.PowerShellGallery.Version),
+                            GalleryUrl = NormalizeOptionalString(project.Metrics.PowerShellGallery.GalleryUrl),
+                            ProjectUrl = NormalizeOptionalString(project.Metrics.PowerShellGallery.ProjectUrl)
+                        },
+                    Release = project.Metrics.Release is null
+                        ? null
+                        : new
+                        {
+                            LatestTag = NormalizeOptionalString(project.Metrics.Release.LatestTag),
+                            LatestName = NormalizeOptionalString(project.Metrics.Release.LatestName),
+                            LatestUrl = NormalizeOptionalString(project.Metrics.Release.LatestUrl),
+                            LatestPublishedAt = NormalizeOptionalString(project.Metrics.Release.LatestPublishedAt),
+                            IsPrerelease = project.Metrics.Release.IsPrerelease,
+                            IsDraft = project.Metrics.Release.IsDraft
+                        }
+                }
+        };
+        var json = JsonSerializer.Serialize(payload, ProjectSitemapFingerprintJsonOptions);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(json))).ToLowerInvariant();
+    }
+
+    private static string[] NormalizeStringArray(string[]? values) =>
+        values is null
+            ? Array.Empty<string>()
+            : values
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim())
+                .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+    private static SortedDictionary<string, string?>? NormalizeStringDictionary(Dictionary<string, string?>? values)
+    {
+        if (values is null || values.Count == 0)
+            return null;
+
+        var normalized = new SortedDictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in values)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+                continue;
+            normalized[pair.Key.Trim()] = NormalizeOptionalString(pair.Value);
+        }
+
+        return normalized.Count == 0 ? null : normalized;
+    }
+
+    private static SortedDictionary<string, bool>? NormalizeBoolDictionary(Dictionary<string, bool>? values)
+    {
+        if (values is null || values.Count == 0)
+            return null;
+
+        var normalized = new SortedDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in values)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+                continue;
+            normalized[pair.Key.Trim()] = pair.Value;
+        }
+
+        return normalized.Count == 0 ? null : normalized;
+    }
+
+    private static ProjectSitemapState? ReadPreviousProjectSitemapState(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return null;
+
+        string? fingerprint = null;
+        DateTimeOffset? lastModified = null;
+
+        foreach (var line in File.ReadLines(path))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Equals("---", StringComparison.Ordinal) && fingerprint is not null)
+                break;
+
+            if (TryReadFrontMatterString(trimmed, "meta.project_sitemap_fingerprint:", out var parsedFingerprint))
+            {
+                fingerprint = parsedFingerprint;
+                continue;
+            }
+
+            if (TryReadFrontMatterString(trimmed, "sitemap.lastmod:", out var parsedLastModified) &&
+                DateTimeOffset.TryParse(parsedLastModified, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+            {
+                lastModified = parsed;
+            }
+        }
+
+        return fingerprint is null && !lastModified.HasValue
+            ? null
+            : new ProjectSitemapState(fingerprint, lastModified);
+    }
+
+    private static bool TryReadFrontMatterString(string line, string key, out string? value)
+    {
+        value = null;
+        if (!line.StartsWith(key, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        value = line[key.Length..].Trim();
+        if ((value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal)) ||
+            (value.StartsWith("'", StringComparison.Ordinal) && value.EndsWith("'", StringComparison.Ordinal)))
+        {
+            value = value[1..^1];
+        }
+
+        return !string.IsNullOrWhiteSpace(value);
     }
 
     private static string? TryGetDictionaryValue(Dictionary<string, string?> dictionary, string key)
@@ -2749,6 +2948,8 @@ internal static partial class WebPipelineRunner
         [JsonExtensionData]
         public Dictionary<string, JsonElement>? ExtensionData { get; set; }
     }
+
+    private sealed record ProjectSitemapState(string? Fingerprint, DateTimeOffset? LastModified);
 
     private sealed class ProjectCatalogEntry
     {

--- a/PowerForge.Web/Models/CollectionSpec.cs
+++ b/PowerForge.Web/Models/CollectionSpec.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace PowerForge.Web;
 
 /// <summary>Defines a content collection (pages, docs, blog).</summary>
@@ -63,6 +65,26 @@ public sealed class CollectionSpec
     public string? AutoSectionDescription { get; set; }
     /// <summary>Optional editorial card defaults used by helper-based list layouts.</summary>
     public EditorialCardsSpec? EditorialCards { get; set; }
+    /// <summary>
+    /// Controls how sitemap lastmod is resolved for collection items. Auto preserves
+    /// article publish dates for editorial collections and prefers source freshness
+    /// for docs, pages, project hubs, and other reference-style content.
+    /// </summary>
+    public SitemapLastModifiedPolicy? SitemapLastModified { get; set; }
+}
+
+/// <summary>Collection-level sitemap lastmod resolution policy.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<SitemapLastModifiedPolicy>))]
+public enum SitemapLastModifiedPolicy
+{
+    /// <summary>Use preset-aware defaults: editorial uses publish date; reference content uses source date.</summary>
+    Auto,
+    /// <summary>Use explicit lastmod metadata first, then front matter publication date, then source git date.</summary>
+    PublishedDate,
+    /// <summary>Use explicit lastmod metadata first, then source git date, then front matter publication date.</summary>
+    SourceDate,
+    /// <summary>Only emit lastmod when explicit lastmod/update metadata is present.</summary>
+    ExplicitOnly
 }
 
 /// <summary>Collection-level editorial card defaults.</summary>

--- a/PowerForge.Web/Models/CollectionSpec.cs
+++ b/PowerForge.Web/Models/CollectionSpec.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace PowerForge.Web;
@@ -74,7 +75,7 @@ public sealed class CollectionSpec
 }
 
 /// <summary>Collection-level sitemap lastmod resolution policy.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<SitemapLastModifiedPolicy>))]
+[JsonConverter(typeof(SitemapLastModifiedPolicyJsonConverter))]
 public enum SitemapLastModifiedPolicy
 {
     /// <summary>Use preset-aware defaults: editorial uses publish date; reference content uses source date.</summary>
@@ -85,6 +86,16 @@ public enum SitemapLastModifiedPolicy
     SourceDate,
     /// <summary>Only emit lastmod when explicit lastmod/update metadata is present.</summary>
     ExplicitOnly
+}
+
+/// <summary>Serializes collection sitemap freshness policies using site-spec camelCase values.</summary>
+public sealed class SitemapLastModifiedPolicyJsonConverter : JsonStringEnumConverter<SitemapLastModifiedPolicy>
+{
+    /// <summary>Initializes a camelCase sitemap freshness policy converter.</summary>
+    public SitemapLastModifiedPolicyJsonConverter()
+        : base(JsonNamingPolicy.CamelCase)
+    {
+    }
 }
 
 /// <summary>Collection-level editorial card defaults.</summary>

--- a/PowerForge.Web/Models/CollectionSpec.cs
+++ b/PowerForge.Web/Models/CollectionSpec.cs
@@ -93,7 +93,7 @@ public sealed class SitemapLastModifiedPolicyJsonConverter : JsonStringEnumConve
 {
     /// <summary>Initializes a camelCase sitemap freshness policy converter.</summary>
     public SitemapLastModifiedPolicyJsonConverter()
-        : base(JsonNamingPolicy.CamelCase)
+        : base(JsonNamingPolicy.CamelCase, allowIntegerValues: false)
     {
     }
 }

--- a/PowerForge.Web/Services/CollectionPresetDefaults.cs
+++ b/PowerForge.Web/Services/CollectionPresetDefaults.cs
@@ -127,7 +127,8 @@ internal static class CollectionPresetDefaults
             AutoGenerateSectionIndex = collection.AutoGenerateSectionIndex,
             AutoSectionTitle = collection.AutoSectionTitle,
             AutoSectionDescription = collection.AutoSectionDescription,
-            EditorialCards = collection.EditorialCards
+            EditorialCards = collection.EditorialCards,
+            SitemapLastModified = collection.SitemapLastModified
         };
 
         if (string.IsNullOrWhiteSpace(resolved.DefaultLayout))

--- a/PowerForge.Web/Services/CollectionPresetDefaults.cs
+++ b/PowerForge.Web/Services/CollectionPresetDefaults.cs
@@ -184,9 +184,18 @@ internal static class CollectionPresetDefaults
                 return true;
         }
 
-        return !string.IsNullOrWhiteSpace(output) &&
-               (output.StartsWith("/blog", StringComparison.OrdinalIgnoreCase) ||
-                output.StartsWith("/news", StringComparison.OrdinalIgnoreCase) ||
-                output.StartsWith("/changelog", StringComparison.OrdinalIgnoreCase));
+        return IsRouteOrChild(output, "/blog") ||
+               IsRouteOrChild(output, "/news") ||
+               IsRouteOrChild(output, "/changelog");
+    }
+
+    private static bool IsRouteOrChild(string? route, string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(route))
+            return false;
+
+        var normalized = route.Trim().TrimEnd('/');
+        return normalized.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith(prefix + "/", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
@@ -223,7 +223,7 @@ public static partial class WebSiteBuilder
                     Title = title,
                     Description = description,
                     Date = matter?.Date,
-                    LastModifiedUtc = ResolveContentLastModifiedUtc(plan.RootPath, file, matter, meta, gitLastModifiedCache),
+                    LastModifiedUtc = ResolveContentLastModifiedUtc(plan.RootPath, file, matter, meta, resolvedCollection, gitLastModifiedCache),
                     Order = matter?.Order,
                     Slug = slugPath,
                     Tags = matter?.Tags ?? Array.Empty<string>(),
@@ -1009,6 +1009,7 @@ public static partial class WebSiteBuilder
         string sourcePath,
         FrontMatter? matter,
         IReadOnlyDictionary<string, object?>? meta,
+        CollectionSpec? collection,
         Dictionary<string, DateTimeOffset?> gitLastModifiedCache)
     {
         if (TryReadMetaDateOffset(meta, out var explicitLastModified,
@@ -1028,13 +1029,37 @@ public static partial class WebSiteBuilder
             return explicitLastModified.ToUniversalTime();
         }
 
-        if (matter?.Date is DateTime published)
-            return NormalizeDateTimeOffset(published);
+        var published = matter?.Date is DateTime date
+            ? NormalizeDateTimeOffset(date)
+            : (DateTimeOffset?)null;
+
+        var policy = ResolveSitemapLastModifiedPolicy(collection);
+        if (policy == SitemapLastModifiedPolicy.Auto &&
+            CollectionPresetDefaults.IsEditorialCollection(collection, collection?.Name))
+        {
+            policy = SitemapLastModifiedPolicy.PublishedDate;
+        }
+        else if (policy == SitemapLastModifiedPolicy.Auto)
+        {
+            policy = SitemapLastModifiedPolicy.SourceDate;
+        }
+
+        if (policy == SitemapLastModifiedPolicy.ExplicitOnly)
+            return null;
+
+        if (policy == SitemapLastModifiedPolicy.PublishedDate)
+        {
+            if (published.HasValue)
+                return published.Value;
+            if (TryGetGitLastModifiedUtc(rootPath, sourcePath, gitLastModifiedCache, out var fallbackGitLastModified))
+                return fallbackGitLastModified;
+            return null;
+        }
 
         if (TryGetGitLastModifiedUtc(rootPath, sourcePath, gitLastModifiedCache, out var gitLastModified))
             return gitLastModified;
 
-        return null;
+        return published;
     }
 
     private static DateTimeOffset? MaxLastModifiedUtc(IEnumerable<DateTimeOffset?> values)
@@ -1050,6 +1075,9 @@ public static partial class WebSiteBuilder
 
         return max;
     }
+
+    private static SitemapLastModifiedPolicy ResolveSitemapLastModifiedPolicy(CollectionSpec? collection) =>
+        collection?.SitemapLastModified ?? SitemapLastModifiedPolicy.Auto;
 
     private static bool TryReadMetaDateOffset(
         IReadOnlyDictionary<string, object?>? meta,

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -452,7 +452,7 @@ public static partial class WebSiteBuilder
             imageAlt = title;
         var isArticle = IsArticleLikePage(item);
         var publishedTime = item.Date?.ToUniversalTime().ToString("O");
-        var modifiedTime = item.LastModifiedUtc?.ToUniversalTime().ToString("O");
+        var modifiedTime = item.LastModifiedUtc?.ToString("O");
 
         var sb = new System.Text.StringBuilder();
         sb.AppendLine("<!-- Open Graph -->");

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -452,6 +452,7 @@ public static partial class WebSiteBuilder
             imageAlt = title;
         var isArticle = IsArticleLikePage(item);
         var publishedTime = item.Date?.ToUniversalTime().ToString("O");
+        var modifiedTime = item.LastModifiedUtc?.ToUniversalTime().ToString("O");
 
         var sb = new System.Text.StringBuilder();
         sb.AppendLine("<!-- Open Graph -->");
@@ -473,6 +474,8 @@ public static partial class WebSiteBuilder
             sb.AppendLine($@"<meta property=""og:site_name"" content=""{System.Web.HttpUtility.HtmlEncode(siteName)}"" />");
         if (isArticle && !string.IsNullOrWhiteSpace(publishedTime))
             sb.AppendLine($@"<meta property=""article:published_time"" content=""{System.Web.HttpUtility.HtmlEncode(publishedTime)}"" />");
+        if (isArticle && !string.IsNullOrWhiteSpace(modifiedTime))
+            sb.AppendLine($@"<meta property=""article:modified_time"" content=""{System.Web.HttpUtility.HtmlEncode(modifiedTime)}"" />");
         if (isArticle)
         {
             foreach (var authorUrl in ResolveContentAuthorUrls(item).Where(static value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.OrdinalIgnoreCase))

--- a/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
@@ -60,7 +60,7 @@ public static partial class WebSiteBuilder
 
         if (item.LastModifiedUtc.HasValue)
         {
-            articleModel["dateModified"] = item.LastModifiedUtc.Value.ToUniversalTime().ToString("O");
+            articleModel["dateModified"] = item.LastModifiedUtc.Value.ToString("O");
         }
         else if (item.Date.HasValue)
         {

--- a/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
@@ -55,9 +55,16 @@ public static partial class WebSiteBuilder
 
         if (item.Date.HasValue)
         {
-            var iso = item.Date.Value.ToUniversalTime().ToString("O");
-            articleModel["datePublished"] = iso;
-            articleModel["dateModified"] = iso;
+            articleModel["datePublished"] = item.Date.Value.ToUniversalTime().ToString("O");
+        }
+
+        if (item.LastModifiedUtc.HasValue)
+        {
+            articleModel["dateModified"] = item.LastModifiedUtc.Value.ToUniversalTime().ToString("O");
+        }
+        else if (item.Date.HasValue)
+        {
+            articleModel["dateModified"] = item.Date.Value.ToUniversalTime().ToString("O");
         }
 
         var imageOverride = ReadMetaString(item.Meta, "article.image", "news.image", "schema.image", "social_image");

--- a/Schemas/powerforge.web.sitespec.schema.json
+++ b/Schemas/powerforge.web.sitespec.schema.json
@@ -168,7 +168,15 @@
         "AutoSectionTitle": { "type": "string" },
         "AutoSectionDescription": { "type": "string" },
         "EditorialCards": { "$ref": "#/$defs/EditorialCardsSpec" },
-        "editorialCards": { "$ref": "#/$defs/EditorialCardsSpec" }
+        "editorialCards": { "$ref": "#/$defs/EditorialCardsSpec" },
+        "SitemapLastModified": {
+          "type": "string",
+          "enum": ["auto", "publishedDate", "sourceDate", "explicitOnly"]
+        },
+        "sitemapLastModified": {
+          "type": "string",
+          "enum": ["auto", "publishedDate", "sourceDate", "explicitOnly"]
+        }
       },
       "required": ["Name", "Input", "Output"]
     },


### PR DESCRIPTION
## Summary
- add collection-level `sitemapLastModified` policy support for editorial vs reference content
- preserve blog/news publish dates by default while letting docs/pages/project hubs use source freshness
- emit explicit project hub `sitemap.lastmod` from meaningful project activity, not volatile counters or rebuild time
- separate article `datePublished` from `dateModified` in JSON-LD and Open Graph metadata

## Validation
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebPipelineRunnerProjectCatalogTests|FullyQualifiedName~WebSiteSitemapFreshnessPolicyTests|FullyQualifiedName~WebSitemapGeneratorCanonicalizationTests|FullyQualifiedName~WebSiteStructuredDataProfilesTests|FullyQualifiedName~WebSiteSocialCardsTests.Build_EmitsArticleStructuredData_ForBlogPages"` passed: 36/36
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj` passed 1637/1638, with one `PowerForgeCliProjectReleaseTests.ProjectRelease_CliPreservesProjectDefaultsFromConfig` CLI output-drain timeout
- reran that failed test alone and it passed: 1/1