### PR TITLE
Add reusable module portal doc sources

### DIFF
--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -692,19 +692,12 @@ Example `portal.sources.json`:
       "placement": { "surface": "knowledge-base", "navigationGroup": "Documentation" }
     },
     {
-      "id": "pspublishmodule-package",
-      "kind": "package",
+      "id": "pspublishmodule",
+      "kind": "module",
       "module": "PSPublishModule",
-      "placement": { "surface": "module", "module": "PSPublishModule", "navigationGroup": "Bundled module docs" }
-    },
-    {
-      "id": "pspublishmodule-repository",
-      "kind": "github",
       "owner": "EvotecIT",
       "repo": "PSPublishModule",
-      "module": "PSPublishModule",
       "include": [ "README.md", "CHANGELOG.md", "Docs/PSPublishModule.PrivateGalleries.md" ],
-      "placement": { "surface": "module", "module": "PSPublishModule", "navigationGroup": "Repository docs" },
       "relationshipDefaults": { "module": "PSPublishModule", "tags": [ "PowerForge", "PrivateGallery" ] }
     },
     {
@@ -729,6 +722,12 @@ Notes:
 - `local` sources read markdown/text files from the website repository.
 - `package` sources project document assets discovered by `private-gallery-index`
   from inspected `.nupkg` content; no module code is imported or executed.
+- `module` sources are a reusable shortcut for company/private gallery sites.
+  They expand to a package-backed source plus a repository-backed source when
+  repository details are present. This lets a team declare one module once and
+  get bundled package docs and related repo docs under the same module page.
+  Use `includePackageDocs:false` or `includeRepositoryDocs:false` to disable
+  either side.
 - `github` sources enumerate repository files through the GitHub tree API and
   fetch raw content when `includeContent` is true. Use `tokenEnv` for private
   repositories or higher API limits.

--- a/Docs/PowerForge.Web.PrivateGallery.md
+++ b/Docs/PowerForge.Web.PrivateGallery.md
@@ -317,7 +317,10 @@ package-bundled documentation can be rendered by the portal docs pipeline.
 
 Status: initial module and related-document page generation is implemented via
 `portal-module-pages`, composing `private-gallery-index` feed data with
-`portal-docs-index` documentation data.
+`portal-docs-index` documentation data. `portal-docs-index` also supports a
+reusable `kind: "module"` source declaration that expands to package-bundled
+docs plus related repository docs when GitHub or Azure DevOps repository details
+are present.
 
 ### Slice 4: Metrics and Quality Signals
 

--- a/PowerForge.Tests/PortalDocsIndexTests.cs
+++ b/PowerForge.Tests/PortalDocsIndexTests.cs
@@ -189,6 +189,119 @@ public sealed class PortalDocsIndexTests
     }
 
     [Fact]
