### PR TITLE
Improve generated installer required prompts

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,6 +11,7 @@
 - DotNet publish CLI overrides (`--target`, `--runtime`, `--framework`, `--style`) are applied before profile resolution so profile-filtered plan/export output matches the executed run.
 - DotNet publish `manifest.json` now emits readable string values for enum fields such as `Category`, `Kind`, and `Style` instead of numeric enum values. Consumers that parse the manifest should treat this as a manifest-contract change.
 - Generated WiX installer inputs can now set `Required` to block generated dialog navigation until the value is provided.
+- Generated WiX required-input prompts now list the required field labels for the current dialog.
 
 ## 2.0.19 - 2025.06.17
 ### What's Changed

--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -175,7 +175,7 @@ Depending on config, the run can emit:
 - Generated MSI builds place the final `.msi` in the sibling `output/` directory, and that final file is listed in `manifest.json`, `manifest.txt`, and `SHA256SUMS.txt`.
 - Use `Harvest: Auto` with `Authoring.PayloadComponentGroupId` to include the prepared publish payload in the generated MSI feature.
 - Component entries require a `Type` discriminator: `File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, or `Shortcut`.
-- Installer inputs can set `Required: true`; generated dialogs block `Next` until text/license/path inputs have a value, or until required checkbox properties are non-empty. Required radio-group inputs must set `DefaultValue` to one of their choices.
+- Installer inputs can set `Required: true`; generated dialogs block `Next` until text/license/path inputs have a value, or until required checkbox properties are non-empty. Required prompts list the required field labels for the current dialog. Required radio-group inputs must set `DefaultValue` to one of their choices.
 - Registry value components can write a literal `Value`, or write an installer property by setting `ValueProperty`, for example persisting `LICENSE_KEY` after the UI collects it.
 - Shortcut components can use `TargetFileId` for an explicitly authored file component, or `Target` such as `[INSTALLFOLDER]MyApp.exe` when the executable comes from harvested payload.
 - WiX still does the compile. The generated project includes `WixToolset.UI.wixext` and `WixToolset.Util.wixext` only when the authoring model needs those extensions.

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -70,8 +70,12 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Equal("2", (string?)newDialogPublish.Attribute("Order"));
         Assert.NotNull(spawnDialogPublish);
         Assert.Equal("1", (string?)spawnDialogPublish.Attribute("Order"));
-        Assert.NotNull(doc.Descendants(Wix + "Dialog").SingleOrDefault(e =>
-            (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg"));
+        var requiredDialog = doc.Descendants(Wix + "Dialog").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg");
+        Assert.NotNull(requiredDialog);
+        Assert.NotNull(requiredDialog.Descendants(Wix + "Control").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "Message" &&
+            (string?)e.Attribute("Text") == "Fill the required field before continuing: License key."));
         Assert.Equal(2, dialog.Descendants(Wix + "RadioButton").Count());
     }
 
@@ -139,6 +143,21 @@ public sealed class PowerForgeInstallerAuthoringTests
         definition.Dialogs.Add(new PowerForgeInstallerDialog
         {
             Id = "PowerForgeRequiredInputDlg",
+            Title = "Reserved"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("reserved", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EmitSource_RejectsReservedRequiredInputDialogIdPrefix()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "PowerForgeRequiredInputDlg2",
             Title = "Reserved"
         });
 
@@ -257,6 +276,103 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Null(secondDialogNext.Attribute("Order"));
         Assert.Single(doc.Descendants(Wix + "Dialog"), e =>
             (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg");
+    }
+
+    [Fact]
+    public void EmitSource_UsesDialogSpecificRequiredInputPrompts()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "ApiEndpoint",
+            PropertyName = "API_ENDPOINT",
+            Label = "API endpoint",
+            Required = true
+        });
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "ApiToken",
+            PropertyName = "API_TOKEN",
+            Label = "API token",
+            Kind = PowerForgeInstallerInputKind.Password,
+            Required = true,
+            Secure = true,
+            Hidden = true
+        });
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "AdvancedDlg",
+            Title = "Advanced",
+            Description = "Choose advanced options.",
+            InputIds = { "ApiEndpoint", "ApiToken" }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        var firstNext = doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "ConfigurationDlg")
+            .Descendants(Wix + "Control")
+            .Single(e => (string?)e.Attribute("Id") == "Next");
+        Assert.NotNull(firstNext.Descendants(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Event") == "SpawnDialog" &&
+            (string?)e.Attribute("Value") == "PowerForgeRequiredInputDlg" &&
+            (string?)e.Attribute("Condition") == "LICENSE_KEY = \"\""));
+
+        var secondNext = doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "AdvancedDlg")
+            .Descendants(Wix + "Control")
+            .Single(e => (string?)e.Attribute("Id") == "Next");
+        Assert.NotNull(secondNext.Descendants(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Event") == "SpawnDialog" &&
+            (string?)e.Attribute("Value") == "PowerForgeRequiredInputDlg2" &&
+            (string?)e.Attribute("Condition") == "API_ENDPOINT = \"\" OR API_TOKEN = \"\""));
+
+        Assert.NotNull(doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg")
+            .Descendants(Wix + "Control")
+            .SingleOrDefault(e =>
+                (string?)e.Attribute("Id") == "Message" &&
+                (string?)e.Attribute("Text") == "Fill the required field before continuing: License key."));
+        Assert.NotNull(doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg2")
+            .Descendants(Wix + "Control")
+            .SingleOrDefault(e =>
+                (string?)e.Attribute("Id") == "Message" &&
+                (string?)e.Attribute("Text") == "Fill required fields before continuing: API endpoint; API token."));
+    }
+
+    [Fact]
+    public void EmitSource_CapsLongRequiredInputPromptLists()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        for (var i = 1; i <= 5; i++)
+        {
+            definition.Inputs.Add(new PowerForgeInstallerInput
+            {
+                Id = "Setting" + i.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                PropertyName = "SETTING_" + i.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Label = "Setting " + i.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Required = true
+            });
+        }
+
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "SettingsDlg",
+            Title = "Settings",
+            InputIds = { "Setting1", "Setting2", "Setting3", "Setting4", "Setting5" }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg")
+            .Descendants(Wix + "Control")
+            .SingleOrDefault(e =>
+                (string?)e.Attribute("Id") == "Message" &&
+                (string?)e.Attribute("Text") == "Fill required fields before continuing: Setting 1; Setting 2; Setting 3; Setting 4; and 1 more."));
     }
 
     [Fact]

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -13,8 +13,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     private static readonly XNamespace WixNamespace = "http://wixtoolset.org/schemas/v4/wxs";
     private static readonly XNamespace UtilNamespace = "http://wixtoolset.org/schemas/v4/wxs/util";
     private static readonly XNamespace UiNamespace = "http://wixtoolset.org/schemas/v4/wxs/ui";
-    private const string RequiredInputDialogId = "PowerForgeRequiredInputDlg";
-    private const string RequiredInputMessage = "All required fields must be filled in before continuing.";
+    private const string RequiredInputDialogIdPrefix = "PowerForgeRequiredInputDlg";
+    private const int MaxRequiredInputLabelsInMessage = 4;
 
     /// <summary>
     /// Emits a WiX v4 source document.
@@ -164,20 +164,31 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XElement(UiNamespace + "WixUI", new XAttribute("Id", "WixUI_InstallDir")));
 
         var dialogs = definition.Dialogs.ToArray();
-        var requiredInputIds = definition.Inputs
-            .Where(input => input.Required)
-            .Select(input => input.Id)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        if (dialogs.Any(dialog => dialog.InputIds.Any(requiredInputIds.Contains)))
+        var dialogInputs = dialogs.ToDictionary(
+            dialog => dialog.Id,
+            dialog => ResolveDialogInputs(dialog, definition.Inputs),
+            StringComparer.OrdinalIgnoreCase);
+        var requiredDialogIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var requiredDialogIndex = 0;
+        foreach (var dialog in dialogs)
         {
-            ui.Add(EmitRequiredInputDialog());
+            var requiredInputs = dialogInputs[dialog.Id]
+                .Where(input => input.Required)
+                .ToArray();
+            if (requiredInputs.Length == 0)
+                continue;
+
+            var requiredDialogId = BuildRequiredInputDialogId(requiredDialogIndex++);
+            requiredDialogIds[dialog.Id] = requiredDialogId;
+            ui.Add(EmitRequiredInputDialog(requiredDialogId, requiredInputs));
         }
 
         for (var i = 0; i < dialogs.Length; i++)
         {
             var previousDialogId = i == 0 ? "InstallDirDlg" : dialogs[i - 1].Id;
             var nextDialogId = i == dialogs.Length - 1 ? "VerifyReadyDlg" : dialogs[i + 1].Id;
-            ui.Add(EmitDialog(dialogs[i], definition.Inputs, previousDialogId, nextDialogId));
+            requiredDialogIds.TryGetValue(dialogs[i].Id, out var requiredDialogId);
+            ui.Add(EmitDialog(dialogs[i], dialogInputs[dialogs[i].Id], previousDialogId, nextDialogId, requiredDialogId));
         }
 
         ui.Add(EmitDialogSequence(dialogs));
@@ -185,13 +196,23 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         return ui;
     }
 
-    private static XElement EmitRequiredInputDialog()
+    private static string BuildRequiredInputDialogId(int index)
+    {
+        // Keep the first generated ID stable for existing one-dialog installer output; suffix only additional prompts.
+        return index == 0
+            ? RequiredInputDialogIdPrefix
+            : RequiredInputDialogIdPrefix + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static XElement EmitRequiredInputDialog(
+        string dialogId,
+        IReadOnlyList<PowerForgeInstallerInput> requiredInputs)
     {
         return new XElement(
             WixNamespace + "Dialog",
-            new XAttribute("Id", RequiredInputDialogId),
-            new XAttribute("Width", "260"),
-            new XAttribute("Height", "95"),
+            new XAttribute("Id", dialogId),
+            new XAttribute("Width", "300"),
+            new XAttribute("Height", "110"),
             new XAttribute("Title", "[ProductName]"),
             new XElement(
                 WixNamespace + "Control",
@@ -199,15 +220,15 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Type", "Text"),
                 new XAttribute("X", "15"),
                 new XAttribute("Y", "15"),
-                new XAttribute("Width", "230"),
-                new XAttribute("Height", "30"),
-                new XAttribute("Text", RequiredInputMessage)),
+                new XAttribute("Width", "270"),
+                new XAttribute("Height", "50"),
+                new XAttribute("Text", BuildRequiredInputMessage(requiredInputs))),
             new XElement(
                 WixNamespace + "Control",
                 new XAttribute("Id", "Ok"),
                 new XAttribute("Type", "PushButton"),
-                new XAttribute("X", "102"),
-                new XAttribute("Y", "65"),
+                new XAttribute("X", "122"),
+                new XAttribute("Y", "85"),
                 new XAttribute("Width", "56"),
                 new XAttribute("Height", "17"),
                 new XAttribute("Default", "yes"),
@@ -218,6 +239,24 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                     new XAttribute("Event", "EndDialog"),
                     new XAttribute("Value", "Return"),
                     new XAttribute("Condition", "1"))));
+    }
+
+    private static string BuildRequiredInputMessage(IReadOnlyList<PowerForgeInstallerInput> requiredInputs)
+    {
+        var labels = requiredInputs
+            .Select(input => string.IsNullOrWhiteSpace(input.Label) ? input.Id : input.Label)
+            .ToArray();
+        var visibleLabels = labels.Take(MaxRequiredInputLabelsInMessage).ToArray();
+        var remaining = labels.Length - visibleLabels.Length;
+        var labelText = string.Join("; ", visibleLabels);
+        if (remaining > 0)
+        {
+            labelText += $"; and {remaining.ToString(System.Globalization.CultureInfo.InvariantCulture)} more";
+        }
+
+        return labels.Length == 1
+            ? $"Fill the required field before continuing: {labelText}."
+            : $"Fill required fields before continuing: {labelText}.";
     }
 
     private static IEnumerable<XElement> EmitDialogSequence(IReadOnlyList<PowerForgeInstallerDialog> dialogs)
@@ -250,9 +289,10 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
     private static XElement EmitDialog(
         PowerForgeInstallerDialog dialog,
-        IReadOnlyList<PowerForgeInstallerInput> inputs,
+        IReadOnlyList<PowerForgeInstallerInput> dialogInputs,
         string previousDialogId,
-        string nextDialogId)
+        string nextDialogId,
+        string? requiredDialogId)
     {
         var element = new XElement(
             WixNamespace + "Dialog",
@@ -286,22 +326,16 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Text", dialog.Description!)));
         }
 
-        var dialogInputs = new List<PowerForgeInstallerInput>();
         var y = 60;
-        foreach (var inputId in dialog.InputIds)
+        foreach (var input in dialogInputs)
         {
-            var input = inputs.FirstOrDefault(i => string.Equals(i.Id, inputId, StringComparison.OrdinalIgnoreCase));
-            if (input is null)
-                throw new InvalidOperationException($"Dialog '{dialog.Id}' references unknown input '{inputId}'.");
-
-            dialogInputs.Add(input);
             AddInputControls(element, input, y);
             y += input.Kind == PowerForgeInstallerInputKind.RadioGroup
                 ? Math.Max(36, input.Choices.Count * 18 + 24)
                 : 42;
         }
 
-        var nextPublishes = BuildNextDialogPublishes(dialogInputs, nextDialogId);
+        var nextPublishes = BuildNextDialogPublishes(dialogInputs, nextDialogId, requiredDialogId);
 
         element.Add(
             new XElement(
@@ -350,7 +384,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
     private static IEnumerable<XElement> BuildNextDialogPublishes(
         IReadOnlyList<PowerForgeInstallerInput> dialogInputs,
-        string nextDialogId)
+        string nextDialogId,
+        string? requiredDialogId)
     {
         var requiredInputs = dialogInputs
             .Where(input => input.Required)
@@ -370,13 +405,17 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
         var missingCondition = string.Join(" OR ", requiredInputs.Select(BuildRequiredInputMissingCondition));
         var satisfiedCondition = string.Join(" AND ", requiredInputs.Select(BuildRequiredInputPresentCondition));
+        if (requiredDialogId is null)
+        {
+            throw new InvalidOperationException("A required-input dialog ID is required when a dialog has required inputs.");
+        }
 
         return new[]
         {
             new XElement(
                 WixNamespace + "Publish",
                 new XAttribute("Event", "SpawnDialog"),
-                new XAttribute("Value", RequiredInputDialogId),
+                new XAttribute("Value", requiredDialogId),
                 new XAttribute("Order", "1"),
                 new XAttribute("Condition", missingCondition)),
             new XElement(
@@ -396,6 +435,23 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     private static string BuildRequiredInputMissingCondition(PowerForgeInstallerInput input)
     {
         return $"{input.PropertyName} = \"\"";
+    }
+
+    private static IReadOnlyList<PowerForgeInstallerInput> ResolveDialogInputs(
+        PowerForgeInstallerDialog dialog,
+        IReadOnlyList<PowerForgeInstallerInput> inputs)
+    {
+        var dialogInputs = new List<PowerForgeInstallerInput>();
+        foreach (var inputId in dialog.InputIds)
+        {
+            var input = inputs.FirstOrDefault(i => string.Equals(i.Id, inputId, StringComparison.OrdinalIgnoreCase));
+            if (input is null)
+                throw new InvalidOperationException($"Dialog '{dialog.Id}' references unknown input '{inputId}'.");
+
+            dialogInputs.Add(input);
+        }
+
+        return dialogInputs;
     }
 
     private static void AddInputControls(XElement dialog, PowerForgeInstallerInput input, int y)
@@ -753,10 +809,10 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         EnsureUnique(
             definition.Dialogs.Select(dialog => dialog.Id),
             "installer dialog ID");
-        if (definition.Dialogs.Any(dialog => string.Equals(dialog.Id, RequiredInputDialogId, StringComparison.OrdinalIgnoreCase)))
+        if (definition.Dialogs.Any(dialog => dialog.Id.StartsWith(RequiredInputDialogIdPrefix, StringComparison.OrdinalIgnoreCase)))
         {
             throw new InvalidOperationException(
-                $"Installer dialog ID '{RequiredInputDialogId}' is reserved for generated required-input validation.");
+                $"Installer dialog IDs starting with '{RequiredInputDialogIdPrefix}' are reserved for generated required-input validation.");
         }
 
         EnsureUnique(


### PR DESCRIPTION
## Summary
- Generate required-input prompt dialogs per authored installer dialog so the message can list the required field labels for that dialog.
- Keep the original `PowerForgeRequiredInputDlg` ID for the first generated prompt, then use numbered generated IDs for additional required dialogs.
- Reserve the generated required-dialog ID prefix and document the clearer prompt behavior.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `$env:POWERFORGE_RUN_WIX_COMPILE_TESTS='1'; dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiPrepareTests|FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests"`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo`
- `git diff --check`