### PR TITLE
Plan private gallery web engine

### DIFF
--- a/Docs/PSPublishModule.PrivateGalleries.md
+++ b/Docs/PSPublishModule.PrivateGalleries.md
@@ -4,6 +4,9 @@ This page describes the supported enterprise flow for consuming private modules
 from Azure Artifacts with PSPublishModule and the related Microsoft Artifact
 Registry (MAR) intake path for Microsoft-owned packages.
 
+For the short maintainer/end-user process used for the Evotec private feed, see
+`Docs/PSPublishModule.PrivateGalleryProcess.md`.
+
 ## Recommended Azure Artifacts Flow
 
 Use Microsoft Entra ID/MFA through Microsoft.PowerShell.PSResourceGet and the

--- a/Docs/PSPublishModule.PrivateGalleryProcess.md
+++ b/Docs/PSPublishModule.PrivateGalleryProcess.md
@@ -1,0 +1,114 @@
+# PSPublishModule Private Gallery Process
+
+This note is the short maintainer and end-user process for using the Evotec
+Azure Artifacts feed as a private PowerShell module gallery.
+
+Feed:
+
+```text
+Organization: evotecpl
+Project:      PowerShellGallery
+Feed:         PowerShellGalleryFeed
+Repository:   EvotecPowerShellGallery
+```
+
+## Goal
+
+Maintainers publish approved modules, including PSPublishModule itself, to the
+private feed. Zone users install or update from that feed without PATs, manual
+NuGet configuration, or special per-command credentials.
+
+Authentication is handled by Microsoft.PowerShell.PSResourceGet and the Azure
+Artifacts Credential Provider. If the user has a valid cached Entra/Azure
+DevOps session, commands use it silently. If the session is missing or expired,
+the credential provider prompts once and caches the refreshed session.
+
+## Maintainer Publish Flow
+
+Add one publish target to the module build configuration. In this repo it lives
+beside the PSGallery and GitHub publish lines in
+`Module/Build/Build-Module.ps1`:
+
+```powershell
+New-ConfigurationPublish -AzureDevOpsOrganization 'evotecpl' -AzureDevOpsProject 'PowerShellGallery' -AzureArtifactsFeed 'PowerShellGalleryFeed' -RepositoryName 'EvotecPowerShellGallery' -Tool PSResourceGet -Enabled:$true
+```
+
+Optional maintainer preflight:
+
+```powershell
+Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+```
+
+The preflight installs or refreshes prerequisites, registers/probes the feed,
+and primes the cached Entra/Azure DevOps session when needed. It is useful for
+first setup, but the publish target also registers or refreshes the repository
+internally before version checks and publishing.
+
+Then run the normal build/publish flow:
+
+```powershell
+.\Build\Build-Module.ps1
+```
+
+Repeat publishing is the same process. Azure Artifacts will reject the same
+package ID/version if it is already present, so publish a new module version for
+each release.
+
+## End-User Bootstrap
+
+Recommended first-time user setup, using PSGallery only to obtain
+PSPublishModule:
+
+```powershell
+Install-Module PSPublishModule -Scope CurrentUser
+
+Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+```
+
+After that, normal install/update commands use the private feed profile:
+
+```powershell
+Install-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+Update-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+```
+
+For other approved private modules, replace `PSPublishModule` with the module
+name.
+
+## Direct PSResourceGet Option
+
+When PSPublishModule is already available and the repository profile has been
+initialized, native PSResourceGet commands also work:
+
+```powershell
+Install-PSResource -Name PSPublishModule -Repository EvotecPowerShellGallery -TrustRepository
+Update-PSResource -Name PSPublishModule
+```
+
+The PSPublishModule wrappers remain preferred for users because they refresh the
+repository registration and run the same access probe/session-prime path before
+installing or updating.
+
+## What Users Should Expect
+
+- No PAT, username, or password is required for normal interactive users.
+- If the credential provider cache is valid, install/update runs without a
+  prompt.
+- If the cache is empty or expired, the Azure Artifacts Credential Provider
+  prompts through the normal Entra-capable browser or device-code flow.
+- After successful login, later commands use the cached session.
+- A synthetic probe package warning is expected when verbose output is enabled;
+  it means the feed was reached but the fake probe package does not exist.
+
+## Proof From Current Validation
+
+The process has been validated with PSPublishModule published to the private
+feed and then installed locally through:
+
+```powershell
+Install-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+```
+
+The verbose output showed the repository was refreshed, the access probe reached
+the feed through PSResourceGet, ExistingSession auth was used, and the installed
+version satisfied the requirement.

