### PR TITLE
Add required module artefact exclusions

### DIFF
--- a/Module/Docs/About/about_ModuleDependencies.md
+++ b/Module/Docs/About/about_ModuleDependencies.md
@@ -94,7 +94,10 @@ New-ConfigurationArtefact -AddRequiredModules
 
 This packaging step only bundles RequiredModule dependencies. ExternalModule entries are intentionally excluded.
 Transitive RequiredModules discovered from bundled dependencies are included so offline artefacts keep the
-dependency chain intact.
+dependency chain intact. PowerShell runtime and module-manager dependencies such as Microsoft.PowerShell.*,
+PackageManagement, PowerShellGet, and PSReadLine are ignored when they are discovered transitively.
+Use New-ConfigurationArtefact -RequiredModulesExcludeModuleName when a project needs additional artefact-only
+exclusions without changing the generated module manifest.
 
 HOW REQUIREDMODULESSOURCE WORKS
 

--- a/Module/Docs/New-ConfigurationArtefact.md
+++ b/Module/Docs/New-ConfigurationArtefact.md
@@ -11,7 +11,7 @@ Tells the module to create an artefact of a specified type.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-ConfigurationArtefact [[-PostScriptMerge] <scriptblock>] [[-PreScriptMerge] <scriptblock>] -Type <ArtefactType> [-Enable] [-IncludeTagName] [-Path <string>] [-AddRequiredModules] [-ModulesPath <string>] [-RequiredModulesPath <string>] [-RequiredModulesRepository <string>] [-RequiredModulesTool <ModuleSaveTool>] [-RequiredModulesSource <RequiredModulesSource>] [-RequiredModulesCredentialUserName <string>] [-RequiredModulesCredentialSecret <string>] [-RequiredModulesCredentialSecretFilePath <string>] [-CopyDirectories <ArtefactCopyMapping[]>] [-CopyFiles <ArtefactCopyMapping[]>] [-CopyDirectoriesRelative] [-CopyFilesRelative] [-DoNotClear] [-ArtefactName <string>] [-ScriptName <string>] [-ID <string>] [-PostScriptMergePath <string>] [-PreScriptMergePath <string>] [<CommonParameters>]
+New-ConfigurationArtefact [[-PostScriptMerge] <scriptblock>] [[-PreScriptMerge] <scriptblock>] -Type <ArtefactType> [-Enable] [-IncludeTagName] [-Path <string>] [-AddRequiredModules] [-RequiredModulesExcludeModuleName <string[]>] [-ModulesPath <string>] [-RequiredModulesPath <string>] [-RequiredModulesRepository <string>] [-RequiredModulesTool <ModuleSaveTool>] [-RequiredModulesSource <RequiredModulesSource>] [-RequiredModulesCredentialUserName <string>] [-RequiredModulesCredentialSecret <string>] [-RequiredModulesCredentialSecretFilePath <string>] [-CopyDirectories <ArtefactCopyMapping[]>] [-CopyFiles <ArtefactCopyMapping[]>] [-CopyDirectoriesRelative] [-CopyFilesRelative] [-DoNotClear] [-ArtefactName <string>] [-ScriptName <string>] [-ID <string>] [-PostScriptMergePath <string>] [-PreScriptMergePath <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -20,6 +20,8 @@ Unpacked (folder) for inspection or offline installation.
 
 When -AddRequiredModules is enabled, required modules are copied from locally available modules (Get-Module -ListAvailable) and,
 when configured, downloaded (via Save-PSResource/Save-Module) before being copied into the artefact.
+Use -RequiredModulesExcludeModuleName to keep selected required modules out of a specific artefact without removing
+them from the generated manifest.
 
 Only RequiredModule dependencies participate in artefact bundling. ExternalModule dependencies are
 intentionally excluded because they represent dependencies that should remain separately installed on the target
@@ -78,6 +80,23 @@ Position: named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True
+```
+
+### -RequiredModulesExcludeModuleName
+Required module names that should not be copied into this artefact when -AddRequiredModules is enabled.
+This only affects artefact bundling; it does not remove modules from the generated manifest.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -ArtefactName

--- a/Module/Help/About/about_ModuleDependencies.help.txt
+++ b/Module/Help/About/about_ModuleDependencies.help.txt
@@ -89,7 +89,10 @@ LONG DESCRIPTION
 
     This packaging step only bundles RequiredModule dependencies. ExternalModule entries are intentionally excluded.
     Transitive RequiredModules discovered from bundled dependencies are included so offline artefacts keep the
-    dependency chain intact.
+    dependency chain intact. PowerShell runtime and module-manager dependencies such as Microsoft.PowerShell.*,
+    PackageManagement, PowerShellGet, and PSReadLine are ignored when they are discovered transitively.
+    Use New-ConfigurationArtefact -RequiredModulesExcludeModuleName when a project needs additional artefact-only
+    exclusions without changing the generated module manifest.
 
     HOW REQUIREDMODULESSOURCE WORKS
 

--- a/PSPublishModule/Cmdlets/NewConfigurationArtefactCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationArtefactCommand.cs
@@ -86,6 +86,13 @@ public sealed class NewConfigurationArtefactCommand : PSCmdlet
     [Alias("RequiredModules")]
     public SwitchParameter AddRequiredModules { get; set; }
 
+    /// <summary>
+    /// Required module names that should not be copied into this artefact when <c>-AddRequiredModules</c> is enabled.
+    /// This only affects artefact bundling; it does not remove modules from the generated manifest.
+    /// </summary>
+    [Parameter]
+    public string[]? RequiredModulesExcludeModuleName { get; set; }
+
     /// <summary>Path where main module (or required module) will be copied to.</summary>
     [Parameter]
     public string? ModulesPath { get; set; }
@@ -194,6 +201,7 @@ public sealed class NewConfigurationArtefactCommand : PSCmdlet
             RequiredModulesSource = MyInvocation.BoundParameters.ContainsKey(nameof(RequiredModulesSource)) ? RequiredModulesSource : null,
             AddRequiredModulesSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(AddRequiredModules)),
             AddRequiredModules = AddRequiredModules.IsPresent,
+            RequiredModulesExcludeModuleName = MyInvocation.BoundParameters.ContainsKey(nameof(RequiredModulesExcludeModuleName)) ? RequiredModulesExcludeModuleName : null,
             RequiredModulesCredentialUserName = RequiredModulesCredentialUserName,
             RequiredModulesCredentialSecret = RequiredModulesCredentialSecret,
             RequiredModulesCredentialSecretFilePath = RequiredModulesCredentialSecretFilePath,

--- a/PowerForge.PowerShell/Models/ArtefactConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/ArtefactConfigurationRequest.cs
@@ -34,6 +34,8 @@ public sealed class ArtefactConfigurationRequest
     public bool AddRequiredModulesSpecified { get; set; }
     /// <summary>Enable required modules copying.</summary>
     public bool AddRequiredModules { get; set; }
+    /// <summary>Required module names that should not be copied into the artefact.</summary>
+    public string[]? RequiredModulesExcludeModuleName { get; set; }
 
     /// <summary>Repository credential username for required modules.</summary>
     public string? RequiredModulesCredentialUserName { get; set; }

--- a/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace PowerForge;
@@ -90,6 +91,15 @@ public sealed class ArtefactConfigurationFactory
 
         if (request.AddRequiredModulesSpecified)
             artefact.Configuration.RequiredModules.Enabled = request.AddRequiredModules;
+
+        if (request.RequiredModulesExcludeModuleName is { Length: > 0 })
+        {
+            artefact.Configuration.RequiredModules.ExcludeModuleName = request.RequiredModulesExcludeModuleName
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
 
         if (!string.IsNullOrWhiteSpace(request.ModulesPath))
         {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.RequiredModules.cs
@@ -329,7 +329,7 @@ public sealed partial class ModulePipelineRunner
                 continue;
 
             var depName = dep.ModuleName.Trim();
-            if (ModulePipelinePlanningHelpers.ShouldSkipManifestDependencyModule(depName))
+            if (ModulePipelinePlanningHelpers.ShouldSkipTransitiveRequiredDependencyModule(depName))
                 continue;
 
             var childVersionSource = ResolveInheritedDependencyVersionSource(depName, sourceDrafts, inheritedVersionSource);

--- a/PowerForge.Tests/ArtefactBuilderLayoutTests.cs
+++ b/PowerForge.Tests/ArtefactBuilderLayoutTests.cs
@@ -83,6 +83,85 @@ public sealed class ArtefactBuilderLayoutTests
         }
     }
 
+    [Theory]
+    [InlineData(ArtefactType.Unpacked)]
+    [InlineData(ArtefactType.Packed)]
+    public void Build_Skips_Configured_Required_Module_Exclusions(ArtefactType artefactType)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var originalPsModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+        string? inspectionRoot = null;
+
+        try
+        {
+            const string moduleName = "DemoModule";
+            const string dependencyName = "DependencyModule";
+            const string excludedName = "ExcludedModule";
+            const string dependencyVersion = "2.1.0";
+
+            var stagingRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "staging"));
+            WriteStagingFixture(stagingRoot.FullName, moduleName);
+
+            var localModulesRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "psmodules"));
+            WriteInstalledModuleFixture(localModulesRoot.FullName, dependencyName, dependencyVersion);
+            WriteInstalledModuleFixture(localModulesRoot.FullName, excludedName, dependencyVersion);
+
+            var updatedPsModulePath = string.Join(
+                Path.PathSeparator,
+                new[] { localModulesRoot.FullName, originalPsModulePath }
+                    .Where(value => !string.IsNullOrWhiteSpace(value)));
+            Environment.SetEnvironmentVariable("PSModulePath", updatedPsModulePath);
+
+            var outputRoot = Path.Combine(root.FullName, "Artefacts", artefactType.ToString());
+
+            var segment = new ConfigurationArtefactSegment
+            {
+                ArtefactType = artefactType,
+                Configuration = new ArtefactConfiguration
+                {
+                    Enabled = true,
+                    Path = outputRoot,
+                    RequiredModules = new ArtefactRequiredModulesConfiguration
+                    {
+                        Enabled = true,
+                        Source = RequiredModulesSource.Installed,
+                        ExcludeModuleName = new[] { excludedName }
+                    }
+                }
+            };
+
+            var builder = new ArtefactBuilder(new NullLogger());
+            var result = builder.Build(
+                segment,
+                projectRoot: root.FullName,
+                stagingPath: stagingRoot.FullName,
+                moduleName: moduleName,
+                moduleVersion: "1.0.0",
+                preRelease: null,
+                requiredModules: new[]
+                {
+                    new RequiredModuleReference(dependencyName, moduleVersion: dependencyVersion),
+                    new RequiredModuleReference(excludedName, moduleVersion: dependencyVersion)
+                });
+
+            inspectionRoot = artefactType == ArtefactType.Packed
+                ? Path.Combine(root.FullName, "Extracted")
+                : result.OutputPath;
+
+            if (artefactType == ArtefactType.Packed)
+                ZipFile.ExtractToDirectory(result.OutputPath, inspectionRoot);
+
+            Assert.True(File.Exists(Path.Combine(inspectionRoot, dependencyName, dependencyName + ".psd1")));
+            Assert.False(Directory.Exists(Path.Combine(inspectionRoot, excludedName)));
+            Assert.DoesNotContain(result.Modules, module => string.Equals(module.Name, excludedName, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PSModulePath", originalPsModulePath);
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static void WriteStagingFixture(string stagingRoot, string moduleName)
     {
         File.WriteAllText(

--- a/PowerForge.Tests/ArtefactConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/ArtefactConfigurationFactoryTests.cs
@@ -19,6 +19,7 @@ public sealed class ArtefactConfigurationFactoryTests
             Path = "Artefacts/Packed",
             ModulesPath = "Modules/Public",
             RequiredModulesPath = "Modules/Required",
+            RequiredModulesExcludeModuleName = new[] { " PackageManagement ", "PowerShellGet", "PackageManagement" },
             CopyDirectories = new[]
             {
                 new ArtefactCopyMapping { Source = "Docs/Help", Destination = "Internals/Help" }
@@ -39,6 +40,7 @@ public sealed class ArtefactConfigurationFactoryTests
         Assert.Equal(Normalize("Artefacts/Packed"), segment.Configuration.Path);
         Assert.Equal(Normalize("Modules/Public"), segment.Configuration.RequiredModules.ModulesPath);
         Assert.Equal(Normalize("Modules/Required"), segment.Configuration.RequiredModules.Path);
+        Assert.Equal(new[] { "PackageManagement", "PowerShellGet" }, segment.Configuration.RequiredModules.ExcludeModuleName);
         Assert.Equal(Normalize("Docs/Help"), segment.Configuration.DirectoryOutput![0].Source);
         Assert.Equal(Normalize("Internals/Help"), segment.Configuration.DirectoryOutput[0].Destination);
         Assert.Equal(Normalize("README.md"), segment.Configuration.FilesOutput![0].Source);

--- a/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
+++ b/PowerForge.Tests/ModulePipelineDependencyMetadataProviderTests.cs
@@ -466,6 +466,47 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
     }
 
     [Fact]
+    public void Run_IgnoresRuntimeProvidedTransitiveDependencies_WhenApprovedModuleIsMergedAway()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new("Parent.Tools", "1.0.0", null, @"C:\Modules\Parent.Tools\1.0.0")
+                },
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference("PackageManagement", moduleVersion: "1.0.0.1"),
+                        new RequiredModuleReference("PowerShellGet", moduleVersion: "1.0.0.1"),
+                        new RequiredModuleReference("PSReadLine", moduleVersion: "2.0.0")
+                    }
+                });
+
+            var runner = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider);
+            var result = runner.Run(CreateApprovedParentSpec(root.FullName, moduleName));
+
+            Assert.True(ManifestEditor.TryGetRequiredModules(result.BuildResult.ManifestPath, out RequiredModuleReference[]? required));
+            var requiredModules = required!;
+            Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "PackageManagement", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "PowerShellGet", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(requiredModules, module => string.Equals(module.ModuleName, "PSReadLine", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_IncludesTransitiveDependenciesForPackaging_WhenParentRemainsRequired()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -489,6 +530,44 @@ public sealed class ModulePipelineDependencyMetadataProviderTests
             Assert.DoesNotContain(plan.RequiredModules, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_IgnoresRuntimeProvidedTransitiveDependenciesForPackaging_WhenParentRemainsRequired()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var provider = new FakeModuleDependencyMetadataProvider(
+                installedModules: new Dictionary<string, InstalledModuleMetadata>(StringComparer.OrdinalIgnoreCase),
+                onlineModules: new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase),
+                installedRequiredModules: new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference("Child.Tools", moduleVersion: "2.0.0"),
+                        new RequiredModuleReference("PackageManagement", moduleVersion: "1.0.0.1"),
+                        new RequiredModuleReference("PowerShellGet", moduleVersion: "1.0.0.1"),
+                        new RequiredModuleReference("PSReadLine", moduleVersion: "2.0.0")
+                    }
+                });
+
+            var spec = CreateRequiredParentSpec(root.FullName, moduleName, ModuleDependencyVersionSource.Auto);
+            var plan = new ModulePipelineRunner(new NullLogger(), new ThrowingPowerShellRunner(), provider).Plan(spec);
+
+            Assert.Contains(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Parent.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "Child.Tools", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "PackageManagement", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "PowerShellGet", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(plan.RequiredModulesForPackaging, module => string.Equals(module.ModuleName, "PSReadLine", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/PowerForge/Models/Configuration/ConfigurationArtefactSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationArtefactSegment.cs
@@ -97,6 +97,9 @@ public sealed class ArtefactRequiredModulesConfiguration
 
     /// <summary>Optional credential used for repository access when downloading required modules.</summary>
     public RepositoryCredential? Credential { get; set; }
+
+    /// <summary>Required module names that should not be copied into the artefact.</summary>
+    public string[] ExcludeModuleName { get; set; } = Array.Empty<string>();
 }
 
 /// <summary>

--- a/PowerForge/Services/ArtefactBuilder.Api.cs
+++ b/PowerForge/Services/ArtefactBuilder.Api.cs
@@ -100,7 +100,7 @@ public sealed partial class ArtefactBuilder
         {
             var tool = cfg.RequiredModules.Tool ?? ModuleSaveTool.Auto;
             var source = cfg.RequiredModules.Source ?? RequiredModulesSource.Installed;
-            foreach (var rm in (requiredModules ?? Array.Empty<RequiredModuleReference>()).Where(m => !string.IsNullOrWhiteSpace(m.ModuleName)))
+            foreach (var rm in FilterRequiredModulesForArtefact(requiredModules, cfg.RequiredModules.ExcludeModuleName))
             {
                 var depEntry = SaveRequiredModuleToFolder(
                     rm,
@@ -167,7 +167,7 @@ public sealed partial class ArtefactBuilder
             {
                 var tool = cfg.RequiredModules.Tool ?? ModuleSaveTool.Auto;
                 var source = cfg.RequiredModules.Source ?? RequiredModulesSource.Installed;
-                foreach (var rm in (requiredModules ?? Array.Empty<RequiredModuleReference>()).Where(m => !string.IsNullOrWhiteSpace(m.ModuleName)))
+                foreach (var rm in FilterRequiredModulesForArtefact(requiredModules, cfg.RequiredModules.ExcludeModuleName))
                 {
                     var depEntry = SaveRequiredModuleToFolder(
                         rm,
@@ -198,6 +198,39 @@ public sealed partial class ArtefactBuilder
         }
 
         return new ArtefactBuildResult(ArtefactType.Packed, cfg.ID, zipPath, modules.ToArray(), copied.ToArray());
+    }
+
+    private IReadOnlyList<RequiredModuleReference> FilterRequiredModulesForArtefact(
+        IReadOnlyList<RequiredModuleReference>? requiredModules,
+        IReadOnlyList<string>? excludedModuleNames)
+    {
+        var modules = (requiredModules ?? Array.Empty<RequiredModuleReference>())
+            .Where(static module => module is not null && !string.IsNullOrWhiteSpace(module.ModuleName))
+            .ToArray();
+        if (modules.Length == 0)
+            return Array.Empty<RequiredModuleReference>();
+
+        var excluded = new HashSet<string>(
+            (excludedModuleNames ?? Array.Empty<string>())
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+        if (excluded.Count == 0)
+            return modules;
+
+        var filtered = new List<RequiredModuleReference>(modules.Length);
+        foreach (var module in modules)
+        {
+            if (excluded.Contains(module.ModuleName!))
+            {
+                _logger.Info($"Skipping required module '{module.ModuleName}' for artefact because it is excluded.");
+                continue;
+            }
+
+            filtered.Add(module);
+        }
+
+        return filtered;
     }
 
     private ArtefactModuleEntry SaveRequiredModuleToFolder(

--- a/PowerForge/Services/ModulePipelinePlanningHelpers.cs
+++ b/PowerForge/Services/ModulePipelinePlanningHelpers.cs
@@ -125,4 +125,18 @@ internal static class ModulePipelinePlanningHelpers
 
         return normalizedModuleName.StartsWith("Microsoft.PowerShell.", StringComparison.OrdinalIgnoreCase);
     }
+
+    internal static bool ShouldSkipTransitiveRequiredDependencyModule(string? moduleName)
+    {
+        var normalizedModuleName = moduleName?.Trim();
+        if (normalizedModuleName is null || normalizedModuleName.Length == 0)
+            return true;
+
+        if (ShouldSkipManifestDependencyModule(normalizedModuleName))
+            return true;
+
+        return normalizedModuleName.Equals("PackageManagement", StringComparison.OrdinalIgnoreCase) ||
+               normalizedModuleName.Equals("PowerShellGet", StringComparison.OrdinalIgnoreCase) ||
+               normalizedModuleName.Equals("PSReadLine", StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary
- add per-artefact RequiredModulesExcludeModuleName support for required-module bundling
- skip transitive PowerShell runtime/module-manager dependencies by default (Microsoft.PowerShell.*, PackageManagement, PowerShellGet, PSReadLine)
- document artefact-only exclusions and cover configuration/build behavior with regression tests

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~ArtefactConfigurationFactoryTests|FullyQualifiedName~ArtefactBuilderLayoutTests|FullyQualifiedName~ModulePipelineDependencyMetadataProviderTests" --no-restore
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~ModulePipelineRegressionParityTests|FullyQualifiedName~ModulePipelineRequiredModulesResolutionTests|FullyQualifiedName~RequiredModuleResolutionEngineTests" --no-restore
- git diff --check