### PR TITLE
Add scripted service MSI support

### DIFF
--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -2,7 +2,7 @@
 Module Name: PSPublishModule
 Module Guid: eb76426a-1992-40a5-82cd-6480f883ef4d
 Download Help Link: https://github.com/EvotecIT/PSPublishModule
-Help Version: 3.0.7
+Help Version: 3.0.9
 Locale: en-US
 ---
 # PSPublishModule Module

--- a/Module/PSPublishModule.psd1
+++ b/Module/PSPublishModule.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.5.2'
     FunctionsToExport      = @()
     GUID                   = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
-    ModuleVersion          = '3.0.7'
+    ModuleVersion          = '3.0.9'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
@@ -185,7 +185,15 @@ public sealed class InvokeDotNetPublishCommand : PSCmdlet
                 },
                 warn: message => WriteWarning(message));
 
-            var workflow = new DotNetPublishWorkflowService(logger).Execute(preparation);
+            var workflow = new DotNetPublishWorkflowService(
+                logger,
+                createProgressReporter: plan => NoInteractive.IsPresent
+                    ? null
+                    : new DotNetPublishCmdletProgressReporter(
+                        message => Host.UI.WriteLine(message),
+                        WriteProgress,
+                        plan.Steps.Length))
+                .Execute(preparation);
 
             if (!string.IsNullOrWhiteSpace(workflow.JsonOutputPath))
             {

--- a/PSPublishModule/Services/DotNetPublishCmdletProgressReporter.cs
+++ b/PSPublishModule/Services/DotNetPublishCmdletProgressReporter.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+internal sealed class DotNetPublishCmdletProgressReporter : IDotNetPublishProgressReporter
+{
+    private const int ActivityId = 3081;
+    private readonly Action<string> _writeLine;
+    private readonly Action<ProgressRecord> _writeProgress;
+    private readonly int _totalSteps;
+    private readonly Dictionary<string, ActiveStep> _activeSteps = new(StringComparer.Ordinal);
+    private int _startedSteps;
+
+    public DotNetPublishCmdletProgressReporter(
+        Action<string> writeLine,
+        Action<ProgressRecord> writeProgress,
+        int totalSteps)
+    {
+        _writeLine = writeLine ?? throw new ArgumentNullException(nameof(writeLine));
+        _writeProgress = writeProgress ?? throw new ArgumentNullException(nameof(writeProgress));
+        _totalSteps = Math.Max(totalSteps, 1);
+    }
+
+    public void StepStarting(DotNetPublishStep step)
+    {
+        var index = Math.Min(++_startedSteps, _totalSteps);
+        var description = Describe(step);
+        _activeSteps[StepKey(step)] = new ActiveStep(index, Stopwatch.StartNew(), description);
+        WriteLine($"[{index}/{_totalSteps}] {description}...");
+        WriteProgress(index, description, ProgressRecordType.Processing);
+    }
+
+    public void StepCompleted(DotNetPublishStep step)
+    {
+        var active = Complete(step);
+        WriteLine($"[{active.Index}/{_totalSteps}] {active.Description} completed in {FormatElapsed(active.Elapsed)}.");
+        WriteProgress(active.Index, active.Description, ProgressRecordType.Processing);
+        if (active.Index >= _totalSteps)
+            WriteProgress(active.Index, "Completed", ProgressRecordType.Completed);
+    }
+
+    public void StepFailed(DotNetPublishStep step, Exception error)
+    {
+        var active = Complete(step);
+        WriteLine($"[{active.Index}/{_totalSteps}] {active.Description} failed after {FormatElapsed(active.Elapsed)}: {error.GetBaseException().Message}");
+        WriteProgress(active.Index, active.Description, ProgressRecordType.Completed);
+    }
+
+    private ActiveStep Complete(DotNetPublishStep step)
+    {
+        var key = StepKey(step);
+        if (_activeSteps.TryGetValue(key, out var active))
+        {
+            active.Stopwatch.Stop();
+            _activeSteps.Remove(key);
+            active.Elapsed = active.Stopwatch.Elapsed;
+            return active;
+        }
+
+        return new ActiveStep(Math.Max(_startedSteps, 1), Stopwatch.StartNew(), Describe(step));
+    }
+
+    private void WriteProgress(int index, string status, ProgressRecordType recordType)
+    {
+        var percent = recordType == ProgressRecordType.Completed
+            ? 100
+            : Math.Min(99, Math.Max(0, (int)Math.Round(index * 100d / _totalSteps)));
+        SafeInvoke(() => _writeProgress(new ProgressRecord(ActivityId, "DotNet publish", status)
+        {
+            PercentComplete = percent,
+            RecordType = recordType
+        }));
+    }
+
+    private void WriteLine(string message)
+        => SafeInvoke(() => _writeLine(message));
+
+    private static void SafeInvoke(Action action)
+    {
+        try { action(); }
+        catch { }
+    }
+
+    private static string StepKey(DotNetPublishStep step)
+        => string.IsNullOrWhiteSpace(step.Key) ? step.Kind.ToString() : step.Key!;
+
+    private static string Describe(DotNetPublishStep step)
+    {
+        var title = string.IsNullOrWhiteSpace(step.Title) ? step.Kind.ToString() : step.Title.Trim();
+        var details = new List<string>();
+        Add(details, step.InstallerId);
+        Add(details, step.TargetName);
+        Add(details, step.BundleId);
+        Add(details, step.StorePackageId);
+        Add(details, step.Framework);
+        Add(details, step.Runtime);
+        if (step.Style.HasValue)
+            details.Add(step.Style.Value.ToString());
+
+        return details.Count == 0
+            ? title
+            : title + " " + string.Join(" ", details);
+    }
+
+    private static void Add(List<string> values, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        values.Add(value!.Trim());
+    }
+
+    private static string FormatElapsed(TimeSpan elapsed)
+        => elapsed.TotalSeconds < 60
+            ? elapsed.TotalSeconds.ToString("0.0", CultureInfo.InvariantCulture) + "s"
+            : elapsed.ToString(@"m\:ss", CultureInfo.InvariantCulture);
+
+    private sealed class ActiveStep
+    {
+        public ActiveStep(int index, Stopwatch stopwatch, string description)
+        {
+            Index = index;
+            Stopwatch = stopwatch;
+            Description = description;
+        }
+
+        public int Index { get; }
+
+        public Stopwatch Stopwatch { get; }
+
+        public string Description { get; }
+
+        public TimeSpan Elapsed { get; set; }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -224,6 +224,8 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
 
             var text = File.ReadAllText(manifestTxt);
             Assert.Contains("MSI app.msi", text, StringComparison.Ordinal);
+            Assert.Contains(msiPath, text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(msiSidecarPath, text, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("->  (", text, StringComparison.Ordinal);
             Assert.Contains("(2 files version=1.2.3)", text, StringComparison.Ordinal);
             Assert.Contains("Store app.store", text, StringComparison.Ordinal);
@@ -530,6 +532,86 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
 
         Assert.True(firstSingleFile >= 0, "Expected style defaults to request single-file publish.");
         Assert.True(finalSingleFile > firstSingleFile, "Expected merged overrides to win by appearing after style defaults.");
+    }
+
+    [Fact]
+    public void BuildRestoreMsBuildProperties_IncludesReadyToRunForRuntimeRestore()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["SyncSELocalHtmlForgeXProject"] = string.Empty
+            },
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Publish = new DotNetPublishPublishOptions
+                    {
+                        ReadyToRun = true
+                    },
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        }
+                    }
+                }
+            }
+        };
+
+        var props = DotNetPublishPipelineRunner.BuildRestoreMsBuildProperties(
+            plan,
+            "Service.csproj",
+            "win-x64");
+
+        Assert.Equal("true", props["PublishReadyToRun"]);
+        Assert.Equal("true", props["SelfContained"]);
+        Assert.Equal("true", props["PublishSingleFile"]);
+        Assert.Equal("true", props["IncludeNativeLibrariesForSelfExtract"]);
+        Assert.True(props.ContainsKey("SyncSELocalHtmlForgeXProject"));
+    }
+
+    [Fact]
+    public void BuildRestoreMsBuildProperties_HonorsPublishReadyToRunOverride()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Publish = new DotNetPublishPublishOptions
+                    {
+                        ReadyToRun = true,
+                        MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["PublishReadyToRun"] = "false"
+                        }
+                    },
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        }
+                    }
+                }
+            }
+        };
+
+        var props = DotNetPublishPipelineRunner.BuildRestoreMsBuildProperties(
+            plan,
+            "Service.csproj",
+            "win-x64");
+
+        Assert.Equal("false", props["PublishReadyToRun"]);
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -135,6 +135,28 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
+    public void FindChangedMsiOutputs_DetectsCustomOutputPathOutsideBin()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var outputPath = Path.Combine(root, "Artifacts", "Msi", "syncse", "SyncSE.msi");
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            File.WriteAllText(outputPath, "msi");
+
+            string[] filtered = InvokeFindChangedMsiOutputs(root, skipBinDirectoryFilter: false);
+            string[] unfiltered = InvokeFindChangedMsiOutputs(root, skipBinDirectoryFilter: true);
+
+            Assert.Empty(filtered);
+            Assert.Contains(Path.GetFullPath(outputPath), unfiltered);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void ResolveGeneratedInstallerOutputDirectory_UsesTemplateFallback_WhenManifestPathMissing()
     {
         var root = CreateTempRoot();
@@ -1080,6 +1102,21 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
         var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         return root;
+    }
+
+    private static string[] InvokeFindChangedMsiOutputs(string root, bool skipBinDirectoryFilter)
+    {
+        var method = typeof(DotNetPublishPipelineRunner).GetMethod("FindChangedMsiOutputs", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        object? raw = method!.Invoke(
+            null,
+            new object?[]
+            {
+                root,
+                new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase),
+                skipBinDirectoryFilter
+            });
+        return Assert.IsType<string[]>(raw);
     }
 
     private static void TryDelete(string path)

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -15,10 +15,79 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
         {
             InstallerId = "TierBridge.MSI",
             Version = "4.0.9498",
-            VersionPropertyName = "ProductVersion"
+            VersionPropertyName = "ProductVersion",
+            OutputFiles = new[] { @"C:\Build\TierBridge.msi" }
         };
 
-        Assert.Equal("TierBridge.MSI 4.0.9498", result.ToString());
+        Assert.Equal(@"TierBridge.MSI 4.0.9498 -> C:\Build\TierBridge.msi", result.ToString());
+    }
+
+    [Fact]
+    public void ResolveInstallerOutputName_AppliesTokensAndStripsMsiExtension()
+    {
+        var plan = new DotNetPublishPlan { Configuration = "Release" };
+        var installer = new DotNetPublishInstallerPlan
+        {
+            Id = "syncse",
+            OutputName = "{target}-{rid}-{version}.msi"
+        };
+        var step = new DotNetPublishStep
+        {
+            TargetName = "GraphEssentialsX.Sync.Service",
+            Runtime = "win-x64",
+            Framework = "net8.0",
+            Style = DotNetPublishStyle.PortableCompat
+        };
+
+        var outputName = DotNetPublishPipelineRunner.ResolveInstallerOutputName(
+            plan,
+            installer,
+            step,
+            "1.0.9638");
+
+        Assert.Equal("GraphEssentialsX.Sync.Service-win-x64-1.0.9638", outputName);
+    }
+
+    [Fact]
+    public void ResolveInstallerOutputDirectory_UsesConfiguredTemplate()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release"
+            };
+            var installer = new DotNetPublishInstallerPlan
+            {
+                Id = "syncse",
+                OutputPath = "Artifacts/Msi/{installer}/{rid}"
+            };
+            var step = new DotNetPublishStep
+            {
+                InstallerId = "syncse",
+                TargetName = "app",
+                Runtime = "win-x64",
+                Framework = "net8.0",
+                Style = DotNetPublishStyle.PortableCompat
+            };
+            var prepare = new DotNetPublishMsiPrepareResult { ManifestPath = string.Empty };
+
+            var outputPath = DotNetPublishPipelineRunner.ResolveInstallerOutputDirectory(
+                plan,
+                installer,
+                "syncse",
+                step,
+                prepare,
+                isGeneratedInstallerProject: true);
+
+            Assert.Equal(Path.Combine(root, "Artifacts", "Msi", "syncse", "win-x64"), outputPath);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -80,9 +80,53 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
                 "syncse",
                 step,
                 prepare,
+                version: null,
                 isGeneratedInstallerProject: true);
 
             Assert.Equal(Path.Combine(root, "Artifacts", "Msi", "syncse", "win-x64"), outputPath);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void ResolveInstallerOutputDirectory_AppliesVersionToken()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release"
