### PR TITLE
Improve PowerForge dependency, AOT, and MSI support

### DIFF
--- a/PSPublishModule/Cmdlets/NewConfigurationModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationModuleCommand.cs
@@ -114,6 +114,12 @@ public sealed class NewConfigurationModuleCommand : PSCmdlet
     [ArgumentCompleter(typeof(AutoLatestCompleter))]
     public string? Guid { get; set; }
 
+    /// <summary>
+    /// Source used when resolving <c>Auto</c>/<c>Latest</c> version values.
+    /// </summary>
+    [Parameter]
+    public PowerForge.ModuleDependencyVersionSource VersionSource { get; set; } = PowerForge.ModuleDependencyVersionSource.Auto;
+
     /// <summary>Emits module dependency configuration objects.</summary>
     protected override void ProcessRecord()
     {
@@ -136,7 +142,8 @@ public sealed class NewConfigurationModuleCommand : PSCmdlet
                     ModuleVersion = null,
                     MinimumVersion = min,
                     RequiredVersion = RequiredVersion,
-                    Guid = Guid
+                    Guid = Guid,
+                    VersionSource = VersionSource
                 }
             };
 

--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -172,6 +172,12 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "ApiFromFile")]
     public SwitchParameter GenerateReleaseNotes { get; set; }
 
+    /// <summary>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "AzureArtifacts")]
+    public SwitchParameter UseAsDependencyVersionSource { get; set; }
+
     /// <summary>Emits publish configuration for the build pipeline.</summary>
     protected override void ProcessRecord()
     {
@@ -206,6 +212,7 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
             ID = ID,
             DoNotMarkAsPreRelease = DoNotMarkAsPreRelease.IsPresent,
             GenerateReleaseNotes = GenerateReleaseNotes.IsPresent,
+            UseAsDependencyVersionSource = UseAsDependencyVersionSource.IsPresent,
             Verbose = MyInvocation.BoundParameters.ContainsKey("Verbose")
         });
 

--- a/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
@@ -31,5 +31,6 @@ internal sealed class PublishConfigurationRequest
     public string? ID { get; set; }
     public bool DoNotMarkAsPreRelease { get; set; }
     public bool GenerateReleaseNotes { get; set; }
+    public bool UseAsDependencyVersionSource { get; set; }
     public bool Verbose { get; set; }
 }

--- a/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
+++ b/PowerForge.PowerShell/Services/LegacySegmentAdapter.cs
@@ -265,7 +265,9 @@ public static class LegacySegmentAdapter
                     ModuleVersion = GetString(d, "ModuleVersion"),
                     MinimumVersion = GetString(d, "MinimumVersion"),
                     RequiredVersion = GetString(d, "RequiredVersion"),
-                    Guid = GetString(d, "Guid")
+                    Guid = GetString(d, "Guid"),
+                    VersionSource = TryParseModuleDependencyVersionSource(GetString(d, "VersionSource"))
+                        ?? ModuleDependencyVersionSource.Auto
                 }
             });
             return;
@@ -282,6 +284,12 @@ public static class LegacySegmentAdapter
     {
         if (string.IsNullOrWhiteSpace(value)) return null;
         return Enum.TryParse<InstallationStrategy>(value!.Trim(), ignoreCase: true, out var parsed) ? parsed : null;
+    }
+
+    private static ModuleDependencyVersionSource? TryParseModuleDependencyVersionSource(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return Enum.TryParse<ModuleDependencyVersionSource>(value!.Trim(), ignoreCase: true, out var parsed) ? parsed : null;
     }
 
     private static AssemblyTypeAcceleratorExportMode? TryParseAssemblyTypeAcceleratorExportMode(string? value)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -138,7 +138,8 @@ public sealed partial class ModulePipelineRunner
                     moduleVersion: module.ModuleVersion,
                     minimumVersion: module.ModuleVersion,
                     requiredVersion: module.RequiredVersion,
-                    guid: module.Guid);
+                    guid: module.Guid,
+                    versionSource: ModuleDependencyVersionSource.Auto);
 
                 if (requiredIndex.TryGetValue(draft.ModuleName, out var idx))
                     requiredModulesDraft[idx] = draft;
@@ -318,7 +319,8 @@ public sealed partial class ModulePipelineRunner
                         moduleVersion: md.ModuleVersion,
                         minimumVersion: md.MinimumVersion,
                         requiredVersion: md.RequiredVersion,
-                        guid: md.Guid);
+                        guid: md.Guid,
+                        versionSource: md.VersionSource);
 
                     if (requiredIndex.TryGetValue(name, out var idx))
                         requiredModulesDraft[idx] = draft;
@@ -620,11 +622,16 @@ public sealed partial class ModulePipelineRunner
         if (roots.Length == 0 && compatible is { Length: > 0 })
             roots = ModulePipelinePlanningHelpers.ResolveInstallRootsFromCompatiblePSEditions(compatible);
 
-        if (!resolveMissingModulesOnlineSet && HasAutoRequiredModules(requiredModulesDraft))
+        if (!resolveMissingModulesOnlineSet && HasOnlineResolvableAutoRequiredModules(requiredModulesDraft))
         {
             resolveMissingModulesOnline = true;
             _logger.Info("ResolveMissingModulesOnline not explicitly set; enabling because RequiredModules use Auto/Latest/Guid Auto.");
         }
+
+        var enabledPublishes = publishes
+            .Where(p => p is not null && p.Configuration?.Enabled == true)
+            .ToArray();
+        var dependencyVersionSourceRepository = ResolvePublishDependencyVersionSource(enabledPublishes);
 
         var requiredModules = ResolveRequiredModules(
             requiredModulesDraft,
@@ -632,7 +639,8 @@ public sealed partial class ModulePipelineRunner
             warnIfRequiredModulesOutdated,
             installMissingModulesPrerelease,
             installMissingModulesRepository,
-            installMissingModulesCredential);
+            installMissingModulesCredential,
+            dependencyVersionSourceRepository);
         if (importModules?.PreferBinaryConflictOrder == true)
             requiredModules = ReorderRequiredModulesForBinaryConflicts(requiredModules, compatible);
         var requiredModulesForPackaging = AreRequiredModuleDraftListsEquivalent(requiredModulesDraft, requiredModulesDraftForPackaging)
