### PR TITLE
Fix route-relative web asset links

### DIFF
--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -340,7 +340,7 @@ public class WebSiteBuilderSafetyAndParityTests
                 """
                 ---
                 title: Register
-                slug: register
+                slug: v1.0
                 ---
 
                 Register
@@ -356,6 +356,79 @@ public class WebSiteBuilderSafetyAndParityTests
                 """);
 
             var spec = BuildBasicSpec("content/docs", "/docs");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.AssetRegistry = new AssetRegistrySpec
+            {
+                Bundles = new[]
+                {
+                    new AssetBundleSpec
+                    {
+                        Name = "global",
+                        Css = new[] { "themes/t/assets/site.css", "blob:https://example.test/style" },
+                        Js = new[] { "themes/t/assets/site.js", "file:///C:/assets/tool.js" }
+                    }
+                },
+                RouteBundles = new[]
+                {
+                    new RouteBundleSpec
+                    {
+                        Match = "/**",
+                        Bundles = new[] { "global" }
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "docs", "v1.0", "index.html"));
+
+            Assert.Contains("href=\"../../themes/t/assets/site.css\"", html, StringComparison.Ordinal);
+            Assert.Contains("src=\"../../themes/t/assets/site.js\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"blob:https://example.test/style\"", html, StringComparison.Ordinal);
+            Assert.Contains("src=\"file:///C:/assets/tool.js\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Build_RendersBareAssetRegistryLinksAtRootForNotFoundPage()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-route-relative-404-assets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "pages");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "404.md"),
+                """
+                ---
+                title: Not found
+                slug: 404
+                ---
+
+                Not found
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{ assets.css_html }}</head>
+                <body>{{ content }}{{ assets.js_html }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/pages", "/");
             spec.ThemesRoot = "themes";
             spec.DefaultTheme = "t";
             spec.ThemeEngine = "scriban";
@@ -385,10 +458,12 @@ public class WebSiteBuilderSafetyAndParityTests
 
             var plan = WebSitePlanner.Plan(spec, configPath);
             var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
-            var html = File.ReadAllText(Path.Combine(build.OutputPath, "docs", "register", "index.html"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "404.html"));
 
-            Assert.Contains("href=\"../../themes/t/assets/site.css\"", html, StringComparison.Ordinal);
-            Assert.Contains("src=\"../../themes/t/assets/site.js\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"themes/t/assets/site.css\"", html, StringComparison.Ordinal);
+            Assert.Contains("src=\"themes/t/assets/site.js\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("../themes/t/assets/site.css", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("../themes/t/assets/site.js", html, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -327,6 +327,77 @@ public class WebSiteBuilderSafetyAndParityTests
     }
 
     [Fact]
+    public void Build_RendersBareAssetRegistryLinksRelativeToCurrentRoute()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-route-relative-assets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var pagesPath = Path.Combine(root, "content", "docs");
+            Directory.CreateDirectory(pagesPath);
+            File.WriteAllText(Path.Combine(pagesPath, "register.md"),
+                """
+                ---
+                title: Register
+                slug: register
+                ---
+
+                Register
+                """);
+
+            WriteScribanTheme(root,
+                """
+                <!doctype html>
+                <html>
+                <head>{{ assets.css_html }}</head>
+                <body>{{ content }}{{ assets.js_html }}</body>
+                </html>
+                """);
+
+            var spec = BuildBasicSpec("content/docs", "/docs");
+            spec.ThemesRoot = "themes";
+            spec.DefaultTheme = "t";
+            spec.ThemeEngine = "scriban";
+            spec.AssetRegistry = new AssetRegistrySpec
+            {
+                Bundles = new[]
+                {
+                    new AssetBundleSpec
+                    {
+                        Name = "global",
+                        Css = new[] { "themes/t/assets/site.css" },
+                        Js = new[] { "themes/t/assets/site.js" }
+                    }
+                },
+                RouteBundles = new[]
+                {
+                    new RouteBundleSpec
+                    {
+                        Match = "/**",
+                        Bundles = new[] { "global" }
+                    }
+                }
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+
+            var plan = WebSitePlanner.Plan(spec, configPath);
+            var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "docs", "register", "index.html"));
+
+            Assert.Contains("href=\"../../themes/t/assets/site.css\"", html, StringComparison.Ordinal);
+            Assert.Contains("src=\"../../themes/t/assets/site.js\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_EmitsTraceWarning_WhenHeadFileCannotBeResolved()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-headfile-warning-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
+++ b/PowerForge.Tests/WebSiteBuilderSafetyAndParityTests.cs
@@ -340,7 +340,7 @@ public class WebSiteBuilderSafetyAndParityTests
                 """
                 ---
                 title: Register
-                slug: v1.0
+                slug: install.html
                 ---
 
                 Register
@@ -366,8 +366,8 @@ public class WebSiteBuilderSafetyAndParityTests
                     new AssetBundleSpec
                     {
                         Name = "global",
-                        Css = new[] { "themes/t/assets/site.css", "blob:https://example.test/style" },
-                        Js = new[] { "themes/t/assets/site.js", "file:///C:/assets/tool.js" }
+                        Css = new[] { "themes/t/assets/site.css", "blob:https://example.test/style", "../assets/section.css" },
+                        Js = new[] { "themes/t/assets/site.js", "file:///C:/assets/tool.js", "./local.js" }
                     }
                 },
                 RouteBundles = new[]
@@ -385,12 +385,14 @@ public class WebSiteBuilderSafetyAndParityTests
 
             var plan = WebSitePlanner.Plan(spec, configPath);
             var build = WebSiteBuilder.Build(spec, plan, Path.Combine(root, "_site"));
-            var html = File.ReadAllText(Path.Combine(build.OutputPath, "docs", "v1.0", "index.html"));
+            var html = File.ReadAllText(Path.Combine(build.OutputPath, "docs", "install.html", "index.html"));
 
             Assert.Contains("href=\"../../themes/t/assets/site.css\"", html, StringComparison.Ordinal);
             Assert.Contains("src=\"../../themes/t/assets/site.js\"", html, StringComparison.Ordinal);
             Assert.Contains("href=\"blob:https://example.test/style\"", html, StringComparison.Ordinal);
             Assert.Contains("src=\"file:///C:/assets/tool.js\"", html, StringComparison.Ordinal);
+            Assert.Contains("href=\"../assets/section.css\"", html, StringComparison.Ordinal);
+            Assert.Contains("src=\"./local.js\"", html, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -106,8 +106,9 @@ public static partial class WebSiteBuilder
             ? string.Empty
             : $"<link rel=\"canonical\" href=\"{System.Web.HttpUtility.HtmlEncode(canonicalUrl)}\" />";
 
-        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, item.OutputPath, assetSlotUsage.UseCssSlot ? spec.Head : null);
-        var jsHtml = RenderJsLinks(jsLinks, item.OutputPath);
+        var assetBaseRoute = ResolveHtmlAssetBaseRoute(item.OutputPath);
+        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, assetBaseRoute, assetSlotUsage.UseCssSlot ? spec.Head : null);
+        var jsHtml = RenderJsLinks(jsLinks, assetBaseRoute);
         var pageTitle = ResolveSeoTitle(spec, item);
         var pageDescription = ResolveMetaDescription(spec, item);
         var descriptionMeta = string.IsNullOrWhiteSpace(pageDescription)

--- a/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.OutputRendering.cs
@@ -106,8 +106,8 @@ public static partial class WebSiteBuilder
             ? string.Empty
             : $"<link rel=\"canonical\" href=\"{System.Web.HttpUtility.HtmlEncode(canonicalUrl)}\" />";
 
-        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, assetSlotUsage.UseCssSlot ? spec.Head : null);
-        var jsHtml = string.Join(Environment.NewLine, jsLinks.Select(j => $"<script src=\"{j}\" defer data-cfasync=\"false\"></script>"));
+        var cssHtml = RenderCssLinks(cssLinks, assetRegistry, item.OutputPath, assetSlotUsage.UseCssSlot ? spec.Head : null);
+        var jsHtml = RenderJsLinks(jsLinks, item.OutputPath);
         var pageTitle = ResolveSeoTitle(spec, item);
         var pageDescription = ResolveMetaDescription(spec, item);
         var descriptionMeta = string.IsNullOrWhiteSpace(pageDescription)

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -132,13 +132,14 @@ public static partial class WebSiteBuilder
 
     private static bool IsExternalOrRootedAssetHref(string href)
     {
-        return href.StartsWith("/", StringComparison.Ordinal) ||
-               href.StartsWith("#", StringComparison.Ordinal) ||
-               href.StartsWith("//", StringComparison.Ordinal) ||
-               href.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
-               href.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
-               href.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ||
-               href.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase);
+        if (href.StartsWith("/", StringComparison.Ordinal) ||
+            href.StartsWith("#", StringComparison.Ordinal) ||
+            href.StartsWith("//", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return Uri.TryCreate(href, UriKind.Absolute, out _);
     }
 
     private static string BuildRelativePrefixForRoute(string route)
@@ -150,12 +151,25 @@ public static partial class WebSiteBuilder
         var isDirectoryRoute = normalized.EndsWith("/", StringComparison.Ordinal);
         var segments = normalized.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         var lastSegment = segments.Length == 0 ? string.Empty : segments[^1];
-        var looksLikeFileRoute = lastSegment.Contains('.', StringComparison.Ordinal);
+        var looksLikeFileRoute = lastSegment.EndsWith(".html", StringComparison.OrdinalIgnoreCase) ||
+                                 lastSegment.EndsWith(".htm", StringComparison.OrdinalIgnoreCase);
         var depth = isDirectoryRoute || !looksLikeFileRoute ? segments.Length : Math.Max(0, segments.Length - 1);
         if (depth <= 0)
             return string.Empty;
 
         return string.Concat(Enumerable.Repeat("../", depth));
+    }
+
+    private static string ResolveHtmlAssetBaseRoute(string route)
+    {
+        var normalized = NormalizePath(route);
+        if (normalized.Equals("404", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Equals("404.html", StringComparison.OrdinalIgnoreCase))
+        {
+            return "/404.html";
+        }
+
+        return route;
     }
 
     private readonly record struct AssetSlotUsage(bool UsePreloadsSlot, bool UseCssSlot);

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -71,14 +71,14 @@ public static partial class WebSiteBuilder
         return sb.ToString();
     }
 