+            };
+            var installer = new DotNetPublishInstallerPlan
+            {
+                Id = "syncse",
+                OutputPath = "Artifacts/Msi/{installer}/{version}"
+            };
+            var step = new DotNetPublishStep
+            {
+                InstallerId = "syncse",
+                TargetName = "app",
+                Runtime = "win-x64",
+                Framework = "net8.0",
+                Style = DotNetPublishStyle.PortableCompat
+            };
+            var prepare = new DotNetPublishMsiPrepareResult { ManifestPath = string.Empty };
+
+            var outputPath = DotNetPublishPipelineRunner.ResolveInstallerOutputDirectory(
+                plan,
+                installer,
+                "syncse",
+                step,
+                prepare,
+                version: "1.0.9646",
+                isGeneratedInstallerProject: true);
+
+            Assert.Equal(Path.Combine(root, "Artifacts", "Msi", "syncse", "1.0.9646"), outputPath);
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishWorkflowServiceTests.cs
+++ b/PowerForge.Tests/DotNetPublishWorkflowServiceTests.cs
@@ -65,15 +65,17 @@ public sealed class DotNetPublishWorkflowServiceTests
     public void Execute_runs_publish_when_plan_only_flags_are_not_set()
     {
         var expectedResult = new DotNetPublishResult { Succeeded = true };
+        var expectedProgress = new TestProgressReporter();
         var service = new DotNetPublishWorkflowService(
             new NullLogger(),
             planPublish: (_, _) => new DotNetPublishPlan(),
             runPublish: (plan, progress) =>
             {
                 Assert.NotNull(plan);
-                Assert.Null(progress);
+                Assert.Same(expectedProgress, progress);
                 return expectedResult;
-            });
+            },
+            createProgressReporter: _ => expectedProgress);
 
         var result = service.Execute(new DotNetPublishPreparedContext
         {
@@ -82,6 +84,15 @@ public sealed class DotNetPublishWorkflowServiceTests
         });
 
         Assert.Same(expectedResult, result.Result);
+    }
+
+    private sealed class TestProgressReporter : IDotNetPublishProgressReporter
+    {
+        public void StepStarting(DotNetPublishStep step) { }
+
+        public void StepCompleted(DotNetPublishStep step) { }
+
+        public void StepFailed(DotNetPublishStep step, Exception error) { }
     }
 
     private sealed class CollectingLogger : ILogger

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -85,9 +85,9 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Start") == "none" &&
             (string?)e.Attribute("Stop") == "uninstall" &&
             (string?)e.Attribute("Remove") == "uninstall"));
-        Assert.NotNull(doc.Descendants(Wix + "SetProperty").SingleOrDefault(e =>
-            (string?)e.Attribute("Id") == "WixQuietExecCmdLine" &&
-            (string?)e.Attribute("Action") == "ServiceComponentSetBackupCommand" &&
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponentSetBackupCommand" &&
+            (string?)e.Attribute("Property") == "WixQuietExecCmdLine" &&
             ((string?)e.Attribute("Value"))?.Contains(@"reg query ""HKLM\SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring"" /v ImagePath", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("|| type nul", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("[TempFolder]tmx-svc.txt", StringComparison.Ordinal) == true));
@@ -103,8 +103,10 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Id") == "ServiceComponentSetInstallServiceUpgrade" &&
             ((string?)e.Attribute("Value"))?.Contains("-PreserveExistingServiceBinPath -UpgradeMode", StringComparison.Ordinal) == true));
 
-        var sequenceActions = doc.Descendants(Wix + "InstallExecuteSequence")
+        var sequenceRows = doc.Descendants(Wix + "InstallExecuteSequence")
             .Descendants(Wix + "Custom")
+            .ToArray();
+        var sequenceActions = sequenceRows
             .Select(e => (string?)e.Attribute("Action"))
             .ToArray();
         Assert.Contains("ServiceComponentBackupImagePath", sequenceActions);
@@ -112,6 +114,18 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Contains("ServiceComponentStopService", sequenceActions);
         Assert.Contains("ServiceComponentSetInstallServiceUpgrade", sequenceActions);
         Assert.Contains("ServiceComponentInstallService", sequenceActions);
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponentSetBackupCommand" &&
+            (string?)e.Attribute("Before") == "RemoveExistingProducts"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponentBackupImagePath" &&
+            (string?)e.Attribute("After") == "ServiceComponentSetBackupCommand"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponentSetStopService" &&
+            (string?)e.Attribute("After") == "ServiceComponentBackupImagePath"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponentStopService" &&
+            (string?)e.Attribute("After") == "ServiceComponentSetStopService"));
     }
 
     [Fact]
@@ -132,13 +146,25 @@ public sealed class PowerForgeInstallerAuthoringTests
             .ToArray();
         Assert.Equal(actionIds.Length, actionIds.Distinct(StringComparer.Ordinal).Count());
 
-        string[] setPropertyActions = doc.Descendants(Wix + "SetProperty")
+        string[] quietExecSetterIds = doc.Descendants(Wix + "CustomAction")
+            .Where(e => (string?)e.Attribute("Property") == "WixQuietExecCmdLine")
+            .Select(e => (string?)e.Attribute("Id"))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .ToArray();
+        Assert.Equal(4, quietExecSetterIds.Length);
+        Assert.Equal(quietExecSetterIds.Length, quietExecSetterIds.Distinct(StringComparer.Ordinal).Count());
+
+        string[] sequenceActions = doc.Descendants(Wix + "InstallExecuteSequence")
+            .Descendants(Wix + "Custom")
             .Select(e => (string?)e.Attribute("Action"))
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Select(id => id!)
             .ToArray();
-        Assert.Equal(2, setPropertyActions.Length);
-        Assert.Equal(setPropertyActions.Length, setPropertyActions.Distinct(StringComparer.Ordinal).Count());
+        int alphaBackup = Array.FindIndex(sequenceActions, id => id.EndsWith("BackupImagePath", StringComparison.Ordinal));
+        int betaBackupSetter = Array.FindLastIndex(sequenceActions, id => id.Contains("SetBackupCommand", StringComparison.Ordinal));
+        Assert.True(alphaBackup >= 0);
+        Assert.True(betaBackupSetter > alphaBackup);
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -87,8 +87,13 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Remove") == "uninstall"));
         Assert.NotNull(doc.Descendants(Wix + "SetProperty").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "WixQuietExecCmdLine" &&
+            (string?)e.Attribute("Action") == "ServiceComponentSetBackupCommand" &&
             ((string?)e.Attribute("Value"))?.Contains(@"reg query ""HKLM\SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring"" /v ImagePath", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("|| type nul", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("[TempFolder]tmx-svc.txt", StringComparison.Ordinal) == true));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponentSetStopService" &&
+            ((string?)e.Attribute("Value"))?.Contains("exit /b 0", StringComparison.Ordinal) == true));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ServiceComponentInstallService" &&
             (string?)e.Attribute("DllEntry") == "WixQuietExec" &&
@@ -107,6 +112,33 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Contains("ServiceComponentStopService", sequenceActions);
         Assert.Contains("ServiceComponentSetInstallServiceUpgrade", sequenceActions);
         Assert.Contains("ServiceComponentInstallService", sequenceActions);
+    }
+
+    [Fact]
+    public void EmitSource_UsesUniqueScriptServiceActionIdsForLongComponentNames()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Clear();
+        AddScriptService(definition, "ServiceComponentWithVeryLongSharedPrefixForTenantAlpha");
+        AddScriptService(definition, "ServiceComponentWithVeryLongSharedPrefixForTenantBeta");
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        string[] actionIds = doc.Descendants(Wix + "CustomAction")
+            .Select(e => (string?)e.Attribute("Id"))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .ToArray();
+        Assert.Equal(actionIds.Length, actionIds.Distinct(StringComparer.Ordinal).Count());
+
+        string[] setPropertyActions = doc.Descendants(Wix + "SetProperty")
+            .Select(e => (string?)e.Attribute("Action"))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .ToArray();
+        Assert.Equal(2, setPropertyActions.Length);
+        Assert.Equal(setPropertyActions.Length, setPropertyActions.Distinct(StringComparer.Ordinal).Count());
     }
 
     [Fact]
@@ -1617,6 +1649,24 @@ public sealed class PowerForgeInstallerAuthoringTests
             Source = payloadFile
         });
         return definition;
+    }
+
+    private static void AddScriptService(PowerForgeInstallerDefinition definition, string componentId)
+    {
+        definition.Components.Add(new PowerForgeInstallerServiceComponent
+        {
+            Id = componentId,
+            FileId = componentId + "Exe",
+            Source = "$(var.PayloadDir)\\" + componentId + ".exe",
+            ServiceName = componentId + ".Service",
+            DisplayName = componentId,
+            ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+            {
+                Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\"",
+                BackupExistingImagePath = true,
+                StopServiceForUpgrade = true
+            }
+        });
     }
 
     private static string CreateTempDirectory()

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -86,21 +86,21 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Stop") == "uninstall" &&
             (string?)e.Attribute("Remove") == "uninstall"));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
-            (string?)e.Attribute("Id") == "ServiceComponentSetBackupCommand" &&
+            (string?)e.Attribute("Id") == "ServiceComponent.SetBackupCommand" &&
             (string?)e.Attribute("Property") == "WixQuietExecCmdLine" &&
             ((string?)e.Attribute("Value"))?.Contains(@"reg query ""HKLM\SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring"" /v ImagePath", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("|| type nul", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("[TempFolder]tmx-svc.txt", StringComparison.Ordinal) == true));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
-            (string?)e.Attribute("Id") == "ServiceComponentSetStopService" &&
+            (string?)e.Attribute("Id") == "ServiceComponent.SetStopService" &&
             ((string?)e.Attribute("Value"))?.Contains("exit /b 0", StringComparison.Ordinal) == true));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
-            (string?)e.Attribute("Id") == "ServiceComponentInstallService" &&
+            (string?)e.Attribute("Id") == "ServiceComponent.InstallService" &&
             (string?)e.Attribute("DllEntry") == "WixQuietExec" &&
             (string?)e.Attribute("Execute") == "deferred" &&
             (string?)e.Attribute("Impersonate") == "no"));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
-            (string?)e.Attribute("Id") == "ServiceComponentSetInstallServiceUpgrade" &&
+            (string?)e.Attribute("Id") == "ServiceComponent.SetInstallServiceUpgrade" &&
             ((string?)e.Attribute("Value"))?.Contains("-PreserveExistingServiceBinPath -UpgradeMode", StringComparison.Ordinal) == true));
 
         var sequenceRows = doc.Descendants(Wix + "InstallExecuteSequence")
@@ -109,23 +109,23 @@ public sealed class PowerForgeInstallerAuthoringTests
         var sequenceActions = sequenceRows
             .Select(e => (string?)e.Attribute("Action"))
             .ToArray();
-        Assert.Contains("ServiceComponentBackupImagePath", sequenceActions);
-        Assert.Contains("ServiceComponentSetStopService", sequenceActions);
-        Assert.Contains("ServiceComponentStopService", sequenceActions);
-        Assert.Contains("ServiceComponentSetInstallServiceUpgrade", sequenceActions);
-        Assert.Contains("ServiceComponentInstallService", sequenceActions);
+        Assert.Contains("ServiceComponent.BackupImagePath", sequenceActions);
+        Assert.Contains("ServiceComponent.SetStopService", sequenceActions);
+        Assert.Contains("ServiceComponent.StopService", sequenceActions);
+        Assert.Contains("ServiceComponent.SetInstallServiceUpgrade", sequenceActions);
+        Assert.Contains("ServiceComponent.InstallService", sequenceActions);
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
-            (string?)e.Attribute("Action") == "ServiceComponentSetBackupCommand" &&
+            (string?)e.Attribute("Action") == "ServiceComponent.SetBackupCommand" &&
             (string?)e.Attribute("Before") == "RemoveExistingProducts"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
-            (string?)e.Attribute("Action") == "ServiceComponentBackupImagePath" &&
-            (string?)e.Attribute("After") == "ServiceComponentSetBackupCommand"));
+            (string?)e.Attribute("Action") == "ServiceComponent.BackupImagePath" &&
+            (string?)e.Attribute("After") == "ServiceComponent.SetBackupCommand"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
-            (string?)e.Attribute("Action") == "ServiceComponentSetStopService" &&
-            (string?)e.Attribute("After") == "ServiceComponentBackupImagePath"));
+            (string?)e.Attribute("Action") == "ServiceComponent.SetStopService" &&
+            (string?)e.Attribute("After") == "ServiceComponent.BackupImagePath"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
-            (string?)e.Attribute("Action") == "ServiceComponentStopService" &&
-            (string?)e.Attribute("After") == "ServiceComponentSetStopService"));
+            (string?)e.Attribute("Action") == "ServiceComponent.StopService" &&
+            (string?)e.Attribute("After") == "ServiceComponent.SetStopService"));
     }
 
     [Fact]
@@ -165,6 +165,92 @@ public sealed class PowerForgeInstallerAuthoringTests
         int betaBackupSetter = Array.FindLastIndex(sequenceActions, id => id.Contains("SetBackupCommand", StringComparison.Ordinal));
         Assert.True(alphaBackup >= 0);
         Assert.True(betaBackupSetter > alphaBackup);