+    public void WebPortalDocsGenerator_ExpandsModuleSourceToPackageAndRepositoryDocs()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-portal-docs-module-source-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(Path.Combine(root, "data", "private-gallery"));
+
+        try
+        {
+            var gallery = new PrivateGalleryDocument
+            {
+                Packages =
+                {
+                    new PrivateGalleryPackage
+                    {
+                        Name = "Contoso.Tools",
+                        LatestVersion = "1.2.3",
+                        Module = new PrivateGalleryModuleMetadata
+                        {
+                            Name = "Contoso.Tools",
+                            Version = "1.2.3",
+                            Documents =
+                            {
+                                new PrivateGalleryDocumentAsset
+                                {
+                                    Path = "README.md",
+                                    Kind = "readme",
+                                    Content = "# Package README\n\nBundled module guidance."
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            File.WriteAllText(Path.Combine(root, "data", "private-gallery", "feed.json"), JsonSerializer.Serialize(gallery, JsonOptions));
+            File.WriteAllText(Path.Combine(root, "portal.sources.json"),
+                """
+                {
+                  "defaults": { "branch": "main" },
+                  "sources": [
+                    {
+                      "id": "contoso-tools",
+                      "kind": "module",
+                      "module": "Contoso.Tools",
+                      "owner": "EvotecIT",
+                      "repo": "Contoso.Tools",
+                      "include": [ "README.md" ],
+                      "relationshipDefaults": { "tags": [ "Internal" ] }
+                    }
+                  ]
+                }
+                """);
+
+            var handler = new StubHttpMessageHandler(request =>
+            {
+                if (request.RequestUri!.AbsoluteUri.Contains("/git/trees/main", StringComparison.Ordinal))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            """
+                            {
+                              "tree": [
+                                { "path": "README.md", "type": "blob" }
+                              ]
+                            }
+                            """,
+                            Encoding.UTF8,
+                            "application/json")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("# Repository README\n\nSource repository guidance.", Encoding.UTF8, "text/markdown")
+                };
+            });
+
+            var result = WebPortalDocsGenerator.Generate(new WebPortalDocsOptions
+            {
+                BaseDirectory = root,
+                SourcesPath = "./portal.sources.json",
+                PrivateGalleryPath = "./data/private-gallery/feed.json",
+                OutputDirectory = "./data/portal"
+            }, handler);
+
+            Assert.Equal(2, result.SourceCount);
+            Assert.Equal(2, result.DocumentCount);
+            Assert.Empty(result.Warnings);
+
+            var docs = JsonSerializer.Deserialize<WebPortalDocsDocument>(File.ReadAllText(result.DocsPath), JsonOptions)!;
+            Assert.Contains(docs.Sources, source => source.Id == "contoso-tools-package" && source.Kind == "package");
+            Assert.Contains(docs.Sources, source => source.Id == "contoso-tools-repository" && source.Kind == "github");
+            Assert.Contains(docs.Documents, doc =>
+                doc.SourceId == "contoso-tools-package" &&
+                doc.SourceKind == "package" &&
+                doc.Module == "Contoso.Tools" &&
+                doc.NavigationGroup == "Bundled module docs" &&
+                doc.Summary == "Bundled module guidance.");
+            Assert.Contains(docs.Documents, doc =>
+                doc.SourceId == "contoso-tools-repository" &&
+                doc.SourceKind == "github" &&
+                doc.Module == "Contoso.Tools" &&
+                doc.NavigationGroup == "Repository docs" &&
+                doc.Summary == "Source repository guidance." &&
+                doc.Tags.Contains("Internal"));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void WebPortalDocsGenerator_FetchesGitHubRepositoryDocs()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-portal-docs-gh-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/PortalDocsIndexTests.cs
+++ b/PowerForge.Tests/PortalDocsIndexTests.cs
@@ -398,6 +398,75 @@ public sealed class PortalDocsIndexTests
     }
 
     [Fact]
+    public void WebPortalDocsGenerator_ModuleRepositorySourceUsesRepositoryCoordinatesForFallbackId()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-portal-docs-module-repo-id-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "portal.sources.json"),
+                """
+                {
+                  "sources": [
+                    {
+                      "kind": "module",
+                      "owner": "EvotecIT",
+                      "repo": "RepoOnly",
+                      "includePackageDocs": false,
+                      "include": [ "README.md" ]
+                    }
+                  ]
+                }
+                """);
+
+            var handler = new StubHttpMessageHandler(request =>
+            {
+                if (request.RequestUri!.AbsoluteUri.Contains("/git/trees/main", StringComparison.Ordinal))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            """
+                            {
+                              "tree": [
+                                { "path": "README.md", "type": "blob" }
+                              ]
+                            }
+                            """,
+                            Encoding.UTF8,
+                            "application/json")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("# Repo Docs\n\nRepository-only docs.", Encoding.UTF8, "text/markdown")
+                };
+            });
+
+            var result = WebPortalDocsGenerator.Generate(new WebPortalDocsOptions
+            {
+                BaseDirectory = root,
+                SourcesPath = "./portal.sources.json",
+                OutputDirectory = "./data/portal"
+            }, handler);
+
+            Assert.Equal(1, result.SourceCount);
+            Assert.Equal(1, result.DocumentCount);
+            Assert.Empty(result.Warnings);
+
+            var docs = JsonSerializer.Deserialize<WebPortalDocsDocument>(File.ReadAllText(result.DocsPath), JsonOptions)!;
+            Assert.Contains(docs.Sources, source => source.Id == "evotecit-repoonly-repository" && source.Kind == "github");
+            Assert.Equal("evotecit-repoonly-repository", Assert.Single(docs.Documents).SourceId);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void WebPortalDocsGenerator_FetchesGitHubRepositoryDocs()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-portal-docs-gh-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/PortalDocsIndexTests.cs
+++ b/PowerForge.Tests/PortalDocsIndexTests.cs
@@ -302,6 +302,102 @@ public sealed class PortalDocsIndexTests
     }
 
     [Fact]
