### PR TITLE
Make publish manifest entries readable

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,6 +9,7 @@
 - Add bundle composition primitives for primary subdirectories, copy items, module includes, and generated scripts.
 - Add bundle post-process signing and MSI harvest exclude patterns for package/MSI reuse across projects.
 - DotNet publish CLI overrides (`--target`, `--runtime`, `--framework`, `--style`) are applied before profile resolution so profile-filtered plan/export output matches the executed run.
+- DotNet publish `manifest.json` now emits readable string values for enum fields such as `Category`, `Kind`, and `Style` instead of numeric enum values. Consumers that parse the manifest should treat this as a manifest-contract change.
 
 ## 2.0.19 - 2025.06.17
 ### What's Changed

--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -94,7 +94,7 @@ Depending on config, the run can emit:
 - benchmark gate results
 - manifests and checksums (for example `manifest.json`, `manifest.txt`, and `SHA256SUMS.txt`)
 
-`manifest.json` is an array of produced outputs. Publish and bundle outputs keep their existing entries; MSI and Store/MSIX outputs are also listed as `Installer` / `StorePackage` categories with `OutputFiles` pointing at the final files relative to the project root. `manifest.txt` mirrors those final MSI and Store package paths for quick operator inspection.
+`manifest.json` is an array of produced outputs with readable string values for fields such as `Category`, `Kind`, and `Style`. Publish and bundle outputs keep their existing entries; MSI and Store/MSIX outputs are also listed as `Installer` / `StorePackage` categories with `OutputFiles` pointing at the final files relative to the project root. `manifest.txt` mirrors those final MSI and Store package paths for quick operator inspection.
 
 ## Style Choices
 

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -186,11 +186,28 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             using var doc = JsonDocument.Parse(File.ReadAllText(manifestJson));
             Assert.Equal(2, doc.RootElement.GetArrayLength());
             var json = File.ReadAllText(manifestJson);
+            Assert.Contains("\"Category\": \"Installer\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Category\": \"StorePackage\"", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"Category\": 2", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"Category\": 3", json, StringComparison.Ordinal);
             Assert.Contains("\"InstallerId\": \"app.msi\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StorePackageId\": \"app.store\"", json, StringComparison.Ordinal);
             Assert.Contains("App.msi", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("App-symbols.msi", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("App.msixupload", json, StringComparison.OrdinalIgnoreCase);
+
+            var installer = FindManifestEntry(doc, "Category", "Installer");
+            Assert.Equal("app.msi", installer.GetProperty("InstallerId").GetString());
+            Assert.Equal("Portable", installer.GetProperty("Style").GetString());
+            Assert.Equal(1, installer.GetProperty("SignedFiles").GetInt32());
+            Assert.False(installer.TryGetProperty("Cleanup", out _));
+
+            var store = FindManifestEntry(doc, "Category", "StorePackage");
+            Assert.Equal("app.store", store.GetProperty("StorePackageId").GetString());
+            Assert.Equal("FrameworkDependent", store.GetProperty("Style").GetString());
+            Assert.False(store.TryGetProperty("SignedFiles", out _));
+            Assert.False(store.TryGetProperty("Cleanup", out _));
+
             foreach (var entry in doc.RootElement.EnumerateArray())
             {
                 if (!entry.TryGetProperty("OutputFiles", out var outputFiles))
@@ -216,6 +233,80 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             Assert.Contains("App-symbols.msi", checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("App.msixbundle", checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("App.msixupload", checksumText, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void WriteManifests_UsesReadablePublishEntryContract()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var manifestJson = Path.Combine(root, "Artifacts", "DotNetPublish", "manifest.json");
+            var manifestTxt = Path.Combine(root, "Artifacts", "DotNetPublish", "manifest.txt");
+            var publishDir = Directory.CreateDirectory(Path.Combine(root, "Artifacts", "Publish", "app")).FullName;
+
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Outputs = new DotNetPublishOutputs
+                {
+                    ManifestJsonPath = manifestJson,
+                    ManifestTextPath = manifestTxt
+                }
+            };
+            var artefacts = new List<DotNetPublishArtefactResult>
+            {
+                new()
+                {
+                    Category = DotNetPublishArtefactCategory.Publish,
+                    Target = "app",
+                    Kind = DotNetPublishTargetKind.Service,
+                    Framework = "net8.0",
+                    Runtime = "win-x64",
+                    Style = DotNetPublishStyle.PortableCompat,
+                    PublishDir = publishDir,
+                    OutputDir = publishDir,
+                    Files = 1,
+                    TotalBytes = 12
+                },
+                new()
+                {
+                    Category = DotNetPublishArtefactCategory.Publish,
+                    Target = "lib",
+                    Kind = DotNetPublishTargetKind.Unknown,
+                    Framework = "net8.0",
+                    Runtime = "win-x64",
+                    Style = DotNetPublishStyle.FrameworkDependent,
+                    PublishDir = publishDir,
+                    OutputDir = publishDir,
+                    Files = 1,
+                    TotalBytes = 12
+                }
+            };
+
+            InvokeWriteManifests(plan, artefacts, new List<DotNetPublishStorePackageResult>(), new List<DotNetPublishMsiBuildResult>());
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(manifestJson));
+            Assert.Equal(2, doc.RootElement.GetArrayLength());
+            var entry = FindManifestEntry(doc, "Target", "app");
+            Assert.Equal("Publish", entry.GetProperty("Category").GetString());
+            Assert.Equal("Service", entry.GetProperty("Kind").GetString());
+            Assert.Equal("PortableCompat", entry.GetProperty("Style").GetString());
+            Assert.False(entry.TryGetProperty("Cleanup", out _));
+            Assert.False(entry.TryGetProperty("OutputFiles", out _));
+
+            var unknownKindEntry = FindManifestEntry(doc, "Target", "lib");
+            Assert.Equal("Publish", unknownKindEntry.GetProperty("Category").GetString());
+            Assert.False(unknownKindEntry.TryGetProperty("Kind", out _));
+
+            var json = File.ReadAllText(manifestJson);
+            Assert.DoesNotContain("\"Kind\": 2", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"Style\": 1", json, StringComparison.Ordinal);
         }
         finally
         {
@@ -603,6 +694,20 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
         var raw = method!.Invoke(null, new object?[] { plan, artefacts, storePackages, msiBuilds });
         Assert.NotNull(raw);
         return Assert.IsType<(string? ManifestJson, string? ManifestText, string? ChecksumsPath)>(raw);
+    }
+
+    private static JsonElement FindManifestEntry(JsonDocument doc, string propertyName, string value)
+    {
+        foreach (var entry in doc.RootElement.EnumerateArray())
+        {
+            if (entry.TryGetProperty(propertyName, out var property)
+                && string.Equals(property.GetString(), value, StringComparison.Ordinal))
+            {
+                return entry;
+            }
+        }
+
+        throw new InvalidOperationException($"Manifest entry with {propertyName}={value} was not found.");
     }
 
     private static string CreateTempRoot()

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PowerForge;
 
@@ -218,7 +219,11 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(jsonPath))
         {
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(jsonPath))!);
-            var json = JsonSerializer.Serialize(manifestEntries, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(manifestEntries, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            });
             File.WriteAllText(jsonPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         }
 
@@ -315,28 +320,53 @@ public sealed partial class DotNetPublishPipelineRunner
         return (jsonPath, txtPath, checksumsPath);
     }
 