@@ -643,7 +651,8 @@ public sealed partial class ModulePipelineRunner
                 warnIfRequiredModulesOutdated,
                 installMissingModulesPrerelease,
                 installMissingModulesRepository,
-                installMissingModulesCredential);
+                installMissingModulesCredential,
+                dependencyVersionSourceRepository);
 
         var approved = approvedModules
             .Where(m => !string.IsNullOrWhiteSpace(m))
@@ -707,9 +716,6 @@ public sealed partial class ModulePipelineRunner
 
         var enabledArtefacts = artefacts
             .Where(a => a is not null && a.Configuration?.Enabled == true)      
-            .ToArray();
-        var enabledPublishes = publishes
-            .Where(p => p is not null && p.Configuration?.Enabled == true)
             .ToArray();
 
         if (formatting is not null &&
@@ -821,6 +827,36 @@ public sealed partial class ModulePipelineRunner
             installMissingModulesCredential: installMissingModulesCredential,
             stagingWasGenerated: stagingWasGenerated,
             deleteGeneratedStagingAfterRun: deleteAfter);
+    }
+
+    private DependencyVersionSourceRepository? ResolvePublishDependencyVersionSource(ConfigurationPublishSegment[] enabledPublishes)
+    {
+        var candidates = (enabledPublishes ?? Array.Empty<ConfigurationPublishSegment>())
+            .Where(static publish => publish?.Configuration?.Enabled == true)
+            .Select(static publish => publish.Configuration)
+            .Where(static publish => publish.UseAsDependencyVersionSource)
+            .ToArray();
+
+        if (candidates.Length == 0)
+            return null;
+
+        if (candidates.Length > 1)
+            throw new InvalidOperationException("Only one enabled New-ConfigurationPublish segment can use -UseAsDependencyVersionSource.");
+
+        var publish = candidates[0];
+        if (publish.Destination != PublishDestination.PowerShellGallery)
+            throw new InvalidOperationException("-UseAsDependencyVersionSource can only be used with PowerShell repository publish destinations.");
+
+        var repository = publish.Repository?.Name ?? publish.RepositoryName;
+        if (string.IsNullOrWhiteSpace(repository))
+            repository = "PSGallery";
+
+        _logger.Info($"Dependency version source: resolving Auto/Latest module dependencies from repository '{repository}'.");
+        return new DependencyVersionSourceRepository(
+            repository,
+            publish.Repository?.Credential,
+            preferOnlineMetadata: true,
+            allowOnlineLookup: true);
     }
 
     private static string[] BuildMissingCsprojReasonList(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
@@ -18,6 +18,10 @@ public sealed partial class ModulePipelineRunner
         => new RequiredModuleResolutionEngine(new NullLogger())
             .HasAutoRequiredModules(ToRequiredModuleDraftDescriptors(drafts));
 
+    private static bool HasOnlineResolvableAutoRequiredModules(IEnumerable<RequiredModuleDraft> drafts)
+        => HasAutoRequiredModules((drafts ?? Array.Empty<RequiredModuleDraft>())
+            .Where(static draft => draft?.VersionSource != ModuleDependencyVersionSource.Installed));
+
     private static bool AreRequiredModuleDraftListsEquivalent(
         IReadOnlyList<RequiredModuleDraft> left,
         IReadOnlyList<RequiredModuleDraft> right)
@@ -31,7 +35,8 @@ public sealed partial class ModulePipelineRunner
         bool warnIfRequiredModulesOutdated,
         bool prerelease,
         string? repository,
-        RepositoryCredential? credential)
+        RepositoryCredential? credential,
+        DependencyVersionSourceRepository? publishVersionSource = null)
     {
         var list = (drafts ?? Array.Empty<RequiredModuleDraft>())
             .Where(d => d is not null && !string.IsNullOrWhiteSpace(d.ModuleName))
@@ -46,8 +51,65 @@ public sealed partial class ModulePipelineRunner
             static kvp => (kvp.Value.Version, kvp.Value.Guid),
             StringComparer.OrdinalIgnoreCase);
 
+        if (publishVersionSource is not null ||
+            list.Any(static draft => draft.VersionSource != ModuleDependencyVersionSource.Auto))
+        {
+            var resolvedByName = new Dictionary<string, RequiredModuleReference>(StringComparer.OrdinalIgnoreCase);
+            foreach (var group in list.GroupBy(draft => ResolveDependencyVersionSource(draft.VersionSource, publishVersionSource)))
+            {
+                var source = group.Key;
+                var lookupRepository = source.PreferOnlineMetadata ? source.Repository : repository;
+                var lookupCredential = source.PreferOnlineMetadata ? source.Credential : credential;
+                var allowOnlineLookup = source.AllowOnlineLookup &&
+                                        (resolveMissingModulesOnline || source.PreferOnlineMetadata);
+                var groupResult = ResolveRequiredModulesFromSingleSource(
+                    group.ToArray(),
+                    installedMetadata,
+                    allowOnlineLookup,
+                    warnIfRequiredModulesOutdated,
+                    prerelease,
+                    lookupRepository,
+                    lookupCredential,
+                    source.PreferOnlineMetadata);
+
+                foreach (var module in groupResult)
+                {
+                    if (!string.IsNullOrWhiteSpace(module.ModuleName))
+                        resolvedByName[module.ModuleName] = module;
+                }
+            }
+
+            return list
+                .Where(static draft => !string.IsNullOrWhiteSpace(draft.ModuleName))
+                .Select(draft => resolvedByName.TryGetValue(draft.ModuleName, out var module)
+                    ? module
+                    : new RequiredModuleReference(draft.ModuleName))
+                .ToArray();
+        }
+
+        return ResolveRequiredModulesFromSingleSource(
+            list,
+            installedMetadata,
+            resolveMissingModulesOnline,
+            warnIfRequiredModulesOutdated,
+            prerelease,
+            repository,
+            credential,
+            preferOnlineMetadata: false);
+    }
+
+    private RequiredModuleReference[] ResolveRequiredModulesFromSingleSource(
+        IReadOnlyList<RequiredModuleDraft> list,
+        IReadOnlyDictionary<string, (string? Version, string? Guid)> installedMetadata,
+        bool resolveMissingModulesOnline,
+        bool warnIfRequiredModulesOutdated,
+        bool prerelease,
+        string? repository,
+        RepositoryCredential? credential,
+        bool preferOnlineMetadata)
+    {
         Func<IReadOnlyCollection<string>, IReadOnlyDictionary<string, (string? Version, string? Guid)>>? onlineLookup = null;
-        if (resolveMissingModulesOnline || warnIfRequiredModulesOutdated)
+        if (resolveMissingModulesOnline || warnIfRequiredModulesOutdated || preferOnlineMetadata)
         {
             onlineLookup = candidates => _moduleDependencyMetadataProvider.ResolveLatestOnlineVersions(candidates, repository, credential, prerelease);
         }
@@ -58,7 +120,8 @@ public sealed partial class ModulePipelineRunner
             installedMetadata,
             onlineLookup,
             resolveMissingModulesOnline,
-            warnIfRequiredModulesOutdated);
+            warnIfRequiredModulesOutdated,
+            preferOnlineMetadata);
     }
 
     private static RequiredModuleReference[] ResolveOutputRequiredModules(
@@ -76,8 +139,63 @@ public sealed partial class ModulePipelineRunner
                 draft.ModuleVersion,
                 draft.MinimumVersion,
                 draft.RequiredVersion,
-                draft.Guid))
+                draft.Guid,
+                draft.VersionSource))
             .ToArray();