--- a/Docs/PowerForge.Web.LibraryEcosystemPlan.md
+++ b/Docs/PowerForge.Web.LibraryEcosystemPlan.md
@@ -9,6 +9,9 @@ This plan focuses on making PowerForge.Web a first-class docs engine for:
 - mixed ecosystems that need one coherent website.
 
 It complements `Docs/PowerForge.Web.Roadmap.md` by turning parity goals into implementation slices with direct value for library, module, and mixed API documentation sites.
+Private gallery delivery is tracked separately in `Docs/PowerForge.Web.PrivateGallery.md`
+because it combines feed inventory, package inspection, docs extraction, and
+website generation.
 
 ## Review Findings (Current Gaps)
 
@@ -70,6 +73,20 @@ Site impact:
 
 Site impact:
 - Better discoverability in larger outputs, especially mixed docs/API sites.
+
+### 5) Private Gallery Indexing
+
+- Add a private gallery indexing lane for Azure Artifacts/private NuGet feeds:
+  - package/version inventory from the feed,
+  - safe `.nupkg` extraction,
+  - `.psd1`, README, docs, examples, and external help XML discovery,
+  - optional package/version metrics,
+  - generated module pages/search data.
+
+Site impact:
+- Internal module consumers get one website for approved private modules,
+  installation commands, command docs, examples, versions, dependencies, and
+  package freshness.
 
 ## Priority Backlog
 
@@ -192,8 +209,9 @@ Acceptance:
 1. Expand xref from type/cmdlet to member/parameter granularity.
 2. Introduce API provider contract while preserving existing dotnet/powershell generators.
 3. Add package/module intelligence pages from project/manifests.
-4. Standardize versioned docs contract and search ranking profiles.
-5. Land plugin contract after core models are stable.
+4. Add private gallery indexing from Azure Artifacts/private NuGet feeds.
+5. Standardize versioned docs contract and search ranking profiles.
+6. Land plugin contract after core models are stable.
 
 ## Guardrails
 

