### PR TITLE
Surface installer outputs in publish manifests

### DIFF
--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -94,7 +94,7 @@ Depending on config, the run can emit:
 - benchmark gate results
 - manifests and checksums (for example `manifest.json`, `manifest.txt`, and `SHA256SUMS.txt`)
 
-`manifest.json` is an array of produced outputs. Publish and bundle outputs keep their existing entries; MSI and Store/MSIX outputs are also listed as `Installer` / `StorePackage` categories with `OutputFiles` pointing at the final files. `manifest.txt` mirrors those final MSI and Store package paths for quick operator inspection.
+`manifest.json` is an array of produced outputs. Publish and bundle outputs keep their existing entries; MSI and Store/MSIX outputs are also listed as `Installer` / `StorePackage` categories with `OutputFiles` pointing at the final files relative to the project root. `manifest.txt` mirrors those final MSI and Store package paths for quick operator inspection.
 
 ## Style Choices
 

--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -92,7 +92,9 @@ Depending on config, the run can emit:
 - MSI prepare/build outputs
 - Microsoft Store / MSIX package outputs (`*.msix`, `*.msixbundle`, `*.msixupload`, `*.appxsym`)
 - benchmark gate results
-- manifests and checksums (for example `SHA256SUMS.txt`)
+- manifests and checksums (for example `manifest.json`, `manifest.txt`, and `SHA256SUMS.txt`)
+
+`manifest.json` is an array of produced outputs. Publish and bundle outputs keep their existing entries; MSI and Store/MSIX outputs are also listed as `Installer` / `StorePackage` categories with `OutputFiles` pointing at the final files. `manifest.txt` mirrors those final MSI and Store package paths for quick operator inspection.
 
 ## Style Choices
 
@@ -169,7 +171,8 @@ Depending on config, the run can emit:
 ## Generated WiX MSI Authoring
 
 - Use `Installers[].Authoring` when the installer should be generated from the DotNet publish config instead of a hand-authored `*.wixproj`.