+    }
+
+    private static DependencyVersionSourceRepository ResolveDependencyVersionSource(
+        ModuleDependencyVersionSource source,
+        DependencyVersionSourceRepository? publishVersionSource)
+    {
+        return source switch
+        {
+            ModuleDependencyVersionSource.Auto => publishVersionSource
+                ?? new DependencyVersionSourceRepository(null, null, preferOnlineMetadata: false, allowOnlineLookup: true),
+            ModuleDependencyVersionSource.Installed => new DependencyVersionSourceRepository(null, null, preferOnlineMetadata: false, allowOnlineLookup: false),
+            ModuleDependencyVersionSource.PSGallery => new DependencyVersionSourceRepository("PSGallery", null, preferOnlineMetadata: true, allowOnlineLookup: true),
+            ModuleDependencyVersionSource.PublishRepository => publishVersionSource
+                ?? throw new InvalidOperationException("Module dependency VersionSource 'PublishRepository' requires one enabled New-ConfigurationPublish segment with -UseAsDependencyVersionSource."),
+            _ => new DependencyVersionSourceRepository(null, null, preferOnlineMetadata: false, allowOnlineLookup: true)
+        };
+    }
+
+    private readonly struct DependencyVersionSourceRepository : IEquatable<DependencyVersionSourceRepository>
+    {
+        public string? Repository { get; }
+        public RepositoryCredential? Credential { get; }
+        public bool PreferOnlineMetadata { get; }
+        public bool AllowOnlineLookup { get; }
+
+        public DependencyVersionSourceRepository(
+            string? repository,
+            RepositoryCredential? credential,
+            bool preferOnlineMetadata,
+            bool allowOnlineLookup)
+        {
+            Repository = string.IsNullOrWhiteSpace(repository) ? null : repository!.Trim();
+            Credential = credential;
+            PreferOnlineMetadata = preferOnlineMetadata;
+            AllowOnlineLookup = allowOnlineLookup;
+        }
+
+        public bool Equals(DependencyVersionSourceRepository other)
+            => string.Equals(Repository, other.Repository, StringComparison.OrdinalIgnoreCase) &&
+               ReferenceEquals(Credential, other.Credential) &&
+               PreferOnlineMetadata == other.PreferOnlineMetadata &&
+               AllowOnlineLookup == other.AllowOnlineLookup;
+
+        public override bool Equals(object? obj)
+            => obj is DependencyVersionSourceRepository other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = StringComparer.OrdinalIgnoreCase.GetHashCode(Repository ?? string.Empty);
+            hash = (hash * 397) ^ (Credential?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ PreferOnlineMetadata.GetHashCode();
+            hash = (hash * 397) ^ AllowOnlineLookup.GetHashCode();
+            return hash;
+        }
     }
 
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.cs
@@ -48,14 +48,27 @@ public sealed partial class ModulePipelineRunner
         public string? MinimumVersion { get; }
         public string? RequiredVersion { get; }
         public string? Guid { get; }
+        public ModuleDependencyVersionSource VersionSource { get; }
 
         public RequiredModuleDraft(string moduleName, string? moduleVersion, string? minimumVersion, string? requiredVersion, string? guid)
+            : this(moduleName, moduleVersion, minimumVersion, requiredVersion, guid, ModuleDependencyVersionSource.Auto)
+        {
+        }
+
+        public RequiredModuleDraft(
+            string moduleName,
+            string? moduleVersion,
+            string? minimumVersion,
+            string? requiredVersion,
+            string? guid,
+            ModuleDependencyVersionSource versionSource)
         {
             ModuleName = moduleName;
             ModuleVersion = moduleVersion;
             MinimumVersion = minimumVersion;
             RequiredVersion = requiredVersion;
             Guid = guid;
+            VersionSource = versionSource;
         }
     }
 

--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -133,6 +133,7 @@ internal sealed class PublishConfigurationFactory
                 OverwriteTagName = request.OverwriteTagName,
                 DoNotMarkAsPreRelease = request.DoNotMarkAsPreRelease,
                 GenerateReleaseNotes = request.GenerateReleaseNotes,
+                UseAsDependencyVersionSource = request.UseAsDependencyVersionSource,
                 Verbose = request.Verbose
             }
         };

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -615,6 +615,110 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     }
 
     [Fact]
