### PR TITLE
Preserve transitive required modules

### DIFF
--- a/Module/Help/About/about_ModuleDependencies.help.txt
+++ b/Module/Help/About/about_ModuleDependencies.help.txt
@@ -31,6 +31,11 @@ LONG DESCRIPTION
         Used by merge and missing-function workflows so selected helper functions can be copied into the built module.
         Use this for helper libraries that should contribute functions, not for runtime dependency declaration.
 
+    When a RequiredModule is also configured as an ApprovedModule and merge-missing behavior removes that parent
+    module from the generated manifest, PowerForge preserves the parent's own RequiredModules as runtime
+    dependencies. Installed module metadata is used by default; explicit dependency declarations and configured
+    dependency version sources, such as PSGallery, take precedence when they are present.
+
     VERSION EXPECTATIONS
 
     You can describe version intent in one of two ways:
@@ -83,6 +88,8 @@ LONG DESCRIPTION
         New-ConfigurationArtefact -AddRequiredModules
 
     This packaging step only bundles RequiredModule dependencies. ExternalModule entries are intentionally excluded.
+    Transitive RequiredModules discovered from bundled dependencies are included so offline artefacts keep the
+    dependency chain intact.
 
     HOW REQUIREDMODULESSOURCE WORKS
 

--- a/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
+++ b/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
@@ -142,9 +142,16 @@ internal sealed class DotNetPublishPreparationService
                     if (profile?.Targets is not { Length: > 0 })
                         continue;
 
+                    var originalTargets = profile.Targets;
                     profile.Targets = profile.Targets
                         .Where(target => !string.IsNullOrWhiteSpace(target) && selected.Contains(target.Trim()))
                         .ToArray();
+                    if (profile.Targets.Length == 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"Profile '{profile.Name}' does not match target override value(s): {string.Join(", ", overrideTargets)}. " +
+                            $"Profile target(s): {string.Join(", ", originalTargets)}.");
+                    }
                 }
             }
 

