### PR TITLE
Tighten generated installer identifier validation

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,7 @@
 - Generated WiX installer inputs can now set `Required` to block generated dialog navigation until the value is provided.
 - Generated WiX required-input prompts now list the required field labels for the current dialog.
 - Generated WiX authoring now validates WiX identifiers, product upgrade GUIDs, and public MSI input properties before writing installer source.
+- Generated WiX authoring now enforces the WiX 72-character identifier limit.
 
 ## 2.0.19 - 2025.06.17
 ### What's Changed

--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -176,7 +176,7 @@ Depending on config, the run can emit:
 - Use `Harvest: Auto` with `Authoring.PayloadComponentGroupId` to include the prepared publish payload in the generated MSI feature.
 - Component entries require a `Type` discriminator: `File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, or `Shortcut`.
 - Installer inputs can set `Required: true`; generated dialogs block `Next` until text/license/path inputs have a value, or until required checkbox properties are non-empty. Required prompts list the required field labels for the current dialog. Required radio-group inputs must set `DefaultValue` to one of their choices.
-- Generated authoring validates WiX identifiers, product upgrade GUIDs, and uppercase public MSI property names for installer inputs before writing the `.wxs` file.
+- Generated authoring validates WiX identifiers, product upgrade GUIDs, and uppercase public MSI property names for installer inputs before writing the `.wxs` file. WiX identifiers must be 72 characters or fewer.
 - Registry value components can write a literal `Value`, or write an installer property by setting `ValueProperty`, for example persisting `LICENSE_KEY` after the UI collects it.
 - Shortcut components can use `TargetFileId` for an explicitly authored file component, or `Target` such as `[INSTALLFOLDER]MyApp.exe` when the executable comes from harvested payload.
 - WiX still does the compile. The generated project includes `WixToolset.UI.wixext` and `WixToolset.Util.wixext` only when the authoring model needs those extensions.

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -609,6 +609,39 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_ThrowsWhenInputIdExceedsWixIdentifierLength()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "A" + new string('B', 72),
+            PropertyName = "LICENSE_KEY",
+            Label = "License key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("valid WiX identifier", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_AcceptsInputIdAtMaxWixIdentifierLength()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "A" + new string('B', 71),
+            PropertyName = "LICENSE_KEY",
+            Label = "License key"
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Root);
+    }
+
+    [Fact]
     public void EmitSource_ThrowsWhenInputPropertyIsNotPublicMsiProperty()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -12,7 +12,7 @@ namespace PowerForge;
 public sealed class PowerForgeWixInstallerSourceEmitter
 {
     private static readonly Regex WixIdentifierPattern = new(
-        "^[A-Za-z_][A-Za-z0-9_.]*$",
+        "^[A-Za-z_][A-Za-z0-9_.]{0,71}$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     private static readonly Regex PublicMsiPropertyPattern = new(


### PR DESCRIPTION
## Summary
- Enforce the WiX 72-character identifier limit in generated installer authoring validation.
- Add rejection and boundary-acceptance regression tests for generated installer identifiers.
- Document the stricter generated authoring contract.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `$env:POWERFORGE_RUN_WIX_COMPILE_TESTS='1'; dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiPrepareTests|FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests"`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo`
- `git diff --check`