-- Leave `InstallerProjectPath` and `InstallerProjectId` empty; `msi.build` writes `Product.wxs` plus a WiX SDK project under `Artifacts/DotNetPublish/Msi/{installer}/{target}/{rid}/{framework}/{style}/generated`.
+- Leave `InstallerProjectPath` and `InstallerProjectId` empty; `msi.build` writes `Product.wxs` plus a WiX SDK project under the MSI prepare artifact directory, next to `prepare.manifest.json`, in `generated/`.
+- Generated MSI builds place the final `.msi` in the sibling `output/` directory, and that final file is listed in `manifest.json`, `manifest.txt`, and `SHA256SUMS.txt`.
 - Use `Harvest: Auto` with `Authoring.PayloadComponentGroupId` to include the prepared publish payload in the generated MSI feature.
 - Component entries require a `Type` discriminator: `File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, or `Shortcut`.
 - Registry value components can write a literal `Value`, or write an installer property by setting `ValueProperty`, for example persisting `LICENSE_KEY` after the UI collects it.

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text.Json;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -113,6 +114,88 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             Assert.True(lines.Length >= 2);
             Assert.Contains(lines, l => l.Contains("manifest.json", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(lines, l => l.Contains("manifest.txt", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void WriteManifests_IncludesInstallerAndStorePackageOutputs()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var manifestJson = Path.Combine(root, "Artifacts", "DotNetPublish", "manifest.json");
+            var manifestTxt = Path.Combine(root, "Artifacts", "DotNetPublish", "manifest.txt");
+            var checksums = Path.Combine(root, "Artifacts", "DotNetPublish", "SHA256SUMS.txt");
+            var msiPath = Path.Combine(root, "Artifacts", "Msi", "app", "output", "App.msi");
+            var msixPath = Path.Combine(root, "Artifacts", "Store", "app", "App.msixbundle");
+            var uploadPath = Path.Combine(root, "Artifacts", "Store", "app", "App.msixupload");
+            Directory.CreateDirectory(Path.GetDirectoryName(msiPath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(msixPath)!);
+            File.WriteAllText(msiPath, "msi");
+            File.WriteAllText(msixPath, "msix");
+            File.WriteAllText(uploadPath, "upload");
+
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Outputs = new DotNetPublishOutputs
+                {
+                    ManifestJsonPath = manifestJson,
+                    ManifestTextPath = manifestTxt,
+                    ChecksumsPath = checksums
+                }
+            };
+            var msiBuilds = new List<DotNetPublishMsiBuildResult>
+            {
+                new()
+                {
+                    InstallerId = "app.msi",
+                    Target = "app",
+                    Framework = "net8.0",
+                    Runtime = "win-x64",
+                    Style = DotNetPublishStyle.Portable,
+                    OutputFiles = new[] { msiPath },
+                    SignedFiles = new[] { msiPath },
+                    Version = "1.2.3"
+                }
+            };
+            var storePackages = new List<DotNetPublishStorePackageResult>
+            {
+                new()
+                {
+                    StorePackageId = "app.store",
+                    Target = "app",
+                    Framework = "net8.0-windows10.0.19041.0",
+                    Runtime = "win-x64",
+                    Style = DotNetPublishStyle.FrameworkDependent,
+                    OutputDir = Path.GetDirectoryName(msixPath)!,
+                    OutputFiles = new[] { msixPath },
+                    UploadFiles = new[] { uploadPath }
+                }
+            };
+
+            InvokeWriteManifests(plan, new List<DotNetPublishArtefactResult>(), storePackages, msiBuilds);
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(manifestJson));
+            Assert.Equal(2, doc.RootElement.GetArrayLength());
+            var json = File.ReadAllText(manifestJson);
+            Assert.Contains("\"InstallerId\": \"app.msi\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"StorePackageId\": \"app.store\"", json, StringComparison.Ordinal);
+            Assert.Contains("App.msi", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("App.msixupload", json, StringComparison.OrdinalIgnoreCase);
+
+            var text = File.ReadAllText(manifestTxt);
+            Assert.Contains("MSI app.msi", text, StringComparison.Ordinal);
+            Assert.Contains("Store app.store", text, StringComparison.Ordinal);
+
+            var checksumText = File.ReadAllText(checksums);
+            Assert.Contains("App.msi", checksumText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("App.msixbundle", checksumText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("App.msixupload", checksumText, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -484,6 +567,22 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.True(method is not null, "TrySignOutput private method not found. Was it renamed or made public?");
         return method!;
+    }
+
+    private static (string? ManifestJson, string? ManifestText, string? ChecksumsPath) InvokeWriteManifests(
+        DotNetPublishPlan plan,
+        List<DotNetPublishArtefactResult> artefacts,
+        List<DotNetPublishStorePackageResult> storePackages,
+        List<DotNetPublishMsiBuildResult> msiBuilds)
+    {
+        var method = typeof(DotNetPublishPipelineRunner).GetMethod(
+            "WriteManifests",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var raw = method!.Invoke(null, new object?[] { plan, artefacts, storePackages, msiBuilds });
+        Assert.NotNull(raw);
+        return Assert.IsType<(string? ManifestJson, string? ManifestText, string? ChecksumsPath)>(raw);
     }
 
     private static string CreateTempRoot()

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -131,11 +131,14 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             var manifestTxt = Path.Combine(root, "Artifacts", "DotNetPublish", "manifest.txt");
             var checksums = Path.Combine(root, "Artifacts", "DotNetPublish", "SHA256SUMS.txt");
             var msiPath = Path.Combine(root, "Artifacts", "Msi", "app", "output", "App.msi");
+            var msiSidecarPath = Path.Combine(root, "Artifacts", "Msi", "app", "symbols", "App-symbols.msi");
             var msixPath = Path.Combine(root, "Artifacts", "Store", "app", "App.msixbundle");
             var uploadPath = Path.Combine(root, "Artifacts", "Store", "app", "App.msixupload");
             Directory.CreateDirectory(Path.GetDirectoryName(msiPath)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(msiSidecarPath)!);
             Directory.CreateDirectory(Path.GetDirectoryName(msixPath)!);
             File.WriteAllText(msiPath, "msi");
+            File.WriteAllText(msiSidecarPath, "symbols");
             File.WriteAllText(msixPath, "msix");
             File.WriteAllText(uploadPath, "upload");
 
@@ -158,7 +161,7 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
                     Framework = "net8.0",
                     Runtime = "win-x64",
                     Style = DotNetPublishStyle.Portable,
-                    OutputFiles = new[] { msiPath },
+                    OutputFiles = new[] { msiPath, msiSidecarPath },
                     SignedFiles = new[] { msiPath },
                     Version = "1.2.3"
                 }
@@ -186,14 +189,31 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             Assert.Contains("\"InstallerId\": \"app.msi\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StorePackageId\": \"app.store\"", json, StringComparison.Ordinal);
             Assert.Contains("App.msi", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("App-symbols.msi", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("App.msixupload", json, StringComparison.OrdinalIgnoreCase);
+            foreach (var entry in doc.RootElement.EnumerateArray())
+            {
+                if (!entry.TryGetProperty("OutputFiles", out var outputFiles))
+                    continue;
+
+                foreach (var file in outputFiles.EnumerateArray())
+                {
+                    var value = file.GetString();
+                    Assert.False(
+                        !string.IsNullOrWhiteSpace(value) && Path.IsPathRooted(value),
+                        $"Manifest OutputFiles should be project-relative, but found '{value}'.");
+                }
+            }
 
             var text = File.ReadAllText(manifestTxt);
             Assert.Contains("MSI app.msi", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("->  (", text, StringComparison.Ordinal);
+            Assert.Contains("(2 files version=1.2.3)", text, StringComparison.Ordinal);
             Assert.Contains("Store app.store", text, StringComparison.Ordinal);
 
             var checksumText = File.ReadAllText(checksums);
             Assert.Contains("App.msi", checksumText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("App-symbols.msi", checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("App.msixbundle", checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("App.msixupload", checksumText, StringComparison.OrdinalIgnoreCase);
         }

--- a/PowerForge/Models/DotNetPublish/DotNetPublishEnums.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishEnums.cs
@@ -205,5 +205,9 @@ public enum DotNetPublishArtefactCategory
     /// <summary>Direct publish output from a target.</summary>
     Publish,
     /// <summary>Composed bundle output derived from one or more published targets.</summary>
-    Bundle
+    Bundle,
+    /// <summary>Installer output such as an MSI package.</summary>
+    Installer,
+    /// <summary>Store package output such as MSIX/AppX artifacts.</summary>
+    StorePackage
 }

--- a/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
@@ -106,6 +106,12 @@ public sealed class DotNetPublishArtefactResult
     /// <summary>Optional bundle identifier for bundle artifacts.</summary>
     public string? BundleId { get; set; }
 
+    /// <summary>Optional installer identifier for installer artifacts.</summary>
+    public string? InstallerId { get; set; }
+
+    /// <summary>Optional Store package identifier for Store/MSIX artifacts.</summary>
+    public string? StorePackageId { get; set; }
+
     /// <summary>Target kind.</summary>
     public DotNetPublishTargetKind Kind { get; set; } = DotNetPublishTargetKind.Unknown;
 
@@ -126,6 +132,9 @@ public sealed class DotNetPublishArtefactResult
 
     /// <summary>Optional zip file path.</summary>
     public string? ZipPath { get; set; }
+
+    /// <summary>File artifacts represented by this manifest entry.</summary>
+    public string[] OutputFiles { get; set; } = Array.Empty<string>();
 
     /// <summary>Total number of files in <see cref="OutputDir"/>.</summary>
     public int Files { get; set; }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -192,6 +192,14 @@ public sealed partial class DotNetPublishPipelineRunner
             .ThenBy(a => a.Style.ToString(), StringComparer.OrdinalIgnoreCase)
             .ThenBy(a => a.OutputDir, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        var orderedMsiBuilds = (msiBuilds ?? new List<DotNetPublishMsiBuildResult>())
+            .OrderBy(a => a.Target, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(a => a.Framework, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(a => a.Runtime, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(a => a.Style.ToString(), StringComparer.OrdinalIgnoreCase)
+            .ThenBy(a => a.InstallerId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var manifestEntries = BuildManifestEntries(orderedArtefacts, orderedStorePackages, orderedMsiBuilds);
 
         var jsonPath = plan.Outputs.ManifestJsonPath;
         var txtPath = plan.Outputs.ManifestTextPath;
@@ -210,7 +218,7 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(jsonPath))
         {
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(jsonPath))!);
-            var json = JsonSerializer.Serialize(orderedArtefacts, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(manifestEntries, new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(jsonPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         }
 
@@ -228,8 +236,16 @@ public sealed partial class DotNetPublishPipelineRunner
 
             foreach (var store in orderedStorePackages)
             {
-                var fileCount = (store.OutputFiles?.Length ?? 0) + (store.UploadFiles?.Length ?? 0) + (store.SymbolFiles?.Length ?? 0);
-                lines.Add($"Store {store.StorePackageId} from {store.Target} ({store.Framework}, {store.Runtime}, {store.Style}) -> {store.OutputDir} ({fileCount} files)");
+                var files = EnumerateStorePackageFiles(store).ToArray();
+                lines.Add($"Store {store.StorePackageId} from {store.Target} ({store.Framework}, {store.Runtime}, {store.Style}) -> {store.OutputDir} ({files.Length} files)");
+            }
+
+            foreach (var build in orderedMsiBuilds)
+            {
+                var files = EnumerateExistingFiles(build.OutputFiles).ToArray();
+                var outputDir = ResolveCommonDirectory(files);
+                var version = string.IsNullOrWhiteSpace(build.Version) ? string.Empty : $" version={build.Version}";
+                lines.Add($"MSI {build.InstallerId} from {build.Target} ({build.Framework}, {build.Runtime}, {build.Style}) -> {outputDir} ({files.Length} files{version})");
             }
 
             File.WriteAllLines(txtPath, lines, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
@@ -258,25 +274,17 @@ public sealed partial class DotNetPublishPipelineRunner
 
             foreach (var store in orderedStorePackages)
             {
-                foreach (var file in (store.OutputFiles ?? Array.Empty<string>())
-                    .Concat(store.UploadFiles ?? Array.Empty<string>())
-                    .Concat(store.SymbolFiles ?? Array.Empty<string>()))
+                foreach (var file in EnumerateStorePackageFiles(store))
                 {
-                    if (string.IsNullOrWhiteSpace(file) || !File.Exists(file))
-                        continue;
-
                     var full = Path.GetFullPath(file);
                     filesToHash[full] = ToManifestRelativePath(plan.ProjectRoot, full);
                 }
             }
 
-            foreach (var build in msiBuilds ?? new List<DotNetPublishMsiBuildResult>())
+            foreach (var build in orderedMsiBuilds)
             {
-                foreach (var file in build.OutputFiles ?? Array.Empty<string>())
+                foreach (var file in EnumerateExistingFiles(build.OutputFiles))
                 {
-                    if (string.IsNullOrWhiteSpace(file) || !File.Exists(file))
-                        continue;
-
                     var full = Path.GetFullPath(file);
                     filesToHash[full] = ToManifestRelativePath(plan.ProjectRoot, full);
                 }
@@ -305,6 +313,109 @@ public sealed partial class DotNetPublishPipelineRunner
         }
 
         return (jsonPath, txtPath, checksumsPath);
+    }
+
+    private static List<DotNetPublishArtefactResult> BuildManifestEntries(
+        IReadOnlyList<DotNetPublishArtefactResult> orderedArtefacts,
+        IReadOnlyList<DotNetPublishStorePackageResult> orderedStorePackages,
+        IReadOnlyList<DotNetPublishMsiBuildResult> orderedMsiBuilds)
+    {
+        var entries = new List<DotNetPublishArtefactResult>(orderedArtefacts ?? Array.Empty<DotNetPublishArtefactResult>());
+
+        foreach (var store in orderedStorePackages ?? Array.Empty<DotNetPublishStorePackageResult>())
+        {
+            var files = EnumerateStorePackageFiles(store).ToArray();
+            entries.Add(new DotNetPublishArtefactResult
+            {
+                Category = DotNetPublishArtefactCategory.StorePackage,
+                StorePackageId = store.StorePackageId,
+                Target = store.Target,
+                Runtime = store.Runtime,
+                Framework = store.Framework,
+                Style = store.Style,
+                PublishDir = store.OutputDir,
+                OutputDir = store.OutputDir,
+                OutputFiles = files,
+                Files = files.Length,
+                TotalBytes = SumFileBytes(files)
+            });
+        }
+
+        foreach (var build in orderedMsiBuilds ?? Array.Empty<DotNetPublishMsiBuildResult>())
+        {
+            var files = EnumerateExistingFiles(build.OutputFiles).ToArray();
+            entries.Add(new DotNetPublishArtefactResult
+            {
+                Category = DotNetPublishArtefactCategory.Installer,
+                InstallerId = build.InstallerId,
+                Target = build.Target,
+                Runtime = build.Runtime,
+                Framework = build.Framework,
+                Style = build.Style,
+                PublishDir = ResolveCommonDirectory(files),
+                OutputDir = ResolveCommonDirectory(files),
+                OutputFiles = files,
+                Files = files.Length,
+                TotalBytes = SumFileBytes(files),
+                SignedFiles = build.SignedFiles?.Length ?? 0
+            });
+        }
+
+        return entries;
+    }
+
+    private static IEnumerable<string> EnumerateStorePackageFiles(DotNetPublishStorePackageResult store)
+    {
+        return EnumerateExistingFiles((store.OutputFiles ?? Array.Empty<string>())
+            .Concat(store.UploadFiles ?? Array.Empty<string>())
+            .Concat(store.SymbolFiles ?? Array.Empty<string>()));
+    }
+
+    private static IEnumerable<string> EnumerateExistingFiles(IEnumerable<string>? files)
+    {
+        foreach (var file in files ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(file))
+                continue;
+
+            var full = Path.GetFullPath(file);
+            if (File.Exists(full))
+                yield return full;
+        }
+    }
+
+    private static long SumFileBytes(IEnumerable<string> files)
+    {
+        long bytes = 0;
+        foreach (var file in files ?? Array.Empty<string>())
+        {
+            try
+            {
+                bytes += new FileInfo(file).Length;
+            }
+            catch
+            {
+                // best effort for manifest summaries
+            }
+        }
+
+        return bytes;
+    }
+
+    private static string ResolveCommonDirectory(IReadOnlyList<string> files)
+    {
+        if (files.Count == 0)
+            return string.Empty;
+
+        var firstDirectory = Path.GetDirectoryName(Path.GetFullPath(files[0])) ?? string.Empty;
+        if (files.Count == 1)
+            return firstDirectory;
+
+        return files
+            .Select(file => Path.GetDirectoryName(Path.GetFullPath(file)) ?? string.Empty)
+            .All(directory => string.Equals(directory, firstDirectory, IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+            ? firstDirectory
+            : string.Empty;
     }
 
     private static string ToManifestRelativePath(string projectRoot, string fullPath)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -199,7 +199,7 @@ public sealed partial class DotNetPublishPipelineRunner
             .ThenBy(a => a.Style.ToString(), StringComparer.OrdinalIgnoreCase)
             .ThenBy(a => a.InstallerId, StringComparer.OrdinalIgnoreCase)
             .ToList();
-        var manifestEntries = BuildManifestEntries(orderedArtefacts, orderedStorePackages, orderedMsiBuilds);
+        var manifestEntries = BuildManifestEntries(plan.ProjectRoot, orderedArtefacts, orderedStorePackages, orderedMsiBuilds);
 
         var jsonPath = plan.Outputs.ManifestJsonPath;
         var txtPath = plan.Outputs.ManifestTextPath;
@@ -243,7 +243,7 @@ public sealed partial class DotNetPublishPipelineRunner
             foreach (var build in orderedMsiBuilds)
             {
                 var files = EnumerateExistingFiles(build.OutputFiles).ToArray();
-                var outputDir = ResolveCommonDirectory(files);
+                var outputDir = ResolveOutputDirectory(files);
                 var version = string.IsNullOrWhiteSpace(build.Version) ? string.Empty : $" version={build.Version}";
                 lines.Add($"MSI {build.InstallerId} from {build.Target} ({build.Framework}, {build.Runtime}, {build.Style}) -> {outputDir} ({files.Length} files{version})");
             }
@@ -316,13 +316,14 @@ public sealed partial class DotNetPublishPipelineRunner
     }
 
     private static List<DotNetPublishArtefactResult> BuildManifestEntries(
+        string projectRoot,
         IReadOnlyList<DotNetPublishArtefactResult> orderedArtefacts,
         IReadOnlyList<DotNetPublishStorePackageResult> orderedStorePackages,
         IReadOnlyList<DotNetPublishMsiBuildResult> orderedMsiBuilds)
     {
-        var entries = new List<DotNetPublishArtefactResult>(orderedArtefacts ?? Array.Empty<DotNetPublishArtefactResult>());
+        var entries = new List<DotNetPublishArtefactResult>(orderedArtefacts);
 
-        foreach (var store in orderedStorePackages ?? Array.Empty<DotNetPublishStorePackageResult>())
+        foreach (var store in orderedStorePackages)
         {
             var files = EnumerateStorePackageFiles(store).ToArray();
             entries.Add(new DotNetPublishArtefactResult
@@ -335,15 +336,16 @@ public sealed partial class DotNetPublishPipelineRunner
                 Style = store.Style,
                 PublishDir = store.OutputDir,
                 OutputDir = store.OutputDir,
-                OutputFiles = files,
+                OutputFiles = files.Select(file => ToManifestRelativePath(projectRoot, file)).ToArray(),
                 Files = files.Length,
                 TotalBytes = SumFileBytes(files)
             });
         }
 
-        foreach (var build in orderedMsiBuilds ?? Array.Empty<DotNetPublishMsiBuildResult>())
+        foreach (var build in orderedMsiBuilds)
         {
             var files = EnumerateExistingFiles(build.OutputFiles).ToArray();
+            var outputDir = ResolveOutputDirectory(files);
             entries.Add(new DotNetPublishArtefactResult
             {
                 Category = DotNetPublishArtefactCategory.Installer,
@@ -352,9 +354,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 Runtime = build.Runtime,
                 Framework = build.Framework,
                 Style = build.Style,
-                PublishDir = ResolveCommonDirectory(files),
-                OutputDir = ResolveCommonDirectory(files),
-                OutputFiles = files,
+                PublishDir = outputDir,
+                OutputDir = outputDir,
+                OutputFiles = files.Select(file => ToManifestRelativePath(projectRoot, file)).ToArray(),
                 Files = files.Length,
                 TotalBytes = SumFileBytes(files),
                 SignedFiles = build.SignedFiles?.Length ?? 0
@@ -387,13 +389,17 @@ public sealed partial class DotNetPublishPipelineRunner
     private static long SumFileBytes(IEnumerable<string> files)
     {
         long bytes = 0;
-        foreach (var file in files ?? Array.Empty<string>())
+        foreach (var file in files)
         {
             try
             {
                 bytes += new FileInfo(file).Length;
             }
-            catch
+            catch (IOException)
+            {
+                // best effort for manifest summaries
+            }
+            catch (UnauthorizedAccessException)
             {
                 // best effort for manifest summaries
             }
@@ -402,20 +408,11 @@ public sealed partial class DotNetPublishPipelineRunner
         return bytes;
     }
 
-    private static string ResolveCommonDirectory(IReadOnlyList<string> files)
+    private static string ResolveOutputDirectory(IReadOnlyList<string> files)
     {
-        if (files.Count == 0)
-            return string.Empty;
-
-        var firstDirectory = Path.GetDirectoryName(Path.GetFullPath(files[0])) ?? string.Empty;
-        if (files.Count == 1)
-            return firstDirectory;
-
-        return files
-            .Select(file => Path.GetDirectoryName(Path.GetFullPath(file)) ?? string.Empty)
-            .All(directory => string.Equals(directory, firstDirectory, IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
-            ? firstDirectory
-            : string.Empty;
+        return files.Count == 0
+            ? string.Empty
+            : Path.GetDirectoryName(Path.GetFullPath(files[0])) ?? string.Empty;
     }
 
     private static string ToManifestRelativePath(string projectRoot, string fullPath)


### PR DESCRIPTION
## Summary
- include MSI and Store/MSIX outputs as first-class entries in DotNet publish manifest.json
- add final MSI and Store package lines to manifest.txt while keeping checksum coverage
- document generated MSI output and manifest behavior

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests|FullyQualifiedName~DotNetPublishPipelineRunnerStorePackageTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo
- TierBridge full package run with POWERFORGE_ROOT=C:\Support\GitHub\PSPublishModule