### PR TITLE
Add bundled sitemap protocol schemas

### DIFF
--- a/PowerForge.Tests/WebSitemapProtocolSchemasTests.cs
+++ b/PowerForge.Tests/WebSitemapProtocolSchemasTests.cs
@@ -1,0 +1,88 @@
+using System.Xml;
+using System.Xml.Schema;
+using PowerForge.Web;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public class WebSitemapProtocolSchemasTests
+{
+    [Fact]
+    public void BundledSchemas_LoadAndCompile()
+    {
+        CompileSchema(WebSitemapProtocolSchemas.GetSitemapSchema());
+        CompileSchema(WebSitemapProtocolSchemas.GetSitemapIndexSchema());
+
+        Assert.Contains("urlset", WebSitemapProtocolSchemas.GetSitemapSchema(), StringComparison.Ordinal);
+        Assert.Contains("sitemapindex", WebSitemapProtocolSchemas.GetSitemapIndexSchema(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExportToDirectory_WritesProtocolSchemas()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-schemas-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var result = WebSitemapProtocolSchemas.ExportToDirectory(root);
+
+            Assert.True(File.Exists(result.SitemapSchemaPath));
+            Assert.True(File.Exists(result.SitemapIndexSchemaPath));
+            Assert.Equal(root, result.OutputDirectory);
+            Assert.Contains(result.Notes, note => note.Contains("published sitemaps.org XSDs", StringComparison.Ordinal));
+            Assert.Contains(result.Notes, note => note.Contains("XHTML language alternate", StringComparison.Ordinal));
+            Assert.Contains("XML Schema for Sitemap files", File.ReadAllText(result.SitemapSchemaPath), StringComparison.Ordinal);
+            Assert.Contains("XML Schema for Sitemap index files", File.ReadAllText(result.SitemapIndexSchemaPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Cli_SitemapSchemas_ExportsProtocolSchemas()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-sitemap-schemas-cli-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var exitCode = WebCliCommandHandlers.HandleSubCommand(
+                "sitemap-schemas",
+                new[] { "--out", root },
+                outputJson: false,
+                new WebConsoleLogger(),
+                outputSchemaVersion: 1);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(Path.Combine(root, WebSitemapProtocolSchemas.SitemapSchemaFileName)));
+            Assert.True(File.Exists(Path.Combine(root, WebSitemapProtocolSchemas.SitemapIndexSchemaFileName)));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static void CompileSchema(string schemaText)
+    {
+        var schemas = new XmlSchemaSet();
+        using var stringReader = new StringReader(schemaText);
+        using var xmlReader = XmlReader.Create(stringReader);
+        schemas.Add(null, xmlReader);
+        schemas.Compile();
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, true);
+        }
+        catch
+        {
+            // ignore cleanup failures
+        }
+    }
+}

--- a/PowerForge.Web.Cli/PowerForgeWebCliJsonContext.cs
+++ b/PowerForge.Web.Cli/PowerForgeWebCliJsonContext.cs
@@ -24,6 +24,7 @@ namespace PowerForge.Web.Cli;
 [JsonSerializable(typeof(WebContentScaffoldResult))]
 [JsonSerializable(typeof(WebLlmsResult))]
 [JsonSerializable(typeof(WebSitemapResult))]
+[JsonSerializable(typeof(WebSitemapProtocolSchemaExportResult))]
 [JsonSerializable(typeof(WebAgentReadinessResult))]
 [JsonSerializable(typeof(WebAgentReadinessCheck))]
 [JsonSerializable(typeof(WebApiDocsResult))]

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Dispatch.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Dispatch.cs
@@ -52,6 +52,8 @@ collection: {{collection}}
             "overlay" => HandleOverlay(subArgs, outputJson, logger, outputSchemaVersion),
             "llms" => HandleLlms(subArgs, outputJson, logger, outputSchemaVersion),
             "sitemap" => HandleSitemap(subArgs, outputJson, logger, outputSchemaVersion),
+            "sitemap-schemas" => HandleSitemapSchemas(subArgs, outputJson, logger, outputSchemaVersion),
+            "sitemap-schema" => HandleSitemapSchemas(subArgs, outputJson, logger, outputSchemaVersion),
             "agent-ready" => HandleAgentReady(subArgs, outputJson, logger, outputSchemaVersion),
             "agentready" => HandleAgentReady(subArgs, outputJson, logger, outputSchemaVersion),
             "xref-merge" => HandleXrefMerge(subArgs, outputJson, logger, outputSchemaVersion),

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
@@ -706,6 +706,42 @@ internal static partial class WebCliCommandHandlers
         return 0;
     }
 
+    private static int HandleSitemapSchemas(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        var outputDirectory = TryGetOptionValue(subArgs, "--out") ??
+                              TryGetOptionValue(subArgs, "--out-dir") ??
+                              TryGetOptionValue(subArgs, "--output-directory") ??
+                              TryGetOptionValue(subArgs, "--path");
+        var overwrite = !HasOption(subArgs, "--no-overwrite");
+
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+            return Fail("Missing required --out.", outputJson, logger, "web.sitemap_schemas");
+
+        var result = WebSitemapProtocolSchemas.ExportToDirectory(outputDirectory, overwrite);
+
+        if (outputJson)
+        {
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = "web.sitemap_schemas",
+                Success = true,
+                ExitCode = 0,
+                Result = WebCliJson.SerializeToElement(
+                    result,
+                    WebCliJson.Context.WebSitemapProtocolSchemaExportResult)
+            });
+            return 0;
+        }
+
+        logger.Success($"Sitemap protocol schemas exported: {result.OutputDirectory}");
+        logger.Info($"sitemap.xsd: {result.SitemapSchemaPath}");
+        logger.Info($"siteindex.xsd: {result.SitemapIndexSchemaPath}");
+        foreach (var note in result.Notes)
+            logger.Info(note);
+        return 0;
+    }
+
     private static int HandleXrefMerge(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
     {
         var outPath = TryGetOptionValue(subArgs, "--out") ??

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -130,6 +130,7 @@ internal static class WebCliHelpers
         Console.WriteLine("                     [--sitemap-json] [--sitemap-json-out <file>] [--html] [--html-out <file>] [--html-template <file>] [--html-css <href>] [--html-title <text>]");
         Console.WriteLine("                     [--no-html-files] [--include-noindex-html] [--exclude <glob[,glob...]>] [--no-default-excludes]");
         Console.WriteLine("                     [--no-text-files] [--no-language-alternates] [--no-generated-sitemap-metadata] [--include-html-sitemap-route]");
+        Console.WriteLine("  powerforge-web sitemap-schemas --out <dir> [--no-overwrite] [--output json]");
         Console.WriteLine("  powerforge-web agent-ready prepare --site-root <dir> [--config <site.json>] [--base-url <url>] [--fail-on-failures] [--output json]");
         Console.WriteLine("  powerforge-web agent-ready verify --site-root <dir> [--config <site.json>] [--base-url <url>] [--fail-on-failures] [--output json]");
         Console.WriteLine("  powerforge-web agent-ready scan --url <url> [--timeout-ms <n>] [--fail-on-failures] [--output json]");

--- a/PowerForge.Web/Assets/SitemapProtocol/siteindex.xsd
+++ b/PowerForge.Web/Assets/SitemapProtocol/siteindex.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+ xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+ targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+ xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<xsd:annotation>
+  <xsd:documentation>
+    XML Schema for Sitemap index files.
+    Last Modifed 2006-07-25
+  </xsd:documentation>
+</xsd:annotation>
+
+<xsd:element name="sitemapindex">
+  <xsd:annotation>
+    <xsd:documentation>
+      Container for a set of up to 1,000 sitemap URLs.
+      This is the root element of the XML file.
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:complexType>
+    <xsd:sequence>
+      <xsd:element ref="sitemap" maxOccurs="1000"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:element>
+
+<xsd:element name="sitemap">
+  <xsd:annotation>
+    <xsd:documentation>
+      Container for the data needed to describe a sitemap.
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:complexType>
+    <xsd:all>
+      <xsd:element ref="loc"/>
+      <xsd:element ref="lastmod" minOccurs="0"/>
+    </xsd:all>
+  </xsd:complexType>
+</xsd:element>
+
+<xsd:element name="loc">
+  <xsd:annotation>
+    <xsd:documentation>
+      REQUIRED: The location URI of a sitemap.
+      The URI must conform to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt).
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType>
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:minLength value="12"/>
+      <xsd:maxLength value="2048"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:element>
+
+<xsd:element name="lastmod">
+  <xsd:annotation>
+    <xsd:documentation>
+      OPTIONAL: The date the sitemap was last modified. The date must conform
+      to the W3C DATETIME format (http://www.w3.org/TR/NOTE-datetime).
+      Example: 2005-05-10
+      Lastmod may also contain a timestamp.
+      Example: 2005-05-10T17:33:30+08:00
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType>
+    <xsd:restriction base="xsd:string">
+      <xsd:minLength value="10"/>
+      <xsd:maxLength value="25"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:element>
+
+</xsd:schema>

--- a/PowerForge.Web/Assets/SitemapProtocol/sitemap.xsd
+++ b/PowerForge.Web/Assets/SitemapProtocol/sitemap.xsd
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+ xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+ targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+ xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<xsd:annotation>
+  <xsd:documentation>
+    XML Schema for Sitemap files.
+    Last Modifed 2006-07-25
+  </xsd:documentation>
+</xsd:annotation>
+
+<xsd:element name="urlset">
+  <xsd:annotation>
+    <xsd:documentation>
+      Container for a set of up to 50,000 document elements.
+      This is the root element of the XML file.
+    </xsd:documentation>
+  </xsd:annotation>
+ <xsd:complexType>
+   <xsd:sequence>
+     <xsd:element ref="url" maxOccurs="unbounded"/>
+   </xsd:sequence>
+ </xsd:complexType>
+</xsd:element>
+
+<xsd:element name="url">
+  <xsd:annotation>
+    <xsd:documentation>
+      Container for the data needed to describe a document to crawl.
+    </xsd:documentation>
+  </xsd:annotation>
+ <xsd:complexType>
+   <xsd:all>
+     <xsd:element ref="loc"/>
+     <xsd:element ref="lastmod" minOccurs="0"/>
+     <xsd:element ref="changefreq" minOccurs="0"/>
+     <xsd:element ref="priority" minOccurs="0"/>
+   </xsd:all>
+ </xsd:complexType>
+</xsd:element>
+
+<xsd:element name="loc">
+  <xsd:annotation>
+    <xsd:documentation>
+      REQUIRED: The location URI of a document.
+      The URI must conform to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt).
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType>
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:minLength value="12"/>
+      <xsd:maxLength value="2048"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:element>
+
+<xsd:element name="lastmod">
+  <xsd:annotation>
+    <xsd:documentation>
+      OPTIONAL: The date the document was last modified. The date must conform
+      to the W3C DATETIME format (http://www.w3.org/TR/NOTE-datetime).
+      Example: 2005-05-10
+      Lastmod may also contain a timestamp.
+      Example: 2005-05-10T17:33:30+08:00
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType>
+    <xsd:restriction base="xsd:string">
+      <xsd:minLength value="10"/>
+      <xsd:maxLength value="25"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:element>
+
+<xsd:element name="changefreq">
+  <xsd:annotation>
+    <xsd:documentation>
+      OPTIONAL: Indicates how frequently the content at a particular URL is
+      likely to change. The value "always" should be used to describe
+      documents that change each time they are accessed. The value "never"
+      should be used to describe archived URLs. Please note that web
+      crawlers may not necessarily crawl pages marked "always" more often.
+      Consider this element as a friendly suggestion and not a command.
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="always"/>
+      <xsd:enumeration value="hourly"/>
+      <xsd:enumeration value="daily"/>
+      <xsd:enumeration value="weekly"/>
+      <xsd:enumeration value="monthly"/>
+      <xsd:enumeration value="yearly"/>
+      <xsd:enumeration value="never"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:element>
+
+<xsd:element name="priority">
+  <xsd:annotation>
+    <xsd:documentation>
+      OPTIONAL: The priority of a particular URL relative to other pages
+      on the same site. The value for this element is a number between
+      0.0 and 1.0 where 0.0 identifies the lowest priority page(s).
+      The default priority of a page is 0.5. Priority is used to select
+      between pages on your site. Setting a priority of 1.0 for all URLs
+      will not help you, as the relative priority of pages on your site
+      is what will be considered.
+    </xsd:documentation>
+  </xsd:annotation>
+  <xsd:simpleType>
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0.0"/>
+      <xsd:maxInclusive value="1.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:element>
+
+
+</xsd:schema>

--- a/PowerForge.Web/Models/WebSitemapProtocolSchemaModels.cs
+++ b/PowerForge.Web/Models/WebSitemapProtocolSchemaModels.cs
@@ -1,0 +1,17 @@
+namespace PowerForge.Web;
+
+/// <summary>Result payload for exporting bundled sitemap protocol schemas.</summary>
+public sealed class WebSitemapProtocolSchemaExportResult
+{
+    /// <summary>Output directory containing the exported schemas.</summary>
+    public string OutputDirectory { get; set; } = string.Empty;
+
+    /// <summary>Path to the exported sitemap.xsd file.</summary>
+    public string SitemapSchemaPath { get; set; } = string.Empty;
+
+    /// <summary>Path to the exported siteindex.xsd file.</summary>
+    public string SitemapIndexSchemaPath { get; set; } = string.Empty;
+
+    /// <summary>Compatibility notes for consumers using the exported schemas.</summary>
+    public string[] Notes { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -44,6 +44,8 @@
     <EmbeddedResource Include="Assets\ApiDocs\docs.js" />
     <EmbeddedResource Include="Assets\ApiDocs\api-header.html" />
     <EmbeddedResource Include="Assets\ApiDocs\api-footer.html" />
+    <EmbeddedResource Include="Assets\SitemapProtocol\sitemap.xsd" />
+    <EmbeddedResource Include="Assets\SitemapProtocol\siteindex.xsd" />
   </ItemGroup>
 
 </Project>

--- a/PowerForge.Web/Services/WebSitemapProtocolSchemas.cs
+++ b/PowerForge.Web/Services/WebSitemapProtocolSchemas.cs
@@ -1,0 +1,75 @@
+using System.Text;
+
+namespace PowerForge.Web;
+
+/// <summary>Provides bundled sitemap.org protocol schemas for offline validation.</summary>
+public static class WebSitemapProtocolSchemas
+{
+    /// <summary>Default file name for the bundled sitemap URL-set schema.</summary>
+    public const string SitemapSchemaFileName = "sitemap.xsd";
+
+    /// <summary>Default file name for the bundled sitemap index schema.</summary>
+    public const string SitemapIndexSchemaFileName = "siteindex.xsd";
+
+    private const string SitemapSchemaResourceName = "PowerForge.Web.Assets.SitemapProtocol.sitemap.xsd";
+    private const string SitemapIndexSchemaResourceName = "PowerForge.Web.Assets.SitemapProtocol.siteindex.xsd";
+
+    private static readonly string[] SchemaNotes =
+    {
+        "These files mirror the published sitemaps.org XSDs for strict offline schema validation.",
+        "They do not allow PowerForge-generated XHTML language alternate links or Google extension elements.",
+        "Pair them with content checks for protocol rules that the published XSDs do not fully encode."
+    };
+
+    /// <summary>Gets the bundled sitemap.xsd content.</summary>
+    public static string GetSitemapSchema()
+        => ReadResourceText(SitemapSchemaResourceName);
+
+    /// <summary>Gets the bundled siteindex.xsd content.</summary>
+    public static string GetSitemapIndexSchema()
+        => ReadResourceText(SitemapIndexSchemaResourceName);
+
+    /// <summary>Gets compatibility notes for consumers using the bundled schemas.</summary>
+    public static string[] GetCompatibilityNotes()
+        => (string[])SchemaNotes.Clone();
+
+    /// <summary>Writes the bundled schemas to <paramref name="outputDirectory"/>.</summary>
+    public static WebSitemapProtocolSchemaExportResult ExportToDirectory(string outputDirectory, bool overwrite = true)
+    {
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+            throw new ArgumentException("Output directory is required.", nameof(outputDirectory));
+
+        var directory = Path.GetFullPath(outputDirectory);
+        Directory.CreateDirectory(directory);
+
+        var sitemapPath = Path.Combine(directory, SitemapSchemaFileName);
+        var sitemapIndexPath = Path.Combine(directory, SitemapIndexSchemaFileName);
+        WriteIfNeeded(sitemapPath, GetSitemapSchema(), overwrite);
+        WriteIfNeeded(sitemapIndexPath, GetSitemapIndexSchema(), overwrite);
+
+        return new WebSitemapProtocolSchemaExportResult
+        {
+            OutputDirectory = directory,
+            SitemapSchemaPath = sitemapPath,
+            SitemapIndexSchemaPath = sitemapIndexPath,
+            Notes = GetCompatibilityNotes()
+        };
+    }
+
+    private static void WriteIfNeeded(string path, string content, bool overwrite)
+    {
+        if (!overwrite && File.Exists(path))
+            return;
+
+        File.WriteAllText(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static string ReadResourceText(string resourceName)
+    {
+        var assembly = typeof(WebSitemapProtocolSchemas).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded sitemap schema resource not found: {resourceName}");
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
+    }
+}


### PR DESCRIPTION
## Summary
- bundle the official sitemap.org `sitemap.xsd` and `siteindex.xsd` in PowerForge.Web so CI and downstream sites do not depend on fetching `www.sitemaps.org`
- expose `WebSitemapProtocolSchemas` plus `powerforge-web sitemap-schemas --out <dir>` for consumers that need local schema files
- add focused tests covering embedded schema loading, export, and CLI dispatch

## Validation
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Debug --filter FullyQualifiedName~WebSitemapProtocolSchemasTests /m:1 /nr:false`
- `dotnet build PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -c Debug -f net10.0 /m:1 /nr:false`
- `dotnet run --project PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -c Debug --framework net10.0 -- sitemap-schemas --out <temp>`
- DomainDetective check: `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Debug --filter FullyQualifiedName~TestSitemapAnalysis /m:1 /nr:false` passed for net472, net8.0, and net10.0; DomainDetective already embeds its own sitemap analyzer schemas.