+    }
+
+    [Fact]
+    public void EmitSource_UsesUniqueScriptServiceActionIdsForOverlappingComponentNames()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Clear();
+        AddScriptService(definition, "ASet");
+        AddScriptService(definition, "A");
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        string[] actionIds = doc.Descendants(Wix + "CustomAction")
+            .Select(e => (string?)e.Attribute("Id"))
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .ToArray();
+        Assert.Equal(actionIds.Length, actionIds.Distinct(StringComparer.Ordinal).Count());
+        Assert.Contains("ASet.InstallService", actionIds);
+        Assert.Contains("A.SetInstallService", actionIds);
+    }
+
+    [Fact]
+    public void EmitSource_UsesUniqueDefaultScriptServiceBackupPaths()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Clear();
+        AddScriptService(definition, "ServiceOne");
+        AddScriptService(definition, "ServiceTwo");
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        string[] backupCommands = doc.Descendants(Wix + "CustomAction")
+            .Where(e => (string?)e.Attribute("Property") == "WixQuietExecCmdLine")
+            .Select(e => (string?)e.Attribute("Value"))
+            .Where(value => value?.Contains("reg query", StringComparison.Ordinal) == true)
+            .Select(value => value!)
+            .ToArray();
+        Assert.Contains(backupCommands, command =>
+            command.Contains("[TempFolder]powerforge-ServiceOne-service-binpath.txt", StringComparison.Ordinal));
+        Assert.Contains(backupCommands, command =>
+            command.Contains("[TempFolder]powerforge-ServiceTwo-service-binpath.txt", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EmitSource_GatesUpgradePrepActionsWithScriptInstallCondition()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Clear();
+        definition.Components.Add(new PowerForgeInstallerServiceComponent
+        {
+            Id = "ConditionalService",
+            FileId = "ConditionalServiceExe",
+            Source = "$(var.PayloadDir)\\ConditionalService.exe",
+            ServiceName = "Conditional.Service",
+            DisplayName = "Conditional Service",
+            ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+            {
+                Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\"",
+                Condition = "INSTALL_CONDITIONAL_SERVICE=1 AND NOT REMOVE=\"ALL\"",
+                BackupExistingImagePath = true,
+                StopServiceForUpgrade = true
+            }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        var upgradePrepRows = doc.Descendants(Wix + "InstallExecuteSequence")
+            .Descendants(Wix + "Custom")
+            .Where(e =>
+                string.Equals((string?)e.Attribute("Action"), "ConditionalService.SetBackupCommand", StringComparison.Ordinal) ||
+                string.Equals((string?)e.Attribute("Action"), "ConditionalService.BackupImagePath", StringComparison.Ordinal) ||
+                string.Equals((string?)e.Attribute("Action"), "ConditionalService.SetStopService", StringComparison.Ordinal) ||
+                string.Equals((string?)e.Attribute("Action"), "ConditionalService.StopService", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(4, upgradePrepRows.Length);
+        Assert.All(upgradePrepRows, row =>
+        {
+            var condition = (string?)row.Attribute("Condition");
+            Assert.Contains("INSTALL_CONDITIONAL_SERVICE=1", condition, StringComparison.Ordinal);
+            Assert.Contains("WIX_UPGRADE_DETECTED", condition, StringComparison.Ordinal);
+        });
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -25,9 +25,19 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Id") == "LICENSE_KEY" &&
             (string?)e.Attribute("Secure") == "yes" &&
             (string?)e.Attribute("Hidden") == "yes"));
-        Assert.NotNull(doc.Descendants(Wix + "ServiceInstall").SingleOrDefault(e =>
+        Assert.NotNull(doc.Descendants(Wix + "Property").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "MONITORINGDATADIR" &&
+            e.Descendants(Wix + "RegistrySearch").Any(search =>
+                (string?)search.Attribute("Name") == "DataDir" &&
+                (string?)search.Attribute("Type") == "raw")));
+        var serviceInstall = doc.Descendants(Wix + "ServiceInstall").SingleOrDefault(e =>
             (string?)e.Attribute("Name") == "TestimoX.Monitoring" &&
-            (string?)e.Attribute("Arguments") == "--config \"[ProgramDataMonitoring]TestimoX.Monitoring.json\""));
+            (string?)e.Attribute("Arguments") == "--config \"[ProgramDataMonitoring]TestimoX.Monitoring.json\"");
+        Assert.NotNull(serviceInstall);
+        Assert.Null(serviceInstall!.Attribute("Account"));
+        Assert.NotNull(doc.Descendants(Wix + "ServiceControl").SingleOrDefault(e =>
+            (string?)e.Attribute("Name") == "TestimoX.Monitoring" &&
+            (string?)e.Attribute("Start") == "install"));
         Assert.NotNull(doc.Descendants(Wix + "RegistryValue").SingleOrDefault(e =>
             (string?)e.Attribute("Key") == @"SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring" &&
             (string?)e.Attribute("Name") == "DelayedAutoStart"));
@@ -39,6 +49,64 @@ public sealed class PowerForgeInstallerAuthoringTests
             .Attribute("Condition"));
         Assert.NotNull(doc.Descendants(Wix + "ComponentGroupRef").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ProductFiles"));
+    }
+
+    [Fact]
+    public void EmitSource_ModelsScriptServiceInstallWithImagePathPreservation()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.Components.Add(new PowerForgeInstallerFileComponent
+        {
+            Id = "InstallServiceScriptComponent",
+            FileId = "InstallServiceScript",
+            Source = "$(var.PayloadDir)\\Install-Service.ps1"
+        });
+        var service = definition.Components.OfType<PowerForgeInstallerServiceComponent>().Single();
+        service.ControlStart = "none";
+        service.ControlStop = "uninstall";
+        service.ControlRemove = "uninstall";
+        service.ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+        {
+            Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\" -ConfigPath \"[ProgramDataMonitoring]TestimoX.Monitoring.json\" -ServiceName \"TestimoX.Monitoring\"",
+            UpgradeCommand = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\" -ConfigPath \"[ProgramDataMonitoring]TestimoX.Monitoring.json\" -ServiceName \"TestimoX.Monitoring\" -BackupPath \"[TempFolder]tmx-svc.txt\" -PreserveExistingServiceBinPath -UpgradeMode",
+            BackupExistingImagePath = true,
+            BackupPath = "[TempFolder]tmx-svc.txt",
+            StopServiceForUpgrade = true,
+            StopDelaySeconds = 30
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.Null(doc.Descendants(Wix + "ServiceInstall").SingleOrDefault(e =>
+            (string?)e.Attribute("Name") == "TestimoX.Monitoring"));
+        Assert.NotNull(doc.Descendants(Wix + "ServiceControl").SingleOrDefault(e =>
+            (string?)e.Attribute("Name") == "TestimoX.Monitoring" &&
+            (string?)e.Attribute("Start") == "none" &&
+            (string?)e.Attribute("Stop") == "uninstall" &&
+            (string?)e.Attribute("Remove") == "uninstall"));
+        Assert.NotNull(doc.Descendants(Wix + "SetProperty").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "WixQuietExecCmdLine" &&
+            ((string?)e.Attribute("Value"))?.Contains(@"reg query ""HKLM\SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring"" /v ImagePath", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("[TempFolder]tmx-svc.txt", StringComparison.Ordinal) == true));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponentInstallService" &&
+            (string?)e.Attribute("DllEntry") == "WixQuietExec" &&
+            (string?)e.Attribute("Execute") == "deferred" &&
+            (string?)e.Attribute("Impersonate") == "no"));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponentSetInstallServiceUpgrade" &&
+            ((string?)e.Attribute("Value"))?.Contains("-PreserveExistingServiceBinPath -UpgradeMode", StringComparison.Ordinal) == true));
+
+        var sequenceActions = doc.Descendants(Wix + "InstallExecuteSequence")
+            .Descendants(Wix + "Custom")
+            .Select(e => (string?)e.Attribute("Action"))
+            .ToArray();
+        Assert.Contains("ServiceComponentBackupImagePath", sequenceActions);
+        Assert.Contains("ServiceComponentSetStopService", sequenceActions);
+        Assert.Contains("ServiceComponentStopService", sequenceActions);
+        Assert.Contains("ServiceComponentSetInstallServiceUpgrade", sequenceActions);
+        Assert.Contains("ServiceComponentInstallService", sequenceActions);
     }
 
     [Fact]
@@ -475,6 +543,7 @@ public sealed class PowerForgeInstallerAuthoringTests
             ShortcutId = "StartMenuShortcut",
             Name = "IntelligenceX Chat",
             TargetFileId = "PrimaryExeFile",
+            Arguments = "--open",
             RegistryKey = @"Software\Evotec\IntelligenceX\Chat"
         });
 