--- a/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
+++ b/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
@@ -137,10 +137,16 @@ internal sealed class DotNetPublishPreparationService
 
             if (spec.Profiles is { Length: > 0 })
             {
+                var activeProfileName = ResolveActiveProfileName(spec);
                 foreach (var profile in spec.Profiles)
                 {
                     if (profile?.Targets is not { Length: > 0 })
                         continue;
+                    if (string.IsNullOrWhiteSpace(activeProfileName) ||
+                        !string.Equals(profile.Name, activeProfileName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
 
                     var originalTargets = profile.Targets;
                     profile.Targets = profile.Targets
@@ -203,6 +209,16 @@ internal sealed class DotNetPublishPreparationService
             spec.DotNet.Build = false;
             spec.DotNet.NoBuildInPublish = true;
         }
+    }
+
+    private static string? ResolveActiveProfileName(DotNetPublishSpec spec)
+    {
+        if (!string.IsNullOrWhiteSpace(spec.Profile))
+            return spec.Profile!.Trim();
+
+        var defaultProfile = (spec.Profiles ?? Array.Empty<DotNetPublishProfile>())
+            .FirstOrDefault(profile => profile is not null && profile.Default);
+        return defaultProfile?.Name;
     }
 
     private static string[] NormalizeStrings(string[]? values)

--- a/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
+++ b/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
@@ -135,6 +135,19 @@ internal sealed class DotNetPublishPreparationService
                 .Where(t => selected.Contains(t.Name))
                 .ToArray();
 
+            if (spec.Profiles is { Length: > 0 })
+            {
+                foreach (var profile in spec.Profiles)
+                {
+                    if (profile?.Targets is not { Length: > 0 })
+                        continue;
+
+                    profile.Targets = profile.Targets
+                        .Where(target => !string.IsNullOrWhiteSpace(target) && selected.Contains(target.Trim()))
+                        .ToArray();
+                }
+            }
+
             if (spec.Installers is { Length: > 0 })
             {
                 spec.Installers = spec.Installers

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.MissingAnalysis.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.MissingAnalysis.cs
@@ -408,10 +408,12 @@ public sealed partial class ModulePipelineRunner
         var required = _moduleDependencyMetadataProvider.GetRequiredModulesForInstalledModule(moduleName);
         foreach (var dep in required)
         {
-            if (string.IsNullOrWhiteSpace(dep))
+            var depName = dep?.ModuleName;
+            if (string.IsNullOrWhiteSpace(depName))
                 continue;
-            if (output.Add(dep))
-                CollectModuleDependencies(dep, visited, output);
+            var normalizedDepName = depName!.Trim();
+            if (output.Add(normalizedDepName))
+                CollectModuleDependencies(normalizedDepName, visited, output);
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -633,55 +633,31 @@ public sealed partial class ModulePipelineRunner
             .ToArray();
         var dependencyVersionSourceRepository = ResolvePublishDependencyVersionSource(enabledPublishes);
 
-        var requiredModules = ResolveRequiredModules(
+        var approved = NormalizeApprovedModules(approvedModules);
+        ApplyMergeDefaultsForPlan(
+            refreshPsd1Only,
+            csproj,
+            approved,
+            mergeModuleSet,
+            mergeMissingSet,
+            ref mergeModule,
+            ref mergeMissing);
+
+        var requiredModuleSets = ResolveRequiredModuleSets(
             requiredModulesDraft,
+            requiredModulesDraftForPackaging,
+            approved,
+            mergeMissing,
+            importModules,
+            compatible,
             resolveMissingModulesOnline,
             warnIfRequiredModulesOutdated,
             installMissingModulesPrerelease,
             installMissingModulesRepository,
             installMissingModulesCredential,
             dependencyVersionSourceRepository);
-        if (importModules?.PreferBinaryConflictOrder == true)
-            requiredModules = ReorderRequiredModulesForBinaryConflicts(requiredModules, compatible);
-        var requiredModulesForPackaging = AreRequiredModuleDraftListsEquivalent(requiredModulesDraft, requiredModulesDraftForPackaging)
-            ? requiredModules.ToArray()
-            : ResolveRequiredModules(
-                requiredModulesDraftForPackaging,
-                resolveMissingModulesOnline,
-                warnIfRequiredModulesOutdated,
-                installMissingModulesPrerelease,
-                installMissingModulesRepository,
-                installMissingModulesCredential,
-                dependencyVersionSourceRepository);
-
-        var approved = approvedModules
-            .Where(m => !string.IsNullOrWhiteSpace(m))
-            .Select(m => m.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        if (refreshPsd1Only)
-        {
-            if (!string.IsNullOrWhiteSpace(csproj))
-                _logger.Info("RefreshPSD1Only enabled: skipping .NET publish/binary rebuild for this run.");
-
-            if (mergeModule)
-                _logger.Info("RefreshPSD1Only enabled: disabling merge for this run.");
-            mergeModule = false;
-            mergeMissing = false;
-        }
-        else if (!mergeModuleSet)
-        {
-            mergeModule = true;
-            _logger.Info("MergeModule not explicitly set; enabling by default for legacy compatibility.");
-        }
-
-        if (!mergeMissingSet && !mergeMissing && approved.Length > 0)
-        {
-            mergeMissing = true;
-            var context = mergeModule ? "and MergeModule is enabled" : "for approved-module inlining";
-            _logger.Info($"MergeMissing not explicitly set; enabling because approved modules are configured {context}.");
-        }
+        var requiredModules = requiredModuleSets.RequiredModules;
+        var requiredModulesForPackaging = requiredModuleSets.RequiredModulesForPackaging;
 
         if (delivery?.Sign == true)
         {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
@@ -257,7 +257,8 @@ public sealed partial class ModulePipelineRunner
             {
                 var preferSourceMetadata = ShouldPreferTransitiveDependencySourceMetadata(
                     item.VersionSource,
-                    publishVersionSource);
+                    publishVersionSource) &&
+                    !HasExplicitVersionConstraint(item.Reference);
                 return new RequiredModuleDraft(
                     item.Reference.ModuleName,
                     preferSourceMetadata ? "Latest" : item.Reference.ModuleVersion,
@@ -369,6 +370,20 @@ public sealed partial class ModulePipelineRunner
         => versionSource == ModuleDependencyVersionSource.PSGallery ||
            versionSource == ModuleDependencyVersionSource.PublishRepository ||
            (versionSource == ModuleDependencyVersionSource.Auto && publishVersionSource is not null);
+
+    private static bool HasExplicitVersionConstraint(RequiredModuleReference reference)
+        => HasExplicitVersionValue(reference.ModuleVersion) ||
+           HasExplicitVersionValue(reference.RequiredVersion) ||
+           HasExplicitVersionValue(reference.MaximumVersion);
+
+    private static bool HasExplicitVersionValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+
+        var trimmed = value.Trim();
+        return !trimmed.Equals("Auto", StringComparison.OrdinalIgnoreCase) &&
+               !trimmed.Equals("Latest", StringComparison.OrdinalIgnoreCase);
+    }
 
     private sealed class RequiredModuleSetResolution
     {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
@@ -98,6 +98,292 @@ public sealed partial class ModulePipelineRunner
             preferOnlineMetadata: false);
     }
 
+    private static string[] NormalizeApprovedModules(IEnumerable<string> approvedModules)
+        => (approvedModules ?? Array.Empty<string>())
+            .Where(static module => !string.IsNullOrWhiteSpace(module))
+            .Select(static module => module.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private void ApplyMergeDefaultsForPlan(
+        bool refreshPsd1Only,
+        string? csproj,
+        IReadOnlyCollection<string> approved,
+        bool mergeModuleSet,
+        bool mergeMissingSet,
+        ref bool mergeModule,
+        ref bool mergeMissing)
+    {
+        if (refreshPsd1Only)
+        {
+            if (!string.IsNullOrWhiteSpace(csproj))
+                _logger.Info("RefreshPSD1Only enabled: skipping .NET publish/binary rebuild for this run.");
+
+            if (mergeModule)
+                _logger.Info("RefreshPSD1Only enabled: disabling merge for this run.");
+            mergeModule = false;
+            mergeMissing = false;
+            return;
+        }
+
+        if (!mergeModuleSet)
+        {
+            mergeModule = true;
+            _logger.Info("MergeModule not explicitly set; enabling by default for legacy compatibility.");
+        }
+
+        if (!mergeMissingSet && !mergeMissing && approved.Count > 0)
+        {
+            mergeMissing = true;
+            var context = mergeModule ? "and MergeModule is enabled" : "for approved-module inlining";
+            _logger.Info($"MergeMissing not explicitly set; enabling because approved modules are configured {context}.");
+        }
+    }
+
+    private RequiredModuleSetResolution ResolveRequiredModuleSets(
+        IReadOnlyList<RequiredModuleDraft> requiredModulesDraft,
+        IReadOnlyList<RequiredModuleDraft> requiredModulesDraftForPackaging,
+        string[] approved,
+        bool mergeMissing,
+        ImportModulesConfiguration? importModules,
+        string[] compatible,
+        bool resolveMissingModulesOnline,
+        bool warnIfRequiredModulesOutdated,
+        bool prerelease,
+        string? repository,
+        RepositoryCredential? credential,
+        DependencyVersionSourceRepository? publishVersionSource = null)
+    {
+        var requiredSourceDrafts = BuildRequiredModuleDraftMap(requiredModulesDraft);
+        var requiredPackagingSourceDrafts = BuildRequiredModuleDraftMap(requiredModulesDraftForPackaging);
+
+        var requiredModules = ResolveRequiredModules(
+            requiredModulesDraft,
+            resolveMissingModulesOnline,
+            warnIfRequiredModulesOutdated,
+            prerelease,
+            repository,
+            credential,
+            publishVersionSource);
+        if (mergeMissing && approved.Length > 0)
+        {
+            var approvedRequiredRoots = approved
+                .Where(requiredSourceDrafts.ContainsKey)
+                .ToArray();
+            requiredModules = IncludeTransitiveRequiredModules(
+                requiredModules,
+                approvedRequiredRoots,
+                requiredSourceDrafts,
+                resolveMissingModulesOnline,
+                warnIfRequiredModulesOutdated,
+                prerelease,
+                repository,
+                credential,
+                publishVersionSource);
+        }
+
+        if (importModules?.PreferBinaryConflictOrder == true)
+            requiredModules = ReorderRequiredModulesForBinaryConflicts(requiredModules, compatible);
+
+        var requiredModulesForPackaging = AreRequiredModuleDraftListsEquivalent(requiredModulesDraft, requiredModulesDraftForPackaging)
+            ? requiredModules.ToArray()
+            : ResolveRequiredModules(
+                requiredModulesDraftForPackaging,
+                resolveMissingModulesOnline,
+                warnIfRequiredModulesOutdated,
+                prerelease,
+                repository,
+                credential,
+                publishVersionSource);
+
+        var requiredPackagingRoots = requiredModulesDraftForPackaging
+            .Select(static draft => draft.ModuleName)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        requiredModulesForPackaging = IncludeTransitiveRequiredModules(
+            requiredModulesForPackaging,
+            requiredPackagingRoots,
+            requiredPackagingSourceDrafts,
+            resolveMissingModulesOnline,
+            warnIfRequiredModulesOutdated,
+            prerelease,
+            repository,
+            credential,
+            publishVersionSource);
+
+        return new RequiredModuleSetResolution(requiredModules, requiredModulesForPackaging);
+    }
+
+    private static Dictionary<string, RequiredModuleDraft> BuildRequiredModuleDraftMap(IEnumerable<RequiredModuleDraft> drafts)
+        => (drafts ?? Array.Empty<RequiredModuleDraft>())
+            .Where(static draft => draft is not null && !string.IsNullOrWhiteSpace(draft.ModuleName))
+            .GroupBy(static draft => draft.ModuleName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.Last(), StringComparer.OrdinalIgnoreCase);
+
+    private RequiredModuleReference[] IncludeTransitiveRequiredModules(
+        RequiredModuleReference[] modules,
+        IEnumerable<string> rootModules,
+        IReadOnlyDictionary<string, RequiredModuleDraft> sourceDrafts,
+        bool resolveMissingModulesOnline,
+        bool warnIfRequiredModulesOutdated,
+        bool prerelease,
+        string? repository,
+        RepositoryCredential? credential,
+        DependencyVersionSourceRepository? publishVersionSource = null)
+    {
+        var output = (modules ?? Array.Empty<RequiredModuleReference>())
+            .Where(static module => module is not null && !string.IsNullOrWhiteSpace(module.ModuleName))
+            .ToList();
+        var known = new HashSet<string>(
+            output.Select(static module => module.ModuleName),
+            StringComparer.OrdinalIgnoreCase);
+
+        var discovered = new List<(RequiredModuleReference Reference, ModuleDependencyVersionSource VersionSource)>();
+        var discoveredIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var root in NormalizeStringArray(rootModules))
+        {
+            var source = ResolveInheritedDependencyVersionSource(root, sourceDrafts, ModuleDependencyVersionSource.Auto);
+            CollectTransitiveRequiredModules(root, source, sourceDrafts, known, discoveredIndex, visited, discovered);
+        }
+
+        if (discovered.Count == 0)
+            return output.ToArray();
+
+        var drafts = discovered
+            .Select(item =>
+            {
+                var preferSourceMetadata = ShouldPreferTransitiveDependencySourceMetadata(
+                    item.VersionSource,
+                    publishVersionSource);
+                return new RequiredModuleDraft(
+                    item.Reference.ModuleName,
+                    preferSourceMetadata ? "Latest" : item.Reference.ModuleVersion,
+                    preferSourceMetadata ? "Latest" : item.Reference.ModuleVersion,
+                    preferSourceMetadata ? null : item.Reference.RequiredVersion,
+                    preferSourceMetadata ? "Auto" : item.Reference.Guid,
+                    item.VersionSource);
+            })
+            .ToArray();
+
+        var resolved = ResolveRequiredModules(
+            drafts,
+            resolveMissingModulesOnline,
+            warnIfRequiredModulesOutdated,
+            prerelease,
+            repository,
+            credential,
+            publishVersionSource);
+
+        var discoveredByName = discovered
+            .GroupBy(static item => item.Reference.ModuleName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.First().Reference, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var module in resolved)
+        {
+            if (module is null || string.IsNullOrWhiteSpace(module.ModuleName))
+                continue;
+            if (!known.Add(module.ModuleName))
+                continue;
+
+            if (discoveredByName.TryGetValue(module.ModuleName, out var original) &&
+                !string.IsNullOrWhiteSpace(original.MaximumVersion))
+            {
+                output.Add(new RequiredModuleReference(
+                    module.ModuleName,
+                    module.ModuleVersion,
+                    module.RequiredVersion,
+                    original.MaximumVersion,
+                    module.Guid));
+                continue;
+            }
+
+            output.Add(module);
+        }
+
+        return output.ToArray();
+    }
+
+    private void CollectTransitiveRequiredModules(
+        string moduleName,
+        ModuleDependencyVersionSource inheritedVersionSource,
+        IReadOnlyDictionary<string, RequiredModuleDraft> sourceDrafts,
+        HashSet<string> known,
+        HashSet<string> discoveredIndex,
+        HashSet<string> visited,
+        List<(RequiredModuleReference Reference, ModuleDependencyVersionSource VersionSource)> discovered)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName))
+            return;
+        var normalizedModuleName = moduleName.Trim();
+        if (!visited.Add(normalizedModuleName))
+            return;
+
+        var required = _moduleDependencyMetadataProvider.GetRequiredModulesForInstalledModule(normalizedModuleName);
+        foreach (var dep in required ?? Array.Empty<RequiredModuleReference>())
+        {
+            if (dep is null || string.IsNullOrWhiteSpace(dep.ModuleName))
+                continue;
+
+            var depName = dep.ModuleName.Trim();
+            if (ModulePipelinePlanningHelpers.ShouldSkipManifestDependencyModule(depName))
+                continue;
+
+            var childVersionSource = ResolveInheritedDependencyVersionSource(depName, sourceDrafts, inheritedVersionSource);
+            if (!known.Contains(depName) && discoveredIndex.Add(depName))
+            {
+                discovered.Add((
+                    new RequiredModuleReference(
+                        depName,
+                        dep.ModuleVersion,
+                        dep.RequiredVersion,
+                        dep.MaximumVersion,
+                        dep.Guid),
+                    childVersionSource));
+            }
+
+            CollectTransitiveRequiredModules(depName, childVersionSource, sourceDrafts, known, discoveredIndex, visited, discovered);
+        }
+    }
+
+    private static ModuleDependencyVersionSource ResolveInheritedDependencyVersionSource(
+        string moduleName,
+        IReadOnlyDictionary<string, RequiredModuleDraft> sourceDrafts,
+        ModuleDependencyVersionSource inheritedVersionSource)
+    {
+        if (!string.IsNullOrWhiteSpace(moduleName) &&
+            sourceDrafts is not null &&
+            sourceDrafts.TryGetValue(moduleName.Trim(), out var draft))
+        {
+            return draft.VersionSource;
+        }
+
+        return inheritedVersionSource;
+    }
+
+    private static bool ShouldPreferTransitiveDependencySourceMetadata(
+        ModuleDependencyVersionSource versionSource,
+        DependencyVersionSourceRepository? publishVersionSource)
+        => versionSource == ModuleDependencyVersionSource.PSGallery ||
+           versionSource == ModuleDependencyVersionSource.PublishRepository ||
+           (versionSource == ModuleDependencyVersionSource.Auto && publishVersionSource is not null);
+
+    private sealed class RequiredModuleSetResolution
+    {
+        public RequiredModuleReference[] RequiredModules { get; }
+        public RequiredModuleReference[] RequiredModulesForPackaging { get; }
+
+        public RequiredModuleSetResolution(
+            RequiredModuleReference[] requiredModules,
+            RequiredModuleReference[] requiredModulesForPackaging)
+        {
+            RequiredModules = requiredModules ?? Array.Empty<RequiredModuleReference>();
+            RequiredModulesForPackaging = requiredModulesForPackaging ?? Array.Empty<RequiredModuleReference>();
+        }
+    }
+
     private RequiredModuleReference[] ResolveRequiredModulesFromSingleSource(
         IReadOnlyList<RequiredModuleDraft> list,
         IReadOnlyDictionary<string, (string? Version, string? Guid)> installedMetadata,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
@@ -258,7 +258,7 @@ public sealed partial class ModulePipelineRunner
                 var preferSourceMetadata = ShouldPreferTransitiveDependencySourceMetadata(
                     item.VersionSource,
                     publishVersionSource) &&
-                    !HasExplicitVersionConstraint(item.Reference);
+                    !HasExplicitDependencyConstraint(item.Reference);
                 return new RequiredModuleDraft(
                     item.Reference.ModuleName,
                     preferSourceMetadata ? "Latest" : item.Reference.ModuleVersion,
@@ -371,10 +371,19 @@ public sealed partial class ModulePipelineRunner
            versionSource == ModuleDependencyVersionSource.PublishRepository ||
            (versionSource == ModuleDependencyVersionSource.Auto && publishVersionSource is not null);
 
-    private static bool HasExplicitVersionConstraint(RequiredModuleReference reference)
+    private static bool HasExplicitDependencyConstraint(RequiredModuleReference reference)
         => HasExplicitVersionValue(reference.ModuleVersion) ||
            HasExplicitVersionValue(reference.RequiredVersion) ||
-           HasExplicitVersionValue(reference.MaximumVersion);
+           HasExplicitVersionValue(reference.MaximumVersion) ||
+           HasExplicitGuidValue(reference.Guid);
+
+    private static bool HasExplicitGuidValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+
+        var trimmed = (value ?? string.Empty).Trim();
+        return !trimmed.Equals("Auto", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static bool HasExplicitVersionValue(string? value)
     {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
@@ -380,7 +380,7 @@ public sealed partial class ModulePipelineRunner
     {
         if (string.IsNullOrWhiteSpace(value)) return false;
 
-        var trimmed = value.Trim();
+        var trimmed = (value ?? string.Empty).Trim();
         return !trimmed.Equals("Auto", StringComparison.OrdinalIgnoreCase) &&
                !trimmed.Equals("Latest", StringComparison.OrdinalIgnoreCase);
     }

--- a/PowerForge.PowerShell/Services/PowerShellModuleDependencyMetadataProvider.cs
+++ b/PowerForge.PowerShell/Services/PowerShellModuleDependencyMetadataProvider.cs
@@ -65,10 +65,10 @@ internal sealed class PowerShellModuleDependencyMetadataProvider : IModuleDepend
         return map;
     }
 
-    public IReadOnlyList<string> GetRequiredModulesForInstalledModule(string moduleName)
+    public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)
     {
         if (string.IsNullOrWhiteSpace(moduleName))
-            return Array.Empty<string>();
+            return Array.Empty<RequiredModuleReference>();
 
         try
         {
@@ -79,20 +79,21 @@ internal sealed class PowerShellModuleDependencyMetadataProvider : IModuleDepend
                 _logger.Warn($"Failed to resolve required modules for '{moduleName}'.");
                 if (_logger.IsVerbose && !string.IsNullOrWhiteSpace(result.StdOut)) _logger.Verbose(result.StdOut.Trim());
                 if (_logger.IsVerbose && !string.IsNullOrWhiteSpace(result.StdErr)) _logger.Verbose(result.StdErr.Trim());
-                return Array.Empty<string>();
+                return Array.Empty<RequiredModuleReference>();
             }
 
             return SplitLines(result.StdOut)
-                .Where(static name => !string.IsNullOrWhiteSpace(name))
-                .Select(static name => name.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(ParseRequiredModuleReferenceLine)
+                .Where(static module => module is not null && !string.IsNullOrWhiteSpace(module.ModuleName))
+                .GroupBy(static module => module!.ModuleName, StringComparer.OrdinalIgnoreCase)
+                .Select(static group => group.First()!)
                 .ToArray();
         }
         catch (Exception ex)
         {
             _logger.Warn($"Failed to resolve required modules for '{moduleName}': {ex.Message}");
             if (_logger.IsVerbose) _logger.Verbose(ex.ToString());
-            return Array.Empty<string>();
+            return Array.Empty<RequiredModuleReference>();
         }
     }
 
@@ -176,6 +177,30 @@ internal sealed class PowerShellModuleDependencyMetadataProvider : IModuleDepend
 
     private static IEnumerable<string> SplitLines(string? text)
         => (text ?? string.Empty).Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+    private static RequiredModuleReference? ParseRequiredModuleReferenceLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return null;
+
+        if (!line.StartsWith("PFREQMOD::ITEM::", StringComparison.Ordinal))
+            return new RequiredModuleReference(line.Trim());
+
+        var parts = line.Split(new[] { "::" }, StringSplitOptions.None);
+        if (parts.Length < 7)
+            return null;
+
+        var name = Decode(parts[2]);
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        return new RequiredModuleReference(
+            name.Trim(),
+            moduleVersion: EmptyToNull(Decode(parts[3])),
+            requiredVersion: EmptyToNull(Decode(parts[4])),
+            maximumVersion: EmptyToNull(Decode(parts[5])),
+            guid: EmptyToNull(Decode(parts[6])));
+    }
 
     private static string EncodeLines(IEnumerable<string> lines)
     {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -740,6 +740,38 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     }
 
     [Fact]
+    public void ExtractBestFailureLine_PrefersFirstConcreteDiagnosticOverGenericFailureSummary()
+    {
+        var output = string.Join(
+            Environment.NewLine,
+            @"C:\src\App.csproj(12,5): error NETSDK1047: Assets file is missing a runtime target.",
+            "Build FAILED.",
+            "    0 Warning(s)",
+            "    1 Error(s)");
+
+        var line = DotNetPublishPipelineRunner.ExtractBestFailureLine(output);
+
+        Assert.Contains("NETSDK1047", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("Build FAILED", line, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RedactCommandLineSecrets_RedactsSensitiveMsBuildAndSwitchValues()
+    {
+        var commandLine = "dotnet publish /p:ApiKey=super-secret --password hunter2 -ClientSecret 'abc123' /p:Configuration=Release";
+
+        var redacted = DotNetPublishPipelineRunner.RedactCommandLineSecrets(commandLine);
+
+        Assert.Contains("/p:ApiKey=<redacted>", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--password <redacted>", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("-ClientSecret '<redacted>'", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("/p:Configuration=Release", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("super-secret", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("hunter2", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("abc123", redacted, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuildRestoreRuntimeIdentifiers_IncludesAllProjectFrameworkRuntimes()
     {
         var plan = new DotNetPublishPlan

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -758,7 +758,7 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     [Fact]
     public void RedactCommandLineSecrets_RedactsSensitiveMsBuildAndSwitchValues()
     {
-        var commandLine = "dotnet publish /p:ApiKey=super-secret --password \"correct horse\" -ClientSecret 'abc123' --Token=token-value /p:Configuration=Release";
+        var commandLine = "dotnet publish /p:ApiKey=super-secret --password \"correct horse\" -ClientSecret 'abc123' --Token=token-value -NuGetApiKey nuget-secret /p:GitHubToken=github-secret /p:Configuration=Release";
 
         var redacted = DotNetPublishPipelineRunner.RedactCommandLineSecrets(commandLine);
 
@@ -766,11 +766,15 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
         Assert.Contains("--password \"<redacted>\"", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("-ClientSecret '<redacted>'", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("--Token=<redacted>", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("-NuGetApiKey <redacted>", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("/p:GitHubToken=<redacted>", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("/p:Configuration=Release", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("super-secret", redacted, StringComparison.Ordinal);
         Assert.DoesNotContain("correct horse", redacted, StringComparison.Ordinal);
         Assert.DoesNotContain("abc123", redacted, StringComparison.Ordinal);
         Assert.DoesNotContain("token-value", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("nuget-secret", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("github-secret", redacted, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -816,6 +820,44 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
 
         Assert.Equal(new[] { "win-arm64", "win-x64" }, runtimes);
         Assert.Equal("win-arm64;win-x64", DotNetPublishPipelineRunner.BuildMsBuildListPropertyValue(runtimes));
+    }
+
+    [Fact]
+    public void BuildRestoreRuntimeIdentifiers_ExcludesRuntimesWithDifferentRestoreProperties()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0",
+                            Runtime = "linux-x64",
+                            Style = DotNetPublishStyle.AotSpeed
+                        }
+                    }
+                }
+            }
+        };
+
+        var runtimes = DotNetPublishPipelineRunner.BuildRestoreRuntimeIdentifiers(
+            plan,
+            "Service.csproj",
+            "win-x64",
+            "net10.0");
+
+        Assert.Equal(new[] { "win-x64" }, runtimes);
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -785,6 +785,54 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     }
 
     [Fact]
+    public void BuildRestoreArguments_DoesNotForceTopLevelFrameworkAcrossProjectReferences()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["UseLocalHtmlForgeX"] = "false"
+            },
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Publish = new DotNetPublishPublishOptions
+                    {
+                        ReadyToRun = true
+                    },
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0-windows",
+                            Runtime = "win-arm64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0-windows",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        }
+                    }
+                }
+            }
+        };
+
+        var args = DotNetPublishPipelineRunner.BuildRestoreArguments(
+            plan,
+            "Service.csproj",
+            "win-arm64",
+            "net10.0-windows");
+
+        Assert.Contains("/p:RuntimeIdentifiers=\"win-arm64;win-x64\"", args);
+        Assert.Contains("/p:PublishReadyToRun=true", args);
+        Assert.DoesNotContain("/p:TargetFramework=net10.0-windows", args);
+    }
+
+    [Fact]
     public void Run_CommandFailure_ReturnsTroubleshootingDetails()
     {
         if (!DotNetPublishPipelineRunner.IsWindows())

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -758,17 +758,19 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     [Fact]
     public void RedactCommandLineSecrets_RedactsSensitiveMsBuildAndSwitchValues()
     {
-        var commandLine = "dotnet publish /p:ApiKey=super-secret --password hunter2 -ClientSecret 'abc123' /p:Configuration=Release";
+        var commandLine = "dotnet publish /p:ApiKey=super-secret --password hunter2 -ClientSecret 'abc123' --Token=token-value /p:Configuration=Release";
 
         var redacted = DotNetPublishPipelineRunner.RedactCommandLineSecrets(commandLine);
 
         Assert.Contains("/p:ApiKey=<redacted>", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("--password <redacted>", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("-ClientSecret '<redacted>'", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--Token=<redacted>", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("/p:Configuration=Release", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("super-secret", redacted, StringComparison.Ordinal);
         Assert.DoesNotContain("hunter2", redacted, StringComparison.Ordinal);
         Assert.DoesNotContain("abc123", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("token-value", redacted, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -813,7 +815,7 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             "net10.0-windows");
 
         Assert.Equal(new[] { "win-arm64", "win-x64" }, runtimes);
-        Assert.Equal("\"win-arm64;win-x64\"", DotNetPublishPipelineRunner.BuildMsBuildListPropertyValue(runtimes));
+        Assert.Equal("win-arm64;win-x64", DotNetPublishPipelineRunner.BuildMsBuildListPropertyValue(runtimes));
     }
 
     [Fact]
@@ -859,7 +861,7 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             "win-arm64",
             "net10.0-windows");
 
-        Assert.Contains("/p:RuntimeIdentifiers=\"win-arm64;win-x64\"", args);
+        Assert.Contains("/p:RuntimeIdentifiers=win-arm64;win-x64", args);
         Assert.Contains("/p:PublishReadyToRun=true", args);
         Assert.DoesNotContain("/p:TargetFramework=net10.0-windows", args);
     }

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -723,6 +723,115 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     }
 
     [Fact]
+    public void ExtractBestFailureLine_PrefersDiagnosticOverTimingFooter()
+    {
+        var output = string.Join(
+            Environment.NewLine,
+            "Build FAILED.",
+            @"C:\src\App.csproj(12,5): error NETSDK1047: Assets file is missing a runtime target.",
+            "    0 Warning(s)",
+            "    1 Error(s)",
+            "Time Elapsed 00:00:01.36");
+
+        var line = DotNetPublishPipelineRunner.ExtractBestFailureLine(output);
+
+        Assert.Contains("NETSDK1047", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("Time Elapsed", line, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildRestoreRuntimeIdentifiers_IncludesAllProjectFrameworkRuntimes()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Targets = new[]
+            {
+                new DotNetPublishTargetPlan
+                {
+                    ProjectPath = "Service.csproj",
+                    Combinations = new[]
+                    {
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0-windows",
+                            Runtime = "win-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net10.0-windows",
+                            Runtime = "win-arm64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        },
+                        new DotNetPublishTargetCombination
+                        {
+                            Framework = "net8.0",
+                            Runtime = "linux-x64",
+                            Style = DotNetPublishStyle.PortableCompat
+                        }
+                    }
+                }
+            }
+        };
+
+        var runtimes = DotNetPublishPipelineRunner.BuildRestoreRuntimeIdentifiers(
+            plan,
+            "Service.csproj",
+            "win-arm64",
+            "net10.0-windows");
+
+        Assert.Equal(new[] { "win-arm64", "win-x64" }, runtimes);
+        Assert.Equal("\"win-arm64;win-x64\"", DotNetPublishPipelineRunner.BuildMsBuildListPropertyValue(runtimes));
+    }
+
+    [Fact]
+    public void Run_CommandFailure_ReturnsTroubleshootingDetails()
+    {
+        if (!DotNetPublishPipelineRunner.IsWindows())
+            return;
+
+        var root = CreateTempRoot();
+        try
+        {
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Steps = new[]
+                {
+                    new DotNetPublishStep
+                    {
+                        Key = "hook:test",
+                        Kind = DotNetPublishStepKind.CommandHook,
+                        Title = "Hook",
+                        HookId = "test",
+                        HookCommand = Path.Combine(Environment.SystemDirectory, "cmd.exe"),
+                        HookArguments = new[] { "/c", "echo useful failure from hook 1>&2 & exit /b 7" },
+                        HookTimeoutSeconds = 10,
+                        HookRequired = true
+                    }
+                }
+            };
+
+            var runner = new DotNetPublishPipelineRunner(new NullLogger());
+            var result = runner.Run(plan, progress: null);
+
+            Assert.False(result.Succeeded);
+            Assert.NotNull(result.Failure);
+            Assert.Equal(7, result.Failure!.ExitCode);
+            Assert.Contains("Step 'hook:test' (CommandHook) failed", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Contains("Command:", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Contains("WorkingDirectory:", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Contains("Log:", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Contains("useful failure from hook", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(result.Failure.LogPath));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void BuildPublishArguments_UsesSdkNativeAotPropertyForAotStyles()
     {
         var plan = new DotNetPublishPlan

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -758,17 +758,17 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
     [Fact]
     public void RedactCommandLineSecrets_RedactsSensitiveMsBuildAndSwitchValues()
     {
-        var commandLine = "dotnet publish /p:ApiKey=super-secret --password hunter2 -ClientSecret 'abc123' --Token=token-value /p:Configuration=Release";
+        var commandLine = "dotnet publish /p:ApiKey=super-secret --password \"correct horse\" -ClientSecret 'abc123' --Token=token-value /p:Configuration=Release";
 
         var redacted = DotNetPublishPipelineRunner.RedactCommandLineSecrets(commandLine);
 
         Assert.Contains("/p:ApiKey=<redacted>", redacted, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("--password <redacted>", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--password \"<redacted>\"", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("-ClientSecret '<redacted>'", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("--Token=<redacted>", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("/p:Configuration=Release", redacted, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("super-secret", redacted, StringComparison.Ordinal);
-        Assert.DoesNotContain("hunter2", redacted, StringComparison.Ordinal);
+        Assert.DoesNotContain("correct horse", redacted, StringComparison.Ordinal);
         Assert.DoesNotContain("abc123", redacted, StringComparison.Ordinal);
         Assert.DoesNotContain("token-value", redacted, StringComparison.Ordinal);
     }

--- a/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
@@ -125,6 +125,59 @@ public sealed class DotNetPublishPreparationServiceTests
     }
 
     [Fact]
+    public void Prepare_from_config_rejects_profile_with_no_selected_targets()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-dotnet-publish-profile-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var configPath = Path.Combine(root.FullName, "publish.json");
+            File.WriteAllText(configPath, """
+{
+  "dotNet": {
+    "projectRoot": "."
+  },
+  "profile": "tools",
+  "profiles": [
+    {
+      "name": "tools",
+      "default": true,
+      "targets": [ "Tool" ]
+    }
+  ],
+  "targets": [
+    {
+      "name": "App",
+      "projectPath": "src/App/App.csproj"
+    },
+    {
+      "name": "Tool",
+      "projectPath": "src/Tool/Tool.csproj"
+    }
+  ]
+}
+""");
+
+            var request = new DotNetPublishPreparationRequest
+            {
+                ParameterSetName = "Config",
+                CurrentPath = root.FullName,
+                ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                ConfigPath = configPath,
+                Target = new[] { "App" }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => new DotNetPublishPreparationService(new NullLogger()).Prepare(request));
+
+            Assert.Contains("Profile 'tools' does not match target override", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Prepare_from_config_applies_project_root_override()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-dotnet-publish-root-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
@@ -19,6 +19,14 @@ public sealed class DotNetPublishPreparationServiceTests
     "restore": true,
     "build": true
   },
+  "profile": "msi",
+  "profiles": [
+    {
+      "name": "msi",
+      "default": true,
+      "targets": [ "App", "Tool" ]
+    }
+  ],
   "targets": [
     {
       "name": "App",
@@ -70,6 +78,8 @@ public sealed class DotNetPublishPreparationServiceTests
             Assert.Equal(Path.Combine(root.FullName, "powerforge.dotnetpublish.generated.json"), context.JsonOutputPath);
             Assert.Single(context.Spec.Targets);
             Assert.Equal("App", context.Spec.Targets[0].Name);
+            Assert.Single(context.Spec.Profiles[0].Targets);
+            Assert.Equal("App", context.Spec.Profiles[0].Targets[0]);
             Assert.Single(context.Spec.Installers);
             Assert.Equal("AppInstaller", context.Spec.Installers[0].Id);
             Assert.Equal(new[] { "linux-x64" }, context.Spec.Targets[0].Publish.Runtimes);

--- a/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
@@ -178,6 +178,68 @@ public sealed class DotNetPublishPreparationServiceTests
     }
 
     [Fact]
+    public void Prepare_from_config_ignores_unselected_profiles_when_filtering_targets()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-dotnet-publish-profile-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var configPath = Path.Combine(root.FullName, "publish.json");
+            File.WriteAllText(configPath, """
+{
+  "dotNet": {
+    "projectRoot": "."
+  },
+  "profile": "app",
+  "profiles": [
+    {
+      "name": "app",
+      "default": true,
+      "targets": [ "App" ]
+    },
+    {
+      "name": "tools",
+      "targets": [ "Tool" ]
+    }
+  ],
+  "targets": [
+    {
+      "name": "App",
+      "projectPath": "src/App/App.csproj"
+    },
+    {
+      "name": "Tool",
+      "projectPath": "src/Tool/Tool.csproj"
+    }
+  ]
+}
+""");
+
+            var request = new DotNetPublishPreparationRequest
+            {
+                ParameterSetName = "Config",
+                CurrentPath = root.FullName,
+                ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                ConfigPath = configPath,
+                Target = new[] { "App" }
+            };
+
+            var context = new DotNetPublishPreparationService(new NullLogger()).Prepare(request);
+
+            Assert.Single(context.Spec.Targets);
+            Assert.Equal("App", context.Spec.Targets[0].Name);
+            var appProfile = Assert.Single(context.Spec.Profiles, profile => string.Equals(profile.Name, "app", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(new[] { "App" }, appProfile.Targets);
+            var toolsProfile = Assert.Single(context.Spec.Profiles, profile => string.Equals(profile.Name, "tools", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(new[] { "Tool" }, toolsProfile.Targets);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Prepare_from_config_applies_project_root_override()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-dotnet-publish-root-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
+++ b/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
@@ -517,8 +517,7 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
                     ["Parent.Tools"] = new[]
                     {
                         new RequiredModuleReference(
-                            "Child.Tools",
-                            guid: "22222222-2222-2222-2222-222222222222")
+                            "Child.Tools")
                     }
                 });
 
@@ -529,6 +528,44 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
             Assert.Equal("2.5.0", child.ModuleVersion);
             Assert.Equal("55555555-5555-5555-5555-555555555555", child.Guid);
             Assert.Equal("PSGallery", provider.LastOnlineRepository);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_PreservesTransitiveGuidConstraint_WhenInheritingRepositoryVersionSource()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Child.Tools"] = ("2.5.0", "55555555-5555-5555-5555-555555555555")
+                },
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference(
+                            "Child.Tools",
+                            guid: "22222222-2222-2222-2222-222222222222")
+                    }
+                });
+
+            var spec = CreateRequiredParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.PSGallery);
+            var plan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(spec);
+
+            var child = Assert.Single(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.Null(child.ModuleVersion);
+            Assert.Equal("22222222-2222-2222-2222-222222222222", child.Guid);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
+++ b/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
@@ -394,12 +394,12 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
         var provider = new FakeModuleDependencyMetadataProvider(
             installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
             onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
-            installedRequiredModules: new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
             {
-                ["Alpha.Tools"] = new[] { "Beta.Tools", "Gamma.Tools" },
-                ["Beta.Tools"] = new[] { "Gamma.Tools", "Delta.Tools" },
-                ["Gamma.Tools"] = Array.Empty<string>(),
-                ["Delta.Tools"] = Array.Empty<string>()
+                ["Alpha.Tools"] = new[] { new RequiredModuleReference("Beta.Tools"), new RequiredModuleReference("Gamma.Tools") },
+                ["Beta.Tools"] = new[] { new RequiredModuleReference("Gamma.Tools"), new RequiredModuleReference("Delta.Tools") },
+                ["Gamma.Tools"] = Array.Empty<RequiredModuleReference>(),
+                ["Delta.Tools"] = Array.Empty<RequiredModuleReference>()
             });
 
         var runner = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider);
@@ -422,6 +422,121 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
         Assert.Equal(4, provider.RequiredModuleLookups);
     }
 
+    [Fact]
+    public void Run_PreservesTransitiveDependency_WhenApprovedModuleIsMergedAway()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new("Parent.Tools", "1.0.0", null, @"C:\Modules\Parent.Tools\1.0.0"),
+                    ["Child.Tools"] = new("Child.Tools", "2.0.0", "22222222-2222-2222-2222-222222222222", @"C:\Modules\Child.Tools\2.0.0")
+                },
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference(
+                            "Child.Tools",
+                            moduleVersion: "2.0.0",
+                            guid: "22222222-2222-2222-2222-222222222222")
+                    }
+                });
+
+            var runner = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider);
+            var result = runner.Run(CreateApprovedParentSpec(root.FullName, moduleName));
+
+            Assert.True(ManifestEditor.TryGetRequiredModules(result.BuildResult.ManifestPath, out RequiredModuleReference[]? required));
+            var requiredModules = required!;
+            Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
+            var child = Assert.Single(requiredModules, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("2.0.0", child.ModuleVersion);
+            Assert.Equal("22222222-2222-2222-2222-222222222222", child.Guid);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_IncludesTransitiveDependenciesForPackaging_WhenParentRemainsRequired()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[] { new RequiredModuleReference("Child.Tools", moduleVersion: "2.0.0") }
+                });
+
+            var spec = CreateRequiredParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.Auto);
+            var plan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(spec);
+
+            Assert.Contains(plan.RequiredModules, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(plan.RequiredModules, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_InheritsDependencyVersionSource_ForTransitiveRequiredModules()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = ("1.1.0", null),
+                    ["Child.Tools"] = ("2.5.0", "55555555-5555-5555-5555-555555555555")
+                },
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference(
+                            "Child.Tools",
+                            moduleVersion: "2.0.0",
+                            guid: "22222222-2222-2222-2222-222222222222")
+                    }
+                });
+
+            var spec = CreateRequiredParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.PSGallery);
+            var plan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(spec);
+
+            var child = Assert.Single(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("2.5.0", child.ModuleVersion);
+            Assert.Equal("55555555-5555-5555-5555-555555555555", child.Guid);
+            Assert.Equal("PSGallery", provider.LastOnlineRepository);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static void WriteMinimalModule(string moduleRoot, string moduleName, string version)
     {
         Directory.CreateDirectory(moduleRoot);
@@ -439,6 +554,64 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
         }) + Environment.NewLine;
 
         File.WriteAllText(Path.Combine(moduleRoot, $"{moduleName}.psd1"), psd1);
+    }
+
+    private static ModulePipelineSpec CreateApprovedParentSpec(string sourcePath, string moduleName)
+    {
+        var spec = CreateRequiredParentSpec(sourcePath, moduleName, ModuleDependencyVersionSource.Auto);
+        spec.Segments = spec.Segments
+            .Concat(new IConfigurationSegment[]
+            {
+                new ConfigurationBuildSegment
+                {
+                    BuildModule = new BuildModuleConfiguration
+                    {
+                        MergeMissing = true
+                    }
+                },
+                new ConfigurationModuleSegment
+                {
+                    Kind = ModuleDependencyKind.ApprovedModule,
+                    Configuration = new ModuleDependencyConfiguration
+                    {
+                        ModuleName = "Parent.Tools"
+                    }
+                }
+            })
+            .ToArray();
+        return spec;
+    }
+
+    private static ModulePipelineSpec CreateRequiredParentSpec(
+        string sourcePath,
+        string moduleName,
+        ModuleDependencyVersionSource versionSource)
+    {
+        return new ModulePipelineSpec
+        {
+            Build = new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = sourcePath,
+                Version = "1.0.0",
+                CsprojPath = null,
+                KeepStaging = true
+            },
+            Install = new ModulePipelineInstallOptions { Enabled = false },
+            Segments = new IConfigurationSegment[]
+            {
+                new ConfigurationModuleSegment
+                {
+                    Kind = ModuleDependencyKind.RequiredModule,
+                    Configuration = new ModuleDependencyConfiguration
+                    {
+                        ModuleName = "Parent.Tools",
+                        ModuleVersion = "1.0.0",
+                        VersionSource = versionSource
+                    }
+                }
+            }
+        };
     }
 
     private static string BuildLibrary(string rootPath, string assemblyName, string version, string projectFolderName)
@@ -496,7 +669,7 @@ public sealed class Marker
     {
         private readonly IReadOnlyDictionary<string, InstalledModuleMetadata> _installedModules;
         private readonly IReadOnlyDictionary<string, (string? Version, string? Guid)> _onlineModules;
-        private readonly IReadOnlyDictionary<string, IReadOnlyList<string>> _installedRequiredModules;
+        private readonly IReadOnlyDictionary<string, IReadOnlyList<RequiredModuleReference>> _installedRequiredModules;
 
         internal int InstalledLookups { get; private set; }
         internal int OnlineLookups { get; private set; }
@@ -506,11 +679,11 @@ public sealed class Marker
         internal FakeModuleDependencyMetadataProvider(
             IReadOnlyDictionary<string, InstalledModuleMetadata> installedModules,
             IReadOnlyDictionary<string, (string? Version, string? Guid)> onlineModules,
-            IReadOnlyDictionary<string, IReadOnlyList<string>>? installedRequiredModules = null)
+            IReadOnlyDictionary<string, IReadOnlyList<RequiredModuleReference>>? installedRequiredModules = null)
         {
             _installedModules = installedModules;
             _onlineModules = onlineModules;
-            _installedRequiredModules = installedRequiredModules ?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+            _installedRequiredModules = installedRequiredModules ?? new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase);
         }
 
         public IReadOnlyDictionary<string, InstalledModuleMetadata> GetLatestInstalledModules(IReadOnlyList<string> names)
@@ -528,15 +701,15 @@ public sealed class Marker
             return result;
         }
 
-        public IReadOnlyList<string> GetRequiredModulesForInstalledModule(string moduleName)
+        public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)
         {
             RequiredModuleLookups++;
             if (string.IsNullOrWhiteSpace(moduleName))
-                return Array.Empty<string>();
+                return Array.Empty<RequiredModuleReference>();
 
             return _installedRequiredModules.TryGetValue(moduleName, out var modules)
                 ? modules
-                : Array.Empty<string>();
+                : Array.Empty<RequiredModuleReference>();
         }
 
         public IReadOnlyDictionary<string, (string? Version, string? Guid)> ResolveLatestOnlineVersions(

--- a/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
+++ b/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
@@ -518,7 +518,6 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
                     {
                         new RequiredModuleReference(
                             "Child.Tools",
-                            moduleVersion: "2.0.0",
                             guid: "22222222-2222-2222-2222-222222222222")
                     }
                 });