-    private static List<DotNetPublishArtefactResult> BuildManifestEntries(
+    private static List<DotNetPublishManifestEntry> BuildManifestEntries(
         string projectRoot,
         IReadOnlyList<DotNetPublishArtefactResult> orderedArtefacts,
         IReadOnlyList<DotNetPublishStorePackageResult> orderedStorePackages,
         IReadOnlyList<DotNetPublishMsiBuildResult> orderedMsiBuilds)
     {
-        var entries = new List<DotNetPublishArtefactResult>(orderedArtefacts);
+        var entries = orderedArtefacts
+            .Select(a => new DotNetPublishManifestEntry
+            {
+                Category = a.Category.ToString(),
+                Target = a.Target,
+                BundleId = EmptyToNull(a.BundleId),
+                InstallerId = EmptyToNull(a.InstallerId),
+                StorePackageId = EmptyToNull(a.StorePackageId),
+                Kind = a.Kind == DotNetPublishTargetKind.Unknown ? null : a.Kind.ToString(),
+                Runtime = a.Runtime,
+                Framework = a.Framework,
+                Style = a.Style.ToString(),
+                PublishDir = a.PublishDir,
+                OutputDir = a.OutputDir,
+                ZipPath = EmptyToNull(a.ZipPath),
+                OutputFiles = ToManifestOutputFiles(projectRoot, a.OutputFiles),
+                Files = a.Files,
+                TotalBytes = a.TotalBytes,
+                ExePath = EmptyToNull(a.ExePath),
+                ExeBytes = a.ExeBytes,
+                Cleanup = HasCleanup(a.Cleanup) ? a.Cleanup : null,
+                ServicePackage = a.ServicePackage,
+                StateTransfer = a.StateTransfer,
+                SignedFiles = a.SignedFiles > 0 ? a.SignedFiles : null
+            })
+            .ToList();
 
         foreach (var store in orderedStorePackages)
         {
             var files = EnumerateStorePackageFiles(store).ToArray();
-            entries.Add(new DotNetPublishArtefactResult
+            entries.Add(new DotNetPublishManifestEntry
             {
-                Category = DotNetPublishArtefactCategory.StorePackage,
+                Category = DotNetPublishArtefactCategory.StorePackage.ToString(),
                 StorePackageId = store.StorePackageId,
                 Target = store.Target,
                 Runtime = store.Runtime,
                 Framework = store.Framework,
-                Style = store.Style,
+                Style = store.Style.ToString(),
                 PublishDir = store.OutputDir,
                 OutputDir = store.OutputDir,
-                OutputFiles = files.Select(file => ToManifestRelativePath(projectRoot, file)).ToArray(),
+                OutputFiles = ToManifestOutputFiles(projectRoot, files),
                 Files = files.Length,
                 TotalBytes = SumFileBytes(files)
             });
@@ -346,24 +376,75 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             var files = EnumerateExistingFiles(build.OutputFiles).ToArray();
             var outputDir = ResolveOutputDirectory(files);
-            entries.Add(new DotNetPublishArtefactResult
+            entries.Add(new DotNetPublishManifestEntry
             {
-                Category = DotNetPublishArtefactCategory.Installer,
+                Category = DotNetPublishArtefactCategory.Installer.ToString(),
                 InstallerId = build.InstallerId,
                 Target = build.Target,
                 Runtime = build.Runtime,
                 Framework = build.Framework,
-                Style = build.Style,
+                Style = build.Style.ToString(),
                 PublishDir = outputDir,
                 OutputDir = outputDir,
-                OutputFiles = files.Select(file => ToManifestRelativePath(projectRoot, file)).ToArray(),
+                OutputFiles = ToManifestOutputFiles(projectRoot, files),
                 Files = files.Length,
                 TotalBytes = SumFileBytes(files),
-                SignedFiles = build.SignedFiles?.Length ?? 0
+                SignedFiles = build.SignedFiles is { Length: > 0 } ? build.SignedFiles.Length : null
             });
         }
 
         return entries;
+    }
+
+    // Disk manifest projection: keep JSON readability/stability separate from runtime result models.
+    private sealed class DotNetPublishManifestEntry
+    {
+        public string Category { get; set; } = string.Empty;
+        public string Target { get; set; } = string.Empty;
+        public string? BundleId { get; set; }
+        public string? InstallerId { get; set; }
+        public string? StorePackageId { get; set; }
+        public string? Kind { get; set; }
+        public string Runtime { get; set; } = string.Empty;
+        public string Framework { get; set; } = string.Empty;
+        public string Style { get; set; } = string.Empty;
+        public string PublishDir { get; set; } = string.Empty;
+        public string OutputDir { get; set; } = string.Empty;
+        public string? ZipPath { get; set; }
+        public string[]? OutputFiles { get; set; }
+        public int Files { get; set; }
+        public long TotalBytes { get; set; }
+        public string? ExePath { get; set; }
+        public long? ExeBytes { get; set; }
+        public DotNetPublishCleanupResult? Cleanup { get; set; }
+        public DotNetPublishServicePackageResult? ServicePackage { get; set; }
+        public DotNetPublishStateTransferResult? StateTransfer { get; set; }
+        public int? SignedFiles { get; set; }
+    }
+
+    private static bool HasCleanup(DotNetPublishCleanupResult? cleanup)
+    {
+        return cleanup is not null
+            && (cleanup.PdbRemoved != 0
+                || cleanup.DocsRemoved != 0
+                || cleanup.RefPruned);
+    }
+
+    private static string? EmptyToNull(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static string[]? ToManifestOutputFiles(string projectRoot, IEnumerable<string>? files)
+    {
+        var outputFiles = (files ?? Array.Empty<string>())
+            .Where(file => !string.IsNullOrWhiteSpace(file))
+            .Select(file => Path.IsPathRooted(file)
+                ? ToManifestRelativePath(projectRoot, file)
+                : file.Replace('\\', '/'))
+            .ToArray();
+
+        return outputFiles.Length == 0 ? null : outputFiles;
     }
 
     private static IEnumerable<string> EnumerateStorePackageFiles(DotNetPublishStorePackageResult store)


### PR DESCRIPTION
## Summary
- emit dotnet publish manifest entries through a manifest-only DTO so Category, Kind, and Style are readable strings
- omit null/default-only manifest fields such as empty OutputFiles, Cleanup, and SignedFiles noise
- document the readable manifest contract and add focused coverage for publish, MSI, and Store entries

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests|FullyQualifiedName~DotNetPublishPipelineRunnerStorePackageTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo
- dotnet test .\PSPublishModule.sln -c Release
- TierBridge: pwsh -NoProfile -ExecutionPolicy Bypass -File .\Build\Build-TierBridgePackage.ps1 with POWERFORGE_ROOT=C:\Support\GitHub\PSPublishModule