@@ -485,7 +554,8 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Id") == "ProgramMenuFolder"));
         Assert.NotNull(doc.Descendants(Wix + "Shortcut").SingleOrDefault(e =>
             (string?)e.Attribute("Name") == "IntelligenceX Chat" &&
-            (string?)e.Attribute("Target") == "[#PrimaryExeFile]"));
+            (string?)e.Attribute("Target") == "[#PrimaryExeFile]" &&
+            (string?)e.Attribute("Arguments") == "--open"));
         Assert.NotNull(doc.Descendants(Wix + "RegistryValue").SingleOrDefault(e =>
             (string?)e.Attribute("KeyPath") == "yes" &&
             (string?)e.Attribute("Root") == "HKCU" &&
@@ -1026,6 +1096,7 @@ public sealed class PowerForgeInstallerAuthoringTests
         var doc = XDocument.Parse(xml);
 
         Assert.Equal("WixToolset.Sdk/4.0.6", (string?)doc.Root!.Attribute("Sdk"));
+        Assert.Equal("false", doc.Descendants("ManagePackageVersionsCentrally").Single().Value);
         Assert.Equal("false", doc.Descendants("EnableDefaultItems").Single().Value);
         Assert.NotNull(doc.Descendants("PackageReference").SingleOrDefault(e =>
             (string?)e.Attribute("Include") == "WixToolset.Util.wixext"));
@@ -1036,6 +1107,33 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(doc.Descendants("Compile").SingleOrDefault(e =>
             (string?)e.Attribute("Include") == "Harvest.wxs"));
         Assert.Contains("PayloadDir=Artifacts", doc.Descendants("DefineConstants").Single().Value, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitProjectFile_IncludesUtilExtensionForScriptServiceInstall()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Clear();
+        definition.Components.Add(new PowerForgeInstallerServiceComponent
+        {
+            Id = "ServiceComponent",
+            FileId = "ServiceExe",
+            Source = "$(var.PayloadDir)\\Service.exe",
+            ServiceName = "Contoso.Service",
+            DisplayName = "Contoso Service",
+            ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+            {
+                Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\""
+            }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitProjectFile(
+            definition,
+            new PowerForgeWixInstallerProjectOptions { SourceFile = "Generated.wxs" });
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Descendants("PackageReference").SingleOrDefault(e =>
+            (string?)e.Attribute("Include") == "WixToolset.Util.wixext"));
     }
 
     [Fact]
@@ -1233,6 +1331,19 @@ public sealed class PowerForgeInstallerAuthoringTests
                     "MaxLength": 128,
                     "ValidationPattern": "^[A-Za-z0-9-]+$",
                     "ValidationMessage": "Enter a valid license key."
+                  },
+                  {
+                    "Id": "DataDir",
+                    "PropertyName": "MONITORINGDATADIR",
+                    "Label": "Data folder",
+                    "Kind": "FolderPath",
+                    "RegistrySearch": {
+                      "Id": "MonitoringDataDirSearch",
+                      "Root": "HKLM",
+                      "Key": "Software\\Evotec\\TestimoX\\Monitoring",
+                      "Name": "DataDir",
+                      "Type": "raw"
+                    }
                   }
                 ],
                 "Dialogs": [
@@ -1291,13 +1402,18 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(authoring);
         Assert.Equal("TestimoX Monitoring", authoring!.Product.Name);
         Assert.Equal("ProductFiles", authoring.PayloadComponentGroupId);
-        var input = Assert.Single(authoring.Inputs);
+        Assert.Equal(2, authoring.Inputs.Count);
+        var input = authoring.Inputs[0];
         Assert.True(input.Required);
         Assert.Equal("Enter a license key before continuing.", input.RequiredMessage);
         Assert.Equal(16, input.MinLength);
         Assert.Equal(128, input.MaxLength);
         Assert.Equal("^[A-Za-z0-9-]+$", input.ValidationPattern);
         Assert.Equal("Enter a valid license key.", input.ValidationMessage);
+        var dataDir = authoring.Inputs[1];
+        Assert.Equal("MONITORINGDATADIR", dataDir.PropertyName);
+        Assert.NotNull(dataDir.RegistrySearch);
+        Assert.Equal("MonitoringDataDirSearch", dataDir.RegistrySearch!.Id);
         Assert.Single(authoring.Dialogs);
         Assert.Single(authoring.Directories);
 
@@ -1350,6 +1466,21 @@ public sealed class PowerForgeInstallerAuthoringTests
             Description = "Remove %ProgramData% data on uninstall.",
             Kind = PowerForgeInstallerInputKind.Checkbox,
             DefaultValue = "0"
+        });
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "MonitoringDataDirectory",
+            PropertyName = "MONITORINGDATADIR",
+            Label = "Monitoring data folder",
+            Kind = PowerForgeInstallerInputKind.FolderPath,
+            RegistrySearch = new PowerForgeInstallerRegistrySearch
+            {
+                Id = "MonitoringDataDirSearch",
+                Root = "HKLM",
+                Key = @"Software\Evotec\TestimoX\Monitoring",
+                Name = "DataDir",
+                Type = "raw"
+            }
         });
         var preset = new PowerForgeInstallerInput
         {
@@ -1421,7 +1552,8 @@ public sealed class PowerForgeInstallerAuthoringTests
             DisplayName = "TestimoX Monitoring",
             Description = "TestimoX monitoring agent",
             Arguments = "--config \"[ProgramDataMonitoring]TestimoX.Monitoring.json\"",
-            DelayedAutoStart = true
+            DelayedAutoStart = true,
+            ControlStart = "install"
         });
         definition.Components.Add(new PowerForgeInstallerShortcutComponent
         {

--- a/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
@@ -144,6 +144,46 @@ public sealed class PowerForgeInstallerDefinitionValidatorTests
     }
 
     [Fact]
+    public void Validate_RejectsDuplicateRegistrySearchIds()
+    {
+        var definition = CreateValidDefinition();
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "InstallPath",
+            PropertyName = "INSTALL_PATH",
+            Label = "Install path",
+            RegistrySearch = new PowerForgeInstallerRegistrySearch
+            {
+                Id = "ExistingInstallPathSearch",
+                Root = "HKLM",
+                Key = @"Software\Contoso\Product",
+                Name = "InstallPath",
+                Type = "raw"
+            }
+        });
+        definition.Inputs.Add(new PowerForgeInstallerInput
+        {
+            Id = "DataPath",
+            PropertyName = "DATA_PATH",
+            Label = "Data path",
+            RegistrySearch = new PowerForgeInstallerRegistrySearch
+            {
+                Id = "existinginstallpathsearch",
+                Root = "HKLM",
+                Key = @"Software\Contoso\Product",
+                Name = "DataPath",
+                Type = "raw"
+            }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("Duplicate installer registry search ID", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("ExistingInstallPathSearch", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Validate_RejectsMissingDialogIdWithoutNullReference()
     {
         var definition = CreateValidDefinition();

--- a/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
@@ -134,6 +134,12 @@ public sealed class DotNetPublishInstallerPlan
     /// <summary>Optional prepare manifest path template.</summary>
     public string? ManifestPath { get; set; }
 
+    /// <summary>Optional MSI output directory template.</summary>
+    public string? OutputPath { get; set; }
+
+    /// <summary>Optional MSI output file name or base name template.</summary>
+    public string? OutputName { get; set; }
+
     /// <summary>Optional installer project ID used for project-catalog resolution.</summary>
     public string? InstallerProjectId { get; set; }
 

--- a/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
@@ -281,9 +281,14 @@ public sealed class DotNetPublishMsiBuildResult
     public override string ToString()
     {
         var name = string.IsNullOrWhiteSpace(InstallerId) ? "MSI" : InstallerId;
-        return string.IsNullOrWhiteSpace(Version)
+        var label = string.IsNullOrWhiteSpace(Version)
             ? name
             : $"{name} {Version}";
+        var output = (OutputFiles ?? Array.Empty<string>())
+            .FirstOrDefault(file => !string.IsNullOrWhiteSpace(file));
+        return string.IsNullOrWhiteSpace(output)
+            ? label
+            : $"{label} -> {output}";
     }
 }
 

--- a/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
@@ -167,6 +167,18 @@ public sealed class DotNetPublishInstaller
     public string? ManifestPath { get; set; }
 
     /// <summary>
+    /// Optional MSI output directory template.
+    /// Supports tokens: <c>{installer}</c>, <c>{target}</c>, <c>{rid}</c>, <c>{framework}</c>, <c>{style}</c>, <c>{configuration}</c>, <c>{version}</c>.
+    /// </summary>
+    public string? OutputPath { get; set; }
+
+    /// <summary>
+    /// Optional MSI output file name or base name template.
+    /// Supports tokens: <c>{installer}</c>, <c>{target}</c>, <c>{rid}</c>, <c>{framework}</c>, <c>{style}</c>, <c>{configuration}</c>, <c>{version}</c>.
+    /// </summary>
+    public string? OutputName { get; set; }
+
+    /// <summary>
     /// Optional installer project ID (resolved from <see cref="DotNetPublishSpec.Projects"/>) used by <c>msi.build</c>.
     /// </summary>
     public string? InstallerProjectId { get; set; }

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -191,6 +191,42 @@ public sealed class PowerForgeInstallerInput
     /// Choices for radio or combo style inputs.
     /// </summary>
     public List<PowerForgeInstallerInputChoice> Choices { get; set; } = new();
+
+    /// <summary>
+    /// Optional registry search used to remember this property between installs and upgrades.
+    /// </summary>
+    public PowerForgeInstallerRegistrySearch? RegistrySearch { get; set; }
+}
+
+/// <summary>
+/// Registry search metadata for an MSI property.
+/// </summary>
+public sealed class PowerForgeInstallerRegistrySearch
+{
+    /// <summary>
+    /// WiX registry search id.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Registry root, for example HKLM or HKCU.
+    /// </summary>
+    public string Root { get; set; } = "HKLM";
+
+    /// <summary>
+    /// Registry key path below <see cref="Root"/>.
+    /// </summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Registry value name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// WiX registry search type, for example raw.
+    /// </summary>
+    public string Type { get; set; } = "raw";
 }
 
 /// <summary>
@@ -447,6 +483,67 @@ public sealed class PowerForgeInstallerServiceComponent : PowerForgeInstallerCom
     /// Whether the service should use delayed auto-start.
     /// </summary>
     public bool DelayedAutoStart { get; set; }
+
+    /// <summary>
+    /// ServiceControl start behavior, for example none, install, uninstall, or both.
+    /// </summary>
+    public string ControlStart { get; set; } = "none";
+
+    /// <summary>
+    /// ServiceControl stop behavior, for example none, install, uninstall, or both.
+    /// </summary>
+    public string ControlStop { get; set; } = "both";
+
+    /// <summary>
+    /// ServiceControl remove behavior, for example none, install, uninstall, or both.
+    /// </summary>
+    public string ControlRemove { get; set; } = "both";
+
+    /// <summary>
+    /// Optional script-based service install behavior used when a service installer script owns registration.
+    /// </summary>
+    public PowerForgeInstallerServiceScriptInstall? ScriptInstall { get; set; }
+}
+
+/// <summary>
+/// Script-based Windows service install custom actions.
+/// </summary>
+public sealed class PowerForgeInstallerServiceScriptInstall
+{
+    /// <summary>
+    /// Standard install command. Supports WiX formatted properties.
+    /// </summary>
+    public string Command { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional upgrade install command. Supports WiX formatted properties.
+    /// </summary>
+    public string? UpgradeCommand { get; set; }
+
+    /// <summary>
+    /// Condition used for the deferred install action.
+    /// </summary>
+    public string Condition { get; set; } = "NOT REMOVE=\"ALL\"";
+
+    /// <summary>
+    /// Backs up the existing service ImagePath before RemoveExistingProducts.
+    /// </summary>
+    public bool BackupExistingImagePath { get; set; }
+
+    /// <summary>
+    /// Backup file path used for the existing service ImagePath.
+    /// </summary>
+    public string BackupPath { get; set; } = "[TempFolder]powerforge-service-binpath.txt";
+
+    /// <summary>
+    /// Stops the existing service during an upgrade before the old product is removed.
+    /// </summary>
+    public bool StopServiceForUpgrade { get; set; }
+
+    /// <summary>
+    /// Delay after requesting a service stop during upgrade.
+    /// </summary>
+    public int StopDelaySeconds { get; set; } = 30;
 }
 
 /// <summary>
@@ -514,6 +611,11 @@ public sealed class PowerForgeInstallerShortcutComponent : PowerForgeInstallerCo
     /// Optional direct shortcut target such as <c>[INSTALLFOLDER]MyApp.exe</c>.
     /// </summary>
     public string? Target { get; set; }
+
+    /// <summary>
+    /// Optional shortcut arguments.
+    /// </summary>
+    public string? Arguments { get; set; }
 
     /// <summary>
     /// Working directory id.

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -531,9 +531,9 @@ public sealed class PowerForgeInstallerServiceScriptInstall
     public bool BackupExistingImagePath { get; set; }
 
     /// <summary>
-    /// Backup file path used for the existing service ImagePath.
+    /// Backup file path used for the existing service ImagePath. Supports <c>{serviceId}</c> and <c>{serviceName}</c> tokens.
     /// </summary>
-    public string BackupPath { get; set; } = "[TempFolder]powerforge-service-binpath.txt";
+    public string BackupPath { get; set; } = "[TempFolder]powerforge-{serviceId}-service-binpath.txt";
 
     /// <summary>
     /// Stops the existing service during an upgrade before the old product is removed.

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -250,7 +250,13 @@ public sealed partial class DotNetPublishPipelineRunner
                 var files = EnumerateExistingFiles(build.OutputFiles).ToArray();
                 var outputDir = ResolveOutputDirectory(files);
                 var version = string.IsNullOrWhiteSpace(build.Version) ? string.Empty : $" version={build.Version}";
-                lines.Add($"MSI {build.InstallerId} from {build.Target} ({build.Framework}, {build.Runtime}, {build.Style}) -> {outputDir} ({files.Length} files{version})");
+                var output = files.Length == 1
+                    ? files[0]
+                    : outputDir;
+                var fileList = files.Length <= 1
+                    ? string.Empty
+                    : $" files=[{string.Join(", ", files)}]";
+                lines.Add($"MSI {build.InstallerId} from {build.Target} ({build.Framework}, {build.Runtime}, {build.Style}) -> {output} ({files.Length} files{version}){fileList}");
             }
 
             File.WriteAllLines(txtPath, lines, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -73,7 +73,8 @@ public sealed partial class DotNetPublishPipelineRunner
             Directory.CreateDirectory(configuredOutputDir);
 
         var outputSearchDir = configuredOutputDir ?? projectDir;
-        var before = SnapshotMsiOutputs(outputSearchDir, skipBinDirectoryFilter: isGeneratedInstallerProject);
+        var skipOutputBinDirectoryFilter = isGeneratedInstallerProject || !string.IsNullOrWhiteSpace(configuredOutputDir);
+        var before = SnapshotMsiOutputs(outputSearchDir, skipBinDirectoryFilter: skipOutputBinDirectoryFilter);
 
         var args = new List<string>
         {
@@ -144,7 +145,7 @@ public sealed partial class DotNetPublishPipelineRunner
         if (versionResolution.Patch.HasValue && !string.IsNullOrWhiteSpace(versionResolution.StatePath))
             WriteMsiVersionState(versionResolution.StatePath!, versionResolution.Patch.Value, versionResolution.Version!);
 
-        var outputs = FindChangedMsiOutputs(outputSearchDir, before, skipBinDirectoryFilter: isGeneratedInstallerProject);
+        var outputs = FindChangedMsiOutputs(outputSearchDir, before, skipBinDirectoryFilter: skipOutputBinDirectoryFilter);
         if (outputs.Length == 0)
             _logger.Warn($"MSI build for '{installerId}' completed, but no changed *.msi outputs were detected under '{outputSearchDir}'.");
         else

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -61,13 +61,17 @@ public sealed partial class DotNetPublishPipelineRunner
             throw new FileNotFoundException($"Installer project path not found: {installerProjectPath}", installerProjectPath);
 
         var projectDir = Path.GetDirectoryName(installerProjectPath)!;
-        var generatedOutputDir = isGeneratedInstallerProject
-            ? ResolveGeneratedInstallerOutputDirectory(plan, installerId, step, prepare)
-            : null;
-        if (!string.IsNullOrWhiteSpace(generatedOutputDir))
-            Directory.CreateDirectory(generatedOutputDir);
+        var configuredOutputDir = ResolveInstallerOutputDirectory(
+            plan,
+            installerConfig,
+            installerId,
+            step,
+            prepare,
+            isGeneratedInstallerProject);
+        if (!string.IsNullOrWhiteSpace(configuredOutputDir))
+            Directory.CreateDirectory(configuredOutputDir);
 
-        var outputSearchDir = generatedOutputDir ?? projectDir;
+        var outputSearchDir = configuredOutputDir ?? projectDir;
         var before = SnapshotMsiOutputs(outputSearchDir, skipBinDirectoryFilter: isGeneratedInstallerProject);
 
         var args = new List<string>
@@ -90,8 +94,11 @@ public sealed partial class DotNetPublishPipelineRunner
             licenseResolution.PropertyName,
             licenseResolution.Path);
         args.AddRange(BuildMsBuildPropertyArgs(installerMsBuildProperties));
-        if (!string.IsNullOrWhiteSpace(generatedOutputDir))
-            args.Add($"/p:OutputPath={EnsureTrailingDirectorySeparator(generatedOutputDir!)}");
+        if (!string.IsNullOrWhiteSpace(configuredOutputDir))
+            args.Add($"/p:OutputPath={EnsureTrailingDirectorySeparator(configuredOutputDir!)}");
+        var configuredOutputName = ResolveInstallerOutputName(plan, installerConfig, step, versionResolution.Version);
+        if (!string.IsNullOrWhiteSpace(configuredOutputName))
+            args.Add($"/p:OutputName={configuredOutputName}");
         args.Add($"/p:PowerForgeMsiInstallerId={installerId}");
         args.Add($"/p:PowerForgeMsiPayloadDir={prepare.StagingDir}");
         if (!string.IsNullOrWhiteSpace(prepare.ManifestPath))
@@ -127,6 +134,10 @@ public sealed partial class DotNetPublishPipelineRunner
 
         _logger.Info(
             $"MSI build starting for '{installerId}' ({target}, {framework}, {runtime}, {style.Value}) -> {Path.GetFileName(installerProjectPath)}");
+        if (!string.IsNullOrWhiteSpace(configuredOutputDir))
+            _logger.Info($"MSI output directory for '{installerId}' -> {configuredOutputDir}");
+        if (!string.IsNullOrWhiteSpace(configuredOutputName))
+            _logger.Info($"MSI output name for '{installerId}' -> {configuredOutputName}.msi");
         RunDotnet(plan.ProjectRoot, args);
 
         if (versionResolution.Patch.HasValue && !string.IsNullOrWhiteSpace(versionResolution.StatePath))
@@ -136,7 +147,11 @@ public sealed partial class DotNetPublishPipelineRunner
         if (outputs.Length == 0)
             _logger.Warn($"MSI build for '{installerId}' completed, but no changed *.msi outputs were detected under '{outputSearchDir}'.");
         else
-            _logger.Info($"MSI build produced {outputs.Length} MSI output(s) for '{installerId}'.");
+        {
+            _logger.Info($"MSI build produced {outputs.Length} MSI output(s) for '{installerId}':");
+            foreach (var output in outputs)
+                _logger.Info($"  -> {output}");
+        }
 
         return new DotNetPublishMsiBuildResult
         {
@@ -242,6 +257,67 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!plan.AllowOutputOutsideProjectRoot)
             EnsurePathWithinRoot(plan.ProjectRoot, path, $"Installer '{installerId}' generated MSI output path");
         return path;
+    }
+
+    internal static string? ResolveInstallerOutputDirectory(
+        DotNetPublishPlan plan,
+        DotNetPublishInstallerPlan? installer,
+        string installerId,
+        DotNetPublishStep step,
+        DotNetPublishMsiPrepareResult prepare,
+        bool isGeneratedInstallerProject)
+    {
+        if (installer is not null && !string.IsNullOrWhiteSpace(installer.OutputPath))
+        {
+            var tokens = BuildInstallerOutputTokens(plan, installerId, step, version: null);
+            var outputPath = installer.OutputPath!;
+            var path = ResolvePath(plan.ProjectRoot, ApplyTemplate(outputPath, tokens));
+            if (!plan.AllowOutputOutsideProjectRoot)
+                EnsurePathWithinRoot(plan.ProjectRoot, path, $"Installer '{installerId}' MSI output path");
+            return path;
+        }
+
+        return isGeneratedInstallerProject
+            ? ResolveGeneratedInstallerOutputDirectory(plan, installerId, step, prepare)
+            : null;
+    }
+
+    internal static string? ResolveInstallerOutputName(
+        DotNetPublishPlan plan,
+        DotNetPublishInstallerPlan? installer,
+        DotNetPublishStep step,
+        string? version)
+    {
+        if (installer is null || string.IsNullOrWhiteSpace(installer.OutputName))
+            return null;
+
+        var tokens = BuildInstallerOutputTokens(plan, installer.Id, step, version);
+        var name = ApplyTemplate(installer.OutputName!, tokens).Trim();
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        name = ToSafeFileName(name, "installer");
+        return name.EndsWith(".msi", StringComparison.OrdinalIgnoreCase)
+            ? Path.GetFileNameWithoutExtension(name)
+            : name;
+    }
+
+    private static Dictionary<string, string> BuildInstallerOutputTokens(
+        DotNetPublishPlan plan,
+        string installerId,
+        DotNetPublishStep step,
+        string? version)
+    {
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["installer"] = installerId,
+            ["target"] = step.TargetName ?? string.Empty,
+            ["rid"] = step.Runtime ?? string.Empty,
+            ["framework"] = step.Framework ?? string.Empty,
+            ["style"] = step.Style?.ToString() ?? string.Empty,
+            ["configuration"] = plan.Configuration ?? "Release",
+            ["version"] = version ?? string.Empty
+        };
     }
 
     private static string ResolveGeneratedInstallerArtifactDirectory(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -67,6 +67,7 @@ public sealed partial class DotNetPublishPipelineRunner
             installerId,
             step,
             prepare,
+            versionResolution.Version,
             isGeneratedInstallerProject);
         if (!string.IsNullOrWhiteSpace(configuredOutputDir))
             Directory.CreateDirectory(configuredOutputDir);
@@ -265,11 +266,12 @@ public sealed partial class DotNetPublishPipelineRunner
         string installerId,
         DotNetPublishStep step,
         DotNetPublishMsiPrepareResult prepare,
+        string? version,
         bool isGeneratedInstallerProject)
     {
         if (installer is not null && !string.IsNullOrWhiteSpace(installer.OutputPath))
         {
-            var tokens = BuildInstallerOutputTokens(plan, installerId, step, version: null);
+            var tokens = BuildInstallerOutputTokens(plan, installerId, step, version);
             var outputPath = installer.OutputPath!;
             var path = ResolvePath(plan.ProjectRoot, ApplyTemplate(outputPath, tokens));
             if (!plan.AllowOutputOutsideProjectRoot)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -708,6 +708,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 Styles = NormalizeStyles(i.Styles),
                 StagingPath = i.StagingPath,
                 ManifestPath = i.ManifestPath,
+                OutputPath = i.OutputPath,
+                OutputName = i.OutputName,
                 InstallerProjectId = i.InstallerProjectId,
                 InstallerProjectPath = i.InstallerProjectPath,
                 Authoring = CloneInstallerDefinition(i.Authoring),
@@ -767,7 +769,17 @@ public sealed partial class DotNetPublishPipelineRunner
                 MinLength = input.MinLength,
                 MaxLength = input.MaxLength,
                 ValidationPattern = input.ValidationPattern,
-                ValidationMessage = input.ValidationMessage
+                ValidationMessage = input.ValidationMessage,
+                RegistrySearch = input.RegistrySearch is null
+                    ? null
+                    : new PowerForgeInstallerRegistrySearch
+                    {
+                        Id = input.RegistrySearch.Id,
+                        Root = input.RegistrySearch.Root,
+                        Key = input.RegistrySearch.Key,
+                        Name = input.RegistrySearch.Name,
+                        Type = input.RegistrySearch.Type
+                    }
             };
             foreach (var choice in input.Choices)
             {
@@ -859,7 +871,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 Arguments = service.Arguments,
                 Account = service.Account,
                 Start = service.Start,
-                DelayedAutoStart = service.DelayedAutoStart
+                DelayedAutoStart = service.DelayedAutoStart,
+                ControlStart = service.ControlStart,
+                ControlStop = service.ControlStop,
+                ControlRemove = service.ControlRemove,
+                ScriptInstall = CloneServiceScriptInstall(service.ScriptInstall)
             },
             PowerForgeInstallerRegistryValueComponent registryValue => new PowerForgeInstallerRegistryValueComponent
             {
@@ -877,6 +893,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 Name = shortcut.Name,
                 TargetFileId = shortcut.TargetFileId,
                 Target = shortcut.Target,
+                Arguments = shortcut.Arguments,
                 WorkingDirectoryId = shortcut.WorkingDirectoryId,
                 RegistryKey = shortcut.RegistryKey,
                 RegistryValueName = shortcut.RegistryValueName
@@ -888,6 +905,23 @@ public sealed partial class DotNetPublishPipelineRunner
         clone.DirectoryRefId = component.DirectoryRefId;
         clone.Guid = component.Guid;
         return clone;
+    }
+
+    private static PowerForgeInstallerServiceScriptInstall? CloneServiceScriptInstall(PowerForgeInstallerServiceScriptInstall? script)
+    {
+        if (script is null)
+            return null;
+
+        return new PowerForgeInstallerServiceScriptInstall
+        {
+            Command = script.Command,
+            UpgradeCommand = script.UpgradeCommand,
+            Condition = script.Condition,
+            BackupExistingImagePath = script.BackupExistingImagePath,
+            BackupPath = script.BackupPath,
+            StopServiceForUpgrade = script.StopServiceForUpgrade,
+            StopDelaySeconds = script.StopDelaySeconds
+        };
     }
 
     private static DotNetPublishStorePackage[] CloneStorePackages(DotNetPublishStorePackage[] storePackages)
@@ -1747,6 +1781,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 Styles = styles,
                 StagingPath = installer.StagingPath,
                 ManifestPath = installer.ManifestPath,
+                OutputPath = installer.OutputPath,
+                OutputName = installer.OutputName,
                 InstallerProjectId = installer.InstallerProjectId,
                 InstallerProjectPath = ResolveInstallerProjectPath(id, installer, projectCatalog, projectRoot),
                 Authoring = authoring,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -10,17 +10,17 @@ public sealed partial class DotNetPublishPipelineRunner
     private void Restore(DotNetPublishPlan plan, string? runtime)
     {
         var workDir = plan.ProjectRoot;
-        var props = BuildMsBuildPropertyArgs(plan.MsBuildProperties);
 
         if (!string.IsNullOrWhiteSpace(runtime))
         {
+            var runtimeValue = runtime!;
             foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
             {
-                _logger.Info($"Restore ({runtime}) -> {p}");
+                _logger.Info($"Restore ({runtimeValue}) -> {p}");
 
                 var args = new List<string> { "restore", p, "--nologo" };
-                args.AddRange(new[] { "-r", runtime! });
-                args.AddRange(props);
+                args.AddRange(new[] { "-r", runtimeValue });
+                args.AddRange(BuildMsBuildPropertyArgs(BuildRestoreMsBuildProperties(plan, p, runtimeValue)));
 
                 RunDotnet(workDir, args);
             }
@@ -28,6 +28,7 @@ public sealed partial class DotNetPublishPipelineRunner
             return;
         }
 
+        var props = BuildMsBuildPropertyArgs(plan.MsBuildProperties);
         if (!string.IsNullOrWhiteSpace(plan.SolutionPath))
         {
             _logger.Info($"Restore -> {plan.SolutionPath}");
@@ -40,6 +41,66 @@ public sealed partial class DotNetPublishPipelineRunner
             _logger.Info($"Restore -> {p}");
             RunDotnet(workDir, new[] { "restore", p, "--nologo" }.Concat(props).ToArray());
         }
+    }
+
+    internal static Dictionary<string, string> BuildRestoreMsBuildProperties(
+        DotNetPublishPlan plan,
+        string projectPath,
+        string runtime)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        var merged = new Dictionary<string, string>(plan.MsBuildProperties, StringComparer.OrdinalIgnoreCase);
+        foreach (var target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+        {
+            if (!string.Equals(target.ProjectPath, projectPath, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var styles = (target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
+                .Where(combination => string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
+                .Select(combination => combination.Style)
+                .Distinct()
+                .ToArray();
+
+            foreach (var style in styles)
+            {
+                foreach (var property in BuildPublishMsBuildProperties(plan, target, style))
+                    merged[property.Key] = property.Value;
+
+                if (IsPortableStyle(style))
+                {
+                    if (!merged.ContainsKey("SelfContained"))
+                        merged["SelfContained"] = "true";
+                    if (!merged.ContainsKey("PublishSingleFile"))
+                        merged["PublishSingleFile"] = "true";
+                    if (!merged.ContainsKey("IncludeNativeLibrariesForSelfExtract"))
+                        merged["IncludeNativeLibrariesForSelfExtract"] = "true";
+                    if (!merged.ContainsKey("PortableTrim"))
+                        merged["PortableTrim"] = (style == DotNetPublishStyle.PortableSize).ToString().ToLowerInvariant();
+                    if (!merged.ContainsKey("PortableTrimMode"))
+                        merged["PortableTrimMode"] = style == DotNetPublishStyle.PortableSize ? "full" : "partial";
+                    if (target.Publish.ReadyToRun.HasValue && !merged.ContainsKey("PublishReadyToRun"))
+                        merged["PublishReadyToRun"] = target.Publish.ReadyToRun.Value.ToString().ToLowerInvariant();
+                }
+
+                if (style == DotNetPublishStyle.AotSpeed || style == DotNetPublishStyle.AotSize)
+                {
+                    if (!merged.ContainsKey("SelfContained"))
+                        merged["SelfContained"] = "true";
+                    if (!merged.ContainsKey("NativeAotPublish"))
+                        merged["NativeAotPublish"] = "true";
+                }
+            }
+        }
+
+        return merged;
+    }
+
+    private static bool IsPortableStyle(DotNetPublishStyle style)
+    {
+        return style == DotNetPublishStyle.Portable
+            || style == DotNetPublishStyle.PortableCompat
+            || style == DotNetPublishStyle.PortableSize;
     }
 
     private void Clean(DotNetPublishPlan plan)

--- a/PowerForge/Services/DotNetPublishWorkflowService.cs
+++ b/PowerForge/Services/DotNetPublishWorkflowService.cs
@@ -9,17 +9,20 @@ internal sealed class DotNetPublishWorkflowService
     private readonly ILogger _logger;
     private readonly Func<DotNetPublishSpec, string?, DotNetPublishPlan> _planPublish;
     private readonly Func<DotNetPublishPlan, IDotNetPublishProgressReporter?, DotNetPublishResult> _runPublish;
+    private readonly Func<DotNetPublishPlan, IDotNetPublishProgressReporter?> _createProgressReporter;
     private readonly Action<DotNetPublishSpec, string> _writeSpecJson;
 
     public DotNetPublishWorkflowService(
         ILogger logger,
         Func<DotNetPublishSpec, string?, DotNetPublishPlan>? planPublish = null,
         Func<DotNetPublishPlan, IDotNetPublishProgressReporter?, DotNetPublishResult>? runPublish = null,
+        Func<DotNetPublishPlan, IDotNetPublishProgressReporter?>? createProgressReporter = null,
         Action<DotNetPublishSpec, string>? writeSpecJson = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _planPublish = planPublish ?? ((spec, sourceLabel) => new DotNetPublishPipelineRunner(_logger).Plan(spec, sourceLabel));
         _runPublish = runPublish ?? ((plan, progress) => new DotNetPublishPipelineRunner(_logger).Run(plan, progress));
+        _createProgressReporter = createProgressReporter ?? (_ => null);
         _writeSpecJson = writeSpecJson ?? WriteSpecJson;
     }
 
@@ -58,7 +61,7 @@ internal sealed class DotNetPublishWorkflowService
 
         return new DotNetPublishWorkflowResult
         {
-            Result = _runPublish(plan, null)
+            Result = _runPublish(plan, _createProgressReporter(plan))
         };
     }
 

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -85,6 +85,16 @@ internal static class PowerForgeInstallerDefinitionValidator
             }
 
             ValidateInputValidationMetadata(input);
+            if (input.RegistrySearch is not null)
+            {
+                Require(input.RegistrySearch.Id, $"input '{input.Id}' registry search ID");
+                RequireWixIdentifier(input.RegistrySearch.Id, $"input '{input.Id}' registry search ID");
+                Require(input.RegistrySearch.Root, $"input '{input.Id}' registry search root");
+                Require(input.RegistrySearch.Key, $"input '{input.Id}' registry search key");
+                Require(input.RegistrySearch.Name, $"input '{input.Id}' registry search name");
+                Require(input.RegistrySearch.Type, $"input '{input.Id}' registry search type");
+            }
+
             if (input.Kind == PowerForgeInstallerInputKind.RadioGroup && input.Choices.Count == 0)
                 throw new InvalidOperationException($"Input '{input.Id}' is a radio group but has no choices.");
             if (input.Required && input.Kind == PowerForgeInstallerInputKind.RadioGroup)
@@ -164,6 +174,12 @@ internal static class PowerForgeInstallerDefinitionValidator
                 Require(service.FileId, nameof(service.FileId));
                 RequireWixIdentifier(service.FileId, $"service component '{service.Id}' FileId");
                 Require(service.Source, nameof(service.Source));
+                Require(service.ServiceName, $"service component '{service.Id}' ServiceName");
+                Require(service.DisplayName, $"service component '{service.Id}' DisplayName");
+                Require(service.ControlStart, $"service component '{service.Id}' ControlStart");
+                Require(service.ControlStop, $"service component '{service.Id}' ControlStop");
+                Require(service.ControlRemove, $"service component '{service.Id}' ControlRemove");
+                ValidateServiceScriptInstall(service);
             }
             else if (component is PowerForgeInstallerRemoveFolderComponent removeFolder)
             {
@@ -184,6 +200,23 @@ internal static class PowerForgeInstallerDefinitionValidator
                         $"Registry value component '{registryValue.Id}' requires Value or ValueProperty.");
                 }
             }
