### PR TITLE
Validate generated installer identifiers

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -12,6 +12,7 @@
 - DotNet publish `manifest.json` now emits readable string values for enum fields such as `Category`, `Kind`, and `Style` instead of numeric enum values. Consumers that parse the manifest should treat this as a manifest-contract change.
 - Generated WiX installer inputs can now set `Required` to block generated dialog navigation until the value is provided.
 - Generated WiX required-input prompts now list the required field labels for the current dialog.
+- Generated WiX authoring now validates WiX identifiers, product upgrade GUIDs, and public MSI input properties before writing installer source.
 
 ## 2.0.19 - 2025.06.17
 ### What's Changed

--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -176,6 +176,7 @@ Depending on config, the run can emit:
 - Use `Harvest: Auto` with `Authoring.PayloadComponentGroupId` to include the prepared publish payload in the generated MSI feature.
 - Component entries require a `Type` discriminator: `File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, or `Shortcut`.
 - Installer inputs can set `Required: true`; generated dialogs block `Next` until text/license/path inputs have a value, or until required checkbox properties are non-empty. Required prompts list the required field labels for the current dialog. Required radio-group inputs must set `DefaultValue` to one of their choices.
+- Generated authoring validates WiX identifiers, product upgrade GUIDs, and uppercase public MSI property names for installer inputs before writing the `.wxs` file.
 - Registry value components can write a literal `Value`, or write an installer property by setting `ValueProperty`, for example persisting `LICENSE_KEY` after the UI collects it.
 - Shortcut components can use `TargetFileId` for an explicitly authored file component, or `Target` such as `[INSTALLFOLDER]MyApp.exe` when the executable comes from harvested payload.
 - WiX still does the compile. The generated project includes `WixToolset.UI.wixext` and `WixToolset.Util.wixext` only when the authoring model needs those extensions.

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -582,6 +582,95 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_ThrowsWhenProductUpgradeCodeIsInvalid()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.UpgradeCode = "not-a-guid";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("valid GUID", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputIdIsNotWixIdentifier()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "License-Key",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("valid WiX identifier", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputPropertyIsNotPublicMsiProperty()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "license_key",
+            Label = "License key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("uppercase public MSI property", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenComponentFileIdIsNotWixIdentifier()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.OfType<PowerForgeInstallerFileComponent>().Single().FileId = "1SmokePayloadFile";
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("valid WiX identifier", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenShortcutWorkingDirectoryIdIsMissing()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Add(new PowerForgeInstallerShortcutComponent
+        {
+            Id = "StartMenuShortcutComponent",
+            ShortcutId = "StartMenuShortcut",
+            Name = "Smoke",
+            Target = "[INSTALLFOLDER]Smoke.exe",
+            WorkingDirectoryId = string.Empty
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("WorkingDirectoryId", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenRegistryValuePropertyIsNotPublicMsiProperty()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Add(new PowerForgeInstallerRegistryValueComponent
+        {
+            Id = "LicenseRegistry",
+            Key = @"Software\Evotec\Test",
+            Name = "LicenseKey",
+            ValueProperty = "license_key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("uppercase public MSI property", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void EmitSource_ThrowsWhenDialogReferencesUnknownInput()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace PowerForge;
@@ -10,6 +11,14 @@ namespace PowerForge;
 /// </summary>
 public sealed class PowerForgeWixInstallerSourceEmitter
 {
+    private static readonly Regex WixIdentifierPattern = new(
+        "^[A-Za-z_][A-Za-z0-9_.]*$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex PublicMsiPropertyPattern = new(
+        "^[A-Z_][A-Z0-9_]*$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     private static readonly XNamespace WixNamespace = "http://wixtoolset.org/schemas/v4/wxs";
     private static readonly XNamespace UtilNamespace = "http://wixtoolset.org/schemas/v4/wxs/util";
     private static readonly XNamespace UiNamespace = "http://wixtoolset.org/schemas/v4/wxs/ui";
@@ -795,10 +804,14 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         Require(definition.Product.Manufacturer, nameof(definition.Product.Manufacturer));
         Require(definition.Product.Version, nameof(definition.Product.Version));
         Require(definition.Product.UpgradeCode, nameof(definition.Product.UpgradeCode));
+        RequireGuid(definition.Product.UpgradeCode, nameof(definition.Product.UpgradeCode));
         Require(definition.InstallDirectoryId, nameof(definition.InstallDirectoryId));
+        RequireWixIdentifier(definition.InstallDirectoryId, nameof(definition.InstallDirectoryId));
         if (definition.UseCompanyFolder)
             Require(definition.CompanyFolderName, nameof(definition.CompanyFolderName));
         Require(definition.InstallDirectoryName, nameof(definition.InstallDirectoryName));
+        if (!string.IsNullOrWhiteSpace(definition.PayloadComponentGroupId))
+            RequireWixIdentifier(definition.PayloadComponentGroupId, nameof(definition.PayloadComponentGroupId));
 
         EnsureUnique(
             definition.Inputs.Select(input => input.Id),
@@ -830,7 +843,9 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         foreach (var input in definition.Inputs)
         {
             Require(input.Id, nameof(input.Id));
+            RequireWixIdentifier(input.Id, $"input '{input.Id}' ID");
             Require(input.PropertyName, nameof(input.PropertyName));
+            RequirePublicMsiProperty(input.PropertyName, $"input '{input.Id}' property");
             if (input.Kind == PowerForgeInstallerInputKind.RadioGroup && input.Choices.Count == 0)
                 throw new InvalidOperationException($"Input '{input.Id}' is a radio group but has no choices.");
             if (input.Required && input.Kind == PowerForgeInstallerInputKind.RadioGroup)
@@ -852,6 +867,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         foreach (var dialog in definition.Dialogs)
         {
             Require(dialog.Id, nameof(dialog.Id));
+            RequireWixIdentifier(dialog.Id, $"dialog '{dialog.Id}' ID");
             Require(dialog.Title, nameof(dialog.Title));
             foreach (var inputId in dialog.InputIds)
             {
@@ -866,11 +882,16 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 throw new InvalidOperationException("Installer directory tree requires StandardDirectoryId or DirectoryRefId.");
             if (!string.IsNullOrWhiteSpace(tree.StandardDirectoryId) && !string.IsNullOrWhiteSpace(tree.DirectoryRefId))
                 throw new InvalidOperationException("Installer directory tree cannot set both StandardDirectoryId and DirectoryRefId.");
+            if (!string.IsNullOrWhiteSpace(tree.StandardDirectoryId))
+                RequireWixIdentifier(tree.StandardDirectoryId, "installer directory tree StandardDirectoryId");
+            if (!string.IsNullOrWhiteSpace(tree.DirectoryRefId))
+                RequireWixIdentifier(tree.DirectoryRefId, "installer directory tree DirectoryRefId");
             if (tree.Segments.Count == 0)
                 throw new InvalidOperationException("Installer directory tree requires at least one segment.");
             foreach (var segment in tree.Segments)
             {
                 Require(segment.Id, nameof(segment.Id));
+                RequireWixIdentifier(segment.Id, $"directory segment '{segment.Id}' ID");
                 Require(segment.Name, nameof(segment.Name));
             }
         }
@@ -878,12 +899,35 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         foreach (var component in definition.Components)
         {
             Require(component.Id, nameof(component.Id));
+            RequireWixIdentifier(component.Id, $"component '{component.Id}' ID");
             Require(component.DirectoryRefId, nameof(component.DirectoryRefId));
+            RequireWixIdentifier(component.DirectoryRefId, $"component '{component.Id}' DirectoryRefId");
             if (component is PowerForgeInstallerShortcutComponent shortcut)
             {
+                Require(shortcut.ShortcutId, nameof(shortcut.ShortcutId));
+                RequireWixIdentifier(shortcut.ShortcutId, $"shortcut component '{shortcut.Id}' ShortcutId");
+                Require(shortcut.WorkingDirectoryId, nameof(shortcut.WorkingDirectoryId));
+                RequireWixIdentifier(shortcut.WorkingDirectoryId, $"shortcut component '{shortcut.Id}' WorkingDirectoryId");
+                if (!string.IsNullOrWhiteSpace(shortcut.TargetFileId))
+                    RequireWixIdentifier(shortcut.TargetFileId, $"shortcut component '{shortcut.Id}' TargetFileId");
                 if (string.IsNullOrWhiteSpace(shortcut.TargetFileId) && string.IsNullOrWhiteSpace(shortcut.Target))
                     throw new InvalidOperationException(
                         $"Shortcut component '{shortcut.Id}' requires TargetFileId or Target.");
+            }
+            else if (component is PowerForgeInstallerFileComponent file)
+            {
+                Require(file.FileId, nameof(file.FileId));
+                RequireWixIdentifier(file.FileId, $"file component '{file.Id}' FileId");
+            }
+            else if (component is PowerForgeInstallerServiceComponent service)
+            {
+                Require(service.FileId, nameof(service.FileId));
+                RequireWixIdentifier(service.FileId, $"service component '{service.Id}' FileId");
+            }
+            else if (component is PowerForgeInstallerRemoveFolderComponent removeFolder)
+            {
+                Require(removeFolder.PropertyName, nameof(removeFolder.PropertyName));
+                RequireWixIdentifier(removeFolder.PropertyName, $"remove-folder component '{removeFolder.Id}' PropertyName");
             }
             else if (component is PowerForgeInstallerRegistryValueComponent registryValue)
             {
@@ -891,6 +935,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 Require(registryValue.Key, nameof(registryValue.Key));
                 Require(registryValue.Name, nameof(registryValue.Name));
                 Require(registryValue.ValueType, nameof(registryValue.ValueType));
+                if (!string.IsNullOrWhiteSpace(registryValue.ValueProperty))
+                    RequirePublicMsiProperty(registryValue.ValueProperty, $"registry value component '{registryValue.Id}' ValueProperty");
                 if (string.IsNullOrWhiteSpace(registryValue.Value) && string.IsNullOrWhiteSpace(registryValue.ValueProperty))
                 {
                     throw new InvalidOperationException(
@@ -918,6 +964,30 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     {
         if (string.IsNullOrWhiteSpace(value))
             throw new InvalidOperationException($"Installer definition requires {name}.");
+    }
+
+    private static void RequireGuid(string? value, string name)
+    {
+        if (!Guid.TryParse(value, out _))
+            throw new InvalidOperationException($"Installer definition requires {name} to be a valid GUID.");
+    }
+
+    private static void RequireWixIdentifier(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !WixIdentifierPattern.IsMatch(value))
+        {
+            throw new InvalidOperationException(
+                $"Installer definition requires {name} to be a valid WiX identifier.");
+        }
+    }
+
+    private static void RequirePublicMsiProperty(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !PublicMsiPropertyPattern.IsMatch(value))
+        {
+            throw new InvalidOperationException(
+                $"Installer definition requires {name} to be an uppercase public MSI property.");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Validate generated installer WiX identifiers before writing `.wxs` source.
- Validate generated installer product upgrade codes as GUIDs.
- Validate generated installer UI input properties and persisted registry value properties as uppercase public MSI properties.
- Document the new fail-fast authoring validation and add regression coverage for invalid IDs/properties.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `$env:POWERFORGE_RUN_WIX_COMPILE_TESTS='1'; dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiPrepareTests|FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests"`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo`
- `git diff --check`