### PR TITLE
fix(docs): keep documentation generation native

### DIFF
--- a/Docs/PSPublishModule.ParityMatrix.md
+++ b/Docs/PSPublishModule.ParityMatrix.md
@@ -25,7 +25,7 @@ Legend:
 | PlaceHolder | Custom placeholders used during merge/build | Applied to merged PSM1 | [OK] |
 | PlaceHolderOption | Skip built-in replacements | Applied during placeholder replacement | [OK] |
 | Documentation (paths) | Emits `Documentation` segment (Path/Readme) | `ConfigurationDocumentationSegment` | [OK] |
-| Documentation (build) | `BuildDocumentation` segment, PlatyPS/HelpOut checks | `ConfigurationBuildDocumentationSegment` + C# docs engine; no module availability check | [PARTIAL] (no pre-check) |
+| Documentation (build) | `BuildDocumentation` segment | `ConfigurationBuildDocumentationSegment` + built-in PowerForge docs engine | [OK] |
 | Delivery metadata | Options.Delivery with internals bundle + repo paths | `ConfigurationOptionsSegment` + delivery metadata written in pipeline | [OK] plus Install/Update command generation |
 | Publish | Gallery/GitHub publish settings | `ConfigurationPublishSegment` + repository registration options | [OK] plus repo/tool controls |
 | Formatting | `Invoke-Formatter` options applied to merge/standard | `ConfigurationFormattingSegment` + formatter settings | [OK] |

