### PR TITLE
fix(msi): support calendar product versions

### DIFF
--- a/Docs/PSPublishModule.DotNetPublish.Quickstart.md
+++ b/Docs/PSPublishModule.DotNetPublish.Quickstart.md
@@ -186,6 +186,7 @@ Depending on config, the run can emit:
 - Registry value components can write a literal `Value`, or write an installer property by setting `ValueProperty`, for example persisting `LICENSE_KEY` after the UI collects it.
 - Shortcut components can use `TargetFileId` for an explicitly authored file component, or `Target` such as `[INSTALLFOLDER]MyApp.exe` when the executable comes from harvested payload.
 - WiX still does the compile. The generated project includes `WixToolset.UI.wixext` and `WixToolset.Util.wixext` only when the authoring model needs those extensions.
+- `Installers[].Versioning.Pattern` defaults to `FixedMajorMinorDatePatch`. Use `UtcShortYearMonthDayMinute` when an MSI line must keep a calendar-based `yy.month.dayMinute` product-version sequence for major-upgrade compatibility with older installer scripts.
 
 ## Microsoft Store / MSIX Packaging
 

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -667,6 +667,97 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
+    public void ResolveMsiVersion_UsesUtcShortYearMonthDayMinutePattern()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                AllowOutputOutsideProjectRoot = false,
+                Configuration = "Release"
+            };
+            var installer = new DotNetPublishInstallerPlan
+            {
+                Id = "app.msi",
+                Versioning = new DotNetPublishMsiVersionOptions
+                {
+                    Enabled = true,
+                    Pattern = DotNetPublishMsiVersionPattern.UtcShortYearMonthDayMinute,
+                    FloorDateUtc = "2099-06-02",
+                    Monotonic = false
+                }
+            };
+            var step = new DotNetPublishStep
+            {
+                InstallerId = "app.msi",
+                TargetName = "app",
+                Framework = "net10.0",
+                Runtime = "win-x64",
+                Style = DotNetPublishStyle.Portable
+            };
+
+            var result = InvokeResolveMsiVersion(plan, installer, step);
+
+            Assert.Equal("99.6.2880", result.Version);
+            Assert.Equal(2880, result.Patch);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void ResolveMsiVersion_DoesNotBumpPatchWhenPreviousStateVersionIsOlder()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var statePath = Path.Combine(root, "state", "version.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(statePath)!);
+            File.WriteAllText(statePath, "{ \"lastPatch\": 9499, \"version\": \"1.0.9499\" }");
+
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                AllowOutputOutsideProjectRoot = false,
+                Configuration = "Release"
+            };
+            var installer = new DotNetPublishInstallerPlan
+            {
+                Id = "app.msi",
+                Versioning = new DotNetPublishMsiVersionOptions
+                {
+                    Enabled = true,
+                    Pattern = DotNetPublishMsiVersionPattern.UtcShortYearMonthDayMinute,
+                    FloorDateUtc = "2099-06-02",
+                    Monotonic = true,
+                    StatePath = "state/version.json"
+                }
+            };
+            var step = new DotNetPublishStep
+            {
+                InstallerId = "app.msi",
+                TargetName = "app",
+                Framework = "net10.0",
+                Runtime = "win-x64",
+                Style = DotNetPublishStyle.Portable
+            };
+
+            var result = InvokeResolveMsiVersion(plan, installer, step);
+
+            Assert.Equal("99.6.2880", result.Version);
+            Assert.Equal(2880, result.Patch);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void ResolveMsiVersion_CapsPatchAtConfiguredLimit()
     {
         var root = CreateTempRoot();

--- a/PowerForge/Models/DotNetPublish/DotNetPublishEnums.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishEnums.cs
@@ -70,6 +70,17 @@ public enum DotNetPublishMsiHarvestMode
 }
 
 /// <summary>
