### PR TITLE
Fix discovered IndexNow key locations

### DIFF
--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -1611,7 +1611,7 @@ Notes:
   - `scopeFromBuildUpdated` (`--fast` defaults this behavior on) when a preceding `build` step updated HTML files.
 - Auth/key options:
   - `key` (inline), `keyPath` (file), or `keyEnv` (defaults to `INDEXNOW_KEY`) can override discovery when needed.
-  - When no explicit key is provided, the runner discovers the public verification file from `siteRoot/indexnow.txt`, `./indexnow.txt`, or `./static/indexnow.txt`. If `keyLocation` names another safe relative path, matching files under `siteRoot`, the pipeline root, or `static` are considered instead.
+  - When no explicit key is provided, the runner discovers the public verification file from `siteRoot/indexnow.txt`, `./indexnow.txt`, or `./static/indexnow.txt` and submits `indexnow.txt` as the public key location. If `keyLocation` names another safe relative path, matching files under `siteRoot`, the pipeline root, or `static` are considered instead.
   - `optionalKey:true` (aliases: `optional-key`, `skipIfMissingKey`) turns a missing explicit/discovered key into a non-failing skip.
   - `keyLocation` can be explicit, otherwise defaults to `https://<host>/<key>.txt`.
 - Endpoint options:

--- a/PowerForge.Tests/WebPipelineRunnerIndexNowTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerIndexNowTests.cs
@@ -292,7 +292,6 @@ public class WebPipelineRunnerIndexNowTests
                       "task": "indexnow",
                       "siteRoot": "./_site",
                       "endpoint": "http://127.0.0.1:{{port}}/indexnow/",
-                      "keyLocation": "https://example.com/indexnow.txt",
                       "sitemap": "./_site/sitemap.xml",
                       "batchSize": 10,
                       "retryCount": 0
@@ -386,6 +385,51 @@ public class WebPipelineRunnerIndexNowTests
             Assert.True(result.Success, result.Steps[0].Message);
             Assert.Contains("custom-key.txt", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("indexnow.txt", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void RunPipeline_IndexNow_UnsafeKeyLocationDoesNotUseDefaultVerificationFile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-pipeline-indexnow-unsafe-key-location-" + Guid.NewGuid().ToString("N"));
+        var siteRoot = Path.Combine(root, "_site");
+        Directory.CreateDirectory(siteRoot);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(siteRoot, "indexnow.txt"), "root-verification-key");
+            File.WriteAllText(Path.Combine(siteRoot, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.com/docs/</loc></url>
+                </urlset>
+                """);
+
+            var pipelinePath = Path.Combine(root, "pipeline.json");
+            File.WriteAllText(pipelinePath,
+                """
+                {
+                  "steps": [
+                    {
+                      "task": "indexnow",
+                      "siteRoot": "./_site",
+                      "keyLocation": "https://example.com/%5c..%5ccustom-key.txt",
+                      "sitemap": "./_site/sitemap.xml",
+                      "optionalKey": true,
+                      "dryRun": true
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+            Assert.Single(result.Steps);
+            Assert.True(result.Steps[0].Success, result.Steps[0].Message);
+            Assert.Contains("skipped", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.IndexNow.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.IndexNow.cs
@@ -137,7 +137,17 @@ internal static partial class WebPipelineRunner
 
         if (string.IsNullOrWhiteSpace(key))
         {
-            key = TryReadIndexNowVerificationKey(baseDir, siteRoot, keyLocation, out keySource);
+            key = TryReadIndexNowVerificationKey(
+                baseDir,
+                siteRoot,
+                keyLocation,
+                out keySource,
+                out var discoveredKeyLocation);
+            if (string.IsNullOrWhiteSpace(keyLocation) &&
+                !string.IsNullOrWhiteSpace(discoveredKeyLocation))
+            {
+                keyLocation = discoveredKeyLocation;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(key))
@@ -203,44 +213,59 @@ internal static partial class WebPipelineRunner
             throw new InvalidOperationException(stepResult.Message);
     }
 
-    private static string? TryReadIndexNowVerificationKey(string baseDir, string? siteRoot, string? keyLocation, out string? source)
+    private sealed class IndexNowKeyCandidate
+    {
+        public string Path { get; set; } = string.Empty;
+        public string KeyLocation { get; set; } = "indexnow.txt";
+    }
+
+    private static string? TryReadIndexNowVerificationKey(
+        string baseDir,
+        string? siteRoot,
+        string? keyLocation,
+        out string? source,
+        out string? discoveredKeyLocation)
     {
         source = null;
+        discoveredKeyLocation = null;
         foreach (var candidate in EnumerateIndexNowKeyCandidates(baseDir, siteRoot, keyLocation))
         {
-            if (string.IsNullOrWhiteSpace(candidate) || !File.Exists(candidate))
+            if (string.IsNullOrWhiteSpace(candidate.Path) || !File.Exists(candidate.Path))
                 continue;
 
-            var key = File.ReadLines(candidate)
+            var key = File.ReadLines(candidate.Path)
                 .Select(static line => line.Trim())
                 .FirstOrDefault(static line => !string.IsNullOrWhiteSpace(line));
             if (string.IsNullOrWhiteSpace(key))
                 continue;
 
-            source = FormatIndexNowKeySource(baseDir, candidate);
+            source = FormatIndexNowKeySource(baseDir, candidate.Path);
+            discoveredKeyLocation = candidate.KeyLocation;
             return key;
         }
 
         return null;
     }
 
-    private static IEnumerable<string> EnumerateIndexNowKeyCandidates(string baseDir, string? siteRoot, string? keyLocation)
+    private static IEnumerable<IndexNowKeyCandidate> EnumerateIndexNowKeyCandidates(string baseDir, string? siteRoot, string? keyLocation)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var keyLocationRelativePaths = EnumerateIndexNowKeyRelativePaths(keyLocation).ToArray();
+        if (keyLocationRelativePaths.Length == 0 && !string.IsNullOrWhiteSpace(keyLocation))
+            yield break;
 
         foreach (var relative in keyLocationRelativePaths)
         {
             if (!string.IsNullOrWhiteSpace(siteRoot))
             {
-                foreach (var candidate in AddCandidateIterator(Path.Combine(siteRoot, relative)))
+                foreach (var candidate in AddCandidateIterator(Path.Combine(siteRoot, relative), relative))
                     yield return candidate;
             }
 
-            foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, relative)))
+            foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, relative), relative))
                 yield return candidate;
 
-            foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "static", relative)))
+            foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "static", relative), relative))
                 yield return candidate;
         }
 