+    public void WebPortalDocsGenerator_ModuleSourceUsesResolvedModuleAndHandlesNullCollections()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-portal-docs-module-source-guards-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        Directory.CreateDirectory(Path.Combine(root, "data", "private-gallery"));
+
+        try
+        {
+            var gallery = new PrivateGalleryDocument
+            {
+                Packages =
+                {
+                    new PrivateGalleryPackage
+                    {
+                        Name = "Contoso.Tools",
+                        Module = new PrivateGalleryModuleMetadata
+                        {
+                            Name = "Contoso.Tools",
+                            Documents =
+                            {
+                                new PrivateGalleryDocumentAsset
+                                {
+                                    Path = "README.md",
+                                    Kind = "readme",
+                                    Content = "# Contoso README\n\nExpected package docs."
+                                }
+                            }
+                        }
+                    },
+                    new PrivateGalleryPackage
+                    {
+                        Name = "Other.Tools",
+                        Module = new PrivateGalleryModuleMetadata
+                        {
+                            Name = "Other.Tools",
+                            Documents =
+                            {
+                                new PrivateGalleryDocumentAsset
+                                {
+                                    Path = "README.md",
+                                    Kind = "readme",
+                                    Content = "# Other README\n\nUnexpected package docs."
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            File.WriteAllText(Path.Combine(root, "data", "private-gallery", "feed.json"), JsonSerializer.Serialize(gallery, JsonOptions));
+            File.WriteAllText(Path.Combine(root, "portal.sources.json"),
+                """
+                {
+                  "sources": [
+                    {
+                      "kind": "module",
+                      "include": null,
+                      "exclude": null,
+                      "classify": null,
+                      "placement": { "module": "Contoso.Tools", "order": null },
+                      "relationshipDefaults": { "tags": null }
+                    },
+                    {
+                      "id": "missing-module",
+                      "kind": "module",
+                      "includeRepositoryDocs": false
+                    }
+                  ]
+                }
+                """);
+
+            var result = WebPortalDocsGenerator.Generate(new WebPortalDocsOptions
+            {
+                BaseDirectory = root,
+                SourcesPath = "./portal.sources.json",
+                PrivateGalleryPath = "./data/private-gallery/feed.json",
+                OutputDirectory = "./data/portal"
+            });
+
+            Assert.Equal(1, result.SourceCount);
+            Assert.Equal(1, result.DocumentCount);
+            Assert.Contains(result.Warnings, warning => warning.Contains("requires module", StringComparison.OrdinalIgnoreCase));
+
+            var docs = JsonSerializer.Deserialize<WebPortalDocsDocument>(File.ReadAllText(result.DocsPath), JsonOptions)!;
+            Assert.Contains(docs.Sources, source => source.Id == "contoso-tools-package" && source.Kind == "package");
+            var document = Assert.Single(docs.Documents);
+            Assert.Equal("Contoso.Tools", document.Module);
+            Assert.Equal("contoso-tools-package", document.SourceId);
+            Assert.DoesNotContain(docs.Documents, doc => doc.Module == "Other.Tools");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void WebPortalDocsGenerator_FetchesGitHubRepositoryDocs()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-portal-docs-gh-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web/Services/WebPortalDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebPortalDocsGenerator.cs
@@ -192,8 +192,20 @@ public static partial class WebPortalDocsGenerator
 
     private static string BuildExpandedSourceId(WebPortalDocsSourceSpec source, string? module, string suffix)
         => string.IsNullOrWhiteSpace(source.Id)
-            ? MakeSafeFragment($"{module}-{suffix}")
+            ? MakeSafeFragment($"{ResolveExpandedSourceKey(source, module)}-{suffix}")
             : $"{source.Id}-{suffix}";
+
+    private static string ResolveExpandedSourceKey(WebPortalDocsSourceSpec source, string? module)
+    {
+        if (!string.IsNullOrWhiteSpace(module))
+            return module!;
+        if (!string.IsNullOrWhiteSpace(source.Owner) && !string.IsNullOrWhiteSpace(source.Repo))
+            return $"{source.Owner}-{source.Repo}";
+        if (!string.IsNullOrWhiteSpace(source.Organization) && !string.IsNullOrWhiteSpace(source.Project) && !string.IsNullOrWhiteSpace(source.Repository ?? source.Repo))
+            return $"{source.Organization}-{source.Project}-{source.Repository ?? source.Repo}";
+
+        return source.Title ?? source.Repository ?? source.Repo ?? source.Path ?? "module";
+    }
 
     private static string DescribeSource(WebPortalDocsSourceSpec source)
         => source.Id ?? source.Title ?? source.Module ?? source.Repo ?? source.Repository ?? "module";

--- a/PowerForge.Web/Services/WebPortalDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebPortalDocsGenerator.cs
@@ -43,7 +43,7 @@ public static partial class WebPortalDocsGenerator
         var gallery = LoadPrivateGallery(galleryPath, document.Warnings);
         using var http = CreateHttpClient(options, messageHandler);
 
-        foreach (var source in sourceSpec.Sources)
+        foreach (var source in ExpandModuleSources(sourceSpec.Sources))
         {
             var normalizedSource = CreateSource(source);
             document.Sources.Add(normalizedSource);
@@ -54,6 +54,7 @@ public static partial class WebPortalDocsGenerator
                 {
                     "local" => IndexLocalSource(sourceSpec.Defaults, source, normalizedSource, baseDir, options, document.Warnings),
                     "package" => IndexPackageSource(sourceSpec.Defaults, source, normalizedSource, gallery, options, document.Warnings),
+                    "module" or "module-docs" or "moduleDocs" => UnsupportedSource(source, normalizedSource, document.Warnings),
                     "github" => await IndexGitHubSource(sourceSpec.Defaults, source, normalizedSource, http, options, token, document.Warnings).ConfigureAwait(false),
                     "azure-devops" or "azuredevops" => await IndexAzureDevOpsSource(sourceSpec.Defaults, source, normalizedSource, http, options, token, document.Warnings).ConfigureAwait(false),
                     _ => UnsupportedSource(source, normalizedSource, document.Warnings)
@@ -120,6 +121,142 @@ public static partial class WebPortalDocsGenerator
         var spec = JsonSerializer.Deserialize<WebPortalDocsSourcesSpec>(File.ReadAllText(sourcesPath), WebJson.Options);
         return spec ?? new WebPortalDocsSourcesSpec();
     }
+
+    private static List<WebPortalDocsSourceSpec> ExpandModuleSources(IEnumerable<WebPortalDocsSourceSpec> sources)
+    {
+        var expanded = new List<WebPortalDocsSourceSpec>();
+        foreach (var source in sources)
+        {
+            if (!IsModuleSource(source))
+            {
+                expanded.Add(source);
+                continue;
+            }
+
+            var module = source.Module ?? source.RelationshipDefaults?.Module ?? source.Placement?.Module;
+            var includePackageDocs = source.IncludePackageDocs ?? source.IncludePackage ?? true;
+            var includeRepositoryDocs = source.IncludeRepositoryDocs ?? source.IncludeRepository ?? HasRepositorySource(source);
+            if (includePackageDocs)
+                expanded.Add(CreatePackageSource(source, module));
+            if (includeRepositoryDocs)
+                expanded.Add(CreateRepositorySource(source, module));
+        }
+
+        return expanded;
+    }
+
+    private static bool IsModuleSource(WebPortalDocsSourceSpec source)
+        => source.Kind?.Equals("module", StringComparison.OrdinalIgnoreCase) == true ||
+           source.Kind?.Equals("module-docs", StringComparison.OrdinalIgnoreCase) == true ||
+           source.Kind?.Equals("moduleDocs", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static WebPortalDocsSourceSpec CreatePackageSource(WebPortalDocsSourceSpec source, string? module)
+    {
+        var copy = CloneSource(source);
+        copy.Id = BuildExpandedSourceId(source, "package");
+        copy.Kind = "package";
+        copy.Title ??= string.IsNullOrWhiteSpace(module) ? "Package docs" : $"{module} package docs";
+        copy.Module = module ?? source.Module;
+        copy.Placement ??= new WebPortalDocsPlacement();
+        copy.Placement.Module ??= module;
+        copy.Placement.Surface ??= "module";
+        copy.Placement.NavigationGroup ??= "Bundled module docs";
+        copy.RelationshipDefaults ??= new WebPortalDocsRelationshipDefaults();
+        copy.RelationshipDefaults.Module ??= module;
+        copy.RelationshipDefaults.Package ??= module;
+        return copy;
+    }
+
+    private static WebPortalDocsSourceSpec CreateRepositorySource(WebPortalDocsSourceSpec source, string? module)
+    {
+        var copy = CloneSource(source);
+        copy.Id = BuildExpandedSourceId(source, "repository");
+        copy.Kind = ResolveRepositoryKind(source);
+        copy.Title ??= string.IsNullOrWhiteSpace(module) ? "Repository docs" : $"{module} repository docs";
+        copy.Module = module ?? source.Module;
+        copy.Placement ??= new WebPortalDocsPlacement();
+        copy.Placement.Module ??= module;
+        copy.Placement.Surface ??= "module";
+        copy.Placement.NavigationGroup ??= "Repository docs";
+        copy.RelationshipDefaults ??= new WebPortalDocsRelationshipDefaults();
+        copy.RelationshipDefaults.Module ??= module;
+        copy.RelationshipDefaults.Package ??= module;
+        return copy;
+    }
+
+    private static string BuildExpandedSourceId(WebPortalDocsSourceSpec source, string suffix)
+        => string.IsNullOrWhiteSpace(source.Id)
+            ? MakeSafeFragment($"{source.Module}-{suffix}")
+            : $"{source.Id}-{suffix}";
+
+    private static string ResolveRepositoryKind(WebPortalDocsSourceSpec source)
+    {
+        if (!string.IsNullOrWhiteSpace(source.RepositoryKind))
+            return source.RepositoryKind!;
+        if (!string.IsNullOrWhiteSpace(source.Organization) || !string.IsNullOrWhiteSpace(source.Project))
+            return "azure-devops";
+        return "github";
+    }
+
+    private static bool HasRepositorySource(WebPortalDocsSourceSpec source)
+        => !string.IsNullOrWhiteSpace(source.Owner) ||
+           !string.IsNullOrWhiteSpace(source.Repo) ||
+           !string.IsNullOrWhiteSpace(source.Organization) ||
+           !string.IsNullOrWhiteSpace(source.Project) ||
+           !string.IsNullOrWhiteSpace(source.Repository);
+
+    private static WebPortalDocsSourceSpec CloneSource(WebPortalDocsSourceSpec source)
+        => new()
+        {
+            Id = source.Id,
+            Kind = source.Kind,
+            Title = source.Title,
+            Description = source.Description,
+            Path = source.Path,
+            Section = source.Section,
+            Module = source.Module,
+            Owner = source.Owner,
+            Repo = source.Repo,
+            Organization = source.Organization,
+            Project = source.Project,
+            Repository = source.Repository,
+            RepositoryKind = source.RepositoryKind,
+            Branch = source.Branch,
+            Authentication = source.Authentication,
+            Auth = source.Auth,
+            Include = source.Include.ToList(),
+            Exclude = source.Exclude.ToList(),
+            Classify = new Dictionary<string, string>(source.Classify, StringComparer.OrdinalIgnoreCase),
+            Placement = ClonePlacement(source.Placement),
+            RelationshipDefaults = CloneRelationshipDefaults(source.RelationshipDefaults),
+            IncludePackage = source.IncludePackage,
+            IncludePackageDocs = source.IncludePackageDocs,
+            IncludeRepository = source.IncludeRepository,
+            IncludeRepositoryDocs = source.IncludeRepositoryDocs
+        };
+
+    private static WebPortalDocsPlacement? ClonePlacement(WebPortalDocsPlacement? placement)
+        => placement is null
+            ? null
+            : new WebPortalDocsPlacement
+            {
+                Surface = placement.Surface,
+                Module = placement.Module,
+                NavigationGroup = placement.NavigationGroup,
+                Order = placement.Order.ToList()
+            };
+
+    private static WebPortalDocsRelationshipDefaults? CloneRelationshipDefaults(WebPortalDocsRelationshipDefaults? defaults)
+        => defaults is null
+            ? null
+            : new WebPortalDocsRelationshipDefaults
+            {
+                Module = defaults.Module,
+                Package = defaults.Package,
+                Version = defaults.Version,
+                Command = defaults.Command,
+                Tags = defaults.Tags.ToList()
+            };
 
     private static PrivateGalleryDocument? LoadPrivateGallery(string? galleryPath, List<string> warnings)
     {
@@ -763,6 +900,8 @@ public static partial class WebPortalDocsGenerator
 
         public string? Repository { get; set; }
 
+        public string? RepositoryKind { get; set; }
+
         public string? Branch { get; set; }
 
         public string? Authentication { get; set; }
@@ -778,6 +917,14 @@ public static partial class WebPortalDocsGenerator
         public WebPortalDocsPlacement? Placement { get; set; }
 
         public WebPortalDocsRelationshipDefaults? RelationshipDefaults { get; set; }
+
+        public bool? IncludePackage { get; set; }
+
+        public bool? IncludePackageDocs { get; set; }
+
+        public bool? IncludeRepository { get; set; }
+
+        public bool? IncludeRepositoryDocs { get; set; }
     }
 
     private sealed class WebPortalDocsPlacement

--- a/PowerForge.Web/Services/WebPortalDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebPortalDocsGenerator.cs
@@ -43,7 +43,7 @@ public static partial class WebPortalDocsGenerator
         var gallery = LoadPrivateGallery(galleryPath, document.Warnings);
         using var http = CreateHttpClient(options, messageHandler);
 
-        foreach (var source in ExpandModuleSources(sourceSpec.Sources))
+        foreach (var source in ExpandModuleSources(sourceSpec.Sources, document.Warnings))
         {
             var normalizedSource = CreateSource(source);
             document.Sources.Add(normalizedSource);
@@ -122,7 +122,7 @@ public static partial class WebPortalDocsGenerator
         return spec ?? new WebPortalDocsSourcesSpec();
     }
 
-    private static List<WebPortalDocsSourceSpec> ExpandModuleSources(IEnumerable<WebPortalDocsSourceSpec> sources)
+    private static List<WebPortalDocsSourceSpec> ExpandModuleSources(IEnumerable<WebPortalDocsSourceSpec> sources, List<string> warnings)
     {
         var expanded = new List<WebPortalDocsSourceSpec>();
         foreach (var source in sources)
@@ -137,7 +137,13 @@ public static partial class WebPortalDocsGenerator
             var includePackageDocs = source.IncludePackageDocs ?? source.IncludePackage ?? true;
             var includeRepositoryDocs = source.IncludeRepositoryDocs ?? source.IncludeRepository ?? HasRepositorySource(source);
             if (includePackageDocs)
-                expanded.Add(CreatePackageSource(source, module));
+            {
+                if (string.IsNullOrWhiteSpace(module))
+                    warnings.Add($"Module source '{DescribeSource(source)}' requires module, relationshipDefaults.module, or placement.module before package docs can be indexed.");
+                else
+                    expanded.Add(CreatePackageSource(source, module));
+            }
+
             if (includeRepositoryDocs)
                 expanded.Add(CreateRepositorySource(source, module));
         }
@@ -153,7 +159,7 @@ public static partial class WebPortalDocsGenerator
     private static WebPortalDocsSourceSpec CreatePackageSource(WebPortalDocsSourceSpec source, string? module)
     {
         var copy = CloneSource(source);
-        copy.Id = BuildExpandedSourceId(source, "package");
+        copy.Id = BuildExpandedSourceId(source, module, "package");
         copy.Kind = "package";
         copy.Title ??= string.IsNullOrWhiteSpace(module) ? "Package docs" : $"{module} package docs";
         copy.Module = module ?? source.Module;
@@ -170,7 +176,7 @@ public static partial class WebPortalDocsGenerator
     private static WebPortalDocsSourceSpec CreateRepositorySource(WebPortalDocsSourceSpec source, string? module)
     {
         var copy = CloneSource(source);
-        copy.Id = BuildExpandedSourceId(source, "repository");
+        copy.Id = BuildExpandedSourceId(source, module, "repository");
         copy.Kind = ResolveRepositoryKind(source);
         copy.Title ??= string.IsNullOrWhiteSpace(module) ? "Repository docs" : $"{module} repository docs";
         copy.Module = module ?? source.Module;
@@ -184,10 +190,13 @@ public static partial class WebPortalDocsGenerator
         return copy;
     }
 
-    private static string BuildExpandedSourceId(WebPortalDocsSourceSpec source, string suffix)
+    private static string BuildExpandedSourceId(WebPortalDocsSourceSpec source, string? module, string suffix)
         => string.IsNullOrWhiteSpace(source.Id)
-            ? MakeSafeFragment($"{source.Module}-{suffix}")
+            ? MakeSafeFragment($"{module}-{suffix}")
             : $"{source.Id}-{suffix}";
+
+    private static string DescribeSource(WebPortalDocsSourceSpec source)
+        => source.Id ?? source.Title ?? source.Module ?? source.Repo ?? source.Repository ?? "module";
 
     private static string ResolveRepositoryKind(WebPortalDocsSourceSpec source)
     {
@@ -224,9 +233,9 @@ public static partial class WebPortalDocsGenerator
             Branch = source.Branch,
             Authentication = source.Authentication,
             Auth = source.Auth,
-            Include = source.Include.ToList(),
-            Exclude = source.Exclude.ToList(),
-            Classify = new Dictionary<string, string>(source.Classify, StringComparer.OrdinalIgnoreCase),
+            Include = CopyList(source.Include),
+            Exclude = CopyList(source.Exclude),
+            Classify = CopyDictionary(source.Classify),
             Placement = ClonePlacement(source.Placement),
             RelationshipDefaults = CloneRelationshipDefaults(source.RelationshipDefaults),
             IncludePackage = source.IncludePackage,
@@ -243,7 +252,7 @@ public static partial class WebPortalDocsGenerator
                 Surface = placement.Surface,
                 Module = placement.Module,
                 NavigationGroup = placement.NavigationGroup,
-                Order = placement.Order.ToList()
+                Order = CopyList(placement.Order)
             };
 
     private static WebPortalDocsRelationshipDefaults? CloneRelationshipDefaults(WebPortalDocsRelationshipDefaults? defaults)
@@ -255,8 +264,16 @@ public static partial class WebPortalDocsGenerator
                 Package = defaults.Package,
                 Version = defaults.Version,
                 Command = defaults.Command,
-                Tags = defaults.Tags.ToList()
+                Tags = CopyList(defaults.Tags)
             };
+
+    private static List<T> CopyList<T>(IEnumerable<T>? values)
+        => values is null ? new List<T>() : values.ToList();
+
+    private static Dictionary<string, string> CopyDictionary(Dictionary<string, string>? values)
+        => values is null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(values, StringComparer.OrdinalIgnoreCase);
 
     private static PrivateGalleryDocument? LoadPrivateGallery(string? galleryPath, List<string> warnings)
     {

--- a/Schemas/powerforge.portal.sources.schema.json
+++ b/Schemas/powerforge.portal.sources.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.portal.sources.schema.json",
+  "title": "PowerForge Portal Sources",
+  "type": "object",
+  "required": [ "sources" ],
+  "properties": {
+    "schemaVersion": { "type": "integer", "const": 1 },
+    "format": { "type": "string", "const": "powerforge.portal.sources" },
+    "defaults": { "$ref": "#/$defs/sourceDefaults" },
+    "sources": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/source" }
+    }
+  },
+  "$defs": {
+    "sourceDefaults": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "branch": { "type": "string" },
+        "include": { "type": "array", "items": { "type": "string" } },
+        "exclude": { "type": "array", "items": { "type": "string" } },
+        "classify": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": [ "kind" ],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string" },
+        "kind": {
+          "type": "string",
+          "enum": [ "local", "package", "github", "azure-devops", "azuredevops", "module", "module-docs", "moduleDocs" ]
+        },
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "path": { "type": "string" },
+        "owner": { "type": "string" },
+        "repo": { "type": "string" },
+        "project": { "type": "string" },
+        "organization": { "type": "string" },
+        "repository": { "type": "string" },
+        "repositoryKind": { "type": "string", "enum": [ "github", "azure-devops", "azuredevops" ] },
+        "branch": { "type": "string" },
+        "authentication": { "type": "string" },
+        "auth": { "type": "string" },
+        "module": { "type": "string" },
+        "section": { "type": "string" },
+        "include": { "type": "array", "items": { "type": "string" } },
+        "exclude": { "type": "array", "items": { "type": "string" } },
+        "includePackage": { "type": "boolean" },
+        "includePackageDocs": { "type": "boolean" },
+        "includeRepository": { "type": "boolean" },
+        "includeRepositoryDocs": { "type": "boolean" },
+        "placement": { "$ref": "#/$defs/placement" },
+        "relationshipDefaults": { "$ref": "#/$defs/relationshipDefaults" }
+      }
+    },
+    "placement": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "surface": { "type": "string" },
+        "module": { "type": "string" },
+        "navigationGroup": { "type": "string" },
+        "order": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "relationshipDefaults": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "module": { "type": "string" },
+        "package": { "type": "string" },
+        "version": { "type": "string" },
+        "command": { "type": "string" },
+        "tags": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `kind: "module"` portal docs sources that expand to package and repository documentation sources
- add engine-owned portal sources schema with module-source options
- document the module source shortcut for private/company gallery sites

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "PortalDocsIndexTests|PortalModulePagesTests"`
- PowerShellGalleryDemo build against this branch with `POWERFORGE_ROOT=C:\Support\GitHub\PSPublishModule-gallery-doc-sources`: `./build.ps1 -Ci`
- local browser smoke on module, generated package README, and SOP pages: 0 warnings/errors