+        }
+    }
+
+    private static void ValidateServiceScriptInstall(PowerForgeInstallerServiceComponent service)
+    {
+        var script = service.ScriptInstall;
+        if (script is null)
+            return;
+
+        Require(script.Command, $"service component '{service.Id}' ScriptInstall.Command");
+        Require(script.Condition, $"service component '{service.Id}' ScriptInstall.Condition");
+        if (script.BackupExistingImagePath)
+            Require(script.BackupPath, $"service component '{service.Id}' ScriptInstall.BackupPath");
+        if (script.StopDelaySeconds < 0)
+        {
+            throw new InvalidOperationException(
+                $"Service component '{service.Id}' ScriptInstall.StopDelaySeconds must be greater than or equal to 0.");
         }
     }
 

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -43,6 +43,9 @@ internal static class PowerForgeInstallerDefinitionValidator
             definition.Inputs.Select(input => input.PropertyName),
             "installer input property");
         EnsureUnique(
+            definition.Inputs.Select(input => input.RegistrySearch?.Id),
+            "installer registry search ID");
+        EnsureUnique(
             definition.Dialogs.Select(dialog => dialog.Id),
             "installer dialog ID");
         // Reserve the whole generated-dialog prefix case-insensitively so authored dialogs cannot

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace PowerForge;
+
+internal static class PowerForgeWixInstallerServiceScriptEmitter
+{
+    private static readonly XNamespace WixNamespace = "http://wixtoolset.org/schemas/v4/wxs";
+
+    internal static bool RequiresUtilExtension(PowerForgeInstallerDefinition definition)
+        => definition.Components
+            .OfType<PowerForgeInstallerServiceComponent>()
+            .Any(service => service.ScriptInstall is not null);
+
+    internal static IEnumerable<XElement> EmitScriptInstallActions(PowerForgeInstallerDefinition definition)
+    {
+        var actions = new List<XElement>();
+        var sequence = new XElement(WixNamespace + "InstallExecuteSequence");
+        foreach (var service in definition.Components.OfType<PowerForgeInstallerServiceComponent>())
+        {
+            if (service.ScriptInstall is null)
+                continue;
+
+            EmitServiceActions(service, actions, sequence);
+        }
+
+        foreach (var action in actions)
+            yield return action;
+        if (sequence.HasElements)
+            yield return sequence;
+    }
+
+    private static void EmitServiceActions(
+        PowerForgeInstallerServiceComponent service,
+        ICollection<XElement> actions,
+        XElement sequence)
+    {
+        var script = service.ScriptInstall!;
+        var ids = BuildIds(service.Id);
+        var upgradeCondition = "WIX_UPGRADE_DETECTED AND NOT REMOVE=\"ALL\"";
+        var standardCondition = string.IsNullOrWhiteSpace(script.UpgradeCommand)
+            ? script.Condition
+            : "NOT WIX_UPGRADE_DETECTED AND NOT REMOVE=\"ALL\"";
+
+        if (script.BackupExistingImagePath)
+        {
+            actions.Add(CreateQuietExecAction(ids.BackupImagePathId, execute: "immediate"));
+            actions.Add(new XElement(
+                WixNamespace + "SetProperty",
+                new XAttribute("Id", "WixQuietExecCmdLine"),
+                new XAttribute("Value", BuildBackupCommand(service, script)),
+                new XAttribute("Before", ids.BackupImagePathId),
+                new XAttribute("Sequence", "execute"),
+                new XAttribute("Condition", upgradeCondition)));
+        }
+
+        if (script.StopServiceForUpgrade)
+        {
+            actions.Add(CreateQuietExecAction(ids.StopServiceId, execute: "immediate"));
+            actions.Add(new XElement(
+                WixNamespace + "CustomAction",
+                new XAttribute("Id", ids.SetStopServiceId),
+                new XAttribute("Property", "WixQuietExecCmdLine"),
+                new XAttribute("Value", BuildStopCommand(service, script)),
+                new XAttribute("Execute", "immediate")));
+        }
+
+        actions.Add(CreateQuietExecAction(ids.InstallServiceId, execute: "deferred", hideTarget: true));
+
+        if (!string.IsNullOrWhiteSpace(script.UpgradeCommand))
+        {
+            actions.Add(CreateSetInstallCommand(ids.SetInstallUpgradeId, ids.InstallServiceId, script.UpgradeCommand!));
+        }
+
+        actions.Add(CreateSetInstallCommand(ids.SetInstallStandardId, ids.InstallServiceId, script.Command));
+        AddSequenceRows(sequence, ids, script, standardCondition, upgradeCondition);
+    }
+
+    private static void AddSequenceRows(
+        XElement sequence,
+        ServiceScriptActionIds ids,
+        PowerForgeInstallerServiceScriptInstall script,
+        string standardCondition,
+        string upgradeCondition)
+    {
+        if (script.BackupExistingImagePath)
+        {
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.BackupImagePathId),
+                new XAttribute("Before", "RemoveExistingProducts"),
+                new XAttribute("Condition", upgradeCondition)));
+        }
+
+        if (script.StopServiceForUpgrade)
+        {
+            var stopSet = new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.SetStopServiceId),
+                new XAttribute("Condition", upgradeCondition));
+            if (script.BackupExistingImagePath)
+                stopSet.Add(new XAttribute("After", ids.BackupImagePathId));
+            else
+                stopSet.Add(new XAttribute("Before", "RemoveExistingProducts"));
+            sequence.Add(stopSet);
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.StopServiceId),
+                new XAttribute("After", ids.SetStopServiceId),
+                new XAttribute("Condition", upgradeCondition)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(script.UpgradeCommand))
+        {
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.SetInstallUpgradeId),
+                new XAttribute("Before", ids.InstallServiceId),
+                new XAttribute("Condition", upgradeCondition)));
+        }
+
+        sequence.Add(new XElement(
+            WixNamespace + "Custom",
+            new XAttribute("Action", ids.SetInstallStandardId),
+            new XAttribute("Before", ids.InstallServiceId),
+            new XAttribute("Condition", standardCondition)));
+        sequence.Add(new XElement(
+            WixNamespace + "Custom",
+            new XAttribute("Action", ids.InstallServiceId),
+                new XAttribute("Before", "InstallFinalize"),
+                new XAttribute("Condition", script.Condition)));
+    }
+
+    private static XElement CreateQuietExecAction(string id, string execute, bool hideTarget = false)
+    {
+        var element = new XElement(
+            WixNamespace + "CustomAction",
+            new XAttribute("Id", id),
+            new XAttribute("BinaryRef", "Wix4UtilCA_$(sys.BUILDARCHSHORT)"),
+            new XAttribute("DllEntry", "WixQuietExec"),
+            new XAttribute("Execute", execute),
+            new XAttribute("Return", "check"));
+        if (string.Equals(execute, "deferred", StringComparison.OrdinalIgnoreCase))
+            element.Add(new XAttribute("Impersonate", "no"));
+        if (hideTarget)
+            element.Add(new XAttribute("HideTarget", "yes"));
+        return element;
+    }
+
+    private static XElement CreateSetInstallCommand(string id, string actionId, string command)
+        => new(
+            WixNamespace + "CustomAction",
+            new XAttribute("Id", id),
+            new XAttribute("Property", actionId),
+            new XAttribute("Value", command),
+            new XAttribute("Execute", "immediate"));
+
+    private static string BuildBackupCommand(
+        PowerForgeInstallerServiceComponent service,
+        PowerForgeInstallerServiceScriptInstall script)
+        => "\"[%ComSpec]\" /c reg query \"HKLM\\SYSTEM\\CurrentControlSet\\Services\\" +
+           service.ServiceName +
+           "\" /v ImagePath > \"" +
+           script.BackupPath +
+           "\" 2>nul";
+
+    private static string BuildStopCommand(
+        PowerForgeInstallerServiceComponent service,
+        PowerForgeInstallerServiceScriptInstall script)
+    {
+        var command = "\"[%ComSpec]\" /c sc.exe stop \"" + service.ServiceName + "\" >nul 2>nul";
+        if (script.StopDelaySeconds > 0)
+        {
+            var pingCount = script.StopDelaySeconds + 1;
+            command += " & ping 127.0.0.1 -n " + pingCount.ToString(CultureInfo.InvariantCulture) + " >nul";
+        }
+
+        return command;
+    }
+
+    private static ServiceScriptActionIds BuildIds(string serviceComponentId)
+    {
+        var prefix = serviceComponentId.Length <= 48
+            ? serviceComponentId
+            : serviceComponentId.Substring(0, 48);
+        return new ServiceScriptActionIds(
+            prefix + "BackupImagePath",
+            prefix + "SetStopService",
+            prefix + "StopService",
+            prefix + "InstallService",
+            prefix + "SetInstallService",
+            prefix + "SetInstallServiceUpgrade");
+    }
+
+    private sealed class ServiceScriptActionIds
+    {
+        internal ServiceScriptActionIds(
+            string backupImagePathId,
+            string setStopServiceId,
+            string stopServiceId,
+            string installServiceId,
+            string setInstallStandardId,
+            string setInstallUpgradeId)
+        {
+            BackupImagePathId = backupImagePathId;
+            SetStopServiceId = setStopServiceId;
+            StopServiceId = stopServiceId;
+            InstallServiceId = installServiceId;
+            SetInstallStandardId = setInstallStandardId;
+            SetInstallUpgradeId = setInstallUpgradeId;
+        }
+
+        internal string BackupImagePathId { get; }
+        internal string SetStopServiceId { get; }
+        internal string StopServiceId { get; }
+        internal string InstallServiceId { get; }
+        internal string SetInstallStandardId { get; }
+        internal string SetInstallUpgradeId { get; }
+    }
+}

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -21,12 +21,13 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
     {
         var actions = new List<XElement>();
         var sequence = new XElement(WixNamespace + "InstallExecuteSequence");
+        string? upgradeSequenceTail = null;
         foreach (var service in definition.Components.OfType<PowerForgeInstallerServiceComponent>())
         {
             if (service.ScriptInstall is null)
                 continue;
 
-            EmitServiceActions(service, actions, sequence);
+            upgradeSequenceTail = EmitServiceActions(service, actions, sequence, upgradeSequenceTail);
         }
 
         foreach (var action in actions)
@@ -35,10 +36,11 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             yield return sequence;
     }
 
