### PR TITLE
Add ALC dependency type accelerator exposure

### DIFF
--- a/PSPublishModule/Cmdlets/NewConfigurationBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationBuildCommand.cs
@@ -271,6 +271,21 @@ public sealed class NewConfigurationBuildCommand : PSCmdlet
     [Alias("UseAssemblyLoadContext")]
     public SwitchParameter NETAssemblyLoadContext { get; set; }
 
+    /// <summary>Controls optional type accelerator exposure for dependency types loaded in the module AssemblyLoadContext.</summary>
+    [Parameter]
+    [Alias("AssemblyTypeAcceleratorMode")]
+    public AssemblyTypeAcceleratorExportMode? NETAssemblyTypeAcceleratorMode { get; set; }
+
+    /// <summary>Fully-qualified dependency type names to expose as PowerShell type accelerators from the module AssemblyLoadContext.</summary>
+    [Parameter]
+    [Alias("AssemblyTypeAccelerators")]
+    public string[]? NETAssemblyTypeAccelerators { get; set; }
+
+    /// <summary>Assembly simple names whose public types may be exposed as PowerShell type accelerators when assembly mode is enabled.</summary>
+    [Parameter]
+    [Alias("AssemblyTypeAcceleratorAssemblies")]
+    public string[]? NETAssemblyTypeAcceleratorAssemblies { get; set; }
+
     /// <summary>Kill locking processes before install.</summary>
     [Parameter] public SwitchParameter KillLockersBeforeInstall { get; set; }
 
@@ -386,6 +401,12 @@ public sealed class NewConfigurationBuildCommand : PSCmdlet
             NETHandleRuntimes = NETHandleRuntimes.IsPresent,
             NETAssemblyLoadContextSpecified = bound.ContainsKey(nameof(NETAssemblyLoadContext)),
             NETAssemblyLoadContext = NETAssemblyLoadContext.IsPresent,
+            NETAssemblyTypeAcceleratorModeSpecified = bound.ContainsKey(nameof(NETAssemblyTypeAcceleratorMode)),
+            NETAssemblyTypeAcceleratorMode = NETAssemblyTypeAcceleratorMode,
+            NETAssemblyTypeAcceleratorsSpecified = bound.ContainsKey(nameof(NETAssemblyTypeAccelerators)),
+            NETAssemblyTypeAccelerators = NETAssemblyTypeAccelerators,
+            NETAssemblyTypeAcceleratorAssembliesSpecified = bound.ContainsKey(nameof(NETAssemblyTypeAcceleratorAssemblies)),
+            NETAssemblyTypeAcceleratorAssemblies = NETAssemblyTypeAcceleratorAssemblies,
             KillLockersBeforeInstallSpecified = bound.ContainsKey(nameof(KillLockersBeforeInstall)),
             KillLockersBeforeInstall = KillLockersBeforeInstall.IsPresent,
             KillLockersForceSpecified = bound.ContainsKey(nameof(KillLockersForce)),

--- a/PowerForge.PowerShell/Models/BuildConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/BuildConfigurationRequest.cs
@@ -102,6 +102,12 @@ internal sealed class BuildConfigurationRequest
     public bool NETHandleRuntimes { get; set; }
     public bool NETAssemblyLoadContextSpecified { get; set; }
     public bool NETAssemblyLoadContext { get; set; }
+    public bool NETAssemblyTypeAcceleratorModeSpecified { get; set; }
+    public AssemblyTypeAcceleratorExportMode? NETAssemblyTypeAcceleratorMode { get; set; }
+    public bool NETAssemblyTypeAcceleratorsSpecified { get; set; }
+    public string[]? NETAssemblyTypeAccelerators { get; set; }
+    public bool NETAssemblyTypeAcceleratorAssembliesSpecified { get; set; }
+    public string[]? NETAssemblyTypeAcceleratorAssemblies { get; set; }
     public bool KillLockersBeforeInstallSpecified { get; set; }
     public bool KillLockersBeforeInstall { get; set; }
     public bool KillLockersForceSpecified { get; set; }

--- a/PowerForge.PowerShell/Services/BuildConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/BuildConfigurationFactory.cs
@@ -178,6 +178,9 @@ internal sealed class BuildConfigurationFactory
         if (request.NETBinaryModuleDocumentationSpecified) { EnsureBuildLibraries(); buildLibraries!.NETBinaryModuleDocumentation = request.NETBinaryModuleDocumentation; }
         if (request.NETHandleRuntimesSpecified) { EnsureBuildLibraries(); buildLibraries!.HandleRuntimes = request.NETHandleRuntimes; }
         if (request.NETAssemblyLoadContextSpecified) { EnsureBuildLibraries(); buildLibraries!.UseAssemblyLoadContext = request.NETAssemblyLoadContext; }
+        if (request.NETAssemblyTypeAcceleratorModeSpecified) { EnsureBuildLibraries(); buildLibraries!.AssemblyTypeAcceleratorMode = request.NETAssemblyTypeAcceleratorMode; }
+        if (request.NETAssemblyTypeAcceleratorsSpecified) { EnsureBuildLibraries(); buildLibraries!.AssemblyTypeAccelerators = request.NETAssemblyTypeAccelerators; }
+        if (request.NETAssemblyTypeAcceleratorAssembliesSpecified) { EnsureBuildLibraries(); buildLibraries!.AssemblyTypeAcceleratorAssemblies = request.NETAssemblyTypeAcceleratorAssemblies; }
         if (request.NETDoNotCopyLibrariesRecursivelySpecified) { EnsureBuildLibraries(); buildLibraries!.NETDoNotCopyLibrariesRecursively = request.NETDoNotCopyLibrariesRecursively; }
 
         if (buildLibraries is null)

--- a/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
+++ b/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
@@ -131,6 +131,12 @@ public static class LegacySegmentAdapter
                             : HasKey(buildLibraries, "NETAssemblyLoadContext")
                                 ? GetBool(buildLibraries, "NETAssemblyLoadContext")
                                 : null,
+                        AssemblyTypeAcceleratorMode = TryParseAssemblyTypeAcceleratorExportMode(GetString(buildLibraries, "AssemblyTypeAcceleratorMode"))
+                            ?? TryParseAssemblyTypeAcceleratorExportMode(GetString(buildLibraries, "NETAssemblyTypeAcceleratorMode")),
+                        AssemblyTypeAccelerators = GetStringArray(buildLibraries, "AssemblyTypeAccelerators")
+                            ?? GetStringArray(buildLibraries, "NETAssemblyTypeAccelerators"),
+                        AssemblyTypeAcceleratorAssemblies = GetStringArray(buildLibraries, "AssemblyTypeAcceleratorAssemblies")
+                            ?? GetStringArray(buildLibraries, "NETAssemblyTypeAcceleratorAssemblies"),
                         NETDoNotCopyLibrariesRecursively = HasKey(buildLibraries, "NETDoNotCopyLibrariesRecursively")
                             ? GetBool(buildLibraries, "NETDoNotCopyLibrariesRecursively")
                             : null
@@ -208,6 +214,12 @@ public static class LegacySegmentAdapter
                         : HasKey(conf, "NETAssemblyLoadContext")
                             ? GetBool(conf, "NETAssemblyLoadContext")
                             : null,
+                    AssemblyTypeAcceleratorMode = TryParseAssemblyTypeAcceleratorExportMode(GetString(conf, "AssemblyTypeAcceleratorMode"))
+                        ?? TryParseAssemblyTypeAcceleratorExportMode(GetString(conf, "NETAssemblyTypeAcceleratorMode")),
+                    AssemblyTypeAccelerators = GetStringArray(conf, "AssemblyTypeAccelerators")
+                        ?? GetStringArray(conf, "NETAssemblyTypeAccelerators"),
+                    AssemblyTypeAcceleratorAssemblies = GetStringArray(conf, "AssemblyTypeAcceleratorAssemblies")
+                        ?? GetStringArray(conf, "NETAssemblyTypeAcceleratorAssemblies"),
                     NETDoNotCopyLibrariesRecursively = HasKey(conf, "NETDoNotCopyLibrariesRecursively")
                         ? GetBool(conf, "NETDoNotCopyLibrariesRecursively")
                         : null
@@ -270,6 +282,12 @@ public static class LegacySegmentAdapter
     {
         if (string.IsNullOrWhiteSpace(value)) return null;
         return Enum.TryParse<InstallationStrategy>(value!.Trim(), ignoreCase: true, out var parsed) ? parsed : null;
+    }
+
+    private static AssemblyTypeAcceleratorExportMode? TryParseAssemblyTypeAcceleratorExportMode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return Enum.TryParse<AssemblyTypeAcceleratorExportMode>(value!.Trim(), ignoreCase: true, out var parsed) ? parsed : null;
     }
 
     private static IDictionary? GetDictionary(IDictionary dict, string key)

--- a/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
+++ b/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
@@ -286,8 +286,10 @@ public static class LegacySegmentAdapter
 
     private static AssemblyTypeAcceleratorExportMode? TryParseAssemblyTypeAcceleratorExportMode(string? value)
     {
-        if (string.IsNullOrWhiteSpace(value)) return null;
-        return Enum.TryParse<AssemblyTypeAcceleratorExportMode>(value!.Trim(), ignoreCase: true, out var parsed) ? parsed : null;
+        if (value is null) return null;
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0) return null;
+        return Enum.TryParse<AssemblyTypeAcceleratorExportMode>(trimmed, ignoreCase: true, out var parsed) ? parsed : null;
     }
 
     private static IDictionary? GetDictionary(IDictionary dict, string key)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MergeAndTests.cs
@@ -369,6 +369,9 @@ public sealed partial class ModulePipelineRunner
                 exportAssemblies,
                 handleRuntimes,
                 useAssemblyLoadContext: plan?.BuildSpec.UseAssemblyLoadContext ?? false,
+                assemblyTypeAcceleratorMode: plan?.BuildSpec.AssemblyTypeAcceleratorMode ?? AssemblyTypeAcceleratorExportMode.None,
+                assemblyTypeAccelerators: plan?.BuildSpec.AssemblyTypeAccelerators,
+                assemblyTypeAcceleratorAssemblies: plan?.BuildSpec.AssemblyTypeAcceleratorAssemblies,
                 conditionalFunctionDependencies: conditionalExportDependencies,
                 targetFrameworks: plan?.BuildSpec.Frameworks,
                 log: message => _logger.Info(message));

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -72,6 +72,9 @@ public sealed partial class ModulePipelineRunner
         bool? doNotCopyLibrariesRecursivelyFromSegments = null;
         bool? handleRuntimesFromSegments = null;
         bool? useAssemblyLoadContextFromSegments = null;
+        AssemblyTypeAcceleratorExportMode? assemblyTypeAcceleratorModeFromSegments = null;
+        string[]? assemblyTypeAcceleratorsFromSegments = null;
+        string[]? assemblyTypeAcceleratorAssembliesFromSegments = null;
         bool? disableBinaryCmdletScanFromSegments = null;
         string? resolveBinaryConflictsProjectName = null;
         bool? binaryModuleDocumentationRequested = null;
@@ -269,6 +272,18 @@ public sealed partial class ModulePipelineRunner
                         useAssemblyLoadContextFromSegments = bl.UseAssemblyLoadContext.Value;
                     else if (bl.NETAssemblyLoadContext.HasValue)
                         useAssemblyLoadContextFromSegments = bl.NETAssemblyLoadContext.Value;