--- a/Docs/PowerForge.Web.PrivateGallery.md
+++ b/Docs/PowerForge.Web.PrivateGallery.md
@@ -1,0 +1,328 @@
+# PowerForge.Web Private Gallery Engine Plan
+
+Last updated: 2026-05-23
+
+This document defines the engine-side plan for building a reusable private
+PowerShell Gallery experience on top of PowerForge.Web. The goal is not a
+one-off feed viewer. The goal is a static, searchable internal gallery site
+where maintainers publish modules to a private feed and PowerForge turns that
+feed plus packaged module documentation into a browsable delivery surface.
+
+## Goal
+
+Private gallery sites should answer the same questions users expect from a
+PowerShell gallery:
+
+- what modules are available,
+- which versions are available,
+- how to register the repository,
+- how to install and update modules,
+- what commands, examples, and docs ship with each module,
+- which dependencies and compatibility constraints apply,
+- which versions are stable, prerelease, deprecated, or hidden,
+- and what package statistics are available from the backing feed.
+
+Maintainers should keep the normal publishing workflow. The website should be
+generated from the published packages and their bundled metadata.
+
+## Architecture
+
+Keep the feature split by responsibility.
+
+### PowerForge
+
+Core gallery indexing belongs in `PowerForge` because it is host-neutral and
+useful outside the website CLI.
+
+Proposed folders:
+
+- `PowerForge/Models/PrivateGallery/`
+- `PowerForge/Services/PrivateGallery/`
+
+Core models:
+
+- `PrivateGalleryFeed`
+- `PrivateGalleryPackage`
+- `PrivateGalleryPackageVersion`
+- `PrivateGalleryModuleMetadata`
+- `PrivateGalleryCommandMetadata`
+- `PrivateGalleryDocumentAsset`
+- `PrivateGalleryPackageMetrics`
+- `PrivateGalleryIndexResult`
+
+Core services:
+
+- `AzureArtifactsFeedClient`
+- `NuGetV3FeedClient`
+- `PrivateGalleryIndexer`
+- `NuGetPackageDownloader`
+- `SafePackageExtractor`
+- `PowerShellModulePackageInspector`
+- `PrivateGalleryMetricsCollector`
+
+This layer owns:
+
+- Azure Artifacts feed/package/version inventory,
+- NuGet V3 package download metadata where useful,
+- safe `.nupkg` extraction,
+- `.psd1` parsing,
+- external help XML parsing,
+- README/changelog/license/docs/examples discovery,
+- exported command metadata,
+- dependency metadata,
+- normalized gallery JSON models.
+
+This layer must not render website pages and must not import or execute uploaded
+modules.
+
+### PowerForge.Web
+
+Website shaping belongs in `PowerForge.Web`.
+
+Proposed files:
+
+- `PowerForge.Web/Models/WebPrivateGallery.cs`
+- `PowerForge.Web/Services/WebPrivateGalleryGenerator.cs`
+- `PowerForge.Web/Services/WebPrivateGalleryPageGenerator.cs`
+- `PowerForge.Web/Services/WebPrivateGallerySearchBuilder.cs`
+
+This layer owns:
+
+- mapping normalized gallery data to website data files,
+- generating gallery content pages,
+- generating search records and facets,
+- connecting module packages to existing PowerShell API docs output,
+- producing theme-friendly page models.
+
+Expected outputs:
+
+- `data/private-gallery/feed.json`
+- `data/private-gallery/modules/<module>.json`
+- `data/private-gallery/modules/<module>/<version>.json`
+- `data/private-gallery/search.json`
+- `content/modules/<module>/index.md`
+- `content/modules/<module>/versions/<version>.md`
+- optional command pages under `content/modules/<module>/commands/`
+
+### PowerForge.Web.Cli
+
+The CLI should stay a thin adapter.
+
+Proposed files:
+
+- `PowerForge.Web.Cli/WebPipelineRunner.Tasks.PrivateGallery.cs`
+- `PowerForge.Web.Cli/WebCliCommandHandlers.PrivateGalleryCommands.cs`
+
+The CLI owns:
+
+- pipeline JSON binding,
+- environment token lookup,
+- mode-aware warning policy,
+- summary output,
+- and calling `PowerForge.Web`.
+
+It should not contain Azure Artifacts, package extraction, or docs parsing
+business logic.
+
+### PSPublishModule
+
+PowerShell cmdlets are optional follow-up UX, not the first implementation
+layer.
+
+Potential later wrappers:
+
+- `New-PrivateGalleryWebsite`
+- `Update-PrivateGalleryIndex`
+- `Test-PrivateGalleryFeed`
+
+Those cmdlets should call the shared PowerForge/PowerForge.Web services rather
+than carrying their own indexing logic.
+
+### PowerForge.PowerShell
+
+Avoid this layer for the first implementation. The gallery indexer should parse
+files, not import modules.
+
+Use `PowerForge.PowerShell` only if a later slice needs PowerShell-host
+behavior that cannot remain host-neutral, such as reusing repository profile
+bootstrap logic or PowerShell-specific credential-provider checks.
+
+## Proposed Pipeline Task
+
+Future task shape:
+
+```json
+{
+  "task": "private-gallery-index",
+  "provider": "azure-artifacts",
+  "organization": "evotecpl",
+  "project": "PowerShellGallery",
+  "feed": "PowerShellGalleryFeed",
+  "repositoryName": "EvotecPowerShellGallery",
+  "includeAllVersions": true,
+  "includePackageContent": true,
+  "includeMetrics": true,
+  "tokenEnv": "AZURE_DEVOPS_TOKEN",
+  "out": "./data/private-gallery",
+  "contentOut": "./content/modules"
+}
+```
+
+The task should run before `build` so templates and search indexing can consume
+generated gallery data.
+
+## Source Data
+
+### Azure Artifacts
+
+Azure Artifacts is the source of truth for published package inventory:
+
+- feed identity,
+- package ids,
+- package versions,
+- latest/listed/deleted state,
+- publish date,
+- feed views,
+- package/version REST URLs,
+- optional package and version metrics.
+
+Use paging and cache-friendly behavior. Respect `Retry-After` and
+`X-RateLimit-*` response headers when present.
+
+### NuGet Package Content
+
+Each published module package is the source of truth for bundled module content:
+
+- `.psd1`,
+- root/module README files,
+- `Docs/`,
+- external help XML,
+- examples,
+- changelog or release notes,
+- license,
+- icon or image assets,
+- command exports,
+- required modules.
+
+The indexer should support a metadata-only mode for fast builds and a content
+inspection mode for full gallery generation.
+
+### Existing PowerForge Data
+
+Private gallery indexing should compose with existing engine capabilities:
+
+- `package-hub` for local `.csproj`/`.psd1` metadata patterns,
+- `apidocs` for PowerShell command help pages,
+- `xref-merge` for linking docs to commands,
+- search index generation for module/docs/command search,
+- `compat-matrix` for dependency and compatibility display.
+
+## Security Rules
+
+Treat uploaded packages as untrusted archives.
+
+- Do not import modules.
+- Do not execute package scripts.
+- Defend against zip-slip paths.
+- Cap extracted file count and total extracted bytes.
+- Ignore unsupported binary files except for known static assets.
+- Parse manifests and help files as data.
+- Keep warnings for malformed package metadata.
+- Make destructive cleanup paths explicit and constrained to the temp workspace.
+
+## Generated Data Contract
+
+The first stable document should be page-agnostic JSON:
+
+```json
+{
+  "schemaVersion": 1,
+  "format": "powerforge.private-gallery",
+  "generatedAtUtc": "2026-05-23T00:00:00Z",
+  "provider": "azure-artifacts",
+  "feed": {
+    "organization": "evotecpl",
+    "project": "PowerShellGallery",
+    "name": "PowerShellGalleryFeed",
+    "repositoryName": "EvotecPowerShellGallery"
+  },
+  "summary": {
+    "packageCount": 0,
+    "versionCount": 0,
+    "commandCount": 0,
+    "documentCount": 0
+  },
+  "packages": []
+}
+```
+
+Per-package JSON can carry heavier details:
+
+- normalized metadata,
+- version table,
+- command list,
+- docs list,
+- examples list,
+- dependencies,
+- install/update command templates,
+- metrics,
+- warnings.
+
+## User-Facing Site Shape
+
+The engine should generate enough data for a frontend to render:
+
+- module listing,
+- module detail,
+- install/update setup commands,
+- version history,
+- command docs,
+- examples,
+- dependencies,
+- download/statistics badges,
+- freshness and quality signals.
+
+The frontend may be rich, but the system of record is the generated data.
+
+## Implementation Slices
+
+### Slice 1: Inventory JSON
+
+- Add core models and `AzureArtifactsFeedClient`.
+- Add `private-gallery-index` pipeline task in metadata-only mode.
+- Emit `feed.json`.
+- Test paging, missing feed, auth failure, and empty feed behavior.
+
+### Slice 2: Safe Package Inspection
+
+- Download selected/latest package versions.
+- Add safe extraction.
+- Parse `.psd1`, README, docs, external help XML, and examples.
+- Emit per-module/per-version JSON.
+
+### Slice 3: Web Page Generation
+
+- Generate module list/detail/version pages.
+- Generate install/update command snippets from repository profile settings.
+- Add search entries for modules, commands, docs, and examples.
+
+### Slice 4: Metrics and Quality Signals
+
+- Add optional package and version metrics.
+- Add quality fields such as has README, has help, has examples, has license,
+  command count, dependency count, and docs freshness.
+- Add CI warning policy and baselines.
+
+### Slice 5: Starter/Theme Contract
+
+- Add a gallery starter profile or gallery feature contract.
+- Add required selectors/partials for module cards, install command blocks,
+  version tables, and command/doc search results.
+
+## Non-Goals
+
+- No live website proxy to Azure DevOps.
+- No runtime package installation from the website.
+- No module import during indexing.
+- No maintainer upload UI in the first engine slices.
+- No replacement for Azure Artifacts as the package system of record.