+    public void BuildRestoreMsBuildProperties_UsesSdkNativeAotPropertyForAotStyles()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Publish = new DotNetPublishPublishOptions(),
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.AotSpeed
+                        }
+                    }
+                }
+            }
+        };
+
+        var props = DotNetPublishPipelineRunner.BuildRestoreMsBuildProperties(
+            plan,
+            "Service.csproj",
+            "win-x64",
+            "net10.0");
+
+        Assert.Equal("true", props["SelfContained"]);
+        Assert.Equal("true", props["PublishAot"]);
+        Assert.False(props.ContainsKey("NativeAotPublish"));
+    }
+
+    [Fact]
+    public void BuildRestoreMsBuildProperties_FiltersAotPropertiesByFramework()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Publish = new DotNetPublishPublishOptions(),
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.AotSpeed
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net8.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        }
+                    }
+                }
+            }
+        };
+
+        var props = DotNetPublishPipelineRunner.BuildRestoreMsBuildProperties(
+            plan,
+            "Service.csproj",
+            "win-x64",
+            "net8.0");
+
+        Assert.Equal("true", props["SelfContained"]);
+        Assert.Equal("true", props["PublishSingleFile"]);
+        Assert.False(props.ContainsKey("PublishAot"));
+    }
+
+    [Fact]
+    public void BuildPublishArguments_UsesSdkNativeAotPropertyForAotStyles()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Configuration = "Release",
+            NoRestoreInPublish = true,
+            Targets = Array.Empty<DotNetPublishTargetPlan>()
+        };
+        var target = new DotNetPublishTargetPlan
+        {
+            ProjectPath = "Service.csproj",
+            Publish = new DotNetPublishPublishOptions()
+        };
+
+        var args = DotNetPublishPipelineRunner.BuildPublishArguments(
+            plan,
+            target,
+            "net10.0",
+            "win-x64",
+            DotNetPublishStyle.AotSpeed,
+            "out");
+
+        Assert.Contains("/p:PublishAot=true", args);
+        Assert.Contains("/p:IlcOptimizationPreference=Speed", args);
+        Assert.DoesNotContain("/p:NativeAotPublish=true", args);
+    }
+
+    [Fact]
     public void BuildWixHarvestFragment_PreservesSubdirectoriesForNestedFiles()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -282,6 +282,11 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
 
             var spec = CreateBaseSpec(root, app);
             var authoring = CreateSimpleAuthoring("ProductFiles");
+            authoring.ExitLaunch = new PowerForgeInstallerExitLaunch
+            {
+                Text = "Open app",
+                Target = "http://127.0.0.1:9000/"
+            };
             authoring.Inputs.Add(new PowerForgeInstallerInput
             {
                 Id = "LicenseKey",
@@ -310,6 +315,9 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             var installerPlan = Assert.Single(plan.Installers);
             Assert.NotNull(installerPlan.Authoring);
             Assert.Equal("ProductFiles", installerPlan.HarvestComponentGroupId);
+            Assert.NotNull(installerPlan.Authoring!.ExitLaunch);
+            Assert.Equal("Open app", installerPlan.Authoring.ExitLaunch!.Text);
+            Assert.Equal("http://127.0.0.1:9000/", installerPlan.Authoring.ExitLaunch.Target);
             var input = Assert.Single(installerPlan.Authoring!.Inputs);
             Assert.True(input.Required);
             Assert.Equal("Enter a license key before continuing.", input.RequiredMessage);

--- a/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
+++ b/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
@@ -68,6 +68,245 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
     }
 
     [Fact]
+    public void Plan_UsesPublishRepositoryAsDependencyVersionSource_WhenPublishOptInIsEnabled()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string dependencyName = "PSWriteHTML";
+
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = dependencyName,
+                            ModuleVersion = "Latest"
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Destination = PublishDestination.PowerShellGallery,
+                            Enabled = true,
+                            RepositoryName = "PSGallery",
+                            UseAsDependencyVersionSource = true
+                        }
+                    }
+                }
+            };
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [dependencyName] = new(dependencyName, "1.41.0.5", null, @"C:\Modules\PSWriteHTML\1.41.0.5")
+                },
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [dependencyName] = ("1.41.0", null)
+                });
+
+            var runner = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider);
+            var plan = runner.Plan(spec);
+
+            var required = Assert.Single(plan.RequiredModules);
+            Assert.Equal(dependencyName, required.ModuleName);
+            Assert.Equal("1.41.0", required.ModuleVersion);
+            Assert.Equal("PSGallery", provider.LastOnlineRepository);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_HonorsInstalledVersionSource_WhenPublishOptInIsEnabled()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string dependencyName = "PSWriteHTML";
+
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = dependencyName,
+                            ModuleVersion = "Latest",
+                            VersionSource = ModuleDependencyVersionSource.Installed
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Destination = PublishDestination.PowerShellGallery,
+                            Enabled = true,
+                            RepositoryName = "PSGallery",
+                            UseAsDependencyVersionSource = true
+                        }
+                    }
+                }
+            };
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [dependencyName] = new(dependencyName, "1.41.0.5", null, @"C:\Modules\PSWriteHTML\1.41.0.5")
+                },
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [dependencyName] = ("1.41.0", null)
+                });
+
+            var runner = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider);
+            var plan = runner.Plan(spec);
+
+            var required = Assert.Single(plan.RequiredModules);
+            Assert.Equal("1.41.0.5", required.ModuleVersion);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_DoesNotResolveInstalledVersionSourceOnline_WhenInstalledModuleIsMissing()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            const string dependencyName = "PSWriteHTML";
+
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = dependencyName,
+                            ModuleVersion = "Latest",
+                            VersionSource = ModuleDependencyVersionSource.Installed
+                        }
+                    }
+                }
+            };
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [dependencyName] = ("1.41.0", null)
+                });
+
+            var runner = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider);
+            var plan = runner.Plan(spec);
+
+            var required = Assert.Single(plan.RequiredModules);
+            Assert.Null(required.ModuleVersion);
+            Assert.Equal(0, provider.OnlineLookups);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_ThrowsForPublishRepositoryVersionSource_WhenNoPublishSourceIsConfigured()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "PSWriteHTML",
+                            ModuleVersion = "Latest",
+                            VersionSource = ModuleDependencyVersionSource.PublishRepository
+                        }
+                    }
+                }
+            };
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase));
+
+            var runner = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Plan(spec));
+            Assert.Contains("UseAsDependencyVersionSource", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_ReordersRequiredModules_ForBinaryConflictOrder_UsingInjectedDependencyMetadataProvider()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -262,6 +501,7 @@ public sealed class Marker
         internal int InstalledLookups { get; private set; }
         internal int OnlineLookups { get; private set; }
         internal int RequiredModuleLookups { get; private set; }
+        internal string? LastOnlineRepository { get; private set; }
 
         internal FakeModuleDependencyMetadataProvider(
             IReadOnlyDictionary<string, InstalledModuleMetadata> installedModules,
@@ -306,6 +546,7 @@ public sealed class Marker
             bool prerelease)
         {
             OnlineLookups++;
+            LastOnlineRepository = repository;
             var result = new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase);
             foreach (var name in names ?? Array.Empty<string>())
             {

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -129,6 +129,38 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_ModelsExitDialogLaunchAction()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.ExitLaunch = new PowerForgeInstallerExitLaunch
+        {
+            Text = "Open TestimoX Monitoring",
+            Target = "http://127.0.0.1:9000/"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Root!.Attribute(XNamespace.Xmlns + "ui"));
+        Assert.NotNull(doc.Root!.Attribute(XNamespace.Xmlns + "util"));
+        Assert.NotNull(doc.Descendants(Wix + "Property").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" &&
+            (string?)e.Attribute("Value") == "Open TestimoX Monitoring"));
+        Assert.NotNull(doc.Descendants(Wix + "Property").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "WixShellExecTarget" &&
+            (string?)e.Attribute("Value") == "http://127.0.0.1:9000/"));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "PowerForgeLaunchOnExit" &&
+            (string?)e.Attribute("BinaryRef") == "Wix4UtilCA_$(sys.BUILDARCHSHORT)" &&
+            (string?)e.Attribute("DllEntry") == "WixShellExec"));
+        Assert.NotNull(doc.Descendants(Wix + "Publish").SingleOrDefault(e =>
+            (string?)e.Attribute("Dialog") == "ExitDialog" &&
+            (string?)e.Attribute("Control") == "Finish" &&
+            (string?)e.Attribute("Event") == "DoAction" &&
+            (string?)e.Attribute("Value") == "PowerForgeLaunchOnExit"));
+    }
+
+    [Fact]
     public void EmitSource_UsesUniqueScriptServiceActionIdsForLongComponentNames()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
