### PR TITLE
Add private gallery publish process

### DIFF
--- a/Docs/PSPublishModule.PrivateGalleries.md
+++ b/Docs/PSPublishModule.PrivateGalleries.md
@@ -4,6 +4,9 @@ This page describes the supported enterprise flow for consuming private modules
 from Azure Artifacts with PSPublishModule and the related Microsoft Artifact
 Registry (MAR) intake path for Microsoft-owned packages.
 
+For the short maintainer/end-user process used for the Evotec private feed, see
+`Docs/PSPublishModule.PrivateGalleryProcess.md`.
+
 ## Recommended Azure Artifacts Flow
 
 Use Microsoft Entra ID/MFA through Microsoft.PowerShell.PSResourceGet and the

--- a/Docs/PSPublishModule.PrivateGalleryProcess.md
+++ b/Docs/PSPublishModule.PrivateGalleryProcess.md
@@ -1,0 +1,114 @@
+# PSPublishModule Private Gallery Process
+
+This note is the short maintainer and end-user process for using the Evotec
+Azure Artifacts feed as a private PowerShell module gallery.
+
+Feed:
+
+```text
+Organization: evotecpl
+Project:      PowerShellGallery
+Feed:         PowerShellGalleryFeed
+Repository:   EvotecPowerShellGallery
+```
+
+## Goal
+
+Maintainers publish approved modules, including PSPublishModule itself, to the
+private feed. Zone users install or update from that feed without PATs, manual
+NuGet configuration, or special per-command credentials.
+
+Authentication is handled by Microsoft.PowerShell.PSResourceGet and the Azure
+Artifacts Credential Provider. If the user has a valid cached Entra/Azure
+DevOps session, commands use it silently. If the session is missing or expired,
+the credential provider prompts once and caches the refreshed session.
+
+## Maintainer Publish Flow
+
+Add one publish target to the module build configuration. In this repo it lives
+beside the PSGallery and GitHub publish lines in
+`Module/Build/Build-Module.ps1`:
+
+```powershell
+New-ConfigurationPublish -AzureDevOpsOrganization 'evotecpl' -AzureDevOpsProject 'PowerShellGallery' -AzureArtifactsFeed 'PowerShellGalleryFeed' -RepositoryName 'EvotecPowerShellGallery' -Tool PSResourceGet -Enabled:$true
+```
+
+Optional maintainer preflight:
+
+```powershell
+Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+```
+
+The preflight installs or refreshes prerequisites, registers/probes the feed,
+and primes the cached Entra/Azure DevOps session when needed. It is useful for
+first setup, but the publish target also registers or refreshes the repository
+internally before version checks and publishing.
+
+Then run the normal build/publish flow:
+
+```powershell
+.\Build\Build-Module.ps1
+```
+
+Repeat publishing is the same process. Azure Artifacts will reject the same
+package ID/version if it is already present, so publish a new module version for
+each release.
+
+## End-User Bootstrap
+
+Recommended first-time user setup, using PSGallery only to obtain
+PSPublishModule:
+
+```powershell
+Install-Module PSPublishModule -Scope CurrentUser
+
+Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+```
+
+After that, normal install/update commands use the private feed profile:
+
+```powershell
+Install-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+Update-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+```
+
+For other approved private modules, replace `PSPublishModule` with the module
+name.
+
+## Direct PSResourceGet Option
+
+When PSPublishModule is already available and the repository profile has been
+initialized, native PSResourceGet commands also work:
+
+```powershell
+Install-PSResource -Name PSPublishModule -Repository EvotecPowerShellGallery -TrustRepository
+Update-PSResource -Name PSPublishModule
+```
+
+The PSPublishModule wrappers remain preferred for users because they refresh the
+repository registration and run the same access probe/session-prime path before
+installing or updating.
+
+## What Users Should Expect
+
+- No PAT, username, or password is required for normal interactive users.
+- If the credential provider cache is valid, install/update runs without a
+  prompt.
+- If the cache is empty or expired, the Azure Artifacts Credential Provider
+  prompts through the normal Entra-capable browser or device-code flow.
+- After successful login, later commands use the cached session.
+- A synthetic probe package warning is expected when verbose output is enabled;
+  it means the feed was reached but the fake probe package does not exist.
+
+## Proof From Current Validation
+
+The process has been validated with PSPublishModule published to the private
+feed and then installed locally through:
+
+```powershell
+Install-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+```
+
+The verbose output showed the repository was refreshed, the access probe reached
+the feed through PSResourceGet, ExistingSession auth was used, and the installed
+version satisfied the requirement.

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -319,6 +319,31 @@ Invoke-ModuleBuild @buildParams -Settings {
     #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true -ID 'ToGitHub' -OverwriteTagName '<TagModuleVersionWithPreRelease>' -GenerateReleaseNotes
 
 
+    # Optional one-time maintainer preflight: installs prerequisites, registers/probes the feed, and primes cached Entra/Azure DevOps auth when needed.
+    #Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+    # Private feed publish target. This registers/refreshes the Azure Artifacts PSResourceGet repository before version checks and publish.
+    #New-ConfigurationPublish -AzureDevOpsOrganization 'evotecpl' -AzureDevOpsProject 'PowerShellGallery' -AzureArtifactsFeed 'PowerShellGalleryFeed' -RepositoryName 'EvotecPowerShellGallery' -Tool PSResourceGet -Enabled:$true
+
+    <#
+    Direct PSResourceGet way:
+    Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+    Install-PSResource -Name PSPublishModule -Repository EvotecPowerShellGallery -TrustRepository
+    Update-PSResource -Name PSPublishModule
+
+    PSPublishModule private module management:
+    Install-Module PSPublishModule -Scope CurrentUser
+    Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+    Install-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+    Update-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+
+    Auth behavior:
+    If the credential provider has a valid cached Entra/Azure DevOps session, it should just use it.
+    If no token exists or the token expired, it should prompt through the Azure Artifacts Credential Provider login flow, usually browser/device-code style.
+    After successful login, the provider caches the session, so later install/update runs should not need anything fancy.
+    No PAT, username, or password should be needed for normal interactive users.
+    #>
+
+
     ### FOR TESTING PURPOSES ONLY ###
     ### SHOWING HOW THINGS WORK HERE ###
 

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -93,6 +95,77 @@ public sealed class ModulePublisherRepositoryVersionTests
         Assert.Contains("not greater than repository version '3.0.0'", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Publish_RegistersConfiguredRepositoryBeforeVersionCheck()
+    {
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        var calls = new List<string>();
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "PSPublishModule.psd1");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '3.0.13'; GUID = 'eb76426a-1992-40a5-82cd-6480f883ef4d'; RootModule = 'PSPublishModule.psm1' }");
+            File.WriteAllText(Path.Combine(stagingRoot, "PSPublishModule.psm1"), string.Empty);
+
+            var runner = new StubPowerShellRunner(request =>
+            {
+                var script = File.ReadAllText(request.ScriptPath!);
+                if (script.Contains("Register-PSResourceRepository", StringComparison.Ordinal))
+                {
+                    calls.Add("register");
+                    return new PowerShellRunResult(0, "PFPSRG::REPO::CREATED::0", string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Find-PSResource", StringComparison.Ordinal))
+                {
+                    calls.Add("find");
+                    return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Publish-PSResource", StringComparison.Ordinal))
+                {
+                    calls.Add("publish");
+                    return new PowerShellRunResult(0, "PFPSRG::PUBLISH::OK", string.Empty, "pwsh.exe");
+                }
+
+                throw new InvalidOperationException("Unexpected PowerShell script invocation.");
+            });
+            var publisher = new ModulePublisher(new NullLogger(), runner);
+
+            var publish = new PublishConfiguration
+            {
+                Destination = PublishDestination.PowerShellGallery,
+                Enabled = true,
+                Tool = PublishTool.PSResourceGet,
+                ApiKey = "AzureDevOps",
+                RepositoryName = "EvotecPowerShellGallery",
+                Repository = new PublishRepositoryConfiguration
+                {
+                    Name = "EvotecPowerShellGallery",
+                    Uri = "https://pkgs.dev.azure.com/evotecpl/PowerShellGallery/_packaging/PowerShellGalleryFeed/nuget/v3/index.json",
+                    Trusted = true,
+                    ApiVersion = RepositoryApiVersion.V3,
+                    EnsureRegistered = true
+                }
+            };
+            var plan = CreatePlan();
+            var buildResult = new ModuleBuildResult(
+                stagingPath: stagingRoot,
+                manifestPath: manifestPath,
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var result = publisher.Publish(publish, plan, buildResult, Array.Empty<ArtefactBuildResult>());
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(new[] { "register", "find", "publish" }, calls);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+                Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
     private static string Encode(string value)
         => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 
@@ -109,18 +182,81 @@ public sealed class ModulePublisherRepositoryVersionTests
             Encode(string.Empty)
         });
 
+    private static ModulePipelinePlan CreatePlan()
+    {
+        return new ModulePipelinePlan(
+            moduleName: "PSPublishModule",
+            projectRoot: @"C:\repo\PSPublishModule",
+            expectedVersion: "3.0.13",
+            resolvedVersion: "3.0.13",
+            preRelease: null,
+            manifest: null,
+            buildSpec: new ModuleBuildSpec
+            {
+                Name = "PSPublishModule",
+                SourcePath = @"C:\repo\PSPublishModule",
+                Version = "3.0.13"
+            },
+            resolvedCsprojPath: null,
+            syncNETProjectVersion: false,
+            compatiblePSEditions: Array.Empty<string>(),
+            requiredModules: Array.Empty<RequiredModuleReference>(),
+            externalModuleDependencies: Array.Empty<string>(),
+            requiredModulesForPackaging: Array.Empty<RequiredModuleReference>(),
+            information: null,
+            documentation: null,
+            delivery: null,
+            documentationBuild: null,
+            compatibilitySettings: null,
+            fileConsistencySettings: null,
+            validationSettings: null,
+            formatting: null,
+            importModules: null,
+            placeHolders: Array.Empty<PlaceHolderReplacement>(),
+            placeHolderOption: null,
+            commandModuleDependencies: new Dictionary<string, string[]>(),
+            testsAfterMerge: Array.Empty<TestConfiguration>(),
+            mergeModule: false,
+            mergeMissing: false,
+            doNotAttemptToFixRelativePaths: false,
+            approvedModules: Array.Empty<string>(),
+            moduleSkip: null,
+            signModule: false,
+            signing: null,
+            publishes: Array.Empty<ConfigurationPublishSegment>(),
+            artefacts: Array.Empty<ConfigurationArtefactSegment>(),
+            installEnabled: false,
+            installStrategy: InstallationStrategy.AutoRevision,
+            installKeepVersions: 3,
+            installRoots: Array.Empty<string>(),
+            installLegacyFlatHandling: LegacyFlatModuleHandling.Warn,
+            installPreserveVersions: Array.Empty<string>(),
+            installMissingModules: false,
+            installMissingModulesForce: false,
+            installMissingModulesPrerelease: false,
+            installMissingModulesRepository: null,
+            installMissingModulesCredential: null,
+            stagingWasGenerated: true,
+            deleteGeneratedStagingAfterRun: true);
+    }
+
     private sealed class StubPowerShellRunner : IPowerShellRunner
     {
-        private readonly PowerShellRunResult _result;
+        private readonly Func<PowerShellRunRequest, PowerShellRunResult> _run;
 
         public StubPowerShellRunner(PowerShellRunResult result)
         {
-            _result = result;
+            _run = _ => result;
+        }
+
+        public StubPowerShellRunner(Func<PowerShellRunRequest, PowerShellRunResult> run)
+        {
+            _run = run;
         }
 
         public PowerShellRunResult Run(PowerShellRunRequest request)
         {
-            return _result;
+            return _run(request);
         }
     }
 

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -126,6 +126,8 @@ public sealed class ModulePublisher
     {
         var credential = repoConfig?.Credential;
         string? temporaryPublishPath = null;
+        var repositoryCreated = false;
+        PublishRepositoryConfiguration? repositoryForPublish = repoConfig;
         var versionText = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
 
         try
@@ -136,6 +138,12 @@ public sealed class ModulePublisher
                 information: plan.Information,
                 delivery: plan.Delivery,
                 includeScriptFolders: includeScriptFolders);
+
+            if (repoConfig is not null && repoConfig.EnsureRegistered && HasRepositoryUris(repoConfig))
+            {
+                repositoryCreated = EnsureRepositoryRegistered(tool, repositoryName, repoConfig);
+                repositoryForPublish = CloneRegisteredRepository(repoConfig);
+            }
 
             if (!publish.Force)
                 EnsureVersionIsGreaterThanRepository(tool, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease, repositoryName, credential);
@@ -157,7 +165,7 @@ public sealed class ModulePublisher
                     RepositoryName = repositoryName,
                     Tool = tool,
                     ApiKey = string.IsNullOrWhiteSpace(publish.ApiKey) ? null : publish.ApiKey,
-                    Repository = repoConfig,
+                    Repository = repositoryForPublish,
                     DestinationPath = null,
                     SkipDependenciesCheck = tool != PublishTool.PowerShellGet,
                     SkipModuleManifestValidate = false
@@ -170,6 +178,18 @@ public sealed class ModulePublisher
         }
         finally
         {
+            if (repositoryCreated && repoConfig is { UnregisterAfterUse: true })
+            {
+                try
+                {
+                    UnregisterRepository(tool, repositoryName);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn($"Failed to unregister repository '{repositoryName}': {ex.Message}");
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(temporaryPublishPath))
                 CleanupTemporaryPublishPath(temporaryPublishPath);
         }
@@ -519,6 +539,79 @@ public sealed class ModulePublisher
 
         return FormatSemVer(resource.Version, resource.PreRelease);
     }
+
+    private static bool HasRepositoryUris(PublishRepositoryConfiguration repo)
+        => repo is not null &&
+           (!string.IsNullOrWhiteSpace(repo.Uri) ||
+            !string.IsNullOrWhiteSpace(repo.SourceUri) ||
+            !string.IsNullOrWhiteSpace(repo.PublishUri));
+
+    private bool EnsureRepositoryRegistered(PublishTool tool, string repositoryName, PublishRepositoryConfiguration repo)
+    {
+        if (tool == PublishTool.PowerShellGet)
+        {
+            var sourceUri = string.IsNullOrWhiteSpace(repo.SourceUri)
+                ? (string.IsNullOrWhiteSpace(repo.Uri) ? repo.PublishUri : repo.Uri)
+                : repo.SourceUri;
+            var publishUri = string.IsNullOrWhiteSpace(repo.PublishUri)
+                ? (string.IsNullOrWhiteSpace(repo.Uri) ? repo.SourceUri : repo.Uri)
+                : repo.PublishUri;
+
+            if (string.IsNullOrWhiteSpace(sourceUri) || string.IsNullOrWhiteSpace(publishUri))
+            {
+                throw new InvalidOperationException(
+                    $"Repository '{repositoryName}' is missing SourceUri/PublishUri/Uri for PowerShellGet registration.");
+            }
+
+            return _powerShellGet.EnsureRepositoryRegistered(
+                repositoryName,
+                sourceUri!,
+                publishUri!,
+                trusted: repo.Trusted,
+                timeout: TimeSpan.FromMinutes(2));
+        }
+
+        var uri = string.IsNullOrWhiteSpace(repo.Uri)
+            ? (string.IsNullOrWhiteSpace(repo.PublishUri) ? repo.SourceUri : repo.PublishUri)
+            : repo.Uri;
+
+        if (string.IsNullOrWhiteSpace(uri))
+            throw new InvalidOperationException($"Repository '{repositoryName}' is missing Uri/PublishUri/SourceUri for PSResourceGet registration.");
+
+        return _psResourceGet.EnsureRepositoryRegistered(
+            name: repositoryName,
+            uri: uri!,
+            trusted: repo.Trusted,
+            priority: repo.Priority,
+            apiVersion: repo.ApiVersion,
+            timeout: TimeSpan.FromMinutes(2));
+    }
+
+    private void UnregisterRepository(PublishTool tool, string repositoryName)
+    {
+        if (tool == PublishTool.PowerShellGet)
+        {
+            _powerShellGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
+            return;
+        }
+
+        _psResourceGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
+    }
+
+    private static PublishRepositoryConfiguration CloneRegisteredRepository(PublishRepositoryConfiguration repo)
+        => new()
+        {
+            Name = repo.Name,
+            Uri = repo.Uri,
+            SourceUri = repo.SourceUri,
+            PublishUri = repo.PublishUri,
+            Trusted = repo.Trusted,
+            Priority = repo.Priority,
+            ApiVersion = repo.ApiVersion,
+            EnsureRegistered = false,
+            UnregisterAfterUse = false,
+            Credential = repo.Credential
+        };
 
     private static (string RepositoryName, PublishRepositoryConfiguration? Repository) ResolveRepository(PublishConfiguration publish)
     {


### PR DESCRIPTION
## Summary
- register configured PowerShell repositories before publish version checks so Azure Artifacts publish targets work without manual pre-registration
- document the Evotec private gallery maintainer and end-user process
- add the private feed one-line publish target note to the module build script

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~ModulePublisherRepositoryVersionTests"
- user validated publish/install against PowerShellGalleryFeed with Install-PrivateModule