### PR TITLE
test(packaging): polish ALC native loader coverage

### DIFF
--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -1,5 +1,4 @@
 using PowerForge;
-using System.Reflection;
 
 public class ModuleBootstrapperGeneratorTests
 {
@@ -162,27 +161,11 @@ public class ModuleBootstrapperGeneratorTests
     [Fact]
     public void BuildAssemblyLoadContextSource_ProbesPackagedRuntimeNativeAssets()
     {
-        var generatorType = typeof(ModuleBootstrapperGenerator);
-        var identityType = generatorType.GetNestedType("AssemblyLoadContextLoaderIdentity", BindingFlags.NonPublic);
-        Assert.NotNull(identityType);
-
-        var identity = Activator.CreateInstance(
-            identityType,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-            binder: null,
-            args: new object[]
-            {
-                "DemoModule.ModuleLoadContext",
-                "DemoModule.ModuleLoadContext",
-                "DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext"
-            },
-            culture: null);
-        Assert.NotNull(identity);
-
-        var method = generatorType.GetMethod("BuildAssemblyLoadContextSource", BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.NotNull(method);
-
-        var source = Assert.IsType<string>(method.Invoke(null, new[] { identity }));
+        var identity = new ModuleBootstrapperGenerator.AssemblyLoadContextLoaderIdentity(
+            "DemoModule.ModuleLoadContext",
+            "DemoModule.ModuleLoadContext",
+            "DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext");
+        var source = ModuleBootstrapperGenerator.BuildAssemblyLoadContextSource(identity);
 
         Assert.Contains("LoadPackagedNativeLibrary", source);
         Assert.Contains("TryLoadPackagedNativeLibrary", source);
@@ -196,6 +179,8 @@ public class ModuleBootstrapperGeneratorTests
         Assert.Contains("yield return \"linux-musl-\" + arch", source);
         Assert.Contains("yield return \"linux-musl\"", source);
         Assert.Contains("yield return \"osx\"", source);
+        Assert.Contains("yield return unmanagedDllName + \".so\";", source);
+        Assert.Contains("yield return \"lib\" + unmanagedDllName + \".so\";", source);
     }
 
     [Fact]

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -518,7 +518,7 @@ internal static class ModuleBootstrapperGenerator
 </Project>
 ";
 
-    private static string BuildAssemblyLoadContextSource(AssemblyLoadContextLoaderIdentity identity)
+    internal static string BuildAssemblyLoadContextSource(AssemblyLoadContextLoaderIdentity identity)
         => $@"using System;
 using System.Collections.Generic;
 using System.IO;
@@ -718,6 +718,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         }}
         else
         {{
+            // Most non-Windows, non-macOS PowerShell hosts use ELF shared objects, so .so is the safest portable fallback.
             yield return unmanagedDllName + "".so"";
             if (!unmanagedDllName.StartsWith(""lib"", StringComparison.Ordinal))
                 yield return ""lib"" + unmanagedDllName + "".so"";
@@ -734,7 +735,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
             .GetAwaiter()
             .GetResult();
 
-    private sealed class AssemblyLoadContextLoaderIdentity
+    internal sealed class AssemblyLoadContextLoaderIdentity
     {
         public AssemblyLoadContextLoaderIdentity(string assemblyName, string ns, string typeName)
         {


### PR DESCRIPTION
## Summary
- expose the generated ALC loader source builder through an internal test seam
- remove private-reflection usage from the native loader coverage
- document the deliberate .so fallback for non-Windows/non-macOS native probing

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --configuration Debug --filter FullyQualifiedName~ModuleBootstrapperGeneratorTests --verbosity normal /nr:false