### PR TITLE
Fix PowerForge web first-paint layout stability

### DIFF
--- a/Docs/PowerForge.Web.WebsiteStarter.md
+++ b/Docs/PowerForge.Web.WebsiteStarter.md
@@ -26,6 +26,7 @@ This is compatible with both "standalone themes" and "themes that extend a vendo
     - `preload` when critical CSS is solid and you want a softer non-blocking path
     - `async` only when the theme's critical CSS truly covers the first paint
   - prefer `Head.Links` for fonts/preconnects instead of hiding `@import` font loads inside inline theme CSS
+  - keep `{{ assets.preloads_html }}` and `{{ assets.css_html }}` early in the head; PowerForge routes `Head.Links` preload/preconnect hints through the preload slot and `rel=stylesheet` links through the CSS slot so late `head_html` placement does not delay font/style discovery
   - when a site needs first-party copies of remote fonts/CSS, prefer `AssetPolicy.Rewrites` with HTTPS `SourceUrl`, `SourceUrlAllowedHosts`, and `DownloadDependencies:true`
 - Always keep escape hatches scoped:
   - baselines for legacy noise

--- a/PowerForge.Tests/WebApiDocsGeneratorSourceAndCssTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorSourceAndCssTests.cs
@@ -152,6 +152,8 @@ public class WebApiDocsGeneratorSourceAndCssTests
             Assert.Contains("id=\"api-namespace\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("initNamespaceCombobox", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("initNavDropdowns", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("PowerForge API docs first-paint control stability", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("body.pf-api-docs .namespace-select", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("<style>body.pf-api-docs", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(".pf-combobox-list::-webkit-scrollbar", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(".member-header pre.member-signature", html, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -471,9 +471,96 @@ public class WebSiteBuilderSafetyAndParityTests
             var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
 
             Assert.Contains("rel=\"preload\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
             Assert.Contains("as=\"font\"", html, StringComparison.Ordinal);
             Assert.Contains("data-asset-role=\"font-preload\"", html, StringComparison.Ordinal);
             Assert.Contains("title=\"Test font\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_RendersHeadStylesheetsBeforeRouteStyles_WithoutDuplicating()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-stylesheet-slot-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css",
+                        Attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["data-asset-role"] = "font-stylesheet"
+                        }
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "icon",
+                        Href = "/favicon.ico"
+                    }
+                }
+            };
+            spec.AssetRegistry = new AssetRegistrySpec
+            {
+                Bundles = new[]
+                {
+                    new AssetBundleSpec
+                    {
+                        Name = "global",
+                        Css = new[] { "/assets/app.css" }
+                    }
+                },
+                RouteBundles = new[]
+                {
+                    new RouteBundleSpec
+                    {
+                        Match = "/**",
+                        Bundles = new[] { "global" }
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            var fontIndex = html.IndexOf("href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal);
+            var appIndex = html.IndexOf("href=\"/assets/app.css\"", StringComparison.Ordinal);
+
+            Assert.True(fontIndex >= 0, "Expected the head stylesheet to render through the CSS asset slot.");
+            Assert.True(appIndex >= 0, "Expected the route stylesheet to render.");
+            Assert.True(fontIndex < appIndex, "Head stylesheets should be emitted before route bundle styles.");
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/assets/app.css\"", StringComparison.Ordinal));
+            Assert.Contains("data-asset-role=\"font-stylesheet\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/favicon.ico\"", html, StringComparison.Ordinal);
         }
         finally
         {
@@ -499,5 +586,17 @@ public class WebSiteBuilderSafetyAndParityTests
                 }
             }
         };
+    }
+
+    private static int CountOccurrences(string text, string value, StringComparison comparison)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, comparison)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
     }
 }

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -750,6 +750,173 @@ public class WebSiteBuilderSafetyAndParityTests
         }
     }
 
+    [Fact]
+    public void Build_KeepsHeadAssetLinksInHeadHtml_WhenAssetSlotsFollowHeadHtml()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-order-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteSimpleTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{HEAD_HTML}}{{PRELOADS}}{{ASSET_CSS}}</head>
+                <body>{{CONTENT}}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "simple";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+            spec.AssetRegistry = new AssetRegistrySpec
+            {
+                Bundles = new[]
+                {
+                    new AssetBundleSpec
+                    {
+                        Name = "global",
+                        Css = new[] { "/assets/app.css" }
+                    }
+                },
+                RouteBundles = new[]
+                {
+                    new RouteBundleSpec
+                    {
+                        Match = "/**",
+                        Bundles = new[] { "global" }
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            var preloadIndex = html.IndexOf("href=\"/fonts/test.woff2\"", StringComparison.Ordinal);
+            var fontIndex = html.IndexOf("href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal);
+            var appIndex = html.IndexOf("href=\"/assets/app.css\"", StringComparison.Ordinal);
+
+            Assert.True(preloadIndex >= 0 && appIndex >= 0 && preloadIndex < appIndex, "Head preloads should stay ahead of route CSS when slots follow head_html.");
+            Assert.True(fontIndex >= 0 && appIndex >= 0 && fontIndex < appIndex, "Head stylesheets should stay ahead of route CSS when slots follow head_html.");
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_IgnoresAssetSlotTokensInsideHtmlComments()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-comment-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteSimpleTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head><!-- {{PRELOADS}}{{ASSET_CSS}} -->{{HEAD_HTML}}</head>
+                <body>{{CONTENT}}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "simple";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
     private static SiteSpec BuildBasicSpec(string input, string output)
     {
         return new SiteSpec

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -569,6 +569,187 @@ public class WebSiteBuilderSafetyAndParityTests
         }
     }
 
+    [Fact]
+    public void Build_RoutesHeadAssetLinksThroughSlots_WhenTemplateSupportsThem()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slots-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteSimpleTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{PRELOADS}}<!-- head-html -->{{HEAD_HTML}}{{ASSET_CSS}}</head>
+                <body>{{CONTENT}}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "simple";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "icon",
+                        Href = "/favicon.ico"
+                    }
+                }
+            };
+            spec.AssetRegistry = new AssetRegistrySpec
+            {
+                Bundles = new[]
+                {
+                    new AssetBundleSpec
+                    {
+                        Name = "global",
+                        Css = new[] { "/assets/app.css" }
+                    }
+                },
+                RouteBundles = new[]
+                {
+                    new RouteBundleSpec
+                    {
+                        Match = "/**",
+                        Bundles = new[] { "global" }
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            var preloadIndex = html.IndexOf("href=\"/fonts/test.woff2\"", StringComparison.Ordinal);
+            var headMarkerIndex = html.IndexOf("<!-- head-html -->", StringComparison.Ordinal);
+            var fontIndex = html.IndexOf("href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal);
+            var appIndex = html.IndexOf("href=\"/assets/app.css\"", StringComparison.Ordinal);
+
+            Assert.True(preloadIndex >= 0 && preloadIndex < headMarkerIndex, "Preload links should render through the preload slot.");
+            Assert.True(fontIndex >= 0 && appIndex >= 0 && fontIndex < appIndex, "Head stylesheets should render through the CSS slot before route styles.");
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/assets/app.css\"", StringComparison.Ordinal));
+            Assert.Contains("href=\"/favicon.ico\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_KeepsHeadAssetLinksInHeadHtml_WhenTemplateLacksAssetSlots()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-fallback-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteSimpleTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{HEAD_HTML}}</head>
+                <body>{{CONTENT}}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "simple";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "icon",
+                        Href = "/favicon.ico"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/favicon.ico\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
     private static SiteSpec BuildBasicSpec(string input, string output)
     {
         return new SiteSpec
@@ -586,6 +767,24 @@ public class WebSiteBuilderSafetyAndParityTests
                 }
             }
         };
+    }
+
+    private static void WriteSimpleTheme(string root, string layout)
+    {
+        var themeRoot = Path.Combine(root, "themes", "t");
+        Directory.CreateDirectory(Path.Combine(themeRoot, "layouts"));
+        File.WriteAllText(Path.Combine(themeRoot, "theme.manifest.json"),
+            """
+            {
+              "schemaVersion": 2,
+              "contractVersion": 2,
+              "name": "t",
+              "engine": "simple",
+              "layoutsPath": "layouts",
+              "defaultLayout": "base"
+            }
+            """);
+        File.WriteAllText(Path.Combine(themeRoot, "layouts", "base.html"), layout);
     }
 
     private static int CountOccurrences(string text, string value, StringComparison comparison)

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -1290,6 +1290,301 @@ public class WebSiteBuilderSafetyAndParityTests
     }
 
     [Fact]
