### PR TITLE
Address generated installer review follow-ups

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -763,10 +763,10 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
 
             Assert.True(File.Exists(projectPath));
             Assert.Equal(
-                Path.Combine(root, "Artifacts", "generated"),
+                Path.Combine(root, "Artifacts", "prepare.manifest", "generated"),
                 Path.GetDirectoryName(projectPath));
             var outputDir = InvokeResolveGeneratedInstallerOutputDirectory(plan, step, prepare);
-            Assert.Equal(Path.Combine(root, "Artifacts", "output"), outputDir);
+            Assert.Equal(Path.Combine(root, "Artifacts", "prepare.manifest", "output"), outputDir);
             var sourcePath = Path.Combine(Path.GetDirectoryName(projectPath)!, "Product.wxs");
             Assert.True(File.Exists(sourcePath));
             Assert.Contains("2.3.4", File.ReadAllText(sourcePath), StringComparison.Ordinal);
@@ -775,6 +775,57 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             Assert.Contains(harvestPath, projectXml, StringComparison.Ordinal);
             Assert.Contains("PayloadDir=", projectXml, StringComparison.Ordinal);
             Assert.Contains(staging, projectXml, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void ResolveGeneratedInstallerOutputDirectory_UsesManifestFileNameForIsolation()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release"
+            };
+            var step = new DotNetPublishStep
+            {
+                InstallerId = "app.msi",
+                TargetName = "app",
+                Framework = "net8.0",
+                Runtime = "win-x64",
+                Style = DotNetPublishStyle.Portable
+            };
+            var prepareA = new DotNetPublishMsiPrepareResult
+            {
+                InstallerId = "app.msi",
+                Target = "app",
+                Framework = "net8.0",
+                Runtime = "win-x64",
+                Style = DotNetPublishStyle.Portable,
+                ManifestPath = Path.Combine(root, "Artifacts", "prepare-a.json")
+            };
+            var prepareB = new DotNetPublishMsiPrepareResult
+            {
+                InstallerId = "app.msi",
+                Target = "app",
+                Framework = "net8.0",
+                Runtime = "win-x64",
+                Style = DotNetPublishStyle.Portable,
+                ManifestPath = Path.Combine(root, "Artifacts", "prepare-b.json")
+            };
+
+            var outputA = InvokeResolveGeneratedInstallerOutputDirectory(plan, step, prepareA);
+            var outputB = InvokeResolveGeneratedInstallerOutputDirectory(plan, step, prepareB);
+
+            Assert.Equal(Path.Combine(root, "Artifacts", "prepare-a", "output"), outputA);
+            Assert.Equal(Path.Combine(root, "Artifacts", "prepare-b", "output"), outputB);
+            Assert.NotEqual(outputA, outputB, StringComparer.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -32,7 +32,11 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Key") == @"SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring" &&
             (string?)e.Attribute("Name") == "DelayedAutoStart"));
         Assert.NotNull(doc.Descendants(Util + "RemoveFolderEx").SingleOrDefault(e =>
-            (string?)e.Attribute("Property") == "ProgramDataMonitoring"));
+            (string?)e.Attribute("Property") == "ProgramDataMonitoring" &&
+            (string?)e.Attribute("Condition") == "REMOVE_DATA=1"));
+        Assert.Null(doc.Descendants(Wix + "Component")
+            .Single(e => (string?)e.Attribute("Id") == "RemoveProgramData")
+            .Attribute("Condition"));
         Assert.NotNull(doc.Descendants(Wix + "ComponentGroupRef").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ProductFiles"));
     }
@@ -484,10 +488,54 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Target") == "[#PrimaryExeFile]"));
         Assert.NotNull(doc.Descendants(Wix + "RegistryValue").SingleOrDefault(e =>
             (string?)e.Attribute("KeyPath") == "yes" &&
+            (string?)e.Attribute("Root") == "HKCU" &&
             (string?)e.Attribute("Key") == @"Software\Evotec\IntelligenceX\Chat"));
         Assert.NotNull(doc.Descendants(Wix + "RemoveFolder").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "StartMenuShortcutComponentRemoveFolder" &&
             (string?)e.Attribute("On") == "uninstall"));
