### PR TITLE
Fix IndexNow verification key discovery

### DIFF
--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -48,7 +48,7 @@ With local additions:
   "$schema": "./Schemas/powerforge.web.pipelinespec.schema.json",
   "extends": "./config/presets/pipeline.web-quality.json",
   "steps": [
-    { "task": "indexnow", "modes": ["ci"], "baseUrl": "https://example.com", "keyEnv": "INDEXNOW_KEY", "sitemap": "./_site/sitemap.xml" }
+    { "task": "indexnow", "modes": ["ci"], "baseUrl": "https://example.com", "siteRoot": "./_site", "sitemap": "./_site/sitemap.xml" }
   ]
 }
 ```
@@ -1582,7 +1582,6 @@ Submits changed or selected canonical URLs to IndexNow-compatible endpoints.
   "baseUrl": "https://docs.example.com",
   "siteRoot": "./_site",
   "scopeFromBuildUpdated": true,
-  "keyEnv": "INDEXNOW_KEY",
   "keyLocation": "https://docs.example.com/your-indexnow-key.txt",
   "batchSize": 500,
   "retryCount": 2,
@@ -1597,7 +1596,6 @@ Explicit URL/path mode:
 {
   "task": "indexnow",
   "baseUrl": "https://api.example.com",
-  "keyEnv": "INDEXNOW_KEY",
   "paths": "/,/docs/,/api/,/blog/",
   "sitemap": "./_site/sitemap.xml",
   "dryRun": true
@@ -1612,8 +1610,9 @@ Notes:
   - `sitemap` (`<loc>` entries from sitemap XML)
   - `scopeFromBuildUpdated` (`--fast` defaults this behavior on) when a preceding `build` step updated HTML files.
 - Auth/key options:
-  - `key` (inline), `keyPath` (file), or `keyEnv` (recommended; defaults to `INDEXNOW_KEY`).
-  - `optionalKey:true` (aliases: `optional-key`, `skipIfMissingKey`) turns missing key into a non-failing skip.
+  - `key` (inline), `keyPath` (file), or `keyEnv` (defaults to `INDEXNOW_KEY`) can override discovery when needed.
+  - When no explicit key is provided, the runner discovers the public verification file from `siteRoot/indexnow.txt`, `./indexnow.txt`, or `./static/indexnow.txt`. If `keyLocation` names another safe relative path, matching files under `siteRoot`, the pipeline root, or `static` are considered instead.
+  - `optionalKey:true` (aliases: `optional-key`, `skipIfMissingKey`) turns a missing explicit/discovered key into a non-failing skip.
   - `keyLocation` can be explicit, otherwise defaults to `https://<host>/<key>.txt`.
 - Endpoint options:
   - default endpoint is `https://api.indexnow.org/indexnow`

--- a/PowerForge.Tests/WebPipelineRunnerIndexNowTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerIndexNowTests.cs
@@ -227,6 +227,173 @@ public class WebPipelineRunnerIndexNowTests
     }
 
     [Fact]