@@ -1278,6 +1310,27 @@ public sealed class PowerForgeInstallerAuthoringTests
 
         Assert.NotNull(doc.Descendants("PackageReference").SingleOrDefault(e =>
             (string?)e.Attribute("Include") == "WixToolset.Util.wixext"));
+    }
+
+    [Fact]
+    public void EmitProjectFile_IncludesUtilAndUiExtensionsForExitLaunch()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.ExitLaunch = new PowerForgeInstallerExitLaunch
+        {
+            Text = "Open app",
+            Target = "http://127.0.0.1:9000/"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitProjectFile(
+            definition,
+            new PowerForgeWixInstallerProjectOptions { SourceFile = "Generated.wxs" });
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Descendants("PackageReference").SingleOrDefault(e =>
+            (string?)e.Attribute("Include") == "WixToolset.Util.wixext"));
+        Assert.NotNull(doc.Descendants("PackageReference").SingleOrDefault(e =>
+            (string?)e.Attribute("Include") == "WixToolset.UI.wixext"));
     }
 
     [Fact]

--- a/PowerForge.Tests/RequiredModuleResolutionEngineTests.cs
+++ b/PowerForge.Tests/RequiredModuleResolutionEngineTests.cs
@@ -17,7 +17,8 @@ public sealed class RequiredModuleResolutionEngineTests
                 moduleVersion: "Latest",
                 minimumVersion: null,
                 requiredVersion: null,
-                guid: "Auto")
+                guid: "Auto",
+                versionSource: ModuleDependencyVersionSource.Auto)
         };
 
         var resolved = engine.ResolveRequiredModules(

--- a/PowerForge/Models/Configuration/ConfigurationEnums.cs
+++ b/PowerForge/Models/Configuration/ConfigurationEnums.cs
@@ -145,6 +145,21 @@ public enum ModuleDependencyKind
 }
 
 /// <summary>
+/// Source used when resolving Auto/Latest module dependency versions.
+/// </summary>
+public enum ModuleDependencyVersionSource
+{
+    /// <summary>Use the build default: installed metadata, with online lookup only when enabled or needed.</summary>
+    Auto,
+    /// <summary>Resolve from locally installed module metadata.</summary>
+    Installed,
+    /// <summary>Resolve from the PowerShell Gallery repository.</summary>
+    PSGallery,
+    /// <summary>Resolve from a publish configuration marked as the dependency version source.</summary>
+    PublishRepository
+}
+
+/// <summary>
 /// Encoding values used by file consistency configuration.
 /// </summary>
 public enum FileConsistencyEncoding

--- a/PowerForge/Models/Configuration/ConfigurationModuleSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationModuleSegment.cs
@@ -40,5 +40,7 @@ public sealed class ModuleDependencyConfiguration
 
     /// <summary>Module GUID (optional; legacy field).</summary>
     public string? Guid { get; set; }
-}
 
+    /// <summary>Source used when resolving Auto/Latest version values.</summary>
+    public ModuleDependencyVersionSource VersionSource { get; set; } = ModuleDependencyVersionSource.Auto;
+}

--- a/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
@@ -60,6 +60,9 @@ public sealed class PublishConfiguration
     /// <summary>When true, asks GitHub to generate release notes automatically.</summary>
     public bool GenerateReleaseNotes { get; set; }
 
