### PR TITLE
Clear stale external manifest dependencies

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -107,6 +107,7 @@ public sealed partial class ModulePipelineRunner
         var requiredPackagingIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var externalModules = new List<string>();
         var externalIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var baselineExternalIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         var segments = (spec.Segments ?? Array.Empty<IConfigurationSegment>())
             .Where(static segment => segment is not null)
@@ -120,15 +121,21 @@ public sealed partial class ModulePipelineRunner
         {
             manifestConfiguration = manifestBaseline.Manifest;
 
+            foreach (var external in manifestBaseline.ExternalModuleDependencies)
+            {
+                if (string.IsNullOrWhiteSpace(external))
+                    continue;
+                if (ModulePipelinePlanningHelpers.ShouldSkipManifestDependencyModule(external))
+                    continue;
+
+                baselineExternalIndex.Add(external.Trim());
+            }
+
             if (!externalDependencyConfigurationIsAuthoritative)
             {
-                foreach (var external in manifestBaseline.ExternalModuleDependencies)
+                foreach (var external in baselineExternalIndex)
                 {
-                    if (string.IsNullOrWhiteSpace(external))
-                        continue;
-
-                    var name = external.Trim();
-                    TryAddExternalModuleDependency(name, externalIndex, externalModules);
+                    TryAddExternalModuleDependency(external, externalIndex, externalModules);
                 }
             }
 
@@ -140,7 +147,7 @@ public sealed partial class ModulePipelineRunner
                 var requiredModuleName = module.ModuleName.Trim();
                 if (ModulePipelinePlanningHelpers.ShouldSkipManifestDependencyModule(requiredModuleName))
                     continue;
-                if (externalIndex.Contains(requiredModuleName))
+                if (externalIndex.Contains(requiredModuleName) || baselineExternalIndex.Contains(requiredModuleName))
                     continue;
 
                 var draft = new RequiredModuleDraft(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -108,18 +108,28 @@ public sealed partial class ModulePipelineRunner
         var externalModules = new List<string>();
         var externalIndex = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        var segments = (spec.Segments ?? Array.Empty<IConfigurationSegment>())
+            .Where(static segment => segment is not null)
+            .ToArray();
+        var externalDependencyConfigurationIsAuthoritative = segments.Any(static segment =>
+            segment is ConfigurationModuleSegment moduleSegment &&
+            moduleSegment.Kind is ModuleDependencyKind.RequiredModule or ModuleDependencyKind.ExternalModule);
+
         var manifestBaseline = TryReadProjectManifestBaseline(projectRoot, moduleName);
         if (manifestBaseline is not null)
         {
             manifestConfiguration = manifestBaseline.Manifest;
 
-            foreach (var external in manifestBaseline.ExternalModuleDependencies)
+            if (!externalDependencyConfigurationIsAuthoritative)
             {
-                if (string.IsNullOrWhiteSpace(external))
-                    continue;
+                foreach (var external in manifestBaseline.ExternalModuleDependencies)
+                {
+                    if (string.IsNullOrWhiteSpace(external))
+                        continue;
 
-                var name = external.Trim();
-                TryAddExternalModuleDependency(name, externalIndex, externalModules);
+                    var name = external.Trim();
+                    TryAddExternalModuleDependency(name, externalIndex, externalModules);
+                }
             }
 
             foreach (var module in manifestBaseline.RequiredModules)
@@ -177,7 +187,7 @@ public sealed partial class ModulePipelineRunner
                 projectUri = manifestBaseline.Manifest.ProjectUri;
         }
 
-        foreach (var segment in (spec.Segments ?? Array.Empty<IConfigurationSegment>()).Where(s => s is not null))
+        foreach (var segment in segments)
         {
             switch (segment)
             {

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -397,6 +397,59 @@ public sealed class ModulePipelineManifestRefreshTests
         }
     }
 
+    [Fact]
+    public void Run_ClearsBaselineDependencyMetadata_WhenModuleDependenciesAreConfigured()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteModuleWithStaleDependencyMetadata(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0",
+                    CsprojPath = null,
+                    KeepStaging = true
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Fresh.Required",
+                            ModuleVersion = "1.2.3",
+                            Guid = "22222222-2222-2222-2222-222222222222"
+                        }
+                    }
+                }
+            };
+
+            var runner = new ModulePipelineRunner(new NullLogger());
+            var plan = runner.Plan(spec);
+            var result = runner.Run(spec, plan);
+            var manifestPath = result.BuildResult.ManifestPath;
+
+            Assert.True(ManifestEditor.TryGetRequiredModules(manifestPath, out RequiredModuleReference[]? requiredModules));
+            Assert.Contains(requiredModules!, module => string.Equals(module.ModuleName, "LegacyOnly", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(requiredModules!, module => string.Equals(module.ModuleName, "Fresh.Required", StringComparison.OrdinalIgnoreCase));
+
+            Assert.True(ManifestEditor.TryGetPsDataStringArray(manifestPath, "ExternalModuleDependencies", out var externalModules));
+            Assert.Empty(externalModules!);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static void WriteModuleWithStaleManifest(string rootPath, string moduleName, string version)
     {
         File.WriteAllText(Path.Combine(rootPath, $"{moduleName}.psm1"), "function Test-Example { 'ok' }");

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -440,6 +440,7 @@ public sealed class ModulePipelineManifestRefreshTests
             Assert.True(ManifestEditor.TryGetRequiredModules(manifestPath, out RequiredModuleReference[]? requiredModules));
             Assert.Contains(requiredModules!, module => string.Equals(module.ModuleName, "LegacyOnly", StringComparison.OrdinalIgnoreCase));
             Assert.Contains(requiredModules!, module => string.Equals(module.ModuleName, "Fresh.Required", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(requiredModules!, module => string.Equals(module.ModuleName, "Az.Accounts", StringComparison.OrdinalIgnoreCase));
 
             Assert.True(ManifestEditor.TryGetPsDataStringArray(manifestPath, "ExternalModuleDependencies", out var externalModules));
             Assert.Empty(externalModules!);


### PR DESCRIPTION
## Summary
- stop seeding stale project-manifest ExternalModuleDependencies when module dependencies are configured in the build script
- keep existing RequiredModules baseline behavior intact
- add a regression test for stale external dependency metadata being cleared

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~ModulePipelineManifestRefreshTests|FullyQualifiedName~ModulePipelineRegressionParityTests|FullyQualifiedName~ModulePipelineApprovedModulesTests" --no-restore
- git diff --check -- PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs PowerForge.Tests/ModulePipelineManifestRefreshTests.cs