-    private static void EmitServiceActions(
+    private static string? EmitServiceActions(
         PowerForgeInstallerServiceComponent service,
         ICollection<XElement> actions,
-        XElement sequence)
+        XElement sequence,
+        string? upgradeSequenceTail)
     {
         var script = service.ScriptInstall!;
         var ids = BuildIds(service.Id);
@@ -49,26 +51,14 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
 
         if (script.BackupExistingImagePath)
         {
+            actions.Add(CreateSetQuietExecCommand(ids.SetBackupCommandId, BuildBackupCommand(service, script)));
             actions.Add(CreateQuietExecAction(ids.BackupImagePathId, execute: "immediate"));
-            actions.Add(new XElement(
-                WixNamespace + "SetProperty",
-                new XAttribute("Id", "WixQuietExecCmdLine"),
-                new XAttribute("Action", ids.SetBackupCommandId),
-                new XAttribute("Value", BuildBackupCommand(service, script)),
-                new XAttribute("Before", ids.BackupImagePathId),
-                new XAttribute("Sequence", "execute"),
-                new XAttribute("Condition", upgradeCondition)));
         }
 
         if (script.StopServiceForUpgrade)
         {
             actions.Add(CreateQuietExecAction(ids.StopServiceId, execute: "immediate"));
-            actions.Add(new XElement(
-                WixNamespace + "CustomAction",
-                new XAttribute("Id", ids.SetStopServiceId),
-                new XAttribute("Property", "WixQuietExecCmdLine"),
-                new XAttribute("Value", BuildStopCommand(service, script)),
-                new XAttribute("Execute", "immediate")));
+            actions.Add(CreateSetQuietExecCommand(ids.SetStopServiceId, BuildStopCommand(service, script)));
         }
 
         actions.Add(CreateQuietExecAction(ids.InstallServiceId, execute: "deferred", hideTarget: true));
@@ -79,41 +69,38 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         }
 
         actions.Add(CreateSetInstallCommand(ids.SetInstallStandardId, ids.InstallServiceId, script.Command));