+    /// <summary>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</summary>
+    public bool UseAsDependencyVersionSource { get; set; }
+
     /// <summary>Verbose mode requested.</summary>
     public bool Verbose { get; set; }
 }

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -49,6 +49,11 @@ public sealed class PowerForgeInstallerDefinition
     public List<PowerForgeInstallerDialog> Dialogs { get; set; } = new();
 
     /// <summary>
+    /// Optional action exposed as a checkbox on the final installer page.
+    /// </summary>
+    public PowerForgeInstallerExitLaunch? ExitLaunch { get; set; }
+
+    /// <summary>
     /// Additional directory trees required by installer components.
     /// </summary>
     public List<PowerForgeInstallerDirectoryTree> Directories { get; set; } = new();
@@ -93,6 +98,32 @@ public sealed class PowerForgeInstallerProduct
     /// Downgrade message shown when a newer version is installed.
     /// </summary>
     public string DowngradeErrorMessage { get; set; } = "A newer version of [ProductName] is already installed.";
+}
+
+/// <summary>
+/// Optional launch action shown on the final WiX exit dialog.
+/// </summary>
+public sealed class PowerForgeInstallerExitLaunch
+{
+    /// <summary>
+    /// Whether the final-page launch checkbox and shell execution action are emitted.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Checkbox text shown on the final installer page.
+    /// </summary>
+    public string Text { get; set; } = "Launch [ProductName]";
+
+    /// <summary>
+    /// Target opened through the shell, for example a URL or formatted executable path.
+    /// </summary>
+    public string Target { get; set; } = string.Empty;
+
+    /// <summary>
+    /// WiX condition controlling the launch action.
+    /// </summary>
+    public string Condition { get; set; } = "WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed";
 }
 
 /// <summary>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -748,7 +748,16 @@ public sealed partial class DotNetPublishPipelineRunner
             CompanyFolderName = definition.CompanyFolderName,
             UseCompanyFolder = definition.UseCompanyFolder,
             InstallDirectoryName = definition.InstallDirectoryName,
-            PayloadComponentGroupId = definition.PayloadComponentGroupId
+            PayloadComponentGroupId = definition.PayloadComponentGroupId,
+            ExitLaunch = definition.ExitLaunch is null
+                ? null
+                : new PowerForgeInstallerExitLaunch
+                {
+                    Enabled = definition.ExitLaunch.Enabled,
+                    Text = definition.ExitLaunch.Text,
+                    Target = definition.ExitLaunch.Target,
+                    Condition = definition.ExitLaunch.Condition
+                }
         };
 
         foreach (var input in definition.Inputs)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.PublishLayout.cs
@@ -75,7 +75,7 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 args.Add("--self-contained");
                 args.Add("true");
