### PR TITLE
Allow website runner source restore outside locked mode

### DIFF
--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -183,7 +183,7 @@ jobs:
             $runnerArgs += '--maintenance-note'
           }
 
-          dotnet run --framework net10.0 --project ./.powerforge-runner/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -- $runnerArgs
+          dotnet run --framework net10.0 -p:RestoreLockedMode=false --project ./.powerforge-runner/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -- $runnerArgs
 
       - name: Upload website reports
         if: always()

--- a/PowerForge.Tests/WebWebsiteRunnerTests.cs
+++ b/PowerForge.Tests/WebWebsiteRunnerTests.cs
@@ -135,6 +135,15 @@ public sealed class WebWebsiteRunnerTests
     }
 
     [Fact]
+    public void BuildSourcePipelineArguments_DisablesLockedRestoreForSourceCheckout()
+    {
+        var arguments = WebWebsiteRunner.BuildSourcePipelineArguments("PowerForge.Web.Cli.csproj", "pipeline.json", "ci");
+
+        Assert.Contains("-p:RestoreLockedMode=false", arguments);
+        Assert.Equal(new[] { "pipeline", "--config", "pipeline.json", "--mode", "ci" }, arguments.SkipWhile(value => value != "--").Skip(1));
+    }
+
+    [Fact]
     public void CreateGitHubGitEnvironment_UsesAskPassFallback_WhenTokenIsProvided()
     {
         var root = Path.Combine(Path.GetTempPath(), "powerforge-website-runner-credentials-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web/Services/WebWebsiteRunner.cs
+++ b/PowerForge.Web/Services/WebWebsiteRunner.cs
@@ -106,11 +106,7 @@ public static class WebWebsiteRunner
         RunProcess(
             "dotnet",
             null,
-            new[]
-            {
-                "run", "--framework", "net10.0", "--project", projectPath, "--",
-                "pipeline", "--config", pipelineConfig, "--mode", NormalizeValue(options.PipelineMode, "ci")
-            },
+            BuildSourcePipelineArguments(projectPath, pipelineConfig, NormalizeValue(options.PipelineMode, "ci")),
             null,
             standardOutput,
             standardError);
@@ -124,6 +120,15 @@ public static class WebWebsiteRunner
             Repository = finalRepository,
             Ref = finalRef,
             LaunchedPath = projectPath
+        };
+    }
+
+    internal static string[] BuildSourcePipelineArguments(string projectPath, string pipelineConfig, string pipelineMode)
+    {
+        return new[]
+        {
+            "run", "--framework", "net10.0", "-p:RestoreLockedMode=false", "--project", projectPath, "--",
+            "pipeline", "--config", pipelineConfig, "--mode", NormalizeValue(pipelineMode, "ci")
         };
     }
 


### PR DESCRIPTION
## Summary\n- let the reusable PowerForge website runner build its temporary source checkout with RestoreLockedMode disabled\n- keeps downstream website consumers pinned by SHA without inheriting transient lock-file restore failures from the runner checkout\n\n## Validation\n- dotnet run --framework net10.0 -p:RestoreLockedMode=false --project .\\PowerForge.Web.Cli\\PowerForge.Web.Cli.csproj -- --help