+    public void Build_KeepsHeadAssetLinksInHeadHtml_WhenSimpleNestedPartialContainsAssetSlots()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-simple-nested-partial-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteSimpleTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{> outer}}{{HEAD_HTML}}</head>
+                <body>{{CONTENT}}</body>
+                </html>
+                """);
+            WriteThemePartial(root, "outer", "{{> inner}}");
+            WriteThemePartial(root, "inner", "{{PRELOADS}}{{ASSET_CSS}}");
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "simple";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_RoutesHeadAssetLinksThroughSlots_WhenScribanIncludeHasArguments()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-scriban-include-args-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{ include "head-assets" "unused" }}<!-- head-html -->{{ head_html }}</head>
+                <body>{{ content }}</body>
+                </html>
+                """);
+            WriteThemePartial(root, "head-assets", "{{ assets.preloads_html }}{{ assets.css_html }}");
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            var preloadIndex = html.IndexOf("href=\"/fonts/test.woff2\"", StringComparison.Ordinal);
+            var fontIndex = html.IndexOf("href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal);
+            var headMarkerIndex = html.IndexOf("<!-- head-html -->", StringComparison.Ordinal);
+
+            Assert.True(preloadIndex >= 0 && preloadIndex < headMarkerIndex, "Preload links should render through the argument-bearing Scriban include.");
+            Assert.True(fontIndex >= 0 && fontIndex < headMarkerIndex, "Head stylesheets should render through the argument-bearing Scriban include.");
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_KeepsHeadAssetLinksInHeadHtml_WhenScribanEscapeBlockContainsAssetSlots()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-scriban-escape-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{%{ {{ assets.preloads_html }}{{ assets.css_html }} }%}{{ head_html }}</head>
+                <body>{{ content }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_KeepsHeadAssetLinksInHeadHtml_WhenScribanTablerowBlockContainsAssetSlots()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-scriban-tablerow-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{ tablerow item in [] }}{{ assets.preloads_html }}{{ assets.css_html }}{{ end }}{{ head_html }}</head>
+                <body>{{ content }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_RendersHeadAssetLinksOnce_WhenNoThemeIsConfigured()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-no-theme-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -917,6 +917,138 @@ public class WebSiteBuilderSafetyAndParityTests
         }
     }
 
