### PR TITLE
Fix generated MSI artifact output

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -9,6 +9,19 @@ namespace PowerForge.Tests;
 public sealed class DotNetPublishPipelineRunnerMsiBuildTests
 {
     [Fact]
+    public void MsiBuildResult_ToString_UsesInstallerAndVersion()
+    {
+        var result = new DotNetPublishMsiBuildResult
+        {
+            InstallerId = "TierBridge.MSI",
+            Version = "4.0.9498",
+            VersionPropertyName = "ProductVersion"
+        };
+
+        Assert.Equal("TierBridge.MSI 4.0.9498", result.ToString());
+    }
+
+    [Fact]
     public void Plan_AddsMsiBuildStep_WhenInstallerProjectPathConfigured()
     {
         var root = CreateTempRoot();
@@ -687,6 +700,11 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             var projectPath = InvokeResolveOrPrepareInstallerProjectPath(plan, plan.Installers[0], step, prepare, "2.3.4");
 
             Assert.True(File.Exists(projectPath));
+            Assert.Equal(
+                Path.Combine(root, "Artifacts", "generated"),
+                Path.GetDirectoryName(projectPath));
+            var outputDir = InvokeResolveGeneratedInstallerOutputDirectory(plan, step, prepare);
+            Assert.Equal(Path.Combine(root, "Artifacts", "output"), outputDir);
             var sourcePath = Path.Combine(Path.GetDirectoryName(projectPath)!, "Product.wxs");
             Assert.True(File.Exists(sourcePath));
             Assert.Contains("2.3.4", File.ReadAllText(sourcePath), StringComparison.Ordinal);
@@ -755,6 +773,19 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
         Assert.NotNull(method);
 
         var raw = method!.Invoke(runner, new object?[] { plan, step, installer, prepare, productVersion });
+        Assert.NotNull(raw);
+        return Assert.IsType<string>(raw);
+    }
+
+    private static string InvokeResolveGeneratedInstallerOutputDirectory(
+        DotNetPublishPlan plan,
+        DotNetPublishStep step,
+        DotNetPublishMsiPrepareResult prepare)
+    {
+        var method = typeof(DotNetPublishPipelineRunner).GetMethod("ResolveGeneratedInstallerOutputDirectory", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var raw = method!.Invoke(null, new object?[] { plan, step.InstallerId!, step, prepare });
         Assert.NotNull(raw);
         return Assert.IsType<string>(raw);
     }

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -22,6 +22,47 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
+    public void ResolveGeneratedInstallerOutputDirectory_UsesTemplateFallback_WhenManifestPathMissing()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release"
+            };
+            var step = new DotNetPublishStep
+            {
+                InstallerId = "app.msi",
+                TargetName = "app",
+                Framework = "net8.0",
+                Runtime = "win-x64",
+                Style = DotNetPublishStyle.Portable
+            };
+            var prepare = new DotNetPublishMsiPrepareResult
+            {
+                InstallerId = "app.msi",
+                Target = "app",
+                Framework = "net8.0",
+                Runtime = "win-x64",
+                Style = DotNetPublishStyle.Portable,
+                ManifestPath = string.Empty
+            };
+
+            var outputDir = InvokeResolveGeneratedInstallerOutputDirectory(plan, step, prepare);
+
+            Assert.Equal(
+                Path.Combine(root, "Artifacts", "DotNetPublish", "Msi", "app.msi", "app", "win-x64", "net8.0", "Portable", "output"),
+                outputDir);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Plan_AddsMsiBuildStep_WhenInstallerProjectPathConfigured()
     {
         var root = CreateTempRoot();

--- a/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
@@ -267,6 +267,15 @@ public sealed class DotNetPublishMsiBuildResult
 
     /// <summary>Resolved client identifier used for license lookup (when configured).</summary>
     public string? ClientId { get; set; }
+
+    /// <summary>Returns a concise display label for PowerShell collection summaries.</summary>
+    public override string ToString()
+    {
+        var name = string.IsNullOrWhiteSpace(InstallerId) ? "MSI" : InstallerId;
+        return string.IsNullOrWhiteSpace(Version)
+            ? name
+            : $"{name} {Version}";
+    }
 }
 
 /// <summary>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -65,10 +65,10 @@ public sealed partial class DotNetPublishPipelineRunner
             ? ResolveGeneratedInstallerOutputDirectory(plan, installerId, step, prepare)
             : null;
         if (!string.IsNullOrWhiteSpace(generatedOutputDir))
-            Directory.CreateDirectory(generatedOutputDir!);
+            Directory.CreateDirectory(generatedOutputDir);
 
         var outputSearchDir = generatedOutputDir ?? projectDir;
-        var before = SnapshotMsiOutputs(outputSearchDir, includeAllMsiOutputs: generatedOutputDir is not null);
+        var before = SnapshotMsiOutputs(outputSearchDir, skipBinDirectoryFilter: isGeneratedInstallerProject);
 
         var args = new List<string>
         {
@@ -131,7 +131,7 @@ public sealed partial class DotNetPublishPipelineRunner
         if (versionResolution.Patch.HasValue && !string.IsNullOrWhiteSpace(versionResolution.StatePath))
             WriteMsiVersionState(versionResolution.StatePath!, versionResolution.Patch.Value, versionResolution.Version!);
 
-        var outputs = FindChangedMsiOutputs(outputSearchDir, before, includeAllMsiOutputs: generatedOutputDir is not null);
+        var outputs = FindChangedMsiOutputs(outputSearchDir, before, skipBinDirectoryFilter: isGeneratedInstallerProject);
         if (outputs.Length == 0)
             _logger.Warn($"MSI build for '{installerId}' completed, but no changed *.msi outputs were detected under '{outputSearchDir}'.");
         else
@@ -245,9 +245,9 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         if (!string.IsNullOrWhiteSpace(prepare.ManifestPath))
         {
-            var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(prepare.ManifestPath!));
+            var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(prepare.ManifestPath));
             if (!string.IsNullOrWhiteSpace(manifestDirectory))
-                return manifestDirectory!;
+                return manifestDirectory;
         }
 
         var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -324,10 +324,10 @@ public sealed partial class DotNetPublishPipelineRunner
         return merged;
     }
 