-                args.Add("/p:NativeAotPublish=true");
+                args.Add("/p:PublishAot=true");
                 args.Add("/p:StripSymbols=true");
                 args.Add($"/p:IlcOptimizationPreference={(style == DotNetPublishStyle.AotSize ? "Size" : "Speed")}");
                 args.Add("/p:InvariantGlobalization=false");

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -14,13 +14,33 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(runtime))
         {
             var runtimeValue = runtime!;
-            foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
+            var restoreRequests = new HashSet<(string ProjectPath, string Framework)>();
+            foreach (var target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
             {
-                _logger.Info($"Restore ({runtimeValue}) -> {p}");
+                var combinations = (target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
+                    .Where(combination => string.Equals(combination.Runtime, runtimeValue, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+                if (combinations.Length == 0)
+                {
+                    restoreRequests.Add((target.ProjectPath, string.Empty));
+                    continue;
+                }
 
-                var args = new List<string> { "restore", p, "--nologo" };
+                foreach (var framework in combinations.Select(combination => combination.Framework).Distinct(StringComparer.OrdinalIgnoreCase))
+                    restoreRequests.Add((target.ProjectPath, framework ?? string.Empty));
+            }
+
+            foreach (var request in restoreRequests)
+            {
+                var framework = request.Framework;
+                var label = string.IsNullOrWhiteSpace(framework) ? runtimeValue : $"{runtimeValue}, {framework}";
+                _logger.Info($"Restore ({label}) -> {request.ProjectPath}");
+
+                var args = new List<string> { "restore", request.ProjectPath, "--nologo" };
                 args.AddRange(new[] { "-r", runtimeValue });
-                args.AddRange(BuildMsBuildPropertyArgs(BuildRestoreMsBuildProperties(plan, p, runtimeValue)));
+                args.AddRange(BuildMsBuildPropertyArgs(BuildRestoreMsBuildProperties(plan, request.ProjectPath, runtimeValue, framework)));
+                if (!string.IsNullOrWhiteSpace(framework))
+                    args.Add($"/p:TargetFramework={framework}");
 
                 RunDotnet(workDir, args);
             }
@@ -46,7 +66,8 @@ public sealed partial class DotNetPublishPipelineRunner
     internal static Dictionary<string, string> BuildRestoreMsBuildProperties(
         DotNetPublishPlan plan,
         string projectPath,
-        string runtime)
+        string runtime,
+        string? framework = null)
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
 
@@ -58,6 +79,8 @@ public sealed partial class DotNetPublishPipelineRunner
 
             var styles = (target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
                 .Where(combination => string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
+                .Where(combination => string.IsNullOrWhiteSpace(framework)
+                    || string.Equals(combination.Framework, framework, StringComparison.OrdinalIgnoreCase))
                 .Select(combination => combination.Style)
                 .Distinct()
                 .ToArray();
@@ -87,8 +110,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 {
                     if (!merged.ContainsKey("SelfContained"))
                         merged["SelfContained"] = "true";
-                    if (!merged.ContainsKey("NativeAotPublish"))
-                        merged["NativeAotPublish"] = "true";
+                    if (!merged.ContainsKey("PublishAot"))
+                        merged["PublishAot"] = "true";
                 }
             }
         }

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -35,6 +35,12 @@ internal static class PowerForgeInstallerDefinitionValidator
         Require(definition.InstallDirectoryName, nameof(definition.InstallDirectoryName));
         if (!string.IsNullOrWhiteSpace(definition.PayloadComponentGroupId))
             RequireWixIdentifier(definition.PayloadComponentGroupId, nameof(definition.PayloadComponentGroupId));
+        if (definition.ExitLaunch is { Enabled: true } exitLaunch)
+        {
+            Require(exitLaunch.Text, nameof(definition.ExitLaunch.Text));
+            Require(exitLaunch.Target, nameof(definition.ExitLaunch.Target));
+            Require(exitLaunch.Condition, nameof(definition.ExitLaunch.Condition));
+        }
 
         EnsureUnique(
             definition.Inputs.Select(input => input.Id),

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -25,7 +25,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         if (definition is null) throw new ArgumentNullException(nameof(definition));
         PowerForgeInstallerDefinitionValidator.Validate(definition);
 
-        var needsUi = definition.Dialogs.Count > 0;
+        var needsUi = definition.Dialogs.Count > 0 || definition.ExitLaunch is { Enabled: true };
         var needsUtil = RequiresUtilExtension(definition);
         var rootAttributes = new List<XAttribute>();
         if (needsUtil)
@@ -47,6 +47,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XElement(WixNamespace + "MediaTemplate", new XAttribute("EmbedCab", "yes")));
 
         EmitProperties(package, definition);
+        EmitExitLaunchAction(package, definition);
         if (needsUi)
             package.Add(EmitUi(definition));
 
@@ -82,6 +83,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             .OrderBy(file => string.Equals(file, options.SourceFile, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
             .ThenBy(file => file, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+        var needsUi = definition.Dialogs.Count > 0 || definition.ExitLaunch is { Enabled: true };
 
         var project = new XElement(
             "Project",
@@ -115,7 +117,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Version", options.SdkVersion)));
         }
 
-        if (definition.Dialogs.Count > 0)
+        if (needsUi)
         {
             packageReferences.Add(new XElement(
                 "PackageReference",
@@ -172,8 +174,30 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                     new XAttribute("Type", input.RegistrySearch.Type)));
             }
 
-            package.Add(property);
+        package.Add(property);
         }
+    }
+
+    private static void EmitExitLaunchAction(XElement package, PowerForgeInstallerDefinition definition)
+    {
+        if (definition.ExitLaunch is not { Enabled: true } exitLaunch)
+            return;
+
+        package.Add(
+            new XElement(
+                WixNamespace + "Property",
+                new XAttribute("Id", "WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT"),
+                new XAttribute("Value", exitLaunch.Text)),
+            new XElement(
+                WixNamespace + "Property",
+                new XAttribute("Id", "WixShellExecTarget"),
+                new XAttribute("Value", exitLaunch.Target)),
+            new XElement(
+                WixNamespace + "CustomAction",
+                new XAttribute("Id", "PowerForgeLaunchOnExit"),
+                new XAttribute("BinaryRef", "Wix4UtilCA_$(sys.BUILDARCHSHORT)"),
+                new XAttribute("DllEntry", "WixShellExec"),
+                new XAttribute("Impersonate", "yes")));
     }
 
     private static XElement EmitUi(PowerForgeInstallerDefinition definition)
@@ -211,8 +235,21 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         }
 
         ui.Add(EmitDialogSequence(dialogs));
+        if (definition.ExitLaunch is { Enabled: true } exitLaunch)
+            ui.Add(EmitExitLaunchPublish(exitLaunch));
 
         return ui;
+    }
+
+    private static XElement EmitExitLaunchPublish(PowerForgeInstallerExitLaunch exitLaunch)
+    {
+        return new XElement(
+            WixNamespace + "Publish",
+            new XAttribute("Dialog", "ExitDialog"),
+            new XAttribute("Control", "Finish"),
+            new XAttribute("Event", "DoAction"),
+            new XAttribute("Value", "PowerForgeLaunchOnExit"),
+            new XAttribute("Condition", exitLaunch.Condition));
     }
 
     private static string BuildRequiredInputDialogId(int index)
@@ -745,6 +782,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
     private static bool RequiresUtilExtension(PowerForgeInstallerDefinition definition)
         => definition.Components.OfType<PowerForgeInstallerRemoveFolderComponent>().Any() ||
+           definition.ExitLaunch is { Enabled: true } ||
            PowerForgeWixInstallerServiceScriptEmitter.RequiresUtilExtension(definition);
 
     private static XElement EmitServiceInstall(PowerForgeInstallerServiceComponent service)

--- a/PowerForge/Services/RequiredModuleResolutionEngine.cs
+++ b/PowerForge/Services/RequiredModuleResolutionEngine.cs
@@ -10,14 +10,22 @@ internal sealed class RequiredModuleDraftDescriptor
     public string? MinimumVersion { get; }
     public string? RequiredVersion { get; }
     public string? Guid { get; }
+    public ModuleDependencyVersionSource VersionSource { get; }
 
-    public RequiredModuleDraftDescriptor(string moduleName, string? moduleVersion, string? minimumVersion, string? requiredVersion, string? guid)
+    public RequiredModuleDraftDescriptor(
+        string moduleName,
+        string? moduleVersion,
+        string? minimumVersion,
+        string? requiredVersion,
+        string? guid,
+        ModuleDependencyVersionSource versionSource)
     {
         ModuleName = moduleName;
         ModuleVersion = moduleVersion;
         MinimumVersion = minimumVersion;
         RequiredVersion = requiredVersion;
         Guid = guid;
+        VersionSource = versionSource;
     }
 }
 
@@ -51,7 +59,8 @@ internal sealed class RequiredModuleResolutionEngine
         IReadOnlyDictionary<string, (string? Version, string? Guid)> installed,
         Func<IReadOnlyCollection<string>, IReadOnlyDictionary<string, (string? Version, string? Guid)>>? onlineLookup,
         bool resolveMissingModulesOnline,
-        bool warnIfRequiredModulesOutdated)
+        bool warnIfRequiredModulesOutdated,
+        bool preferOnlineMetadata = false)
     {
         var list = (drafts ?? Array.Empty<RequiredModuleDraftDescriptor>())
             .Where(static draft => draft is not null && !string.IsNullOrWhiteSpace(draft.ModuleName))
@@ -63,9 +72,9 @@ internal sealed class RequiredModuleResolutionEngine
 
         IReadOnlyDictionary<string, (string? Version, string? Guid)> onlineVersions =
             new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase);