+    [Fact]
+    public void Build_KeepsHeadAssetLinksInHeadHtml_WhenScribanAssetSlotsAreConditional()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-conditional-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{ if false }}{{ assets.preloads_html }}{{ assets.css_html }}{{ end }}{{ head_html }}</head>
+                <body>{{ content }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_RendersHeadAssetLinksOnce_WhenNoThemeIsConfigured()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-no-theme-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
     private static SiteSpec BuildBasicSpec(string input, string output)
     {
         return new SiteSpec
@@ -938,15 +1070,25 @@ public class WebSiteBuilderSafetyAndParityTests
 
     private static void WriteSimpleTheme(string root, string layout)
     {
+        WriteTheme(root, layout, "simple");
+    }
+
+    private static void WriteScribanTheme(string root, string layout)
+    {
+        WriteTheme(root, layout, "scriban");
+    }
+
+    private static void WriteTheme(string root, string layout, string engine)
+    {
         var themeRoot = Path.Combine(root, "themes", "t");
         Directory.CreateDirectory(Path.Combine(themeRoot, "layouts"));
         File.WriteAllText(Path.Combine(themeRoot, "theme.manifest.json"),
-            """
+            $$"""
             {
               "schemaVersion": 2,
               "contractVersion": 2,
               "name": "t",
-              "engine": "simple",
+              "engine": "{{engine}}",
               "layoutsPath": "layouts",
               "defaultLayout": "base"
             }

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -990,6 +990,82 @@ public class WebSiteBuilderSafetyAndParityTests
     }
 
     [Fact]
+    public void Build_UsesLaterRenderedAssetSlots_WhenEarlierScribanSlotsAreConditional()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-later-rendered-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{ if false }}{{ assets.preloads_html }}{{ assets.css_html }}{{ end }}{{ assets.preloads_html }}{{ assets.css_html }}<!-- head-html -->{{ head_html }}</head>
+                <body>{{ content }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            var preloadIndex = html.IndexOf("href=\"/fonts/test.woff2\"", StringComparison.Ordinal);
+            var fontIndex = html.IndexOf("href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal);
+            var headMarkerIndex = html.IndexOf("<!-- head-html -->", StringComparison.Ordinal);
+
+            Assert.True(preloadIndex >= 0 && preloadIndex < headMarkerIndex, "Preload links should use the later rendered preload slot.");
+            Assert.True(fontIndex >= 0 && fontIndex < headMarkerIndex, "Head stylesheets should use the later rendered CSS slot.");
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_RendersHeadAssetLinksOnce_WhenNoThemeIsConfigured()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-no-theme-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -918,6 +918,78 @@ public class WebSiteBuilderSafetyAndParityTests
     }
 
     [Fact]
+    public void Build_IgnoresAssetSlotTokensInsideScribanComments()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-scriban-comment-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{# {{ assets.preloads_html }}{{ assets.css_html }} #}}{{ head_html }}</head>
+                <body>{{ content }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_KeepsHeadAssetLinksInHeadHtml_WhenScribanAssetSlotsAreConditional()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-conditional-" + Guid.NewGuid().ToString("N"));
@@ -942,6 +1014,78 @@ public class WebSiteBuilderSafetyAndParityTests
                 <!doctype html>
                 <html>
                 <head>{{ if false }}{{ assets.preloads_html }}{{ assets.css_html }}{{ end }}{{ head_html }}</head>
+                <body>{{ content }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            Assert.Contains("href=\"/fonts/test.woff2\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"/fonts/site-fonts.css\"", html, StringComparison.Ordinal);
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_KeepsHeadAssetLinksInHeadHtml_WhenScribanAssetSlotsAreInsideFunction()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-func-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{ func head_assets }}{{ assets.preloads_html }}{{ assets.css_html }}{{ end }}{{ head_html }}</head>
                 <body>{{ content }}</body>
                 </html>
                 """);
@@ -1066,6 +1210,86 @@ public class WebSiteBuilderSafetyAndParityTests
     }
 
     [Fact]
+    public void Build_RoutesHeadAssetLinksThroughSlots_WhenAssetSlotsAreInPartial()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-slot-partial-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "index.md"),
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home
+                """);
+
+            WriteSimpleTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{> head-assets}}<!-- head-html -->{{HEAD_HTML}}</head>
+                <body>{{CONTENT}}</body>
+                </html>
+                """);
+            WriteThemePartial(root, "head-assets",
+                """
+                {{PRELOADS}}{{ASSET_CSS}}
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "simple";
+            spec.Head = new HeadSpec
+            {
+                Links = new[]
+                {
+                    new HeadLinkSpec
+                    {
+                        Rel = "preload",
+                        Href = "/fonts/test.woff2",
+                        As = "font",
+                        Type = "font/woff2",
+                        Crossorigin = "anonymous"
+                    },
+                    new HeadLinkSpec
+                    {
+                        Rel = "stylesheet",
+                        Href = "/fonts/site-fonts.css"
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "index.html"));
+
+            var preloadIndex = html.IndexOf("href=\"/fonts/test.woff2\"", StringComparison.Ordinal);
+            var fontIndex = html.IndexOf("href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal);
+            var headMarkerIndex = html.IndexOf("<!-- head-html -->", StringComparison.Ordinal);
+
+            Assert.True(preloadIndex >= 0 && preloadIndex < headMarkerIndex, "Preload links should render through the partial asset slot.");
+            Assert.True(fontIndex >= 0 && fontIndex < headMarkerIndex, "Head stylesheets should render through the partial CSS slot.");
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/test.woff2\"", StringComparison.Ordinal));
+            Assert.Equal(1, CountOccurrences(html, "href=\"/fonts/site-fonts.css\"", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_RendersHeadAssetLinksOnce_WhenNoThemeIsConfigured()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-head-asset-no-theme-" + Guid.NewGuid().ToString("N"));
@@ -1170,6 +1394,13 @@ public class WebSiteBuilderSafetyAndParityTests
             }
             """);
         File.WriteAllText(Path.Combine(themeRoot, "layouts", "base.html"), layout);
+    }
+
+    private static void WriteThemePartial(string root, string name, string content)
+    {
+        var partialsRoot = Path.Combine(root, "themes", "t", "partials");
+        Directory.CreateDirectory(partialsRoot);
+        File.WriteAllText(Path.Combine(partialsRoot, name + ".html"), content);
     }
 
     private static int CountOccurrences(string text, string value, StringComparison comparison)

--- a/PowerForge.Web/Assets/ApiDocs/fallback.css
+++ b/PowerForge.Web/Assets/ApiDocs/fallback.css
@@ -51,10 +51,10 @@ body.pf-api-docs .nav-dropdown.open .nav-dropdown-arrow{transform:rotate(180deg)
 .filter-buttons{display:flex;flex-wrap:wrap;gap:6px}
 .filter-button{background:#0f172a;border:1px solid rgba(148,163,184,.2);color:#cbd5f5;border-radius:999px;padding:4px 10px;font-size:.75rem;cursor:pointer}
 .filter-button.active{background:#1f2937;border-color:var(--pf-accent,#a78bfa);color:#e6e9f3}
-.namespace-select{width:100%;padding:6px 8px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3}
+.namespace-select{appearance:none;width:100%;min-height:30px;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left}
 body.pf-api-docs .namespace-select.pf-enhanced-native{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important}
 body.pf-api-docs .pf-combobox{position:relative}
-body.pf-api-docs .pf-combobox-trigger{position:relative;width:100%;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+body.pf-api-docs .pf-combobox-trigger{position:relative;width:100%;min-height:30px;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 body.pf-api-docs .pf-combobox-trigger:focus-visible{outline:2px solid var(--pf-accent,#a78bfa);outline-offset:1px}
 body.pf-api-docs .pf-combobox-trigger::after{content:"";position:absolute;right:10px;top:50%;width:8px;height:8px;border-right:2px solid #94a3b8;border-bottom:2px solid #94a3b8;transform:translateY(-65%) rotate(45deg);transition:transform .15s ease}
 body.pf-api-docs .pf-combobox.open .pf-combobox-trigger::after{transform:translateY(-40%) rotate(225deg)}

--- a/PowerForge.Web/Assets/ApiDocs/fallback.css
+++ b/PowerForge.Web/Assets/ApiDocs/fallback.css
@@ -51,10 +51,10 @@ body.pf-api-docs .nav-dropdown.open .nav-dropdown-arrow{transform:rotate(180deg)
 .filter-buttons{display:flex;flex-wrap:wrap;gap:6px}
 .filter-button{background:#0f172a;border:1px solid rgba(148,163,184,.2);color:#cbd5f5;border-radius:999px;padding:4px 10px;font-size:.75rem;cursor:pointer}
 .filter-button.active{background:#1f2937;border-color:var(--pf-accent,#a78bfa);color:#e6e9f3}
-.namespace-select{appearance:none;width:100%;min-height:30px;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left}
+.namespace-select{appearance:none;width:100%;min-height:2.45rem;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left}
 body.pf-api-docs .namespace-select.pf-enhanced-native{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important}
 body.pf-api-docs .pf-combobox{position:relative}
-body.pf-api-docs .pf-combobox-trigger{position:relative;width:100%;min-height:30px;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+body.pf-api-docs .pf-combobox-trigger{position:relative;width:100%;min-height:2.45rem;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 body.pf-api-docs .pf-combobox-trigger:focus-visible{outline:2px solid var(--pf-accent,#a78bfa);outline-offset:1px}
 body.pf-api-docs .pf-combobox-trigger::after{content:"";position:absolute;right:10px;top:50%;width:8px;height:8px;border-right:2px solid #94a3b8;border-bottom:2px solid #94a3b8;transform:translateY(-65%) rotate(45deg);transition:transform .15s ease}
 body.pf-api-docs .pf-combobox.open .pf-combobox-trigger::after{transform:translateY(-40%) rotate(225deg)}

--- a/PowerForge.Web/Assets/ApiDocs/fallback.css
+++ b/PowerForge.Web/Assets/ApiDocs/fallback.css
@@ -51,7 +51,7 @@ body.pf-api-docs .nav-dropdown.open .nav-dropdown-arrow{transform:rotate(180deg)
 .filter-buttons{display:flex;flex-wrap:wrap;gap:6px}
 .filter-button{background:#0f172a;border:1px solid rgba(148,163,184,.2);color:#cbd5f5;border-radius:999px;padding:4px 10px;font-size:.75rem;cursor:pointer}
 .filter-button.active{background:#1f2937;border-color:var(--pf-accent,#a78bfa);color:#e6e9f3}
-.namespace-select{appearance:none;width:100%;min-height:2.45rem;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left}
+.namespace-select{width:100%;min-height:2.45rem;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left}
 body.pf-api-docs .namespace-select.pf-enhanced-native{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important}
 body.pf-api-docs .pf-combobox{position:relative}
 body.pf-api-docs .pf-combobox-trigger{position:relative;width:100%;min-height:2.45rem;padding:6px 30px 6px 10px;border-radius:10px;border:1px solid rgba(148,163,184,.3);background:#0f172a;color:#e6e9f3;font-size:.82rem;line-height:1.2;text-align:left;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.SuitePortal.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.SuitePortal.cs
@@ -26,7 +26,7 @@ public static partial class WebApiDocsGenerator
         ApplyNavFallback(options, warnings, ref header, ref footer);
         ApplyNavTokens(options, warnings, ref header, ref footer);
         var bodyClass = ResolveBodyClass(options.BodyClass);
-        var criticalCss = ResolveCriticalCss(options, warnings);
+        var criticalCss = BuildApiDocsCriticalCss(options, warnings);
         var cssLinks = BuildCssLinks(options.CssHref);
         var fallbackCss = LoadAsset(options, "fallback.css", null);
         var cssBlock = BuildCssBlockWithFallback(fallbackCss, cssLinks);

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
@@ -36,7 +36,7 @@ public static partial class WebApiDocsGenerator
         ApplyNavFallback(options, warnings, ref header, ref footer);
         ApplyNavTokens(options, warnings, ref header, ref footer);
         var bodyClass = ResolveBodyClass(options.BodyClass);
-        var criticalCss = ResolveCriticalCss(options, warnings);
+        var criticalCss = BuildApiDocsCriticalCss(options, warnings);
         var codeLanguage = GetDefaultCodeLanguage(options);
         var (prismCss, prismScripts) = BuildApiPrismAssets(options, codeLanguage);
         var cssLinks = BuildCssLinks(options.CssHref);
@@ -113,7 +113,7 @@ public static partial class WebApiDocsGenerator
         ApplyNavFallback(options, warnings, ref header, ref footer);
         ApplyNavTokens(options, warnings, ref header, ref footer);
         var bodyClass = ResolveBodyClass(options.BodyClass);
-        var criticalCss = ResolveCriticalCss(options, warnings);
+        var criticalCss = BuildApiDocsCriticalCss(options, warnings);
         var codeLanguage = GetDefaultCodeLanguage(options);
         var (prismCss, prismScripts) = BuildApiPrismAssets(options, codeLanguage);
         var cssLinks = BuildCssLinks(options.CssHref);
@@ -621,6 +621,30 @@ $@"<!doctype html>
 
         return null;
     }
+
+    private const string ApiDocsLayoutStabilityCss = """
+/* PowerForge API docs first-paint control stability. */
+body.pf-api-docs .namespace-select,
+body.pf-api-docs .pf-combobox-trigger{
+  box-sizing:border-box;
+  width:100%;
+  min-height:2.45rem;
+  line-height:1.2;
+}
+body.pf-api-docs .filter-button,
+body.pf-api-docs .sidebar-reset,
+body.pf-api-docs .sidebar-tools button,
+body.pf-api-docs .api-suite-search-filter{
+  box-sizing:border-box;
+  min-height:1.9rem;
+  line-height:1.2;
+}
+""";
+
+    private static string BuildApiDocsCriticalCss(WebApiDocsOptions options, List<string> warnings) =>
+        JoinHtmlFragments(
+            ResolveCriticalCss(options, warnings),
+            WrapStyle(ApiDocsLayoutStabilityCss));
 
     private static string ResolveCriticalCss(WebApiDocsOptions options, List<string> warnings)
     {

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -82,7 +82,7 @@ public static partial class WebSiteBuilder
         var assetSlotUsage = ResolveAssetSlotUsage(themeTemplate);
         var cssLinks = ResolveCssLinks(assetRegistry, item.OutputPath);
         var jsLinks = ResolveJsLinks(assetRegistry, item.OutputPath);
-        var preloads = RenderPreloads(assetRegistry, assetSlotUsage.HasPreloadsSlot ? spec.Head : null);
+        var preloads = RenderPreloads(assetRegistry, assetSlotUsage.UsePreloadsSlot ? spec.Head : null);
         var criticalCss = RenderCriticalCss(assetRegistry, rootPath, renderCache);
         var assetMs = measure.ElapsedMilliseconds;
         measure.Restart();
@@ -93,7 +93,7 @@ public static partial class WebSiteBuilder
             ? string.Empty
             : $"<link rel=\"canonical\" href=\"{System.Web.HttpUtility.HtmlEncode(canonicalUrl)}\" />";
 
-        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, assetSlotUsage.HasCssSlot ? spec.Head : null);
+        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, assetSlotUsage.UseCssSlot ? spec.Head : null);
         var jsHtml = string.Join(Environment.NewLine, jsLinks.Select(j => $"<script src=\"{j}\" defer data-cfasync=\"false\"></script>"));
         var pageTitle = ResolveSeoTitle(spec, item);
         var pageDescription = ResolveMetaDescription(spec, item);
@@ -115,8 +115,8 @@ public static partial class WebSiteBuilder
             item,
             allItems,
             rootPath,
-            includeEarlyHeadLinks: !assetSlotUsage.HasPreloadsSlot,
-            includeStylesheetHeadLinks: !assetSlotUsage.HasCssSlot);
+            includeEarlyHeadLinks: !assetSlotUsage.UsePreloadsSlot,
+            includeStylesheetHeadLinks: !assetSlotUsage.UseCssSlot);
         var bodyClass = BuildBodyClass(spec, item);
         var openGraph = BuildOpenGraphHtml(spec, item, outputRoot);
         var structuredData = BuildStructuredDataHtml(spec, item, breadcrumbs);

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -66,9 +66,23 @@ public static partial class WebSiteBuilder
         var assetRegistry = renderCache.AssetRegistry;
         var measure = Stopwatch.StartNew();
 
+        string? themeTemplate = null;
+        ITemplateEngine? themeEngine = null;
+        if (!string.IsNullOrWhiteSpace(themeRoot) && Directory.Exists(themeRoot))
+        {
+            var layoutName = item.Template ?? item.Layout ?? manifest?.DefaultLayout ?? "base";
+            var layoutPath = loader.ResolveLayoutPath(themeRoot, manifest, layoutName);
+            if (!string.IsNullOrWhiteSpace(layoutPath))
+            {
+                themeTemplate = ReadCachedText(renderCache.LayoutTemplateCache, layoutPath);
+                themeEngine = ThemeEngineRegistry.Resolve(spec.ThemeEngine ?? manifest?.Engine);
+            }
+        }
+
+        var assetSlotUsage = ResolveAssetSlotUsage(themeTemplate);
         var cssLinks = ResolveCssLinks(assetRegistry, item.OutputPath);
         var jsLinks = ResolveJsLinks(assetRegistry, item.OutputPath);
-        var preloads = RenderPreloads(assetRegistry, spec.Head);
+        var preloads = RenderPreloads(assetRegistry, assetSlotUsage.HasPreloadsSlot ? spec.Head : null);
         var criticalCss = RenderCriticalCss(assetRegistry, rootPath, renderCache);
         var assetMs = measure.ElapsedMilliseconds;
         measure.Restart();
@@ -79,7 +93,7 @@ public static partial class WebSiteBuilder
             ? string.Empty
             : $"<link rel=\"canonical\" href=\"{System.Web.HttpUtility.HtmlEncode(canonicalUrl)}\" />";
 
-        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, spec.Head);
+        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, assetSlotUsage.HasCssSlot ? spec.Head : null);
         var jsHtml = string.Join(Environment.NewLine, jsLinks.Select(j => $"<script src=\"{j}\" defer data-cfasync=\"false\"></script>"));
         var pageTitle = ResolveSeoTitle(spec, item);
         var pageDescription = ResolveMetaDescription(spec, item);
@@ -96,7 +110,13 @@ public static partial class WebSiteBuilder
         var listItems = ApplyPagination(fullListItems, pagination);
         var listMs = measure.ElapsedMilliseconds;
         measure.Restart();
-        var headHtml = BuildHeadHtml(spec, item, allItems, rootPath);
+        var headHtml = BuildHeadHtml(
+            spec,
+            item,
+            allItems,
+            rootPath,
+            includeEarlyHeadLinks: !assetSlotUsage.HasPreloadsSlot,
+            includeStylesheetHeadLinks: !assetSlotUsage.HasCssSlot);
         var bodyClass = BuildBodyClass(spec, item);
         var openGraph = BuildOpenGraphHtml(spec, item, outputRoot);
         var structuredData = BuildStructuredDataHtml(spec, item, breadcrumbs);
@@ -151,23 +171,16 @@ public static partial class WebSiteBuilder
             Pagination = pagination
         };
 
-        if (!string.IsNullOrWhiteSpace(themeRoot) && Directory.Exists(themeRoot))
+        if (themeTemplate is not null && themeEngine is not null)
         {
-            var layoutName = item.Template ?? item.Layout ?? manifest?.DefaultLayout ?? "base";
-            var layoutPath = loader.ResolveLayoutPath(themeRoot, manifest, layoutName);
-            if (!string.IsNullOrWhiteSpace(layoutPath))
+            var html = themeEngine.Render(themeTemplate, renderContext, name =>
             {
-                var template = ReadCachedText(renderCache.LayoutTemplateCache, layoutPath);
-                var engine = ThemeEngineRegistry.Resolve(spec.ThemeEngine ?? manifest?.Engine);
-                var html = engine.Render(template, renderContext, name =>
-                {
-                    var partialPath = loader.ResolvePartialPath(themeRoot, manifest, name);
-                    return partialPath is null ? null : ReadCachedText(renderCache.PartialTemplateCache, partialPath);
-                });
-                html = RebaseSelectedLanguageRootHtml(spec, html);
-                ReportSlowRenderTiming(item, pageTimer.ElapsedMilliseconds, assetMs, navMs, listMs, headMs, taxonomyMs, localizationMs);
-                return html;
-            }
+                var partialPath = loader.ResolvePartialPath(themeRoot!, manifest, name);
+                return partialPath is null ? null : ReadCachedText(renderCache.PartialTemplateCache, partialPath);
+            });
+            html = RebaseSelectedLanguageRootHtml(spec, html);
+            ReportSlowRenderTiming(item, pageTimer.ElapsedMilliseconds, assetMs, navMs, listMs, headMs, taxonomyMs, localizationMs);
+            return html;
         }
 
         var htmlLang = System.Web.HttpUtility.HtmlEncode(renderContext.Localization.Current.Code ?? "en");

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -68,7 +68,7 @@ public static partial class WebSiteBuilder
 
         var cssLinks = ResolveCssLinks(assetRegistry, item.OutputPath);
         var jsLinks = ResolveJsLinks(assetRegistry, item.OutputPath);
-        var preloads = RenderPreloads(assetRegistry);
+        var preloads = RenderPreloads(assetRegistry, spec.Head);
         var criticalCss = RenderCriticalCss(assetRegistry, rootPath, renderCache);
         var assetMs = measure.ElapsedMilliseconds;
         measure.Restart();
@@ -79,7 +79,7 @@ public static partial class WebSiteBuilder
             ? string.Empty
             : $"<link rel=\"canonical\" href=\"{System.Web.HttpUtility.HtmlEncode(canonicalUrl)}\" />";
 
-        var cssHtml = RenderCssLinks(cssLinks, assetRegistry);
+        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, spec.Head);
         var jsHtml = string.Join(Environment.NewLine, jsLinks.Select(j => $"<script src=\"{j}\" defer data-cfasync=\"false\"></script>"));
         var pageTitle = ResolveSeoTitle(spec, item);
         var pageDescription = ResolveMetaDescription(spec, item);

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -68,6 +68,7 @@ public static partial class WebSiteBuilder
 
         string? themeTemplate = null;
         ITemplateEngine? themeEngine = null;
+        var assetSlotTemplateKind = AssetSlotTemplateKind.Simple;
         Func<string, string?>? partialResolver = null;
         if (!string.IsNullOrWhiteSpace(themeRoot) && Directory.Exists(themeRoot))
         {
@@ -77,6 +78,8 @@ public static partial class WebSiteBuilder
             {
                 themeTemplate = ReadCachedText(renderCache.LayoutTemplateCache, layoutPath);
                 themeEngine = ThemeEngineRegistry.Resolve(spec.ThemeEngine ?? manifest?.Engine);
+                if (themeEngine is ScribanTemplateEngine)
+                    assetSlotTemplateKind = AssetSlotTemplateKind.Scriban;
             }
         }
 
@@ -89,7 +92,7 @@ public static partial class WebSiteBuilder
             };
         }
 
-        var assetSlotUsage = ResolveAssetSlotUsage(themeTemplate, partialResolver);
+        var assetSlotUsage = ResolveAssetSlotUsage(themeTemplate, partialResolver, assetSlotTemplateKind);
         var cssLinks = ResolveCssLinks(assetRegistry, item.OutputPath);
         var jsLinks = ResolveJsLinks(assetRegistry, item.OutputPath);
         var preloads = RenderPreloads(assetRegistry, assetSlotUsage.UsePreloadsSlot ? spec.Head : null);

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -68,6 +68,7 @@ public static partial class WebSiteBuilder
 
         string? themeTemplate = null;
         ITemplateEngine? themeEngine = null;
+        Func<string, string?>? partialResolver = null;
         if (!string.IsNullOrWhiteSpace(themeRoot) && Directory.Exists(themeRoot))
         {
             var layoutName = item.Template ?? item.Layout ?? manifest?.DefaultLayout ?? "base";
@@ -79,7 +80,16 @@ public static partial class WebSiteBuilder
             }
         }
 
-        var assetSlotUsage = ResolveAssetSlotUsage(themeTemplate);
+        if (themeTemplate is not null && themeRoot is not null)
+        {
+            partialResolver = name =>
+            {
+                var partialPath = loader.ResolvePartialPath(themeRoot, manifest, name);
+                return partialPath is null ? null : ReadCachedText(renderCache.PartialTemplateCache, partialPath);
+            };
+        }
+
+        var assetSlotUsage = ResolveAssetSlotUsage(themeTemplate, partialResolver);
         var cssLinks = ResolveCssLinks(assetRegistry, item.OutputPath);
         var jsLinks = ResolveJsLinks(assetRegistry, item.OutputPath);
         var preloads = RenderPreloads(assetRegistry, assetSlotUsage.UsePreloadsSlot ? spec.Head : null);
@@ -173,11 +183,7 @@ public static partial class WebSiteBuilder
 
         if (themeTemplate is not null && themeEngine is not null)
         {
-            var html = themeEngine.Render(themeTemplate, renderContext, name =>
-            {
-                var partialPath = loader.ResolvePartialPath(themeRoot!, manifest, name);
-                return partialPath is null ? null : ReadCachedText(renderCache.PartialTemplateCache, partialPath);
-            });
+            var html = themeEngine.Render(themeTemplate, renderContext, partialResolver ?? (_ => null));
             html = RebaseSelectedLanguageRootHtml(spec, html);
             ReportSlowRenderTiming(item, pageTimer.ElapsedMilliseconds, assetMs, navMs, listMs, headMs, taxonomyMs, localizationMs);
             return html;

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -12,17 +12,34 @@ namespace PowerForge.Web;
 
 public static partial class WebSiteBuilder
 {
-    private static string RenderPreloads(AssetRegistrySpec? assets)
+    private static readonly HashSet<string> EarlyHeadLinkRels = new(StringComparer.OrdinalIgnoreCase)
     {
-        if (assets?.Preloads is null || assets.Preloads.Length == 0)
-            return string.Empty;
+        "preload",
+        "modulepreload",
+        "preconnect",
+        "dns-prefetch",
+        "prefetch"
+    };
 
-        return string.Join(Environment.NewLine, assets.Preloads.Select(p =>
+    private static string RenderPreloads(AssetRegistrySpec? assets, HeadSpec? head = null)
+    {
+        var parts = new List<string>();
+
+        var headHints = RenderHeadLinks(head, static link => IsEarlyHeadLink(link.Rel));
+        if (!string.IsNullOrWhiteSpace(headHints))
+            parts.Add(headHints);
+
+        if (assets?.Preloads is { Length: > 0 })
         {
-            var type = string.IsNullOrWhiteSpace(p.Type) ? string.Empty : $" type=\"{p.Type}\"";
-            var cross = string.IsNullOrWhiteSpace(p.Crossorigin) ? string.Empty : $" crossorigin=\"{p.Crossorigin}\"";
-            return $"<link rel=\"preload\" href=\"{p.Href}\" as=\"{p.As}\"{type}{cross} />";
-        }));
+            parts.Add(string.Join(Environment.NewLine, assets.Preloads.Select(p =>
+            {
+                var type = string.IsNullOrWhiteSpace(p.Type) ? string.Empty : $" type=\"{p.Type}\"";
+                var cross = string.IsNullOrWhiteSpace(p.Crossorigin) ? string.Empty : $" crossorigin=\"{p.Crossorigin}\"";
+                return $"<link rel=\"preload\" href=\"{p.Href}\" as=\"{p.As}\"{type}{cross} />";
+            })));
+        }
+
+        return string.Join(Environment.NewLine, parts);
     }
 
     private static string RenderCriticalCss(AssetRegistrySpec? assets, string rootPath, BuildRenderCache? renderCache = null)
@@ -48,19 +65,27 @@ public static partial class WebSiteBuilder
         return sb.ToString();
     }
 
-    private static string RenderCssLinks(IEnumerable<string> cssLinks, AssetRegistrySpec? assets)
+    private static string RenderCssLinks(IEnumerable<string> cssLinks, AssetRegistrySpec? assets, HeadSpec? head = null)
     {
+        var parts = new List<string>();
+        var headStyles = RenderHeadLinks(head, static link => IsStylesheetHeadLink(link.Rel));
+        if (!string.IsNullOrWhiteSpace(headStyles))
+            parts.Add(headStyles);
+
         var links = cssLinks.ToArray();
-        if (links.Length == 0) return string.Empty;
+        if (links.Length == 0) return string.Join(Environment.NewLine, parts);
 
         var strategy = WebAssetCssStrategy.Normalize(assets?.CssStrategy);
         if (strategy.Equals("async", StringComparison.OrdinalIgnoreCase))
-            return string.Join(Environment.NewLine, links.Select(RenderAsyncCssLink));
+            parts.Add(string.Join(Environment.NewLine, links.Select(RenderAsyncCssLink)));
 
-        if (strategy.Equals("preload", StringComparison.OrdinalIgnoreCase))
-            return string.Join(Environment.NewLine, links.Select(RenderPreloadCssLink));
+        else if (strategy.Equals("preload", StringComparison.OrdinalIgnoreCase))
+            parts.Add(string.Join(Environment.NewLine, links.Select(RenderPreloadCssLink)));
 
-        return string.Join(Environment.NewLine, links.Select(c => $"<link rel=\"stylesheet\" href=\"{c}\" />"));
+        else
+            parts.Add(string.Join(Environment.NewLine, links.Select(c => $"<link rel=\"stylesheet\" href=\"{c}\" />")));
+
+        return string.Join(Environment.NewLine, parts);
     }
 
     private static string RenderAsyncCssLink(string href)
@@ -81,7 +106,7 @@ public static partial class WebSiteBuilder
         var head = spec.Head;
         if (head is not null)
         {
-            var links = RenderHeadLinks(head);
+            var links = RenderHeadLinks(head, static link => !IsAssetSlotHeadLink(link.Rel));
             if (!string.IsNullOrWhiteSpace(links))
                 parts.Add(links);
 
@@ -283,15 +308,32 @@ public static partial class WebSiteBuilder
             .FirstOrDefault();
     }
 
-    private static string RenderHeadLinks(HeadSpec head)
+    private static bool IsEarlyHeadLink(string? rel)
     {
-        if (head.Links.Length == 0)
+        if (string.IsNullOrWhiteSpace(rel))
+            return false;
+
+        return EarlyHeadLinkRels.Contains(rel.Trim());
+    }
+
+    private static bool IsStylesheetHeadLink(string? rel) =>
+        !string.IsNullOrWhiteSpace(rel) &&
+        rel.Trim().Equals("stylesheet", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsAssetSlotHeadLink(string? rel) =>
+        IsEarlyHeadLink(rel) || IsStylesheetHeadLink(rel);
+
+    private static string RenderHeadLinks(HeadSpec? head, Func<HeadLinkSpec, bool>? predicate = null)
+    {
+        if (head?.Links is null || head.Links.Length == 0)
             return string.Empty;
 
         var sb = new System.Text.StringBuilder();
         foreach (var link in head.Links)
         {
             if (string.IsNullOrWhiteSpace(link.Rel) || string.IsNullOrWhiteSpace(link.Href))
+                continue;
+            if (predicate is not null && !predicate(link))
                 continue;
 
             sb.Append("<link");

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -100,13 +100,43 @@ public static partial class WebSiteBuilder
 <noscript><link rel=""stylesheet"" href=""{href}"" /></noscript>";
     }
 
-    private static string BuildHeadHtml(SiteSpec spec, ContentItem item, IReadOnlyList<ContentItem> allItems, string rootPath)
+    private readonly record struct AssetSlotUsage(bool HasPreloadsSlot, bool HasCssSlot);
+
+    private static AssetSlotUsage ResolveAssetSlotUsage(string? template)
+    {
+        if (string.IsNullOrWhiteSpace(template))
+            return new AssetSlotUsage(true, true);
+
+        return new AssetSlotUsage(
+            ContainsScribanToken(template, "assets.preloads_html") || ContainsSimpleToken(template, "PRELOADS"),
+            ContainsScribanToken(template, "assets.css_html") || ContainsSimpleToken(template, "ASSET_CSS"));
+    }
+
+    private static bool ContainsScribanToken(string template, string token) =>
+        template.Contains(token, StringComparison.OrdinalIgnoreCase);
+
+    private static bool ContainsSimpleToken(string template, string token) =>
+        Regex.IsMatch(
+            template,
+            @"\{\{\s*" + Regex.Escape(token) + @"\s*\}\}",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+            RegexTimeout);
+
+    private static string BuildHeadHtml(
+        SiteSpec spec,
+        ContentItem item,
+        IReadOnlyList<ContentItem> allItems,
+        string rootPath,
+        bool includeEarlyHeadLinks = false,
+        bool includeStylesheetHeadLinks = false)
     {
         var parts = new List<string>();
         var head = spec.Head;
         if (head is not null)
         {
-            var links = RenderHeadLinks(head, static link => !IsAssetSlotHeadLink(link.Rel));
+            var links = RenderHeadLinks(
+                head,
+                link => ShouldRenderHeadLinkInHeadHtml(link.Rel, includeEarlyHeadLinks, includeStylesheetHeadLinks));
             if (!string.IsNullOrWhiteSpace(links))
                 parts.Add(links);
 
@@ -322,6 +352,17 @@ public static partial class WebSiteBuilder
 
     private static bool IsAssetSlotHeadLink(string? rel) =>
         IsEarlyHeadLink(rel) || IsStylesheetHeadLink(rel);
+
+    private static bool ShouldRenderHeadLinkInHeadHtml(string? rel, bool includeEarlyHeadLinks, bool includeStylesheetHeadLinks)
+    {
+        if (IsEarlyHeadLink(rel))
+            return includeEarlyHeadLinks;
+
+        if (IsStylesheetHeadLink(rel))
+            return includeStylesheetHeadLinks;
+
+        return true;
+    }
 
     private static string RenderHeadLinks(HeadSpec? head, Func<HeadLinkSpec, bool>? predicate = null)
     {

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -100,27 +100,45 @@ public static partial class WebSiteBuilder
 <noscript><link rel=""stylesheet"" href=""{href}"" /></noscript>";
     }
 
-    private readonly record struct AssetSlotUsage(bool HasPreloadsSlot, bool HasCssSlot);
+    private readonly record struct AssetSlotUsage(bool UsePreloadsSlot, bool UseCssSlot);
 
     private static AssetSlotUsage ResolveAssetSlotUsage(string? template)
     {
         if (string.IsNullOrWhiteSpace(template))
             return new AssetSlotUsage(true, true);
 
+        var searchableTemplate = HtmlCommentRegex.Replace(template, string.Empty);
+        var headIndex = FindFirstRenderedTokenIndex(searchableTemplate, "head_html", "HEAD_HTML");
+        var preloadsIndex = FindFirstRenderedTokenIndex(searchableTemplate, "assets.preloads_html", "PRELOADS");
+        var cssIndex = FindFirstRenderedTokenIndex(searchableTemplate, "assets.css_html", "ASSET_CSS");
+
         return new AssetSlotUsage(
-            ContainsScribanToken(template, "assets.preloads_html") || ContainsSimpleToken(template, "PRELOADS"),
-            ContainsScribanToken(template, "assets.css_html") || ContainsSimpleToken(template, "ASSET_CSS"));
+            ShouldUseAssetSlot(preloadsIndex, headIndex),
+            ShouldUseAssetSlot(cssIndex, headIndex));
     }
 
-    private static bool ContainsScribanToken(string template, string token) =>
-        template.Contains(token, StringComparison.OrdinalIgnoreCase);
+    private static bool ShouldUseAssetSlot(int slotIndex, int headIndex) =>
+        slotIndex >= 0 && (headIndex < 0 || slotIndex < headIndex);
 
-    private static bool ContainsSimpleToken(string template, string token) =>
-        Regex.IsMatch(
-            template,
-            @"\{\{\s*" + Regex.Escape(token) + @"\s*\}\}",
-            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
-            RegexTimeout);
+    private static int FindFirstRenderedTokenIndex(string template, params string[] tokens)
+    {
+        var index = -1;
+        foreach (var token in tokens)
+        {
+            var match = Regex.Match(
+                template,
+                @"\{\{[-~]?\s*" + Regex.Escape(token) + @"\s*[-~]?\}\}",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+                RegexTimeout);
+            if (!match.Success)
+                continue;
+
+            if (index < 0 || match.Index < index)
+                index = match.Index;
+        }
+
+        return index;
+    }
 
     private static string BuildHeadHtml(
         SiteSpec spec,

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -132,12 +132,36 @@ public static partial class WebSiteBuilder
                 RegexTimeout);
             if (!match.Success)
                 continue;
+            if (IsInsideScribanControlBlock(template, match.Index))
+                continue;
 
             if (index < 0 || match.Index < index)
                 index = match.Index;
         }
 
         return index;
+    }
+
+    private static bool IsInsideScribanControlBlock(string template, int index)
+    {
+        var depth = 0;
+        foreach (Match match in Regex.Matches(
+                     template,
+                     @"\{\{[-~]?\s*(?<keyword>if|unless|case|for|while|capture|with|end)\b",
+                     RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+                     RegexTimeout))
+        {
+            if (match.Index >= index)
+                break;
+
+            var keyword = match.Groups["keyword"].Value;
+            if (keyword.Equals("end", StringComparison.OrdinalIgnoreCase))
+                depth = Math.Max(0, depth - 1);
+            else
+                depth++;
+        }
+
+        return depth > 0;
     }
 
     private static string BuildHeadHtml(
@@ -367,9 +391,6 @@ public static partial class WebSiteBuilder
     private static bool IsStylesheetHeadLink(string? rel) =>
         !string.IsNullOrWhiteSpace(rel) &&
         rel.Trim().Equals("stylesheet", StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsAssetSlotHeadLink(string? rel) =>
-        IsEarlyHeadLink(rel) || IsStylesheetHeadLink(rel);
 
     private static bool ShouldRenderHeadLinkInHeadHtml(string? rel, bool includeEarlyHeadLinks, bool includeStylesheetHeadLinks)
     {

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -20,6 +20,11 @@ public static partial class WebSiteBuilder
         "dns-prefetch",
         "prefetch"
     };
+    private static readonly Regex ScribanCommentRegex = new(@"\{\{[-~]?\s*#.*?#\s*[-~]?\}\}", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.CultureInvariant, RegexTimeout);
+    private static readonly Regex ScribanControlBlockRegex = new(@"\{\{[-~]?\s*(?<keyword>if|unless|case|for|while|capture|with|func|end)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+    private static readonly Regex SimplePartialReferenceRegex = new(@"\{\{>\s*(?<name>[^\s}]+)\s*\}\}", RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
+    private static readonly Regex ScribanPartialReferenceRegex = new(@"\{\{[-~]?\s*include\s+[""'](?<name>[^""']+)[""']\s*[-~]?\}\}", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+    private const int MaxAssetSlotPartialDepth = 8;
 
     private static string RenderPreloads(AssetRegistrySpec? assets, HeadSpec? head = null)
     {
@@ -102,12 +107,15 @@ public static partial class WebSiteBuilder
 
     private readonly record struct AssetSlotUsage(bool UsePreloadsSlot, bool UseCssSlot);
 
-    private static AssetSlotUsage ResolveAssetSlotUsage(string? template)
+    private static AssetSlotUsage ResolveAssetSlotUsage(string? template, Func<string, string?>? partialResolver = null)
     {
         if (string.IsNullOrWhiteSpace(template))
+        {
+            // The built-in no-theme renderer emits PreloadsHtml and CssHtml directly, so keep those slots active.
             return new AssetSlotUsage(true, true);
+        }
 
-        var searchableTemplate = HtmlCommentRegex.Replace(template, string.Empty);
+        var searchableTemplate = BuildAssetSlotSearchTemplate(template, partialResolver);
         var headIndex = FindFirstRenderedTokenIndex(searchableTemplate, "head_html", "HEAD_HTML");
         var preloadsIndex = FindFirstRenderedTokenIndex(searchableTemplate, "assets.preloads_html", "PRELOADS");
         var cssIndex = FindFirstRenderedTokenIndex(searchableTemplate, "assets.css_html", "ASSET_CSS");
@@ -119,6 +127,52 @@ public static partial class WebSiteBuilder
 
     private static bool ShouldUseAssetSlot(int slotIndex, int headIndex) =>
         slotIndex >= 0 && (headIndex < 0 || slotIndex < headIndex);
+
+    private static string BuildAssetSlotSearchTemplate(string template, Func<string, string?>? partialResolver)
+    {
+        var searchable = StripNonRenderedComments(template);
+        return ExpandAssetSlotPartialReferences(searchable, partialResolver, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0);
+    }
+
+    private static string StripNonRenderedComments(string template) =>
+        ScribanCommentRegex.Replace(HtmlCommentRegex.Replace(template, string.Empty), string.Empty);
+
+    private static string ExpandAssetSlotPartialReferences(
+        string template,
+        Func<string, string?>? partialResolver,
+        HashSet<string> seen,
+        int depth)
+    {
+        if (partialResolver is null || depth >= MaxAssetSlotPartialDepth || string.IsNullOrEmpty(template))
+            return template;
+
+        string ReplacePartial(Match match)
+        {
+            var name = match.Groups["name"].Value;
+            if (string.IsNullOrWhiteSpace(name) || !seen.Add(name))
+                return string.Empty;
+
+            try
+            {
+                var partial = partialResolver(name);
+                if (string.IsNullOrWhiteSpace(partial))
+                    return string.Empty;
+
+                return ExpandAssetSlotPartialReferences(
+                    StripNonRenderedComments(partial),
+                    partialResolver,
+                    seen,
+                    depth + 1);
+            }
+            finally
+            {
+                seen.Remove(name);
+            }
+        }
+
+        var expanded = SimplePartialReferenceRegex.Replace(template, ReplacePartial);
+        return ScribanPartialReferenceRegex.Replace(expanded, ReplacePartial);
+    }
 
     private static int FindFirstRenderedTokenIndex(string template, params string[] tokens)
     {
@@ -146,11 +200,7 @@ public static partial class WebSiteBuilder
     {
         var depth = 0;
         // Branch truth is runtime data, so any slot inside a Scriban block stays conservative.
-        foreach (Match match in Regex.Matches(
-                     template,
-                     @"\{\{[-~]?\s*(?<keyword>if|unless|case|for|while|capture|with|end)\b",
-                     RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
-                     RegexTimeout))
+        foreach (Match match in ScribanControlBlockRegex.Matches(template))
         {
             if (match.Index >= index)
                 break;

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -125,18 +125,18 @@ public static partial class WebSiteBuilder
         var index = -1;
         foreach (var token in tokens)
         {
-            var match = Regex.Match(
+            foreach (Match match in Regex.Matches(
                 template,
                 @"\{\{[-~]?\s*" + Regex.Escape(token) + @"\s*[-~]?\}\}",
                 RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
-                RegexTimeout);
-            if (!match.Success)
-                continue;
-            if (IsInsideScribanControlBlock(template, match.Index))
-                continue;
+                RegexTimeout))
+            {
+                if (IsInsideScribanControlBlock(template, match.Index))
+                    continue;
 
-            if (index < 0 || match.Index < index)
-                index = match.Index;
+                if (index < 0 || match.Index < index)
+                    index = match.Index;
+            }
         }
 
         return index;
@@ -145,6 +145,7 @@ public static partial class WebSiteBuilder
     private static bool IsInsideScribanControlBlock(string template, int index)
     {
         var depth = 0;
+        // Branch truth is runtime data, so any slot inside a Scriban block stays conservative.
         foreach (Match match in Regex.Matches(
                      template,
                      @"\{\{[-~]?\s*(?<keyword>if|unless|case|for|while|capture|with|end)\b",

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -21,9 +21,10 @@ public static partial class WebSiteBuilder
         "prefetch"
     };
     private static readonly Regex ScribanCommentRegex = new(@"\{\{[-~]?\s*#.*?#\s*[-~]?\}\}", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.CultureInvariant, RegexTimeout);
-    private static readonly Regex ScribanControlBlockRegex = new(@"\{\{[-~]?\s*(?<keyword>if|unless|case|for|while|capture|with|func|end)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+    private static readonly Regex ScribanEscapeBlockRegex = new(@"\{%\{.*?\}%\}", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.CultureInvariant, RegexTimeout);
+    private static readonly Regex ScribanControlBlockRegex = new(@"\{\{[-~]?\s*(?<keyword>if|unless|case|for|while|capture|with|func|tablerow|wrap|end)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
     private static readonly Regex SimplePartialReferenceRegex = new(@"\{\{>\s*(?<name>[^\s}]+)\s*\}\}", RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
-    private static readonly Regex ScribanPartialReferenceRegex = new(@"\{\{[-~]?\s*include\s+[""'](?<name>[^""']+)[""']\s*[-~]?\}\}", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
+    private static readonly Regex ScribanPartialReferenceRegex = new(@"\{\{[-~]?\s*include\s+[""'](?<name>[^""']+)[""'][^}]*[-~]?\}\}", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexTimeout);
     private const int MaxAssetSlotPartialDepth = 8;
 
     private static string RenderPreloads(AssetRegistrySpec? assets, HeadSpec? head = null)
@@ -107,7 +108,16 @@ public static partial class WebSiteBuilder
 
     private readonly record struct AssetSlotUsage(bool UsePreloadsSlot, bool UseCssSlot);
 
-    private static AssetSlotUsage ResolveAssetSlotUsage(string? template, Func<string, string?>? partialResolver = null)
+    private enum AssetSlotTemplateKind
+    {
+        Simple,
+        Scriban
+    }
+
+    private static AssetSlotUsage ResolveAssetSlotUsage(
+        string? template,
+        Func<string, string?>? partialResolver = null,
+        AssetSlotTemplateKind templateKind = AssetSlotTemplateKind.Simple)
     {
         if (string.IsNullOrWhiteSpace(template))
         {
@@ -115,7 +125,7 @@ public static partial class WebSiteBuilder
             return new AssetSlotUsage(true, true);
         }
 
-        var searchableTemplate = BuildAssetSlotSearchTemplate(template, partialResolver);
+        var searchableTemplate = BuildAssetSlotSearchTemplate(template, partialResolver, templateKind);
         var headIndex = FindFirstRenderedTokenIndex(searchableTemplate, "head_html", "HEAD_HTML");
         var preloadsIndex = FindFirstRenderedTokenIndex(searchableTemplate, "assets.preloads_html", "PRELOADS");
         var cssIndex = FindFirstRenderedTokenIndex(searchableTemplate, "assets.css_html", "ASSET_CSS");
@@ -128,18 +138,26 @@ public static partial class WebSiteBuilder
     private static bool ShouldUseAssetSlot(int slotIndex, int headIndex) =>
         slotIndex >= 0 && (headIndex < 0 || slotIndex < headIndex);
 
-    private static string BuildAssetSlotSearchTemplate(string template, Func<string, string?>? partialResolver)
+    private static string BuildAssetSlotSearchTemplate(
+        string template,
+        Func<string, string?>? partialResolver,
+        AssetSlotTemplateKind templateKind)
     {
-        var searchable = StripNonRenderedComments(template);
-        return ExpandAssetSlotPartialReferences(searchable, partialResolver, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0);
+        var searchable = StripNonRenderedTemplateRegions(template);
+        return ExpandAssetSlotPartialReferences(searchable, partialResolver, templateKind, new HashSet<string>(StringComparer.OrdinalIgnoreCase), 0);
     }
 
-    private static string StripNonRenderedComments(string template) =>
-        ScribanCommentRegex.Replace(HtmlCommentRegex.Replace(template, string.Empty), string.Empty);
+    private static string StripNonRenderedTemplateRegions(string template) =>
+        ScribanEscapeBlockRegex.Replace(
+            ScribanCommentRegex.Replace(
+                HtmlCommentRegex.Replace(template, string.Empty),
+                string.Empty),
+            string.Empty);
 
     private static string ExpandAssetSlotPartialReferences(
         string template,
         Func<string, string?>? partialResolver,
+        AssetSlotTemplateKind templateKind,
         HashSet<string> seen,
         int depth)
     {
@@ -158,11 +176,11 @@ public static partial class WebSiteBuilder
                 if (string.IsNullOrWhiteSpace(partial))
                     return string.Empty;
 
-                return ExpandAssetSlotPartialReferences(
-                    StripNonRenderedComments(partial),
-                    partialResolver,
-                    seen,
-                    depth + 1);
+                partial = StripNonRenderedTemplateRegions(partial);
+                if (templateKind == AssetSlotTemplateKind.Simple)
+                    return partial;
+
+                return ExpandAssetSlotPartialReferences(partial, partialResolver, templateKind, seen, depth + 1);
             }
             finally
             {
@@ -170,8 +188,9 @@ public static partial class WebSiteBuilder
             }
         }
 
-        var expanded = SimplePartialReferenceRegex.Replace(template, ReplacePartial);
-        return ScribanPartialReferenceRegex.Replace(expanded, ReplacePartial);
+        return templateKind == AssetSlotTemplateKind.Simple
+            ? SimplePartialReferenceRegex.Replace(template, ReplacePartial)
+            : ScribanPartialReferenceRegex.Replace(template, ReplacePartial);
     }
 
     private static int FindFirstRenderedTokenIndex(string template, params string[] tokens)


### PR DESCRIPTION
## Summary- route `Head.Links` preload/preconnect hints through the preload slot and `rel=stylesheet` links through the CSS slot before route bundle CSS- keep those asset-slot links out of `head_html` so templates that place `head_html` later do not delay font/style discovery or duplicate links- add API docs first-paint control sizing for namespace selects, enhanced combobox triggers, and filter/action buttons## Validation- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSiteBuilderSafetyAndParityTests|FullyQualifiedName~WebApiDocsGeneratorSourceAndCssTests"`- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --no-restore --filter "FullyQualifiedName~WebSiteBuilderSafetyAndParityTests|FullyQualifiedName~WebApiDocsGeneratorSourceAndCssTests"`- `dotnet run --framework net10.0 --project PowerForge.Web.Cli\PowerForge.Web.Cli.csproj -- build --config Samples\PowerForge.Web.CodeGlyphX.Sample\site.json --out Artifacts\layout-stability-sample --clean`- `dotnet run --framework net10.0 --project PowerForge.Web.Cli\PowerForge.Web.Cli.csproj -- build --config C:\Support\GitHub\Website\site.json --out Artifacts\layout-stability-website-probe --clean`- `dotnet run --framework net10.0 --project PowerForge.Web.Cli\PowerForge.Web.Cli.csproj -- apidocs --type csharp --format html --template docs --xml PowerForge.Web\bin\Debug\net10.0\PowerForge.Web.xml --assembly PowerForge.Web\bin\Debug\net10.0\PowerForge.Web.dll --out Artifacts\layout-stability-api-docs-html --title "PowerForge.Web API" --base-url /api`- Browser checked generated API docs and generated Website homepage on localhost: API controls stayed stable across reload, homepage font stylesheet rendered before app CSS, no console errors.
Additional HtmlForgeX validation after PR creation:
- Rebuilt `C:\Support\GitHub\HtmlForgeX\Website\site.json` with this branch into `Artifacts\layout-stability-htmlforgex-website`.
- Generated HtmlForgeX API docs into that output with `/css/app.css,/css/api.css` and confirmed the API page emits `PowerForge API docs first-paint control stability` before CSS links.
- Browser checked `http://localhost:8099/` and `http://localhost:8099/api/`; API filter buttons, namespace select, and enhanced combobox dimensions stayed stable across reload with no console errors.