### PR TITLE
Fix Windows Pages artifact archive

### DIFF
--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -236,14 +236,12 @@ jobs:
           Write-Host "::group::Archive Pages artifact"
           $tarArgs = @(
             '--dereference',
-            '--hard-dereference',
             '--directory',
             $env:PAGES_ARTIFACT_PATH,
             '-cf',
             (Join-Path $env:RUNNER_TEMP 'artifact.tar'),
             '--exclude=.git',
             '--exclude=.github',
-            '--force-local',
             '.'
           )
           tar @tarArgs


### PR DESCRIPTION
## Summary
- remove GNU tar-only flags from the Windows Pages artifact archive step in the shared PowerForge website runner
- keep Linux/macOS archive behavior unchanged

## Validation
- Windows tar smoke command matching the workflow arguments completed successfully
- git diff --check

## Context
TestimoX post-merge deploy reached the Pages archive step after the seo-doctor guardrail fix, then failed because Windows tar.exe does not support --hard-dereference or --force-local.