### PR TITLE
Add ExitLaunch to publish schema

### DIFF
--- a/Module/Examples/DotNetPublish/Example.GeneratedServiceMsi.json
+++ b/Module/Examples/DotNetPublish/Example.GeneratedServiceMsi.json
@@ -49,6 +49,14 @@
         "CompanyFolderName": "Evotec",
         "InstallDirectoryName": "My Service",
         "PayloadComponentGroupId": "ProductFiles",
+        "ExitLaunch": {
+          "Enabled": true,
+          "Text": "Open My Service",
+          "Target": "http://127.0.0.1:9000/"
+        },
+        "LicenseAgreement": {
+          "Path": "Installer\\My.Service\\License.rtf"
+        },
         "Inputs": [
           {
             "Id": "LicenseKey",

--- a/Module/Examples/DotNetPublish/README.md
+++ b/Module/Examples/DotNetPublish/README.md
@@ -55,7 +55,7 @@ Invoke-DotNetPublish -ConfigPath '.\powerforge.dotnetpublish.json' -ExitCode
 ## Notes
 
 - `Example.ServiceMsi.json` expects a WiX installer project (`*.wixproj`).
-- `Example.GeneratedServiceMsi.json` uses `Installers[].Authoring` to generate `Product.wxs` and a WiX SDK project during `msi.build`; use `Type` on each authoring component (`File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, `Shortcut`).
+- `Example.GeneratedServiceMsi.json` uses `Installers[].Authoring` to generate `Product.wxs` and a WiX SDK project during `msi.build`; use `Type` on each authoring component (`File`, `Folder`, `RemoveFolder`, `Service`, `RegistryValue`, `Shortcut`). It also shows typed finish-page launch and RTF license agreement authoring through `ExitLaunch` and `LicenseAgreement`.
 - `Example.RebuildState.json` is aimed at preserve/restore deployments and service-aware rebuild flows.
 - `Example.PortableBundleMsi.json` shows how to use `Bundles`, include sidecar targets, and build an MSI from the composed bundle instead of the raw publish output.
 - `Example.PackageBundleMsi.json` is the starter for TierBridge-style packages: composed service/CLI payload, shipped PowerShell module, generated scripts, ZIP, and MSI from the bundle.

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -287,6 +287,10 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
                 Text = "Open app",
                 Target = "http://127.0.0.1:9000/"
             };
+            authoring.LicenseAgreement = new PowerForgeInstallerLicenseAgreement
+            {
+                Path = "Build/App-License.rtf"
+            };
             authoring.Inputs.Add(new PowerForgeInstallerInput
             {
                 Id = "LicenseKey",
@@ -318,6 +322,8 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             Assert.NotNull(installerPlan.Authoring!.ExitLaunch);
             Assert.Equal("Open app", installerPlan.Authoring.ExitLaunch!.Text);
             Assert.Equal("http://127.0.0.1:9000/", installerPlan.Authoring.ExitLaunch.Target);
+            Assert.NotNull(installerPlan.Authoring.LicenseAgreement);
+            Assert.Equal("Build/App-License.rtf", installerPlan.Authoring.LicenseAgreement!.Path);
             var input = Assert.Single(installerPlan.Authoring!.Inputs);
             Assert.True(input.Required);
             Assert.Equal("Enter a license key before continuing.", input.RequiredMessage);

--- a/PowerForge.Tests/PowerForgeCliProjectReleaseTests.cs
+++ b/PowerForge.Tests/PowerForgeCliProjectReleaseTests.cs
@@ -88,6 +88,7 @@ public sealed class PowerForgeCliProjectReleaseTests
                 try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
                 throw new TimeoutException("PowerForge CLI project release plan test timed out.");
             }
+            process.WaitForExit();
 
             var outputDrainTimedOut = false;
             var drainTask = Task.WhenAll(stdoutClosed.Task, stderrClosed.Task);

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -1713,6 +1713,28 @@ public sealed class PowerForgeInstallerAuthoringTests
                 string.Equals(reference.GetString(), "#/$defs/PowerForgeInstallerLicenseAgreement", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void DotNetPublishExample_UsesTypedGeneratedInstallerLaunchAndLicense()
+    {
+        using var example = JsonDocument.Parse(File.ReadAllText(Path.Combine(
+            ResolveRepositoryRoot(),
+            "Module",
+            "Examples",
+            "DotNetPublish",
+            "Example.GeneratedServiceMsi.json")));
+
+        var authoring = example.RootElement
+            .GetProperty("Installers")[0]
+            .GetProperty("Authoring");
+        var exitLaunch = authoring.GetProperty("ExitLaunch");
+        Assert.True(exitLaunch.GetProperty("Enabled").GetBoolean());
+        Assert.Equal("Open My Service", exitLaunch.GetProperty("Text").GetString());
+        Assert.Equal("http://127.0.0.1:9000/", exitLaunch.GetProperty("Target").GetString());
+
+        var licenseAgreement = authoring.GetProperty("LicenseAgreement");
+        Assert.Equal(@"Installer\My.Service\License.rtf", licenseAgreement.GetProperty("Path").GetString());
+    }
+
     private static PowerForgeInstallerDefinition CreateMonitoringInstaller()
     {
         var definition = new PowerForgeInstallerDefinition

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -161,6 +161,25 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_ModelsLicenseAgreementRtfVariable()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.LicenseAgreement = new PowerForgeInstallerLicenseAgreement
+        {
+            Path = @"Build\Installer\SyncSE-License.rtf"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Root!.Attribute(XNamespace.Xmlns + "ui"));
+        Assert.NotNull(doc.Descendants(Wix + "WixVariable").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "WixUILicenseRtf" &&
+            (string?)e.Attribute("Value") == @"Build\Installer\SyncSE-License.rtf"));
+        Assert.NotNull(doc.Descendants(Wix + "UI").SingleOrDefault());
+    }
+
+    [Fact]
     public void EmitSource_UsesUniqueScriptServiceActionIdsForLongComponentNames()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
@@ -1334,6 +1353,26 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitProjectFile_IncludesUiExtensionForLicenseAgreement()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.LicenseAgreement = new PowerForgeInstallerLicenseAgreement
+        {
+            Path = @"Build\Installer\SyncSE-License.rtf"
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitProjectFile(
+            definition,
+            new PowerForgeWixInstallerProjectOptions { SourceFile = "Generated.wxs" });
+        var doc = XDocument.Parse(xml);
+
+        Assert.DoesNotContain(doc.Descendants("PackageReference"), e =>
+            (string?)e.Attribute("Include") == "WixToolset.Util.wixext");
+        Assert.NotNull(doc.Descendants("PackageReference").SingleOrDefault(e =>
+            (string?)e.Attribute("Include") == "WixToolset.UI.wixext"));
+    }
+
+    [Fact]
     public void PrepareWorkspace_WritesGeneratedSourceAndProject()
     {
         var root = CreateTempDirectory();
@@ -1520,6 +1559,9 @@ public sealed class PowerForgeInstallerAuthoringTests
                   "Target": "http://127.0.0.1:9000/",
                   "Condition": "WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed"
                 },
+                "LicenseAgreement": {
+                  "Path": "Build\\Installer\\TestimoX-Monitoring-License.rtf"
+                },
                 "Inputs": [
                   {
                     "Id": "LicenseKey",
@@ -1623,6 +1665,9 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.True(authoring.ExitLaunch!.Enabled);
         Assert.Equal("Open TestimoX Monitoring", authoring.ExitLaunch.Text);
         Assert.Equal("http://127.0.0.1:9000/", authoring.ExitLaunch.Target);
+        Assert.NotNull(authoring.LicenseAgreement);
+        Assert.True(authoring.LicenseAgreement!.Enabled);
+        Assert.Equal(@"Build\Installer\TestimoX-Monitoring-License.rtf", authoring.LicenseAgreement.Path);
 
         var service = Assert.IsType<PowerForgeInstallerServiceComponent>(authoring.Components[0]);
         Assert.Equal("TestimoX.Monitoring", service.ServiceName);
@@ -1647,6 +1692,7 @@ public sealed class PowerForgeInstallerAuthoringTests
 
         var definitions = schema.RootElement.GetProperty("$defs");
         Assert.True(definitions.TryGetProperty("PowerForgeInstallerExitLaunch", out _));
+        Assert.True(definitions.TryGetProperty("PowerForgeInstallerLicenseAgreement", out _));
 
         var exitLaunch = definitions
             .GetProperty("PowerForgeInstallerDefinition")
@@ -1656,6 +1702,15 @@ public sealed class PowerForgeInstallerAuthoringTests
             exitLaunch.GetProperty("anyOf").EnumerateArray(),
             option => option.TryGetProperty("$ref", out var reference) &&
                 string.Equals(reference.GetString(), "#/$defs/PowerForgeInstallerExitLaunch", StringComparison.Ordinal));
+
+        var licenseAgreement = definitions
+            .GetProperty("PowerForgeInstallerDefinition")
+            .GetProperty("properties")
+            .GetProperty("LicenseAgreement");
+        Assert.Contains(
+            licenseAgreement.GetProperty("anyOf").EnumerateArray(),
+            option => option.TryGetProperty("$ref", out var reference) &&
+                string.Equals(reference.GetString(), "#/$defs/PowerForgeInstallerLicenseAgreement", StringComparison.Ordinal));
     }
 
     private static PowerForgeInstallerDefinition CreateMonitoringInstaller()

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -1514,6 +1514,12 @@ public sealed class PowerForgeInstallerAuthoringTests
                 "CompanyFolderName": "TestimoX",
                 "InstallDirectoryName": "Monitoring",
                 "PayloadComponentGroupId": "ProductFiles",
+                "ExitLaunch": {
+                  "Enabled": true,
+                  "Text": "Open TestimoX Monitoring",
+                  "Target": "http://127.0.0.1:9000/",
+                  "Condition": "WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed"
+                },
                 "Inputs": [
                   {
                     "Id": "LicenseKey",
@@ -1613,6 +1619,10 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Equal("MonitoringDataDirSearch", dataDir.RegistrySearch!.Id);
         Assert.Single(authoring.Dialogs);
         Assert.Single(authoring.Directories);
+        Assert.NotNull(authoring.ExitLaunch);
+        Assert.True(authoring.ExitLaunch!.Enabled);
+        Assert.Equal("Open TestimoX Monitoring", authoring.ExitLaunch.Text);
+        Assert.Equal("http://127.0.0.1:9000/", authoring.ExitLaunch.Target);
 
         var service = Assert.IsType<PowerForgeInstallerServiceComponent>(authoring.Components[0]);
         Assert.Equal("TestimoX.Monitoring", service.ServiceName);
@@ -1627,6 +1637,25 @@ public sealed class PowerForgeInstallerAuthoringTests
         var serialized = JsonSerializer.Serialize(authoring.Components[2], options);
         Assert.Contains("\"Type\":\"RegistryValue\"", serialized, StringComparison.Ordinal);
         Assert.Contains("\"ValueProperty\":\"LICENSE_KEY\"", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DotNetPublishSchema_AllowsInstallerExitLaunch()
+    {
+        using var schema = JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(ResolveRepositoryRoot(), "Schemas", "powerforge.dotnetpublish.schema.json")));
+
+        var definitions = schema.RootElement.GetProperty("$defs");
+        Assert.True(definitions.TryGetProperty("PowerForgeInstallerExitLaunch", out _));
+
+        var exitLaunch = definitions
+            .GetProperty("PowerForgeInstallerDefinition")
+            .GetProperty("properties")
+            .GetProperty("ExitLaunch");
+        Assert.Contains(
+            exitLaunch.GetProperty("anyOf").EnumerateArray(),
+            option => option.TryGetProperty("$ref", out var reference) &&
+                string.Equals(reference.GetString(), "#/$defs/PowerForgeInstallerExitLaunch", StringComparison.Ordinal));
     }
 
     private static PowerForgeInstallerDefinition CreateMonitoringInstaller()
@@ -1770,6 +1799,22 @@ public sealed class PowerForgeInstallerAuthoringTests
         });
 
         return definition;
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PSPublishModule.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
     }
 
     private static PowerForgeInstallerDefinition CreateMonitoringCompileInstaller(string payloadRoot)

--- a/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerDefinitionValidatorTests.cs
@@ -34,6 +34,18 @@ public sealed class PowerForgeInstallerDefinitionValidatorTests
     }
 
     [Fact]
+    public void Validate_RejectsEnabledLicenseAgreementWithoutPath()
+    {
+        var definition = CreateValidDefinition();
+        definition.LicenseAgreement = new PowerForgeInstallerLicenseAgreement();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PowerForgeInstallerDefinitionValidator.Validate(definition));
+
+        Assert.Contains("Path", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Validate_RejectsLowercasePublicMsiProperties()
     {
         var definition = CreateValidDefinition();

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -54,6 +54,11 @@ public sealed class PowerForgeInstallerDefinition
     public PowerForgeInstallerExitLaunch? ExitLaunch { get; set; }
 
     /// <summary>
+    /// Optional RTF license agreement shown by WiX UI before installation.
+    /// </summary>
+    public PowerForgeInstallerLicenseAgreement? LicenseAgreement { get; set; }
+
+    /// <summary>
     /// Additional directory trees required by installer components.
     /// </summary>
     public List<PowerForgeInstallerDirectoryTree> Directories { get; set; } = new();
@@ -124,6 +129,22 @@ public sealed class PowerForgeInstallerExitLaunch
     /// WiX condition controlling the launch action.
     /// </summary>
     public string Condition { get; set; } = "WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed";
+}
+
+/// <summary>
+/// RTF license agreement displayed by the generated WiX UI.
+/// </summary>
+public sealed class PowerForgeInstallerLicenseAgreement
+{
+    /// <summary>
+    /// Whether the generated installer uses the configured RTF license agreement.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Path to an RTF file. Relative paths are resolved against the publish project root.
+    /// </summary>
+    public string Path { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -195,6 +195,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var definition = CloneInstallerDefinition(installer.Authoring)!;
         if (!string.IsNullOrWhiteSpace(productVersion))
             definition.Product.Version = productVersion!;
+        ResolveGeneratedInstallerLicenseAgreementPath(definition, plan.ProjectRoot);
         if (string.IsNullOrWhiteSpace(definition.PayloadComponentGroupId) &&
             !string.IsNullOrWhiteSpace(prepare.HarvestComponentGroupId))
         {
@@ -224,6 +225,19 @@ public sealed partial class DotNetPublishPipelineRunner
             .PrepareWorkspace(definition, request);
         _logger.Info($"Generated WiX installer project for '{installerId}' -> {workspace.ProjectPath}");
         return workspace.ProjectPath;
+    }
+
+    private static void ResolveGeneratedInstallerLicenseAgreementPath(
+        PowerForgeInstallerDefinition definition,
+        string projectRoot)
+    {
+        if (definition.LicenseAgreement is not { Enabled: true } licenseAgreement ||
+            string.IsNullOrWhiteSpace(licenseAgreement.Path))
+        {
+            return;
+        }
+
+        licenseAgreement.Path = ResolvePath(projectRoot, licenseAgreement.Path);
     }
 
     private static bool IsGeneratedInstallerProject(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -757,6 +757,13 @@ public sealed partial class DotNetPublishPipelineRunner
                     Text = definition.ExitLaunch.Text,
                     Target = definition.ExitLaunch.Target,
                     Condition = definition.ExitLaunch.Condition
+                },
+            LicenseAgreement = definition.LicenseAgreement is null
+                ? null
+                : new PowerForgeInstallerLicenseAgreement
+                {
+                    Enabled = definition.LicenseAgreement.Enabled,
+                    Path = definition.LicenseAgreement.Path
                 }
         };
 

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -41,6 +41,8 @@ internal static class PowerForgeInstallerDefinitionValidator
             Require(exitLaunch.Target, nameof(definition.ExitLaunch.Target));
             Require(exitLaunch.Condition, nameof(definition.ExitLaunch.Condition));
         }
+        if (definition.LicenseAgreement is { Enabled: true } licenseAgreement)
+            Require(licenseAgreement.Path, nameof(definition.LicenseAgreement.Path));
 
         EnsureUnique(
             definition.Inputs.Select(input => input.Id),

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -25,7 +25,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         if (definition is null) throw new ArgumentNullException(nameof(definition));
         PowerForgeInstallerDefinitionValidator.Validate(definition);
 
-        var needsUi = definition.Dialogs.Count > 0 || definition.ExitLaunch is { Enabled: true };
+        var needsUi = RequiresUiExtension(definition);
         var needsUtil = RequiresUtilExtension(definition);
         var rootAttributes = new List<XAttribute>();
         if (needsUtil)
@@ -47,6 +47,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XElement(WixNamespace + "MediaTemplate", new XAttribute("EmbedCab", "yes")));
 
         EmitProperties(package, definition);
+        EmitLicenseAgreement(package, definition);
         EmitExitLaunchAction(package, definition);
         if (needsUi)
             package.Add(EmitUi(definition));
@@ -83,7 +84,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             .OrderBy(file => string.Equals(file, options.SourceFile, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
             .ThenBy(file => file, StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        var needsUi = definition.Dialogs.Count > 0 || definition.ExitLaunch is { Enabled: true };
+        var needsUi = RequiresUiExtension(definition);
 
         var project = new XElement(
             "Project",
@@ -198,6 +199,17 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("BinaryRef", "Wix4UtilCA_$(sys.BUILDARCHSHORT)"),
                 new XAttribute("DllEntry", "WixShellExec"),
                 new XAttribute("Impersonate", "yes")));
+    }
+
+    private static void EmitLicenseAgreement(XElement package, PowerForgeInstallerDefinition definition)
+    {
+        if (definition.LicenseAgreement is not { Enabled: true } licenseAgreement)
+            return;
+
+        package.Add(new XElement(
+            WixNamespace + "WixVariable",
+            new XAttribute("Id", "WixUILicenseRtf"),
+            new XAttribute("Value", licenseAgreement.Path)));
     }
 
     private static XElement EmitUi(PowerForgeInstallerDefinition definition)
@@ -784,6 +796,11 @@ public sealed class PowerForgeWixInstallerSourceEmitter
         => definition.Components.OfType<PowerForgeInstallerRemoveFolderComponent>().Any() ||
            definition.ExitLaunch is { Enabled: true } ||
            PowerForgeWixInstallerServiceScriptEmitter.RequiresUtilExtension(definition);
+
+    private static bool RequiresUiExtension(PowerForgeInstallerDefinition definition)
+        => definition.Dialogs.Count > 0 ||
+           definition.ExitLaunch is { Enabled: true } ||
+           definition.LicenseAgreement is { Enabled: true };
 
     private static XElement EmitServiceInstall(PowerForgeInstallerServiceComponent service)
     {

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -222,6 +222,16 @@
       },
       "required": ["Id", "Title"]
     },
+    "PowerForgeInstallerExitLaunch": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "Text": { "type": "string", "minLength": 1 },
+        "Target": { "type": "string", "minLength": 1 },
+        "Condition": { "type": "string", "minLength": 1 }
+      }
+    },
     "PowerForgeInstallerDirectorySegment": {
       "type": "object",
       "additionalProperties": false,
@@ -426,6 +436,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/PowerForgeInstallerDialog" }
         },
+        "ExitLaunch": { "anyOf": [{ "$ref": "#/$defs/PowerForgeInstallerExitLaunch" }, { "type": "null" }] },
         "Directories": {
           "type": "array",
           "items": { "$ref": "#/$defs/PowerForgeInstallerDirectoryTree" }

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -232,6 +232,14 @@
         "Condition": { "type": "string", "minLength": 1 }
       }
     },
+    "PowerForgeInstallerLicenseAgreement": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Enabled": { "type": "boolean" },
+        "Path": { "type": "string", "minLength": 1 }
+      }
+    },
     "PowerForgeInstallerDirectorySegment": {
       "type": "object",
       "additionalProperties": false,
@@ -437,6 +445,7 @@
           "items": { "$ref": "#/$defs/PowerForgeInstallerDialog" }
         },
         "ExitLaunch": { "anyOf": [{ "$ref": "#/$defs/PowerForgeInstallerExitLaunch" }, { "type": "null" }] },
+        "LicenseAgreement": { "anyOf": [{ "$ref": "#/$defs/PowerForgeInstallerLicenseAgreement" }, { "type": "null" }] },
         "Directories": {
           "type": "array",
           "items": { "$ref": "#/$defs/PowerForgeInstallerDirectoryTree" }


### PR DESCRIPTION
## Summary
- Add the typed installer ExitLaunch contract to the dotnet publish JSON schema.
- Add typed MSI LicenseAgreement support backed by WiX WixUILicenseRtf.
- Cover ExitLaunch and LicenseAgreement deserialization, schema exposure, WiX emission, generated-plan cloning, validator behavior, and the generated service MSI example.
- Document the generated MSI launch/license authoring pattern in DotNetPublish examples.
- Stabilize the CLI project-release test output drain by waiting for async readers to flush after process exit.

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests|FullyQualifiedName~PowerForgeInstallerDefinitionValidatorTests|FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests"
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeCliProjectReleaseTests"
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests"
- dotnet test .\PSPublishModule.sln -c Release --no-restore
- git diff --check