### PR TITLE
[codex] Fix Core dependency preflight host baseline

### DIFF
--- a/PowerForge.PowerShell/Services/BinaryDependencyPreflightService.cs
+++ b/PowerForge.PowerShell/Services/BinaryDependencyPreflightService.cs
@@ -46,6 +46,19 @@ public sealed class BinaryDependencyPreflightService
         "UIAutomationTypes"
     };
 
+    // Assemblies PowerShell 7 commonly provides at runtime but a Desktop validation host may not expose.
+    private static readonly string[] WellKnownCoreRuntimeAssemblyNames =
+    {
+        "System.Buffers",
+        "System.Collections.Immutable",
+        "System.Memory",
+        "System.Net.ServicePoint",
+        "System.Numerics.Vectors",
+        "System.Runtime.CompilerServices.Unsafe",
+        "System.Text.Encoding.CodePages",
+        "System.Threading.Tasks.Extensions"
+    };
+
     private readonly ILogger _logger;
 
     /// <summary>
@@ -668,6 +681,10 @@ public sealed class BinaryDependencyPreflightService
 
             return set;
         }
+
+        // Core validation may run from a Desktop host, so seed assemblies PowerShell 7 provides at runtime.
+        foreach (var name in WellKnownCoreRuntimeAssemblyNames)
+            set.Add(name);
 
         AddAssembliesFromDirectory(set, Path.GetDirectoryName(typeof(object).Assembly.Location));
         AddAssembliesFromDirectory(set, Path.GetDirectoryName(typeof(PSObject).Assembly.Location));

--- a/PowerForge.Tests/BinaryDependencyPreflightServiceTests.cs
+++ b/PowerForge.Tests/BinaryDependencyPreflightServiceTests.cs
@@ -358,14 +358,44 @@ public sealed class BinaryDependencyPreflightServiceTests
     [Fact]
     public void DesktopHostBaseline_DoesNotTreatCoreRuntimeAssembliesAsBuiltIn()
     {
+        var hostAssemblies = GetHostProvidedAssemblyNamesForTest("Desktop");
+        var coreRuntimeAssemblies = GetWellKnownCoreRuntimeAssemblyNamesForTest();
+
+        Assert.Contains(hostAssemblies, name => string.Equals(name, "System.Management.Automation", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(hostAssemblies, name => string.Equals(name, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var assemblyName in coreRuntimeAssemblies)
+            Assert.DoesNotContain(hostAssemblies, name => string.Equals(name, assemblyName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void CoreHostBaseline_IncludesKnownPowerShellRuntimeAssemblies()
+    {
+        var hostAssemblies = GetHostProvidedAssemblyNamesForTest("Core");
+        var coreRuntimeAssemblies = GetWellKnownCoreRuntimeAssemblyNamesForTest();
+
+        foreach (var assemblyName in coreRuntimeAssemblies)
+            Assert.Contains(hostAssemblies, name => string.Equals(name, assemblyName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static System.Collections.Generic.IReadOnlyCollection<string> GetHostProvidedAssemblyNamesForTest(string edition)
+    {
         var method = typeof(BinaryDependencyPreflightService).GetMethod(
             "GetHostProvidedAssemblyNames",
             System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
         Assert.NotNull(method);
 
-        var hostAssemblies = (System.Collections.Generic.IReadOnlyCollection<string>)method!.Invoke(null, new object[] { "Desktop" })!;
-        Assert.Contains(hostAssemblies, name => string.Equals(name, "System.Management.Automation", StringComparison.OrdinalIgnoreCase));
-        Assert.DoesNotContain(hostAssemblies, name => string.Equals(name, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase));
+        return (System.Collections.Generic.IReadOnlyCollection<string>)method.Invoke(null, new object[] { edition })!;
+    }
+
+    private static System.Collections.Generic.IReadOnlyCollection<string> GetWellKnownCoreRuntimeAssemblyNamesForTest()
+    {
+        var field = typeof(BinaryDependencyPreflightService).GetField(
+            "WellKnownCoreRuntimeAssemblyNames",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        return (System.Collections.Generic.IReadOnlyCollection<string>)field.GetValue(null)!;
     }
 
     private static DependencyFixture CreateDependencyFixture(string rootPath)


### PR DESCRIPTION
## Summary
- Add a Core/PowerShell runtime assembly baseline for dependency preflight checks.
- Keep Desktop preflight behavior unchanged while preventing Core checks from depending on the process that launched the build.
- Add regression coverage for common PS7-provided assemblies such as System.Memory, System.Collections.Immutable, System.Net.ServicePoint, System.Text.Encoding.CodePages, and System.Runtime.CompilerServices.Unsafe.

## Root cause
When PSWriteOffice package validation was launched from Windows PowerShell 5.1, PowerForge validated the `Lib/Core` payload using host-provided assemblies discovered from the current Desktop process. That made PS7 runtime assemblies look missing even though PowerShell 7 provides them at runtime. Launching the same full validation from `pwsh` passed, which confirmed this was a host-sensitive preflight false positive rather than a PSWriteOffice or OfficeIMO packaging/runtime failure.

## Validation
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~DesktopHostBaseline_DoesNotTreatCoreRuntimeAssembliesAsBuiltIn|FullyQualifiedName~CoreHostBaseline_IncludesKnownPowerShellRuntimeAssemblies" --no-restore`
- PSWriteOffice packaged module import verified in Windows PowerShell 5.1 and PowerShell 7.6.1: 221 commands in both engines.
- PSWriteOffice AngleSharp/HTML path verified in both engines with `ConvertFrom-OfficeWordHtml` producing DOCX output.

## Review follow-up
- Addressed Claude review suggestions by adding an intent comment, renaming the Core baseline test, and strengthening Desktop negative assertions.