+                    if (bl.AssemblyTypeAcceleratorMode.HasValue)
+                        assemblyTypeAcceleratorModeFromSegments = bl.AssemblyTypeAcceleratorMode.Value;
+                    else if (bl.NETAssemblyTypeAcceleratorMode.HasValue)
+                        assemblyTypeAcceleratorModeFromSegments = bl.NETAssemblyTypeAcceleratorMode.Value;
+                    if (bl.AssemblyTypeAccelerators is { Length: > 0 })
+                        assemblyTypeAcceleratorsFromSegments = bl.AssemblyTypeAccelerators;
+                    else if (bl.NETAssemblyTypeAccelerators is { Length: > 0 })
+                        assemblyTypeAcceleratorsFromSegments = bl.NETAssemblyTypeAccelerators;
+                    if (bl.AssemblyTypeAcceleratorAssemblies is { Length: > 0 })
+                        assemblyTypeAcceleratorAssembliesFromSegments = bl.AssemblyTypeAcceleratorAssemblies;
+                    else if (bl.NETAssemblyTypeAcceleratorAssemblies is { Length: > 0 })
+                        assemblyTypeAcceleratorAssembliesFromSegments = bl.NETAssemblyTypeAcceleratorAssemblies;
                     if (bl.BinaryModuleCmdletScanDisabled.HasValue) disableBinaryCmdletScanFromSegments = bl.BinaryModuleCmdletScanDisabled.Value;
                     if (bl.NETBinaryModuleDocumentation.HasValue) binaryModuleDocumentationRequested = bl.NETBinaryModuleDocumentation.Value;
                     break;
@@ -508,6 +523,22 @@ public sealed partial class ModulePipelineRunner
             exportAssemblies = new[] { inferred! };
         }
 
+        var assemblyTypeAccelerators = NormalizeStringArray(assemblyTypeAcceleratorsFromSegments ?? spec.Build.AssemblyTypeAccelerators);
+        var assemblyTypeAcceleratorAssemblies = NormalizeStringArray(assemblyTypeAcceleratorAssembliesFromSegments ?? spec.Build.AssemblyTypeAcceleratorAssemblies);
+        var assemblyTypeAcceleratorMode =
+            assemblyTypeAcceleratorModeFromSegments
+            ?? spec.Build.AssemblyTypeAcceleratorMode;
+        if (assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAccelerators.Length > 0)
+            assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.AllowList;
+        if (assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAcceleratorAssemblies.Length > 0)
+            assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.Assembly;
+
+        var typeAcceleratorsRequireAlc = assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None
+            || assemblyTypeAccelerators.Length > 0
+            || assemblyTypeAcceleratorAssemblies.Length > 0;
+        var effectiveUseAssemblyLoadContext = (useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext)
+            || typeAcceleratorsRequireAlc;
+
         var csprojRequiredReasons = refreshPsd1Only
             ? Array.Empty<string>()
             : BuildMissingCsprojReasonList(
@@ -518,7 +549,8 @@ public sealed partial class ModulePipelineRunner
                 excludeLibraryFilterFromSegments,
                 doNotCopyLibrariesRecursivelyFromSegments,
                 handleRuntimesFromSegments,
-                useAssemblyLoadContextFromSegments,
+                effectiveUseAssemblyLoadContext,
+                typeAcceleratorsRequireAlc,
                 resolveBinaryConflictsProjectName,
                 binaryModuleDocumentationRequested == true);
 
@@ -543,7 +575,10 @@ public sealed partial class ModulePipelineRunner
             ExcludeLibraryFilter = excludeLibraryFilterFromSegments ?? spec.Build.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively,
             HandleRuntimes = handleRuntimesFromSegments ?? spec.Build.HandleRuntimes,
-            UseAssemblyLoadContext = useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext,
+            UseAssemblyLoadContext = effectiveUseAssemblyLoadContext,
+            AssemblyTypeAcceleratorMode = assemblyTypeAcceleratorMode,
+            AssemblyTypeAccelerators = assemblyTypeAccelerators,
+            AssemblyTypeAcceleratorAssemblies = assemblyTypeAcceleratorAssemblies,
             DisableBinaryCmdletScan = disableBinaryCmdletScanFromSegments ?? spec.Build.DisableBinaryCmdletScan,
             CsprojRequiredReasons = string.IsNullOrWhiteSpace(csproj) ? csprojRequiredReasons : Array.Empty<string>(),
             BinaryConflictPriorityModuleNames = requiredModulesDraft
@@ -795,7 +830,8 @@ public sealed partial class ModulePipelineRunner
         string[]? excludeLibraryFilterFromSegments,
         bool? doNotCopyLibrariesRecursivelyFromSegments,
         bool? handleRuntimesFromSegments,
-        bool? useAssemblyLoadContextFromSegments,
+        bool effectiveUseAssemblyLoadContext,
+        bool typeAcceleratorsRequireAlc,
         string? resolveBinaryConflictsProjectName,
         bool binaryModuleDocumentationRequested)
     {
@@ -808,8 +844,6 @@ public sealed partial class ModulePipelineRunner
             doNotCopyLibrariesRecursivelyFromSegments ?? spec.Build.DoNotCopyLibrariesRecursively;
         var effectiveHandleRuntimes =
             handleRuntimesFromSegments ?? spec.Build.HandleRuntimes;
-        var effectiveUseAssemblyLoadContext =
-            useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext;
         var hasExplicitBinaryIntentBeyondFramework =
             syncNETProjectVersion
             || hasBinaryModules
@@ -819,6 +853,7 @@ public sealed partial class ModulePipelineRunner
             || effectiveDoNotCopyLibrariesRecursively
             || effectiveHandleRuntimes
             || effectiveUseAssemblyLoadContext
+            || typeAcceleratorsRequireAlc
             || binaryModuleDocumentationRequested;
 
         if (syncNETProjectVersion)
@@ -845,6 +880,9 @@ public sealed partial class ModulePipelineRunner
         if (effectiveUseAssemblyLoadContext)
             reasons.Add("UseAssemblyLoadContext");
 
+        if (typeAcceleratorsRequireAlc)
+            reasons.Add("NETAssemblyTypeAccelerators");
+
         if (binaryModuleDocumentationRequested)
             reasons.Add("NETBinaryModuleDocumentation");
 
@@ -856,6 +894,15 @@ public sealed partial class ModulePipelineRunner
     private static bool HasAnyConfiguredValues(string[]? values)
         => values is { Length: > 0 } &&
            values.Any(static value => !string.IsNullOrWhiteSpace(value));
+
+    private static string[] NormalizeStringArray(string[]? values)
+        => values is { Length: > 0 }
+            ? values
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : Array.Empty<string>();
 
     private bool TryAddExternalModuleDependency(
         string moduleName,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -531,10 +531,10 @@ public sealed partial class ModulePipelineRunner
             assemblyTypeAcceleratorModeFromSegments
             ?? spec.Build.AssemblyTypeAcceleratorMode
             ?? AssemblyTypeAcceleratorExportMode.None;
-        if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAccelerators.Length > 0)
-            assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.AllowList;
         if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAcceleratorAssemblies.Length > 0)
             assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.Assembly;
+        if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAccelerators.Length > 0)
+            assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.AllowList;
 
         var requestedUseAssemblyLoadContext = useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext;
         var typeAcceleratorsRequireAlc = assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None;

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -276,13 +276,13 @@ public sealed partial class ModulePipelineRunner
                         assemblyTypeAcceleratorModeFromSegments = bl.AssemblyTypeAcceleratorMode.Value;
                     else if (bl.NETAssemblyTypeAcceleratorMode.HasValue)
                         assemblyTypeAcceleratorModeFromSegments = bl.NETAssemblyTypeAcceleratorMode.Value;
-                    if (bl.AssemblyTypeAccelerators is { Length: > 0 })
+                    if (bl.AssemblyTypeAccelerators is not null)
                         assemblyTypeAcceleratorsFromSegments = bl.AssemblyTypeAccelerators;
-                    else if (bl.NETAssemblyTypeAccelerators is { Length: > 0 })
+                    else if (bl.NETAssemblyTypeAccelerators is not null)
                         assemblyTypeAcceleratorsFromSegments = bl.NETAssemblyTypeAccelerators;
-                    if (bl.AssemblyTypeAcceleratorAssemblies is { Length: > 0 })
+                    if (bl.AssemblyTypeAcceleratorAssemblies is not null)
                         assemblyTypeAcceleratorAssembliesFromSegments = bl.AssemblyTypeAcceleratorAssemblies;
-                    else if (bl.NETAssemblyTypeAcceleratorAssemblies is { Length: > 0 })
+                    else if (bl.NETAssemblyTypeAcceleratorAssemblies is not null)
                         assemblyTypeAcceleratorAssembliesFromSegments = bl.NETAssemblyTypeAcceleratorAssemblies;
                     if (bl.BinaryModuleCmdletScanDisabled.HasValue) disableBinaryCmdletScanFromSegments = bl.BinaryModuleCmdletScanDisabled.Value;
                     if (bl.NETBinaryModuleDocumentation.HasValue) binaryModuleDocumentationRequested = bl.NETBinaryModuleDocumentation.Value;
@@ -525,19 +525,20 @@ public sealed partial class ModulePipelineRunner
 
         var assemblyTypeAccelerators = NormalizeStringArray(assemblyTypeAcceleratorsFromSegments ?? spec.Build.AssemblyTypeAccelerators);
         var assemblyTypeAcceleratorAssemblies = NormalizeStringArray(assemblyTypeAcceleratorAssembliesFromSegments ?? spec.Build.AssemblyTypeAcceleratorAssemblies);
+        var assemblyTypeAcceleratorModeSpecified = assemblyTypeAcceleratorModeFromSegments.HasValue;
         var assemblyTypeAcceleratorMode =
             assemblyTypeAcceleratorModeFromSegments
             ?? spec.Build.AssemblyTypeAcceleratorMode;
-        if (assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAccelerators.Length > 0)
+        if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAccelerators.Length > 0)
             assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.AllowList;
-        if (assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAcceleratorAssemblies.Length > 0)
+        if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAcceleratorAssemblies.Length > 0)
             assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.Assembly;
 
-        var typeAcceleratorsRequireAlc = assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None
-            || assemblyTypeAccelerators.Length > 0
-            || assemblyTypeAcceleratorAssemblies.Length > 0;
-        var effectiveUseAssemblyLoadContext = (useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext)
-            || typeAcceleratorsRequireAlc;
+        var requestedUseAssemblyLoadContext = useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext;
+        var typeAcceleratorsRequireAlc = assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None;
+        var effectiveUseAssemblyLoadContext = requestedUseAssemblyLoadContext || typeAcceleratorsRequireAlc;
+        if (typeAcceleratorsRequireAlc && !requestedUseAssemblyLoadContext)
+            _logger.Info("Assembly type accelerators requested; UseAssemblyLoadContext automatically enabled.");
 
         var csprojRequiredReasons = refreshPsd1Only
             ? Array.Empty<string>()
@@ -549,7 +550,7 @@ public sealed partial class ModulePipelineRunner
                 excludeLibraryFilterFromSegments,
                 doNotCopyLibrariesRecursivelyFromSegments,
                 handleRuntimesFromSegments,