-    private static string RenderCssLinks(IEnumerable<string> cssLinks, AssetRegistrySpec? assets, HeadSpec? head = null)
+    private static string RenderCssLinks(IEnumerable<string> cssLinks, AssetRegistrySpec? assets, string route, HeadSpec? head = null)
     {
         var parts = new List<string>();
         var headStyles = RenderHeadLinks(head, static link => IsStylesheetHeadLink(link.Rel));
         if (!string.IsNullOrWhiteSpace(headStyles))
             parts.Add(headStyles);
 
-        var links = cssLinks.ToArray();
+        var links = cssLinks.Select(link => ResolveRouteRelativeAssetHref(link, route)).ToArray();
         if (links.Length == 0) return string.Join(Environment.NewLine, parts);
 
         var strategy = WebAssetCssStrategy.Normalize(assets?.CssStrategy);
@@ -94,6 +94,13 @@ public static partial class WebSiteBuilder
         return string.Join(Environment.NewLine, parts);
     }
 
+    private static string RenderJsLinks(IEnumerable<string> jsLinks, string route)
+    {
+        return string.Join(
+            Environment.NewLine,
+            jsLinks.Select(j => $"<script src=\"{ResolveRouteRelativeAssetHref(j, route)}\" defer data-cfasync=\"false\"></script>"));
+    }
+
     private static string RenderAsyncCssLink(string href)
     {
         return $@"<link rel=""stylesheet"" href=""{href}"" media=""print"" onload=""this.media='all'"" />
@@ -104,6 +111,51 @@ public static partial class WebSiteBuilder
     {
         return $@"<link rel=""preload"" href=""{href}"" as=""style"" onload=""this.onload=null;this.rel='stylesheet'"" />
 <noscript><link rel=""stylesheet"" href=""{href}"" /></noscript>";
+    }
+
+    private static string ResolveRouteRelativeAssetHref(string href, string route)
+    {
+        if (string.IsNullOrWhiteSpace(href))
+            return href;
+
+        var trimmed = href.Trim();
+        if (IsExternalOrRootedAssetHref(trimmed))
+            return trimmed;
+
+        var cleanHref = trimmed.StartsWith("./", StringComparison.Ordinal)
+            ? trimmed.Substring(2)
+            : trimmed;
+
+        var prefix = BuildRelativePrefixForRoute(route);
+        return prefix + cleanHref.TrimStart('/');
+    }
+
+    private static bool IsExternalOrRootedAssetHref(string href)
+    {
+        return href.StartsWith("/", StringComparison.Ordinal) ||
+               href.StartsWith("#", StringComparison.Ordinal) ||
+               href.StartsWith("//", StringComparison.Ordinal) ||
+               href.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+               href.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+               href.StartsWith("data:", StringComparison.OrdinalIgnoreCase) ||
+               href.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BuildRelativePrefixForRoute(string route)
+    {
+        if (string.IsNullOrWhiteSpace(route) || route == "/")
+            return string.Empty;
+
+        var normalized = route.Replace('\\', '/').Trim();
+        var isDirectoryRoute = normalized.EndsWith("/", StringComparison.Ordinal);
+        var segments = normalized.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var lastSegment = segments.Length == 0 ? string.Empty : segments[^1];
+        var looksLikeFileRoute = lastSegment.Contains('.', StringComparison.Ordinal);
+        var depth = isDirectoryRoute || !looksLikeFileRoute ? segments.Length : Math.Max(0, segments.Length - 1);
+        if (depth <= 0)
+            return string.Empty;
+
+        return string.Concat(Enumerable.Repeat("../", depth));
     }
 
     private readonly record struct AssetSlotUsage(bool UsePreloadsSlot, bool UseCssSlot);

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -122,12 +122,14 @@ public static partial class WebSiteBuilder
         if (IsExternalOrRootedAssetHref(trimmed))
             return trimmed;
 
-        var cleanHref = trimmed.StartsWith("./", StringComparison.Ordinal)
-            ? trimmed.Substring(2)
-            : trimmed;
+        if (trimmed.StartsWith("./", StringComparison.Ordinal) ||
+            trimmed.StartsWith("../", StringComparison.Ordinal))
+        {
+            return trimmed;
+        }
 
         var prefix = BuildRelativePrefixForRoute(route);
-        return prefix + cleanHref.TrimStart('/');
+        return prefix + trimmed.TrimStart('/');
     }
 
     private static bool IsExternalOrRootedAssetHref(string href)
@@ -150,9 +152,8 @@ public static partial class WebSiteBuilder
         var normalized = route.Replace('\\', '/').Trim();
         var isDirectoryRoute = normalized.EndsWith("/", StringComparison.Ordinal);
         var segments = normalized.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
-        var lastSegment = segments.Length == 0 ? string.Empty : segments[^1];
-        var looksLikeFileRoute = lastSegment.EndsWith(".html", StringComparison.OrdinalIgnoreCase) ||
-                                 lastSegment.EndsWith(".htm", StringComparison.OrdinalIgnoreCase);
+        var normalizedPath = NormalizePath(normalized);
+        var looksLikeFileRoute = normalizedPath.Equals("404.html", StringComparison.OrdinalIgnoreCase);
         var depth = isDirectoryRoute || !looksLikeFileRoute ? segments.Length : Math.Max(0, segments.Length - 1);
         if (depth <= 0)
             return string.Empty;


### PR DESCRIPTION
## Summary
- Rebase bare AssetRegistry CSS/JS hrefs relative to the current rendered route
- Preserve external, root-absolute, data, hash, and mailto asset hrefs
- Add coverage for nested pages using route-bundled theme assets

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "WebSiteBuilderSafetyAndParityTests|WebSiteBuilderPrismAssetInjectionTests" --no-restore