@@ -530,6 +529,58 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
             Assert.Equal("2.5.0", child.ModuleVersion);
             Assert.Equal("55555555-5555-5555-5555-555555555555", child.Guid);
             Assert.Equal("PSGallery", provider.LastOnlineRepository);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_PreservesTransitiveVersionConstraints_WhenInheritingRepositoryVersionSource()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Exact.Child"] = ("5.0.0", "55555555-5555-5555-5555-555555555555"),
+                    ["Minimum.Child"] = ("6.0.0", "66666666-6666-6666-6666-666666666666")
+                },
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference(
+                            "Exact.Child",
+                            requiredVersion: "2.0.0",
+                            guid: "22222222-2222-2222-2222-222222222222"),
+                        new RequiredModuleReference(
+                            "Minimum.Child",
+                            moduleVersion: "3.0.0",
+                            maximumVersion: "3.9.9",
+                            guid: "33333333-3333-3333-3333-333333333333")
+                    }
+                });
+
+            var spec = CreateRequiredParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.PSGallery);
+            var plan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(spec);
+
+            var exact = Assert.Single(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Exact.Child", StringComparison.OrdinalIgnoreCase));
+            Assert.Null(exact.ModuleVersion);
+            Assert.Equal("2.0.0", exact.RequiredVersion);
+            Assert.Equal("22222222-2222-2222-2222-222222222222", exact.Guid);
+
+            var minimum = Assert.Single(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Minimum.Child", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("3.0.0", minimum.ModuleVersion);
+            Assert.Null(minimum.RequiredVersion);
+            Assert.Equal("3.9.9", minimum.MaximumVersion);
+            Assert.Equal("33333333-3333-3333-3333-333333333333", minimum.Guid);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -444,8 +444,8 @@ public sealed class ModulePipelineHostedOperationsTests
                     static name => new InstalledModuleMetadata(name, null, null, null),
                     StringComparer.OrdinalIgnoreCase);
 
-        public IReadOnlyList<string> GetRequiredModulesForInstalledModule(string moduleName)
-            => Array.Empty<string>();
+        public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)
+            => Array.Empty<RequiredModuleReference>();
 
         public IReadOnlyDictionary<string, (string? Version, string? Guid)> ResolveLatestOnlineVersions(
             IReadOnlyCollection<string> names,

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -510,8 +510,8 @@ public sealed class ModulePipelineManifestRefreshTests
         public IReadOnlyDictionary<string, InstalledModuleMetadata> GetLatestInstalledModules(IReadOnlyList<string> names)
             => new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase);
 