-                effectiveUseAssemblyLoadContext,
+                requestedUseAssemblyLoadContext,
                 typeAcceleratorsRequireAlc,
                 resolveBinaryConflictsProjectName,
                 binaryModuleDocumentationRequested == true);
@@ -830,7 +831,7 @@ public sealed partial class ModulePipelineRunner
         string[]? excludeLibraryFilterFromSegments,
         bool? doNotCopyLibrariesRecursivelyFromSegments,
         bool? handleRuntimesFromSegments,
-        bool effectiveUseAssemblyLoadContext,
+        bool useAssemblyLoadContextRequested,
         bool typeAcceleratorsRequireAlc,
         string? resolveBinaryConflictsProjectName,
         bool binaryModuleDocumentationRequested)
@@ -852,7 +853,7 @@ public sealed partial class ModulePipelineRunner
             || HasAnyConfiguredValues(spec.Build.ExcludeLibraryFilter)
             || effectiveDoNotCopyLibrariesRecursively
             || effectiveHandleRuntimes
-            || effectiveUseAssemblyLoadContext
+            || useAssemblyLoadContextRequested
             || typeAcceleratorsRequireAlc
             || binaryModuleDocumentationRequested;
 
@@ -877,7 +878,7 @@ public sealed partial class ModulePipelineRunner
         if (effectiveHandleRuntimes)
             reasons.Add("NETHandleRuntimes");
 
-        if (effectiveUseAssemblyLoadContext)
+        if (useAssemblyLoadContextRequested)
             reasons.Add("UseAssemblyLoadContext");
 
         if (typeAcceleratorsRequireAlc)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -525,10 +525,12 @@ public sealed partial class ModulePipelineRunner
 
         var assemblyTypeAccelerators = NormalizeStringArray(assemblyTypeAcceleratorsFromSegments ?? spec.Build.AssemblyTypeAccelerators);
         var assemblyTypeAcceleratorAssemblies = NormalizeStringArray(assemblyTypeAcceleratorAssembliesFromSegments ?? spec.Build.AssemblyTypeAcceleratorAssemblies);
-        var assemblyTypeAcceleratorModeSpecified = assemblyTypeAcceleratorModeFromSegments.HasValue;
+        var assemblyTypeAcceleratorModeSpecified = assemblyTypeAcceleratorModeFromSegments.HasValue
+            || spec.Build.AssemblyTypeAcceleratorMode.HasValue;
         var assemblyTypeAcceleratorMode =
             assemblyTypeAcceleratorModeFromSegments
-            ?? spec.Build.AssemblyTypeAcceleratorMode;
+            ?? spec.Build.AssemblyTypeAcceleratorMode
+            ?? AssemblyTypeAcceleratorExportMode.None;
         if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAccelerators.Length > 0)
             assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.AllowList;
         if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAcceleratorAssemblies.Length > 0)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -527,14 +527,12 @@ public sealed partial class ModulePipelineRunner
         var assemblyTypeAcceleratorAssemblies = NormalizeStringArray(assemblyTypeAcceleratorAssembliesFromSegments ?? spec.Build.AssemblyTypeAcceleratorAssemblies);
         var assemblyTypeAcceleratorModeSpecified = assemblyTypeAcceleratorModeFromSegments.HasValue
             || spec.Build.AssemblyTypeAcceleratorMode.HasValue;
-        var assemblyTypeAcceleratorMode =
-            assemblyTypeAcceleratorModeFromSegments
-            ?? spec.Build.AssemblyTypeAcceleratorMode
-            ?? AssemblyTypeAcceleratorExportMode.None;
-        if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAcceleratorAssemblies.Length > 0)
-            assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.Assembly;
-        if (!assemblyTypeAcceleratorModeSpecified && assemblyTypeAcceleratorMode == AssemblyTypeAcceleratorExportMode.None && assemblyTypeAccelerators.Length > 0)
-            assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.AllowList;
+        var assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorOptions.ResolveMode(
+            assemblyTypeAcceleratorModeSpecified
+                ? assemblyTypeAcceleratorModeFromSegments ?? spec.Build.AssemblyTypeAcceleratorMode
+                : null,
+            assemblyTypeAccelerators,
+            assemblyTypeAcceleratorAssemblies);
 
         var requestedUseAssemblyLoadContext = useAssemblyLoadContextFromSegments ?? spec.Build.UseAssemblyLoadContext;
         var typeAcceleratorsRequireAlc = assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None;

--- a/PowerForge.Tests/BuildConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/BuildConfigurationFactoryTests.cs
@@ -29,6 +29,10 @@ public sealed class BuildConfigurationFactoryTests
             NETProjectPath = "src/Sample.csproj",
             NETAssemblyLoadContextSpecified = true,
             NETAssemblyLoadContext = true,
+            NETAssemblyTypeAcceleratorModeSpecified = true,
+            NETAssemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.AllowList,
+            NETAssemblyTypeAcceleratorsSpecified = true,
+            NETAssemblyTypeAccelerators = new[] { "HtmlAgilityPack.HtmlEntity" },
             SkipBuiltinReplacementsSpecified = true,
             SkipBuiltinReplacements = true
         });
@@ -51,6 +55,8 @@ public sealed class BuildConfigurationFactoryTests
         Assert.Equal("Release", libraries.BuildLibraries.Configuration);
         Assert.Equal("src/Sample.csproj", libraries.BuildLibraries.NETProjectPath);
         Assert.True(libraries.BuildLibraries.UseAssemblyLoadContext);
+        Assert.Equal(AssemblyTypeAcceleratorExportMode.AllowList, libraries.BuildLibraries.AssemblyTypeAcceleratorMode);
+        Assert.Equal(new[] { "HtmlAgilityPack.HtmlEntity" }, libraries.BuildLibraries.AssemblyTypeAccelerators);
 
         var placeholder = Assert.IsType<ConfigurationPlaceHolderOptionSegment>(segments[3]);
         Assert.True(placeholder.PlaceHolderOption.SkipBuiltinReplacements);

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -214,21 +214,63 @@ public class ModuleBootstrapperGeneratorTests
                 assemblyTypeAccelerators: new[] { "Dependency.Widget" });
 
             var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
-            Assert.Contains("Register-PowerForgeAssemblyTypeAccelerators", bootstrapper);
+            Assert.Contains("$RegisterPowerForgeAssemblyTypeAccelerators = {", bootstrapper);
             Assert.Contains("$Mode = 'AllowList'", bootstrapper);
             Assert.Contains("$RequestedTypes = @('Dependency.Widget')", bootstrapper);
             Assert.Contains("System.Management.Automation.TypeAccelerators", bootstrapper);
             Assert.Contains("AssemblyLoadContext]::GetLoadContext($ModuleAssembly)", bootstrapper);
-            Assert.Contains("Add-PowerForgeTypeAccelerator", bootstrapper);
+            Assert.Contains("$AddPowerForgeTypeAccelerator = {", bootstrapper);
             Assert.Contains("Type accelerator '$Name' already exists", bootstrapper);
+            Assert.Contains("$PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove", bootstrapper);
+            Assert.Contains("& $PreviousPowerForgeOnRemove @args", bootstrapper);
             Assert.Contains("OnRemove", bootstrapper);
-            Assert.Contains("Register-PowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder", bootstrapper);
+            Assert.Contains("& $RegisterPowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder", bootstrapper);
+            Assert.DoesNotContain("function Register-PowerForgeAssemblyTypeAccelerators", bootstrapper);
         }
         finally
         {
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
         }
