### PR TITLE
Add installer input validation metadata

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -14,6 +14,7 @@
 - Generated WiX required-input prompts now list the required field labels for the current dialog.
 - Generated WiX authoring now validates WiX identifiers, product upgrade GUIDs, and public MSI input properties before writing installer source.
 - Generated WiX authoring now enforces the WiX 72-character identifier limit.
+- Generated installer inputs now carry validation metadata (`MinLength`, `MaxLength`, `ValidationPattern`, `ValidationMessage`) with authoring-time checks for metadata shape and default values.
 
 ## 2.0.19 - 2025.06.17
 ### What's Changed

--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -176,6 +176,7 @@ Depending on config, the run can emit:
 - Use `Harvest: Auto` with `Authoring.PayloadComponentGroupId` to include the prepared publish payload in the generated MSI feature.
 - Component entries require a `Type` discriminator: `File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, or `Shortcut`.
 - Installer inputs can set `Required: true`; generated dialogs block `Next` until text/license/path inputs have a value, or until required checkbox properties are non-empty. Required prompts list the required field labels for the current dialog. Required radio-group inputs must set `DefaultValue` to one of their choices.
+- Installer inputs can define validation metadata (`MinLength`, `MaxLength`, `ValidationPattern`, `ValidationMessage`) for text, password, path, and license-key inputs. Generated authoring validates metadata shape and authored default values before writing the `.wxs`; runtime UI enforcement beyond `Required` is reserved for the follow-up validation layer.
 - Generated authoring validates WiX identifiers, product upgrade GUIDs, and uppercase public MSI property names for installer inputs before writing the `.wxs` file. WiX identifiers must be 72 characters or fewer.
 - Registry value components can write a literal `Value`, or write an installer property by setting `ValueProperty`, for example persisting `LICENSE_KEY` after the UI collects it.
 - Shortcut components can use `TargetFileId` for an explicitly authored file component, or `Target` such as `[INSTALLFOLDER]MyApp.exe` when the executable comes from harvested payload.

--- a/Module/Examples/DotNetPublish/Example.GeneratedServiceMsi.json
+++ b/Module/Examples/DotNetPublish/Example.GeneratedServiceMsi.json
@@ -57,7 +57,11 @@
             "Kind": "LicenseKey",
             "Secure": true,
             "Hidden": true,
-            "Required": true
+            "Required": true,
+            "MinLength": 16,
+            "MaxLength": 128,
+            "ValidationPattern": "^[A-Za-z0-9-]+$",
+            "ValidationMessage": "Enter a valid license key."
           }
         ],
         "Dialogs": [

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -146,6 +146,18 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             var app = CreateProject(root, "App/App.csproj");
 
             var spec = CreateBaseSpec(root, app);
+            var authoring = CreateSimpleAuthoring("ProductFiles");
+            authoring.Inputs.Add(new PowerForgeInstallerInput
+            {
+                Id = "LicenseKey",
+                PropertyName = "LICENSE_KEY",
+                Label = "License key",
+                Kind = PowerForgeInstallerInputKind.LicenseKey,
+                MinLength = 16,
+                MaxLength = 128,
+                ValidationPattern = "^[A-Za-z0-9-]+$",
+                ValidationMessage = "Enter a valid license key."
+            });
             spec.Installers = new[]
             {
                 new DotNetPublishInstaller
@@ -153,7 +165,7 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
                     Id = "app.msi",
                     PrepareFromTarget = "app",
                     Harvest = DotNetPublishMsiHarvestMode.Auto,
-                    Authoring = CreateSimpleAuthoring("ProductFiles")
+                    Authoring = authoring
                 }
             };
 
@@ -161,6 +173,11 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             var installerPlan = Assert.Single(plan.Installers);
             Assert.NotNull(installerPlan.Authoring);
             Assert.Equal("ProductFiles", installerPlan.HarvestComponentGroupId);
+            var input = Assert.Single(installerPlan.Authoring!.Inputs);
+            Assert.Equal(16, input.MinLength);
+            Assert.Equal(128, input.MaxLength);
+            Assert.Equal("^[A-Za-z0-9-]+$", input.ValidationPattern);
+            Assert.Equal("Enter a valid license key.", input.ValidationMessage);
 
             var prepareStep = Assert.Single(plan.Steps, s => s.Kind == DotNetPublishStepKind.MsiPrepare);
             Assert.Equal("ProductFiles", prepareStep.HarvestComponentGroupId);

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -658,6 +658,172 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_ThrowsWhenInputValidationLengthRangeIsInvalid()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            MinLength = 20,
+            MaxLength = 10
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("MinLength cannot be greater than MaxLength", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputValidationPatternIsInvalid()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            ValidationPattern = "["
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("valid .NET regular expression", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputDefaultValueViolatesValidationMetadata()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            DefaultValue = "abc",
+            MinLength = 5
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("shorter than MinLength", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputDefaultValueExceedsMaxLength()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            DefaultValue = "ABCDE",
+            MaxLength = 4
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("longer than MaxLength", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputDefaultValueFailsValidationPattern()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            DefaultValue = "abc",
+            ValidationPattern = "^[A-Z0-9-]+$"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("does not match ValidationPattern", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputValidationLengthIsNegative()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            MinLength = -1
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("MinLength must be greater than or equal to 0", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenInputValidationMaxLengthIsNegative()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            MaxLength = -1
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("MaxLength must be greater than or equal to 0", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenCheckboxUsesInputValidationMetadata()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "RemoveData",
+            PropertyName = "REMOVE_DATA",
+            Label = "Remove data",
+            Kind = PowerForgeInstallerInputKind.Checkbox,
+            MinLength = 1
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("validation metadata", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_ThrowsWhenCheckboxUsesValidationMessageOnly()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "RemoveData",
+            PropertyName = "REMOVE_DATA",
+            Label = "Remove data",
+            Kind = PowerForgeInstallerInputKind.Checkbox,
+            ValidationMessage = "Choose whether to remove data."
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+        Assert.Contains("validation metadata", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void EmitSource_ThrowsWhenComponentFileIdIsNotWixIdentifier()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
@@ -948,7 +1114,11 @@ public sealed class PowerForgeInstallerAuthoringTests
                     "Kind": "LicenseKey",
                     "Secure": true,
                     "Hidden": true,
-                    "Required": true
+                    "Required": true,
+                    "MinLength": 16,
+                    "MaxLength": 128,
+                    "ValidationPattern": "^[A-Za-z0-9-]+$",
+                    "ValidationMessage": "Enter a valid license key."
                   }
                 ],
                 "Dialogs": [
@@ -1009,6 +1179,10 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Equal("ProductFiles", authoring.PayloadComponentGroupId);
         var input = Assert.Single(authoring.Inputs);
         Assert.True(input.Required);
+        Assert.Equal(16, input.MinLength);
+        Assert.Equal(128, input.MaxLength);
+        Assert.Equal("^[A-Za-z0-9-]+$", input.ValidationPattern);
+        Assert.Equal("Enter a valid license key.", input.ValidationMessage);
         Assert.Single(authoring.Dialogs);
         Assert.Single(authoring.Directories);
 

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -163,6 +163,26 @@ public sealed class PowerForgeInstallerInput
     public bool Required { get; set; }
 
     /// <summary>
+    /// Minimum accepted text length for authored validation metadata.
+    /// </summary>
+    public int? MinLength { get; set; }
+
+    /// <summary>
+    /// Maximum accepted text length for authored validation metadata.
+    /// </summary>
+    public int? MaxLength { get; set; }
+
+    /// <summary>
+    /// Optional .NET regular expression used to validate authored default values.
+    /// </summary>
+    public string? ValidationPattern { get; set; }
+
+    /// <summary>
+    /// Message to show when generated runtime validation is added for this input.
+    /// </summary>
+    public string? ValidationMessage { get; set; }
+
+    /// <summary>
     /// Choices for radio or combo style inputs.
     /// </summary>
     public List<PowerForgeInstallerInputChoice> Choices { get; set; } = new();

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -762,7 +762,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 DefaultValue = input.DefaultValue,
                 Secure = input.Secure,
                 Hidden = input.Hidden,
-                Required = input.Required
+                Required = input.Required,
+                MinLength = input.MinLength,
+                MaxLength = input.MaxLength,
+                ValidationPattern = input.ValidationPattern,
+                ValidationMessage = input.ValidationMessage
             };
             foreach (var choice in input.Choices)
             {

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -24,6 +24,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     private static readonly XNamespace UiNamespace = "http://wixtoolset.org/schemas/v4/wxs/ui";
     private const string RequiredInputDialogIdPrefix = "PowerForgeRequiredInputDlg";
     private const int MaxRequiredInputLabelsInMessage = 4;
+    private static readonly TimeSpan ValidationPatternMatchTimeout = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Emits a WiX v4 source document.
@@ -846,6 +847,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             RequireWixIdentifier(input.Id, $"input '{input.Id}' ID");
             Require(input.PropertyName, nameof(input.PropertyName));
             RequirePublicMsiProperty(input.PropertyName, $"input '{input.Id}' property");
+            ValidateInputValidationMetadata(input);
             if (input.Kind == PowerForgeInstallerInputKind.RadioGroup && input.Choices.Count == 0)
                 throw new InvalidOperationException($"Input '{input.Id}' is a radio group but has no choices.");
             if (input.Required && input.Kind == PowerForgeInstallerInputKind.RadioGroup)
@@ -943,6 +945,100 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                         $"Registry value component '{registryValue.Id}' requires Value or ValueProperty.");
                 }
             }
+        }
+    }
+
+    private static void ValidateInputValidationMetadata(PowerForgeInstallerInput input)
+    {
+        var hasValidationRule = input.MinLength.HasValue ||
+                                input.MaxLength.HasValue ||
+                                input.ValidationPattern is not null;
+        var hasValidationMetadata = hasValidationRule || !string.IsNullOrWhiteSpace(input.ValidationMessage);
+        if (hasValidationMetadata && !SupportsInputValidationMetadata(input.Kind))
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' validation metadata can only be used with text, password, path, or license-key inputs.");
+        }
+
+        if (input.MinLength is < 0)
+            throw new InvalidOperationException($"Input '{input.Id}' MinLength must be greater than or equal to 0.");
+        if (input.MaxLength is < 0)
+            throw new InvalidOperationException($"Input '{input.Id}' MaxLength must be greater than or equal to 0.");
+        if (input.MinLength.HasValue &&
+            input.MaxLength.HasValue &&
+            input.MinLength.Value > input.MaxLength.Value)
+        {
+            throw new InvalidOperationException($"Input '{input.Id}' MinLength cannot be greater than MaxLength.");
+        }
+
+        Regex? validationRegex = null;
+        if (input.ValidationPattern is not null)
+        {
+            if (string.IsNullOrWhiteSpace(input.ValidationPattern))
+            {
+                throw new InvalidOperationException($"Input '{input.Id}' ValidationPattern cannot be empty.");
+            }
+
+            try
+            {
+                validationRegex = new Regex(
+                    input.ValidationPattern,
+                    RegexOptions.CultureInvariant,
+                    ValidationPatternMatchTimeout);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Input '{input.Id}' ValidationPattern must be a valid .NET regular expression.",
+                    ex);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(input.ValidationMessage) && !hasValidationRule)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' ValidationMessage requires MinLength, MaxLength, or ValidationPattern.");
+        }
+
+        if (input.DefaultValue is not null)
+            ValidateInputDefaultValue(input, validationRegex);
+    }
+
+    private static bool SupportsInputValidationMetadata(PowerForgeInstallerInputKind kind)
+        => kind == PowerForgeInstallerInputKind.Text ||
+           kind == PowerForgeInstallerInputKind.Password ||
+           kind == PowerForgeInstallerInputKind.FilePath ||
+           kind == PowerForgeInstallerInputKind.FolderPath ||
+           kind == PowerForgeInstallerInputKind.LicenseKey;
+
+    private static void ValidateInputDefaultValue(PowerForgeInstallerInput input, Regex? validationRegex)
+    {
+        var defaultValue = input.DefaultValue!;
+        if (input.MinLength.HasValue && defaultValue.Length < input.MinLength.Value)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' default value is shorter than MinLength.");
+        }
+
+        if (input.MaxLength.HasValue && defaultValue.Length > input.MaxLength.Value)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' default value is longer than MaxLength.");
+        }
+
+        try
+        {
+            if (validationRegex is not null && !validationRegex.IsMatch(defaultValue))
+            {
+                throw new InvalidOperationException(
+                    $"Input '{input.Id}' default value does not match ValidationPattern.");
+            }
+        }
+        catch (RegexMatchTimeoutException ex)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' default value validation timed out while evaluating ValidationPattern.",
+                ex);
         }
     }
 

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -167,6 +167,10 @@
         "Secure": { "type": "boolean" },
         "Hidden": { "type": "boolean" },
         "Required": { "type": "boolean" },
+        "MinLength": { "type": ["integer", "null"], "minimum": 0 },
+        "MaxLength": { "type": ["integer", "null"], "minimum": 0 },
+        "ValidationPattern": { "type": ["string", "null"] },
+        "ValidationMessage": { "type": ["string", "null"] },
         "Choices": {
           "type": "array",
           "items": { "$ref": "#/$defs/PowerForgeInstallerInputChoice" }


### PR DESCRIPTION
## Summary
- Add installer input validation metadata: `MinLength`, `MaxLength`, `ValidationPattern`, and `ValidationMessage`.
- Validate metadata shape and authored default values before generated WiX source is written, including a timeout for user-authored regex patterns.
- Preserve validation metadata through MSI plan cloning and expose it in the dotnet publish schema/example/docs.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"`
- `$env:POWERFORGE_RUN_WIX_COMPILE_TESTS='1'; dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~DotNetPublishPipelineRunnerMsiPrepareTests"`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo`
- `git diff --check`
- `git diff --cached --check`

Note: a local rerun of `DotNetPublishPipelineRunnerHardeningTests` hangs on the pre-existing `TrySignOutput_WhenMissingToolAndPolicyFail_Throws` test; CI covers the full gate.