-        public IReadOnlyList<string> GetRequiredModulesForInstalledModule(string moduleName)
-            => Array.Empty<string>();
+        public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)
+            => Array.Empty<RequiredModuleReference>();
 
         public IReadOnlyDictionary<string, (string? Version, string? Guid)> ResolveLatestOnlineVersions(
             IReadOnlyCollection<string> names,

--- a/PowerForge.Tests/ModulePipelineMissingAnalysisServiceTests.cs
+++ b/PowerForge.Tests/ModulePipelineMissingAnalysisServiceTests.cs
@@ -131,8 +131,8 @@ public sealed class ModulePipelineMissingAnalysisServiceTests
         public IReadOnlyDictionary<string, InstalledModuleMetadata> GetLatestInstalledModules(IReadOnlyList<string> names)
             => new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase);
 
-        public IReadOnlyList<string> GetRequiredModulesForInstalledModule(string moduleName)
-            => Array.Empty<string>();
+        public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)
+            => Array.Empty<RequiredModuleReference>();
 
         public IReadOnlyDictionary<string, (string? Version, string? Guid)> ResolveLatestOnlineVersions(
             IReadOnlyCollection<string> names,

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
@@ -149,8 +149,8 @@ public sealed class ModulePipelineScriptExecutionSeamTests
                     static name => new InstalledModuleMetadata(name, null, null, null),
                     StringComparer.OrdinalIgnoreCase);
 