-        AddSequenceRows(sequence, ids, script, standardCondition, upgradeCondition);
+        return AddSequenceRows(sequence, ids, script, standardCondition, upgradeCondition, upgradeSequenceTail);
     }
 
-    private static void AddSequenceRows(
+    private static string? AddSequenceRows(
         XElement sequence,
         ServiceScriptActionIds ids,
         PowerForgeInstallerServiceScriptInstall script,
         string standardCondition,
-        string upgradeCondition)
+        string upgradeCondition,
+        string? upgradeSequenceTail)
     {
+        string? tail = upgradeSequenceTail;
         if (script.BackupExistingImagePath)
         {
+            AddUpgradeSequenceRow(sequence, ids.SetBackupCommandId, tail, upgradeCondition);
             sequence.Add(new XElement(
                 WixNamespace + "Custom",
                 new XAttribute("Action", ids.BackupImagePathId),
-                new XAttribute("Before", "RemoveExistingProducts"),
+                new XAttribute("After", ids.SetBackupCommandId),
                 new XAttribute("Condition", upgradeCondition)));
+            tail = ids.BackupImagePathId;
         }
 
         if (script.StopServiceForUpgrade)
         {
-            var stopSet = new XElement(
-                WixNamespace + "Custom",
-                new XAttribute("Action", ids.SetStopServiceId),
-                new XAttribute("Condition", upgradeCondition));
-            if (script.BackupExistingImagePath)
-                stopSet.Add(new XAttribute("After", ids.BackupImagePathId));
-            else
-                stopSet.Add(new XAttribute("Before", "RemoveExistingProducts"));
-            sequence.Add(stopSet);
+            AddUpgradeSequenceRow(sequence, ids.SetStopServiceId, tail, upgradeCondition);
             sequence.Add(new XElement(
                 WixNamespace + "Custom",
                 new XAttribute("Action", ids.StopServiceId),
                 new XAttribute("After", ids.SetStopServiceId),
                 new XAttribute("Condition", upgradeCondition)));
+            tail = ids.StopServiceId;
         }
 
         if (!string.IsNullOrWhiteSpace(script.UpgradeCommand))
@@ -135,6 +122,24 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             new XAttribute("Action", ids.InstallServiceId),
             new XAttribute("Before", "InstallFinalize"),
             new XAttribute("Condition", script.Condition)));
+        return tail;
+    }
+
+    private static void AddUpgradeSequenceRow(
+        XElement sequence,
+        string actionId,
+        string? afterActionId,
+        string condition)
+    {
+        var element = new XElement(
+            WixNamespace + "Custom",
+            new XAttribute("Action", actionId),
+            new XAttribute("Condition", condition));
+        if (string.IsNullOrWhiteSpace(afterActionId))
+            element.Add(new XAttribute("Before", "RemoveExistingProducts"));
+        else
+            element.Add(new XAttribute("After", afterActionId!));
+        sequence.Add(element);
     }
 
     private static XElement CreateQuietExecAction(string id, string execute, bool hideTarget = false)
@@ -160,6 +165,9 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             new XAttribute("Property", actionId),
             new XAttribute("Value", command),
             new XAttribute("Execute", "immediate"));
+
+    private static XElement CreateSetQuietExecCommand(string id, string command)
+        => CreateSetInstallCommand(id, "WixQuietExecCmdLine", command);
 
     private static string BuildBackupCommand(
         PowerForgeInstallerServiceComponent service,

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace PowerForge;
@@ -44,14 +45,15 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
     {
         var script = service.ScriptInstall!;
         var ids = BuildIds(service.Id);
-        var upgradeCondition = "WIX_UPGRADE_DETECTED AND NOT REMOVE=\"ALL\"";
+        var resolvedBackupPath = ResolveBackupPath(service, script);
+        var upgradeCondition = CombineConditions(script.Condition, "WIX_UPGRADE_DETECTED", "NOT REMOVE=\"ALL\"");
         var standardCondition = string.IsNullOrWhiteSpace(script.UpgradeCommand)
             ? script.Condition
-            : "NOT WIX_UPGRADE_DETECTED AND NOT REMOVE=\"ALL\"";
+            : CombineConditions(script.Condition, "NOT WIX_UPGRADE_DETECTED", "NOT REMOVE=\"ALL\"");
 
         if (script.BackupExistingImagePath)
         {
-            actions.Add(CreateSetQuietExecCommand(ids.SetBackupCommandId, BuildBackupCommand(service, script)));
+            actions.Add(CreateSetQuietExecCommand(ids.SetBackupCommandId, BuildBackupCommand(service, resolvedBackupPath)));
             actions.Add(CreateQuietExecAction(ids.BackupImagePathId, execute: "immediate"));
         }
 
@@ -171,13 +173,13 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
 
     private static string BuildBackupCommand(
         PowerForgeInstallerServiceComponent service,
-        PowerForgeInstallerServiceScriptInstall script)
+        string backupPath)
         => "\"[%ComSpec]\" /c reg query \"HKLM\\SYSTEM\\CurrentControlSet\\Services\\" +
            service.ServiceName +
            "\" /v ImagePath > \"" +
-           script.BackupPath +
+           backupPath +
            "\" 2>nul || type nul > \"" +
-           script.BackupPath +
+           backupPath +
            "\"";
 
     private static string BuildStopCommand(
@@ -200,13 +202,43 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             ? serviceComponentId
             : serviceComponentId.Substring(0, 32) + "_" + HashId(serviceComponentId);
         return new ServiceScriptActionIds(
-            prefix + "BackupImagePath",
-            prefix + "SetBackupCommand",
-            prefix + "SetStopService",
-            prefix + "StopService",
-            prefix + "InstallService",
-            prefix + "SetInstallService",
-            prefix + "SetInstallServiceUpgrade");
+            BuildActionId(prefix, "BackupImagePath"),
+            BuildActionId(prefix, "SetBackupCommand"),
+            BuildActionId(prefix, "SetStopService"),
+            BuildActionId(prefix, "StopService"),
+            BuildActionId(prefix, "InstallService"),
+            BuildActionId(prefix, "SetInstallService"),
+            BuildActionId(prefix, "SetInstallServiceUpgrade"));
+    }
+
+    private static string BuildActionId(string prefix, string suffix)
+        => prefix + "." + suffix;
+
+    private static string ResolveBackupPath(
+        PowerForgeInstallerServiceComponent service,
+        PowerForgeInstallerServiceScriptInstall script)
+        => ReplaceToken(
+            ReplaceToken(script.BackupPath, "{serviceId}", service.Id),
+            "{serviceName}",
+            service.ServiceName);
+
+    private static string ReplaceToken(string value, string token, string replacement)
+        => Regex.Replace(
+            value,
+            Regex.Escape(token),
+            _ => replacement,
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static string CombineConditions(params string[] conditions)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var parts = conditions
+            .Where(condition => !string.IsNullOrWhiteSpace(condition))
+            .Select(condition => condition.Trim())
+            .Where(condition => seen.Add(condition))
+            .Select(condition => "(" + condition + ")")
+            .ToArray();
+        return string.Join(" AND ", parts);
     }
 
     private static string HashId(string value)

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Xml.Linq;
 
 namespace PowerForge;
@@ -51,6 +53,7 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             actions.Add(new XElement(
                 WixNamespace + "SetProperty",
                 new XAttribute("Id", "WixQuietExecCmdLine"),
+                new XAttribute("Action", ids.SetBackupCommandId),
                 new XAttribute("Value", BuildBackupCommand(service, script)),
                 new XAttribute("Before", ids.BackupImagePathId),
                 new XAttribute("Sequence", "execute"),
@@ -130,8 +133,8 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         sequence.Add(new XElement(
             WixNamespace + "Custom",
             new XAttribute("Action", ids.InstallServiceId),
-                new XAttribute("Before", "InstallFinalize"),
-                new XAttribute("Condition", script.Condition)));
+            new XAttribute("Before", "InstallFinalize"),
+            new XAttribute("Condition", script.Condition)));
     }
 
     private static XElement CreateQuietExecAction(string id, string execute, bool hideTarget = false)
@@ -165,7 +168,9 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
            service.ServiceName +
            "\" /v ImagePath > \"" +
            script.BackupPath +
-           "\" 2>nul";
+           "\" 2>nul || type nul > \"" +
+           script.BackupPath +
+           "\"";
 
     private static string BuildStopCommand(
         PowerForgeInstallerServiceComponent service,
@@ -178,16 +183,17 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             command += " & ping 127.0.0.1 -n " + pingCount.ToString(CultureInfo.InvariantCulture) + " >nul";
         }
 
-        return command;
+        return command + " & exit /b 0";
     }
 
     private static ServiceScriptActionIds BuildIds(string serviceComponentId)
     {
-        var prefix = serviceComponentId.Length <= 48
+        var prefix = serviceComponentId.Length <= 32
             ? serviceComponentId
-            : serviceComponentId.Substring(0, 48);
+            : serviceComponentId.Substring(0, 32) + "_" + HashId(serviceComponentId);
         return new ServiceScriptActionIds(
             prefix + "BackupImagePath",
+            prefix + "SetBackupCommand",
             prefix + "SetStopService",
             prefix + "StopService",
             prefix + "InstallService",
@@ -195,10 +201,18 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             prefix + "SetInstallServiceUpgrade");
     }
 