--- a/Module/Docs/New-ConfigurationDocumentation.md
+++ b/Module/Docs/New-ConfigurationDocumentation.md
@@ -11,7 +11,7 @@ Enables or disables creation of documentation from the module using PowerForge.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-ConfigurationDocumentation -Path <string> -PathReadme <string> [-Enable] [-StartClean] [-UpdateWhenNew] [-SyncExternalHelpToProjectRoot] [-SkipExternalHelp] [-SkipAboutTopics] [-SkipFallbackExamples] [-ExternalHelpCulture <string>] [-ExternalHelpFileName <string>] [-AboutTopicsSourcePath <string[]>] [-Tool <DocumentationTool>] [<CommonParameters>]
+New-ConfigurationDocumentation -Path <string> -PathReadme <string> [-Enable] [-StartClean] [-UpdateWhenNew] [-SyncExternalHelpToProjectRoot] [-SkipExternalHelp] [-SkipAboutTopics] [-SkipFallbackExamples] [-ExternalHelpCulture <string>] [-ExternalHelpFileName <string>] [-AboutTopicsSourcePath <string[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -215,22 +215,6 @@ Type: SwitchParameter
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
-
-Required: False
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
-
-### -Tool
-Documentation engine (legacy parameter; kept for compatibility).
-
-```yaml
-Type: DocumentationTool
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values: PlatyPS, HelpOut, PowerForge
 
 Required: False
 Position: named

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -16176,23 +16176,6 @@ back to the project root (e.g. en-US\&lt;ModuleName&gt;-help.xml).</maml:para>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Tool</maml:name>
-          <maml:description>
-            <maml:para>Documentation engine (legacy parameter; kept for compatibility).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">DocumentationTool</command:parameterValue>
-          <command:parameterValueGroup>
-            <command:parameterValue required="false" variableLength="false">PlatyPS</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">HelpOut</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">PowerForge</command:parameterValue>
-          </command:parameterValueGroup>
-          <dev:type>
-            <maml:name>DocumentationTool</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>UpdateWhenNew</maml:name>
           <maml:description>
             <maml:para>When enabled, generated documentation is also synced back to the project folder&#xD;
@@ -16338,23 +16321,6 @@ back to the project root (e.g. en-US\&lt;ModuleName&gt;-help.xml).</maml:para>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
           <maml:name>SwitchParameter</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-        <maml:name>Tool</maml:name>
-        <maml:description>
-          <maml:para>Documentation engine (legacy parameter; kept for compatibility).</maml:para>
-        </maml:description>
-        <command:parameterValue required="false" variableLength="false">DocumentationTool</command:parameterValue>
-        <command:parameterValueGroup>
-          <command:parameterValue required="false" variableLength="false">PlatyPS</command:parameterValue>
-          <command:parameterValue required="false" variableLength="false">HelpOut</command:parameterValue>
-          <command:parameterValue required="false" variableLength="false">PowerForge</command:parameterValue>
-        </command:parameterValueGroup>
-        <dev:type>
-          <maml:name>DocumentationTool</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/PSPublishModule/Cmdlets/NewConfigurationDocumentationCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationDocumentationCommand.cs
@@ -78,9 +78,6 @@ public sealed class NewConfigurationDocumentationCommand : PSCmdlet
     /// <summary>Path to the readme file that will be used for the documentation.</summary>
     [Parameter(Mandatory = true)] public string PathReadme { get; set; } = string.Empty;
 
-    /// <summary>Documentation engine (legacy parameter; kept for compatibility).</summary>
-    [Parameter(DontShow = true)] public PowerForge.DocumentationTool Tool { get; set; } = PowerForge.DocumentationTool.PowerForge;
-
     /// <summary>Emits documentation configuration for the build pipeline.</summary>
     protected override void ProcessRecord()
     {

--- a/PowerForge.Cli/Program.cs
+++ b/PowerForge.Cli/Program.cs
@@ -616,7 +616,7 @@ internal static partial class Program
 
                 if (plan.DocumentationBuild is not null && plan.DocumentationBuild.Enable)
                 {
-                    logger.Info($"Docs: {plan.Documentation?.Path} ({plan.DocumentationBuild.Tool})");
+                    logger.Info($"Docs: {plan.Documentation?.Path}");
                 }
 
                 if (plan.Artefacts.Length > 0) logger.Info($"Artefacts: {plan.Artefacts.Length}");

--- a/PowerForge.PowerShell/Services/DocumentationConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/DocumentationConfigurationFactory.cs
@@ -41,7 +41,6 @@ internal sealed class DocumentationConfigurationFactory
                     StartClean = request.StartClean,
                     UpdateWhenNew = request.UpdateWhenNew,
                     SyncExternalHelpToProjectRoot = request.SyncExternalHelpToProjectRoot,
-                    Tool = DocumentationTool.PowerForge,
                     IncludeAboutTopics = !request.SkipAboutTopics,
                     GenerateFallbackExamples = !request.SkipFallbackExamples,
                     GenerateExternalHelp = !request.SkipExternalHelp,

--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -95,7 +95,6 @@ public sealed class DocumentationEngine
         {
             return new DocumentationBuildResult(
                 enabled: false,
-                tool: DocumentationTool.PowerForge,
                 docsPath: ResolvePath(stagingPath, documentation.Path),
                 readmePath: ResolvePath(stagingPath, documentation.PathReadme, optional: true),
                 succeeded: true,
@@ -233,7 +232,6 @@ public sealed class DocumentationEngine
 
             return new DocumentationBuildResult(
                 enabled: true,
-                tool: DocumentationTool.PowerForge,
                 docsPath: docsPath,
                 readmePath: readmePath,
                 succeeded: true,
@@ -248,7 +246,6 @@ public sealed class DocumentationEngine
 
             return new DocumentationBuildResult(
                 enabled: true,
-                tool: DocumentationTool.PowerForge,
                 docsPath: docsPath,
                 readmePath: readmePath,
                 succeeded: false,

--- a/PowerForge.Tests/DocumentationBinaryFixtureTests.cs
+++ b/PowerForge.Tests/DocumentationBinaryFixtureTests.cs
@@ -131,6 +131,94 @@ public sealed class DocumentationBinaryFixtureTests
         return outputDirectory;
     }
 
+    [Fact]
+    public void DocumentationEngine_HandlesCommandParameterNamedKeys()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "pf-docs-keys-parameter-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            const string moduleName = "KeyCollisionModule";
+            var modulePath = Path.Combine(tempRoot, moduleName + ".psm1");
+            var manifestPath = Path.Combine(tempRoot, moduleName + ".psd1");
+
+            File.WriteAllText(modulePath, """
+function Invoke-KeyCollision {
+    <#
+    .SYNOPSIS
+    Invokes a documentation extraction fixture.
+
+    .PARAMETER Keys
+    Key names that exercise dictionary key/member collision handling.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]] $Keys
+    )
+
+    $Keys
+}
+""", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            File.WriteAllText(manifestPath, """
+@{
+    RootModule = 'KeyCollisionModule.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '77777777-7777-7777-7777-777777777777'
+    Author = 'PowerForge.Tests'
+    Description = 'Script fixture module for documentation extraction key collision tests.'
+    FunctionsToExport = @('Invoke-KeyCollision')
+    CmdletsToExport = @()
+    AliasesToExport = @()
+    VariablesToExport = @()
+}
+""", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            var engine = new DocumentationEngine(new PowerShellRunner(), new NullLogger());
+            var result = engine.Build(
+                moduleName: moduleName,
+                stagingPath: tempRoot,
+                moduleManifestPath: manifestPath,
+                documentation: new DocumentationConfiguration
+                {
+                    Path = "Docs",
+                    PathReadme = Path.Combine("Docs", "Readme.md")
+                },
+                buildDocumentation: new BuildDocumentationConfiguration
+                {
+                    Enable = true,
+                    StartClean = true,
+                    GenerateExternalHelp = true,
+                    IncludeAboutTopics = false,
+                    GenerateFallbackExamples = true
+                });
+
+            Assert.True(result.Succeeded, result.ErrorMessage);
+
+            var markdownPath = Path.Combine(tempRoot, "Docs", "Invoke-KeyCollision.md");
+            Assert.True(File.Exists(markdownPath), $"Expected generated markdown help at '{markdownPath}'.");
+
+            var markdown = File.ReadAllText(markdownPath);
+            Assert.Contains("### -Keys", markdown);
+            Assert.Contains("Key names that exercise dictionary key/member collision handling.", markdown);
+            Assert.DoesNotContain("ParameterType", markdown);
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(tempRoot))
+                    Directory.Delete(tempRoot, true);
+            }
+            catch
+            {
+                // Best effort cleanup; do not mask assertion failures.
+            }
+        }
+    }
+
     private static string NormalizeText(string text)
         => (text ?? string.Empty).Replace("\r\n", "\n").Trim();
 }

--- a/PowerForge/Models/Configuration/ConfigurationDocumentationSegments.cs
+++ b/PowerForge/Models/Configuration/ConfigurationDocumentationSegments.cs
@@ -57,9 +57,6 @@ public sealed class BuildDocumentationConfiguration
     /// </summary>
     public bool SyncExternalHelpToProjectRoot { get; set; }
 
-    /// <summary>Documentation tool selection.</summary>
-    public DocumentationTool Tool { get; set; } = DocumentationTool.PowerForge;
-
     /// <summary>
     /// When enabled, converts <c>about_*.help.txt</c> / <c>about_*.txt</c> / <c>about_*.md</c> / <c>about_*.markdown</c> topic files found in the module
     /// into markdown pages under <c>Docs/About</c>.

--- a/PowerForge/Models/Configuration/ConfigurationEnums.cs
+++ b/PowerForge/Models/Configuration/ConfigurationEnums.cs
@@ -247,19 +247,6 @@ public enum DeliveryBundleDestination
 }
 
 /// <summary>
-/// Documentation tool used by documentation configuration.
-/// </summary>
-public enum DocumentationTool
-{
-    /// <summary>Legacy: Use PlatyPS to generate markdown help.</summary>
-    PlatyPS,
-    /// <summary>Legacy: Use HelpOut to generate markdown help.</summary>
-    HelpOut,
-    /// <summary>Use PowerForge built-in generator.</summary>
-    PowerForge
-}
-
-/// <summary>
 /// Artefact type for artefact configuration.
 /// </summary>
 public enum ArtefactType

--- a/PowerForge/Models/DocumentationBuildResult.cs
+++ b/PowerForge/Models/DocumentationBuildResult.cs
@@ -8,9 +8,6 @@ public sealed class DocumentationBuildResult
     /// <summary>True when documentation generation was enabled.</summary>
     public bool Enabled { get; }
 
-    /// <summary>Tool used to generate documentation.</summary>
-    public DocumentationTool Tool { get; }
-
     /// <summary>Full path to the docs output folder.</summary>
     public string DocsPath { get; }
 
@@ -40,7 +37,6 @@ public sealed class DocumentationBuildResult
     /// </summary>
     public DocumentationBuildResult(
         bool enabled,
-        DocumentationTool tool,
         string docsPath,
         string readmePath,
         bool succeeded,
@@ -50,7 +46,6 @@ public sealed class DocumentationBuildResult
         string? errorMessage)
     {
         Enabled = enabled;
-        Tool = tool;
         DocsPath = docsPath;
         ReadmePath = readmePath;
         Succeeded = succeeded;

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -101,7 +101,11 @@ try {
 
     $commonParamNames = @('Verbose','Debug','ErrorAction','ErrorVariable','WarningAction','WarningVariable','InformationAction','InformationVariable','OutVariable','OutBuffer','PipelineVariable','WhatIf','Confirm','ProgressAction')
     $paramNames = @()
-    try { if ($c -and $c.Parameters) { $paramNames = @($c.Parameters.Keys) } } catch { $paramNames = @() }
+    try {
+      if ($c -and $c.Parameters) {
+        $paramNames = @($c.Parameters.GetEnumerator() | ForEach-Object { [string]$_.Key })
+      }
+    } catch { $paramNames = @() }
     foreach ($hp in $helpParameters) { try { $paramNames += [string]$hp.Name } catch {
       # best effort: keep extracting other parameters even when one help node is incomplete
     } }
@@ -138,8 +142,8 @@ try {
 
       try {
         if ($pmeta -and $pmeta.ParameterSets) {
-          foreach ($setName in @($pmeta.ParameterSets.Keys)) {
-            $psm = $pmeta.ParameterSets[$setName]
+          foreach ($setEntry in @($pmeta.ParameterSets.GetEnumerator())) {
+            $psm = $setEntry.Value
             if ($psm) {
               if ($psm.IsMandatory) { $required = $true }
               $pPos = [int]$psm.Position
@@ -323,8 +327,8 @@ try {
 
         $supportsPipeline = $false
         try {
-          foreach ($setName in @($pmeta.ParameterSets.Keys)) {
-            $psm = $pmeta.ParameterSets[$setName]
+          foreach ($setEntry in @($pmeta.ParameterSets.GetEnumerator())) {
+            $psm = $setEntry.Value
             if ($psm -and ($psm.ValueFromPipeline -or $psm.ValueFromPipelineByPropertyName)) {
               $supportsPipeline = $true
               break

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace PowerForge;
 
 /// <summary>
-/// Writes markdown help files in a PlatyPS-compatible structure.
+/// Writes PowerShell command markdown help files.
 /// </summary>
 internal sealed class MarkdownHelpWriter
 {

--- a/README.MD
+++ b/README.MD
@@ -142,7 +142,7 @@ Compatibility aliases from PSMaintenance are preserved: `Show-Documentation`, `I
 
 PowerForge can generate PowerShell help from a built module:
 
-- Markdown help (PlatyPS-compatible): `Docs/*.md`
+- Markdown help: `Docs/*.md`
 - External help for `Get-Help` (MAML): `<culture>/<ModuleName>-help.xml` (default culture: `en-US`)
 - About topics (from `about_*.help.txt` / `about_*.txt`): converted to `Docs/About/*.md` and listed in `Docs/Readme.md`
 

--- a/Schemas/powerforge.common.schema.json
+++ b/Schemas/powerforge.common.schema.json
@@ -64,10 +64,6 @@
       "type": "string",
       "enum": ["Internals", "Root", "Both", "None"]
     },
-    "DocumentationTool": {
-      "type": "string",
-      "enum": ["PlatyPS", "HelpOut", "PowerForge"]
-    },
     "TestExecutionWhen": {
       "type": "string",
       "enum": ["AfterMerge"]

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -120,7 +120,6 @@
         "StartClean": { "type": "boolean" },
         "UpdateWhenNew": { "type": "boolean" },
         "SyncExternalHelpToProjectRoot": { "type": "boolean" },
-        "Tool": { "$ref": "powerforge.common.schema.json#/$defs/DocumentationTool" },
         "IncludeAboutTopics": { "type": "boolean" },
         "GenerateFallbackExamples": { "type": "boolean" },
         "GenerateExternalHelp": { "type": "boolean" },

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 **Goals**
 - Move PSPublishModule behavior into a reusable C# library and thin PowerShell wrappers.
 - Make functionality reusable by GitHub Actions and other repos without scripts.
-- Replace PlatyPS/HelpOut with a C# help/doc generator.
+- Keep documentation generation inside the built-in PowerForge help/doc engine.
 - Fix reliability: versioned installs, safe formatting, deterministic encodings, no “in use” self-build pain.
 - Keep today’s UX (messages, defaults) while improving robustness/performance.
 - Enable future tooling (VSCode extension) via stable machine-readable outputs and JSON configuration.
@@ -24,7 +24,7 @@
 - `PowerForge` build/export detection supports explicit binary assembly names (`ExportAssemblies`) and will not clobber existing manifest exports when binaries are missing (`DisableBinaryCmdletScan` + safe fallback).
 - `New-Configuration*` cmdlets now emit typed `PowerForge` configuration segment objects (no `OrderedDictionary`/`Hashtable` outputs); the legacy DSL parser accepts both typed segments and legacy dictionaries.
 - `PowerForge.Cli` supports `build`/`install` via `--config <json>` and machine output via `--output json` (stable envelope with `schemaVersion` + `command` + `success` + `exitCode` + payload; source-generated System.Text.Json for AOT/trim), plus `pipeline`/`run` to execute a full typed pipeline spec from JSON (segment array + build/install options), and `plan` to preview the pipeline without running it.
-- `ModulePipelineRunner` now executes `ConfigurationDocumentationSegment`/`ConfigurationBuildDocumentationSegment` (PowerForge docs generator; no PlatyPS/HelpOut), `ConfigurationArtefactSegment` (Packed/Unpacked) including optional required-module bundling via PSResourceGet `Save-PSResource` (out-of-proc) with PowerShellGet `Save-Module` fallback, and `ConfigurationPublishSegment` (PSResourceGet `Publish-PSResource` + GitHub releases), producing typed results.
+- `ModulePipelineRunner` now executes `ConfigurationDocumentationSegment`/`ConfigurationBuildDocumentationSegment` (built-in PowerForge docs generator), `ConfigurationArtefactSegment` (Packed/Unpacked) including optional required-module bundling via PSResourceGet `Save-PSResource` (out-of-proc) with PowerShellGet `Save-Module` fallback, and `ConfigurationPublishSegment` (PSResourceGet `Publish-PSResource` + GitHub releases), producing typed results.
 - `Invoke-ModuleBuild` routes both the simple build path and the legacy DSL (`-Settings {}` / `Build-Module {}`) through the PowerForge pipeline (C#); the legacy PowerShell `Start-*` build scripts were removed.
 - `Module/Build/Build-ModuleSelf.ps1` self-builds by building `PowerForge.Cli` and running the JSON pipeline (`powerforge.json`) so PSPublishModule can self-build without file locking.
 - PowerShell compatibility analysis no longer depends on PowerShell helper functions (moved to C# analyzer).
@@ -98,12 +98,12 @@
 - Exact installs sync the target directory to staging (remove stale files that are not present in the new build).
 - PowerShell wrappers call C# installer; messages preserved.
 
-**Phase 3 — Docs Engine (replace PlatyPS/HelpOut)**
+**Phase 3 — Docs Engine**
 - `DocumentationEngine` service:
-  - Source (MVP): out-of-proc `Get-Command` + `Get-Help` (no PlatyPS/HelpOut) for script + cmdlet parity.
-  - Emit (MVP): PlatyPS-style Markdown help files + module page (Readme.md) + external help MAML (`<culture>\<ModuleName>-help.xml`).
-  - Keep legacy knobs (`Tool`, `UpdateWhenNew`) as no-ops for compatibility.
-- PlatyPS/HelpOut usage removed (legacy enum values remain for compatibility).
+  - Source (MVP): out-of-proc `Get-Command` + `Get-Help` for script + cmdlet parity.
+  - Emit (MVP): Markdown help files + module page (Readme.md) + external help MAML (`<culture>\<ModuleName>-help.xml`).
+  - `UpdateWhenNew` remains as the project-root sync switch.
+- Documentation generation uses the built-in PowerForge engine only.
 
 **Phase 4 — CLI + GitHub Actions + VSCode**
 - `PowerForge.Cli` tool commands (all backed by `PowerForge` services):
@@ -138,7 +138,7 @@
 - Keep PowerShell module multi-targeting (`net472` + modern) without blocking CLI AOT.
 
 **Deprecations To Remove (when parity reached)**
-- PlatyPS and HelpOut usage (done: replaced by PowerForge docs generator; legacy enum values remain for compatibility).
+- External documentation providers (done: documentation generation uses the built-in PowerForge engine only).
 - In-proc PSScriptAnalyzer formatting.
 - Unversioned installs to `...\\Modules\\Name\\`.
 - Scripted `Publish-Module` flow; prefer `PowerForge` publishers or out-of-proc PSResourceGet wrapper only when requested.
@@ -204,7 +204,7 @@
   - [x] Add `--view auto|standard|ansi` (auto disables live UI in CI).
   - [x] Add interactive Spectre.Console progress for `docs`/`pack`/`pipeline` in Standard view (auto disables in CI and when `--output json`/`--no-color`/`--quiet`).
   - [x] Document the JSON schema (VSCode extension baseline): `JSON_SCHEMA.md` + `Schemas/`.
-- [x] Finish docs engine MVP and remove PlatyPS/HelpOut.
+- [x] Finish docs engine MVP and keep documentation generation in PowerForge.
 - [x] Add GitHub composite actions calling the CLI.
 - [ ] Validate AOT publish for CLI (code is AOT/trim-friendly; verify end-to-end publish in CI with a native toolchain on Windows runners).
   - [ ] Current blocker: `dotnet publish -p:PublishAot=true` fails due to AOT analysis errors in `Microsoft.PowerShell.SDK` (System.Management.Automation), `Newtonsoft.Json`, and related dependencies (single-file + reflection-heavy APIs).


### PR DESCRIPTION
## Summary
- remove the legacy documentation provider surface so PowerForge uses only the built-in documentation engine
- drop the hidden `New-ConfigurationDocumentation -Tool` parameter and schema/config `DocumentationTool` entries
- fix native help extraction for commands with parameters named `Keys` by enumerating dictionary entries explicitly
- refresh current docs/help text so the removed provider knob is no longer advertised

## Validation
- `dotnet build .\PSPublishModule.sln -c Release --nologo`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~Documentation" --nologo`
- imported `PSPublishModule\bin\Release\net8.0\PSPublishModule.dll` and confirmed `New-ConfigurationDocumentation` no longer exposes `Tool`
- parsed updated schema JSON files with `ConvertFrom-Json`