--- a/Docs/PowerForge.Web.Roadmap.md
+++ b/Docs/PowerForge.Web.Roadmap.md
@@ -11,6 +11,8 @@ This document is the single source of truth for:
 
 Companion execution plan for C# libraries + PowerShell modules:
 - `Docs/PowerForge.Web.LibraryEcosystemPlan.md`
+Companion private gallery plan:
+- `Docs/PowerForge.Web.PrivateGallery.md`
 Companion SEO parity plan (Yoast-informed capability mapping):
 - `Docs/PowerForge.Web.SeoParityPlan.md`
 
@@ -160,6 +162,9 @@ Legend:
   - Code: `PowerForge.Web/Services/WebPackageHubGenerator.cs`, `PowerForge.Web/Models/WebPackageHub.cs`
   - CLI wiring: `PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs`, `PowerForge.Web.Cli/WebPipelineRunner.Tasks.cs`
 - **Partial**: Package hub currently emits metadata JSON only; turnkey rendered pages/layout contracts remain theme-driven.
+- **Missing**: Private PowerShell gallery indexing from Azure Artifacts/private NuGet feeds.
+  - Planned: `Docs/PowerForge.Web.PrivateGallery.md`
+  - Scope: feed inventory, safe `.nupkg` inspection, bundled docs/help/examples extraction, metrics, generated data/pages/search.
 
 ### Quality Gates (Verify/Audit/Doctor) + Budgets
 

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -319,6 +319,31 @@ Invoke-ModuleBuild @buildParams -Settings {
     #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true -ID 'ToGitHub' -OverwriteTagName '<TagModuleVersionWithPreRelease>' -GenerateReleaseNotes
 
 
+    # Optional one-time maintainer preflight: installs prerequisites, registers/probes the feed, and primes cached Entra/Azure DevOps auth when needed.
+    #Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+    # Private feed publish target. This registers/refreshes the Azure Artifacts PSResourceGet repository before version checks and publish.
+    #New-ConfigurationPublish -AzureDevOpsOrganization 'evotecpl' -AzureDevOpsProject 'PowerShellGallery' -AzureArtifactsFeed 'PowerShellGalleryFeed' -RepositoryName 'EvotecPowerShellGallery' -Tool PSResourceGet -Enabled:$true
+
+    <#
+    Direct PSResourceGet way:
+    Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+    Install-PSResource -Name PSPublishModule -Repository EvotecPowerShellGallery -TrustRepository
+    Update-PSResource -Name PSPublishModule
+
+    PSPublishModule private module management:
+    Install-Module PSPublishModule -Scope CurrentUser
+    Initialize-ModuleRepository -ProfileName EvotecPowerShellGallery -Organization evotecpl -Project PowerShellGallery -Feed PowerShellGalleryFeed -InstallPrerequisites
+    Install-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+    Update-PrivateModule -ProfileName EvotecPowerShellGallery -Name PSPublishModule -InstallPrerequisites
+
+    Auth behavior:
+    If the credential provider has a valid cached Entra/Azure DevOps session, it should just use it.
+    If no token exists or the token expired, it should prompt through the Azure Artifacts Credential Provider login flow, usually browser/device-code style.
+    After successful login, the provider caches the session, so later install/update runs should not need anything fancy.
+    No PAT, username, or password should be needed for normal interactive users.
+    #>
+
+
     ### FOR TESTING PURPOSES ONLY ###
     ### SHOWING HOW THINGS WORK HERE ###
 

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -93,6 +95,77 @@ public sealed class ModulePublisherRepositoryVersionTests
         Assert.Contains("not greater than repository version '3.0.0'", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Publish_RegistersConfiguredRepositoryBeforeVersionCheck()
+    {
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        var calls = new List<string>();
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "PSPublishModule.psd1");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '3.0.13'; GUID = 'eb76426a-1992-40a5-82cd-6480f883ef4d'; RootModule = 'PSPublishModule.psm1' }");
+            File.WriteAllText(Path.Combine(stagingRoot, "PSPublishModule.psm1"), string.Empty);
+
+            var runner = new StubPowerShellRunner(request =>
+            {
+                var script = File.ReadAllText(request.ScriptPath!);
+                if (script.Contains("Register-PSResourceRepository", StringComparison.Ordinal))
+                {
+                    calls.Add("register");
+                    return new PowerShellRunResult(0, "PFPSRG::REPO::CREATED::0", string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Find-PSResource", StringComparison.Ordinal))
+                {
+                    calls.Add("find");
+                    return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Publish-PSResource", StringComparison.Ordinal))
+                {
+                    calls.Add("publish");
+                    return new PowerShellRunResult(0, "PFPSRG::PUBLISH::OK", string.Empty, "pwsh.exe");
+                }
+
+                throw new InvalidOperationException("Unexpected PowerShell script invocation.");
+            });
+            var publisher = new ModulePublisher(new NullLogger(), runner);
+
+            var publish = new PublishConfiguration
+            {
+                Destination = PublishDestination.PowerShellGallery,
+                Enabled = true,
+                Tool = PublishTool.PSResourceGet,
+                ApiKey = "AzureDevOps",
+                RepositoryName = "EvotecPowerShellGallery",
+                Repository = new PublishRepositoryConfiguration
+                {
+                    Name = "EvotecPowerShellGallery",
+                    Uri = "https://pkgs.dev.azure.com/evotecpl/PowerShellGallery/_packaging/PowerShellGalleryFeed/nuget/v3/index.json",
+                    Trusted = true,
+                    ApiVersion = RepositoryApiVersion.V3,
+                    EnsureRegistered = true
+                }
+            };
+            var plan = CreatePlan();
+            var buildResult = new ModuleBuildResult(
+                stagingPath: stagingRoot,
+                manifestPath: manifestPath,
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var result = publisher.Publish(publish, plan, buildResult, Array.Empty<ArtefactBuildResult>());
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(new[] { "register", "find", "publish" }, calls);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+                Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
     private static string Encode(string value)
         => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 
@@ -109,18 +182,81 @@ public sealed class ModulePublisherRepositoryVersionTests
             Encode(string.Empty)
         });
 
+    private static ModulePipelinePlan CreatePlan()
+    {
+        return new ModulePipelinePlan(
+            moduleName: "PSPublishModule",
+            projectRoot: @"C:\repo\PSPublishModule",
+            expectedVersion: "3.0.13",
+            resolvedVersion: "3.0.13",
+            preRelease: null,
+            manifest: null,
+            buildSpec: new ModuleBuildSpec
+            {
+                Name = "PSPublishModule",
+                SourcePath = @"C:\repo\PSPublishModule",
+                Version = "3.0.13"
+            },
+            resolvedCsprojPath: null,
+            syncNETProjectVersion: false,
+            compatiblePSEditions: Array.Empty<string>(),
+            requiredModules: Array.Empty<RequiredModuleReference>(),
+            externalModuleDependencies: Array.Empty<string>(),
+            requiredModulesForPackaging: Array.Empty<RequiredModuleReference>(),
+            information: null,
+            documentation: null,
+            delivery: null,
+            documentationBuild: null,
+            compatibilitySettings: null,
+            fileConsistencySettings: null,
+            validationSettings: null,
+            formatting: null,
+            importModules: null,
+            placeHolders: Array.Empty<PlaceHolderReplacement>(),
+            placeHolderOption: null,
+            commandModuleDependencies: new Dictionary<string, string[]>(),
+            testsAfterMerge: Array.Empty<TestConfiguration>(),
+            mergeModule: false,
+            mergeMissing: false,
+            doNotAttemptToFixRelativePaths: false,
+            approvedModules: Array.Empty<string>(),
+            moduleSkip: null,
+            signModule: false,
+            signing: null,
+            publishes: Array.Empty<ConfigurationPublishSegment>(),
+            artefacts: Array.Empty<ConfigurationArtefactSegment>(),
+            installEnabled: false,
+            installStrategy: InstallationStrategy.AutoRevision,
+            installKeepVersions: 3,
+            installRoots: Array.Empty<string>(),
+            installLegacyFlatHandling: LegacyFlatModuleHandling.Warn,
+            installPreserveVersions: Array.Empty<string>(),
+            installMissingModules: false,
+            installMissingModulesForce: false,
+            installMissingModulesPrerelease: false,
+            installMissingModulesRepository: null,
+            installMissingModulesCredential: null,
+            stagingWasGenerated: true,
+            deleteGeneratedStagingAfterRun: true);
+    }
+
     private sealed class StubPowerShellRunner : IPowerShellRunner
     {
-        private readonly PowerShellRunResult _result;
+        private readonly Func<PowerShellRunRequest, PowerShellRunResult> _run;
 
         public StubPowerShellRunner(PowerShellRunResult result)
         {
-            _result = result;
+            _run = _ => result;
+        }
+
+        public StubPowerShellRunner(Func<PowerShellRunRequest, PowerShellRunResult> run)
+        {
+            _run = run;
         }
 
         public PowerShellRunResult Run(PowerShellRunRequest request)
         {
-            return _result;
+            return _run(request);
         }
     }
 

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -126,6 +126,8 @@ public sealed class ModulePublisher
     {
         var credential = repoConfig?.Credential;
         string? temporaryPublishPath = null;
+        var repositoryCreated = false;
+        PublishRepositoryConfiguration? repositoryForPublish = repoConfig;
         var versionText = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
 
         try
@@ -136,6 +138,12 @@ public sealed class ModulePublisher
                 information: plan.Information,
                 delivery: plan.Delivery,
                 includeScriptFolders: includeScriptFolders);
+
+            if (repoConfig is not null && repoConfig.EnsureRegistered && HasRepositoryUris(repoConfig))
+            {
+                repositoryCreated = EnsureRepositoryRegistered(tool, repositoryName, repoConfig);
+                repositoryForPublish = CloneRegisteredRepository(repoConfig);
+            }
 
             if (!publish.Force)
                 EnsureVersionIsGreaterThanRepository(tool, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease, repositoryName, credential);
@@ -157,7 +165,7 @@ public sealed class ModulePublisher
                     RepositoryName = repositoryName,
                     Tool = tool,
                     ApiKey = string.IsNullOrWhiteSpace(publish.ApiKey) ? null : publish.ApiKey,
-                    Repository = repoConfig,
+                    Repository = repositoryForPublish,
                     DestinationPath = null,
                     SkipDependenciesCheck = tool != PublishTool.PowerShellGet,
                     SkipModuleManifestValidate = false
@@ -170,6 +178,18 @@ public sealed class ModulePublisher
         }
         finally
         {
+            if (repositoryCreated && repoConfig is { UnregisterAfterUse: true })
+            {
+                try
+                {
+                    UnregisterRepository(tool, repositoryName);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn($"Failed to unregister repository '{repositoryName}': {ex.Message}");
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(temporaryPublishPath))
                 CleanupTemporaryPublishPath(temporaryPublishPath);
         }
@@ -519,6 +539,79 @@ public sealed class ModulePublisher
 
         return FormatSemVer(resource.Version, resource.PreRelease);
     }
+
+    private static bool HasRepositoryUris(PublishRepositoryConfiguration repo)
+        => repo is not null &&
+           (!string.IsNullOrWhiteSpace(repo.Uri) ||
+            !string.IsNullOrWhiteSpace(repo.SourceUri) ||
+            !string.IsNullOrWhiteSpace(repo.PublishUri));
+
+    private bool EnsureRepositoryRegistered(PublishTool tool, string repositoryName, PublishRepositoryConfiguration repo)
+    {
+        if (tool == PublishTool.PowerShellGet)
+        {
+            var sourceUri = string.IsNullOrWhiteSpace(repo.SourceUri)
+                ? (string.IsNullOrWhiteSpace(repo.Uri) ? repo.PublishUri : repo.Uri)
+                : repo.SourceUri;
+            var publishUri = string.IsNullOrWhiteSpace(repo.PublishUri)
+                ? (string.IsNullOrWhiteSpace(repo.Uri) ? repo.SourceUri : repo.Uri)
+                : repo.PublishUri;
+
+            if (string.IsNullOrWhiteSpace(sourceUri) || string.IsNullOrWhiteSpace(publishUri))
+            {
+                throw new InvalidOperationException(
+                    $"Repository '{repositoryName}' is missing SourceUri/PublishUri/Uri for PowerShellGet registration.");
+            }
+
+            return _powerShellGet.EnsureRepositoryRegistered(
+                repositoryName,
+                sourceUri!,
+                publishUri!,
+                trusted: repo.Trusted,
+                timeout: TimeSpan.FromMinutes(2));
+        }
+
+        var uri = string.IsNullOrWhiteSpace(repo.Uri)
+            ? (string.IsNullOrWhiteSpace(repo.PublishUri) ? repo.SourceUri : repo.PublishUri)
+            : repo.Uri;
+
+        if (string.IsNullOrWhiteSpace(uri))
+            throw new InvalidOperationException($"Repository '{repositoryName}' is missing Uri/PublishUri/SourceUri for PSResourceGet registration.");
+
+        return _psResourceGet.EnsureRepositoryRegistered(
+            name: repositoryName,
+            uri: uri!,
+            trusted: repo.Trusted,
+            priority: repo.Priority,
+            apiVersion: repo.ApiVersion,
+            timeout: TimeSpan.FromMinutes(2));
+    }
+
+    private void UnregisterRepository(PublishTool tool, string repositoryName)
+    {
+        if (tool == PublishTool.PowerShellGet)
+        {
+            _powerShellGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
+            return;
+        }
+
+        _psResourceGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
+    }
+
+    private static PublishRepositoryConfiguration CloneRegisteredRepository(PublishRepositoryConfiguration repo)
+        => new()
+        {
+            Name = repo.Name,
+            Uri = repo.Uri,
+            SourceUri = repo.SourceUri,
+            PublishUri = repo.PublishUri,
+            Trusted = repo.Trusted,
+            Priority = repo.Priority,
+            ApiVersion = repo.ApiVersion,
+            EnsureRegistered = false,
+            UnregisterAfterUse = false,
+            Credential = repo.Credential
+        };
 
     private static (string RepositoryName, PublishRepositoryConfiguration? Repository) ResolveRepository(PublishConfiguration publish)
     {


### PR DESCRIPTION
## Summary
- add the PowerForge.Web private gallery engine plan as a dedicated architecture document
- define library boundaries for PowerForge, PowerForge.Web, PowerForge.Web.Cli, PSPublishModule, and PowerForge.PowerShell
- cross-link the private gallery indexing lane from the web roadmap and library ecosystem plan

## Validation
- git diff --check -- Docs/PowerForge.Web.PrivateGallery.md Docs/PowerForge.Web.Roadmap.md Docs/PowerForge.Web.LibraryEcosystemPlan.md

## Stacking
- stacked on top of #390 / `codex/private-gallery-publish-flow`