+    }
+
+    [Fact]
+    public void Generate_WithAssemblyLoadContextAssemblyTypeAccelerators_WritesAssemblyModeWithEnumerationGuard()
+    {
+        var block = BuildTypeAcceleratorBlock(
+            AssemblyTypeAcceleratorExportMode.Assembly,
+            Array.Empty<string>(),
+            new[] { "Dependency" });
+
+        Assert.Contains("$Mode = 'Assembly'", block);
+        Assert.Contains("$RequestedAssemblies = @('Dependency')", block);
+        Assert.Contains("$ExportedTypes = @($Assembly.GetExportedTypes())", block);
+        Assert.Contains("Could not enumerate exported types from assembly '$AssemblyName'", block);
+        Assert.Contains("& $AddPowerForgeTypeAccelerator -Type $Type", block);
+    }
+
+    [Fact]
+    public void Generate_WithTypeAcceleratorModeNone_DoesNotInferFromConfiguredLists()
+    {
+        var block = BuildTypeAcceleratorBlock(
+            AssemblyTypeAcceleratorExportMode.None,
+            new[] { "Dependency.Widget" },
+            Array.Empty<string>());
+
+        Assert.Equal(string.Empty, block);
+    }
+
+    private static string BuildTypeAcceleratorBlock(
+        AssemblyTypeAcceleratorExportMode mode,
+        IReadOnlyList<string>? typeNames,
+        IReadOnlyList<string>? assemblyNames)
+    {
+        var method = typeof(ModuleBootstrapperGenerator).GetMethod(
+            "BuildTypeAcceleratorBlock",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+
+        return Assert.IsType<string>(method.Invoke(null, new object?[] { mode, typeNames, assemblyNames }));
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -222,7 +222,8 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("AssemblyLoadContext]::GetLoadContext($ModuleAssembly)", bootstrapper);
             Assert.Contains("$AddPowerForgeTypeAccelerator = {", bootstrapper);
             Assert.Contains("Type accelerator '$Name' already exists", bootstrapper);
-            Assert.Contains("if ([object]::ReferenceEquals($Existing[$Name], $Type)) {\r\n                return", bootstrapper);
+            Assert.Contains("if ([object]::ReferenceEquals($Existing[$Name], $Type)) {", bootstrapper);
+            Assert.Contains("return", bootstrapper);
             Assert.Contains("$PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove", bootstrapper);
             Assert.Contains("& $PreviousPowerForgeOnRemove @args", bootstrapper);
             Assert.Contains("OnRemove", bootstrapper);

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -281,6 +281,36 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void Generate_WithAssemblyLoadContextTypeAcceleratorModeNone_DoesNotWriteTypeAcceleratorComment()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-none-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
+        File.WriteAllText(Path.Combine(root, "Lib", "Core", "DemoModule.dll"), string.Empty);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true,
+                assemblyTypeAcceleratorMode: AssemblyTypeAcceleratorExportMode.None);
+
+            var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
+            Assert.DoesNotContain("Type accelerator registration relies on", bootstrapper);
+            Assert.DoesNotContain("$RegisterPowerForgeAssemblyTypeAccelerators", bootstrapper);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Generate_WithScriptLayoutOnly_WritesScriptLoaderWithoutBinaryLoader()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-script-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -255,6 +255,21 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void Generate_WithAssemblyLoadContextAssemblyOnlyTypeAccelerators_WritesEmptyAllowList()
+    {
+        var block = ModuleBootstrapperGenerator.BuildTypeAcceleratorBlock(
+            AssemblyTypeAcceleratorExportMode.Assembly,
+            Array.Empty<string>(),
+            new[] { "Dependency" });
+
+        Assert.Contains("$Mode = 'Assembly'", block);
+        Assert.Contains("$RequestedTypes = @()", block);
+        Assert.Contains("$RequestedAssemblies = @('Dependency')", block);
+        Assert.Contains("$ExportedTypes = @($Assembly.GetExportedTypes())", block);
+        Assert.Contains("foreach ($TypeName in $RequestedTypes)", block);
+    }
+
+    [Fact]
     public void Generate_WithTypeAcceleratorModeNone_DoesNotInferFromConfiguredLists()
     {
         var block = ModuleBootstrapperGenerator.BuildTypeAcceleratorBlock(

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -242,14 +242,16 @@ public class ModuleBootstrapperGeneratorTests
     {
         var block = ModuleBootstrapperGenerator.BuildTypeAcceleratorBlock(
             AssemblyTypeAcceleratorExportMode.Assembly,
-            Array.Empty<string>(),
+            new[] { "Dependency.Widget" },
             new[] { "Dependency" });
 
         Assert.Contains("$Mode = 'Assembly'", block);
+        Assert.Contains("$RequestedTypes = @('Dependency.Widget')", block);
         Assert.Contains("$RequestedAssemblies = @('Dependency')", block);
         Assert.Contains("$ExportedTypes = @($Assembly.GetExportedTypes())", block);
         Assert.Contains("Could not enumerate exported types from assembly '$AssemblyName'", block);
         Assert.Contains("& $AddPowerForgeTypeAccelerator -Type $Type", block);
+        Assert.Contains("foreach ($TypeName in $RequestedTypes)", block);
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -218,14 +218,17 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("$Mode = 'AllowList'", bootstrapper);
             Assert.Contains("$RequestedTypes = @('Dependency.Widget')", bootstrapper);
             Assert.Contains("System.Management.Automation.TypeAccelerators", bootstrapper);
+            Assert.Contains("$TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')", bootstrapper);
             Assert.Contains("AssemblyLoadContext]::GetLoadContext($ModuleAssembly)", bootstrapper);
             Assert.Contains("$AddPowerForgeTypeAccelerator = {", bootstrapper);
             Assert.Contains("Type accelerator '$Name' already exists", bootstrapper);
+            Assert.Contains("if ([object]::ReferenceEquals($Existing[$Name], $Type)) {\r\n                return", bootstrapper);
             Assert.Contains("$PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove", bootstrapper);
             Assert.Contains("& $PreviousPowerForgeOnRemove @args", bootstrapper);
             Assert.Contains("OnRemove", bootstrapper);
             Assert.Contains("& $RegisterPowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder", bootstrapper);
             Assert.DoesNotContain("function Register-PowerForgeAssemblyTypeAccelerators", bootstrapper);
+            Assert.DoesNotContain("$Mode -eq 'None'", bootstrapper);
         }
         finally
         {
@@ -237,7 +240,7 @@ public class ModuleBootstrapperGeneratorTests
     [Fact]
     public void Generate_WithAssemblyLoadContextAssemblyTypeAccelerators_WritesAssemblyModeWithEnumerationGuard()
     {
-        var block = BuildTypeAcceleratorBlock(
+        var block = ModuleBootstrapperGenerator.BuildTypeAcceleratorBlock(
             AssemblyTypeAcceleratorExportMode.Assembly,
             Array.Empty<string>(),
             new[] { "Dependency" });
@@ -252,25 +255,12 @@ public class ModuleBootstrapperGeneratorTests
     [Fact]
     public void Generate_WithTypeAcceleratorModeNone_DoesNotInferFromConfiguredLists()
     {
-        var block = BuildTypeAcceleratorBlock(
+        var block = ModuleBootstrapperGenerator.BuildTypeAcceleratorBlock(
             AssemblyTypeAcceleratorExportMode.None,
             new[] { "Dependency.Widget" },
             Array.Empty<string>());
 
         Assert.Equal(string.Empty, block);
-    }
-
-    private static string BuildTypeAcceleratorBlock(
-        AssemblyTypeAcceleratorExportMode mode,
-        IReadOnlyList<string>? typeNames,
-        IReadOnlyList<string>? assemblyNames)
-    {
-        var method = typeof(ModuleBootstrapperGenerator).GetMethod(
-            "BuildTypeAcceleratorBlock",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        Assert.NotNull(method);
-
-        return Assert.IsType<string>(method.Invoke(null, new object?[] { mode, typeNames, assemblyNames }));
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -192,6 +192,46 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    [Trait("Category", "Integration")]
+    public void Generate_WithAssemblyLoadContextTypeAccelerators_WritesAllowListedRegistrationBlock()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-types-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
+        File.WriteAllText(Path.Combine(root, "Lib", "Core", "DemoModule.dll"), string.Empty);
+        File.WriteAllText(Path.Combine(root, "Lib", "Core", "Dependency.dll"), string.Empty);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true,
+                assemblyTypeAcceleratorMode: AssemblyTypeAcceleratorExportMode.AllowList,
+                assemblyTypeAccelerators: new[] { "Dependency.Widget" });
+
+            var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
+            Assert.Contains("Register-PowerForgeAssemblyTypeAccelerators", bootstrapper);
+            Assert.Contains("$Mode = 'AllowList'", bootstrapper);
+            Assert.Contains("$RequestedTypes = @('Dependency.Widget')", bootstrapper);
+            Assert.Contains("System.Management.Automation.TypeAccelerators", bootstrapper);
+            Assert.Contains("AssemblyLoadContext]::GetLoadContext($ModuleAssembly)", bootstrapper);
+            Assert.Contains("Add-PowerForgeTypeAccelerator", bootstrapper);
+            Assert.Contains("Type accelerator '$Name' already exists", bootstrapper);
+            Assert.Contains("OnRemove", bootstrapper);
+            Assert.Contains("Register-PowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder", bootstrapper);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Generate_WithScriptLayoutOnly_WritesScriptLoaderWithoutBinaryLoader()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-script-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -543,6 +543,41 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void Plan_ExplicitBuildSpecTypeAcceleratorModeNone_DoesNotInferAllowListFromConfiguredTypes()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0",
+                    AssemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.None,
+                    AssemblyTypeAccelerators = new[] { "HtmlAgilityPack.HtmlEntity" }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.False(plan.BuildSpec.UseAssemblyLoadContext);
+            Assert.Equal(AssemblyTypeAcceleratorExportMode.None, plan.BuildSpec.AssemblyTypeAcceleratorMode);
+            Assert.Equal(new[] { "HtmlAgilityPack.HtmlEntity" }, plan.BuildSpec.AssemblyTypeAccelerators);
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_LaterBuildLibrariesSegmentCanClearTypeAcceleratorLists()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -621,6 +656,42 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
             Assert.Contains("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", bootstrapper);
             Assert.Contains("$Mode = 'AllowList'", bootstrapper);
             Assert.Contains("$RequestedTypes = @('Dependency.Widget')", bootstrapper);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void BuildToStaging_DirectBuildSpecExplicitNone_DoesNotEmitTypeAcceleratorBootstrapper()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "DemoModule";
+            var source = Path.Combine(tempRoot.FullName, "src");
+            var staging = Path.Combine(tempRoot.FullName, "staging");
+            WriteMinimalBinaryModule(source, moduleName);
+
+            var pipeline = ModuleBuildPipelineFactory.Create(new NullLogger());
+            var result = pipeline.BuildToStaging(new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = source,
+                StagingPath = staging,
+                Version = "1.0.0",
+                Frameworks = new[] { "net8.0" },
+                ExportAssemblies = new[] { moduleName + ".dll" },
+                DisableBinaryCmdletScan = true,
+                AssemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.None,
+                AssemblyTypeAccelerators = new[] { "Dependency.Widget" }
+            });
+
+            var bootstrapper = File.ReadAllText(Path.Combine(result.StagingPath, moduleName + ".psm1"));
+            Assert.DoesNotContain("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", bootstrapper);
+            Assert.DoesNotContain("$RegisterPowerForgeAssemblyTypeAccelerators", bootstrapper);
+            Assert.DoesNotContain("Dependency.Widget", bootstrapper);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -490,7 +490,137 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
             Assert.True(plan.BuildSpec.UseAssemblyLoadContext);
             Assert.Equal(AssemblyTypeAcceleratorExportMode.AllowList, plan.BuildSpec.AssemblyTypeAcceleratorMode);
             Assert.Equal(new[] { "HtmlAgilityPack.HtmlEntity" }, plan.BuildSpec.AssemblyTypeAccelerators);
-            Assert.Equal(new[] { "UseAssemblyLoadContext", "NETAssemblyTypeAccelerators" }, plan.BuildSpec.CsprojRequiredReasons);
+            Assert.Equal(new[] { "NETAssemblyTypeAccelerators" }, plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_ExplicitTypeAcceleratorModeNone_DoesNotInferAllowListFromConfiguredTypes()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            AssemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.None,
+                            AssemblyTypeAccelerators = new[] { "HtmlAgilityPack.HtmlEntity" }
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.False(plan.BuildSpec.UseAssemblyLoadContext);
+            Assert.Equal(AssemblyTypeAcceleratorExportMode.None, plan.BuildSpec.AssemblyTypeAcceleratorMode);
+            Assert.Equal(new[] { "HtmlAgilityPack.HtmlEntity" }, plan.BuildSpec.AssemblyTypeAccelerators);
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_LaterBuildLibrariesSegmentCanClearTypeAcceleratorLists()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            AssemblyTypeAccelerators = new[] { "HtmlAgilityPack.HtmlEntity" }
+                        }
+                    },
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            AssemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.None,
+                            AssemblyTypeAccelerators = Array.Empty<string>()
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.False(plan.BuildSpec.UseAssemblyLoadContext);
+            Assert.Equal(AssemblyTypeAcceleratorExportMode.None, plan.BuildSpec.AssemblyTypeAcceleratorMode);
+            Assert.Empty(plan.BuildSpec.AssemblyTypeAccelerators);
+            Assert.Empty(plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void BuildToStaging_DirectBuildSpecTypeAccelerators_EnableAssemblyLoadContextBootstrapper()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "DemoModule";
+            var source = Path.Combine(tempRoot.FullName, "src");
+            var staging = Path.Combine(tempRoot.FullName, "staging");
+            WriteMinimalBinaryModule(source, moduleName);
+
+            var pipeline = ModuleBuildPipelineFactory.Create(new NullLogger());
+            var result = pipeline.BuildToStaging(new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = source,
+                StagingPath = staging,
+                Version = "1.0.0",
+                Frameworks = new[] { "net8.0" },
+                ExportAssemblies = new[] { moduleName + ".dll" },
+                DisableBinaryCmdletScan = true,
+                AssemblyTypeAccelerators = new[] { "Dependency.Widget" }
+            });
+
+            var bootstrapper = File.ReadAllText(Path.Combine(result.StagingPath, moduleName + ".psm1"));
+            Assert.Contains("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", bootstrapper);
+            Assert.Contains("$Mode = 'AllowList'", bootstrapper);
+            Assert.Contains("$RequestedTypes = @('Dependency.Widget')", bootstrapper);
         }
         finally
         {
@@ -586,5 +716,26 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
         {
             try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
         }
+    }
+
+    private static void WriteMinimalBinaryModule(string moduleRoot, string moduleName)
+    {
+        Directory.CreateDirectory(moduleRoot);
+        Directory.CreateDirectory(Path.Combine(moduleRoot, "Lib", "Core"));
+        File.WriteAllText(Path.Combine(moduleRoot, moduleName + ".psm1"), string.Empty);
+        File.WriteAllText(Path.Combine(moduleRoot, "Lib", "Core", moduleName + ".dll"), string.Empty);
+
+        var psd1 = string.Join(Environment.NewLine, new[]
+        {
+            "@{",
+            $"    RootModule = '{moduleName}.psm1'",
+            "    ModuleVersion = '1.0.0'",
+            "    FunctionsToExport = @()",
+            "    CmdletsToExport = @()",
+            "    AliasesToExport = @()",
+            "}"
+        }) + Environment.NewLine;
+
+        File.WriteAllText(Path.Combine(moduleRoot, moduleName + ".psd1"), psd1);
     }
 }

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -456,6 +456,49 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void Plan_TypeAccelerators_EnableAssemblyLoadContextAndRecordMissingCsprojReason()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            AssemblyTypeAccelerators = new[] { "HtmlAgilityPack.HtmlEntity" }
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(plan.BuildSpec.UseAssemblyLoadContext);
+            Assert.Equal(AssemblyTypeAcceleratorExportMode.AllowList, plan.BuildSpec.AssemblyTypeAcceleratorMode);
+            Assert.Equal(new[] { "HtmlAgilityPack.HtmlEntity" }, plan.BuildSpec.AssemblyTypeAccelerators);
+            Assert.Equal(new[] { "UseAssemblyLoadContext", "NETAssemblyTypeAccelerators" }, plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_UsesLastBuildLibrariesValue_ForDoNotCopyLibrariesRecursivelyReason()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -499,6 +499,51 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void Plan_TypeAcceleratorLists_InferAssemblyModeWhenBothListsAreConfigured()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "src"));
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "PSParseHTML",
+                    SourcePath = projectRoot.FullName,
+                    Version = "1.0.0"
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            AssemblyTypeAccelerators = new[] { "HtmlAgilityPack.HtmlEntity" },
+                            AssemblyTypeAcceleratorAssemblies = new[] { "HtmlAgilityPack" }
+                        }
+                    }
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+
+            Assert.True(plan.BuildSpec.UseAssemblyLoadContext);
+            Assert.Equal(AssemblyTypeAcceleratorExportMode.Assembly, plan.BuildSpec.AssemblyTypeAcceleratorMode);
+            Assert.Equal(new[] { "HtmlAgilityPack.HtmlEntity" }, plan.BuildSpec.AssemblyTypeAccelerators);
+            Assert.Equal(new[] { "HtmlAgilityPack" }, plan.BuildSpec.AssemblyTypeAcceleratorAssemblies);
+            Assert.Equal(new[] { "NETAssemblyTypeAccelerators" }, plan.BuildSpec.CsprojRequiredReasons);
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_ExplicitTypeAcceleratorModeNone_DoesNotInferAllowListFromConfiguredTypes()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Models/AssemblyTypeAcceleratorOptions.cs
+++ b/PowerForge/Models/AssemblyTypeAcceleratorOptions.cs
@@ -3,7 +3,7 @@ namespace PowerForge;
 /// <summary>
 /// Shared helpers for resolving AssemblyLoadContext type accelerator settings.
 /// </summary>
-public static class AssemblyTypeAcceleratorOptions
+internal static class AssemblyTypeAcceleratorOptions
 {
     /// <summary>
     /// Resolves the effective type accelerator export mode from an optional explicit mode and configured lists.

--- a/PowerForge/Models/AssemblyTypeAcceleratorOptions.cs
+++ b/PowerForge/Models/AssemblyTypeAcceleratorOptions.cs
@@ -1,0 +1,34 @@
+namespace PowerForge;
+
+/// <summary>
+/// Shared helpers for resolving AssemblyLoadContext type accelerator settings.
+/// </summary>
+public static class AssemblyTypeAcceleratorOptions
+{
+    /// <summary>
+    /// Resolves the effective type accelerator export mode from an optional explicit mode and configured lists.
+    /// </summary>
+    public static AssemblyTypeAcceleratorExportMode ResolveMode(
+        AssemblyTypeAcceleratorExportMode? mode,
+        IReadOnlyList<string>? typeNames,
+        IReadOnlyList<string>? assemblyNames)
+    {
+        if (mode.HasValue)
+            return mode.Value;
+
+        if (HasAnyConfiguredValue(assemblyNames))
+            return AssemblyTypeAcceleratorExportMode.Assembly;
+
+        if (HasAnyConfiguredValue(typeNames))
+            return AssemblyTypeAcceleratorExportMode.AllowList;
+
+        return AssemblyTypeAcceleratorExportMode.None;
+    }
+
+    /// <summary>
+    /// Returns true when the configured list contains at least one non-blank value.
+    /// </summary>
+    public static bool HasAnyConfiguredValue(IReadOnlyList<string>? values)
+        => values is { Count: > 0 }
+           && values.Any(static value => !string.IsNullOrWhiteSpace(value));
+}

--- a/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
@@ -103,6 +103,8 @@ public enum AssemblyTypeAcceleratorExportMode
     /// <summary>Register only explicitly configured fully-qualified type names.</summary>
     AllowList = 1,
 
-    /// <summary>Register all public types from explicitly configured assemblies.</summary>
+    /// <summary>
+    /// Register all public types from explicitly configured assemblies, plus any explicitly configured type names.
+    /// </summary>
     Assembly = 2
 }

--- a/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationBuildLibrariesSegment.cs
@@ -70,6 +70,39 @@ public sealed class BuildLibrariesConfiguration
     /// <summary>Legacy alias for <see cref="UseAssemblyLoadContext"/>.</summary>
     public bool? NETAssemblyLoadContext { get; set; }
 
+    /// <summary>Controls optional PowerShell type accelerator exposure for assemblies loaded in the module AssemblyLoadContext.</summary>
+    public AssemblyTypeAcceleratorExportMode? AssemblyTypeAcceleratorMode { get; set; }
+
+    /// <summary>Legacy .NET build alias for <see cref="AssemblyTypeAcceleratorMode"/>.</summary>
+    public AssemblyTypeAcceleratorExportMode? NETAssemblyTypeAcceleratorMode { get; set; }
+
+    /// <summary>Fully-qualified type names to expose as PowerShell type accelerators from the module AssemblyLoadContext.</summary>
+    public string[]? AssemblyTypeAccelerators { get; set; }
+
+    /// <summary>Legacy .NET build alias for <see cref="AssemblyTypeAccelerators"/>.</summary>
+    public string[]? NETAssemblyTypeAccelerators { get; set; }
+
+    /// <summary>Assembly simple names whose public types may be exposed as PowerShell type accelerators when assembly mode is enabled.</summary>
+    public string[]? AssemblyTypeAcceleratorAssemblies { get; set; }
+
+    /// <summary>Legacy .NET build alias for <see cref="AssemblyTypeAcceleratorAssemblies"/>.</summary>
+    public string[]? NETAssemblyTypeAcceleratorAssemblies { get; set; }
+
     /// <summary>Do not copy libraries recursively (legacy).</summary>
     public bool? NETDoNotCopyLibrariesRecursively { get; set; }
+}
+
+/// <summary>
+/// Controls how PowerForge exposes types loaded in a module-scoped AssemblyLoadContext to PowerShell callers.
+/// </summary>
+public enum AssemblyTypeAcceleratorExportMode
+{
+    /// <summary>Do not register type accelerators for ALC-loaded dependency types.</summary>
+    None = 0,
+
+    /// <summary>Register only explicitly configured fully-qualified type names.</summary>
+    AllowList = 1,
+
+    /// <summary>Register all public types from explicitly configured assemblies.</summary>
+    Assembly = 2
 }