-    private static Dictionary<string, DateTime> SnapshotMsiOutputs(string root, bool includeAllMsiOutputs = false)
+    private static Dictionary<string, DateTime> SnapshotMsiOutputs(string root, bool skipBinDirectoryFilter = false)
     {
         var map = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
-        foreach (var file in EnumerateMsiFiles(root, includeAllMsiOutputs))
+        foreach (var file in EnumerateMsiFiles(root, skipBinDirectoryFilter))
         {
             try
             {
@@ -345,10 +345,10 @@ public sealed partial class DotNetPublishPipelineRunner
     private static string[] FindChangedMsiOutputs(
         string root,
         IReadOnlyDictionary<string, DateTime> before,
-        bool includeAllMsiOutputs = false)
+        bool skipBinDirectoryFilter = false)
     {
         var results = new List<string>();
-        foreach (var file in EnumerateMsiFiles(root, includeAllMsiOutputs))
+        foreach (var file in EnumerateMsiFiles(root, skipBinDirectoryFilter))
         {
             try
             {
@@ -368,7 +368,7 @@ public sealed partial class DotNetPublishPipelineRunner
             .ToArray();
     }
 
-    private static IEnumerable<string> EnumerateMsiFiles(string root, bool includeAllMsiOutputs = false)
+    private static IEnumerable<string> EnumerateMsiFiles(string root, bool skipBinDirectoryFilter = false)
     {
         if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
             return Array.Empty<string>();
@@ -376,7 +376,7 @@ public sealed partial class DotNetPublishPipelineRunner
         try
         {
             var files = Directory.EnumerateFiles(root, "*.msi", SearchOption.AllDirectories);
-            if (includeAllMsiOutputs)
+            if (skipBinDirectoryFilter)
                 return files;
 
             return files.Where(p =>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -49,6 +49,7 @@ public sealed partial class DotNetPublishPipelineRunner
             .FirstOrDefault(i => string.Equals(i.Id, installerId, StringComparison.OrdinalIgnoreCase));
         var versionResolution = ResolveMsiVersion(plan, installerConfig, step);
         var licenseResolution = ResolveInstallerClientLicense(plan, installerConfig, step);
+        var isGeneratedInstallerProject = IsGeneratedInstallerProject(step, installerConfig);
 
         var installerProjectPath = ResolveOrPrepareInstallerProjectPath(
             plan,
@@ -60,7 +61,14 @@ public sealed partial class DotNetPublishPipelineRunner
             throw new FileNotFoundException($"Installer project path not found: {installerProjectPath}", installerProjectPath);
 
         var projectDir = Path.GetDirectoryName(installerProjectPath)!;
-        var before = SnapshotMsiOutputs(projectDir);
+        var generatedOutputDir = isGeneratedInstallerProject
+            ? ResolveGeneratedInstallerOutputDirectory(plan, installerId, step, prepare)
+            : null;
+        if (!string.IsNullOrWhiteSpace(generatedOutputDir))
+            Directory.CreateDirectory(generatedOutputDir!);
+
+        var outputSearchDir = generatedOutputDir ?? projectDir;
+        var before = SnapshotMsiOutputs(outputSearchDir, includeAllMsiOutputs: generatedOutputDir is not null);
 
         var args = new List<string>
         {
@@ -73,6 +81,8 @@ public sealed partial class DotNetPublishPipelineRunner
 
         if (plan.Restore)
             args.Add("--no-restore");
+        if (!string.IsNullOrWhiteSpace(generatedOutputDir))
+            args.Add($"/p:OutputPath={EnsureTrailingDirectorySeparator(generatedOutputDir!)}");
 
         var installerMsBuildProperties = BuildInstallerMsBuildProperties(
             plan.MsBuildProperties,
@@ -121,9 +131,9 @@ public sealed partial class DotNetPublishPipelineRunner
         if (versionResolution.Patch.HasValue && !string.IsNullOrWhiteSpace(versionResolution.StatePath))
             WriteMsiVersionState(versionResolution.StatePath!, versionResolution.Patch.Value, versionResolution.Version!);
 
-        var outputs = FindChangedMsiOutputs(projectDir, before);
+        var outputs = FindChangedMsiOutputs(outputSearchDir, before, includeAllMsiOutputs: generatedOutputDir is not null);
         if (outputs.Length == 0)
-            _logger.Warn($"MSI build for '{installerId}' completed, but no changed *.msi outputs were detected under '{projectDir}'.");
+            _logger.Warn($"MSI build for '{installerId}' completed, but no changed *.msi outputs were detected under '{outputSearchDir}'.");
         else
             _logger.Info($"MSI build produced {outputs.Length} MSI output(s) for '{installerId}'.");
 
@@ -173,7 +183,7 @@ public sealed partial class DotNetPublishPipelineRunner
             definition.PayloadComponentGroupId = prepare.HarvestComponentGroupId;
         }
 
-        var generatedDir = ResolveGeneratedInstallerProjectDirectory(plan, installerId, step);
+        var generatedDir = ResolveGeneratedInstallerProjectDirectory(plan, installerId, step, prepare);
         var request = new PowerForgeWixInstallerCompileRequest
         {
             WorkingDirectory = generatedDir,
@@ -192,11 +202,54 @@ public sealed partial class DotNetPublishPipelineRunner
         return workspace.ProjectPath;
     }
 
+    private static bool IsGeneratedInstallerProject(
+        DotNetPublishStep step,
+        DotNetPublishInstallerPlan? installer)
+    {
+        return string.IsNullOrWhiteSpace(step.InstallerProjectPath)
+            && string.IsNullOrWhiteSpace(installer?.InstallerProjectPath)
+            && installer?.Authoring is not null;
+    }
+
     private static string ResolveGeneratedInstallerProjectDirectory(
         DotNetPublishPlan plan,
         string installerId,
-        DotNetPublishStep step)
+        DotNetPublishStep step,
+        DotNetPublishMsiPrepareResult prepare)
     {
+        var artifactDir = ResolveGeneratedInstallerArtifactDirectory(plan, installerId, step, prepare);
+        var path = Path.Combine(artifactDir, "generated");
+        if (!plan.AllowOutputOutsideProjectRoot)
+            EnsurePathWithinRoot(plan.ProjectRoot, path, $"Installer '{installerId}' generated WiX project path");
+        return path;
+    }
+
+    private static string ResolveGeneratedInstallerOutputDirectory(
+        DotNetPublishPlan plan,
+        string installerId,
+        DotNetPublishStep step,
+        DotNetPublishMsiPrepareResult prepare)
+    {
+        var artifactDir = ResolveGeneratedInstallerArtifactDirectory(plan, installerId, step, prepare);
+        var path = Path.Combine(artifactDir, "output");
+        if (!plan.AllowOutputOutsideProjectRoot)
+            EnsurePathWithinRoot(plan.ProjectRoot, path, $"Installer '{installerId}' generated MSI output path");
+        return path;
+    }
+
+    private static string ResolveGeneratedInstallerArtifactDirectory(
+        DotNetPublishPlan plan,
+        string installerId,
+        DotNetPublishStep step,
+        DotNetPublishMsiPrepareResult prepare)
+    {
+        if (!string.IsNullOrWhiteSpace(prepare.ManifestPath))
+        {
+            var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(prepare.ManifestPath!));
+            if (!string.IsNullOrWhiteSpace(manifestDirectory))
+                return manifestDirectory!;
+        }
+
         var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["installer"] = installerId,
@@ -207,11 +260,9 @@ public sealed partial class DotNetPublishPipelineRunner
             ["configuration"] = plan.Configuration ?? "Release"
         };
         var relativePath = ApplyTemplate(
-            "Artifacts/DotNetPublish/Msi/{installer}/{target}/{rid}/{framework}/{style}/generated",
+            "Artifacts/DotNetPublish/Msi/{installer}/{target}/{rid}/{framework}/{style}",
             tokens);
         var path = ResolvePath(plan.ProjectRoot, relativePath);
-        if (!plan.AllowOutputOutsideProjectRoot)
-            EnsurePathWithinRoot(plan.ProjectRoot, path, $"Installer '{installerId}' generated WiX project path");
         return path;
     }
 
@@ -273,10 +324,10 @@ public sealed partial class DotNetPublishPipelineRunner
         return merged;
     }
 
-    private static Dictionary<string, DateTime> SnapshotMsiOutputs(string root)
+    private static Dictionary<string, DateTime> SnapshotMsiOutputs(string root, bool includeAllMsiOutputs = false)
     {
         var map = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
-        foreach (var file in EnumerateMsiFiles(root))
+        foreach (var file in EnumerateMsiFiles(root, includeAllMsiOutputs))
         {
             try
             {
@@ -291,10 +342,13 @@ public sealed partial class DotNetPublishPipelineRunner
         return map;
     }
 
-    private static string[] FindChangedMsiOutputs(string root, IReadOnlyDictionary<string, DateTime> before)
+    private static string[] FindChangedMsiOutputs(
+        string root,
+        IReadOnlyDictionary<string, DateTime> before,
+        bool includeAllMsiOutputs = false)
     {
         var results = new List<string>();
-        foreach (var file in EnumerateMsiFiles(root))
+        foreach (var file in EnumerateMsiFiles(root, includeAllMsiOutputs))
         {
             try
             {
@@ -314,17 +368,20 @@ public sealed partial class DotNetPublishPipelineRunner
             .ToArray();
     }
 
-    private static IEnumerable<string> EnumerateMsiFiles(string root)
+    private static IEnumerable<string> EnumerateMsiFiles(string root, bool includeAllMsiOutputs = false)
     {
         if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
             return Array.Empty<string>();
 
         try
         {
-            return Directory.EnumerateFiles(root, "*.msi", SearchOption.AllDirectories)
-                .Where(p =>
-                    p.IndexOf($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) >= 0
-                    || p.IndexOf($"{Path.AltDirectorySeparatorChar}bin{Path.AltDirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) >= 0);
+            var files = Directory.EnumerateFiles(root, "*.msi", SearchOption.AllDirectories);
+            if (includeAllMsiOutputs)
+                return files;
+
+            return files.Where(p =>
+                p.IndexOf($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) >= 0
+                || p.IndexOf($"{Path.AltDirectorySeparatorChar}bin{Path.AltDirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) >= 0);
         }
         catch
         {


### PR DESCRIPTION
## Summary
- place generated WiX projects next to the MSI prepare manifest instead of the fallback DotNetPublish path
- build generated MSI projects with an explicit output folder under the MSI artifact directory
- improve MSI build result display labels for PowerShell summaries

## Validation
- dotnet test .\\PowerForge.Tests\\PowerForge.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests
- dotnet build .\\PSPublishModule\\PSPublishModule.csproj -c Debug -f net8.0 --nologo
- TierBridge full package run with POWERFORGE_ROOT=C:\\Support\\GitHub\\PSPublishModule