+    private static string HashId(string value)
+    {
+        using var sha256 = SHA256.Create();
+        var bytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(value));
+        return BitConverter.ToString(bytes, 0, 5).Replace("-", string.Empty);
+    }
+
     private sealed class ServiceScriptActionIds
     {
         internal ServiceScriptActionIds(
             string backupImagePathId,
+            string setBackupCommandId,
             string setStopServiceId,
             string stopServiceId,
             string installServiceId,
@@ -206,6 +220,7 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             string setInstallUpgradeId)
         {
             BackupImagePathId = backupImagePathId;
+            SetBackupCommandId = setBackupCommandId;
             SetStopServiceId = setStopServiceId;
             StopServiceId = stopServiceId;
             InstallServiceId = installServiceId;
@@ -214,6 +229,7 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         }
 
         internal string BackupImagePathId { get; }
+        internal string SetBackupCommandId { get; }
         internal string SetStopServiceId { get; }
         internal string StopServiceId { get; }
         internal string InstallServiceId { get; }

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -26,7 +26,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         PowerForgeInstallerDefinitionValidator.Validate(definition);
 
         var needsUi = definition.Dialogs.Count > 0;
-        var needsUtil = definition.Components.OfType<PowerForgeInstallerRemoveFolderComponent>().Any();
+        var needsUtil = RequiresUtilExtension(definition);
         var rootAttributes = new List<XAttribute>();
         if (needsUtil)
             rootAttributes.Add(new XAttribute(XNamespace.Xmlns + "util", UtilNamespace.NamespaceName));
@@ -51,6 +51,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             package.Add(EmitUi(definition));
 
         package.Add(EmitFeature(definition));
+        package.Add(PowerForgeWixInstallerServiceScriptEmitter.EmitScriptInstallActions(definition));
 
         var root = new XElement(WixNamespace + "Wix", rootAttributes, package);
         root.Add(EmitDirectories(definition));
@@ -88,6 +89,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XElement(
                 "PropertyGroup",
                 new XElement("OutputType", "Package"),
+                new XElement("ManagePackageVersionsCentrally", "false"),
                 new XElement("EnableDefaultItems", "false"),
                 new XElement("Platform", options.Platform)));
 
@@ -105,7 +107,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         }
 
         var packageReferences = new List<XElement>();
-        if (definition.Components.OfType<PowerForgeInstallerRemoveFolderComponent>().Any())
+        if (RequiresUtilExtension(definition))
         {
             packageReferences.Add(new XElement(
                 "PackageReference",
@@ -141,6 +143,14 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
         foreach (var input in definition.Inputs)
         {
+            if (string.IsNullOrWhiteSpace(input.DefaultValue) &&
+                !input.Secure &&
+                !input.Hidden &&
+                input.RegistrySearch is null)
+            {
+                continue;
+            }
+
             var property = new XElement(
                 WixNamespace + "Property",
                 new XAttribute("Id", input.PropertyName));
@@ -151,6 +161,16 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 property.Add(new XAttribute("Secure", "yes"));
             if (input.Hidden)
                 property.Add(new XAttribute("Hidden", "yes"));
+            if (input.RegistrySearch is not null)
+            {
+                property.Add(new XElement(
+                    WixNamespace + "RegistrySearch",
+                    new XAttribute("Id", input.RegistrySearch.Id),
+                    new XAttribute("Root", input.RegistrySearch.Root),
+                    new XAttribute("Key", input.RegistrySearch.Key),
+                    new XAttribute("Name", input.RegistrySearch.Name),
+                    new XAttribute("Type", input.RegistrySearch.Type)));
+            }
 
             package.Add(property);
         }
@@ -697,21 +717,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XAttribute("Source", service.Source),
             new XAttribute("KeyPath", "yes")));
 
-        var serviceInstall = new XElement(
-            WixNamespace + "ServiceInstall",
-            new XAttribute("Id", service.Id + "Install"),
-            new XAttribute("Name", service.ServiceName),
-            new XAttribute("DisplayName", service.DisplayName),
-            new XAttribute("Start", service.Start),
-            new XAttribute("Type", "ownProcess"),
-            new XAttribute("ErrorControl", "normal"),
-            new XAttribute("Vital", "yes"),
-            new XAttribute("Account", service.Account));
-        if (!string.IsNullOrWhiteSpace(service.Description))
-            serviceInstall.Add(new XAttribute("Description", service.Description!));
-        if (!string.IsNullOrWhiteSpace(service.Arguments))
-            serviceInstall.Add(new XAttribute("Arguments", service.Arguments!));
-        component.Add(serviceInstall);
+        if (service.ScriptInstall is null)
+            component.Add(EmitServiceInstall(service));
 
         if (service.DelayedAutoStart)
         {
@@ -728,12 +735,43 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             WixNamespace + "ServiceControl",
             new XAttribute("Id", service.Id + "Control"),
             new XAttribute("Name", service.ServiceName),
-            new XAttribute("Start", "none"),
-            new XAttribute("Stop", "both"),
-            new XAttribute("Remove", "both"),
+            new XAttribute("Start", service.ControlStart),
+            new XAttribute("Stop", service.ControlStop),
+            new XAttribute("Remove", service.ControlRemove),
             new XAttribute("Wait", "yes")));
 
         return component;
+    }
+
+    private static bool RequiresUtilExtension(PowerForgeInstallerDefinition definition)
+        => definition.Components.OfType<PowerForgeInstallerRemoveFolderComponent>().Any() ||
+           PowerForgeWixInstallerServiceScriptEmitter.RequiresUtilExtension(definition);
+
+    private static XElement EmitServiceInstall(PowerForgeInstallerServiceComponent service)
+    {
+        var serviceInstall = new XElement(
+            WixNamespace + "ServiceInstall",
+            new XAttribute("Id", service.Id + "Install"),
+            new XAttribute("Name", service.ServiceName),
+            new XAttribute("DisplayName", service.DisplayName),
+            new XAttribute("Start", service.Start),
+            new XAttribute("Type", "ownProcess"),
+            new XAttribute("ErrorControl", "normal"),
+            new XAttribute("Vital", "yes"));
+        if (!IsLocalSystemAccount(service.Account))
+            serviceInstall.Add(new XAttribute("Account", service.Account));
+        if (!string.IsNullOrWhiteSpace(service.Description))
+            serviceInstall.Add(new XAttribute("Description", service.Description!));
+        if (!string.IsNullOrWhiteSpace(service.Arguments))
+            serviceInstall.Add(new XAttribute("Arguments", service.Arguments!));
+        return serviceInstall;
+    }
+
+    private static bool IsLocalSystemAccount(string? account)
+    {
+        return string.IsNullOrWhiteSpace(account)
+            || string.Equals(account, "LocalSystem", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(account, @"NT AUTHORITY\LocalSystem", StringComparison.OrdinalIgnoreCase);
     }
 
     private static XElement EmitRegistryValueComponent(PowerForgeInstallerRegistryValueComponent registryValue)
@@ -764,12 +802,15 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         var target = !string.IsNullOrWhiteSpace(shortcut.Target)
             ? shortcut.Target!
             : "[#" + shortcut.TargetFileId + "]";
-        component.Add(new XElement(
+        var shortcutElement = new XElement(
             WixNamespace + "Shortcut",
             new XAttribute("Id", shortcut.ShortcutId),
             new XAttribute("Name", shortcut.Name),
             new XAttribute("Target", target),
-            new XAttribute("WorkingDirectory", shortcut.WorkingDirectoryId)));
+            new XAttribute("WorkingDirectory", shortcut.WorkingDirectoryId));
+        if (!string.IsNullOrWhiteSpace(shortcut.Arguments))
+            shortcutElement.Add(new XAttribute("Arguments", shortcut.Arguments!));
+        component.Add(shortcutElement);
         component.Add(new XElement(
             WixNamespace + "RemoveFolder",
             new XAttribute("Id", shortcut.Id + "RemoveFolder"),

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -154,6 +154,18 @@
       },
       "required": ["Value", "Text"]
     },
+    "PowerForgeInstallerRegistrySearch": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Id": { "type": "string", "minLength": 1 },
+        "Root": { "type": "string", "minLength": 1 },
+        "Key": { "type": "string", "minLength": 1 },
+        "Name": { "type": "string", "minLength": 1 },
+        "Type": { "type": "string", "minLength": 1 }
+      },
+      "required": ["Id", "Root", "Key", "Name"]
+    },
     "PowerForgeInstallerInput": {
       "type": "object",
       "additionalProperties": false,
@@ -172,6 +184,7 @@
         "MaxLength": { "type": ["integer", "null"], "minimum": 0 },
         "ValidationPattern": { "type": ["string", "null"] },
         "ValidationMessage": { "type": ["string", "null"] },
+        "RegistrySearch": { "anyOf": [{ "$ref": "#/$defs/PowerForgeInstallerRegistrySearch" }, { "type": "null" }] },
         "Choices": {
           "type": "array",
           "items": { "$ref": "#/$defs/PowerForgeInstallerInputChoice" }
@@ -293,9 +306,32 @@
         "Arguments": { "type": ["string", "null"] },
         "Account": { "type": "string" },
         "Start": { "type": "string" },
-        "DelayedAutoStart": { "type": "boolean" }
+        "DelayedAutoStart": { "type": "boolean" },
+        "ControlStart": { "type": "string" },
+        "ControlStop": { "type": "string" },
+        "ControlRemove": { "type": "string" },
+        "ScriptInstall": {
+          "anyOf": [
+            { "$ref": "#/$defs/PowerForgeInstallerServiceScriptInstall" },
+            { "type": "null" }
+          ]
+        }
       },
       "required": ["Type", "Id", "FileId", "Source", "ServiceName", "DisplayName"]
+    },
+    "PowerForgeInstallerServiceScriptInstall": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Command": { "type": "string", "minLength": 1 },
+        "UpgradeCommand": { "type": ["string", "null"], "minLength": 1 },
+        "Condition": { "type": "string", "minLength": 1 },
+        "BackupExistingImagePath": { "type": "boolean" },
+        "BackupPath": { "type": "string", "minLength": 1 },
+        "StopServiceForUpgrade": { "type": "boolean" },
+        "StopDelaySeconds": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["Command"]
     },
     "PowerForgeInstallerShortcutComponent": {
       "type": "object",
@@ -309,6 +345,7 @@
         "Name": { "type": "string", "minLength": 1 },
         "TargetFileId": { "type": ["string", "null"], "minLength": 1 },
         "Target": { "type": ["string", "null"], "minLength": 1 },
+        "Arguments": { "type": ["string", "null"], "minLength": 1 },
         "WorkingDirectoryId": { "type": "string", "minLength": 1 },
         "RegistryKey": { "type": "string", "minLength": 1 },
         "RegistryValueName": { "type": "string", "minLength": 1 }
@@ -636,6 +673,8 @@
         "Styles": { "type": "array", "items": { "$ref": "#/$defs/DotNetPublishStyle" } },
         "StagingPath": { "type": ["string", "null"] },
         "ManifestPath": { "type": ["string", "null"] },
+        "OutputPath": { "type": ["string", "null"] },
+        "OutputName": { "type": ["string", "null"] },
         "InstallerProjectId": { "type": ["string", "null"] },
         "InstallerProjectPath": { "type": ["string", "null"] },
         "Authoring": { "anyOf": [{ "$ref": "#/$defs/PowerForgeInstallerDefinition" }, { "type": "null" }] },


### PR DESCRIPTION
## Summary

- add declarative MSI output path/name support, publish progress reporting, and restore/property handling needed by generated service MSI builds
- add PowerForge installer authoring support for script-owned Windows service installation, including upgrade ImagePath backup, optional pre-upgrade stop, separate standard/upgrade install commands, and configurable ServiceControl stop/remove behavior
- extend the dotnet publish schema, plan cloning, manifests, and authoring tests for the new service packaging surface

## Why

SyncSE can use the simple generated ServiceInstall path, but TestimoX.Monitoring needs a stronger installer bridge where the service install script owns registration and preserves customized service command lines across upgrades. This makes that behavior reusable in PowerForge instead of hardcoding it into one MSI.

## Validation

- `dotnet test C:\Support\GitHub\PSPublishModule\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter PowerForgeInstallerAuthoringTests --no-restore --nologo` passed: 48 tests
- `dotnet build C:\Support\GitHub\PSPublishModule\PowerForge\PowerForge.csproj -c Release -f net472 --no-restore --nologo` passed with 0 warnings/errors
- `git diff --check origin/main...HEAD` passed

Note: the focused test run emitted existing `Magick.NET-Q8-AnyCPU` NuGet vulnerability warnings from PowerForge.Web/PowerForge.Web.Cli restore/build output; they are unrelated to this installer change.