+    }
+
+    [Fact]
+    public void EmitSource_UsesPerUserInstallRootForPerUserPackages()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.Scope = PowerForgeInstallerScope.PerUser;
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Descendants(Wix + "StandardDirectory").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "LocalAppDataFolder"));
+        Assert.DoesNotContain(doc.Descendants(Wix + "StandardDirectory"), e =>
+            (string?)e.Attribute("Id") == "ProgramFiles64Folder");
+    }
+
+    [Fact]
+    public void EmitSource_EscapesRequiredPromptFormattedCharacters()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "ApiToken",
+            PropertyName = "API_TOKEN",
+            Label = "API [TOKEN]",
+            Required = true
+        });
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = "ApiDlg",
+            Title = "API",
+            InputIds = { "ApiToken" }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        var message = doc.Descendants(Wix + "Dialog")
+            .Single(e => (string?)e.Attribute("Id") == "PowerForgeRequiredInputDlg")
+            .Descendants(Wix + "Control")
+            .Single(e => (string?)e.Attribute("Id") == "Message");
+        Assert.Equal("Fill the required field before continuing: API [\\[]TOKEN[\\]].", (string?)message.Attribute("Text"));
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
@@ -132,7 +132,7 @@ public sealed class PowerForgeInstallerDefinitionValidatorTests
         definition.Inputs.Add(new PowerForgeInstallerInput
         {
             Id = "OtherLicenseKey",
-            PropertyName = "license_key",
+            PropertyName = "LICENSE_KEY",
             Label = "Other license key"
         });
 
