### PR TITLE
Normalize Markdown help example indentation

### DIFF
--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -72,4 +72,34 @@ Show-DemoOutput
         Assert.Contains("PS> Show-DemoOutput\r\n        Name        Status", exampleSection, StringComparison.Ordinal);
         Assert.Contains("\r\n        Service A   Healthy\r\n        Service B   Watching", exampleSection, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void RenderCommandMarkdown_PreservesSingleBlockBodyIndentationAfterInlinePrompt()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Invoke-DemoBlock",
+            Synopsis = "Invokes a demo block.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+ForEach-Object {
+        $_.Name
+        $_.Status
+        }
+""",
+                    Remarks = "Keeps authored block formatting."
+                }
+            }
+        };
+
+        var markdown = MarkdownHelpWriter.RenderCommandMarkdown("DemoModule", command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> ForEach-Object {\r\n        $_.Name", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\n        $_.Status\r\n        }", exampleSection, StringComparison.Ordinal);
+    }
 }

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -42,4 +42,34 @@ $plan = New-DemoDeckPlan {
         Assert.DoesNotContain("\r\n            Add-DemoSection", exampleSection, StringComparison.Ordinal);
         Assert.DoesNotContain("\r\n        New-DemoDeck -Path", exampleSection, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void RenderCommandMarkdown_PreservesAuthoredIndentationAfterInlinePrompt()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Show-DemoOutput",
+            Synopsis = "Shows demo output.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+Show-DemoOutput
+        Name        Status
+        Service A   Healthy
+        Service B   Watching
+""",
+                    Remarks = "Shows aligned console output."
+                }
+            }
+        };
+
+        var markdown = MarkdownHelpWriter.RenderCommandMarkdown("DemoModule", command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> Show-DemoOutput\r\n        Name        Status", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\n        Service A   Healthy\r\n        Service B   Watching", exampleSection, StringComparison.Ordinal);
+    }
 }

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -102,4 +102,34 @@ ForEach-Object {
         Assert.Contains("PS> ForEach-Object {\r\n        $_.Name", exampleSection, StringComparison.Ordinal);
         Assert.Contains("\r\n        $_.Status\r\n        }", exampleSection, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void RenderCommandMarkdown_IgnoresQuotedDelimitersWhenPreservingSingleBlockIndentation()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Invoke-DemoBlock",
+            Synopsis = "Invokes a demo block.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+ForEach-Object {
+        "}"
+        Get-Process
+        }
+""",
+                    Remarks = "Keeps authored block formatting."
+                }
+            }
+        };
+
+        var markdown = MarkdownHelpWriter.RenderCommandMarkdown("DemoModule", command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> ForEach-Object {\r\n        \"}\"", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\n        Get-Process\r\n        }", exampleSection, StringComparison.Ordinal);
+    }
 }

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using PowerForge;
+using Xunit;
+
+public class MarkdownHelpWriterTests
+{
+    [Fact]
+    public void RenderCommandMarkdown_NormalizesIncidentalExampleIndentation()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Add-DemoDeck",
+            Synopsis = "Adds a demo deck.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+$plan = New-DemoDeckPlan {
+            Add-DemoSection -Title 'Service Review'
+            Add-DemoCardGrid -Cards @(
+                @{ Title = 'Availability'; Items = @('Healthy', 'No critical incidents') }
+                @{ Title = 'Risk'; Items = @('One dependency on watch') }
+            )
+        }
+        New-DemoDeck -Path .\Examples\Documents\DesignerDeck.pptx {
+            Add-DemoDeck -Plan $plan
+        }
+""",
+                    Remarks = "Uses the current deck plan."
+                }
+            }
+        };
+
+        var markdown = MarkdownHelpWriter.RenderCommandMarkdown("DemoModule", command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> $plan = New-DemoDeckPlan {\r\n    Add-DemoSection -Title 'Service Review'", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\nNew-DemoDeck -Path .\\Examples\\Documents\\DesignerDeck.pptx {\r\n    Add-DemoDeck -Plan $plan\r\n}", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n            Add-DemoSection", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n        New-DemoDeck -Path", exampleSection, StringComparison.Ordinal);
+    }
+}

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -345,9 +345,9 @@ internal sealed class MarkdownHelpWriter
 
     private static string RenderMarkdownExampleCode(string commandName, DocumentationExampleHelp example)
     {
-        var code = string.IsNullOrWhiteSpace(example.Code)
+        var code = NormalizeMarkdownExampleCode(string.IsNullOrWhiteSpace(example.Code)
             ? commandName
-            : example.Code.Replace("\r\n", "\n").TrimEnd('\n', '\r');
+            : example.Code);
 
         var introduction = (example.Introduction ?? string.Empty)
             .Replace("\r\n", "\n")
@@ -365,6 +365,91 @@ internal sealed class MarkdownHelpWriter
 
         lines[0] = introduction + lines[0];
         return string.Join(Environment.NewLine, lines);
+    }
+
+    private static string NormalizeMarkdownExampleCode(string code)
+    {
+        var normalized = (code ?? string.Empty)
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n')
+            .Trim('\n');
+
+        if (normalized.Length == 0)
+            return string.Empty;
+
+        var lines = normalized.Split('\n');
+        RemoveSharedIndent(lines, GetCommonIndent(lines));
+        RemoveSharedIndentAfterInlineFirstLine(lines);
+
+        return string.Join("\n", lines).TrimEnd('\n');
+    }
+
+    private static void RemoveSharedIndentAfterInlineFirstLine(string[] lines)
+    {
+        var firstNonBlank = Array.FindIndex(lines, line => !string.IsNullOrWhiteSpace(line));
+        if (firstNonBlank < 0 || CountLeadingWhitespace(lines[firstNonBlank]) > 0)
+            return;
+
+        var indent = GetCommonIndent(lines.Skip(firstNonBlank + 1));
+        if (indent < 8)
+            return;
+
+        for (var i = firstNonBlank + 1; i < lines.Length; i++)
+        {
+            lines[i] = RemoveLeadingWhitespace(lines[i], indent);
+        }
+    }
+
+    private static int GetCommonIndent(IEnumerable<string> lines)
+    {
+        var common = int.MaxValue;
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var indent = CountLeadingWhitespace(line);
+            common = Math.Min(common, indent);
+        }
+
+        return common == int.MaxValue ? 0 : common;
+    }
+
+    private static void RemoveSharedIndent(string[] lines, int indent)
+    {
+        if (indent <= 0)
+            return;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            lines[i] = RemoveLeadingWhitespace(lines[i], indent);
+        }
+    }
+
+    private static int CountLeadingWhitespace(string line)
+    {
+        var count = 0;
+        while (count < line.Length && (line[count] == ' ' || line[count] == '\t'))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string RemoveLeadingWhitespace(string line, int count)
+    {
+        if (string.IsNullOrEmpty(line) || count <= 0)
+            return line;
+
+        var index = 0;
+        while (index < line.Length && index < count && (line[index] == ' ' || line[index] == '\t'))
+        {
+            index++;
+        }
+
+        return index == 0 ? line : line[index..];
     }
 
     private static string GetRelativeLink(string fromDirectory, string toPath)

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -397,7 +397,7 @@ internal sealed class MarkdownHelpWriter
         if (indent < 8)
             return;
 
-        if (!HasTopLevelBlockLine(lines, firstNonBlank + 1, indent))
+        if (!HasAdditionalTopLevelLineAfterOpenedBlock(lines[firstNonBlank], lines, firstNonBlank + 1, indent))
             return;
 
         for (var i = firstNonBlank + 1; i < lines.Length; i++)
@@ -415,16 +415,27 @@ internal sealed class MarkdownHelpWriter
             || trimmed.EndsWith("(", StringComparison.Ordinal);
     }
 