--- a/PowerForge/Models/ModuleBuildSpec.cs
+++ b/PowerForge/Models/ModuleBuildSpec.cs
@@ -112,6 +112,21 @@ public sealed class ModuleBuildSpec
     public bool UseAssemblyLoadContext { get; set; }
 
     /// <summary>
+    /// Controls optional type accelerator exposure for assemblies loaded in the module AssemblyLoadContext.
+    /// </summary>
+    public AssemblyTypeAcceleratorExportMode AssemblyTypeAcceleratorMode { get; set; }
+
+    /// <summary>
+    /// Fully-qualified type names to expose as PowerShell type accelerators from the module AssemblyLoadContext.
+    /// </summary>
+    public string[] AssemblyTypeAccelerators { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Assembly simple names whose public types may be exposed as PowerShell type accelerators when assembly mode is enabled.
+    /// </summary>
+    public string[] AssemblyTypeAcceleratorAssemblies { get; set; } = Array.Empty<string>();
+
+    /// <summary>
     /// When true, keeps the staging directory after a successful build.
     /// </summary>
     public bool KeepStaging { get; set; }

--- a/PowerForge/Models/ModuleBuildSpec.cs
+++ b/PowerForge/Models/ModuleBuildSpec.cs
@@ -114,7 +114,7 @@ public sealed class ModuleBuildSpec
     /// <summary>
     /// Controls optional type accelerator exposure for assemblies loaded in the module AssemblyLoadContext.
     /// </summary>
-    public AssemblyTypeAcceleratorExportMode AssemblyTypeAcceleratorMode { get; set; }
+    public AssemblyTypeAcceleratorExportMode? AssemblyTypeAcceleratorMode { get; set; }
 
     /// <summary>
     /// Fully-qualified type names to expose as PowerShell type accelerators from the module AssemblyLoadContext.

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -63,6 +63,7 @@ if ($PSEdition -eq 'Core') {
         $ModuleAssembly = [{{LoaderTypeName}}]::LoadModule($ModuleAssemblyPath, '{{ModuleName}}')
         $InnerModule = & $ImportModule -Assembly $ModuleAssembly -Force -PassThru -ErrorAction Stop
 
+{{TypeAcceleratorBlock}}
         if ($InnerModule) {
             # Import-Module -Assembly loads the inner binary module into its own module object. PowerShell has no
             # public API to copy those exported cmdlets back to the script-module wrapper, so this uses the same

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -63,6 +63,7 @@ if ($PSEdition -eq 'Core') {
         $ModuleAssembly = [{{LoaderTypeName}}]::LoadModule($ModuleAssemblyPath, '{{ModuleName}}')
         $InnerModule = & $ImportModule -Assembly $ModuleAssembly -Force -PassThru -ErrorAction Stop
 
+        # Type accelerator registration relies on $ModuleAssembly and $LibFolder from this ALC loader scope.
 {{TypeAcceleratorBlock}}
         if ($InnerModule) {
             # Import-Module -Assembly loads the inner binary module into its own module object. PowerShell has no

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -63,7 +63,6 @@ if ($PSEdition -eq 'Core') {
         $ModuleAssembly = [{{LoaderTypeName}}]::LoadModule($ModuleAssemblyPath, '{{ModuleName}}')
         $InnerModule = & $ImportModule -Assembly $ModuleAssembly -Force -PassThru -ErrorAction Stop
 
-        # Type accelerator registration relies on $ModuleAssembly and $LibFolder from this ALC loader scope.
 {{TypeAcceleratorBlock}}
         if ($InnerModule) {
             # Import-Module -Assembly loads the inner binary module into its own module object. PowerShell has no

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -20,6 +20,9 @@ internal static class ModuleBootstrapperGenerator
         IReadOnlyList<string>? exportAssemblies,
         bool handleRuntimes,
         bool useAssemblyLoadContext = false,
+        AssemblyTypeAcceleratorExportMode assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorExportMode.None,
+        IReadOnlyList<string>? assemblyTypeAccelerators = null,
+        IReadOnlyList<string>? assemblyTypeAcceleratorAssemblies = null,
         IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies = null,
         IReadOnlyList<string>? targetFrameworks = null,
         Action<string>? log = null)
@@ -66,6 +69,9 @@ internal static class ModuleBootstrapperGenerator
             includeScriptLoader: hasScriptFolders,
             handleRuntimes: handleRuntimes,
             useAssemblyLoadContext: useAssemblyLoadContext,
+            assemblyTypeAcceleratorMode: assemblyTypeAcceleratorMode,
+            assemblyTypeAccelerators: assemblyTypeAccelerators,
+            assemblyTypeAcceleratorAssemblies: assemblyTypeAcceleratorAssemblies,
             conditionalFunctionDependencies: conditionalFunctionDependencies);
         WritePowerShellFile(psm1Path, psm1Content);
     }
@@ -239,6 +245,9 @@ internal static class ModuleBootstrapperGenerator
         bool includeScriptLoader,
         bool handleRuntimes,
         bool useAssemblyLoadContext,
+        AssemblyTypeAcceleratorExportMode assemblyTypeAcceleratorMode,
+        IReadOnlyList<string>? assemblyTypeAccelerators,
+        IReadOnlyList<string>? assemblyTypeAcceleratorAssemblies,
         IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies)
     {
         var loaderIdentity = useAssemblyLoadContext
@@ -257,7 +266,11 @@ internal static class ModuleBootstrapperGenerator
                     ["ModuleName"] = EscapePsSingleQuoted(moduleName),
                     ["LoaderAssemblyName"] = EscapePsSingleQuoted(loaderIdentity?.AssemblyName ?? string.Empty),
                     ["LoaderTypeName"] = loaderIdentity?.TypeName ?? string.Empty,
-                    ["RuntimeHandlerBlock"] = handleRuntimes ? BuildRuntimeHandlerBlock() : string.Empty
+                    ["RuntimeHandlerBlock"] = handleRuntimes ? BuildRuntimeHandlerBlock() : string.Empty,
+                    ["TypeAcceleratorBlock"] = BuildTypeAcceleratorBlock(
+                        assemblyTypeAcceleratorMode,
+                        assemblyTypeAccelerators,
+                        assemblyTypeAcceleratorAssemblies)
                 })
             : string.Empty;
 
@@ -646,6 +659,209 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
                        "}",
                        string.Empty
                    });