@@ -141,6 +141,42 @@ public sealed class PowerForgeInstallerDefinitionValidatorTests
 
         Assert.Contains("Duplicate installer input property", ex.Message, StringComparison.Ordinal);
         Assert.Contains("LICENSE_KEY", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_RejectsMissingDialogIdWithoutNullReference()
+    {
+        var definition = CreateValidDefinition();
+        definition.Dialogs.Add(new PowerForgeInstallerDialog
+        {
+            Id = null!,
+            Title = "Configuration"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("requires Id", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_RejectsCompanyFolderDirectoryCollision()
+    {
+        var definition = CreateValidDefinition();
+        definition.Directories.Add(new PowerForgeInstallerDirectoryTree
+        {
+            StandardDirectoryId = "CommonAppDataFolder",
+            Segments =
+            {
+                new PowerForgeInstallerDirectorySegment { Id = "CompanyFolder", Name = "Evotec" }
+            }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("Duplicate installer directory ID", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("CompanyFolder", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -79,10 +79,8 @@ public sealed partial class DotNetPublishPipelineRunner
             "--nologo"
         };
 
-        if (plan.Restore)
+        if (plan.Restore && !isGeneratedInstallerProject)
             args.Add("--no-restore");
-        if (!string.IsNullOrWhiteSpace(generatedOutputDir))
-            args.Add($"/p:OutputPath={EnsureTrailingDirectorySeparator(generatedOutputDir!)}");
 
         var installerMsBuildProperties = BuildInstallerMsBuildProperties(
             plan.MsBuildProperties,
@@ -92,9 +90,12 @@ public sealed partial class DotNetPublishPipelineRunner
             licenseResolution.PropertyName,
             licenseResolution.Path);
         args.AddRange(BuildMsBuildPropertyArgs(installerMsBuildProperties));
+        if (!string.IsNullOrWhiteSpace(generatedOutputDir))
+            args.Add($"/p:OutputPath={EnsureTrailingDirectorySeparator(generatedOutputDir!)}");
         args.Add($"/p:PowerForgeMsiInstallerId={installerId}");
         args.Add($"/p:PowerForgeMsiPayloadDir={prepare.StagingDir}");
-        args.Add($"/p:PowerForgeMsiPrepareManifest={prepare.ManifestPath}");
+        if (!string.IsNullOrWhiteSpace(prepare.ManifestPath))
+            args.Add($"/p:PowerForgeMsiPrepareManifest={prepare.ManifestPath}");
         args.Add($"/p:PowerForgeMsiSourceTarget={prepare.Target}");
         args.Add($"/p:PowerForgeMsiSourceFramework={prepare.Framework}");
         args.Add($"/p:PowerForgeMsiSourceRuntime={prepare.Runtime}");
@@ -182,6 +183,12 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             definition.PayloadComponentGroupId = prepare.HarvestComponentGroupId;
         }
+        if (!string.IsNullOrWhiteSpace(definition.PayloadComponentGroupId) &&
+            string.IsNullOrWhiteSpace(prepare.HarvestPath))
+        {
+            throw new InvalidOperationException(
+                $"Generated installer '{installerId}' references payload component group '{definition.PayloadComponentGroupId}' but no harvested WiX source is available.");
+        }
 
         var generatedDir = ResolveGeneratedInstallerProjectDirectory(plan, installerId, step, prepare);
         var request = new PowerForgeWixInstallerCompileRequest
@@ -245,9 +252,15 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         if (!string.IsNullOrWhiteSpace(prepare.ManifestPath))
         {
-            var manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(prepare.ManifestPath));
+            var manifestPath = Path.GetFullPath(prepare.ManifestPath);
+            var manifestDirectory = Path.GetDirectoryName(manifestPath);
             if (!string.IsNullOrWhiteSpace(manifestDirectory))
-                return manifestDirectory;
+            {
+                var manifestName = ToSafeFileName(
+                    Path.GetFileNameWithoutExtension(manifestPath),
+                    "manifest");
+                return Path.Combine(manifestDirectory, manifestName);
+            }
         }
 
         var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -272,7 +285,8 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         request.DefineConstants["PayloadDir"] = prepare.StagingDir;
         request.DefineConstants["PowerForgeMsiPayloadDir"] = prepare.StagingDir;
-        request.DefineConstants["PowerForgeMsiPrepareManifest"] = prepare.ManifestPath;
+        if (!string.IsNullOrWhiteSpace(prepare.ManifestPath))
+            request.DefineConstants["PowerForgeMsiPrepareManifest"] = prepare.ManifestPath;
         request.DefineConstants["PowerForgeMsiSourceTarget"] = prepare.Target;
         request.DefineConstants["PowerForgeMsiSourceFramework"] = prepare.Framework;
         request.DefineConstants["PowerForgeMsiSourceRuntime"] = prepare.Runtime;

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -47,15 +47,22 @@ internal static class PowerForgeInstallerDefinitionValidator
             "installer dialog ID");
         // Reserve the whole generated-dialog prefix case-insensitively so authored dialogs cannot
         // collide with future generated validation prompts such as PowerForgeRequiredInputDlg2.
-        if (definition.Dialogs.Any(dialog => dialog.Id.StartsWith(RequiredInputDialogIdPrefix, StringComparison.OrdinalIgnoreCase)))
+        if (definition.Dialogs.Any(dialog =>
+            !string.IsNullOrWhiteSpace(dialog.Id) &&
+            dialog.Id.StartsWith(RequiredInputDialogIdPrefix, StringComparison.OrdinalIgnoreCase)))
         {
             throw new InvalidOperationException(
                 $"Installer dialog IDs starting with '{RequiredInputDialogIdPrefix}' are reserved for generated required-input validation.");
         }
 
+        var directoryIds = definition.Directories
+            .SelectMany(tree => tree.Segments)
+            .Select(segment => segment.Id)
+            .Concat(new[] { definition.InstallDirectoryId });
+        if (definition.UseCompanyFolder)
+            directoryIds = directoryIds.Concat(new[] { "CompanyFolder" });
         EnsureUnique(
-            definition.Directories.SelectMany(tree => tree.Segments).Select(segment => segment.Id)
-                .Concat(new[] { definition.InstallDirectoryId }),
+            directoryIds,
             "installer directory ID");
         EnsureUnique(
             definition.Components.Select(component => component.Id),
@@ -150,11 +157,13 @@ internal static class PowerForgeInstallerDefinitionValidator
             {
                 Require(file.FileId, nameof(file.FileId));
                 RequireWixIdentifier(file.FileId, $"file component '{file.Id}' FileId");
+                Require(file.Source, nameof(file.Source));
             }
             else if (component is PowerForgeInstallerServiceComponent service)
             {
                 Require(service.FileId, nameof(service.FileId));
                 RequireWixIdentifier(service.FileId, $"service component '{service.Id}' FileId");
+                Require(service.Source, nameof(service.Source));
             }
             else if (component is PowerForgeInstallerRemoveFolderComponent removeFolder)
             {

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerFormatting.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerFormatting.cs
@@ -1,0 +1,32 @@
+using System.Text;
+
+namespace PowerForge;
+
+internal static class PowerForgeWixInstallerFormatting
+{
+    internal static string ToWixScope(PowerForgeInstallerScope scope)
+    {
+        return scope == PowerForgeInstallerScope.PerUser ? "perUser" : "perMachine";
+    }
+
+    internal static string ResolveInstallRootDirectoryId(PowerForgeInstallerScope scope)
+    {
+        return scope == PowerForgeInstallerScope.PerUser ? "LocalAppDataFolder" : "ProgramFiles64Folder";
+    }
+
+    internal static string EscapeFormattedText(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (ch == '[')
+                builder.Append(@"[\[]");
+            else if (ch == ']')
+                builder.Append(@"[\]]");
+            else
+                builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -39,7 +39,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XAttribute("Manufacturer", definition.Product.Manufacturer),
             new XAttribute("Version", definition.Product.Version),
             new XAttribute("UpgradeCode", definition.Product.UpgradeCode),
-            new XAttribute("Scope", ToWixScope(definition.Product.Scope)),
+            new XAttribute("Scope", PowerForgeWixInstallerFormatting.ToWixScope(definition.Product.Scope)),
             new XAttribute("Compressed", "yes"),
             new XElement(
                 WixNamespace + "MajorUpgrade",
@@ -57,7 +57,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         root.Add(EmitComponents(definition));
 
         var document = new XDocument(new XDeclaration("1.0", "utf-8", null), root);
-        return document.ToString(SaveOptions.DisableFormatting);
+        return document.ToString(SaveOptions.None);
     }
 
     /// <summary>
@@ -129,7 +129,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             sourceFiles.Select(file => new XElement("Compile", new XAttribute("Include", file)))));
 
         return new XDocument(new XDeclaration("1.0", "utf-8", null), project)
-            .ToString(SaveOptions.DisableFormatting);
+            .ToString(SaveOptions.None);
     }
 
     private static void EmitProperties(XElement package, PowerForgeInstallerDefinition definition)
@@ -245,11 +245,11 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         if (requiredInputs.Count == 1 &&
             !string.IsNullOrWhiteSpace(requiredInputs[0].RequiredMessage))
         {
-            return requiredInputs[0].RequiredMessage!.Trim();
+            return PowerForgeWixInstallerFormatting.EscapeFormattedText(requiredInputs[0].RequiredMessage!.Trim());
         }
 
         var labels = requiredInputs
-            .Select(input => string.IsNullOrWhiteSpace(input.Label) ? input.Id : input.Label)
+            .Select(input => PowerForgeWixInstallerFormatting.EscapeFormattedText(string.IsNullOrWhiteSpace(input.Label) ? input.Id : input.Label))
             .ToArray();
         var visibleLabels = labels.Take(MaxRequiredInputLabelsInMessage).ToArray();
         var remaining = labels.Length - visibleLabels.Length;
@@ -574,7 +574,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 WixNamespace + "Fragment",
                 new XElement(
                     WixNamespace + "StandardDirectory",
-                    new XAttribute("Id", "ProgramFiles64Folder"),
+                    new XAttribute("Id", PowerForgeWixInstallerFormatting.ResolveInstallRootDirectoryId(definition.Product.Scope)),
                     programFilesChild))
         };
 
@@ -678,12 +678,13 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     private static XElement EmitRemoveFolderComponent(PowerForgeInstallerRemoveFolderComponent removeFolder)
     {
         var component = CreateComponent(removeFolder);
-        if (!string.IsNullOrWhiteSpace(removeFolder.Condition))
-            component.Add(new XAttribute("Condition", removeFolder.Condition));
-        component.Add(new XElement(
+        var element = new XElement(
             UtilNamespace + "RemoveFolderEx",
             new XAttribute("On", "uninstall"),
-            new XAttribute("Property", removeFolder.PropertyName)));
+            new XAttribute("Property", removeFolder.PropertyName));
+        if (!string.IsNullOrWhiteSpace(removeFolder.Condition))
+            element.Add(new XAttribute("Condition", removeFolder.Condition));
+        component.Add(element);
         return component;
     }
 
@@ -757,6 +758,9 @@ public sealed class PowerForgeWixInstallerSourceEmitter
     private static XElement EmitShortcutComponent(PowerForgeInstallerShortcutComponent shortcut)
     {
         var component = CreateComponent(shortcut);
+        if (string.IsNullOrWhiteSpace(shortcut.Target) && string.IsNullOrWhiteSpace(shortcut.TargetFileId))
+            throw new InvalidOperationException($"Shortcut component '{shortcut.Id}' requires TargetFileId or Target.");
+
         var target = !string.IsNullOrWhiteSpace(shortcut.Target)
             ? shortcut.Target!
             : "[#" + shortcut.TargetFileId + "]";
@@ -789,8 +793,4 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XAttribute("Guid", component.Guid));
     }
 
-    private static string ToWixScope(PowerForgeInstallerScope scope)
-    {
-        return scope == PowerForgeInstallerScope.PerUser ? "perUser" : "perMachine";
-    }
 }

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -315,8 +315,18 @@
       },
       "required": ["Type", "Id", "ShortcutId", "Name"],
       "anyOf": [
-        { "required": ["TargetFileId"] },
-        { "required": ["Target"] }
+        {
+          "required": ["TargetFileId"],
+          "properties": {
+            "TargetFileId": { "type": "string", "minLength": 1, "pattern": "\\S" }
+          }
+        },
+        {
+          "required": ["Target"],
+          "properties": {
+            "Target": { "type": "string", "minLength": 1, "pattern": "\\S" }
+          }
+        }
       ]
     },
     "PowerForgeInstallerRegistryValueComponent": {
@@ -337,8 +347,18 @@
       },
       "required": ["Type", "Id", "Key", "Name"],
       "anyOf": [
-        { "required": ["Value"] },
-        { "required": ["ValueProperty"] }
+        {
+          "required": ["Value"],
+          "properties": {
+            "Value": { "type": "string", "pattern": "\\S" }
+          }
+        },
+        {
+          "required": ["ValueProperty"],
+          "properties": {
+            "ValueProperty": { "type": "string", "minLength": 1, "pattern": "\\S" }
+          }
+        }
       ]
     },
     "PowerForgeInstallerComponent": {


### PR DESCRIPTION
## Summary
- address valid generated WiX/MSI review follow-ups from closed installer PRs: generated workspace/output isolation, generated-project restore behavior, forced generated OutputPath precedence, and missing harvest validation for payload group references
- harden installer authoring validation/schema for null-only shortcut and registry payloads, missing file/service sources, reserved dialog IDs, and CompanyFolder ID collisions
- improve generated WiX output/debuggability and required-prompt formatting, including per-user install root selection and RemoveFolderEx condition placement

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~PowerForgeInstallerDefinitionValidatorTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"
- $env:POWERFORGE_RUN_WIX_COMPILE_TESTS='1'; dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"
- dotnet build .\PowerForge\PowerForge.csproj -c Release -f net472 --nologo
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 --nologo
- node .\Build\linecount.js --root PowerForge\Services\Installers --max 800 --ext .cs
- git diff --check
- git diff --cached --check