@@ -252,23 +277,29 @@ internal static partial class WebPipelineRunner
 
         if (!string.IsNullOrWhiteSpace(siteRoot))
         {
-            foreach (var candidate in AddCandidateIterator(Path.Combine(siteRoot, "indexnow.txt")))
+            foreach (var candidate in AddCandidateIterator(Path.Combine(siteRoot, "indexnow.txt"), "indexnow.txt"))
                 yield return candidate;
         }
 
-        foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "indexnow.txt")))
+        foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "indexnow.txt"), "indexnow.txt"))
             yield return candidate;
-        foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "static", "indexnow.txt")))
+        foreach (var candidate in AddCandidateIterator(Path.Combine(baseDir, "static", "indexnow.txt"), "indexnow.txt"))
             yield return candidate;
 
-        IEnumerable<string> AddCandidateIterator(string? path)
+        IEnumerable<IndexNowKeyCandidate> AddCandidateIterator(string? path, string keyLocationValue)
         {
             if (string.IsNullOrWhiteSpace(path))
                 yield break;
 
             var full = Path.GetFullPath(path);
             if (seen.Add(full))
-                yield return full;
+            {
+                yield return new IndexNowKeyCandidate
+                {
+                    Path = full,
+                    KeyLocation = keyLocationValue
+                };
+            }
         }
     }
 
@@ -291,7 +322,7 @@ internal static partial class WebPipelineRunner
                 return relative;
             }
         }
-        catch
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or PathTooLongException)
         {
             // Fall back to the full path when the platform cannot compute a relative display path.
         }
@@ -314,7 +345,7 @@ internal static partial class WebPipelineRunner
         if (string.IsNullOrWhiteSpace(path))
             yield break;
 
-        path = Uri.UnescapeDataString(path.TrimStart('/').Replace('\\', '/'));
+        path = Uri.UnescapeDataString(path.TrimStart('/')).Replace('\\', '/');
         var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (string.IsNullOrWhiteSpace(path) ||
             segments.Any(static segment => segment.Equals("..", StringComparison.Ordinal)) ||


### PR DESCRIPTION
## Summary
- propagate auto-discovered verification files into the submitted IndexNow keyLocation when no keyLocation is configured
- prevent unsafe or unparseable configured keyLocation values from falling back to default indexnow.txt files
- re-normalize encoded backslashes before path traversal validation and narrow display-path exception handling

## Validation
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebPipelineRunnerIndexNowTests"`
- `git diff --check`

## Review follow-up
Addresses valid Codex feedback left on PR #360 around discovered keyLocation propagation, configured keyLocation fallback, and encoded backslash traversal handling.