### PR TITLE
Require generated installer inputs

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,6 +10,7 @@
 - Add bundle post-process signing and MSI harvest exclude patterns for package/MSI reuse across projects.
 - DotNet publish CLI overrides (`--target`, `--runtime`, `--framework`, `--style`) are applied before profile resolution so profile-filtered plan/export output matches the executed run.
 - DotNet publish `manifest.json` now emits readable string values for enum fields such as `Category`, `Kind`, and `Style` instead of numeric enum values. Consumers that parse the manifest should treat this as a manifest-contract change.
+- Generated WiX installer inputs can now set `Required` to block generated dialog navigation until the value is provided.
 
 ## 2.0.19 - 2025.06.17
 ### What's Changed

--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -175,6 +175,7 @@ Depending on config, the run can emit:
 - Generated MSI builds place the final `.msi` in the sibling `output/` directory, and that final file is listed in `manifest.json`, `manifest.txt`, and `SHA256SUMS.txt`.
 - Use `Harvest: Auto` with `Authoring.PayloadComponentGroupId` to include the prepared publish payload in the generated MSI feature.
 - Component entries require a `Type` discriminator: `File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, or `Shortcut`.
+- Installer inputs can set `Required: true`; generated dialogs block `Next` until text/license/path inputs have a value, or until required checkbox properties are non-empty. Required radio-group inputs must set `DefaultValue` to one of their choices.
 - Registry value components can write a literal `Value`, or write an installer property by setting `ValueProperty`, for example persisting `LICENSE_KEY` after the UI collects it.
 - Shortcut components can use `TargetFileId` for an explicitly authored file component, or `Target` such as `[INSTALLFOLDER]MyApp.exe` when the executable comes from harvested payload.
 - WiX still does the compile. The generated project includes `WixToolset.UI.wixext` and `WixToolset.Util.wixext` only when the authoring model needs those extensions.

--- a/Module/Examples/DotNetPublish/Example.GeneratedServiceMsi.json
+++ b/Module/Examples/DotNetPublish/Example.GeneratedServiceMsi.json
@@ -56,7 +56,8 @@
             "Label": "License key",
             "Kind": "LicenseKey",
             "Secure": true,
-            "Hidden": true
+            "Hidden": true,
+            "Required": true
           }
         ],
         "Dialogs": [

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -54,13 +54,152 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Id") == "RemoveData" &&
             (string?)e.Attribute("Type") == "CheckBox" &&
             (string?)e.Attribute("Property") == "REMOVE_DATA"));
-        Assert.NotNull(dialog.Descendants(Wix + "Control").Single(e =>
-                (string?)e.Attribute("Id") == "Next")
-            .Descendants(Wix + "Publish")
+        var next = dialog.Descendants(Wix + "Control").Single(e =>
+            (string?)e.Attribute("Id") == "Next");
+        var newDialogPublish = next.Descendants(Wix + "Publish")
             .SingleOrDefault(e =>
                 (string?)e.Attribute("Event") == "NewDialog" &&
-                (string?)e.Attribute("Value") == "VerifyReadyDlg"));
+                (string?)e.Attribute("Condition") == "LICENSE_KEY <> \"\"" &&
+                (string?)e.Attribute("Value") == "VerifyReadyDlg");
+        var spawnDialogPublish = next.Descendants(Wix + "Publish")
+            .SingleOrDefault(e =>
+                (string?)e.Attribute("Event") == "SpawnDialog" &&
+                (string?)e.Attribute("Value") == "PowerForgeRequiredInputDlg" &&
+                (string?)e.Attribute("Condition") == "LICENSE_KEY = \"\"");
+        Assert.NotNull(newDialogPublish);
+        Assert.Equal("2", (string?)newDialogPublish.Attribute("Order"));
+        Assert.NotNull(spawnDialogPublish);
+        Assert.Equal("1", (string?)spawnDialogPublish.Attribute("Order"));
+        Assert.NotNull(doc.Descendants(Wix + "Dialog").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg"));
         Assert.Equal(2, dialog.Descendants(Wix + "RadioButton").Count());
+    }
+
+    [Fact]
+    public void EmitSource_DoesNotAddPublishOrderWhenDialogHasNoRequiredInputs()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "OptionalSetting",
+            PropertyName = "OPTIONAL_SETTING",
+            Label = "Optional setting"
+        });
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "OptionalDlg",
+            Title = "Optional settings",
+            InputIds = { "OptionalSetting" }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.DoesNotContain(doc.Descendants(Wix + "Dialog"), e =>
+            (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg");
+
+        var nextPublish = doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "OptionalDlg")
+            .Descendants(Wix + "Control")
+            .Single(e => (string?)e.Attribute("Id") == "Next")
+            .Descendants(Wix + "Publish")
+            .Single(e => (string?)e.Attribute("Event") == "NewDialog");
+
+        Assert.Equal("1", (string?)nextPublish.Attribute("Condition"));
+        Assert.Null(nextPublish.Attribute("Order"));
+    }
+
+    [Fact]
+    public void EmitSource_RequiresCheckboxInputsWhenConfigured()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.Inputs.Single(input => input.Id == "RemoveData").Required = true;
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        var next = doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "ConfigurationDlg")
+            .Descendants(Wix + "Control")
+            .Single(e => (string?)e.Attribute("Id") == "Next");
+
+        Assert.NotNull(next.Descendants(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Event") == "SpawnDialog" &&
+            (string?)e.Attribute("Value") == "PowerForgeRequiredInputDlg" &&
+            (string?)e.Attribute("Condition") == "LICENSE_KEY = \"\" OR REMOVE_DATA = \"\""));
+        Assert.NotNull(next.Descendants(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Event") == "NewDialog" &&
+            (string?)e.Attribute("Condition") == "LICENSE_KEY <> \"\" AND REMOVE_DATA <> \"\""));
+    }
+
+    [Fact]
+    public void EmitSource_RejectsReservedRequiredInputDialogId()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "PowerForgeRequiredInputDlg",
+            Title = "Reserved"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("reserved", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EmitSource_RejectsRequiredRadioGroupWithoutDefaultValue()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        var input = new PowerForgeInstallerInput
+        {
+            Id = "Preset",
+            PropertyName = "INIT_PRESET",
+            Label = "Configuration preset",
+            Kind = PowerForgeInstallerInputKind.RadioGroup,
+            Required = true
+        };
+        input.Choices.Add(new PowerForgeInstallerInputChoice { Value = "none", Text = "None" });
+        input.Choices.Add(new PowerForgeInstallerInputChoice { Value = "core", Text = "Core AD" });
+        definition.Inputs.Add(input);
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "ConfigurationDlg",
+            Title = "Configuration",
+            InputIds = { "Preset" }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("required radio group", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EmitSource_RejectsRequiredRadioGroupWithUnknownDefaultValue()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        var input = new PowerForgeInstallerInput
+        {
+            Id = "Preset",
+            PropertyName = "INIT_PRESET",
+            Label = "Configuration preset",
+            Kind = PowerForgeInstallerInputKind.RadioGroup,
+            Required = true,
+            DefaultValue = "missing"
+        };
+        input.Choices.Add(new PowerForgeInstallerInputChoice { Value = "none", Text = "None" });
+        input.Choices.Add(new PowerForgeInstallerInputChoice { Value = "core", Text = "Core AD" });
+        definition.Inputs.Add(input);
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "ConfigurationDlg",
+            Title = "Configuration",
+            InputIds = { "Preset" }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("default value", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -96,6 +235,8 @@ public sealed class PowerForgeInstallerAuthoringTests
             .Descendants(Wix + "Publish")
             .Single(e => (string?)e.Attribute("Event") == "NewDialog");
         Assert.Equal("AdvancedDlg", (string?)firstDialogNext.Attribute("Value"));
+        Assert.Equal("LICENSE_KEY <> \"\"", (string?)firstDialogNext.Attribute("Condition"));
+        Assert.Equal("2", (string?)firstDialogNext.Attribute("Order"));
 
         var secondDialogBack = doc.Descendants(Wix + "Dialog")
             .Single(e => (string?)e.Attribute("Id") == "AdvancedDlg")
@@ -104,6 +245,18 @@ public sealed class PowerForgeInstallerAuthoringTests
             .Descendants(Wix + "Publish")
             .Single(e => (string?)e.Attribute("Event") == "NewDialog");
         Assert.Equal("ConfigurationDlg", (string?)secondDialogBack.Attribute("Value"));
+
+        var secondDialogNext = doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "AdvancedDlg")
+            .Descendants(Wix + "Control")
+            .Single(e => (string?)e.Attribute("Id") == "Next")
+            .Descendants(Wix + "Publish")
+            .Single(e => (string?)e.Attribute("Event") == "NewDialog");
+        Assert.Equal("VerifyReadyDlg", (string?)secondDialogNext.Attribute("Value"));
+        Assert.Equal("1", (string?)secondDialogNext.Attribute("Condition"));
+        Assert.Null(secondDialogNext.Attribute("Order"));
+        Assert.Single(doc.Descendants(Wix + "Dialog"), e =>
+            (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg");
     }
 
     [Fact]
@@ -556,7 +709,8 @@ public sealed class PowerForgeInstallerAuthoringTests
                     "Label": "License key",
                     "Kind": "LicenseKey",
                     "Secure": true,
-                    "Hidden": true
+                    "Hidden": true,
+                    "Required": true
                   }
                 ],
                 "Dialogs": [
@@ -615,7 +769,8 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(authoring);
         Assert.Equal("TestimoX Monitoring", authoring!.Product.Name);
         Assert.Equal("ProductFiles", authoring.PayloadComponentGroupId);
-        Assert.Single(authoring.Inputs);
+        var input = Assert.Single(authoring.Inputs);
+        Assert.True(input.Required);
         Assert.Single(authoring.Dialogs);
         Assert.Single(authoring.Directories);
 
@@ -657,7 +812,8 @@ public sealed class PowerForgeInstallerAuthoringTests
             Label = "License key",
             Kind = PowerForgeInstallerInputKind.LicenseKey,
             Secure = true,
-            Hidden = true
+            Hidden = true,
+            Required = true
         });
         definition.Inputs.Add(new PowerForgeInstallerInput
         {

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -157,6 +157,12 @@ public sealed class PowerForgeInstallerInput
     public bool Hidden { get; set; }
 
     /// <summary>
+    /// Requires a non-empty value before a generated dialog can continue. Checkbox inputs follow MSI semantics:
+    /// any non-empty property value is treated as checked. Required radio groups must set a default choice.
+    /// </summary>
+    public bool Required { get; set; }
+
+    /// <summary>
     /// Choices for radio or combo style inputs.
     /// </summary>
     public List<PowerForgeInstallerInputChoice> Choices { get; set; } = new();

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -761,7 +761,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 Kind = input.Kind,
                 DefaultValue = input.DefaultValue,
                 Secure = input.Secure,
-                Hidden = input.Hidden
+                Hidden = input.Hidden,
+                Required = input.Required
             };
             foreach (var choice in input.Choices)
             {

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -13,6 +13,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     private static readonly XNamespace WixNamespace = "http://wixtoolset.org/schemas/v4/wxs";
     private static readonly XNamespace UtilNamespace = "http://wixtoolset.org/schemas/v4/wxs/util";
     private static readonly XNamespace UiNamespace = "http://wixtoolset.org/schemas/v4/wxs/ui";
+    private const string RequiredInputDialogId = "PowerForgeRequiredInputDlg";
+    private const string RequiredInputMessage = "All required fields must be filled in before continuing.";
 
     /// <summary>
     /// Emits a WiX v4 source document.
@@ -162,6 +164,15 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XElement(UiNamespace + "WixUI", new XAttribute("Id", "WixUI_InstallDir")));
 
         var dialogs = definition.Dialogs.ToArray();
+        var requiredInputIds = definition.Inputs
+            .Where(input => input.Required)
+            .Select(input => input.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (dialogs.Any(dialog => dialog.InputIds.Any(requiredInputIds.Contains)))
+        {
+            ui.Add(EmitRequiredInputDialog());
+        }
+
         for (var i = 0; i < dialogs.Length; i++)
         {
             var previousDialogId = i == 0 ? "InstallDirDlg" : dialogs[i - 1].Id;
@@ -172,6 +183,41 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         ui.Add(EmitDialogSequence(dialogs));
 
         return ui;
+    }
+
+    private static XElement EmitRequiredInputDialog()
+    {
+        return new XElement(
+            WixNamespace + "Dialog",
+            new XAttribute("Id", RequiredInputDialogId),
+            new XAttribute("Width", "260"),
+            new XAttribute("Height", "95"),
+            new XAttribute("Title", "[ProductName]"),
+            new XElement(
+                WixNamespace + "Control",
+                new XAttribute("Id", "Message"),
+                new XAttribute("Type", "Text"),
+                new XAttribute("X", "15"),
+                new XAttribute("Y", "15"),
+                new XAttribute("Width", "230"),
+                new XAttribute("Height", "30"),
+                new XAttribute("Text", RequiredInputMessage)),
+            new XElement(
+                WixNamespace + "Control",
+                new XAttribute("Id", "Ok"),
+                new XAttribute("Type", "PushButton"),
+                new XAttribute("X", "102"),
+                new XAttribute("Y", "65"),
+                new XAttribute("Width", "56"),
+                new XAttribute("Height", "17"),
+                new XAttribute("Default", "yes"),
+                new XAttribute("Cancel", "yes"),
+                new XAttribute("Text", "OK"),
+                new XElement(
+                    WixNamespace + "Publish",
+                    new XAttribute("Event", "EndDialog"),
+                    new XAttribute("Value", "Return"),
+                    new XAttribute("Condition", "1"))));
     }
 
     private static IEnumerable<XElement> EmitDialogSequence(IReadOnlyList<PowerForgeInstallerDialog> dialogs)
@@ -240,6 +286,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Text", dialog.Description!)));
         }
 
+        var dialogInputs = new List<PowerForgeInstallerInput>();
         var y = 60;
         foreach (var inputId in dialog.InputIds)
         {
@@ -247,11 +294,14 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             if (input is null)
                 throw new InvalidOperationException($"Dialog '{dialog.Id}' references unknown input '{inputId}'.");
 
+            dialogInputs.Add(input);
             AddInputControls(element, input, y);
             y += input.Kind == PowerForgeInstallerInputKind.RadioGroup
                 ? Math.Max(36, input.Choices.Count * 18 + 24)
                 : 42;
         }
+
+        var nextPublishes = BuildNextDialogPublishes(dialogInputs, nextDialogId);
 
         element.Add(
             new XElement(
@@ -278,11 +328,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Height", "17"),
                 new XAttribute("Default", "yes"),
                 new XAttribute("Text", "&Next"),
-                new XElement(
-                    WixNamespace + "Publish",
-                    new XAttribute("Event", "NewDialog"),
-                    new XAttribute("Value", nextDialogId),
-                    new XAttribute("Condition", "1"))),
+                nextPublishes),
             new XElement(
                 WixNamespace + "Control",
                 new XAttribute("Id", "Cancel"),
@@ -300,6 +346,56 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                     new XAttribute("Condition", "1"))));
 
         return element;
+    }
+
+    private static IEnumerable<XElement> BuildNextDialogPublishes(
+        IReadOnlyList<PowerForgeInstallerInput> dialogInputs,
+        string nextDialogId)
+    {
+        var requiredInputs = dialogInputs
+            .Where(input => input.Required)
+            .ToArray();
+
+        if (requiredInputs.Length == 0)
+        {
+            return new[]
+            {
+                new XElement(
+                    WixNamespace + "Publish",
+                    new XAttribute("Event", "NewDialog"),
+                    new XAttribute("Value", nextDialogId),
+                    new XAttribute("Condition", "1"))
+            };
+        }
+
+        var missingCondition = string.Join(" OR ", requiredInputs.Select(BuildRequiredInputMissingCondition));
+        var satisfiedCondition = string.Join(" AND ", requiredInputs.Select(BuildRequiredInputPresentCondition));
+
+        return new[]
+        {
+            new XElement(
+                WixNamespace + "Publish",
+                new XAttribute("Event", "SpawnDialog"),
+                new XAttribute("Value", RequiredInputDialogId),
+                new XAttribute("Order", "1"),
+                new XAttribute("Condition", missingCondition)),
+            new XElement(
+                WixNamespace + "Publish",
+                new XAttribute("Event", "NewDialog"),
+                new XAttribute("Value", nextDialogId),
+                new XAttribute("Order", "2"),
+                new XAttribute("Condition", satisfiedCondition))
+        };
+    }
+
+    private static string BuildRequiredInputPresentCondition(PowerForgeInstallerInput input)
+    {
+        return $"{input.PropertyName} <> \"\"";
+    }
+
+    private static string BuildRequiredInputMissingCondition(PowerForgeInstallerInput input)
+    {
+        return $"{input.PropertyName} = \"\"";
     }
 
     private static void AddInputControls(XElement dialog, PowerForgeInstallerInput input, int y)
@@ -657,6 +753,12 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         EnsureUnique(
             definition.Dialogs.Select(dialog => dialog.Id),
             "installer dialog ID");
+        if (definition.Dialogs.Any(dialog => string.Equals(dialog.Id, RequiredInputDialogId, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Installer dialog ID '{RequiredInputDialogId}' is reserved for generated required-input validation.");
+        }
+
         EnsureUnique(
             definition.Directories.SelectMany(tree => tree.Segments).Select(segment => segment.Id)
                 .Concat(new[] { definition.InstallDirectoryId }),
@@ -675,6 +777,20 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             Require(input.PropertyName, nameof(input.PropertyName));
             if (input.Kind == PowerForgeInstallerInputKind.RadioGroup && input.Choices.Count == 0)
                 throw new InvalidOperationException($"Input '{input.Id}' is a radio group but has no choices.");
+            if (input.Required && input.Kind == PowerForgeInstallerInputKind.RadioGroup)
+            {
+                if (string.IsNullOrWhiteSpace(input.DefaultValue))
+                {
+                    throw new InvalidOperationException(
+                        $"Input '{input.Id}' is a required radio group but has no default value.");
+                }
+
+                if (!input.Choices.Any(choice => string.Equals(choice.Value, input.DefaultValue, StringComparison.Ordinal)))
+                {
+                    throw new InvalidOperationException(
+                        $"Input '{input.Id}' is a required radio group but its default value does not match any choice.");
+                }
+            }
         }
 
         foreach (var dialog in definition.Dialogs)

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -166,6 +166,7 @@
         "DefaultValue": { "type": ["string", "null"] },
         "Secure": { "type": "boolean" },
         "Hidden": { "type": "boolean" },
+        "Required": { "type": "boolean" },
         "Choices": {
           "type": "array",
           "items": { "$ref": "#/$defs/PowerForgeInstallerInputChoice" }


### PR DESCRIPTION
## Summary
- add `Required` to generated WiX installer inputs and preserve it through DotNet publish planning
- block generated dialog `Next` navigation until required text/license/path/radio inputs have a value or required checkbox inputs are checked
- emit a small generated required-input dialog, update schema/docs/example, and cover the behavior in installer authoring tests

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiPrepareTests|FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests"
- POWERFORGE_RUN_WIX_COMPILE_TESTS=1 dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo
- TierBridge: pwsh -NoProfile -ExecutionPolicy Bypass -File .\Build\Build-TierBridgePackage.ps1 with POWERFORGE_ROOT=C:\Support\GitHub\PSPublishModule