-    private static bool HasTopLevelBlockLine(string[] lines, int startIndex, int indent)
+    private static bool HasAdditionalTopLevelLineAfterOpenedBlock(string firstLine, string[] lines, int startIndex, int indent)
     {
+        var blockDepth = Math.Max(0, CountBlockDepthDelta(firstLine));
         for (var i = startIndex; i < lines.Length; i++)
         {
             var line = lines[i];
-            if (string.IsNullOrWhiteSpace(line) || CountLeadingWhitespace(line) != indent)
+            if (string.IsNullOrWhiteSpace(line))
                 continue;
 
-            if (LooksLikeTopLevelPowerShellLine(RemoveLeadingWhitespace(line, indent)))
+            line = RemoveLeadingWhitespace(line, indent);
+            var trimmed = line.TrimStart();
+            var isCandidateTopLevel = CountLeadingWhitespace(line) == 0;
+            if (isCandidateTopLevel
+                && blockDepth == 0
+                && !StartsWithBlockClose(trimmed)
+                && LooksLikeTopLevelPowerShellLine(trimmed))
+            {
                 return true;
+            }
+
+            blockDepth = Math.Max(0, blockDepth + CountBlockDepthDelta(line));
         }
 
         return false;
@@ -435,9 +446,6 @@ internal sealed class MarkdownHelpWriter
         var trimmed = line.TrimStart();
         if (trimmed.Length == 0)
             return false;
-
-        if (trimmed[0] == '}' || trimmed[0] == ')' || trimmed[0] == ']')
-            return true;
 
         if (trimmed[0] == '$' || trimmed[0] == '[' || trimmed[0] == '&' || trimmed[0] == '.')
             return true;
@@ -453,6 +461,32 @@ internal sealed class MarkdownHelpWriter
         }
 
         return dashIndex + 1 < trimmed.Length && char.IsLetter(trimmed[dashIndex + 1]);