+    public async Task RunPipeline_IndexNow_PostsWithVerificationFileKey()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-indexnow-verification-key-" + Guid.NewGuid().ToString("N"));
+        var siteRoot = Path.Combine(root, "_site");
+        Directory.CreateDirectory(siteRoot);
+
+        HttpListener? listener = null;
+        CancellationTokenSource? cts = null;
+        Task<string?>? serverTask = null;
+
+        try
+        {
+            var port = GetFreePort();
+            listener = new HttpListener();
+            listener.Prefixes.Add($"http://127.0.0.1:{port}/indexnow/");
+            listener.Start();
+
+            cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            serverTask = Task.Run(async () =>
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    HttpListenerContext context;
+                    try
+                    {
+                        context = await listener.GetContextAsync();
+                    }
+                    catch when (cts.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    string body;
+                    using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+                    {
+                        body = await reader.ReadToEndAsync();
+                    }
+
+                    context.Response.StatusCode = 200;
+                    var responseBytes = Encoding.UTF8.GetBytes("{\"ok\":true}");
+                    context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+                    context.Response.Close();
+                    return body;
+                }
+
+                return null;
+            }, cts.Token);
+
+            File.WriteAllText(Path.Combine(siteRoot, "indexnow.txt"), "verification-file-key");
+            File.WriteAllText(Path.Combine(siteRoot, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.com/docs/</loc></url>
+                </urlset>
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                $$"""
+                {
+                  "steps": [
+                    {
+                      "task": "indexnow",
+                      "siteRoot": "./_site",
+                      "endpoint": "http://127.0.0.1:{{port}}/indexnow/",
+                      "keyLocation": "https://example.com/indexnow.txt",
+                      "sitemap": "./_site/sitemap.xml",
+                      "batchSize": 10,
+                      "retryCount": 0
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.Single(result.Steps);
+            Assert.True(result.Steps[0].Success, result.Steps[0].Message);
+            Assert.True(result.Success, result.Steps[0].Message);
+            Assert.Contains("indexnow.txt", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+
+            var body = await serverTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(string.IsNullOrWhiteSpace(body));
+
+            using var payload = JsonDocument.Parse(body!);
+            Assert.Equal("example.com", payload.RootElement.GetProperty("host").GetString());
+            Assert.Equal("verification-file-key", payload.RootElement.GetProperty("key").GetString());
+            Assert.Equal("https://example.com/indexnow.txt", payload.RootElement.GetProperty("keyLocation").GetString());
+
+            var submittedUrls = payload.RootElement.GetProperty("urlList")
+                .EnumerateArray()
+                .Select(static item => item.GetString())
+                .Where(static item => !string.IsNullOrWhiteSpace(item))
+                .ToArray();
+            Assert.Single(submittedUrls);
+            Assert.Contains("https://example.com/docs/", submittedUrls);
+        }
+        finally
+        {
+            if (cts is not null)
+            {
+                try { cts.Cancel(); } catch { }
+                cts.Dispose();
+            }
+            if (listener is not null)
+            {
+                try { listener.Stop(); } catch { }
+                try { listener.Close(); } catch { }
+            }
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void RunPipeline_IndexNow_CustomKeyLocationRequiresMatchingVerificationFile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-indexnow-custom-key-location-" + Guid.NewGuid().ToString("N"));
+        var siteRoot = Path.Combine(root, "_site");
+        Directory.CreateDirectory(siteRoot);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(siteRoot, "indexnow.txt"), "root-verification-key");
+            File.WriteAllText(Path.Combine(siteRoot, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.com/docs/</loc></url>
+                </urlset>
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "indexnow",
+                      "siteRoot": "./_site",
+                      "keyLocation": "https://example.com/custom-key.txt",
+                      "sitemap": "./_site/sitemap.xml",
+                      "optionalKey": true,
+                      "dryRun": true
+                    }
+                  ]
+                }
+                """);
+
+            var missingCustomKey = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.Single(missingCustomKey.Steps);
+            Assert.True(missingCustomKey.Steps[0].Success, missingCustomKey.Steps[0].Message);
+            Assert.Contains("skipped", missingCustomKey.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+
+            File.WriteAllText(Path.Combine(siteRoot, "custom-key.txt"), "custom-verification-key");
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.Single(result.Steps);
+            Assert.True(result.Steps[0].Success, result.Steps[0].Message);
+            Assert.True(result.Success, result.Steps[0].Message);
+            Assert.Contains("custom-key.txt", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("indexnow.txt", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void RunPipeline_IndexNow_DryRun_FiltersLocalAndPrivateTargetUrls()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-indexnow-filter-private-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.IndexNow.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.IndexNow.cs
@@ -121,22 +121,34 @@ internal static partial class WebPipelineRunner
         }
 
         var keyEnv = GetString(step, "keyEnv") ?? GetString(step, "key-env") ?? "INDEXNOW_KEY";
+        var keyLocation = GetString(step, "keyLocation") ?? GetString(step, "key-location");
         var optionalKey = GetBool(step, "optionalKey") ??
                           GetBool(step, "optional-key") ??
                           GetBool(step, "skipIfMissingKey") ??
                           GetBool(step, "skip-if-missing-key") ??
                           false;
+        string? keySource = null;
         if (string.IsNullOrWhiteSpace(key))
+        {
             key = Environment.GetEnvironmentVariable(keyEnv);
+            if (!string.IsNullOrWhiteSpace(key))
+                keySource = $"env '{keyEnv}'";
+        }
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            key = TryReadIndexNowVerificationKey(baseDir, siteRoot, keyLocation, out keySource);
+        }
+
         if (string.IsNullOrWhiteSpace(key))
         {
             if (optionalKey)
             {
                 stepResult.Success = true;
-                stepResult.Message = $"indexnow: skipped (missing key env '{keyEnv}')";
+                stepResult.Message = $"indexnow: skipped (missing key env '{keyEnv}' and verification file)";
                 return;
             }
-            throw new InvalidOperationException($"indexnow: missing key (set env '{keyEnv}' or provide key/keyPath).");
+            throw new InvalidOperationException($"indexnow: missing key (set env '{keyEnv}', provide key/keyPath, or publish indexnow.txt).");
         }
 
         var endpointValues = new List<string>();
@@ -149,7 +161,7 @@ internal static partial class WebPipelineRunner
             Urls = normalizedUrls,
             Endpoints = endpointValues,
             Key = key,
-            KeyLocation = GetString(step, "keyLocation") ?? GetString(step, "key-location"),
+            KeyLocation = keyLocation,
             Host = GetString(step, "host"),
             DryRun = GetBool(step, "dryRun") ?? GetBool(step, "dry-run") ?? false,
             FailOnRequestError = failOnRequestError,
@@ -185,8 +197,133 @@ internal static partial class WebPipelineRunner
 
         stepResult.Success = submissionResult.Success;
         stepResult.Message = BuildIndexNowSummary(submissionResult);
+        if (!string.IsNullOrWhiteSpace(keySource))
+            stepResult.Message += $", key={keySource}";
         if (!submissionResult.Success)
             throw new InvalidOperationException(stepResult.Message);
+    }
+
+    private static string? TryReadIndexNowVerificationKey(string baseDir, string? siteRoot, string? keyLocation, out string? source)
+    {
+        source = null;
+        foreach (var candidate in EnumerateIndexNowKeyCandidates(baseDir, siteRoot, keyLocation))
+        {
+            if (string.IsNullOrWhiteSpace(candidate) || !File.Exists(candidate))
+                continue;
+
+            var key = File.ReadLines(candidate)
+                .Select(static line => line.Trim())
+                .FirstOrDefault(static line => !string.IsNullOrWhiteSpace(line));
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+
+            source = FormatIndexNowKeySource(baseDir, candidate);
+            return key;
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateIndexNowKeyCandidates(string baseDir, string? siteRoot, string? keyLocation)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var keyLocationRelativePaths = EnumerateIndexNowKeyRelativePaths(keyLocation).ToArray();
+
+        foreach (var relative in keyLocationRelativePaths)
+        {
+            if (!string.IsNullOrWhiteSpace(siteRoot))
+            {
+                foreach (var candidate in AddCandidateIterator(Path.Combine(siteRoot, relative)))
+                    yield return candidate;
+            }
+
+            foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, relative)))
+                yield return candidate;
+
+            foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "static", relative)))
+                yield return candidate;
+        }
+
+        if (keyLocationRelativePaths.Length > 0 &&
+            !keyLocationRelativePaths.Any(IsRootIndexNowVerificationPath))
+        {
+            yield break;
+        }
+
+        if (!string.IsNullOrWhiteSpace(siteRoot))
+        {
+            foreach (var candidate in AddCandidateIterator(Path.Combine(siteRoot, "indexnow.txt")))
+                yield return candidate;
+        }
+
+        foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "indexnow.txt")))
+            yield return candidate;
+        foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "static", "indexnow.txt")))
+            yield return candidate;
+
+        IEnumerable<string> AddCandidateIterator(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                yield break;
+
+            var full = Path.GetFullPath(path);
+            if (seen.Add(full))
+                yield return full;
+        }
+    }
+
+    private static bool IsRootIndexNowVerificationPath(string relativePath)
+        => relativePath
+            .Replace('\\', '/')
+            .Trim('/')
+            .Equals("indexnow.txt", StringComparison.OrdinalIgnoreCase);
+
+    private static string FormatIndexNowKeySource(string baseDir, string path)
+    {
+        var full = Path.GetFullPath(path);
+        try
+        {
+            var relative = Path.GetRelativePath(Path.GetFullPath(baseDir), full);
+            if (!string.IsNullOrWhiteSpace(relative) &&
+                !relative.StartsWith("..", StringComparison.Ordinal) &&
+                !Path.IsPathRooted(relative))
+            {
+                return relative;
+            }
+        }
+        catch
+        {
+            // Fall back to the full path when the platform cannot compute a relative display path.
+        }
+
+        return full;
+    }
+
+    private static IEnumerable<string> EnumerateIndexNowKeyRelativePaths(string? keyLocation)
+    {
+        if (string.IsNullOrWhiteSpace(keyLocation))
+            yield break;
+
+        var trimmed = keyLocation.Trim();
+        string? path = null;
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+            path = uri.AbsolutePath;
+        else
+            path = trimmed;
+
+        if (string.IsNullOrWhiteSpace(path))
+            yield break;
+
+        path = Uri.UnescapeDataString(path.TrimStart('/').Replace('\\', '/'));
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (string.IsNullOrWhiteSpace(path) ||
+            segments.Any(static segment => segment.Equals("..", StringComparison.Ordinal)) ||
+            Path.IsPathRooted(path))
+        {
+            yield break;
+        }
+
+        yield return path;
     }
 
     private static IEnumerable<string> ReadIndexNowStringList(JsonElement step, params string[] names)


### PR DESCRIPTION
## Summary
- discover IndexNow keys from published verification files when no explicit key is configured
- keep `key`, `keyPath`, and `keyEnv` as override paths while preserving optional skip behavior
- document verification-file discovery and cover it with a posting regression test

## Validation
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebPipelineRunnerIndexNowTests"`
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj` (first full run had two timing failures outside IndexNow)
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName=PowerForge.Tests.WebStaticServerTests.ServeWithPortFallback_UsesNextAvailablePort_AndServesContent|FullyQualifiedName=PowerForge.Tests.PowerForgeCliProjectReleaseTests.ProjectRelease_CliPreservesProjectDefaultsFromConfig"`
- `git diff --check`