+    }
+
+    private static string BuildTypeAcceleratorBlock(
+        AssemblyTypeAcceleratorExportMode mode,
+        IReadOnlyList<string>? typeNames,
+        IReadOnlyList<string>? assemblyNames)
+    {
+        var normalizedTypes = NormalizePowerShellStringArray(typeNames);
+        var normalizedAssemblies = NormalizePowerShellStringArray(assemblyNames);
+        if (mode == AssemblyTypeAcceleratorExportMode.None && normalizedTypes.Length > 0)
+            mode = AssemblyTypeAcceleratorExportMode.AllowList;
+        if (mode == AssemblyTypeAcceleratorExportMode.None && normalizedAssemblies.Length > 0)
+            mode = AssemblyTypeAcceleratorExportMode.Assembly;
+        if (mode == AssemblyTypeAcceleratorExportMode.None)
+            return string.Empty;
+
+        return $@"
+function Register-PowerForgeAssemblyTypeAccelerators {{
+    param(
+        [Parameter(Mandatory = $true)][System.Reflection.Assembly] $ModuleAssembly,
+        [Parameter(Mandatory = $true)][string] $LibFolder
+    )
+
+    $Mode = '{mode}'
+    $RequestedTypes = {BuildPowerShellArrayLiteral(normalizedTypes)}
+    $RequestedAssemblies = {BuildPowerShellArrayLiteral(normalizedAssemblies)}
+    if ($Mode -eq 'None') {{
+        return
+    }}
+
+    $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+    if ($null -eq $TypeAccelerators) {{
+        Write-Warning -Message 'PowerShell type accelerator APIs are not available. ALC dependency type exposure is disabled.'
+        return
+    }}
+
+    $AddTypeAccelerator = $TypeAccelerators.GetMethod('Add', [type[]]@([string], [type]))
+    $GetTypeAccelerators = $TypeAccelerators.GetMethod('Get', [type[]]@())
+    if ($null -eq $AddTypeAccelerator -or $null -eq $GetTypeAccelerators) {{
+        Write-Warning -Message 'PowerShell type accelerator APIs are incomplete. ALC dependency type exposure is disabled.'
+        return
+    }}
+
+    $ModuleAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext($ModuleAssembly)
+    if ($null -eq $ModuleAlc) {{
+        Write-Warning -Message 'Unable to resolve the module AssemblyLoadContext. ALC dependency type exposure is disabled.'
+        return
+    }}
+
+    if ($null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {{
+        $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{{}}
+    }}
+
+    function Import-PowerForgeAlcAssembly {{
+        param([Parameter(Mandatory = $true)][string] $AssemblyName)
+
+        foreach ($Assembly in $ModuleAlc.Assemblies) {{
+            if ($Assembly.GetName().Name -eq $AssemblyName) {{
+                return $Assembly
+            }}
+        }}
+
+        try {{
+            return $ModuleAlc.LoadFromAssemblyName([System.Reflection.AssemblyName]::new($AssemblyName))
+        }} catch {{
+            $AssemblyPath = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder, $AssemblyName + '.dll')
+            if (Test-Path -LiteralPath $AssemblyPath) {{
+                try {{
+                    $AssemblyNameObject = [System.Reflection.AssemblyName]::GetAssemblyName($AssemblyPath)
+                    return $ModuleAlc.LoadFromAssemblyName($AssemblyNameObject)
+                }} catch {{
+                    Write-Warning -Message ""Could not load ALC assembly '$AssemblyName' for type accelerator exposure: $($_.Exception.Message)""
+                }}
+            }}
+        }}
+
+        return $null
+    }}
+
+    function Find-PowerForgeAlcType {{
+        param([Parameter(Mandatory = $true)][string] $TypeName)
+
+        foreach ($Assembly in $ModuleAlc.Assemblies) {{
+            $Type = $Assembly.GetType($TypeName, $false, $false)
+            if ($null -ne $Type) {{
+                return $Type
+            }}
+        }}
+
+        $LibDirectory = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder)
+        if (-not (Test-Path -LiteralPath $LibDirectory)) {{
+            return $null
+        }}
+
+        foreach ($File in Get-ChildItem -LiteralPath $LibDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {{
+            try {{
+                $AssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($File.FullName)
+                $Assembly = Import-PowerForgeAlcAssembly -AssemblyName $AssemblyName.Name
+                if ($null -eq $Assembly) {{
+                    continue
+                }}
+
+                $Type = $Assembly.GetType($TypeName, $false, $false)
+                if ($null -ne $Type) {{
+                    return $Type
+                }}
+            }} catch {{
+                continue
+            }}
+        }}
+
+        return $null
+    }}
+
+    function Add-PowerForgeTypeAccelerator {{
+        param([Parameter(Mandatory = $true)][type] $Type)
+
+        if ([string]::IsNullOrWhiteSpace($Type.FullName)) {{
+            return
+        }}
+
+        $Name = $Type.FullName
+        $Existing = $GetTypeAccelerators.Invoke($null, @())
+        if ($Existing.ContainsKey($Name)) {{
+            if ([object]::ReferenceEquals($Existing[$Name], $Type)) {{
+                $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
+            }} else {{
+                Write-Warning -Message ""Type accelerator '$Name' already exists. Keeping the existing accelerator and skipping the ALC type from $($Type.Assembly.GetName().Name).""
+            }}
+            return
+        }}
+
+        $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
+        $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
+    }}
+
+    if ($Mode -eq 'Assembly') {{
+        foreach ($AssemblyName in $RequestedAssemblies) {{
+            $Assembly = Import-PowerForgeAlcAssembly -AssemblyName $AssemblyName
+            if ($null -eq $Assembly) {{
+                Write-Warning -Message ""Assembly '$AssemblyName' was not found in the module AssemblyLoadContext. No type accelerators were registered for it.""
+                continue
+            }}
+
+            foreach ($Type in $Assembly.GetExportedTypes()) {{
+                Add-PowerForgeTypeAccelerator -Type $Type
+            }}
+        }}
+    }}
+
+    foreach ($TypeName in $RequestedTypes) {{
+        $Type = Find-PowerForgeAlcType -TypeName $TypeName
+        if ($null -eq $Type) {{
+            Write-Warning -Message ""Type '$TypeName' was not found in the module AssemblyLoadContext. No type accelerator was registered.""
+            continue
+        }}
+
+        Add-PowerForgeTypeAccelerator -Type $Type
+    }}
+
+    if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {{
+        $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+        $ExecutionContext.SessionState.Module.OnRemove = {{
+            $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+            if ($null -eq $TypeAccelerators -or $null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {{
+                return
+            }}
+
+            $GetTypeAccelerators = $TypeAccelerators.GetMethod('Get', [type[]]@())
+            $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
+            if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {{
+                return
+            }}
+
+            $Existing = $GetTypeAccelerators.Invoke($null, @())
+            foreach ($Entry in @($script:PowerForgeRegisteredAssemblyTypeAccelerators.GetEnumerator())) {{
+                if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {{
+                    $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                }}
+            }}
+        }}.GetNewClosure()
+    }}
+}}
+
+Register-PowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder
+";
+    }
+
+    private static string[] NormalizePowerShellStringArray(IReadOnlyList<string>? values)
+        => values is { Count: > 0 }
+            ? values
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : Array.Empty<string>();
+
+    private static string BuildPowerShellArrayLiteral(IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+            return "@()";
+
+        return "@(" + string.Join(", ", values.Select(static value => "'" + EscapePsSingleQuoted(value) + "'")) + ")";
     }
 
     private static string RenderModuleBootstrapperTemplate(

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -672,8 +672,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         if (mode == AssemblyTypeAcceleratorExportMode.None)
             return string.Empty;
 
-        return $@"
-$RegisterPowerForgeAssemblyTypeAccelerators = {{
+        return $@"$RegisterPowerForgeAssemblyTypeAccelerators = {{
     param(
         [Parameter(Mandatory = $true)][System.Reflection.Assembly] $ModuleAssembly,
         [Parameter(Mandatory = $true)][string] $LibFolder
@@ -691,6 +690,25 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
     if ([string]::IsNullOrWhiteSpace($LibFolder)) {{
         Write-Warning -Message 'Module library folder was not available. ALC dependency type exposure is disabled.'
         return
+    }}
+
+    if ([IO.Path]::IsPathRooted($LibFolder) -or $LibFolder.Contains([IO.Path]::DirectorySeparatorChar) -or $LibFolder.Contains([IO.Path]::AltDirectorySeparatorChar) -or $LibFolder.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0) {{
+        Write-Warning -Message ""Module library folder '$LibFolder' must be a simple folder name. ALC dependency type exposure is disabled.""
+        return
+    }}
+
+    if ($Mode -eq 'AllowList' -and $RequestedTypes.Count -eq 0) {{
+        Write-Warning -Message 'AllowList type accelerator mode was configured without type names. No ALC dependency type accelerators will be registered.'
+        return
+    }}
+
+    if ($Mode -eq 'Assembly' -and $RequestedAssemblies.Count -eq 0) {{
+        if ($RequestedTypes.Count -eq 0) {{
+            Write-Warning -Message 'Assembly type accelerator mode was configured without assembly names or type names. No ALC dependency type accelerators will be registered.'
+            return
+        }}
+
+        Write-Warning -Message 'Assembly type accelerator mode was configured without assembly names. Only explicitly configured type names will be registered.'
     }}
 
     $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -693,7 +693,7 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
         return
     }}
 
-    if ([IO.Path]::IsPathRooted($LibFolder) -or $LibFolder.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0) {{
+    if ([IO.Path]::IsPathRooted($LibFolder) -or $LibFolder.Contains('..') -or $LibFolder.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0) {{
         Write-Warning -Message ""Module library folder '$LibFolder' must be a simple folder name. ALC dependency type exposure is disabled.""
         return
     }}
@@ -887,7 +887,11 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
 }}
 
 # Type accelerator exposure is PowerShell Core-only because it depends on AssemblyLoadContext.
-& $RegisterPowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder
+try {{
+    & $RegisterPowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder
+}} catch {{
+    Write-Warning -Message ""ALC type accelerator registration failed: $($_.Exception.Message)""
+}}
 ";
     }
 

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -683,6 +683,16 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
     $RequestedTypes = {BuildPowerShellArrayLiteral(normalizedTypes)}
     $RequestedAssemblies = {BuildPowerShellArrayLiteral(normalizedAssemblies)}
 
+    if ($null -eq $ModuleAssembly) {{
+        Write-Warning -Message 'Module assembly was not available. ALC dependency type exposure is disabled.'
+        return
+    }}
+
+    if ([string]::IsNullOrWhiteSpace($LibFolder)) {{
+        Write-Warning -Message 'Module library folder was not available. ALC dependency type exposure is disabled.'
+        return
+    }}
+
     $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
     if ($null -eq $TypeAccelerators) {{
         Write-Warning -Message 'PowerShell type accelerator APIs are not available. ALC dependency type exposure is disabled.'

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -334,6 +334,7 @@ internal static class ModuleBootstrapperGenerator
             var result = RunProcess(
                 "dotnet",
                 buildRoot,
+                // Disable MSBuild node reuse so short-lived helper builds exit cleanly in CI and tests.
                 new[] { "build", projectPath, "-c", "Release", "-o", outputRoot, "-nologo", "-v:minimal", "-nr:false" },
                 AssemblyLoadContextLoaderBuildTimeout);
             if (result.ExitCode != 0)
@@ -661,7 +662,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
                    });
     }
 
-    private static string BuildTypeAcceleratorBlock(
+    internal static string BuildTypeAcceleratorBlock(
         AssemblyTypeAcceleratorExportMode mode,
         IReadOnlyList<string>? typeNames,
         IReadOnlyList<string>? assemblyNames)
@@ -681,9 +682,6 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
     $Mode = '{mode}'
     $RequestedTypes = {BuildPowerShellArrayLiteral(normalizedTypes)}
     $RequestedAssemblies = {BuildPowerShellArrayLiteral(normalizedAssemblies)}
-    if ($Mode -eq 'None') {{
-        return
-    }}
 
     $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
     if ($null -eq $TypeAccelerators) {{
@@ -692,7 +690,7 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
     }}
 
     $AddTypeAccelerator = $TypeAccelerators.GetMethod('Add', [type[]]@([string], [type]))
-    $GetTypeAccelerators = $TypeAccelerators.GetMethod('Get', [type[]]@())
+    $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
     if ($null -eq $AddTypeAccelerator -or $null -eq $GetTypeAccelerators) {{
         Write-Warning -Message 'PowerShell type accelerator APIs are incomplete. ALC dependency type exposure is disabled.'
         return
@@ -777,10 +775,10 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
         }}
 
         $Name = $Type.FullName
-        $Existing = $GetTypeAccelerators.Invoke($null, @())
+        $Existing = $GetTypeAccelerators.GetValue($null)
         if ($Existing.ContainsKey($Name)) {{
             if ([object]::ReferenceEquals($Existing[$Name], $Type)) {{
-                $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
+                return
             }} else {{
                 Write-Warning -Message ""Type accelerator '$Name' already exists. Keeping the existing accelerator and skipping the ALC type from $($Type.Assembly.GetName().Name).""
             }}
@@ -832,13 +830,13 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
                     return
                 }}
 
-                $GetTypeAccelerators = $TypeAccelerators.GetMethod('Get', [type[]]@())
+                $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
                 $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
                 if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {{
                     return
                 }}
 
-                $Existing = $GetTypeAccelerators.Invoke($null, @())
+                $Existing = $GetTypeAccelerators.GetValue($null)
                 foreach ($Entry in @($script:PowerForgeRegisteredAssemblyTypeAccelerators.GetEnumerator())) {{
                     if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {{
                         $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -672,7 +672,8 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         if (mode == AssemblyTypeAcceleratorExportMode.None)
             return string.Empty;
 
-        return $@"$RegisterPowerForgeAssemblyTypeAccelerators = {{
+        return $@"        # Type accelerator registration relies on $ModuleAssembly and $LibFolder from this ALC loader scope.
+$RegisterPowerForgeAssemblyTypeAccelerators = {{
     param(
         [Parameter(Mandatory = $true)][System.Reflection.Assembly] $ModuleAssembly,
         [Parameter(Mandatory = $true)][string] $LibFolder
@@ -692,7 +693,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         return
     }}
 
-    if ([IO.Path]::IsPathRooted($LibFolder) -or $LibFolder.Contains([IO.Path]::DirectorySeparatorChar) -or $LibFolder.Contains([IO.Path]::AltDirectorySeparatorChar) -or $LibFolder.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0) {{
+    if ([IO.Path]::IsPathRooted($LibFolder) -or $LibFolder.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0) {{
         Write-Warning -Message ""Module library folder '$LibFolder' must be a simple folder name. ALC dependency type exposure is disabled.""
         return
     }}
@@ -813,7 +814,13 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
             return
         }}
 
-        $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
+        try {{
+            $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
+        }} catch {{
+            Write-Warning -Message ""Type accelerator '$Name' could not be registered from $($Type.Assembly.GetName().Name): $($_.Exception.Message)""
+            return
+        }}
+
         $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
     }}
 

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -334,7 +334,7 @@ internal static class ModuleBootstrapperGenerator
             var result = RunProcess(
                 "dotnet",
                 buildRoot,
-                new[] { "build", projectPath, "-c", "Release", "-o", outputRoot, "-nologo", "-v:minimal" },
+                new[] { "build", projectPath, "-c", "Release", "-o", outputRoot, "-nologo", "-v:minimal", "-nr:false" },
                 AssemblyLoadContextLoaderBuildTimeout);
             if (result.ExitCode != 0)
             {
@@ -668,15 +668,11 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
     {
         var normalizedTypes = NormalizePowerShellStringArray(typeNames);
         var normalizedAssemblies = NormalizePowerShellStringArray(assemblyNames);
-        if (mode == AssemblyTypeAcceleratorExportMode.None && normalizedTypes.Length > 0)
-            mode = AssemblyTypeAcceleratorExportMode.AllowList;
-        if (mode == AssemblyTypeAcceleratorExportMode.None && normalizedAssemblies.Length > 0)
-            mode = AssemblyTypeAcceleratorExportMode.Assembly;
         if (mode == AssemblyTypeAcceleratorExportMode.None)
             return string.Empty;
 
         return $@"
-function Register-PowerForgeAssemblyTypeAccelerators {{
+$RegisterPowerForgeAssemblyTypeAccelerators = {{
     param(
         [Parameter(Mandatory = $true)][System.Reflection.Assembly] $ModuleAssembly,
         [Parameter(Mandatory = $true)][string] $LibFolder
@@ -712,7 +708,7 @@ function Register-PowerForgeAssemblyTypeAccelerators {{
         $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{{}}
     }}
 
-    function Import-PowerForgeAlcAssembly {{
+    $ImportPowerForgeAlcAssembly = {{
         param([Parameter(Mandatory = $true)][string] $AssemblyName)
 
         foreach ($Assembly in $ModuleAlc.Assemblies) {{
@@ -738,7 +734,7 @@ function Register-PowerForgeAssemblyTypeAccelerators {{
         return $null
     }}
 
-    function Find-PowerForgeAlcType {{
+    $FindPowerForgeAlcType = {{
         param([Parameter(Mandatory = $true)][string] $TypeName)
 
         foreach ($Assembly in $ModuleAlc.Assemblies) {{
@@ -756,7 +752,7 @@ function Register-PowerForgeAssemblyTypeAccelerators {{
         foreach ($File in Get-ChildItem -LiteralPath $LibDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {{
             try {{
                 $AssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($File.FullName)
-                $Assembly = Import-PowerForgeAlcAssembly -AssemblyName $AssemblyName.Name
+                $Assembly = & $ImportPowerForgeAlcAssembly -AssemblyName $AssemblyName.Name
                 if ($null -eq $Assembly) {{
                     continue
                 }}
@@ -773,7 +769,7 @@ function Register-PowerForgeAssemblyTypeAccelerators {{
         return $null
     }}
 
-    function Add-PowerForgeTypeAccelerator {{
+    $AddPowerForgeTypeAccelerator = {{
         param([Parameter(Mandatory = $true)][type] $Type)
 
         if ([string]::IsNullOrWhiteSpace($Type.FullName)) {{
@@ -797,53 +793,68 @@ function Register-PowerForgeAssemblyTypeAccelerators {{
 
     if ($Mode -eq 'Assembly') {{
         foreach ($AssemblyName in $RequestedAssemblies) {{
-            $Assembly = Import-PowerForgeAlcAssembly -AssemblyName $AssemblyName
+            $Assembly = & $ImportPowerForgeAlcAssembly -AssemblyName $AssemblyName
             if ($null -eq $Assembly) {{
                 Write-Warning -Message ""Assembly '$AssemblyName' was not found in the module AssemblyLoadContext. No type accelerators were registered for it.""
                 continue
             }}
 
-            foreach ($Type in $Assembly.GetExportedTypes()) {{
-                Add-PowerForgeTypeAccelerator -Type $Type
+            try {{
+                $ExportedTypes = @($Assembly.GetExportedTypes())
+            }} catch {{
+                Write-Warning -Message ""Could not enumerate exported types from assembly '$AssemblyName' for type accelerator exposure: $($_.Exception.Message)""
+                continue
+            }}
+
+            foreach ($Type in $ExportedTypes) {{
+                & $AddPowerForgeTypeAccelerator -Type $Type
             }}
         }}
     }}
 
     foreach ($TypeName in $RequestedTypes) {{
-        $Type = Find-PowerForgeAlcType -TypeName $TypeName
+        $Type = & $FindPowerForgeAlcType -TypeName $TypeName
         if ($null -eq $Type) {{
             Write-Warning -Message ""Type '$TypeName' was not found in the module AssemblyLoadContext. No type accelerator was registered.""
             continue
         }}
 
-        Add-PowerForgeTypeAccelerator -Type $Type
+        & $AddPowerForgeTypeAccelerator -Type $Type
     }}
 
     if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {{
         $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+        $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
         $ExecutionContext.SessionState.Module.OnRemove = {{
-            $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
-            if ($null -eq $TypeAccelerators -or $null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {{
-                return
-            }}
+            try {{
+                $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+                if ($null -eq $TypeAccelerators -or $null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {{
+                    return
+                }}
 
-            $GetTypeAccelerators = $TypeAccelerators.GetMethod('Get', [type[]]@())
-            $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
-            if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {{
-                return
-            }}
+                $GetTypeAccelerators = $TypeAccelerators.GetMethod('Get', [type[]]@())
+                $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
+                if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {{
+                    return
+                }}
 
-            $Existing = $GetTypeAccelerators.Invoke($null, @())
-            foreach ($Entry in @($script:PowerForgeRegisteredAssemblyTypeAccelerators.GetEnumerator())) {{
-                if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {{
-                    $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                $Existing = $GetTypeAccelerators.Invoke($null, @())
+                foreach ($Entry in @($script:PowerForgeRegisteredAssemblyTypeAccelerators.GetEnumerator())) {{
+                    if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {{
+                        $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                    }}
+                }}
+            }} finally {{
+                if ($null -ne $PreviousPowerForgeOnRemove) {{
+                    & $PreviousPowerForgeOnRemove @args
                 }}
             }}
         }}.GetNewClosure()
     }}
 }}
 
-Register-PowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder
+# Type accelerator exposure is PowerShell Core-only because it depends on AssemblyLoadContext.
+& $RegisterPowerForgeAssemblyTypeAccelerators -ModuleAssembly $ModuleAssembly -LibFolder $LibFolder
 ";
     }
 

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -193,11 +193,11 @@ public sealed class ModuleBuildPipeline
         if (mode.HasValue)
             return mode.Value;
 
-        if (HasAnyConfiguredValue(typeNames))
-            return AssemblyTypeAcceleratorExportMode.AllowList;
-
         if (HasAnyConfiguredValue(assemblyNames))
             return AssemblyTypeAcceleratorExportMode.Assembly;
+
+        if (HasAnyConfiguredValue(typeNames))
+            return AssemblyTypeAcceleratorExportMode.AllowList;
 
         return AssemblyTypeAcceleratorExportMode.None;
     }

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -155,14 +155,23 @@ public sealed class ModuleBuildPipeline
         // This keeps artefacts and installs aligned with historical PSPublishModule behavior for binary/mixed modules.
         if (!spec.RefreshManifestOnly)
         {
+            var assemblyTypeAcceleratorMode = ResolveAssemblyTypeAcceleratorMode(
+                spec.AssemblyTypeAcceleratorMode,
+                spec.AssemblyTypeAccelerators,
+                spec.AssemblyTypeAcceleratorAssemblies);
+            var useAssemblyLoadContext = spec.UseAssemblyLoadContext
+                || assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None;
+            if (useAssemblyLoadContext && !spec.UseAssemblyLoadContext)
+                _logger.Info("Assembly type accelerators requested; UseAssemblyLoadContext automatically enabled.");
+
             ModuleBootstrapperGenerator.Generate(
                 staging,
                 spec.Name,
                 exports,
                 spec.ExportAssemblies,
                 spec.HandleRuntimes,
-                spec.UseAssemblyLoadContext,
-                spec.AssemblyTypeAcceleratorMode,
+                useAssemblyLoadContext,
+                assemblyTypeAcceleratorMode,
                 spec.AssemblyTypeAccelerators,
                 spec.AssemblyTypeAcceleratorAssemblies,
                 targetFrameworks: spec.Frameworks,
@@ -175,6 +184,27 @@ public sealed class ModuleBuildPipeline
 
         return new ModuleBuildResult(staging, psd1, exports, buildNotes);
     }
+
+    private static AssemblyTypeAcceleratorExportMode ResolveAssemblyTypeAcceleratorMode(
+        AssemblyTypeAcceleratorExportMode mode,
+        IReadOnlyList<string>? typeNames,
+        IReadOnlyList<string>? assemblyNames)
+    {
+        if (mode != AssemblyTypeAcceleratorExportMode.None)
+            return mode;
+
+        if (HasAnyConfiguredValue(typeNames))
+            return AssemblyTypeAcceleratorExportMode.AllowList;
+
+        if (HasAnyConfiguredValue(assemblyNames))
+            return AssemblyTypeAcceleratorExportMode.Assembly;
+
+        return AssemblyTypeAcceleratorExportMode.None;
+    }
+
+    private static bool HasAnyConfiguredValue(IReadOnlyList<string>? values)
+        => values is { Count: > 0 }
+           && values.Any(static value => !string.IsNullOrWhiteSpace(value));
 
     /// <summary>
     /// Installs a staged module to versioned roots, resolving the final version first.

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -155,7 +155,7 @@ public sealed class ModuleBuildPipeline
         // This keeps artefacts and installs aligned with historical PSPublishModule behavior for binary/mixed modules.
         if (!spec.RefreshManifestOnly)
         {
-            var assemblyTypeAcceleratorMode = ResolveAssemblyTypeAcceleratorMode(
+            var assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorOptions.ResolveMode(
                 spec.AssemblyTypeAcceleratorMode,
                 spec.AssemblyTypeAccelerators,
                 spec.AssemblyTypeAcceleratorAssemblies);
@@ -184,27 +184,6 @@ public sealed class ModuleBuildPipeline
 
         return new ModuleBuildResult(staging, psd1, exports, buildNotes);
     }
-
-    private static AssemblyTypeAcceleratorExportMode ResolveAssemblyTypeAcceleratorMode(
-        AssemblyTypeAcceleratorExportMode? mode,
-        IReadOnlyList<string>? typeNames,
-        IReadOnlyList<string>? assemblyNames)
-    {
-        if (mode.HasValue)
-            return mode.Value;
-
-        if (HasAnyConfiguredValue(assemblyNames))
-            return AssemblyTypeAcceleratorExportMode.Assembly;
-
-        if (HasAnyConfiguredValue(typeNames))
-            return AssemblyTypeAcceleratorExportMode.AllowList;
-
-        return AssemblyTypeAcceleratorExportMode.None;
-    }
-
-    private static bool HasAnyConfiguredValue(IReadOnlyList<string>? values)
-        => values is { Count: > 0 }
-           && values.Any(static value => !string.IsNullOrWhiteSpace(value));
 
     /// <summary>
     /// Installs a staged module to versioned roots, resolving the final version first.

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -162,6 +162,9 @@ public sealed class ModuleBuildPipeline
                 spec.ExportAssemblies,
                 spec.HandleRuntimes,
                 spec.UseAssemblyLoadContext,
+                spec.AssemblyTypeAcceleratorMode,
+                spec.AssemblyTypeAccelerators,
+                spec.AssemblyTypeAcceleratorAssemblies,
                 targetFrameworks: spec.Frameworks,
                 log: message => _logger.Info(message));
         }

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -186,12 +186,12 @@ public sealed class ModuleBuildPipeline
     }
 
     private static AssemblyTypeAcceleratorExportMode ResolveAssemblyTypeAcceleratorMode(
-        AssemblyTypeAcceleratorExportMode mode,
+        AssemblyTypeAcceleratorExportMode? mode,
         IReadOnlyList<string>? typeNames,
         IReadOnlyList<string>? assemblyNames)
     {
-        if (mode != AssemblyTypeAcceleratorExportMode.None)
-            return mode;
+        if (mode.HasValue)
+            return mode.Value;
 
         if (HasAnyConfiguredValue(typeNames))
             return AssemblyTypeAcceleratorExportMode.AllowList;

--- a/Schemas/powerforge.buildspec.schema.json
+++ b/Schemas/powerforge.buildspec.schema.json
@@ -29,7 +29,7 @@
     "ExportAssemblies": { "type": "array", "items": { "type": "string" } },
     "DisableBinaryCmdletScan": { "type": "boolean" },
     "UseAssemblyLoadContext": { "type": "boolean" },
-    "AssemblyTypeAcceleratorMode": { "type": "string", "enum": ["None", "AllowList", "Assembly"] },
+    "AssemblyTypeAcceleratorMode": { "type": ["string", "null"], "enum": ["None", "AllowList", "Assembly", null] },
     "AssemblyTypeAccelerators": { "type": "array", "items": { "type": "string" } },
     "AssemblyTypeAcceleratorAssemblies": { "type": "array", "items": { "type": "string" } },
     "KeepStaging": { "type": "boolean" }

--- a/Schemas/powerforge.buildspec.schema.json
+++ b/Schemas/powerforge.buildspec.schema.json
@@ -28,8 +28,11 @@
 
     "ExportAssemblies": { "type": "array", "items": { "type": "string" } },
     "DisableBinaryCmdletScan": { "type": "boolean" },
+    "UseAssemblyLoadContext": { "type": "boolean" },
+    "AssemblyTypeAcceleratorMode": { "type": "string", "enum": ["None", "AllowList", "Assembly"] },
+    "AssemblyTypeAccelerators": { "type": "array", "items": { "type": "string" } },
+    "AssemblyTypeAcceleratorAssemblies": { "type": "array", "items": { "type": "string" } },
     "KeepStaging": { "type": "boolean" }
   },
   "required": ["Name", "SourcePath"]
 }
-

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -93,6 +93,12 @@
         "HandleRuntimes": { "type": ["boolean", "null"] },
         "UseAssemblyLoadContext": { "type": ["boolean", "null"] },
         "NETAssemblyLoadContext": { "type": ["boolean", "null"] },
+        "AssemblyTypeAcceleratorMode": { "type": ["string", "null"], "enum": ["None", "AllowList", "Assembly", null] },
+        "NETAssemblyTypeAcceleratorMode": { "type": ["string", "null"], "enum": ["None", "AllowList", "Assembly", null] },
+        "AssemblyTypeAccelerators": { "type": ["array", "null"], "items": { "type": "string" } },
+        "NETAssemblyTypeAccelerators": { "type": ["array", "null"], "items": { "type": "string" } },
+        "AssemblyTypeAcceleratorAssemblies": { "type": ["array", "null"], "items": { "type": "string" } },
+        "NETAssemblyTypeAcceleratorAssemblies": { "type": ["array", "null"], "items": { "type": "string" } },
         "NETDoNotCopyLibrariesRecursively": { "type": ["boolean", "null"] }
       }
     },


### PR DESCRIPTION
## Summary
- add BuildLibraries/NETBuildLibraries options for AssemblyLoadContext dependency type accelerator exposure
- generate bootstrapper registration/removal logic for allow-listed or assembly-scoped accelerator exports
- surface the options through New-ConfigurationBuild, legacy segment adapters, build specs, and schemas

## Why
PowerShell modules packaged through an AssemblyLoadContext can hide dependency static APIs from callers. This lets modules selectively expose dependency types such as HtmlAgilityPack.HtmlEntity without breaking isolation or forcing consumers to know the loader internals.

## Validation
- dotnet build PSPublishModule\PSPublishModule.csproj -f net8.0 -v:minimal
- dotnet build PSPublishModule\PSPublishModule.csproj -f net472 -v:minimal
- dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~ModuleBootstrapperGeneratorTests|FullyQualifiedName~BuildConfigurationFactoryTests|FullyQualifiedName~ModulePipelineExportAssemblyInferenceTests" -v:minimal
- git diff --cached --check
