### PR TITLE
Pin PowerForge housekeeping setup-dotnet action

### DIFF
--- a/.github/actions/github-housekeeping/action.yml
+++ b/.github/actions/github-housekeeping/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         global-json-file: ${{ github.action_path }}/../../../global.json
 


### PR DESCRIPTION
## Summary
- pin the nested actions/setup-dotnet usage in the PowerForge GitHub housekeeping composite action to the full v4.3.1 commit SHA
- keep downstream reusable workflow consumers compatible with org policies requiring pinned actions

## Validation
- dotnet build .\\PowerForge.Cli\\PowerForge.Cli.csproj -c Release