### PR TITLE
Prune expired GitHub artifacts

### DIFF
--- a/PowerForge.Tests/GitHubArtifactCleanupServiceTests.cs
+++ b/PowerForge.Tests/GitHubArtifactCleanupServiceTests.cs
@@ -110,7 +110,38 @@ public sealed class GitHubArtifactCleanupServiceTests
         Assert.Equal(22, result.Planned[0].Id);
     }
 
-    private static FakeArtifact Artifact(long id, string name, int daysAgo)
+    [Fact]
+    public void Prune_ExpiredArtifacts_AreDeletionCandidatesEvenInsideKeepWindow()
+    {
+        var artifacts = new[]
+        {
+            Artifact(id: 31, name: "github-pages", daysAgo: 1, expired: true),
+            Artifact(id: 32, name: "github-pages", daysAgo: 2, expired: false)
+        };
+
+        var handler = new FakeGitHubArtifactsHandler(artifacts);
+        using var client = new HttpClient(handler);
+        var service = new GitHubArtifactCleanupService(new NullLogger(), client);
+
+        var result = service.Prune(new GitHubArtifactCleanupSpec
+        {
+            Repository = "EvotecIT/TestimoX",
+            Token = "test-token",
+            KeepLatestPerName = 1,
+            MaxAgeDays = 1,
+            MaxDelete = 10,
+            DryRun = true
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.MatchedArtifacts);
+        Assert.Single(result.Planned);
+        Assert.Equal(31, result.Planned[0].Id);
+        Assert.Equal("expired", result.Planned[0].Reason);
+        Assert.Equal(1, result.KeptByRecentWindow);
+    }
+
+    private static FakeArtifact Artifact(long id, string name, int daysAgo, bool expired = false)
     {
         var timestamp = DateTimeOffset.UtcNow.AddDays(-daysAgo);
         return new FakeArtifact
@@ -119,7 +150,8 @@ public sealed class GitHubArtifactCleanupServiceTests
             Name = name,
             SizeInBytes = 1024 + id,
             CreatedAt = timestamp,
-            UpdatedAt = timestamp
+            UpdatedAt = timestamp,
+            Expired = expired
         };
     }
 
@@ -152,7 +184,7 @@ public sealed class GitHubArtifactCleanupServiceTests
                         id = a.Id,
                         name = a.Name,
                         size_in_bytes = a.SizeInBytes,
-                        expired = false,
+                        expired = a.Expired,
                         created_at = a.CreatedAt.ToString("O"),
                         updated_at = a.UpdatedAt.ToString("O"),
                         workflow_run = new { id = 1000 + a.Id }
@@ -199,5 +231,6 @@ public sealed class GitHubArtifactCleanupServiceTests
         public long SizeInBytes { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public DateTimeOffset UpdatedAt { get; set; }
+        public bool Expired { get; set; }
     }
 }

--- a/PowerForge/Services/GitHubArtifactCleanupService.cs
+++ b/PowerForge/Services/GitHubArtifactCleanupService.cs
@@ -58,7 +58,6 @@ public sealed class GitHubArtifactCleanupService
             : (DateTimeOffset?)null;
 
         var matched = allArtifacts
-            .Where(a => !a.Expired)
             .Where(a => MatchesAnyPattern(a.Name, normalized.IncludeNames, defaultWhenEmpty: true))
             .Where(a => !MatchesAnyPattern(a.Name, normalized.ExcludeNames, defaultWhenEmpty: false))
             .ToArray();
@@ -73,15 +72,24 @@ public sealed class GitHubArtifactCleanupService
                 .OrderByDescending(GetSortTimestamp)
                 .ThenByDescending(a => a.Id)
                 .ToArray();
+            var nonExpiredIndex = 0;
 
             for (var index = 0; index < ordered.Length; index++)
             {
                 var artifact = ordered[index];
-                if (index < normalized.KeepLatestPerName)
+                if (artifact.Expired)
                 {
-                    keptByRecentWindow++;
+                    planned.Add(ToItem(artifact, reason: "expired"));
                     continue;
                 }
+
+                if (nonExpiredIndex < normalized.KeepLatestPerName)
+                {
+                    keptByRecentWindow++;
+                    nonExpiredIndex++;
+                    continue;
+                }
+                nonExpiredIndex++;
 
                 if (ageCutoff is not null && GetSortTimestamp(artifact) > ageCutoff.Value)
                 {


### PR DESCRIPTION
## Summary
- include GitHub-expired Actions artifacts in artifact cleanup matching
- plan expired artifacts for deletion even when they fall inside the keep/latest or age windows
- add focused coverage for expired artifacts remaining deletion candidates

## Context
TestimoX website maintenance scanned 5,339 GitHub Actions artifacts, all expired, but planned/deleted 0 because the cleanup service filtered expired artifacts out before matching. Those expired artifacts can still count against GitHub Actions artifact storage until GitHub removes or recalculates them, so cleanup needs to delete them explicitly.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter GitHubArtifactCleanupServiceTests --no-restore --nologo`
- `git diff --check`