### PR TITLE
Add installer validator contract tests

### DIFF
--- a/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
@@ -1,0 +1,227 @@
+using System;
+
+namespace PowerForge.Tests;
+
+public sealed class PowerForgeInstallerDefinitionValidatorTests
+{
+    [Fact]
+    public void Validate_PassesForMinimalValidDefinition()
+    {
+        PowerForgeInstallerDefinitionValidator.Validate(CreateValidDefinition());
+    }
+
+    [Fact]
+    public void Validate_ThrowsWhenDefinitionIsNull()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(null!));
+
+        Assert.Equal("definition", ex.ParamName);
+    }
+
+    [Fact]
+    public void Validate_AllowsUnderscorePrefixedPublicMsiProperties()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "ConfigPath",
+            PropertyName = "_CONFIG_PATH",
+            Label = "Configuration path"
+        });
+
+        PowerForgeInstallerDefinitionValidator.Validate(definition);
+    }
+
+    [Fact]
+    public void Validate_RejectsLowercasePublicMsiProperties()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "ConfigPath",
+            PropertyName = "_config_path",
+            Label = "Configuration path"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("uppercase public MSI property", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("PowerForgeRequiredInputDlg")]
+    [InlineData("powerforgerequiredinputdlg2")]
+    [InlineData("POWERFORGEREQUIREDINPUTDLG2")]
+    [InlineData("PowerForgeRequiredInputDlg2")]
+    public void Validate_RejectsReservedRequiredInputDialogPrefixCaseInsensitively(string dialogId)
+    {
+        var definition = CreateValidDefinition();
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = dialogId,
+            Title = "Reserved"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("reserved", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateAuthoringIdsAfterTrimming()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key"
+        });
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = " LicenseKey ",
+            PropertyName = "OTHER_LICENSE_KEY",
+            Label = "Other license key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("Duplicate installer input ID", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("LicenseKey", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(" LicenseKey ", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateAuthoringIdsCaseInsensitively()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key"
+        });
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "licensekey",
+            PropertyName = "OTHER_LICENSE_KEY",
+            Label = "Other license key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("Duplicate installer input ID", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("LicenseKey", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateInputPropertyNames()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key"
+        });
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "OtherLicenseKey",
+            PropertyName = "license_key",
+            Label = "Other license key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("Duplicate installer input property", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("LICENSE_KEY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateDialogIds()
+    {
+        var definition = CreateValidDefinition();
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "ConfigurationDlg",
+            Title = "Configuration"
+        });
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "configurationdlg",
+            Title = "Configuration Duplicate"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("Duplicate installer dialog ID", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_RejectsValidationMessageWithoutValidationRule()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            ValidationMessage = "Enter a valid license key."
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("ValidationMessage requires MinLength, MaxLength, or ValidationPattern", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_AllowsValidationMessageWithValidationRule()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "LicenseKey",
+            PropertyName = "LICENSE_KEY",
+            Label = "License key",
+            Kind = PowerForgeInstallerInputKind.LicenseKey,
+            MinLength = 16,
+            ValidationMessage = "Enter a valid license key."
+        });
+
+        PowerForgeInstallerDefinitionValidator.Validate(definition);
+    }
+
+    private static PowerForgeInstallerDefinition CreateValidDefinition()
+    {
+        var definition = new PowerForgeInstallerDefinition
+        {
+            Product =
+            {
+                Name = "PowerForge Installer Smoke",
+                Manufacturer = "Evotec",
+                Version = "1.0.0",
+                UpgradeCode = "{0288b3b9-c153-4b2f-878e-022b4f8abb42}"
+            },
+            CompanyFolderName = "Evotec",
+            InstallDirectoryName = "PowerForge Installer Smoke",
+            PayloadComponentGroupId = "ProductFiles"
+        };
+
+        definition.Components.Add(new PowerForgeInstallerFolderComponent
+        {
+            Id = "InstallFolderComponent",
+            DirectoryRefId = "INSTALLFOLDER"
+        });
+
+        return definition;
+    }
+}

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -45,6 +45,8 @@ internal static class PowerForgeInstallerDefinitionValidator
         EnsureUnique(
             definition.Dialogs.Select(dialog => dialog.Id),
             "installer dialog ID");
+        // Reserve the whole generated-dialog prefix case-insensitively so authored dialogs cannot
+        // collide with future generated validation prompts such as PowerForgeRequiredInputDlg2.
         if (definition.Dialogs.Any(dialog => dialog.Id.StartsWith(RequiredInputDialogIdPrefix, StringComparison.OrdinalIgnoreCase)))
         {
             throw new InvalidOperationException(


### PR DESCRIPTION
## Summary
- add direct contract tests for the extracted installer definition validator
- lock down underscore-prefixed public MSI properties, case-insensitive generated-dialog reservation, trimmed duplicate IDs, and validation-message metadata rules
- document the generated-dialog prefix reservation in the validator

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerDefinitionValidatorTests|FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"
- dotnet build .\PowerForge\PowerForge.csproj -c Release -f net472 --nologo
- node .\Build\linecount.js --root PowerForge\Services\Installers --max 800 --ext .cs
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo
- git diff --check
- git diff --cached --check