+    }
+
+    private static bool StartsWithBlockClose(string trimmed)
+        => trimmed.Length > 0 && (trimmed[0] == '}' || trimmed[0] == ')' || trimmed[0] == ']');
+
+    private static int CountBlockDepthDelta(string line)
+    {
+        var delta = 0;
+        foreach (var ch in line)
+        {
+            switch (ch)
+            {
+                case '{':
+                case '(':
+                case '[':
+                    delta++;
+                    break;
+                case '}':
+                case ')':
+                case ']':
+                    delta--;
+                    break;
+            }
+        }
+
+        return delta;
     }
 
     private static int GetCommonIndent(IEnumerable<string> lines)

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -469,8 +469,41 @@ internal sealed class MarkdownHelpWriter
     private static int CountBlockDepthDelta(string line)
     {
         var delta = 0;
-        foreach (var ch in line)
+        var inSingleQuotedString = false;
+        var inDoubleQuotedString = false;
+        for (var i = 0; i < line.Length; i++)
         {
+            var ch = line[i];
+            if (ch == '`' && inDoubleQuotedString)
+            {
+                i++;
+                continue;
+            }
+
+            if (!inSingleQuotedString && !inDoubleQuotedString && ch == '#')
+                break;
+
+            if (!inDoubleQuotedString && ch == '\'')
+            {
+                if (inSingleQuotedString && i + 1 < line.Length && line[i + 1] == '\'')
+                {
+                    i++;
+                    continue;
+                }
+
+                inSingleQuotedString = !inSingleQuotedString;
+                continue;
+            }
+
+            if (!inSingleQuotedString && ch == '"')
+            {
+                inDoubleQuotedString = !inDoubleQuotedString;
+                continue;
+            }
+
+            if (inSingleQuotedString || inDoubleQuotedString)
+                continue;
+
             switch (ch)
             {
                 case '{':

--- a/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MarkdownHelpWriter.cs
@@ -390,14 +390,69 @@ internal sealed class MarkdownHelpWriter
         if (firstNonBlank < 0 || CountLeadingWhitespace(lines[firstNonBlank]) > 0)
             return;
 
+        if (!LooksLikePowerShellBlockOpening(lines[firstNonBlank]))
+            return;
+
         var indent = GetCommonIndent(lines.Skip(firstNonBlank + 1));
         if (indent < 8)
+            return;
+
+        if (!HasTopLevelBlockLine(lines, firstNonBlank + 1, indent))
             return;
 
         for (var i = firstNonBlank + 1; i < lines.Length; i++)
         {
             lines[i] = RemoveLeadingWhitespace(lines[i], indent);
         }
+    }
+
+    private static bool LooksLikePowerShellBlockOpening(string line)
+    {
+        var trimmed = line.TrimEnd();
+        return trimmed.EndsWith("{", StringComparison.Ordinal)
+            || trimmed.EndsWith("@(", StringComparison.Ordinal)
+            || trimmed.EndsWith("@{", StringComparison.Ordinal)
+            || trimmed.EndsWith("(", StringComparison.Ordinal);
+    }
+
+    private static bool HasTopLevelBlockLine(string[] lines, int startIndex, int indent)
+    {
+        for (var i = startIndex; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (string.IsNullOrWhiteSpace(line) || CountLeadingWhitespace(line) != indent)
+                continue;
+
+            if (LooksLikeTopLevelPowerShellLine(RemoveLeadingWhitespace(line, indent)))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool LooksLikeTopLevelPowerShellLine(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.Length == 0)
+            return false;
+
+        if (trimmed[0] == '}' || trimmed[0] == ')' || trimmed[0] == ']')
+            return true;
+
+        if (trimmed[0] == '$' || trimmed[0] == '[' || trimmed[0] == '&' || trimmed[0] == '.')
+            return true;
+
+        var dashIndex = trimmed.IndexOf('-');
+        if (dashIndex <= 0)
+            return false;
+
+        for (var i = 0; i < dashIndex; i++)
+        {
+            if (!char.IsLetter(trimmed[i]))
+                return false;
+        }
+
+        return dashIndex + 1 < trimmed.Length && char.IsLetter(trimmed[dashIndex + 1]);
     }
 
     private static int GetCommonIndent(IEnumerable<string> lines)
@@ -449,7 +504,7 @@ internal sealed class MarkdownHelpWriter
             index++;
         }
 
-        return index == 0 ? line : line[index..];
+        return index == 0 ? line : line.Substring(index);
     }
 
     private static string GetRelativeLink(string fromDirectory, string toPath)


### PR DESCRIPTION
## Summary
- normalize incidental indentation in generated Markdown help example code fences
- preserve normal PowerShell block indentation while removing XML/MAML formatting drift
- add a focused regression test for multi-line examples with a `PS> ` introduction

## Root cause
Generated help can carry XML/MAML indentation into `DocumentationExampleHelp.Code`. `MarkdownHelpWriter` rendered that code verbatim and then prefixed the first line with `PS> `, which made following lines appear over-indented in GitHub diffs and rendered Markdown.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~MarkdownHelpWriterTests" --no-restore`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~DocumentationGenerationTests|FullyQualifiedName~MarkdownHelpWriterTests" --no-restore`
- `git diff --check`

Note: I also started the full `PowerForge.Tests` project, but stopped it after several silent minutes. The focused documentation tests covering this renderer path passed.
