### PR TITLE
Fix runner housekeeping runs-on labels

### DIFF
--- a/.github/workflows/powerforge-github-runner-housekeeping.yml
+++ b/.github/workflows/powerforge-github-runner-housekeeping.yml
@@ -89,7 +89,7 @@ permissions:
 jobs:
   housekeeping:
     # runs-on is resolved before any steps run, so the fallback must stay inline here.
-    runs-on: ${{ fromJson(inputs.runner_labels_json != '' && inputs.runner_labels_json || (inputs['runner-labels'] != '' && inputs['runner-labels'] || '["self-hosted","linux"]')) }}
+    runs-on: ${{ fromJson(inputs.runner_labels_json != '' && inputs.runner_labels_json || '["self-hosted","linux"]') }}
     timeout-minutes: 20
     steps:
       - name: Resolve workflow inputs

--- a/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
@@ -18,7 +18,7 @@ public sealed class GitHubRunnerHousekeepingWorkflowTests
         Assert.Contains("runner-labels", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("fromJson(", runsOnLine, StringComparison.Ordinal);
         Assert.Contains("inputs.runner_labels_json != '' && inputs.runner_labels_json", runsOnLine, StringComparison.Ordinal);
-        Assert.Contains("inputs['runner-labels'] != '' && inputs['runner-labels']", runsOnLine, StringComparison.Ordinal);
+        Assert.DoesNotContain("inputs['runner-labels']", runsOnLine, StringComparison.Ordinal);
         Assert.Contains("'[\"self-hosted\",\"linux\"]'", runsOnLine, StringComparison.Ordinal);
         Assert.Contains("./.powerforge/pspublishmodule/.github/actions/github-housekeeping", workflowYaml, StringComparison.Ordinal);
         Assert.Contains(".powerforge/runner-housekeeping.json", workflowYaml, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- simplifies the runner housekeeping reusable workflow `runs-on` expression to use the pre-job-safe `runner_labels_json` input only
- keeps the legacy `runner-labels` input available for step-level compatibility, but removes it from pre-job runner resolution
- updates the workflow guard test for the `runs-on` expression

## Evidence
- `git diff --check`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter GitHubRunnerHousekeepingWorkflowTests`

Automation: `powerforge-workflow-failure-sweeper`