### PR TITLE
Make website report uploads best effort

### DIFF
--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -186,6 +186,7 @@ jobs:
 
       - name: Upload website reports
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ inputs.report_artifact_name }}


### PR DESCRIPTION
## Summary
- keep diagnostic website report artifact uploads from failing otherwise successful website pipelines when artifact storage quota is exhausted
- leave Pages deployment artifact uploads strict

## Validation
- git diff --check