### PR TITLE
fix(packaging): resolve ALC native runtime assets

### DIFF
--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -1,4 +1,5 @@
 using PowerForge;
+using System.Reflection;
 
 public class ModuleBootstrapperGeneratorTests
 {
@@ -156,6 +157,45 @@ public class ModuleBootstrapperGeneratorTests
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
         }
+    }
+
+    [Fact]
+    public void BuildAssemblyLoadContextSource_ProbesPackagedRuntimeNativeAssets()
+    {
+        var generatorType = typeof(ModuleBootstrapperGenerator);
+        var identityType = generatorType.GetNestedType("AssemblyLoadContextLoaderIdentity", BindingFlags.NonPublic);
+        Assert.NotNull(identityType);
+
+        var identity = Activator.CreateInstance(
+            identityType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[]
+            {
+                "DemoModule.ModuleLoadContext",
+                "DemoModule.ModuleLoadContext",
+                "DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext"
+            },
+            culture: null);
+        Assert.NotNull(identity);
+
+        var method = generatorType.GetMethod("BuildAssemblyLoadContextSource", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var source = Assert.IsType<string>(method.Invoke(null, new[] { identity }));
+
+        Assert.Contains("LoadPackagedNativeLibrary", source);
+        Assert.Contains("TryLoadPackagedNativeLibrary", source);
+        Assert.Contains("Path.Combine(_assemblyDirectory, \"runtimes\", rid, \"native\", fileName)", source);
+        Assert.Contains("RuntimeInformation.ProcessArchitecture", source);
+        Assert.Contains("RuntimeInformation.RuntimeIdentifier", source);
+        Assert.Contains("LoadUnmanagedDllFromPath(path)", source);
+        Assert.Contains("BadImageFormatException || ex is DllNotFoundException || ex is FileLoadException", source);
+        Assert.Contains("yield return \"win-\" + arch", source);
+        Assert.Contains("yield return \"linux-\" + arch", source);
+        Assert.Contains("yield return \"linux-musl-\" + arch", source);
+        Assert.Contains("yield return \"linux-musl\"", source);
+        Assert.Contains("yield return \"osx\"", source);
     }
 
     [Fact]

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -523,6 +523,7 @@ internal static class ModuleBootstrapperGenerator
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 namespace {identity.Namespace};
@@ -588,8 +589,12 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
     {{
         var resolvedPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
-        return !string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath)
-            ? LoadUnmanagedDllFromPath(resolvedPath)
+        if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
+            return LoadUnmanagedDllFromPath(resolvedPath);
+
+        var packagedLibrary = LoadPackagedNativeLibrary(unmanagedDllName);
+        return packagedLibrary != IntPtr.Zero
+            ? packagedLibrary
             : IntPtr.Zero;
     }}
 
@@ -598,6 +603,125 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         // Called only while LoadModule holds Sync; keep the one-time main assembly load under that lock.
         _moduleAssembly ??= LoadFromAssemblyPath(_moduleAssemblyPath);
         return _moduleAssembly;
+    }}
+
+    private IntPtr LoadPackagedNativeLibrary(string unmanagedDllName)
+    {{
+        if (string.IsNullOrWhiteSpace(unmanagedDllName))
+            return IntPtr.Zero;
+
+        foreach (var rid in GetRuntimeIdentifiers())
+        {{
+            foreach (var fileName in GetNativeLibraryFileNames(unmanagedDllName))
+            {{
+                var path = Path.Combine(_assemblyDirectory, ""runtimes"", rid, ""native"", fileName);
+                if (File.Exists(path))
+                {{
+                    var loaded = TryLoadPackagedNativeLibrary(path);
+                    if (loaded != IntPtr.Zero)
+                        return loaded;
+                }}
+            }}
+        }}
+
+        foreach (var fileName in GetNativeLibraryFileNames(unmanagedDllName))
+        {{
+            var path = Path.Combine(_assemblyDirectory, fileName);
+            if (File.Exists(path))
+            {{
+                var loaded = TryLoadPackagedNativeLibrary(path);
+                if (loaded != IntPtr.Zero)
+                    return loaded;
+            }}
+        }}
+
+        return IntPtr.Zero;
+    }}
+
+    private IntPtr TryLoadPackagedNativeLibrary(string path)
+    {{
+        try
+        {{
+            return LoadUnmanagedDllFromPath(path);
+        }}
+        catch (Exception ex) when (ex is BadImageFormatException || ex is DllNotFoundException || ex is FileLoadException)
+        {{
+            return IntPtr.Zero;
+        }}
+    }}
+
+    private static IEnumerable<string> GetRuntimeIdentifiers()
+    {{
+        var runtimeIdentifier = RuntimeInformation.RuntimeIdentifier ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(runtimeIdentifier))
+            yield return runtimeIdentifier;
+
+        var arch = RuntimeInformation.ProcessArchitecture switch
+        {{
+            Architecture.X64 => ""x64"",
+            Architecture.X86 => ""x86"",
+            Architecture.Arm64 => ""arm64"",
+            Architecture.Arm => ""arm"",
+            _ => null
+        }};
+        var isMusl = runtimeIdentifier.Contains(""musl"", StringComparison.OrdinalIgnoreCase);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {{
+            if (arch is not null)
+                yield return ""win-"" + arch;
+            yield return ""win"";
+        }}
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {{
+            if (arch is not null)
+                yield return ""osx-"" + arch;
+            yield return ""osx"";
+        }}
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {{
+            if (arch is not null)
+            {{
+                if (isMusl)
+                {{
+                    yield return ""linux-musl-"" + arch;
+                    yield return ""linux-musl"";
+                    yield return ""linux-"" + arch;
+                }}
+                else
+                {{
+                    yield return ""linux-"" + arch;
+                    yield return ""linux-musl-"" + arch;
+                    yield return ""linux-musl"";
+                }}
+            }}
+            yield return ""linux"";
+        }}
+    }}
+
+    private static IEnumerable<string> GetNativeLibraryFileNames(string unmanagedDllName)
+    {{
+        yield return unmanagedDllName;
+
+        if (Path.HasExtension(unmanagedDllName))
+            yield break;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {{
+            yield return unmanagedDllName + "".dll"";
+        }}
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {{
+            yield return unmanagedDllName + "".dylib"";
+            if (!unmanagedDllName.StartsWith(""lib"", StringComparison.Ordinal))
+                yield return ""lib"" + unmanagedDllName + "".dylib"";
+        }}
+        else
+        {{
+            yield return unmanagedDllName + "".so"";
+            if (!unmanagedDllName.StartsWith(""lib"", StringComparison.Ordinal))
+                yield return ""lib"" + unmanagedDllName + "".so"";
+        }}
     }}
 }}
 ";


### PR DESCRIPTION
## Summary
- add a packaged native runtime fallback to the generated AssemblyLoadContext loader
- probe runtimes/<rid>/native assets when AssemblyDependencyResolver has no deps.json mapping
- add generator coverage for the native probing source

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --configuration Debug --no-restore --filter FullyQualifiedName~ModuleBootstrapperGeneratorTests --verbosity normal /nr:false