-        public IReadOnlyList<string> GetRequiredModulesForInstalledModule(string moduleName)
-            => Array.Empty<string>();
+        public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)
+            => Array.Empty<RequiredModuleReference>();
 
         public IReadOnlyDictionary<string, (string? Version, string? Guid)> ResolveLatestOnlineVersions(
             IReadOnlyCollection<string> names,

--- a/PowerForge/Abstractions/IModuleDependencyMetadataProvider.cs
+++ b/PowerForge/Abstractions/IModuleDependencyMetadataProvider.cs
@@ -6,7 +6,7 @@ internal interface IModuleDependencyMetadataProvider
 {
     IReadOnlyDictionary<string, InstalledModuleMetadata> GetLatestInstalledModules(IReadOnlyList<string> names);
 
-    IReadOnlyList<string> GetRequiredModulesForInstalledModule(string moduleName);
+    IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName);
 
     IReadOnlyDictionary<string, (string? Version, string? Guid)> ResolveLatestOnlineVersions(
         IReadOnlyCollection<string> names,

--- a/PowerForge/Scripts/ModulePipeline/Get-RequiredModules.ps1
+++ b/PowerForge/Scripts/ModulePipeline/Get-RequiredModules.ps1
@@ -6,18 +6,137 @@ function Encode([string]$value) {
   return [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([string]$value))
 }
 
+function Get-ManifestPath {
+  param($Module)
+
+  if ($Module.Path -and [System.IO.Path]::GetExtension([string]$Module.Path) -ieq '.psd1' -and (Test-Path -LiteralPath $Module.Path)) {
+    return [string]$Module.Path
+  }
+
+  if ($Module.ModuleBase) {
+    $candidate = Join-Path -Path ([string]$Module.ModuleBase) -ChildPath ($Module.Name + '.psd1')
+    if (Test-Path -LiteralPath $candidate) {
+      return [string]$candidate
+    }
+
+    $manifest = Get-ChildItem -LiteralPath ([string]$Module.ModuleBase) -Filter '*.psd1' -File -ErrorAction SilentlyContinue |
+      Select-Object -First 1
+    if ($null -ne $manifest) {
+      return [string]$manifest.FullName
+    }
+  }
+
+  return $null
+}
+
+function Get-EntryValue {
+  param(
+    $Entry,
+    [string[]]$Keys
+  )
+
+  foreach ($key in $Keys) {
+    if ($Entry.ContainsKey($key)) {
+      $value = $Entry[$key]
+      if ($null -ne $value) {
+        return [string]$value
+      }
+    }
+  }
+
+  return ''
+}
+
+function ConvertTo-RequiredModuleRecord {
+  param($Entry)
+
+  if ($null -eq $Entry) {
+    return $null
+  }
+
+  if ($Entry -is [string]) {
+    if ([string]::IsNullOrWhiteSpace($Entry)) {
+      return $null
+    }
+
+    return [pscustomobject]@{
+      ModuleName = [string]$Entry
+      ModuleVersion = ''
+      RequiredVersion = ''
+      MaximumVersion = ''
+      Guid = ''
+    }
+  }
+
+  if ($Entry -is [System.Collections.IDictionary]) {
+    $moduleName = Get-EntryValue -Entry $Entry -Keys @('ModuleName', 'Name')
+    if ([string]::IsNullOrWhiteSpace($moduleName)) {
+      return $null
+    }
+
+    return [pscustomobject]@{
+      ModuleName = $moduleName
+      ModuleVersion = Get-EntryValue -Entry $Entry -Keys @('ModuleVersion', 'Version')
+      RequiredVersion = Get-EntryValue -Entry $Entry -Keys @('RequiredVersion')
+      MaximumVersion = Get-EntryValue -Entry $Entry -Keys @('MaximumVersion')
+      Guid = Get-EntryValue -Entry $Entry -Keys @('Guid')
+    }
+  }
+
+  $moduleName = if ($Entry.Name) { [string]$Entry.Name } else { '' }
+  if ([string]::IsNullOrWhiteSpace($moduleName)) {
+    return $null
+  }
+
+  return [pscustomobject]@{
+    ModuleName = $moduleName
+    ModuleVersion = if ($Entry.Version) { [string]$Entry.Version } else { '' }
+    RequiredVersion = if ($Entry.RequiredVersion) { [string]$Entry.RequiredVersion } else { '' }
+    MaximumVersion = if ($Entry.MaximumVersion) { [string]$Entry.MaximumVersion } else { '' }
+    Guid = if ($Entry.Guid) { [string]$Entry.Guid } else { '' }
+  }
+}
+
+function Write-RequiredModuleRecord {
+  param($Record)
+
+  if ($null -eq $Record) {
+    return
+  }
+
+  $fields = @(
+    [string]$Record.ModuleName,
+    [string]$Record.ModuleVersion,
+    [string]$Record.RequiredVersion,
+    [string]$Record.MaximumVersion,
+    [string]$Record.Guid
+  ) | ForEach-Object { Encode $_ }
+  Write-Output ('PFREQMOD::ITEM::' + ($fields -join '::'))
+}
+
 $mod = Get-Module -ListAvailable -Name $name |
   Sort-Object Version -Descending |
   Select-Object -First 1
 if ($null -eq $mod) { return @() }
+
+$manifestPath = Get-ManifestPath -Module $mod
+if ($manifestPath) {
+  try {
+    $manifestData = Import-PowerShellDataFile -Path $manifestPath
+    $rawRequiredModules = $manifestData.RequiredModules
+    if ($null -ne $rawRequiredModules) {
+      foreach ($entry in @($rawRequiredModules)) {
+        Write-RequiredModuleRecord -Record (ConvertTo-RequiredModuleRecord -Entry $entry)
+      }
+      return
+    }
+  } catch {
+    # Fall back to the module metadata below when raw manifest parsing is unavailable.
+  }
+}
+
 $req = $mod.RequiredModules
 if ($null -eq $req) { return @() }
 $req | ForEach-Object {
-  $moduleName = [string]$_.Name
-  $moduleVersion = if ($_.Version) { [string]$_.Version } else { '' }
-  $requiredVersion = if ($_.RequiredVersion) { [string]$_.RequiredVersion } else { '' }
-  $maximumVersion = if ($_.MaximumVersion) { [string]$_.MaximumVersion } else { '' }
-  $guid = if ($_.Guid) { [string]$_.Guid } else { '' }
-  $fields = @($moduleName, $moduleVersion, $requiredVersion, $maximumVersion, $guid) | ForEach-Object { Encode $_ }
-  Write-Output ('PFREQMOD::ITEM::' + ($fields -join '::'))
+  Write-RequiredModuleRecord -Record (ConvertTo-RequiredModuleRecord -Entry $_)
 }

--- a/PowerForge/Scripts/ModulePipeline/Get-RequiredModules.ps1
+++ b/PowerForge/Scripts/ModulePipeline/Get-RequiredModules.ps1
@@ -1,8 +1,23 @@
-﻿param($name)
+param($name)
+$ErrorActionPreference = 'Stop'
+
+function Encode([string]$value) {
+  if ($null -eq $value) { $value = '' }
+  return [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes([string]$value))
+}
+
 $mod = Get-Module -ListAvailable -Name $name |
   Sort-Object Version -Descending |
   Select-Object -First 1
 if ($null -eq $mod) { return @() }
 $req = $mod.RequiredModules
 if ($null -eq $req) { return @() }
-$req | ForEach-Object { $_.Name }
+$req | ForEach-Object {
+  $moduleName = [string]$_.Name
+  $moduleVersion = if ($_.Version) { [string]$_.Version } else { '' }
+  $requiredVersion = if ($_.RequiredVersion) { [string]$_.RequiredVersion } else { '' }
+  $maximumVersion = if ($_.MaximumVersion) { [string]$_.MaximumVersion } else { '' }
+  $guid = if ($_.Guid) { [string]$_.Guid } else { '' }
+  $fields = @($moduleName, $moduleVersion, $requiredVersion, $maximumVersion, $guid) | ForEach-Object { Encode $_ }
+  Write-Output ('PFREQMOD::ITEM::' + ($fields -join '::'))
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -26,6 +26,38 @@ public sealed partial class DotNetPublishPipelineRunner
         return (text ?? string.Empty).Trim();
     }
 
+    internal static string ExtractBestFailureLine(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return string.Empty;
+
+        var lines = (text ?? string.Empty)
+            .Replace("\r\n", "\n")
+            .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => (line ?? string.Empty).Trim())
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+        if (lines.Length == 0) return string.Empty;
+
+        var diagnostics = lines
+            .Where(IsDiagnosticFailureLine)
+            .ToArray();
+        if (diagnostics.Length > 0)
+            return diagnostics[^1];
+
+        return lines[^1];
+    }
+
+    private static bool IsDiagnosticFailureLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return false;
+
+        return line.Contains(": error ", StringComparison.OrdinalIgnoreCase)
+            || line.Contains(" error ", StringComparison.OrdinalIgnoreCase)
+            || line.StartsWith("error ", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("exception", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("failed", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string ToSafeFileName(string? input, string fallback)
     {
         var s = string.IsNullOrWhiteSpace(input) ? fallback : input!.Trim();
@@ -74,8 +106,38 @@ public sealed partial class DotNetPublishPipelineRunner
         failure.StdOutTail = TailLines(cmdEx.StdOut, maxLines: 80, maxChars: 8000);
         failure.StdErrTail = TailLines(cmdEx.StdErr, maxLines: 80, maxChars: 8000);
         failure.LogPath = TryWriteFailureLog(plan, stepEx.Step, cmdEx);
+        errorMessage = BuildCommandFailureMessage(stepEx.Step, cmdEx, failure);
 
         return failure;
+    }
+
+    private static string BuildCommandFailureMessage(
+        DotNetPublishStep step,
+        DotNetPublishCommandException command,
+        DotNetPublishFailure? failure)
+    {
+        if (step is null) throw new ArgumentNullException(nameof(step));
+        if (command is null) throw new ArgumentNullException(nameof(command));
+
+        var detail = ExtractBestFailureLine(!string.IsNullOrWhiteSpace(failure?.StdErrTail)
+            ? failure!.StdErrTail
+            : failure?.StdOutTail);
+        if (string.IsNullOrWhiteSpace(detail))
+            detail = command.Message;
+
+        var parts = new List<string>
+        {
+            $"Step '{step.Key}' ({step.Kind}) failed with exit code {command.ExitCode}.",
+            $"Command: {command.CommandLine}",
+            $"WorkingDirectory: {command.WorkingDirectory}"
+        };
+
+        if (!string.IsNullOrWhiteSpace(failure?.LogPath))
+            parts.Add($"Log: {failure!.LogPath}");
+        if (!string.IsNullOrWhiteSpace(detail))
+            parts.Add($"Error: {detail}");
+
+        return string.Join(Environment.NewLine, parts);
     }
 
     private static string? TryWriteFailureLog(DotNetPublishPlan plan, DotNetPublishStep step, DotNetPublishCommandException ex)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace PowerForge;
 
@@ -38,24 +39,42 @@ public sealed partial class DotNetPublishPipelineRunner
             .ToArray();
         if (lines.Length == 0) return string.Empty;
 
-        var diagnostics = lines
-            .Where(IsDiagnosticFailureLine)
-            .ToArray();
-        if (diagnostics.Length > 0)
-            return diagnostics[diagnostics.Length - 1];
+        var diagnostic = lines.FirstOrDefault(IsConcreteErrorLine);
+        if (!string.IsNullOrWhiteSpace(diagnostic))
+            return diagnostic;
+
+        diagnostic = lines.FirstOrDefault(IsExceptionLine);
+        if (!string.IsNullOrWhiteSpace(diagnostic))
+            return diagnostic;
+
+        diagnostic = lines.FirstOrDefault(IsFailureLine);
+        if (!string.IsNullOrWhiteSpace(diagnostic))
+            return diagnostic;
 
         return lines[lines.Length - 1];
     }
 
-    private static bool IsDiagnosticFailureLine(string line)
+    private static bool IsConcreteErrorLine(string line)
     {
         if (string.IsNullOrWhiteSpace(line)) return false;
 
         return line.Contains(": error ", StringComparison.OrdinalIgnoreCase)
             || line.Contains(" error ", StringComparison.OrdinalIgnoreCase)
-            || line.StartsWith("error ", StringComparison.OrdinalIgnoreCase)
-            || line.Contains("exception", StringComparison.OrdinalIgnoreCase)
-            || line.Contains("failed", StringComparison.OrdinalIgnoreCase);
+            || line.StartsWith("error ", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsExceptionLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return false;
+
+        return line.Contains("exception", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsFailureLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return false;
+
+        return line.Contains("failed", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ToSafeFileName(string? input, string fallback)
@@ -128,7 +147,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var parts = new List<string>
         {
             $"Step '{step.Key}' ({step.Kind}) failed with exit code {command.ExitCode}.",
-            $"Command: {command.CommandLine}",
+            $"Command: {RedactCommandLineSecrets(command.CommandLine)}",
             $"WorkingDirectory: {command.WorkingDirectory}"
         };
 
@@ -139,6 +158,44 @@ public sealed partial class DotNetPublishPipelineRunner
 
         return string.Join(Environment.NewLine, parts);
     }
+
+    internal static string RedactCommandLineSecrets(string? commandLine)
+    {
+        if (string.IsNullOrWhiteSpace(commandLine)) return string.Empty;
+
+        var redacted = commandLine!;
+        foreach (var key in SensitiveCommandLineKeys)
+        {
+            var escaped = Regex.Escape(key);
+            redacted = Regex.Replace(
+                redacted,
+                $@"(?<prefix>(^|\s)([-/]+p:)?{escaped}\s*[:=]\s*)(?<quote>[""']?)(?<value>[^\s""']+)(\k<quote>)",
+                match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            redacted = Regex.Replace(
+                redacted,
+                $@"(?<prefix>(^|\s)[-/]+{escaped}\s+)(?<quote>[""']?)(?<value>[^\s""']+)(\k<quote>)",
+                match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        }
+
+        return redacted;
+    }
+
+    private static readonly string[] SensitiveCommandLineKeys =
+    {
+        "AccessKey",
+        "AccessToken",
+        "ApiKey",
+        "ApiToken",
+        "CertificatePFXPassword",
+        "ClientSecret",
+        "Password",
+        "PfxPassword",
+        "PublishApiKey",
+        "Secret",
+        "Token"
+    };
 
     private static string? TryWriteFailureLog(DotNetPublishPlan plan, DotNetPublishStep step, DotNetPublishCommandException ex)
     {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -164,28 +164,27 @@ public sealed partial class DotNetPublishPipelineRunner
         if (string.IsNullOrWhiteSpace(commandLine)) return string.Empty;
 
         var redacted = commandLine!;
-        foreach (var key in SensitiveCommandLineKeys)
-        {
-            var escaped = Regex.Escape(key);
-            redacted = Regex.Replace(
-                redacted,
-                $@"(?<prefix>(^|\s)([-/]+p:)?{escaped}\s*[:=]\s*)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
-                match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
-                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-            redacted = Regex.Replace(
-                redacted,
-                $@"(?<prefix>(^|\s)[-/]+{escaped}\s+)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
-                match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
-                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-            redacted = Regex.Replace(
-                redacted,
-                $@"(?<prefix>(^|\s)[-/]+{escaped}\s*[:=]\s*)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
-                match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
-                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-        }
+        redacted = Regex.Replace(
+            redacted,
+            $@"(?<prefix>(^|\s)([-/]+p:)?{SensitiveCommandLineKeyPattern}\s*[:=]\s*)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
+            RedactCommandLineSecretMatch,
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        redacted = Regex.Replace(
+            redacted,
+            $@"(?<prefix>(^|\s)[-/]+{SensitiveCommandLineKeyPattern}\s+)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
+            RedactCommandLineSecretMatch,
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        redacted = Regex.Replace(
+            redacted,
+            $@"(?<prefix>(^|\s)[-/]+{SensitiveCommandLineKeyPattern}\s*[:=]\s*)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
+            RedactCommandLineSecretMatch,
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         return redacted;
     }
+
+    private static string RedactCommandLineSecretMatch(Match match)
+        => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}";
 
     private static readonly string[] SensitiveCommandLineKeys =
     {
@@ -201,6 +200,9 @@ public sealed partial class DotNetPublishPipelineRunner
         "Secret",
         "Token"
     };
+
+    private static readonly string SensitiveCommandLineKeyPattern =
+        $@"[A-Za-z0-9_.:-]*(?:{string.Join("|", SensitiveCommandLineKeys.Select(Regex.Escape))})";
 
     private static string? TryWriteFailureLog(DotNetPublishPlan plan, DotNetPublishStep step, DotNetPublishCommandException ex)
     {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -169,17 +169,17 @@ public sealed partial class DotNetPublishPipelineRunner
             var escaped = Regex.Escape(key);
             redacted = Regex.Replace(
                 redacted,
-                $@"(?<prefix>(^|\s)([-/]+p:)?{escaped}\s*[:=]\s*)(?<quote>[""']?)(?<value>[^\s""']+)(\k<quote>)",
+                $@"(?<prefix>(^|\s)([-/]+p:)?{escaped}\s*[:=]\s*)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
                 match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
                 RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
             redacted = Regex.Replace(
                 redacted,
-                $@"(?<prefix>(^|\s)[-/]+{escaped}\s+)(?<quote>[""']?)(?<value>[^\s""']+)(\k<quote>)",
+                $@"(?<prefix>(^|\s)[-/]+{escaped}\s+)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
                 match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
                 RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
             redacted = Regex.Replace(
                 redacted,
-                $@"(?<prefix>(^|\s)[-/]+{escaped}\s*[:=]\s*)(?<quote>[""']?)(?<value>[^\s""']+)(\k<quote>)",
+                $@"(?<prefix>(^|\s)[-/]+{escaped}\s*[:=]\s*)(?:(?<quote>[""'])(?<value>.*?)\k<quote>|(?<value>[^\s""']+))",
                 match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
                 RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -177,6 +177,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 $@"(?<prefix>(^|\s)[-/]+{escaped}\s+)(?<quote>[""']?)(?<value>[^\s""']+)(\k<quote>)",
                 match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
                 RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            redacted = Regex.Replace(
+                redacted,
+                $@"(?<prefix>(^|\s)[-/]+{escaped}\s*[:=]\s*)(?<quote>[""']?)(?<value>[^\s""']+)(\k<quote>)",
+                match => $"{match.Groups["prefix"].Value}{match.Groups["quote"].Value}<redacted>{match.Groups["quote"].Value}",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
         }
 
         return redacted;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -42,9 +42,9 @@ public sealed partial class DotNetPublishPipelineRunner
             .Where(IsDiagnosticFailureLine)
             .ToArray();
         if (diagnostics.Length > 0)
-            return diagnostics[^1];
+            return diagnostics[diagnostics.Length - 1];
 
-        return lines[^1];
+        return lines[lines.Length - 1];
     }
 
     private static bool IsDiagnosticFailureLine(string line)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Hooks.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Hooks.cs
@@ -62,7 +62,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var stdoutTail = TailLines(result.StdOut, maxLines: 40, maxChars: 4000);
         var message = result.TimedOut
             ? $"Hook '{step.HookId}' timed out after {Math.Max(1, step.HookTimeoutSeconds)} seconds."
-            : ExtractLastNonEmptyLine(!string.IsNullOrWhiteSpace(stderrTail) ? stderrTail : stdoutTail);
+            : ExtractBestFailureLine(!string.IsNullOrWhiteSpace(stderrTail) ? stderrTail : stdoutTail);
         if (string.IsNullOrWhiteSpace(message))
             message = $"Hook '{step.HookId}' failed with exit code {result.ExitCode}.";
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -288,7 +288,7 @@ public sealed partial class DotNetPublishPipelineRunner
             var stderrTail = TailLines(stderr, maxLines: 80, maxChars: 8000);
             var stdoutTail = TailLines(stdout, maxLines: 80, maxChars: 8000);
 
-            var msg = ExtractLastNonEmptyLine(!string.IsNullOrWhiteSpace(stderrTail) ? stderrTail : stdoutTail);
+            var msg = ExtractBestFailureLine(!string.IsNullOrWhiteSpace(stderrTail) ? stderrTail : stdoutTail);
             if (string.IsNullOrWhiteSpace(msg)) msg = "dotnet failed.";
 
             throw new DotNetPublishCommandException(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -37,7 +37,11 @@ public sealed partial class DotNetPublishPipelineRunner
                 _logger.Info($"Restore ({label}) -> {request.ProjectPath}");
 
                 var args = new List<string> { "restore", request.ProjectPath, "--nologo" };
-                args.AddRange(new[] { "-r", runtimeValue });
+                var runtimeIdentifiers = BuildRestoreRuntimeIdentifiers(plan, request.ProjectPath, runtimeValue, framework);
+                if (runtimeIdentifiers.Length <= 1)
+                    args.AddRange(new[] { "-r", runtimeValue });
+                else
+                    args.Add($"/p:RuntimeIdentifiers={BuildMsBuildListPropertyValue(runtimeIdentifiers)}");
                 args.AddRange(BuildMsBuildPropertyArgs(BuildRestoreMsBuildProperties(plan, request.ProjectPath, runtimeValue, framework)));
                 if (!string.IsNullOrWhiteSpace(framework))
                     args.Add($"/p:TargetFramework={framework}");
@@ -118,6 +122,36 @@ public sealed partial class DotNetPublishPipelineRunner
 
         return merged;
     }
+
+    internal static string[] BuildRestoreRuntimeIdentifiers(
+        DotNetPublishPlan plan,
+        string projectPath,
+        string runtime,
+        string? framework = null)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        var runtimes = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+            .Where(target => string.Equals(target.ProjectPath, projectPath, StringComparison.OrdinalIgnoreCase))
+            .SelectMany(target => target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
+            .Where(combination => string.IsNullOrWhiteSpace(framework)
+                || string.Equals(combination.Framework, framework, StringComparison.OrdinalIgnoreCase))
+            .Select(combination => combination.Runtime)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (runtimes.Length == 0 && !string.IsNullOrWhiteSpace(runtime))
+            return new[] { runtime };
+
+        return runtimes;
+    }
+
+    internal static string BuildMsBuildListPropertyValue(IEnumerable<string> values)
+        => "\"" + string.Join(";", (values ?? Array.Empty<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())) + "\"";
 
     private static bool IsPortableStyle(DotNetPublishStyle style)
     {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -139,6 +139,7 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
 
+        var baselineProperties = BuildRestoreMsBuildProperties(plan, projectPath, runtime, framework);
         var runtimes = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
             .Where(target => string.Equals(target.ProjectPath, projectPath, StringComparison.OrdinalIgnoreCase))
             .SelectMany(target => target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
@@ -147,6 +148,9 @@ public sealed partial class DotNetPublishPipelineRunner
             .Select(combination => combination.Runtime)
             .Where(value => !string.IsNullOrWhiteSpace(value))
             .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(candidate => RestorePropertiesEquivalent(
+                baselineProperties,
+                BuildRestoreMsBuildProperties(plan, projectPath, candidate!, framework)))
             .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -154,6 +158,24 @@ public sealed partial class DotNetPublishPipelineRunner
             return new[] { runtime };
 
         return runtimes;
+    }
+
+    private static bool RestorePropertiesEquivalent(
+        IReadOnlyDictionary<string, string> left,
+        IReadOnlyDictionary<string, string> right)
+    {
+        if (left.Count != right.Count)
+            return false;
+
+        foreach (var property in left)
+        {
+            if (!right.TryGetValue(property.Key, out var value))
+                return false;
+            if (!string.Equals(property.Value, value, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
     }
 
     internal static string BuildMsBuildListPropertyValue(IEnumerable<string> values)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -157,9 +157,9 @@ public sealed partial class DotNetPublishPipelineRunner
     }
 
     internal static string BuildMsBuildListPropertyValue(IEnumerable<string> values)
-        => "\"" + string.Join(";", (values ?? Array.Empty<string>())
+        => string.Join(";", (values ?? Array.Empty<string>())
             .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Select(value => value.Trim())) + "\"";
+            .Select(value => value.Trim()));
 
     private static bool IsPortableStyle(DotNetPublishStyle style)
     {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -36,17 +36,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 var label = string.IsNullOrWhiteSpace(framework) ? runtimeValue : $"{runtimeValue}, {framework}";
                 _logger.Info($"Restore ({label}) -> {request.ProjectPath}");
 
-                var args = new List<string> { "restore", request.ProjectPath, "--nologo" };
-                var runtimeIdentifiers = BuildRestoreRuntimeIdentifiers(plan, request.ProjectPath, runtimeValue, framework);
-                if (runtimeIdentifiers.Length <= 1)
-                    args.AddRange(new[] { "-r", runtimeValue });
-                else
-                    args.Add($"/p:RuntimeIdentifiers={BuildMsBuildListPropertyValue(runtimeIdentifiers)}");
-                args.AddRange(BuildMsBuildPropertyArgs(BuildRestoreMsBuildProperties(plan, request.ProjectPath, runtimeValue, framework)));
-                if (!string.IsNullOrWhiteSpace(framework))
-                    args.Add($"/p:TargetFramework={framework}");
-
-                RunDotnet(workDir, args);
+                RunDotnet(workDir, BuildRestoreArguments(plan, request.ProjectPath, runtimeValue, framework));
             }
 
             return;
@@ -121,6 +111,24 @@ public sealed partial class DotNetPublishPipelineRunner
         }
 
         return merged;
+    }
+
+    internal static List<string> BuildRestoreArguments(
+        DotNetPublishPlan plan,
+        string projectPath,
+        string runtime,
+        string? framework = null)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        var args = new List<string> { "restore", projectPath, "--nologo" };
+        var runtimeIdentifiers = BuildRestoreRuntimeIdentifiers(plan, projectPath, runtime, framework);
+        if (runtimeIdentifiers.Length <= 1)
+            args.AddRange(new[] { "-r", runtime });
+        else
+            args.Add($"/p:RuntimeIdentifiers={BuildMsBuildListPropertyValue(runtimeIdentifiers)}");
+        args.AddRange(BuildMsBuildPropertyArgs(BuildRestoreMsBuildProperties(plan, projectPath, runtime, framework)));
+        return args;
     }
 
     internal static string[] BuildRestoreRuntimeIdentifiers(


### PR DESCRIPTION
## Summary
- preserve transitive RequiredModules when an approved module is merged away
- include transitive RequiredModules in artefact packaging dependency sets
- keep installed metadata as the default while honoring dependency version sources such as PSGallery for discovered dependencies

## Validation
- dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release --no-restore --nologo
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~RequiredModules|FullyQualifiedName~DependencyMetadataProvider|FullyQualifiedName~ApprovedModules" --no-restore --nologo
- git diff --check

Fixes #22