### PR TITLE
Extract generated installer definition validation

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,7 @@
 - Generated WiX authoring now validates WiX identifiers, product upgrade GUIDs, and public MSI input properties before writing installer source.
 - Generated WiX authoring now enforces the WiX 72-character identifier limit.
 - Generated installer inputs now carry validation metadata (`MinLength`, `MaxLength`, `ValidationPattern`, `ValidationMessage`) with authoring-time checks for metadata shape and default values.
+- Generated installer definition validation now lives in a dedicated validator instead of the WiX source emitter.
 
 ## 2.0.19 - 2025.06.17
 ### What's Changed

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PowerForge;
+
+internal static class PowerForgeInstallerDefinitionValidator
+{
+    internal const string RequiredInputDialogIdPrefix = "PowerForgeRequiredInputDlg";
+
+    private static readonly Regex WixIdentifierPattern = new(
+        "^[A-Za-z_][A-Za-z0-9_.]{0,71}$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly Regex PublicMsiPropertyPattern = new(
+        "^[A-Z_][A-Z0-9_]*$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private static readonly TimeSpan ValidationPatternMatchTimeout = TimeSpan.FromSeconds(2);
+
+    internal static void Validate(PowerForgeInstallerDefinition definition)
+    {
+        if (definition is null) throw new ArgumentNullException(nameof(definition));
+
+        Require(definition.Product.Name, nameof(definition.Product.Name));
+        Require(definition.Product.Manufacturer, nameof(definition.Product.Manufacturer));
+        Require(definition.Product.Version, nameof(definition.Product.Version));
+        Require(definition.Product.UpgradeCode, nameof(definition.Product.UpgradeCode));
+        RequireGuid(definition.Product.UpgradeCode, nameof(definition.Product.UpgradeCode));
+        Require(definition.InstallDirectoryId, nameof(definition.InstallDirectoryId));
+        RequireWixIdentifier(definition.InstallDirectoryId, nameof(definition.InstallDirectoryId));
+        if (definition.UseCompanyFolder)
+            Require(definition.CompanyFolderName, nameof(definition.CompanyFolderName));
+        Require(definition.InstallDirectoryName, nameof(definition.InstallDirectoryName));
+        if (!string.IsNullOrWhiteSpace(definition.PayloadComponentGroupId))
+            RequireWixIdentifier(definition.PayloadComponentGroupId, nameof(definition.PayloadComponentGroupId));
+
+        EnsureUnique(
+            definition.Inputs.Select(input => input.Id),
+            "installer input ID");
+        EnsureUnique(
+            definition.Inputs.Select(input => input.PropertyName),
+            "installer input property");
+        EnsureUnique(
+            definition.Dialogs.Select(dialog => dialog.Id),
+            "installer dialog ID");
+        if (definition.Dialogs.Any(dialog => dialog.Id.StartsWith(RequiredInputDialogIdPrefix, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException(
+                $"Installer dialog IDs starting with '{RequiredInputDialogIdPrefix}' are reserved for generated required-input validation.");
+        }
+
+        EnsureUnique(
+            definition.Directories.SelectMany(tree => tree.Segments).Select(segment => segment.Id)
+                .Concat(new[] { definition.InstallDirectoryId }),
+            "installer directory ID");
+        EnsureUnique(
+            definition.Components.Select(component => component.Id),
+            "installer component ID");
+
+        var inputIds = new HashSet<string>(
+            definition.Inputs.Select(input => input.Id),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var input in definition.Inputs)
+        {
+            Require(input.Id, nameof(input.Id));
+            RequireWixIdentifier(input.Id, $"input '{input.Id}' ID");
+            Require(input.PropertyName, nameof(input.PropertyName));
+            RequirePublicMsiProperty(input.PropertyName, $"input '{input.Id}' property");
+            ValidateInputValidationMetadata(input);
+            if (input.Kind == PowerForgeInstallerInputKind.RadioGroup && input.Choices.Count == 0)
+                throw new InvalidOperationException($"Input '{input.Id}' is a radio group but has no choices.");
+            if (input.Required && input.Kind == PowerForgeInstallerInputKind.RadioGroup)
+            {
+                if (string.IsNullOrWhiteSpace(input.DefaultValue))
+                {
+                    throw new InvalidOperationException(
+                        $"Input '{input.Id}' is a required radio group but has no default value.");
+                }
+
+                if (!input.Choices.Any(choice => string.Equals(choice.Value, input.DefaultValue, StringComparison.Ordinal)))
+                {
+                    throw new InvalidOperationException(
+                        $"Input '{input.Id}' is a required radio group but its default value does not match any choice.");
+                }
+            }
+        }
+
+        foreach (var dialog in definition.Dialogs)
+        {
+            Require(dialog.Id, nameof(dialog.Id));
+            RequireWixIdentifier(dialog.Id, $"dialog '{dialog.Id}' ID");
+            Require(dialog.Title, nameof(dialog.Title));
+            foreach (var inputId in dialog.InputIds)
+            {
+                if (!inputIds.Contains(inputId))
+                    throw new InvalidOperationException($"Dialog '{dialog.Id}' references unknown input '{inputId}'.");
+            }
+        }
+
+        foreach (var tree in definition.Directories)
+        {
+            if (string.IsNullOrWhiteSpace(tree.StandardDirectoryId) && string.IsNullOrWhiteSpace(tree.DirectoryRefId))
+                throw new InvalidOperationException("Installer directory tree requires StandardDirectoryId or DirectoryRefId.");
+            if (!string.IsNullOrWhiteSpace(tree.StandardDirectoryId) && !string.IsNullOrWhiteSpace(tree.DirectoryRefId))
+                throw new InvalidOperationException("Installer directory tree cannot set both StandardDirectoryId and DirectoryRefId.");
+            if (!string.IsNullOrWhiteSpace(tree.StandardDirectoryId))
+                RequireWixIdentifier(tree.StandardDirectoryId, "installer directory tree StandardDirectoryId");
+            if (!string.IsNullOrWhiteSpace(tree.DirectoryRefId))
+                RequireWixIdentifier(tree.DirectoryRefId, "installer directory tree DirectoryRefId");
+            if (tree.Segments.Count == 0)
+                throw new InvalidOperationException("Installer directory tree requires at least one segment.");
+            foreach (var segment in tree.Segments)
+            {
+                Require(segment.Id, nameof(segment.Id));
+                RequireWixIdentifier(segment.Id, $"directory segment '{segment.Id}' ID");
+                Require(segment.Name, nameof(segment.Name));
+            }
+        }
+
+        foreach (var component in definition.Components)
+        {
+            Require(component.Id, nameof(component.Id));
+            RequireWixIdentifier(component.Id, $"component '{component.Id}' ID");
+            Require(component.DirectoryRefId, nameof(component.DirectoryRefId));
+            RequireWixIdentifier(component.DirectoryRefId, $"component '{component.Id}' DirectoryRefId");
+            if (component is PowerForgeInstallerShortcutComponent shortcut)
+            {
+                Require(shortcut.ShortcutId, nameof(shortcut.ShortcutId));
+                RequireWixIdentifier(shortcut.ShortcutId, $"shortcut component '{shortcut.Id}' ShortcutId");
+                Require(shortcut.WorkingDirectoryId, nameof(shortcut.WorkingDirectoryId));
+                RequireWixIdentifier(shortcut.WorkingDirectoryId, $"shortcut component '{shortcut.Id}' WorkingDirectoryId");
+                if (!string.IsNullOrWhiteSpace(shortcut.TargetFileId))
+                    RequireWixIdentifier(shortcut.TargetFileId, $"shortcut component '{shortcut.Id}' TargetFileId");
+                if (string.IsNullOrWhiteSpace(shortcut.TargetFileId) && string.IsNullOrWhiteSpace(shortcut.Target))
+                    throw new InvalidOperationException(
+                        $"Shortcut component '{shortcut.Id}' requires TargetFileId or Target.");
+            }
+            else if (component is PowerForgeInstallerFileComponent file)
+            {
+                Require(file.FileId, nameof(file.FileId));
+                RequireWixIdentifier(file.FileId, $"file component '{file.Id}' FileId");
+            }
+            else if (component is PowerForgeInstallerServiceComponent service)
+            {
+                Require(service.FileId, nameof(service.FileId));
+                RequireWixIdentifier(service.FileId, $"service component '{service.Id}' FileId");
+            }
+            else if (component is PowerForgeInstallerRemoveFolderComponent removeFolder)
+            {
+                Require(removeFolder.PropertyName, nameof(removeFolder.PropertyName));
+                RequireWixIdentifier(removeFolder.PropertyName, $"remove-folder component '{removeFolder.Id}' PropertyName");
+            }
+            else if (component is PowerForgeInstallerRegistryValueComponent registryValue)
+            {
+                Require(registryValue.Root, nameof(registryValue.Root));
+                Require(registryValue.Key, nameof(registryValue.Key));
+                Require(registryValue.Name, nameof(registryValue.Name));
+                Require(registryValue.ValueType, nameof(registryValue.ValueType));
+                if (!string.IsNullOrWhiteSpace(registryValue.ValueProperty))
+                    RequirePublicMsiProperty(registryValue.ValueProperty, $"registry value component '{registryValue.Id}' ValueProperty");
+                if (string.IsNullOrWhiteSpace(registryValue.Value) && string.IsNullOrWhiteSpace(registryValue.ValueProperty))
+                {
+                    throw new InvalidOperationException(
+                        $"Registry value component '{registryValue.Id}' requires Value or ValueProperty.");
+                }
+            }
+        }
+    }
+
+    private static void ValidateInputValidationMetadata(PowerForgeInstallerInput input)
+    {
+        var hasValidationRule = input.MinLength.HasValue ||
+                                input.MaxLength.HasValue ||
+                                input.ValidationPattern is not null;
+        var hasValidationMetadata = hasValidationRule || !string.IsNullOrWhiteSpace(input.ValidationMessage);
+        if (hasValidationMetadata && !SupportsInputValidationMetadata(input.Kind))
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' validation metadata can only be used with text, password, path, or license-key inputs.");
+        }
+
+        if (input.MinLength is < 0)
+            throw new InvalidOperationException($"Input '{input.Id}' MinLength must be greater than or equal to 0.");
+        if (input.MaxLength is < 0)
+            throw new InvalidOperationException($"Input '{input.Id}' MaxLength must be greater than or equal to 0.");
+        if (input.MinLength.HasValue &&
+            input.MaxLength.HasValue &&
+            input.MinLength.Value > input.MaxLength.Value)
+        {
+            throw new InvalidOperationException($"Input '{input.Id}' MinLength cannot be greater than MaxLength.");
+        }
+
+        Regex? validationRegex = null;
+        if (input.ValidationPattern is not null)
+        {
+            if (string.IsNullOrWhiteSpace(input.ValidationPattern))
+            {
+                throw new InvalidOperationException($"Input '{input.Id}' ValidationPattern cannot be empty.");
+            }
+
+            try
+            {
+                validationRegex = new Regex(
+                    input.ValidationPattern,
+                    RegexOptions.CultureInvariant,
+                    ValidationPatternMatchTimeout);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Input '{input.Id}' ValidationPattern must be a valid .NET regular expression.",
+                    ex);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(input.ValidationMessage) && !hasValidationRule)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' ValidationMessage requires MinLength, MaxLength, or ValidationPattern.");
+        }
+
+        if (input.DefaultValue is not null)
+            ValidateInputDefaultValue(input, validationRegex);
+    }
+
+    private static bool SupportsInputValidationMetadata(PowerForgeInstallerInputKind kind)
+        => kind == PowerForgeInstallerInputKind.Text ||
+           kind == PowerForgeInstallerInputKind.Password ||
+           kind == PowerForgeInstallerInputKind.FilePath ||
+           kind == PowerForgeInstallerInputKind.FolderPath ||
+           kind == PowerForgeInstallerInputKind.LicenseKey;
+
+    private static void ValidateInputDefaultValue(PowerForgeInstallerInput input, Regex? validationRegex)
+    {
+        var defaultValue = input.DefaultValue!;
+        if (input.MinLength.HasValue && defaultValue.Length < input.MinLength.Value)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' default value is shorter than MinLength.");
+        }
+
+        if (input.MaxLength.HasValue && defaultValue.Length > input.MaxLength.Value)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' default value is longer than MaxLength.");
+        }
+
+        try
+        {
+            if (validationRegex is not null && !validationRegex.IsMatch(defaultValue))
+            {
+                throw new InvalidOperationException(
+                    $"Input '{input.Id}' default value does not match ValidationPattern.");
+            }
+        }
+        catch (RegexMatchTimeoutException ex)
+        {
+            throw new InvalidOperationException(
+                $"Input '{input.Id}' default value validation timed out while evaluating ValidationPattern.",
+                ex);
+        }
+    }
+
+    private static void EnsureUnique(IEnumerable<string?> values, string label)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                continue;
+
+            var normalized = value!.Trim();
+            if (!seen.Add(normalized))
+                throw new InvalidOperationException($"Duplicate {label} detected: {normalized}.");
+        }
+    }
+
+    private static void Require(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException($"Installer definition requires {name}.");
+    }
+
+    private static void RequireGuid(string? value, string name)
+    {
+        if (!Guid.TryParse(value, out _))
+            throw new InvalidOperationException($"Installer definition requires {name} to be a valid GUID.");
+    }
+
+    private static void RequireWixIdentifier(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !WixIdentifierPattern.IsMatch(value))
+        {
+            throw new InvalidOperationException(
+                $"Installer definition requires {name} to be a valid WiX identifier.");
+        }
+    }
+
+    private static void RequirePublicMsiProperty(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !PublicMsiPropertyPattern.IsMatch(value))
+        {
+            throw new InvalidOperationException(
+                $"Installer definition requires {name} to be an uppercase public MSI property.");
+        }
+    }
+}

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerProjectOptions.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerProjectOptions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace PowerForge;
+
+/// <summary>
+/// Options for emitting a WiX SDK project around generated WiX source.
+/// </summary>
+public sealed class PowerForgeWixInstallerProjectOptions
+{
+    /// <summary>
+    /// WiX SDK version used by the generated project.
+    /// </summary>
+    public string SdkVersion { get; set; } = "4.0.6";
+
+    /// <summary>
+    /// WiX platform.
+    /// </summary>
+    public string Platform { get; set; } = "x64";
+
+    /// <summary>
+    /// Generated WiX source file included by the project.
+    /// </summary>
+    public string SourceFile { get; set; } = "Product.wxs";
+
+    /// <summary>
+    /// Additional WiX source files included by the generated project.
+    /// </summary>
+    public List<string> AdditionalSourceFiles { get; } = new();
+
+    /// <summary>
+    /// MSBuild define constants passed to WiX.
+    /// </summary>
+    public Dictionary<string, string> DefineConstants { get; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace PowerForge;
@@ -11,20 +10,10 @@ namespace PowerForge;
 /// </summary>
 public sealed class PowerForgeWixInstallerSourceEmitter
 {
-    private static readonly Regex WixIdentifierPattern = new(
-        "^[A-Za-z_][A-Za-z0-9_.]{0,71}$",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
-
-    private static readonly Regex PublicMsiPropertyPattern = new(
-        "^[A-Z_][A-Z0-9_]*$",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled);
-
     private static readonly XNamespace WixNamespace = "http://wixtoolset.org/schemas/v4/wxs";
     private static readonly XNamespace UtilNamespace = "http://wixtoolset.org/schemas/v4/wxs/util";
     private static readonly XNamespace UiNamespace = "http://wixtoolset.org/schemas/v4/wxs/ui";
-    private const string RequiredInputDialogIdPrefix = "PowerForgeRequiredInputDlg";
     private const int MaxRequiredInputLabelsInMessage = 4;
-    private static readonly TimeSpan ValidationPatternMatchTimeout = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Emits a WiX v4 source document.
@@ -34,7 +23,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     public string EmitSource(PowerForgeInstallerDefinition definition)
     {
         if (definition is null) throw new ArgumentNullException(nameof(definition));
-        Validate(definition);
+        PowerForgeInstallerDefinitionValidator.Validate(definition);
 
         var needsUi = definition.Dialogs.Count > 0;
         var needsUtil = definition.Components.OfType<PowerForgeInstallerRemoveFolderComponent>().Any();
@@ -210,8 +199,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     {
         // Keep the first generated ID stable for existing one-dialog installer output; suffix only additional prompts.
         return index == 0
-            ? RequiredInputDialogIdPrefix
-            : RequiredInputDialogIdPrefix + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            ? PowerForgeInstallerDefinitionValidator.RequiredInputDialogIdPrefix
+            : PowerForgeInstallerDefinitionValidator.RequiredInputDialogIdPrefix + (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static XElement EmitRequiredInputDialog(
@@ -798,322 +787,4 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     {
         return scope == PowerForgeInstallerScope.PerUser ? "perUser" : "perMachine";
     }
-
-    private static void Validate(PowerForgeInstallerDefinition definition)
-    {
-        Require(definition.Product.Name, nameof(definition.Product.Name));
-        Require(definition.Product.Manufacturer, nameof(definition.Product.Manufacturer));
-        Require(definition.Product.Version, nameof(definition.Product.Version));
-        Require(definition.Product.UpgradeCode, nameof(definition.Product.UpgradeCode));
-        RequireGuid(definition.Product.UpgradeCode, nameof(definition.Product.UpgradeCode));
-        Require(definition.InstallDirectoryId, nameof(definition.InstallDirectoryId));
-        RequireWixIdentifier(definition.InstallDirectoryId, nameof(definition.InstallDirectoryId));
-        if (definition.UseCompanyFolder)
-            Require(definition.CompanyFolderName, nameof(definition.CompanyFolderName));
-        Require(definition.InstallDirectoryName, nameof(definition.InstallDirectoryName));
-        if (!string.IsNullOrWhiteSpace(definition.PayloadComponentGroupId))
-            RequireWixIdentifier(definition.PayloadComponentGroupId, nameof(definition.PayloadComponentGroupId));
-
-        EnsureUnique(
-            definition.Inputs.Select(input => input.Id),
-            "installer input ID");
-        EnsureUnique(
-            definition.Inputs.Select(input => input.PropertyName),
-            "installer input property");
-        EnsureUnique(
-            definition.Dialogs.Select(dialog => dialog.Id),
-            "installer dialog ID");
-        if (definition.Dialogs.Any(dialog => dialog.Id.StartsWith(RequiredInputDialogIdPrefix, StringComparison.OrdinalIgnoreCase)))
-        {
-            throw new InvalidOperationException(
-                $"Installer dialog IDs starting with '{RequiredInputDialogIdPrefix}' are reserved for generated required-input validation.");
-        }
-
-        EnsureUnique(
-            definition.Directories.SelectMany(tree => tree.Segments).Select(segment => segment.Id)
-                .Concat(new[] { definition.InstallDirectoryId }),
-            "installer directory ID");
-        EnsureUnique(
-            definition.Components.Select(component => component.Id),
-            "installer component ID");
-
-        var inputIds = new HashSet<string>(
-            definition.Inputs.Select(input => input.Id),
-            StringComparer.OrdinalIgnoreCase);
-
-        foreach (var input in definition.Inputs)
-        {
-            Require(input.Id, nameof(input.Id));
-            RequireWixIdentifier(input.Id, $"input '{input.Id}' ID");
-            Require(input.PropertyName, nameof(input.PropertyName));
-            RequirePublicMsiProperty(input.PropertyName, $"input '{input.Id}' property");
-            ValidateInputValidationMetadata(input);
-            if (input.Kind == PowerForgeInstallerInputKind.RadioGroup && input.Choices.Count == 0)
-                throw new InvalidOperationException($"Input '{input.Id}' is a radio group but has no choices.");
-            if (input.Required && input.Kind == PowerForgeInstallerInputKind.RadioGroup)
-            {
-                if (string.IsNullOrWhiteSpace(input.DefaultValue))
-                {
-                    throw new InvalidOperationException(
-                        $"Input '{input.Id}' is a required radio group but has no default value.");
-                }
-
-                if (!input.Choices.Any(choice => string.Equals(choice.Value, input.DefaultValue, StringComparison.Ordinal)))
-                {
-                    throw new InvalidOperationException(
-                        $"Input '{input.Id}' is a required radio group but its default value does not match any choice.");
-                }
-            }
-        }
-
-        foreach (var dialog in definition.Dialogs)
-        {
-            Require(dialog.Id, nameof(dialog.Id));
-            RequireWixIdentifier(dialog.Id, $"dialog '{dialog.Id}' ID");
-            Require(dialog.Title, nameof(dialog.Title));
-            foreach (var inputId in dialog.InputIds)
-            {
-                if (!inputIds.Contains(inputId))
-                    throw new InvalidOperationException($"Dialog '{dialog.Id}' references unknown input '{inputId}'.");
-            }
-        }
-
-        foreach (var tree in definition.Directories)
-        {
-            if (string.IsNullOrWhiteSpace(tree.StandardDirectoryId) && string.IsNullOrWhiteSpace(tree.DirectoryRefId))
-                throw new InvalidOperationException("Installer directory tree requires StandardDirectoryId or DirectoryRefId.");
-            if (!string.IsNullOrWhiteSpace(tree.StandardDirectoryId) && !string.IsNullOrWhiteSpace(tree.DirectoryRefId))
-                throw new InvalidOperationException("Installer directory tree cannot set both StandardDirectoryId and DirectoryRefId.");
-            if (!string.IsNullOrWhiteSpace(tree.StandardDirectoryId))
-                RequireWixIdentifier(tree.StandardDirectoryId, "installer directory tree StandardDirectoryId");
-            if (!string.IsNullOrWhiteSpace(tree.DirectoryRefId))
-                RequireWixIdentifier(tree.DirectoryRefId, "installer directory tree DirectoryRefId");
-            if (tree.Segments.Count == 0)
-                throw new InvalidOperationException("Installer directory tree requires at least one segment.");
-            foreach (var segment in tree.Segments)
-            {
-                Require(segment.Id, nameof(segment.Id));
-                RequireWixIdentifier(segment.Id, $"directory segment '{segment.Id}' ID");
-                Require(segment.Name, nameof(segment.Name));
-            }
-        }
-
-        foreach (var component in definition.Components)
-        {
-            Require(component.Id, nameof(component.Id));
-            RequireWixIdentifier(component.Id, $"component '{component.Id}' ID");
-            Require(component.DirectoryRefId, nameof(component.DirectoryRefId));
-            RequireWixIdentifier(component.DirectoryRefId, $"component '{component.Id}' DirectoryRefId");
-            if (component is PowerForgeInstallerShortcutComponent shortcut)
-            {
-                Require(shortcut.ShortcutId, nameof(shortcut.ShortcutId));
-                RequireWixIdentifier(shortcut.ShortcutId, $"shortcut component '{shortcut.Id}' ShortcutId");
-                Require(shortcut.WorkingDirectoryId, nameof(shortcut.WorkingDirectoryId));
-                RequireWixIdentifier(shortcut.WorkingDirectoryId, $"shortcut component '{shortcut.Id}' WorkingDirectoryId");
-                if (!string.IsNullOrWhiteSpace(shortcut.TargetFileId))
-                    RequireWixIdentifier(shortcut.TargetFileId, $"shortcut component '{shortcut.Id}' TargetFileId");
-                if (string.IsNullOrWhiteSpace(shortcut.TargetFileId) && string.IsNullOrWhiteSpace(shortcut.Target))
-                    throw new InvalidOperationException(
-                        $"Shortcut component '{shortcut.Id}' requires TargetFileId or Target.");
-            }
-            else if (component is PowerForgeInstallerFileComponent file)
-            {
-                Require(file.FileId, nameof(file.FileId));
-                RequireWixIdentifier(file.FileId, $"file component '{file.Id}' FileId");
-            }
-            else if (component is PowerForgeInstallerServiceComponent service)
-            {
-                Require(service.FileId, nameof(service.FileId));
-                RequireWixIdentifier(service.FileId, $"service component '{service.Id}' FileId");
-            }
-            else if (component is PowerForgeInstallerRemoveFolderComponent removeFolder)
-            {
-                Require(removeFolder.PropertyName, nameof(removeFolder.PropertyName));
-                RequireWixIdentifier(removeFolder.PropertyName, $"remove-folder component '{removeFolder.Id}' PropertyName");
-            }
-            else if (component is PowerForgeInstallerRegistryValueComponent registryValue)
-            {
-                Require(registryValue.Root, nameof(registryValue.Root));
-                Require(registryValue.Key, nameof(registryValue.Key));
-                Require(registryValue.Name, nameof(registryValue.Name));
-                Require(registryValue.ValueType, nameof(registryValue.ValueType));
-                if (!string.IsNullOrWhiteSpace(registryValue.ValueProperty))
-                    RequirePublicMsiProperty(registryValue.ValueProperty, $"registry value component '{registryValue.Id}' ValueProperty");
-                if (string.IsNullOrWhiteSpace(registryValue.Value) && string.IsNullOrWhiteSpace(registryValue.ValueProperty))
-                {
-                    throw new InvalidOperationException(
-                        $"Registry value component '{registryValue.Id}' requires Value or ValueProperty.");
-                }
-            }
-        }
-    }
-
-    private static void ValidateInputValidationMetadata(PowerForgeInstallerInput input)
-    {
-        var hasValidationRule = input.MinLength.HasValue ||
-                                input.MaxLength.HasValue ||
-                                input.ValidationPattern is not null;
-        var hasValidationMetadata = hasValidationRule || !string.IsNullOrWhiteSpace(input.ValidationMessage);
-        if (hasValidationMetadata && !SupportsInputValidationMetadata(input.Kind))
-        {
-            throw new InvalidOperationException(
-                $"Input '{input.Id}' validation metadata can only be used with text, password, path, or license-key inputs.");
-        }
-
-        if (input.MinLength is < 0)
-            throw new InvalidOperationException($"Input '{input.Id}' MinLength must be greater than or equal to 0.");
-        if (input.MaxLength is < 0)
-            throw new InvalidOperationException($"Input '{input.Id}' MaxLength must be greater than or equal to 0.");
-        if (input.MinLength.HasValue &&
-            input.MaxLength.HasValue &&
-            input.MinLength.Value > input.MaxLength.Value)
-        {
-            throw new InvalidOperationException($"Input '{input.Id}' MinLength cannot be greater than MaxLength.");
-        }
-
-        Regex? validationRegex = null;
-        if (input.ValidationPattern is not null)
-        {
-            if (string.IsNullOrWhiteSpace(input.ValidationPattern))
-            {
-                throw new InvalidOperationException($"Input '{input.Id}' ValidationPattern cannot be empty.");
-            }
-
-            try
-            {
-                validationRegex = new Regex(
-                    input.ValidationPattern,
-                    RegexOptions.CultureInvariant,
-                    ValidationPatternMatchTimeout);
-            }
-            catch (ArgumentException ex)
-            {
-                throw new InvalidOperationException(
-                    $"Input '{input.Id}' ValidationPattern must be a valid .NET regular expression.",
-                    ex);
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(input.ValidationMessage) && !hasValidationRule)
-        {
-            throw new InvalidOperationException(
-                $"Input '{input.Id}' ValidationMessage requires MinLength, MaxLength, or ValidationPattern.");
-        }
-
-        if (input.DefaultValue is not null)
-            ValidateInputDefaultValue(input, validationRegex);
-    }
-
-    private static bool SupportsInputValidationMetadata(PowerForgeInstallerInputKind kind)
-        => kind == PowerForgeInstallerInputKind.Text ||
-           kind == PowerForgeInstallerInputKind.Password ||
-           kind == PowerForgeInstallerInputKind.FilePath ||
-           kind == PowerForgeInstallerInputKind.FolderPath ||
-           kind == PowerForgeInstallerInputKind.LicenseKey;
-
-    private static void ValidateInputDefaultValue(PowerForgeInstallerInput input, Regex? validationRegex)
-    {
-        var defaultValue = input.DefaultValue!;
-        if (input.MinLength.HasValue && defaultValue.Length < input.MinLength.Value)
-        {
-            throw new InvalidOperationException(
-                $"Input '{input.Id}' default value is shorter than MinLength.");
-        }
-
-        if (input.MaxLength.HasValue && defaultValue.Length > input.MaxLength.Value)
-        {
-            throw new InvalidOperationException(
-                $"Input '{input.Id}' default value is longer than MaxLength.");
-        }
-
-        try
-        {
-            if (validationRegex is not null && !validationRegex.IsMatch(defaultValue))
-            {
-                throw new InvalidOperationException(
-                    $"Input '{input.Id}' default value does not match ValidationPattern.");
-            }
-        }
-        catch (RegexMatchTimeoutException ex)
-        {
-            throw new InvalidOperationException(
-                $"Input '{input.Id}' default value validation timed out while evaluating ValidationPattern.",
-                ex);
-        }
-    }
-
-    private static void EnsureUnique(IEnumerable<string?> values, string label)
-    {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var value in values)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-                continue;
-
-            var normalized = value!.Trim();
-            if (!seen.Add(normalized))
-                throw new InvalidOperationException($"Duplicate {label} detected: {normalized}.");
-        }
-    }
-
-    private static void Require(string? value, string name)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            throw new InvalidOperationException($"Installer definition requires {name}.");
-    }
-
-    private static void RequireGuid(string? value, string name)
-    {
-        if (!Guid.TryParse(value, out _))
-            throw new InvalidOperationException($"Installer definition requires {name} to be a valid GUID.");
-    }
-
-    private static void RequireWixIdentifier(string? value, string name)
-    {
-        if (string.IsNullOrWhiteSpace(value) || !WixIdentifierPattern.IsMatch(value))
-        {
-            throw new InvalidOperationException(
-                $"Installer definition requires {name} to be a valid WiX identifier.");
-        }
-    }
-
-    private static void RequirePublicMsiProperty(string? value, string name)
-    {
-        if (string.IsNullOrWhiteSpace(value) || !PublicMsiPropertyPattern.IsMatch(value))
-        {
-            throw new InvalidOperationException(
-                $"Installer definition requires {name} to be an uppercase public MSI property.");
-        }
-    }
-}
-
-/// <summary>
-/// Options for emitting a WiX SDK project around generated WiX source.
-/// </summary>
-public sealed class PowerForgeWixInstallerProjectOptions
-{
-    /// <summary>
-    /// WiX SDK version used by the generated project.
-    /// </summary>
-    public string SdkVersion { get; set; } = "4.0.6";
-
-    /// <summary>
-    /// WiX platform.
-    /// </summary>
-    public string Platform { get; set; } = "x64";
-
-    /// <summary>
-    /// Generated WiX source file included by the project.
-    /// </summary>
-    public string SourceFile { get; set; } = "Product.wxs";
-
-    /// <summary>
-    /// Additional WiX source files included by the generated project.
-    /// </summary>
-    public List<string> AdditionalSourceFiles { get; } = new();
-
-    /// <summary>
-    /// MSBuild define constants passed to WiX.
-    /// </summary>
-    public Dictionary<string, string> DefineConstants { get; } = new(StringComparer.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
## Summary
- Extract generated installer definition validation into a dedicated internal validator.
- Keep generated required-input dialog ID ownership shared through the validator constant.
- Move WiX project emission options into their own file and bring the source emitter back under the installer-folder line-count guard.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"`
- `$env:POWERFORGE_RUN_WIX_COMPILE_TESTS='1'; dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiPrepareTests"`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo`
- `node .\Build\linecount.js --root PowerForge\Services\Installers --max 800 --ext .cs`
- `git diff --check`
- `git diff --cached --check`