+/// Version pattern used when PowerForge resolves MSI product versions.
+/// </summary>
+public enum DotNetPublishMsiVersionPattern
+{
+    /// <summary>Use configured major/minor values and a date-floor patch segment.</summary>
+    FixedMajorMinorDatePatch,
+    /// <summary>Use UTC short year, month, and day-minute patch segments: <c>yy.month.dayMinute</c>.</summary>
+    UtcShortYearMonthDayMinute
+}
+
+/// <summary>
 /// Microsoft Store / MSIX packaging build mode.
 /// </summary>
 public enum DotNetPublishStoreBuildMode

--- a/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
@@ -695,6 +695,11 @@ public sealed class DotNetPublishMsiVersionOptions
     public bool Enabled { get; set; }
 
     /// <summary>
+    /// Version pattern used to resolve the MSI product version. Default keeps the historical PowerForge behavior.
+    /// </summary>
+    public DotNetPublishMsiVersionPattern Pattern { get; set; } = DotNetPublishMsiVersionPattern.FixedMajorMinorDatePatch;
+
+    /// <summary>
     /// Major version segment (0-255). Default: 1.
     /// </summary>
     public int Major { get; set; } = 1;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -510,11 +510,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var minor = Clamp(v.Minor, 0, 255);
         var patchCap = Clamp(v.PatchCap, 1, 65535);
 
-        var floorDate = string.IsNullOrWhiteSpace(v.FloorDateUtc)
-            ? DateTime.UtcNow.Date
-            : ParseUtcDate(v.FloorDateUtc!);
-
-        var basePatch = DaysSince20000101(floorDate);
+        var basePatch = ResolveMsiVersionSegments(v, ref major, ref minor);
         var patch = Clamp(basePatch, 0, patchCap);
         var propertyName = string.IsNullOrWhiteSpace(v.PropertyName) ? "ProductVersion" : v.PropertyName!.Trim();
         string? statePath = null;
@@ -539,9 +535,9 @@ public sealed partial class DotNetPublishPipelineRunner
             if (!plan.AllowOutputOutsideProjectRoot)
                 EnsurePathWithinRoot(plan.ProjectRoot, statePath, $"Installer '{installer.Id}' version state path");
 
-            var previous = ReadMsiVersionStatePatch(statePath);
-            if (previous.HasValue && previous.Value >= patch)
-                patch = Math.Min(patchCap, previous.Value + 1);
+            var previous = ReadMsiVersionState(statePath);
+            if (ShouldBumpMsiPatch(previous, major, minor, patch))
+                patch = Math.Min(patchCap, previous!.LastPatch + 1);
         }
 
         if (patch >= patchCap && basePatch > patchCap)
@@ -553,6 +549,31 @@ public sealed partial class DotNetPublishPipelineRunner
 
         var version = $"{major}.{minor}.{patch}";
         return new MsiVersionResolution(version, propertyName, patch, statePath);
+    }
+
+    private static int ResolveMsiVersionSegments(DotNetPublishMsiVersionOptions options, ref int major, ref int minor)
+    {
+        switch (options.Pattern)
+        {
+            case DotNetPublishMsiVersionPattern.UtcShortYearMonthDayMinute:
+                var stamp = DateTime.UtcNow;
+                if (!string.IsNullOrWhiteSpace(options.FloorDateUtc))
+                {
+                    var floor = ParseUtcDate(options.FloorDateUtc!);
+                    if (floor > stamp)
+                        stamp = floor;
+                }
+
+                major = Clamp(stamp.Year - 2000, 0, 255);
+                minor = Clamp(stamp.Month, 0, 255);
+                return (stamp.Day * 1440) + (stamp.Hour * 60) + stamp.Minute;
+            case DotNetPublishMsiVersionPattern.FixedMajorMinorDatePatch:
+            default:
+                var floorDate = string.IsNullOrWhiteSpace(options.FloorDateUtc)
+                    ? DateTime.UtcNow.Date
+                    : ParseUtcDate(options.FloorDateUtc!);
+                return DaysSince20000101(floorDate);
+        }
     }
 
     private MsiClientLicenseResolution ResolveInstallerClientLicense(
@@ -602,24 +623,52 @@ public sealed partial class DotNetPublishPipelineRunner
         return MsiClientLicenseResolution.None();
     }
 
