### PR TITLE
Validate Pages artifact archive in website CI

### DIFF
--- a/.github/workflows/powerforge-website-ci.yml
+++ b/.github/workflows/powerforge-website-ci.yml
@@ -29,6 +29,14 @@ on:
         required: false
         type: string
         default: "powerforge-website-reports"
+      validate_pages_artifact:
+        required: false
+        type: boolean
+        default: false
+      pages_artifact_path:
+        required: false
+        type: string
+        default: ""
       powerforge_lock_path:
         required: false
         type: string
@@ -97,6 +105,8 @@ jobs:
       powerforge_web_tag: ${{ inputs.powerforge_web_tag }}
       pipeline_mode: ci
       use_playwright_cache: true
+      validate_pages_artifact: ${{ inputs.validate_pages_artifact }}
+      pages_artifact_path: ${{ inputs.pages_artifact_path }}
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
       repository_read_token: ${{ secrets.repository_read_token }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -73,6 +73,10 @@ on:
         required: false
         type: boolean
         default: false
+      validate_pages_artifact:
+        required: false
+        type: boolean
+        default: false
       pages_artifact_path:
         required: false
         type: string
@@ -195,8 +199,16 @@ jobs:
             ./${{ inputs.website_root }}/_site/_reports/**
           if-no-files-found: ignore
 
+      - name: Cleanup Playwright cache before Pages artifact
+        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact) && inputs.use_playwright_cache }}
+        shell: pwsh
+        run: |
+          if (-not [string]::IsNullOrWhiteSpace($env:PLAYWRIGHT_BROWSERS_PATH) -and (Test-Path -LiteralPath $env:PLAYWRIGHT_BROWSERS_PATH)) {
+            Remove-Item -LiteralPath $env:PLAYWRIGHT_BROWSERS_PATH -Recurse -Force
+          }
+
       - name: Archive Pages artifact
-        if: ${{ inputs.upload_pages_artifact && runner.os == 'Linux' }}
+        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact) && runner.os == 'Linux' }}
         shell: sh
         env:
           PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
@@ -212,7 +224,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Archive Pages artifact
-        if: ${{ inputs.upload_pages_artifact && runner.os == 'macOS' }}
+        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact) && runner.os == 'macOS' }}
         shell: sh
         env:
           PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
@@ -228,16 +240,30 @@ jobs:
           echo "::endgroup::"
 
       - name: Archive Pages artifact
-        if: ${{ inputs.upload_pages_artifact && runner.os == 'Windows' }}
+        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact) && runner.os == 'Windows' }}
         shell: pwsh
         env:
           PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
         run: |
           Write-Host "::group::Archive Pages artifact"
+          $resolvedArtifactPath = [System.IO.Path]::GetFullPath($env:PAGES_ARTIFACT_PATH)
+          if (-not (Test-Path -LiteralPath $resolvedArtifactPath)) {
+            throw "Pages artifact path not found: $resolvedArtifactPath"
+          }
+
+          $tempRoot = [System.IO.Path]::GetPathRoot($env:RUNNER_TEMP)
+          $freeBytes = ([System.IO.DriveInfo]::new($tempRoot)).AvailableFreeSpace
+          $sourceBytes = (Get-ChildItem -LiteralPath $resolvedArtifactPath -Recurse -Force -File | Measure-Object -Property Length -Sum).Sum
+          $requiredBytes = [Math]::Max(1GB, [int64]($sourceBytes * 1.1))
+          Write-Host ("Pages artifact source: {0:n0} bytes; runner temp free: {1:n0} bytes; required estimate: {2:n0} bytes" -f $sourceBytes, $freeBytes, $requiredBytes)
+          if ($freeBytes -lt $requiredBytes) {
+            throw "Not enough free space on $tempRoot to archive Pages artifact. Free $freeBytes bytes, estimated need $requiredBytes bytes for $resolvedArtifactPath."
+          }
+
           $tarArgs = @(
             '--dereference',
             '--directory',
-            $env:PAGES_ARTIFACT_PATH,
+            $resolvedArtifactPath,
             '-cf',
             (Join-Path $env:RUNNER_TEMP 'artifact.tar'),
             '--exclude=.git',

--- a/Module/PSPublishModule.Tests.ps1
+++ b/Module/PSPublishModule.Tests.ps1
@@ -90,7 +90,6 @@ $env:PSPUBLISHMODULE_TEST_SOURCE_ROOT = $script:SourceRoot
 $PSDInformation = Import-PowerShellDataFile -Path $PrimaryModule.FullName
 $RequiredModules = @(
     'Pester'
-    'PSWriteColor'
     if ($PSDInformation.RequiredModules) {
         $PSDInformation.RequiredModules
     }
@@ -106,6 +105,30 @@ foreach ($Module in $RequiredModules) {
         $Exists = Get-Module -ListAvailable $Module -ErrorAction SilentlyContinue
         if (-not $Exists) {
             Install-Module -Name $Module -Force -SkipPublisherCheck
+        }
+    }
+}
+
+if (-not (Get-Command -Name Write-Color -ErrorAction SilentlyContinue)) {
+    function Write-Color {
+        param(
+            [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+            [AllowEmptyCollection()]
+            [object[]] $Text,
+
+            [object[]] $Color,
+
+            [int] $LinesBefore = 0
+        )
+
+        for ($index = 0; $index -lt $LinesBefore; $index++) {
+            Write-Host
+        }
+
+        if ($Text -and $Text.Count -gt 0) {
+            Write-Host (($Text | ForEach-Object { [string] $_ }) -join '')
+        } else {
+            Write-Host
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a validate_pages_artifact mode to the reusable website runner so PR checks can exercise Pages artifact archiving without uploading/deploying Pages
- expose the option through powerforge-website-ci.yml for website repositories
- clean the Playwright cache before Pages archive and print Windows free-space/source-size diagnostics before tar runs

## Why
TestimoX deploy failed after green PR checks because PR website CI skipped the deploy-only Pages artifact archive path. This makes that failure mode visible during PR checks when a site opts in.

## Validation
- Windows tar archive smoke command passed locally
- git diff --check