-        if ((resolveMissingModulesOnline || warnIfRequiredModulesOutdated) && onlineLookup is not null)
+        if ((resolveMissingModulesOnline || warnIfRequiredModulesOutdated || preferOnlineMetadata) && onlineLookup is not null)
         {
-            var candidates = BuildOnlineLookupCandidates(list, installed, warnIfRequiredModulesOutdated);
+            var candidates = BuildOnlineLookupCandidates(list, installed, warnIfRequiredModulesOutdated, preferOnlineMetadata);
             if (candidates.Count > 0)
                 onlineVersions = onlineLookup(candidates) ??
                                  new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase);
@@ -84,13 +93,13 @@ internal sealed class RequiredModuleResolutionEngine
 
             if (onlineVersions.TryGetValue(draft.ModuleName, out var onlineInfo))
             {
-                if (string.IsNullOrWhiteSpace(availableVersion) && !string.IsNullOrWhiteSpace(onlineInfo.Version))
+                if ((preferOnlineMetadata || string.IsNullOrWhiteSpace(availableVersion)) && !string.IsNullOrWhiteSpace(onlineInfo.Version))
                 {
                     availableVersion = onlineInfo.Version;
                     resolvedOnline.Add(draft.ModuleName);
                 }
 
-                if (string.IsNullOrWhiteSpace(availableGuid) && !string.IsNullOrWhiteSpace(onlineInfo.Guid))
+                if ((preferOnlineMetadata || string.IsNullOrWhiteSpace(availableGuid)) && !string.IsNullOrWhiteSpace(onlineInfo.Guid))
                     availableGuid = onlineInfo.Guid;
             }
 
@@ -233,7 +242,8 @@ internal sealed class RequiredModuleResolutionEngine
     private static IReadOnlyCollection<string> BuildOnlineLookupCandidates(
         IEnumerable<RequiredModuleDraftDescriptor> drafts,
         IReadOnlyDictionary<string, (string? Version, string? Guid)> installed,
-        bool warnIfRequiredModulesOutdated)
+        bool warnIfRequiredModulesOutdated,
+        bool preferOnlineMetadata)
     {
         var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var draft in drafts ?? Array.Empty<RequiredModuleDraftDescriptor>())
@@ -246,9 +256,9 @@ internal sealed class RequiredModuleResolutionEngine
 
             installed.TryGetValue(draft.ModuleName, out var info);
             var minimumSource = !string.IsNullOrWhiteSpace(draft.MinimumVersion) ? draft.MinimumVersion : draft.ModuleVersion;
-            var needsVersionLookup = string.IsNullOrWhiteSpace(info.Version) &&
-                                     (IsAutoOrLatest(draft.RequiredVersion) || IsAutoOrLatest(minimumSource));
-            var needsGuidLookup = string.IsNullOrWhiteSpace(info.Guid) && IsAutoGuid(draft.Guid);
+            var hasAutoVersion = IsAutoOrLatest(draft.RequiredVersion) || IsAutoOrLatest(minimumSource);
+            var needsVersionLookup = hasAutoVersion && (preferOnlineMetadata || string.IsNullOrWhiteSpace(info.Version));
+            var needsGuidLookup = IsAutoGuid(draft.Guid) && (preferOnlineMetadata || string.IsNullOrWhiteSpace(info.Guid));
             if (needsVersionLookup || needsGuidLookup)
                 candidates.Add(draft.ModuleName);
         }
@@ -323,10 +333,10 @@ internal sealed class RequiredModuleResolutionEngine
         }
     }
 
-    private static Dictionary<(string ModuleName, string ModuleVersion, string MinimumVersion, string RequiredVersion, string Guid), int>
+    private static Dictionary<(string ModuleName, string ModuleVersion, string MinimumVersion, string RequiredVersion, string Guid, ModuleDependencyVersionSource VersionSource), int>
         BuildDraftCounts(IEnumerable<RequiredModuleDraftDescriptor> drafts)
     {
-        var counts = new Dictionary<(string ModuleName, string ModuleVersion, string MinimumVersion, string RequiredVersion, string Guid), int>();
+        var counts = new Dictionary<(string ModuleName, string ModuleVersion, string MinimumVersion, string RequiredVersion, string Guid, ModuleDependencyVersionSource VersionSource), int>();
         foreach (var draft in drafts ?? Array.Empty<RequiredModuleDraftDescriptor>())
         {
             if (draft is null || string.IsNullOrWhiteSpace(draft.ModuleName))
@@ -337,7 +347,8 @@ internal sealed class RequiredModuleResolutionEngine
                 ModuleVersion: NormalizeDraftValue(draft.ModuleVersion),
                 MinimumVersion: NormalizeDraftValue(draft.MinimumVersion),
                 RequiredVersion: NormalizeDraftValue(draft.RequiredVersion),
-                Guid: NormalizeDraftValue(draft.Guid));
+                Guid: NormalizeDraftValue(draft.Guid),
+                VersionSource: draft.VersionSource);
 
             counts.TryGetValue(key, out var current);
             counts[key] = current + 1;


### PR DESCRIPTION
## Summary
- keep publish repository dependency version source work from this branch
- make PowerForge `AotSpeed`/`AotSize` publish styles emit real `PublishAot=true` and framework-aware restore properties
- add reusable MSI finish-page launch support via `Authoring.ExitLaunch`, including WiX Util/UI extension wiring and validation
- preserve `ExitLaunch` through DotNetPublish plan cloning so JSON config reaches generated WiX authoring

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release -p:RestoreLockedMode=false --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests" --nologo`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net8.0 --nologo`
- Used by GraphEssentialsX SyncSE AOT MSI publish: generated MSI includes finish-page `Open SyncSE Studio` launch action and signed output.