-    private static int? ReadMsiVersionStatePatch(string statePath)
+    private static MsiVersionState? ReadMsiVersionState(string statePath)
     {
         try
         {
             if (!File.Exists(statePath)) return null;
             var json = File.ReadAllText(statePath);
-            var state = JsonSerializer.Deserialize<MsiVersionState>(
+            return JsonSerializer.Deserialize<MsiVersionState>(
                 json,
                 new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true
                 });
-            return state?.LastPatch;
         }
         catch
         {
             return null;
         }
+    }
+
+    private static bool ShouldBumpMsiPatch(MsiVersionState? previous, int major, int minor, int patch)
+    {
+        if (previous is null || previous.LastPatch < patch)
+            return false;
+
+        if (TryParseMsiVersion(previous.Version, out var previousMajor, out var previousMinor, out _)
+            && (previousMajor < major || (previousMajor == major && previousMinor < minor)))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseMsiVersion(string? version, out int major, out int minor, out int patch)
+    {
+        major = 0;
+        minor = 0;
+        patch = 0;
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+
+        var parts = version!.Split('.');
+        return parts.Length >= 3
+            && int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out major)
+            && int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out minor)
+            && int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out patch);
     }
 
     private static void WriteMsiVersionState(string statePath, int patch, string version)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -1186,6 +1186,7 @@ public sealed partial class DotNetPublishPipelineRunner
         return new DotNetPublishMsiVersionOptions
         {
             Enabled = versioning.Enabled,
+            Pattern = versioning.Pattern,
             Major = versioning.Major,
             Minor = versioning.Minor,
             FloorDateUtc = versioning.FloorDateUtc,
@@ -2532,6 +2533,8 @@ public sealed partial class DotNetPublishPipelineRunner
         if (clone is null) return null;
         if (!clone.Enabled) return clone;
 
+        if (!Enum.IsDefined(typeof(DotNetPublishMsiVersionPattern), clone.Pattern))
+            throw new ArgumentException($"Installer '{installerId}' Versioning.Pattern is not supported.");
         if (clone.Major < 0 || clone.Major > 255)
             throw new ArgumentException($"Installer '{installerId}' Versioning.Major must be between 0 and 255.");
         if (clone.Minor < 0 || clone.Minor > 255)

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -98,11 +98,16 @@
       "type": "string",
       "enum": ["Verify", "Update"]
     },
+    "DotNetPublishMsiVersionPattern": {
+      "type": "string",
+      "enum": ["FixedMajorMinorDatePatch", "UtcShortYearMonthDayMinute"]
+    },
     "DotNetPublishMsiVersionOptions": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "Enabled": { "type": "boolean" },
+        "Pattern": { "$ref": "#/$defs/DotNetPublishMsiVersionPattern" },
         "Major": { "type": "integer", "minimum": 0, "maximum": 255 },
         "Minor": { "type": "integer", "minimum": 0, "maximum": 255 },
         "FloorDateUtc": { "type": ["string", "null"] },


### PR DESCRIPTION
## Summary
- add an explicit `UtcShortYearMonthDayMinute` MSI versioning pattern for calendar-based product-version lines
- keep the existing fixed-major/minor date-patch behavior as the default
- avoid monotonic patch bumps when the persisted state version is older than the newly resolved major/minor line
- document the new pattern and cover it with focused MSI version resolver tests

## Validation
- `dotnet.exe test PowerForge.Tests\PowerForge.Tests.csproj -c Debug --filter "FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests" /m:1 /nr:false`
- `dotnet.exe build PowerForge\PowerForge.csproj -c Debug -f net472 /m:1 /nr:false`
- `dotnet.exe build PSPublishModule\PSPublishModule.csproj -c Debug -f net8.0 /m:1 /nr:false`
- `git diff --check`
