### PR TITLE
Make PowerShell tooling dependencies feature-scoped

### DIFF
--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -143,9 +143,9 @@ Invoke-ModuleBuild @buildParams -Settings {
     }
     New-ConfigurationManifest @Manifest
 
-    # Add standard module dependencies (directly, but can be used with loop as well)
-    New-ConfigurationModule -Type RequiredModule -Name 'powershellget' -Guid 'Auto' -Version 'Latest'
-    New-ConfigurationModule -Type RequiredModule -Name 'Pester' -Version Auto -Guid Auto
+    # Keep feature-specific tooling out of the module manifest RequiredModules list.
+    # Test workflows install/use Pester on demand, and repository/download workflows
+    # probe PSResourceGet first with PowerShellGet fallback when those features run.
 
     # Do not add inbox Microsoft.PowerShell.* modules as Required/External dependencies.
     # They are part of the runtime and publishing them as gallery dependencies breaks

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -2,7 +2,7 @@
 Module Name: PSPublishModule
 Module Guid: eb76426a-1992-40a5-82cd-6480f883ef4d
 Download Help Link: https://github.com/EvotecIT/PSPublishModule
-Help Version: 3.0.22
+Help Version: 3.0.23
 Locale: en-US
 ---
 # PSPublishModule Module

--- a/Module/PSPublishModule.psd1
+++ b/Module/PSPublishModule.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.5.2'
     FunctionsToExport      = @()
     GUID                   = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
-    ModuleVersion          = '3.0.22'
+    ModuleVersion          = '3.0.23'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{
@@ -20,15 +20,7 @@
             ExternalModuleDependencies = @()
         }
     }
-    RequiredModules        = @(@{
-            Guid            = '1d73a601-4a6c-43c5-ba3f-619b18bbb404'
-            ModuleName      = 'powershellget'
-            ModuleVersion   = '2.2.5'
-        }, @{
-            Guid            = 'a699dea5-2c73-4616-a270-1f7abb777e71'
-            ModuleName      = 'Pester'
-            ModuleVersion   = '5.7.1'
-        })
+    RequiredModules        = @()
     RootModule             = 'PSPublishModule.psm1'
     NestedModules          = @()
     ScriptsToProcess       = @()

--- a/Module/Tests/ModuleTestingFunctions.Tests.ps1
+++ b/Module/Tests/ModuleTestingFunctions.Tests.ps1
@@ -21,7 +21,8 @@
             $result.ModuleName | Should -Be 'PSPublishModule'
             $result.ModuleVersion | Should -Not -BeNullOrEmpty
             $result.ManifestPath | Should -Match '\.psd1$'
-            $result.RequiredModules | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties.Name | Should -Contain 'RequiredModules'
+            @($result.RequiredModules).Count | Should -Be 0
         }
 
         It "Should throw error for invalid path" {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -281,7 +281,7 @@ public sealed partial class ModulePipelineRunner
 
     private static bool IsAutoGuid(string? value)
         => !string.IsNullOrWhiteSpace(value) &&
-           value.Trim().Equals("Auto", StringComparison.OrdinalIgnoreCase);
+           value!.Trim().Equals("Auto", StringComparison.OrdinalIgnoreCase);
 
     private bool ArtefactRequiresRequiredModuleDownloadTool(
         ConfigurationArtefactSegment artefact,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -246,8 +246,7 @@ public sealed partial class ModulePipelineRunner
         if (drafts.Length == 0)
             return false;
 
-        if (publishVersionSource is not null ||
-            warnIfRequiredModulesOutdated ||
+        if (warnIfRequiredModulesOutdated ||
             HasRepositoryPreferredOnlineRequiredModules(drafts, publishVersionSource))
         {
             return true;
@@ -318,13 +317,68 @@ public sealed partial class ModulePipelineRunner
         if (requiredModule is null || string.IsNullOrWhiteSpace(requiredModule.ModuleName))
             return false;
 
-        var installed = _moduleDependencyMetadataProvider.GetLatestInstalledModules(new[] { requiredModule.ModuleName.Trim() });
-        return !installed.TryGetValue(requiredModule.ModuleName.Trim(), out var metadata) ||
-               !IsInstalledModuleAvailable(
-                   metadata,
-                   requiredModule.RequiredVersion,
-                   requiredModule.ModuleVersion,
-                   requiredModule.MaximumVersion);
+        var name = requiredModule.ModuleName.Trim();
+        var requiredVersion = NormalizeLocatorVersionArgument(requiredModule.RequiredVersion);
+        var minimumVersion = NormalizeLocatorVersionArgument(requiredModule.ModuleVersion);
+        var maximumVersion = NormalizeLocatorVersionArgument(requiredModule.MaximumVersion);
+        var installed = _moduleDependencyMetadataProvider.GetLatestInstalledModules(new[] { name });
+        if (!installed.TryGetValue(name, out var metadata) || !HasInstalledModuleMetadata(metadata))
+            return true;
+
+        if (IsInstalledModuleAvailable(metadata, requiredVersion, minimumVersion, maximumVersion))
+        {
+            return false;
+        }
+
+        return !HasInstalledRequiredModule(name, requiredVersion, minimumVersion, maximumVersion);
+    }
+
+    private static bool HasInstalledModuleMetadata(InstalledModuleMetadata metadata)
+        => metadata is not null &&
+           (!string.IsNullOrWhiteSpace(metadata.Version) ||
+            !string.IsNullOrWhiteSpace(metadata.ModuleBasePath));
+
+    private bool HasInstalledRequiredModule(
+        string moduleName,
+        string? requiredVersion,
+        string? minimumVersion,
+        string? maximumVersion)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName) ||
+            (string.IsNullOrWhiteSpace(requiredVersion) &&
+             string.IsNullOrWhiteSpace(minimumVersion) &&
+             string.IsNullOrWhiteSpace(maximumVersion)))
+        {
+            return false;
+        }
+
+        var script = EmbeddedScripts.Load("Scripts/ModuleLocator/Find-InstalledModule.ps1");
+        var args = new[]
+        {
+            moduleName.Trim(),
+            requiredVersion ?? string.Empty,
+            minimumVersion ?? string.Empty,
+            maximumVersion ?? string.Empty
+        };
+        var result = RunScript(_powerShellRunner, script, args, TimeSpan.FromMinutes(2));
+        if (result.ExitCode != 0)
+        {
+            if (_logger.IsVerbose && !string.IsNullOrWhiteSpace(result.StdOut)) _logger.Verbose(result.StdOut.Trim());
+            if (_logger.IsVerbose && !string.IsNullOrWhiteSpace(result.StdErr)) _logger.Verbose(result.StdErr.Trim());
+            return false;
+        }
+
+        return SplitLines(result.StdOut)
+            .Any(static line => line.StartsWith("PFMODLOC::FOUND::", StringComparison.Ordinal));
+    }
+
+    private static string? NormalizeLocatorVersionArgument(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var trimmed = value!.Trim();
+        return IsAutoVersion(trimmed) ? null : trimmed;
     }
 
     private static bool IsInstalledModuleAvailable(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -244,7 +244,7 @@ public sealed partial class ModulePipelineRunner
         return resolveMissingModulesOnline && HasOnlineResolvableAutoRequiredModules(drafts);
     }
 
-    private static bool ArtefactRequiresRequiredModuleDownloadTool(
+    private bool ArtefactRequiresRequiredModuleDownloadTool(
         ConfigurationArtefactSegment artefact,
         IReadOnlyList<RequiredModuleReference> requiredModulesForPackaging)
     {
@@ -262,11 +262,96 @@ public sealed partial class ModulePipelineRunner
                 .Select(static name => name.Trim()),
             StringComparer.OrdinalIgnoreCase);
 
-        return source == RequiredModulesSource.Download &&
-               (requiredModulesForPackaging ?? Array.Empty<RequiredModuleReference>())
-            .Any(module => module is not null &&
-                           !string.IsNullOrWhiteSpace(module.ModuleName) &&
-                           !excluded.Contains(module.ModuleName!));
+        var modules = (requiredModulesForPackaging ?? Array.Empty<RequiredModuleReference>())
+            .Where(module => module is not null &&
+                             !string.IsNullOrWhiteSpace(module.ModuleName) &&
+                             !excluded.Contains(module.ModuleName!))
+            .ToArray();
+        if (modules.Length == 0)
+            return false;
+
+        return source == RequiredModulesSource.Download ||
+               modules.Any(RequiredModuleNeedsDownload);
+    }
+
+    private bool RequiredModuleNeedsDownload(RequiredModuleReference requiredModule)
+    {
+        if (requiredModule is null || string.IsNullOrWhiteSpace(requiredModule.ModuleName))
+            return false;
+
+        var installed = _moduleDependencyMetadataProvider.GetLatestInstalledModules(new[] { requiredModule.ModuleName.Trim() });
+        return !installed.TryGetValue(requiredModule.ModuleName.Trim(), out var metadata) ||
+               !IsInstalledModuleAvailable(
+                   metadata,
+                   requiredModule.RequiredVersion,
+                   requiredModule.ModuleVersion,
+                   requiredModule.MaximumVersion);
+    }
+
+    private static bool IsInstalledModuleAvailable(
+        InstalledModuleMetadata metadata,
+        string? requiredVersion,
+        string? minimumVersion,
+        string? maximumVersion)
+    {
+        if (metadata is null || string.IsNullOrWhiteSpace(metadata.ModuleBasePath))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(requiredVersion) &&
+            string.IsNullOrWhiteSpace(minimumVersion) &&
+            string.IsNullOrWhiteSpace(maximumVersion))
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(metadata.Version) ||
+            !TryParseVersion(metadata.Version, out var installedVersion))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(requiredVersion))
+            return TryParseVersion(requiredVersion, out var required) &&
+                   installedVersion.CompareTo(required) == 0;
+
+        if (!string.IsNullOrWhiteSpace(minimumVersion) &&
+            (!TryParseVersion(minimumVersion, out var minimum) ||
+             installedVersion.CompareTo(minimum) < 0))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(maximumVersion) &&
+            (!TryParseVersion(maximumVersion, out var maximum) ||
+             installedVersion.CompareTo(maximum) > 0))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static RequiredModuleDraft[] ReadRequiredModuleDraftsFromManifest(ModulePipelineSpec spec)
+    {
+        var moduleName = spec?.Build?.Name;
+        var sourcePath = spec?.Build?.SourcePath;
+        if (string.IsNullOrWhiteSpace(moduleName) || string.IsNullOrWhiteSpace(sourcePath))
+            return Array.Empty<RequiredModuleDraft>();
+
+        var manifestPath = Path.Combine(sourcePath, $"{moduleName}.psd1");
+        if (!File.Exists(manifestPath))
+            return Array.Empty<RequiredModuleDraft>();
+
+        return ModuleManifestValueReader.ReadRequiredModules(manifestPath)
+            .Where(static module => module is not null && !string.IsNullOrWhiteSpace(module.ModuleName))
+            .Select(static module => new RequiredModuleDraft(
+                moduleName: module.ModuleName.Trim(),
+                moduleVersion: module.ModuleVersion,
+                minimumVersion: null,
+                requiredVersion: module.RequiredVersion,
+                guid: module.Guid,
+                versionSource: ModuleDependencyVersionSource.Auto))
+            .ToArray();
     }
 
     private void EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(ModulePipelineSpec spec)
@@ -342,6 +427,13 @@ public sealed partial class ModulePipelineRunner
 
         if (refreshPsd1Only)
             return;
+
+        var manifestRequiredModuleDrafts = ReadRequiredModuleDraftsFromManifest(spec);
+        if (manifestRequiredModuleDrafts.Length > 0)
+        {
+            requiredModulesDraft.AddRange(manifestRequiredModuleDrafts);
+            requiredModulesDraftForPackaging.AddRange(manifestRequiredModuleDrafts);
+        }
 
         if (!resolveMissingModulesOnlineSet && HasOnlineResolvableAutoRequiredModules(requiredModulesDraft))
             resolveMissingModulesOnline = true;

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -97,14 +97,32 @@ public sealed partial class ModulePipelineRunner
         if (deps.Length == 0)
             return Array.Empty<ModuleDependencyInstallResult>();
 
+        return EnsureFeatureToolDependenciesInstalled(
+            deps,
+            plan.InstallMissingModulesForce,
+            plan.InstallMissingModulesRepository,
+            plan.InstallMissingModulesCredential,
+            plan.InstallMissingModulesPrerelease);
+    }
+
+    private ModuleDependencyInstallResult[] EnsureFeatureToolDependenciesInstalled(
+        ModuleDependency[] deps,
+        bool force,
+        string? repository,
+        RepositoryCredential? credential,
+        bool prerelease)
+    {
+        if (deps.Length == 0)
+            return Array.Empty<ModuleDependencyInstallResult>();
+
         _logger.Info($"Ensuring build feature tool modules ({deps.Length}): {string.Join(", ", deps.Select(d => d.Name))}");
 
         var results = _hostedOperations.EnsureDependenciesInstalled(
             dependencies: deps,
-            force: plan.InstallMissingModulesForce,
-            repository: plan.InstallMissingModulesRepository,
-            credential: plan.InstallMissingModulesCredential,
-            prerelease: plan.InstallMissingModulesPrerelease,
+            force: force,
+            repository: repository,
+            credential: credential,
+            prerelease: prerelease,
             skipModules: null);
 
         var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
@@ -145,13 +163,26 @@ public sealed partial class ModulePipelineRunner
                     AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
                     break;
                 case PublishTool.Auto:
-                    if (!IsAutoPublishToolAvailable() &&
-                        !dependencies.ContainsKey("Microsoft.PowerShell.PSResourceGet") &&
-                        !dependencies.ContainsKey("PowerShellGet"))
-                    {
-                        AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
-                    }
+                    AddRepositoryToolDependencyForAuto(dependencies);
+                    break;
+            }
+        }
 
+        foreach (var artefact in plan.Artefacts ?? Array.Empty<ConfigurationArtefactSegment>())
+        {
+            if (!ArtefactRequiresRequiredModuleDownloadTool(artefact, plan.RequiredModulesForPackaging))
+                continue;
+
+            switch (artefact.Configuration.RequiredModules.Tool ?? ModuleSaveTool.Auto)
+            {
+                case ModuleSaveTool.PowerShellGet:
+                    AddFeatureDependency(dependencies, new ModuleDependency("PowerShellGet", minimumVersion: PowerShellGetMinimumVersion));
+                    break;
+                case ModuleSaveTool.PSResourceGet:
+                    AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
+                    break;
+                case ModuleSaveTool.Auto:
+                    AddRepositoryToolDependencyForAuto(dependencies);
                     break;
             }
         }
@@ -161,7 +192,93 @@ public sealed partial class ModulePipelineRunner
             .ToArray();
     }
 
-    private bool IsAutoPublishToolAvailable()
+    private void EnsureRequiredModuleOnlineResolutionToolInstalledIfNeeded(
+        IReadOnlyList<RequiredModuleDraft> requiredModules,
+        IReadOnlyList<RequiredModuleDraft> requiredModulesForPackaging,
+        bool resolveMissingModulesOnline,
+        bool warnIfRequiredModulesOutdated,
+        DependencyVersionSourceRepository? publishVersionSource,
+        bool force,
+        string? repository,
+        RepositoryCredential? credential,
+        bool prerelease)
+    {
+        if (!RequiresRequiredModuleOnlineResolutionTool(
+                requiredModules,
+                requiredModulesForPackaging,
+                resolveMissingModulesOnline,
+                warnIfRequiredModulesOutdated,
+                publishVersionSource))
+        {
+            return;
+        }
+
+        if (IsRepositoryToolAvailable())
+            return;
+
+        EnsureFeatureToolDependenciesInstalled(
+            new[] { new ModuleDependency("Microsoft.PowerShell.PSResourceGet") },
+            force,
+            repository,
+            credential,
+            prerelease);
+    }
+
+    private static bool RequiresRequiredModuleOnlineResolutionTool(
+        IReadOnlyList<RequiredModuleDraft> requiredModules,
+        IReadOnlyList<RequiredModuleDraft> requiredModulesForPackaging,
+        bool resolveMissingModulesOnline,
+        bool warnIfRequiredModulesOutdated,
+        DependencyVersionSourceRepository? publishVersionSource)
+    {
+        var drafts = (requiredModules ?? Array.Empty<RequiredModuleDraft>())
+            .Concat(requiredModulesForPackaging ?? Array.Empty<RequiredModuleDraft>())
+            .Where(static draft => draft is not null && !string.IsNullOrWhiteSpace(draft.ModuleName))
+            .ToArray();
+        if (drafts.Length == 0)
+            return false;
+
+        if (publishVersionSource is not null || warnIfRequiredModulesOutdated)
+            return true;
+
+        return resolveMissingModulesOnline && HasOnlineResolvableAutoRequiredModules(drafts);
+    }
+
+    private static bool ArtefactRequiresRequiredModuleDownloadTool(
+        ConfigurationArtefactSegment artefact,
+        IReadOnlyList<RequiredModuleReference> requiredModulesForPackaging)
+    {
+        var cfg = artefact.Configuration;
+        if (cfg?.Enabled != true || cfg.RequiredModules.Enabled != true)
+            return false;
+
+        var source = cfg.RequiredModules.Source ?? RequiredModulesSource.Installed;
+        if (source == RequiredModulesSource.Installed)
+            return false;
+
+        var excluded = new HashSet<string>(
+            (cfg.RequiredModules.ExcludeModuleName ?? Array.Empty<string>())
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+
+        return (requiredModulesForPackaging ?? Array.Empty<RequiredModuleReference>())
+            .Any(module => module is not null &&
+                           !string.IsNullOrWhiteSpace(module.ModuleName) &&
+                           !excluded.Contains(module.ModuleName!));
+    }
+
+    private void AddRepositoryToolDependencyForAuto(IDictionary<string, ModuleDependency> dependencies)
+    {
+        if (!IsRepositoryToolAvailable() &&
+            !dependencies.ContainsKey("Microsoft.PowerShell.PSResourceGet") &&
+            !dependencies.ContainsKey("PowerShellGet"))
+        {
+            AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
+        }
+    }
+
+    private bool IsRepositoryToolAvailable()
     {
         var installed = _moduleDependencyMetadataProvider.GetLatestInstalledModules(new[]
         {
@@ -169,8 +286,17 @@ public sealed partial class ModulePipelineRunner
             "PowerShellGet"
         });
 
-        return installed.ContainsKey("Microsoft.PowerShell.PSResourceGet") ||
-               installed.ContainsKey("PowerShellGet");
+        return IsInstalledModuleAvailable(installed, "Microsoft.PowerShell.PSResourceGet") ||
+               IsInstalledModuleAvailable(installed, "PowerShellGet");
+    }
+
+    private static bool IsInstalledModuleAvailable(
+        IReadOnlyDictionary<string, InstalledModuleMetadata> installed,
+        string moduleName)
+    {
+        return installed.TryGetValue(moduleName, out var metadata) &&
+               (!string.IsNullOrWhiteSpace(metadata.Version) ||
+                !string.IsNullOrWhiteSpace(metadata.ModuleBasePath));
     }
 
     private static void AddFeatureDependency(IDictionary<string, ModuleDependency> dependencies, ModuleDependency dependency)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -262,10 +262,105 @@ public sealed partial class ModulePipelineRunner
                 .Select(static name => name.Trim()),
             StringComparer.OrdinalIgnoreCase);
 
-        return (requiredModulesForPackaging ?? Array.Empty<RequiredModuleReference>())
+        return source == RequiredModulesSource.Download &&
+               (requiredModulesForPackaging ?? Array.Empty<RequiredModuleReference>())
             .Any(module => module is not null &&
                            !string.IsNullOrWhiteSpace(module.ModuleName) &&
                            !excluded.Contains(module.ModuleName!));
+    }
+
+    private void EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(ModulePipelineSpec spec)
+    {
+        if (spec is null) return;
+
+        var requiredModulesDraft = new List<RequiredModuleDraft>();
+        var requiredModulesDraftForPackaging = new List<RequiredModuleDraft>();
+        var publishes = new List<ConfigurationPublishSegment>();
+        var resolveMissingModulesOnline = false;
+        var resolveMissingModulesOnlineSet = false;
+        var warnIfRequiredModulesOutdated = false;
+        var refreshPsd1Only = false;
+        var installMissingModulesForce = false;
+        var installMissingModulesPrerelease = false;
+        string? installMissingModulesRepository = null;
+        RepositoryCredential? installMissingModulesCredential = null;
+
+        foreach (var segment in spec.Segments ?? Array.Empty<IConfigurationSegment>())
+        {
+            switch (segment)
+            {
+                case ConfigurationBuildSegment build:
+                {
+                    var cfg = build.BuildModule;
+                    if (cfg.ResolveMissingModulesOnline.HasValue)
+                    {
+                        resolveMissingModulesOnline = cfg.ResolveMissingModulesOnline.Value;
+                        resolveMissingModulesOnlineSet = true;
+                    }
+
+                    if (cfg.WarnIfRequiredModulesOutdated.HasValue)
+                        warnIfRequiredModulesOutdated = cfg.WarnIfRequiredModulesOutdated.Value;
+                    if (cfg.RefreshPSD1Only.HasValue)
+                        refreshPsd1Only = cfg.RefreshPSD1Only.Value;
+                    if (cfg.InstallMissingModulesForce.HasValue)
+                        installMissingModulesForce = cfg.InstallMissingModulesForce.Value;
+                    if (cfg.InstallMissingModulesPrerelease.HasValue)
+                        installMissingModulesPrerelease = cfg.InstallMissingModulesPrerelease.Value;
+                    if (!string.IsNullOrWhiteSpace(cfg.InstallMissingModulesRepository))
+                        installMissingModulesRepository = cfg.InstallMissingModulesRepository;
+                    if (cfg.InstallMissingModulesCredential is not null)
+                        installMissingModulesCredential = cfg.InstallMissingModulesCredential;
+                    break;
+                }
+                case ConfigurationModuleSegment moduleSeg:
+                {
+                    var cfg = moduleSeg.Configuration;
+                    if (moduleSeg.Kind != ModuleDependencyKind.RequiredModule ||
+                        cfg is null ||
+                        string.IsNullOrWhiteSpace(cfg.ModuleName) ||
+                        ModulePipelinePlanningHelpers.ShouldSkipManifestDependencyModule(cfg.ModuleName))
+                    {
+                        break;
+                    }
+
+                    var draft = new RequiredModuleDraft(
+                        moduleName: cfg.ModuleName.Trim(),
+                        moduleVersion: cfg.ModuleVersion,
+                        minimumVersion: cfg.MinimumVersion,
+                        requiredVersion: cfg.RequiredVersion,
+                        guid: cfg.Guid,
+                        versionSource: cfg.VersionSource);
+                    requiredModulesDraft.Add(draft);
+                    requiredModulesDraftForPackaging.Add(draft);
+                    break;
+                }
+                case ConfigurationPublishSegment publish:
+                    publishes.Add(publish);
+                    break;
+            }
+        }
+
+        if (refreshPsd1Only)
+            return;
+
+        if (!resolveMissingModulesOnlineSet && HasOnlineResolvableAutoRequiredModules(requiredModulesDraft))
+            resolveMissingModulesOnline = true;
+
+        var dependencyVersionSourceRepository = ResolvePublishDependencyVersionSource(
+            publishes
+                .Where(static publish => publish is not null && publish.Configuration?.Enabled == true)
+                .ToArray());
+
+        EnsureRequiredModuleOnlineResolutionToolInstalledIfNeeded(
+            requiredModulesDraft,
+            requiredModulesDraftForPackaging,
+            resolveMissingModulesOnline,
+            warnIfRequiredModulesOutdated,
+            dependencyVersionSourceRepository,
+            installMissingModulesForce,
+            installMissingModulesRepository,
+            installMissingModulesCredential,
+            installMissingModulesPrerelease);
     }
 
     private void AddRepositoryToolDependencyForAuto(IDictionary<string, ModuleDependency> dependencies)
@@ -287,16 +382,37 @@ public sealed partial class ModulePipelineRunner
         });
 
         return IsInstalledModuleAvailable(installed, "Microsoft.PowerShell.PSResourceGet") ||
-               IsInstalledModuleAvailable(installed, "PowerShellGet");
+               IsInstalledModuleAvailable(installed, "PowerShellGet", PowerShellGetMinimumVersion);
     }
 
     private static bool IsInstalledModuleAvailable(
         IReadOnlyDictionary<string, InstalledModuleMetadata> installed,
-        string moduleName)
+        string moduleName,
+        string? minimumVersion = null)
     {
-        return installed.TryGetValue(moduleName, out var metadata) &&
-               (!string.IsNullOrWhiteSpace(metadata.Version) ||
-                !string.IsNullOrWhiteSpace(metadata.ModuleBasePath));
+        if (!installed.TryGetValue(moduleName, out var metadata))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(metadata.Version) &&
+            string.IsNullOrWhiteSpace(metadata.ModuleBasePath))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(minimumVersion))
+            return true;
+
+        return !string.IsNullOrWhiteSpace(metadata.Version) &&
+               TryParseVersion(metadata.Version, out var installedVersion) &&
+               TryParseVersion(minimumVersion, out var requiredVersion) &&
+               installedVersion.CompareTo(requiredVersion) >= 0;
+    }
+
+    private static bool TryParseVersion(string? value, out Version version)
+    {
+        var parsed = Version.TryParse(value, out var result);
+        version = result ?? new Version(0, 0);
+        return parsed;
     }
 
     private static void AddFeatureDependency(IDictionary<string, ModuleDependency> dependencies, ModuleDependency dependency)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -71,7 +71,7 @@ public sealed partial class ModulePipelineRunner
             repository: plan.InstallMissingModulesRepository,
             credential: plan.InstallMissingModulesCredential,
             prerelease: plan.InstallMissingModulesPrerelease,
-            skipModules: null);
+            skipModules: plan.ModuleSkip);
 
         var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
         if (failures.Length > 0)
@@ -105,7 +105,7 @@ public sealed partial class ModulePipelineRunner
             repository: plan.InstallMissingModulesRepository,
             credential: plan.InstallMissingModulesCredential,
             prerelease: plan.InstallMissingModulesPrerelease,
-            skipModules: plan.ModuleSkip);
+            skipModules: null);
 
         var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
         if (failures.Length > 0)
@@ -142,8 +142,10 @@ public sealed partial class ModulePipelineRunner
                     AddFeatureDependency(dependencies, new ModuleDependency("PowerShellGet", minimumVersion: PowerShellGetMinimumVersion));
                     break;
                 case PublishTool.PSResourceGet:
-                case PublishTool.Auto:
                     AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
+                    break;
+                case PublishTool.Auto:
+                    AddFeatureDependency(dependencies, new ModuleDependency("PowerShellGet", minimumVersion: PowerShellGetMinimumVersion));
                     break;
             }
         }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -123,9 +123,7 @@ public sealed partial class ModulePipelineRunner
         _logger.Info($"Ensuring build feature tool modules ({deps.Length}): {string.Join(", ", deps.Select(d => d.Name))}");
 
         var results = new List<ModuleDependencyInstallResult>();
-        var repositoryBootstrap = ShouldInstallRepositoryToolFirst(deps)
-            ? deps.FirstOrDefault(IsRepositoryToolDependency)
-            : null;
+        var repositoryBootstrap = ResolveRepositoryToolBootstrapDependency(deps);
         var remainingDeps = deps;
         if (repositoryBootstrap is not null)
         {
@@ -137,7 +135,8 @@ public sealed partial class ModulePipelineRunner
                 prerelease: prerelease,
                 skipModules: null));
             remainingDeps = deps
-                .Where(dependency => !IsRepositoryToolDependency(dependency))
+                .Where(dependency =>
+                    !string.Equals(dependency.Name, repositoryBootstrap.Name, StringComparison.OrdinalIgnoreCase))
                 .ToArray();
         }
 
@@ -904,16 +903,31 @@ public sealed partial class ModulePipelineRunner
             AddRepositoryToolDependencyIfNeeded(dependencies, added);
     }
 
-    private bool ShouldInstallRepositoryToolFirst(IReadOnlyList<ModuleDependency> dependencies)
-        => dependencies is { Count: > 1 } &&
-           !IsRepositoryToolAvailable() &&
-           dependencies.Any(IsRepositoryToolDependency) &&
-           dependencies.Any(dependency => !IsRepositoryToolDependency(dependency));
+    private ModuleDependency? ResolveRepositoryToolBootstrapDependency(IReadOnlyList<ModuleDependency> dependencies)
+    {
+        if (dependencies is not { Count: > 0 } || IsRepositoryToolAvailable())
+            return null;
+
+        var psResourceGet = dependencies.FirstOrDefault(IsPSResourceGetDependency);
+        if (psResourceGet is not null && dependencies.Count > 1)
+            return psResourceGet;
+
+        return dependencies.Any(IsPowerShellGetDependency)
+            ? new ModuleDependency("Microsoft.PowerShell.PSResourceGet")
+            : null;
+    }
 
     private static bool IsRepositoryToolDependency(ModuleDependency dependency)
         => dependency is not null &&
-           (string.Equals(dependency.Name, "Microsoft.PowerShell.PSResourceGet", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(dependency.Name, "PowerShellGet", StringComparison.OrdinalIgnoreCase));
+           (IsPSResourceGetDependency(dependency) || IsPowerShellGetDependency(dependency));
+
+    private static bool IsPSResourceGetDependency(ModuleDependency dependency)
+        => dependency is not null &&
+           string.Equals(dependency.Name, "Microsoft.PowerShell.PSResourceGet", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsPowerShellGetDependency(ModuleDependency dependency)
+        => dependency is not null &&
+           string.Equals(dependency.Name, "PowerShellGet", StringComparison.OrdinalIgnoreCase);
 
     private bool IsRepositoryToolAvailable()
     {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -89,11 +89,13 @@ public sealed partial class ModulePipelineRunner
         return results.ToArray();
     }
 
-    private ModuleDependencyInstallResult[] EnsureFeatureToolDependenciesInstalled(ModulePipelinePlan plan)
+    private ModuleDependencyInstallResult[] EnsureFeatureToolDependenciesInstalled(
+        ModulePipelinePlan plan,
+        IReadOnlyList<RequiredModuleReference>? packagingRequiredModules = null)
     {
         if (plan is null) return Array.Empty<ModuleDependencyInstallResult>();
 
-        var deps = ResolveFeatureToolDependencies(plan);
+        var deps = ResolveFeatureToolDependencies(plan, packagingRequiredModules);
         if (deps.Length == 0)
             return Array.Empty<ModuleDependencyInstallResult>();
 
@@ -141,7 +143,9 @@ public sealed partial class ModulePipelineRunner
         return results.ToArray();
     }
 
-    private ModuleDependency[] ResolveFeatureToolDependencies(ModulePipelinePlan plan)
+    private ModuleDependency[] ResolveFeatureToolDependencies(
+        ModulePipelinePlan plan,
+        IReadOnlyList<RequiredModuleReference>? packagingRequiredModules)
     {
         var dependencies = new Dictionary<string, ModuleDependency>(StringComparer.OrdinalIgnoreCase);
 
@@ -170,8 +174,12 @@ public sealed partial class ModulePipelineRunner
 
         foreach (var artefact in plan.Artefacts ?? Array.Empty<ConfigurationArtefactSegment>())
         {
-            if (!ArtefactRequiresRequiredModuleDownloadTool(artefact, plan.RequiredModulesForPackaging))
+            if (!ArtefactRequiresRequiredModuleDownloadTool(
+                    artefact,
+                    packagingRequiredModules ?? plan.RequiredModulesForPackaging))
+            {
                 continue;
+            }
 
             switch (artefact.Configuration.RequiredModules.Tool ?? ModuleSaveTool.Auto)
             {
@@ -238,11 +246,42 @@ public sealed partial class ModulePipelineRunner
         if (drafts.Length == 0)
             return false;
 
-        if (publishVersionSource is not null || warnIfRequiredModulesOutdated)
+        if (publishVersionSource is not null ||
+            warnIfRequiredModulesOutdated ||
+            HasRepositoryPreferredOnlineRequiredModules(drafts, publishVersionSource))
+        {
             return true;
+        }
 
         return resolveMissingModulesOnline && HasOnlineResolvableAutoRequiredModules(drafts);
     }
+
+    private static bool HasRepositoryPreferredOnlineRequiredModules(
+        IEnumerable<RequiredModuleDraft> drafts,
+        DependencyVersionSourceRepository? publishVersionSource)
+        => HasAutoRequiredModules((drafts ?? Array.Empty<RequiredModuleDraft>())
+            .Where(draft => draft is not null &&
+                            ResolveDependencyVersionSource(draft.VersionSource, publishVersionSource).PreferOnlineMetadata));
+
+    private static bool ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(ModulePipelinePlan plan)
+    {
+        if (plan is null || plan.BuildSpec.RefreshManifestOnly)
+            return false;
+
+        return HasOnlineResolvableRequiredModuleReferences(plan.RequiredModules) ||
+               HasOnlineResolvableRequiredModuleReferences(plan.RequiredModulesForPackaging);
+    }
+
+    private static bool HasOnlineResolvableRequiredModuleReferences(IEnumerable<RequiredModuleReference> modules)
+        => (modules ?? Array.Empty<RequiredModuleReference>())
+            .Any(static module => module is not null &&
+                                  !string.IsNullOrWhiteSpace(module.ModuleName) &&
+                                  (IsAutoVersion(module.ModuleVersion) ||
+                                   IsAutoGuid(module.Guid)));
+
+    private static bool IsAutoGuid(string? value)
+        => !string.IsNullOrWhiteSpace(value) &&
+           value.Trim().Equals("Auto", StringComparison.OrdinalIgnoreCase);
 
     private bool ArtefactRequiresRequiredModuleDownloadTool(
         ConfigurationArtefactSegment artefact,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -153,7 +153,12 @@ public sealed partial class ModulePipelineRunner
         var dependencies = new Dictionary<string, ModuleDependency>(StringComparer.OrdinalIgnoreCase);
 
         if (plan.TestsAfterMerge is { Length: > 0 })
+        {
             AddFeatureDependency(dependencies, new ModuleDependency("Pester", minimumVersion: PesterMinimumVersion));
+            AddRepositoryToolDependencyForAuto(dependencies);
+        }
+        if (plan.ValidationSettings?.Tests is { Enable: true, SkipDependencies: false, Severity: not ValidationSeverity.Off } tests)
+            AddTestSuiteFeatureDependencies(dependencies, tests.AdditionalModules, tests.SkipModules);
 
         foreach (var publish in plan.Publishes ?? Array.Empty<ConfigurationPublishSegment>())
         {
@@ -295,7 +300,7 @@ public sealed partial class ModulePipelineRunner
             !string.IsNullOrWhiteSpace(skipName) &&
             string.Equals(skipName.Trim(), moduleName.Trim(), StringComparison.OrdinalIgnoreCase)) == true;
 
-    private static bool RequiresRequiredModuleOnlineResolutionTool(
+    private bool RequiresRequiredModuleOnlineResolutionTool(
         IReadOnlyList<RequiredModuleDraft> requiredModules,
         IReadOnlyList<RequiredModuleDraft> requiredModulesForPackaging,
         bool resolveMissingModulesOnline,
@@ -315,6 +320,9 @@ public sealed partial class ModulePipelineRunner
             return true;
         }
 
+        if (HasRepositoryPreferredTransitiveRequiredModules(drafts, publishVersionSource))
+            return true;
+
         return resolveMissingModulesOnline && HasOnlineResolvableAutoRequiredModules(drafts);
     }
 
@@ -324,6 +332,81 @@ public sealed partial class ModulePipelineRunner
         => HasAutoRequiredModules((drafts ?? Array.Empty<RequiredModuleDraft>())
             .Where(draft => draft is not null &&
                             ResolveDependencyVersionSource(draft.VersionSource, publishVersionSource).PreferOnlineMetadata));
+
+    private bool HasRepositoryPreferredTransitiveRequiredModules(
+        IEnumerable<RequiredModuleDraft> drafts,
+        DependencyVersionSourceRepository? publishVersionSource)
+    {
+        var sourceDrafts = BuildRequiredModuleDraftMap(drafts ?? Array.Empty<RequiredModuleDraft>());
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var draft in sourceDrafts.Values)
+        {
+            if (draft is null || string.IsNullOrWhiteSpace(draft.ModuleName))
+                continue;
+
+            var source = ResolveDependencyVersionSource(draft.VersionSource, publishVersionSource);
+            if (!source.PreferOnlineMetadata)
+                continue;
+
+            if (HasRepositoryPreferredTransitiveRequiredModules(
+                    draft.ModuleName,
+                    draft.VersionSource,
+                    sourceDrafts,
+                    publishVersionSource,
+                    visited))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool HasRepositoryPreferredTransitiveRequiredModules(
+        string moduleName,
+        ModuleDependencyVersionSource inheritedVersionSource,
+        IReadOnlyDictionary<string, RequiredModuleDraft> sourceDrafts,
+        DependencyVersionSourceRepository? publishVersionSource,
+        HashSet<string> visited)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName) || !visited.Add(moduleName.Trim()))
+            return false;
+
+        var source = ResolveDependencyVersionSource(inheritedVersionSource, publishVersionSource);
+        if (!source.PreferOnlineMetadata)
+            return false;
+
+        var required = _moduleDependencyMetadataProvider.GetRequiredModulesForInstalledModule(moduleName.Trim());
+        foreach (var dep in required ?? Array.Empty<RequiredModuleReference>())
+        {
+            if (dep is null || string.IsNullOrWhiteSpace(dep.ModuleName))
+                continue;
+
+            var depName = dep.ModuleName.Trim();
+            if (ModulePipelinePlanningHelpers.ShouldSkipTransitiveRequiredDependencyModule(depName))
+                continue;
+
+            var childVersionSource = ResolveInheritedDependencyVersionSource(depName, sourceDrafts, inheritedVersionSource);
+            if (ShouldPreferTransitiveDependencySourceMetadata(childVersionSource, publishVersionSource) &&
+                !HasExplicitDependencyConstraint(dep))
+            {
+                return true;
+            }
+
+            if (HasRepositoryPreferredTransitiveRequiredModules(
+                    depName,
+                    childVersionSource,
+                    sourceDrafts,
+                    publishVersionSource,
+                    visited))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private bool ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(
         ModulePipelineSpec spec,
@@ -731,6 +814,38 @@ public sealed partial class ModulePipelineRunner
         {
             AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
         }
+    }
+
+    private void AddTestSuiteFeatureDependencies(
+        IDictionary<string, ModuleDependency> dependencies,
+        IEnumerable<string>? additionalModules,
+        IEnumerable<string>? skipModules)
+    {
+        var skip = new HashSet<string>(
+            (skipModules ?? Array.Empty<string>())
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+
+        var before = dependencies.Count;
+        foreach (var name in additionalModules ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var moduleName = name.Trim();
+            if (skip.Contains(moduleName))
+                continue;
+
+            AddFeatureDependency(
+                dependencies,
+                moduleName.Equals("Pester", StringComparison.OrdinalIgnoreCase)
+                    ? new ModuleDependency(moduleName, minimumVersion: PesterMinimumVersion)
+                    : new ModuleDependency(moduleName));
+        }
+
+        if (dependencies.Count > before)
+            AddRepositoryToolDependencyForAuto(dependencies);
     }
 
     private bool IsRepositoryToolAvailable()

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -8,6 +8,9 @@ namespace PowerForge;
 
 public sealed partial class ModulePipelineRunner
 {
+    private const string PesterMinimumVersion = "5.7.1";
+    private const string PowerShellGetMinimumVersion = "2.2.5";
+
     private ModuleDependencyInstallResult[] EnsureBuildDependenciesInstalled(ModulePipelinePlan plan)
     {
         if (plan is null) return Array.Empty<ModuleDependencyInstallResult>();
@@ -68,7 +71,7 @@ public sealed partial class ModulePipelineRunner
             repository: plan.InstallMissingModulesRepository,
             credential: plan.InstallMissingModulesCredential,
             prerelease: plan.InstallMissingModulesPrerelease,
-            skipModules: plan.ModuleSkip);
+            skipModules: null);
 
         var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
         if (failures.Length > 0)
@@ -84,6 +87,100 @@ public sealed partial class ModulePipelineRunner
         }
 
         return results.ToArray();
+    }
+
+    private ModuleDependencyInstallResult[] EnsureFeatureToolDependenciesInstalled(ModulePipelinePlan plan)
+    {
+        if (plan is null) return Array.Empty<ModuleDependencyInstallResult>();
+
+        var deps = ResolveFeatureToolDependencies(plan);
+        if (deps.Length == 0)
+            return Array.Empty<ModuleDependencyInstallResult>();
+
+        _logger.Info($"Ensuring build feature tool modules ({deps.Length}): {string.Join(", ", deps.Select(d => d.Name))}");
+
+        var results = _hostedOperations.EnsureDependenciesInstalled(
+            dependencies: deps,
+            force: plan.InstallMissingModulesForce,
+            repository: plan.InstallMissingModulesRepository,
+            credential: plan.InstallMissingModulesCredential,
+            prerelease: plan.InstallMissingModulesPrerelease,
+            skipModules: plan.ModuleSkip);
+
+        var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
+        if (failures.Length > 0)
+            throw new InvalidOperationException($"Build feature tool dependency installation failed for {failures.Length} module{(failures.Length == 1 ? string.Empty : "s")}.");
+
+        if (results.Count > 0)
+        {
+            var installed = results.Count(r => r.Status == ModuleDependencyInstallStatus.Installed);
+            var updated = results.Count(r => r.Status == ModuleDependencyInstallStatus.Updated);
+            var satisfied = results.Count(r => r.Status == ModuleDependencyInstallStatus.Satisfied);
+            var skipped = results.Count(r => r.Status == ModuleDependencyInstallStatus.Skipped);
+            _logger.Info($"Build feature tool dependency summary: {installed} installed, {updated} updated, {satisfied} satisfied, {skipped} skipped.");
+        }
+
+        return results.ToArray();
+    }
+
+    private static ModuleDependency[] ResolveFeatureToolDependencies(ModulePipelinePlan plan)
+    {
+        var dependencies = new Dictionary<string, ModuleDependency>(StringComparer.OrdinalIgnoreCase);
+
+        if (plan.TestsAfterMerge is { Length: > 0 })
+            AddFeatureDependency(dependencies, new ModuleDependency("Pester", minimumVersion: PesterMinimumVersion));
+
+        foreach (var publish in plan.Publishes ?? Array.Empty<ConfigurationPublishSegment>())
+        {
+            var cfg = publish.Configuration;
+            if (cfg is null || !cfg.Enabled || cfg.Destination != PublishDestination.PowerShellGallery)
+                continue;
+
+            switch (cfg.Tool)
+            {
+                case PublishTool.PowerShellGet:
+                    AddFeatureDependency(dependencies, new ModuleDependency("PowerShellGet", minimumVersion: PowerShellGetMinimumVersion));
+                    break;
+                case PublishTool.PSResourceGet:
+                case PublishTool.Auto:
+                    AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
+                    break;
+            }
+        }
+
+        return dependencies.Values
+            .OrderBy(static dependency => dependency.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static void AddFeatureDependency(IDictionary<string, ModuleDependency> dependencies, ModuleDependency dependency)
+    {
+        if (!dependencies.TryGetValue(dependency.Name, out var existing))
+        {
+            dependencies[dependency.Name] = dependency;
+            return;
+        }
+
+        if (HasStrongerVersionConstraint(dependency, existing))
+            dependencies[dependency.Name] = dependency;
+    }
+
+    private static bool HasStrongerVersionConstraint(ModuleDependency candidate, ModuleDependency existing)
+    {
+        if (!string.IsNullOrWhiteSpace(candidate.RequiredVersion) &&
+            !string.Equals(candidate.RequiredVersion, existing.RequiredVersion, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(existing.RequiredVersion) &&
+            string.IsNullOrWhiteSpace(existing.MinimumVersion) &&
+            !string.IsNullOrWhiteSpace(candidate.MinimumVersion))
+        {
+            return true;
+        }
+
+        return false;
     }
 
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -66,7 +66,8 @@ public sealed partial class ModulePipelineRunner
         _logger.Info($"Installing missing modules ({deps.Length}): {string.Join(", ", deps.Select(d => d.Name))}");
 
         var results = new List<ModuleDependencyInstallResult>();
-        results.AddRange(EnsureRepositoryToolDependencyInstalledForAuto(plan));
+        if (RequiredModuleInstallNeedsRepositoryTool(plan, deps))
+            results.AddRange(EnsureRepositoryToolDependencyInstalledForAuto(plan));
         results.AddRange(_hostedOperations.EnsureDependenciesInstalled(
             dependencies: deps,
             force: plan.InstallMissingModulesForce,
@@ -104,8 +105,8 @@ public sealed partial class ModulePipelineRunner
         return EnsureFeatureToolDependenciesInstalled(
             deps,
             plan.InstallMissingModulesForce,
-            plan.InstallMissingModulesRepository,
-            plan.InstallMissingModulesCredential,
+            repository: null,
+            credential: null,
             plan.InstallMissingModulesPrerelease);
     }
 
@@ -229,8 +230,8 @@ public sealed partial class ModulePipelineRunner
         EnsureFeatureToolDependenciesInstalled(
             new[] { new ModuleDependency("Microsoft.PowerShell.PSResourceGet") },
             force,
-            repository,
-            credential,
+            repository: null,
+            credential: null,
             prerelease);
     }
 
@@ -242,10 +243,57 @@ public sealed partial class ModulePipelineRunner
         return EnsureFeatureToolDependenciesInstalled(
             new[] { new ModuleDependency("Microsoft.PowerShell.PSResourceGet") },
             plan.InstallMissingModulesForce,
-            plan.InstallMissingModulesRepository,
-            plan.InstallMissingModulesCredential,
+            repository: null,
+            credential: null,
             plan.InstallMissingModulesPrerelease);
     }
+
+    private bool RequiredModuleInstallNeedsRepositoryTool(ModulePipelinePlan plan, IReadOnlyList<ModuleDependency> dependencies)
+    {
+        if (plan is null || plan.InstallMissingModulesForce)
+            return true;
+
+        var candidates = (dependencies ?? Array.Empty<ModuleDependency>())
+            .Where(dependency => dependency is not null &&
+                                 !string.IsNullOrWhiteSpace(dependency.Name) &&
+                                 !IsModuleSkipped(plan.ModuleSkip, dependency.Name))
+            .ToArray();
+        if (candidates.Length == 0)
+            return false;
+
+        var installed = _moduleDependencyMetadataProvider.GetLatestInstalledModules(
+            candidates.Select(static dependency => dependency.Name.Trim()).ToArray());
+        return candidates.Any(dependency => RequiredModuleInstallNeedsRepositoryTool(dependency, installed));
+    }
+
+    private bool RequiredModuleInstallNeedsRepositoryTool(
+        ModuleDependency dependency,
+        IReadOnlyDictionary<string, InstalledModuleMetadata> installed)
+    {
+        var name = dependency.Name.Trim();
+        var requiredVersion = NormalizeLocatorVersionArgument(dependency.RequiredVersion);
+        var minimumVersion = NormalizeLocatorVersionArgument(dependency.MinimumVersion);
+        var maximumVersion = NormalizeLocatorVersionArgument(dependency.MaximumVersion);
+
+        if (!installed.TryGetValue(name, out var metadata) || !HasInstalledModuleMetadata(metadata))
+            return true;
+
+        if (IsInstalledModuleAvailable(metadata, requiredVersion, minimumVersion, maximumVersion))
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(requiredVersion) &&
+            HasInstalledRequiredModule(name, requiredVersion, minimumVersion: null, maximumVersion: null))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsModuleSkipped(ModuleSkipConfiguration? skip, string moduleName)
+        => skip?.IgnoreModuleName?.Any(skipName =>
+            !string.IsNullOrWhiteSpace(skipName) &&
+            string.Equals(skipName.Trim(), moduleName.Trim(), StringComparison.OrdinalIgnoreCase)) == true;
 
     private static bool RequiresRequiredModuleOnlineResolutionTool(
         IReadOnlyList<RequiredModuleDraft> requiredModules,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -122,13 +122,35 @@ public sealed partial class ModulePipelineRunner
 
         _logger.Info($"Ensuring build feature tool modules ({deps.Length}): {string.Join(", ", deps.Select(d => d.Name))}");
 
-        var results = _hostedOperations.EnsureDependenciesInstalled(
-            dependencies: deps,
-            force: force,
-            repository: repository,
-            credential: credential,
-            prerelease: prerelease,
-            skipModules: null);
+        var results = new List<ModuleDependencyInstallResult>();
+        var repositoryBootstrap = ShouldInstallRepositoryToolFirst(deps)
+            ? deps.FirstOrDefault(IsRepositoryToolDependency)
+            : null;
+        var remainingDeps = deps;
+        if (repositoryBootstrap is not null)
+        {
+            results.AddRange(_hostedOperations.EnsureDependenciesInstalled(
+                dependencies: new[] { repositoryBootstrap },
+                force: force,
+                repository: repository,
+                credential: credential,
+                prerelease: prerelease,
+                skipModules: null));
+            remainingDeps = deps
+                .Where(dependency => !IsRepositoryToolDependency(dependency))
+                .ToArray();
+        }
+
+        if (remainingDeps.Length > 0)
+        {
+            results.AddRange(_hostedOperations.EnsureDependenciesInstalled(
+                dependencies: remainingDeps,
+                force: force,
+                repository: repository,
+                credential: credential,
+                prerelease: prerelease,
+                skipModules: null));
+        }
 
         var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
         if (failures.Length > 0)
@@ -154,11 +176,18 @@ public sealed partial class ModulePipelineRunner
 
         if (plan.TestsAfterMerge is { Length: > 0 })
         {
-            AddFeatureDependency(dependencies, new ModuleDependency("Pester", minimumVersion: PesterMinimumVersion));
-            AddRepositoryToolDependencyForAuto(dependencies);
+            var pester = new ModuleDependency("Pester", minimumVersion: PesterMinimumVersion);
+            AddFeatureDependency(dependencies, pester);
+            AddRepositoryToolDependencyIfNeeded(dependencies, new[] { pester });
         }
         if (plan.ValidationSettings?.Tests is { Enable: true, SkipDependencies: false, Severity: not ValidationSeverity.Off } tests)
             AddTestSuiteFeatureDependencies(dependencies, tests.AdditionalModules, tests.SkipModules);
+        if (plan.ValidationSettings?.ScriptAnalyzer is { Enable: true, InstallIfUnavailable: true, Severity: not ValidationSeverity.Off })
+        {
+            var dependency = new ModuleDependency("PSScriptAnalyzer");
+            AddFeatureDependency(dependencies, dependency);
+            AddRepositoryToolDependencyIfNeeded(dependencies, new[] { dependency });
+        }
 
         foreach (var publish in plan.Publishes ?? Array.Empty<ConfigurationPublishSegment>())
         {
@@ -262,6 +291,24 @@ public sealed partial class ModulePipelineRunner
             .Where(dependency => dependency is not null &&
                                  !string.IsNullOrWhiteSpace(dependency.Name) &&
                                  !IsModuleSkipped(plan.ModuleSkip, dependency.Name))
+            .ToArray();
+        if (candidates.Length == 0)
+            return false;
+
+        var installed = _moduleDependencyMetadataProvider.GetLatestInstalledModules(
+            candidates.Select(static dependency => dependency.Name.Trim()).ToArray());
+        return candidates.Any(dependency => RequiredModuleInstallNeedsRepositoryTool(dependency, installed));
+    }
+
+    private bool FeatureToolDependenciesNeedRepositoryTool(IReadOnlyList<ModuleDependency> dependencies)
+    {
+        if (dependencies is null || dependencies.Count == 0 || IsRepositoryToolAvailable())
+            return false;
+
+        var candidates = dependencies
+            .Where(dependency => dependency is not null &&
+                                 !string.IsNullOrWhiteSpace(dependency.Name) &&
+                                 !IsRepositoryToolDependency(dependency))
             .ToArray();
         if (candidates.Length == 0)
             return false;
@@ -816,6 +863,14 @@ public sealed partial class ModulePipelineRunner
         }
     }
 
+    private void AddRepositoryToolDependencyIfNeeded(
+        IDictionary<string, ModuleDependency> dependencies,
+        IReadOnlyList<ModuleDependency> candidates)
+    {
+        if (FeatureToolDependenciesNeedRepositoryTool(candidates))
+            AddRepositoryToolDependencyForAuto(dependencies);
+    }
+
     private void AddTestSuiteFeatureDependencies(
         IDictionary<string, ModuleDependency> dependencies,
         IEnumerable<string>? additionalModules,
@@ -828,6 +883,7 @@ public sealed partial class ModulePipelineRunner
             StringComparer.OrdinalIgnoreCase);
 
         var before = dependencies.Count;
+        var added = new List<ModuleDependency>();
         foreach (var name in additionalModules ?? Array.Empty<string>())
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -837,16 +893,27 @@ public sealed partial class ModulePipelineRunner
             if (skip.Contains(moduleName))
                 continue;
 
-            AddFeatureDependency(
-                dependencies,
-                moduleName.Equals("Pester", StringComparison.OrdinalIgnoreCase)
-                    ? new ModuleDependency(moduleName, minimumVersion: PesterMinimumVersion)
-                    : new ModuleDependency(moduleName));
+            var dependency = moduleName.Equals("Pester", StringComparison.OrdinalIgnoreCase)
+                ? new ModuleDependency(moduleName, minimumVersion: PesterMinimumVersion)
+                : new ModuleDependency(moduleName);
+            AddFeatureDependency(dependencies, dependency);
+            added.Add(dependency);
         }
 
         if (dependencies.Count > before)
-            AddRepositoryToolDependencyForAuto(dependencies);
+            AddRepositoryToolDependencyIfNeeded(dependencies, added);
     }
+
+    private bool ShouldInstallRepositoryToolFirst(IReadOnlyList<ModuleDependency> dependencies)
+        => dependencies is { Count: > 1 } &&
+           !IsRepositoryToolAvailable() &&
+           dependencies.Any(IsRepositoryToolDependency) &&
+           dependencies.Any(dependency => !IsRepositoryToolDependency(dependency));
+
+    private static bool IsRepositoryToolDependency(ModuleDependency dependency)
+        => dependency is not null &&
+           (string.Equals(dependency.Name, "Microsoft.PowerShell.PSResourceGet", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(dependency.Name, "PowerShellGet", StringComparison.OrdinalIgnoreCase));
 
     private bool IsRepositoryToolAvailable()
     {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -65,13 +65,15 @@ public sealed partial class ModulePipelineRunner
 
         _logger.Info($"Installing missing modules ({deps.Length}): {string.Join(", ", deps.Select(d => d.Name))}");
 
-        var results = _hostedOperations.EnsureDependenciesInstalled(
+        var results = new List<ModuleDependencyInstallResult>();
+        results.AddRange(EnsureRepositoryToolDependencyInstalledForAuto(plan));
+        results.AddRange(_hostedOperations.EnsureDependenciesInstalled(
             dependencies: deps,
             force: plan.InstallMissingModulesForce,
             repository: plan.InstallMissingModulesRepository,
             credential: plan.InstallMissingModulesCredential,
             prerelease: plan.InstallMissingModulesPrerelease,
-            skipModules: plan.ModuleSkip);
+            skipModules: plan.ModuleSkip));
 
         var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
         if (failures.Length > 0)
@@ -232,6 +234,19 @@ public sealed partial class ModulePipelineRunner
             prerelease);
     }
 
+    private ModuleDependencyInstallResult[] EnsureRepositoryToolDependencyInstalledForAuto(ModulePipelinePlan plan)
+    {
+        if (plan is null || IsRepositoryToolAvailable())
+            return Array.Empty<ModuleDependencyInstallResult>();
+
+        return EnsureFeatureToolDependenciesInstalled(
+            new[] { new ModuleDependency("Microsoft.PowerShell.PSResourceGet") },
+            plan.InstallMissingModulesForce,
+            plan.InstallMissingModulesRepository,
+            plan.InstallMissingModulesCredential,
+            plan.InstallMissingModulesPrerelease);
+    }
+
     private static bool RequiresRequiredModuleOnlineResolutionTool(
         IReadOnlyList<RequiredModuleDraft> requiredModules,
         IReadOnlyList<RequiredModuleDraft> requiredModulesForPackaging,
@@ -262,21 +277,45 @@ public sealed partial class ModulePipelineRunner
             .Where(draft => draft is not null &&
                             ResolveDependencyVersionSource(draft.VersionSource, publishVersionSource).PreferOnlineMetadata));
 
-    private static bool ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(ModulePipelinePlan plan)
+    private bool ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(
+        ModulePipelineSpec spec,
+        ModulePipelinePlan plan)
     {
         if (plan is null || plan.BuildSpec.RefreshManifestOnly)
             return false;
 
-        return HasOnlineResolvableRequiredModuleReferences(plan.RequiredModules) ||
-               HasOnlineResolvableRequiredModuleReferences(plan.RequiredModulesForPackaging);
+        if (HasOnlineResolvableRequiredModuleReferences(plan.RequiredModules) ||
+            HasOnlineResolvableRequiredModuleReferences(plan.RequiredModulesForPackaging))
+        {
+            return true;
+        }
+
+        var input = CollectRequiredModulePreflightInput(spec);
+        return RequiresRequiredModuleOnlineResolutionTool(
+            input.RequiredModules,
+            input.RequiredModulesForPackaging,
+            input.ResolveMissingModulesOnline,
+            input.WarnIfRequiredModulesOutdated,
+            input.PublishVersionSource);
     }
 
     private static bool HasOnlineResolvableRequiredModuleReferences(IEnumerable<RequiredModuleReference> modules)
         => (modules ?? Array.Empty<RequiredModuleReference>())
             .Any(static module => module is not null &&
                                   !string.IsNullOrWhiteSpace(module.ModuleName) &&
-                                  (IsAutoVersion(module.ModuleVersion) ||
+                                  (IsAutoOrLatestVersionValue(module.ModuleVersion) ||
+                                   IsAutoOrLatestVersionValue(module.RequiredVersion) ||
                                    IsAutoGuid(module.Guid)));
+
+    private static bool IsAutoOrLatestVersionValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var trimmed = value!.Trim();
+        return trimmed.Equals("Auto", StringComparison.OrdinalIgnoreCase) ||
+               trimmed.Equals("Latest", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static bool IsAutoGuid(string? value)
         => !string.IsNullOrWhiteSpace(value) &&
@@ -440,7 +479,7 @@ public sealed partial class ModulePipelineRunner
             .Select(static module => new RequiredModuleDraft(
                 moduleName: module.ModuleName.Trim(),
                 moduleVersion: module.ModuleVersion,
-                minimumVersion: null,
+                minimumVersion: module.ModuleVersion,
                 requiredVersion: module.RequiredVersion,
                 guid: module.Guid,
                 versionSource: ModuleDependencyVersionSource.Auto))
@@ -451,8 +490,31 @@ public sealed partial class ModulePipelineRunner
     {
         if (spec is null) return;
 
+        var input = CollectRequiredModulePreflightInput(spec);
+        if (input.RefreshPsd1Only)
+            return;
+
+        EnsureRequiredModuleOnlineResolutionToolInstalledIfNeeded(
+            input.RequiredModules,
+            input.RequiredModulesForPackaging,
+            input.ResolveMissingModulesOnline,
+            input.WarnIfRequiredModulesOutdated,
+            input.PublishVersionSource,
+            input.InstallMissingModulesForce,
+            input.InstallMissingModulesRepository,
+            input.InstallMissingModulesCredential,
+            input.InstallMissingModulesPrerelease);
+    }
+
+    private RequiredModulePreflightInput CollectRequiredModulePreflightInput(ModulePipelineSpec spec)
+    {
+        if (spec is null)
+            return RequiredModulePreflightInput.Empty;
+
         var requiredModulesDraft = new List<RequiredModuleDraft>();
+        var requiredIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var requiredModulesDraftForPackaging = new List<RequiredModuleDraft>();
+        var requiredPackagingIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var publishes = new List<ConfigurationPublishSegment>();
         var resolveMissingModulesOnline = false;
         var resolveMissingModulesOnlineSet = false;
@@ -462,6 +524,12 @@ public sealed partial class ModulePipelineRunner
         var installMissingModulesPrerelease = false;
         string? installMissingModulesRepository = null;
         RepositoryCredential? installMissingModulesCredential = null;
+
+        foreach (var draft in ReadRequiredModuleDraftsFromManifest(spec))
+        {
+            AddOrReplaceRequiredModuleDraft(requiredModulesDraft, requiredIndex, draft);
+            AddOrReplaceRequiredModuleDraft(requiredModulesDraftForPackaging, requiredPackagingIndex, draft);
+        }
 
         foreach (var segment in spec.Segments ?? Array.Empty<IConfigurationSegment>())
         {
@@ -508,24 +576,14 @@ public sealed partial class ModulePipelineRunner
                         requiredVersion: cfg.RequiredVersion,
                         guid: cfg.Guid,
                         versionSource: cfg.VersionSource);
-                    requiredModulesDraft.Add(draft);
-                    requiredModulesDraftForPackaging.Add(draft);
+                    AddOrReplaceRequiredModuleDraft(requiredModulesDraft, requiredIndex, draft);
+                    AddOrReplaceRequiredModuleDraft(requiredModulesDraftForPackaging, requiredPackagingIndex, draft);
                     break;
                 }
                 case ConfigurationPublishSegment publish:
                     publishes.Add(publish);
                     break;
             }
-        }
-
-        if (refreshPsd1Only)
-            return;
-
-        var manifestRequiredModuleDrafts = ReadRequiredModuleDraftsFromManifest(spec);
-        if (manifestRequiredModuleDrafts.Length > 0)
-        {
-            requiredModulesDraft.AddRange(manifestRequiredModuleDrafts);
-            requiredModulesDraftForPackaging.AddRange(manifestRequiredModuleDrafts);
         }
 
         if (!resolveMissingModulesOnlineSet && HasOnlineResolvableAutoRequiredModules(requiredModulesDraft))
@@ -536,16 +594,85 @@ public sealed partial class ModulePipelineRunner
                 .Where(static publish => publish is not null && publish.Configuration?.Enabled == true)
                 .ToArray());
 
-        EnsureRequiredModuleOnlineResolutionToolInstalledIfNeeded(
-            requiredModulesDraft,
-            requiredModulesDraftForPackaging,
+        return new RequiredModulePreflightInput(
             resolveMissingModulesOnline,
             warnIfRequiredModulesOutdated,
             dependencyVersionSourceRepository,
             installMissingModulesForce,
             installMissingModulesRepository,
             installMissingModulesCredential,
-            installMissingModulesPrerelease);
+            installMissingModulesPrerelease,
+            refreshPsd1Only,
+            requiredModulesDraft.ToArray(),
+            requiredModulesDraftForPackaging.ToArray());
+    }
+
+    private static void AddOrReplaceRequiredModuleDraft(
+        List<RequiredModuleDraft> drafts,
+        Dictionary<string, int> index,
+        RequiredModuleDraft draft)
+    {
+        if (draft is null || string.IsNullOrWhiteSpace(draft.ModuleName))
+            return;
+
+        if (index.TryGetValue(draft.ModuleName, out var existingIndex))
+        {
+            drafts[existingIndex] = draft;
+            return;
+        }
+
+        index[draft.ModuleName] = drafts.Count;
+        drafts.Add(draft);
+    }
+
+    private sealed class RequiredModulePreflightInput
+    {
+        public static RequiredModulePreflightInput Empty { get; } = new(
+            resolveMissingModulesOnline: false,
+            warnIfRequiredModulesOutdated: false,
+            publishVersionSource: null,
+            installMissingModulesForce: false,
+            installMissingModulesRepository: null,
+            installMissingModulesCredential: null,
+            installMissingModulesPrerelease: false,
+            refreshPsd1Only: false,
+            requiredModules: Array.Empty<RequiredModuleDraft>(),
+            requiredModulesForPackaging: Array.Empty<RequiredModuleDraft>());
+
+        public bool ResolveMissingModulesOnline { get; }
+        public bool WarnIfRequiredModulesOutdated { get; }
+        public DependencyVersionSourceRepository? PublishVersionSource { get; }
+        public bool InstallMissingModulesForce { get; }
+        public string? InstallMissingModulesRepository { get; }
+        public RepositoryCredential? InstallMissingModulesCredential { get; }
+        public bool InstallMissingModulesPrerelease { get; }
+        public bool RefreshPsd1Only { get; }
+        public RequiredModuleDraft[] RequiredModules { get; }
+        public RequiredModuleDraft[] RequiredModulesForPackaging { get; }
+
+        public RequiredModulePreflightInput(
+            bool resolveMissingModulesOnline,
+            bool warnIfRequiredModulesOutdated,
+            DependencyVersionSourceRepository? publishVersionSource,
+            bool installMissingModulesForce,
+            string? installMissingModulesRepository,
+            RepositoryCredential? installMissingModulesCredential,
+            bool installMissingModulesPrerelease,
+            bool refreshPsd1Only,
+            RequiredModuleDraft[] requiredModules,
+            RequiredModuleDraft[] requiredModulesForPackaging)
+        {
+            ResolveMissingModulesOnline = resolveMissingModulesOnline;
+            WarnIfRequiredModulesOutdated = warnIfRequiredModulesOutdated;
+            PublishVersionSource = publishVersionSource;
+            InstallMissingModulesForce = installMissingModulesForce;
+            InstallMissingModulesRepository = installMissingModulesRepository;
+            InstallMissingModulesCredential = installMissingModulesCredential;
+            InstallMissingModulesPrerelease = installMissingModulesPrerelease;
+            RefreshPsd1Only = refreshPsd1Only;
+            RequiredModules = requiredModules ?? Array.Empty<RequiredModuleDraft>();
+            RequiredModulesForPackaging = requiredModulesForPackaging ?? Array.Empty<RequiredModuleDraft>();
+        }
     }
 
     private void AddRepositoryToolDependencyForAuto(IDictionary<string, ModuleDependency> dependencies)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -123,7 +123,7 @@ public sealed partial class ModulePipelineRunner
         return results.ToArray();
     }
 
-    private static ModuleDependency[] ResolveFeatureToolDependencies(ModulePipelinePlan plan)
+    private ModuleDependency[] ResolveFeatureToolDependencies(ModulePipelinePlan plan)
     {
         var dependencies = new Dictionary<string, ModuleDependency>(StringComparer.OrdinalIgnoreCase);
 
@@ -145,7 +145,13 @@ public sealed partial class ModulePipelineRunner
                     AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
                     break;
                 case PublishTool.Auto:
-                    AddFeatureDependency(dependencies, new ModuleDependency("PowerShellGet", minimumVersion: PowerShellGetMinimumVersion));
+                    if (!IsAutoPublishToolAvailable() &&
+                        !dependencies.ContainsKey("Microsoft.PowerShell.PSResourceGet") &&
+                        !dependencies.ContainsKey("PowerShellGet"))
+                    {
+                        AddFeatureDependency(dependencies, new ModuleDependency("Microsoft.PowerShell.PSResourceGet"));
+                    }
+
                     break;
             }
         }
@@ -153,6 +159,18 @@ public sealed partial class ModulePipelineRunner
         return dependencies.Values
             .OrderBy(static dependency => dependency.Name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private bool IsAutoPublishToolAvailable()
+    {
+        var installed = _moduleDependencyMetadataProvider.GetLatestInstalledModules(new[]
+        {
+            "Microsoft.PowerShell.PSResourceGet",
+            "PowerShellGet"
+        });
+
+        return installed.ContainsKey("Microsoft.PowerShell.PSResourceGet") ||
+               installed.ContainsKey("PowerShellGet");
     }
 
     private static void AddFeatureDependency(IDictionary<string, ModuleDependency> dependencies, ModuleDependency dependency)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -650,6 +650,17 @@ public sealed partial class ModulePipelineRunner
             .ToArray();
         var dependencyVersionSourceRepository = ResolvePublishDependencyVersionSource(enabledPublishes);
 
+        EnsureRequiredModuleOnlineResolutionToolInstalledIfNeeded(
+            requiredModulesDraft,
+            requiredModulesDraftForPackaging,
+            resolveMissingModulesOnline,
+            warnIfRequiredModulesOutdated,
+            dependencyVersionSourceRepository,
+            installMissingModulesForce,
+            installMissingModulesRepository,
+            installMissingModulesCredential,
+            installMissingModulesPrerelease);
+
         var approved = NormalizeApprovedModules(approvedModules);
         ApplyMergeDefaultsForPlan(
             refreshPsd1Only,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -650,17 +650,6 @@ public sealed partial class ModulePipelineRunner
             .ToArray();
         var dependencyVersionSourceRepository = ResolvePublishDependencyVersionSource(enabledPublishes);
 
-        EnsureRequiredModuleOnlineResolutionToolInstalledIfNeeded(
-            requiredModulesDraft,
-            requiredModulesDraftForPackaging,
-            resolveMissingModulesOnline,
-            warnIfRequiredModulesOutdated,
-            dependencyVersionSourceRepository,
-            installMissingModulesForce,
-            installMissingModulesRepository,
-            installMissingModulesCredential,
-            installMissingModulesPrerelease);
-
         var approved = NormalizeApprovedModules(approvedModules);
         ApplyMergeDefaultsForPlan(
             refreshPsd1Only,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Helpers.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Helpers.cs
@@ -13,7 +13,8 @@ public sealed partial class ModulePipelineRunner
             var results = new List<ModuleDependencyInstallResult>();
             if (plan.InstallMissingModules)
                 results.AddRange(EnsureBuildDependenciesInstalled(plan));
-            results.AddRange(EnsureFeatureToolDependenciesInstalled(plan));
+            var packagingRequiredModules = ResolveOutputRequiredModules(plan.RequiredModulesForPackaging, plan.MergeMissing, plan.ApprovedModules);
+            results.AddRange(EnsureFeatureToolDependenciesInstalled(plan, packagingRequiredModules));
             return results.ToArray();
         }
         catch (Exception ex)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Helpers.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Helpers.cs
@@ -8,11 +8,13 @@ public sealed partial class ModulePipelineRunner
 {
     private ModuleDependencyInstallResult[] EnsureBuildDependenciesInstalledIfNeeded(ModulePipelinePlan plan)
     {
-        if (!plan.InstallMissingModules) return Array.Empty<ModuleDependencyInstallResult>();
-
         try
         {
-            return EnsureBuildDependenciesInstalled(plan);
+            var results = new List<ModuleDependencyInstallResult>();
+            if (plan.InstallMissingModules)
+                results.AddRange(EnsureBuildDependenciesInstalled(plan));
+            results.AddRange(EnsureFeatureToolDependenciesInstalled(plan));
+            return results.ToArray();
         }
         catch (Exception ex)
         {

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
@@ -7,6 +7,7 @@ public sealed partial class ModulePipelineRunner
     /// </summary>
     public ModulePipelineResult Run(ModulePipelineSpec spec)
     {
+        EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(spec);
         var plan = Plan(spec);
         return Run(spec, plan, progress: null);
     }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
@@ -9,16 +9,29 @@ public sealed partial class ModulePipelineRunner
     {
         EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(spec);
         var plan = Plan(spec);
-        return Run(spec, plan, progress: null);
+        return Run(spec, plan, progress: null, preflightPrecomputedPlan: false);
     }
 
     /// <summary>
     /// Executes the pipeline described by <paramref name="spec"/> using a precomputed <paramref name="plan"/>.
     /// </summary>
     public ModulePipelineResult Run(ModulePipelineSpec spec, ModulePipelinePlan plan, IModulePipelineProgressReporter? progress = null)
+        => Run(spec, plan, progress, preflightPrecomputedPlan: true);
+
+    private ModulePipelineResult Run(
+        ModulePipelineSpec spec,
+        ModulePipelinePlan plan,
+        IModulePipelineProgressReporter? progress,
+        bool preflightPrecomputedPlan)
     {
         if (spec is null) throw new ArgumentNullException(nameof(spec));
         if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        if (preflightPrecomputedPlan && ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(plan))
+        {
+            EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(spec);
+            plan = Plan(spec);
+        }
 
         var manifestRequiredModules = ResolveOutputRequiredModules(plan.RequiredModules, plan.MergeMissing, plan.ApprovedModules);
         var packagingRequiredModules = ResolveOutputRequiredModules(plan.RequiredModulesForPackaging, plan.MergeMissing, plan.ApprovedModules);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.cs
@@ -27,7 +27,7 @@ public sealed partial class ModulePipelineRunner
         if (spec is null) throw new ArgumentNullException(nameof(spec));
         if (plan is null) throw new ArgumentNullException(nameof(plan));
 
-        if (preflightPrecomputedPlan && ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(plan))
+        if (preflightPrecomputedPlan && ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(spec, plan))
         {
             EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(spec);
             plan = Plan(spec);

--- a/PowerForge.PowerShell/Services/ModuleTestSuiteService.cs
+++ b/PowerForge.PowerShell/Services/ModuleTestSuiteService.cs
@@ -194,23 +194,33 @@ public sealed class ModuleTestSuiteService
         if (deps.Count == 0)
             return Array.Empty<ModuleDependencyInstallResult>();
 
-        AddRepositoryToolBootstrapDependency(deps, spec.SkipModules);
-
         var installer = new ModuleDependencyInstaller(_runner, _logger);
+        var bootstrapResults = Array.Empty<ModuleDependencyInstallResult>();
+        if (ShouldBootstrapRepositoryTool(deps, spec.SkipModules))
+        {
+            bootstrapResults = installer.EnsureInstalled(
+                dependencies: new[] { new ModuleDependency(RepositoryToolModuleName) },
+                skipModules: spec.SkipModules,
+                force: spec.Force)
+                .ToArray();
+        }
+
         var results = installer.EnsureInstalled(
             dependencies: deps,
             skipModules: spec.SkipModules,
-            force: spec.Force);
+            force: spec.Force)
+            .ToArray();
 
-        var failures = results.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
+        var allResults = bootstrapResults.Concat(results).ToArray();
+        var failures = allResults.Where(r => r.Status == ModuleDependencyInstallStatus.Failed).ToArray();
         if (failures.Length > 0)
             throw new InvalidOperationException($"Dependency installation failed for {failures.Length} module{(failures.Length == 1 ? string.Empty : "s")}.");
 
-        return results.ToArray();
+        return allResults;
     }
 
-    private void AddRepositoryToolBootstrapDependency(
-        List<ModuleDependency> dependencies,
+    private bool ShouldBootstrapRepositoryTool(
+        IReadOnlyList<ModuleDependency> dependencies,
         IEnumerable<string>? skipModules)
     {
         var skip = new HashSet<string>(
@@ -225,10 +235,10 @@ public sealed class ModuleTestSuiteService
             !IsRepositoryToolModule(dependency.Name) &&
             !skip.Contains(dependency.Name));
         if (!hasInstallTarget)
-            return;
+            return false;
 
         if (IsRepositoryToolAvailable())
-            return;
+            return false;
 
         if (skip.Contains(RepositoryToolModuleName) ||
             dependencies.Any(static dependency =>
@@ -236,10 +246,10 @@ public sealed class ModuleTestSuiteService
                 !string.IsNullOrWhiteSpace(dependency.Name) &&
                 IsRepositoryToolModule(dependency.Name)))
         {
-            return;
+            return false;
         }
 
-        dependencies.Insert(0, new ModuleDependency(RepositoryToolModuleName));
+        return true;
     }
 
     private static bool IsRepositoryToolModule(string moduleName)

--- a/PowerForge.PowerShell/Services/ModuleTestSuiteService.cs
+++ b/PowerForge.PowerShell/Services/ModuleTestSuiteService.cs
@@ -13,6 +13,8 @@ namespace PowerForge;
 /// </summary>
 public sealed class ModuleTestSuiteService
 {
+    private const string RepositoryToolModuleName = "Microsoft.PowerShell.PSResourceGet";
+
     private readonly IPowerShellRunner _runner;
     private readonly ILogger _logger;
 
@@ -192,6 +194,8 @@ public sealed class ModuleTestSuiteService
         if (deps.Count == 0)
             return Array.Empty<ModuleDependencyInstallResult>();
 
+        AddRepositoryToolBootstrapDependency(deps, spec.SkipModules);
+
         var installer = new ModuleDependencyInstaller(_runner, _logger);
         var results = installer.EnsureInstalled(
             dependencies: deps,
@@ -203,6 +207,81 @@ public sealed class ModuleTestSuiteService
             throw new InvalidOperationException($"Dependency installation failed for {failures.Length} module{(failures.Length == 1 ? string.Empty : "s")}.");
 
         return results.ToArray();
+    }
+
+    private void AddRepositoryToolBootstrapDependency(
+        List<ModuleDependency> dependencies,
+        IEnumerable<string>? skipModules)
+    {
+        var skip = new HashSet<string>(
+            (skipModules ?? Array.Empty<string>())
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+
+        var hasInstallTarget = dependencies.Any(dependency =>
+            dependency is not null &&
+            !string.IsNullOrWhiteSpace(dependency.Name) &&
+            !IsRepositoryToolModule(dependency.Name) &&
+            !skip.Contains(dependency.Name));
+        if (!hasInstallTarget)
+            return;
+
+        if (IsRepositoryToolAvailable())
+            return;
+
+        if (skip.Contains(RepositoryToolModuleName) ||
+            dependencies.Any(static dependency =>
+                dependency is not null &&
+                !string.IsNullOrWhiteSpace(dependency.Name) &&
+                IsRepositoryToolModule(dependency.Name)))
+        {
+            return;
+        }
+
+        dependencies.Insert(0, new ModuleDependency(RepositoryToolModuleName));
+    }
+
+    private static bool IsRepositoryToolModule(string moduleName)
+        => moduleName.Equals(RepositoryToolModuleName, StringComparison.OrdinalIgnoreCase) ||
+           moduleName.Equals("PowerShellGet", StringComparison.OrdinalIgnoreCase);
+
+    private bool IsRepositoryToolAvailable()
+    {
+        try
+        {
+            var psResourceGet = new PSResourceGetClient(_runner, _logger).GetAvailability(TimeSpan.FromMinutes(1));
+            if (psResourceGet.Available)
+                return true;
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsVerbose)
+                _logger.Verbose($"PSResourceGet availability probe failed: {ex.Message}");
+        }
+
+        try
+        {
+            var powerShellGet = new PowerShellGetClient(_runner, _logger).GetAvailability(TimeSpan.FromMinutes(1));
+            return powerShellGet.Available && VersionMeetsMinimum(powerShellGet.Version, "2.2.5");
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsVerbose)
+                _logger.Verbose($"PowerShellGet availability probe failed: {ex.Message}");
+        }
+
+        return false;
+    }
+
+    private static bool VersionMeetsMinimum(string? actual, string minimum)
+    {
+        if (string.IsNullOrWhiteSpace(actual))
+            return false;
+
+        return Version.TryParse(actual!.Trim(), out var actualVersion) &&
+               Version.TryParse(minimum, out var minimumVersion) &&
+               actualVersion.CompareTo(minimumVersion) >= 0;
     }
 
     private static string ResolveTestPath(string projectRoot, string? testPath)

--- a/PowerForge.Tests/ModuleDependencyInstallerExactVersionTests.cs
+++ b/PowerForge.Tests/ModuleDependencyInstallerExactVersionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using Xunit;
@@ -116,6 +117,53 @@ public sealed class ModuleDependencyInstallerExactVersionTests
         Assert.Equal(1, runner.InstallCalls);
     }
 
+    [Fact]
+    public void EnsureInstalled_BootstrapsPSResourceGetDirectly_WhenRepositoryClientsAreUnavailable()
+    {
+        var moduleRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            Uri? downloadedUri = null;
+            var runner = new ToolUnavailablePowerShellRunner();
+            var installer = new ModuleDependencyInstaller(
+                runner,
+                new NullLogger(),
+                galleryVersionResolver: (packageId, includePrerelease, timeout) => new[]
+                {
+                    new PowerShellGalleryPackageVersion("1.1.0", isListed: true, isPrerelease: false),
+                    new PowerShellGalleryPackageVersion("1.2.0", isListed: true, isPrerelease: false)
+                },
+                directPackageDownloader: (uri, destination, timeout) =>
+                {
+                    downloadedUri = uri;
+                    CreatePSResourceGetPackage(destination, "1.2.0");
+                },
+                currentUserModuleRootResolver: () => moduleRoot.FullName);
+
+            var results = installer.EnsureInstalled(new[]
+            {
+                new ModuleDependency("Microsoft.PowerShell.PSResourceGet", minimumVersion: "1.1.1")
+            });
+
+            var result = Assert.Single(results);
+            Assert.Equal(ModuleDependencyInstallStatus.Installed, result.Status);
+            Assert.Equal("DirectPowerShellGallery", result.Installer);
+            Assert.NotNull(downloadedUri);
+            Assert.Contains("/Microsoft.PowerShell.PSResourceGet/1.2.0", downloadedUri!.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(Path.Combine(
+                moduleRoot.FullName,
+                "Microsoft.PowerShell.PSResourceGet",
+                "1.2.0",
+                "Microsoft.PowerShell.PSResourceGet.psd1")));
+            Assert.Equal(1, runner.PSResourceGetInstallCalls);
+            Assert.Equal(1, runner.PowerShellGetInstallCalls);
+        }
+        finally
+        {
+            try { moduleRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private sealed class StubPowerShellRunner : IPowerShellRunner
     {
         private readonly IReadOnlyDictionary<string, string?> _latestInstalledVersions;
@@ -195,4 +243,69 @@ public sealed class ModuleDependencyInstallerExactVersionTests
         private static string Encode(string value)
             => Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty));
     }
+
+    private sealed class ToolUnavailablePowerShellRunner : IPowerShellRunner
+    {
+        public int PSResourceGetInstallCalls { get; private set; }
+        public int PowerShellGetInstallCalls { get; private set; }
+
+        public PowerShellRunResult Run(PowerShellRunRequest request)
+        {
+            Assert.NotNull(request.ScriptPath);
+            var script = File.ReadAllText(request.ScriptPath!);
+
+            if (script.Contains(InstalledVersionsMarker, StringComparison.Ordinal))
+            {
+                var names = DecodeLines(request.Arguments[0]);
+                var lines = names.Select(name => InstalledVersionsMarker + Encode(name) + "::" + Encode(string.Empty));
+                return new PowerShellRunResult(0, string.Join(Environment.NewLine, lines), string.Empty, "pwsh.exe");
+            }
+
+            if (script.Contains(PsResourceInstallMarker, StringComparison.Ordinal))
+            {
+                PSResourceGetInstallCalls++;
+                return new PowerShellRunResult(3, "PFPSRG::ERROR::" + Encode("PSResourceGet unavailable"), string.Empty, "pwsh.exe");
+            }
+
+            if (script.Contains(PowerShellGetInstallMarker, StringComparison.Ordinal))
+            {
+                PowerShellGetInstallCalls++;
+                return new PowerShellRunResult(3, "PFMOD::ERROR::" + Encode("PowerShellGet unavailable"), string.Empty, "pwsh.exe");
+            }
+
+            throw new InvalidOperationException("Unexpected script invocation in test.");
+        }
+    }
+
+    private static void CreatePSResourceGetPackage(string destinationPath, string version)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+        using var archive = ZipFile.Open(destinationPath, ZipArchiveMode.Create);
+        AddEntry(archive, "Microsoft.PowerShell.PSResourceGet.psd1", "@{ ModuleVersion = '" + version + "' }");
+        AddEntry(archive, "Microsoft.PowerShell.PSResourceGet.psm1", string.Empty);
+        AddEntry(archive, "Microsoft.PowerShell.PSResourceGet.nuspec", "<package />");
+        AddEntry(archive, "package/services/metadata/core-properties/metadata.psmdcp", string.Empty);
+        AddEntry(archive, "[Content_Types].xml", string.Empty);
+
+        static void AddEntry(ZipArchive archive, string path, string content)
+        {
+            var entry = archive.CreateEntry(path);
+            using var stream = entry.Open();
+            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            writer.Write(content);
+        }
+    }
+
+    private static string[] DecodeLines(string value)
+    {
+        var text = Encoding.UTF8.GetString(Convert.FromBase64String(value));
+        return text
+            .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static line => line.Trim())
+            .Where(static line => line.Length > 0)
+            .ToArray();
+    }
+
+    private static string Encode(string value)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty));
 }

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -86,6 +86,73 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_HonorsModuleSkipForDeclaredDependencies()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            InstallMissingModules = true
+                        }
+                    },
+                    new ConfigurationModuleSkipSegment
+                    {
+                        Configuration = new ModuleSkipConfiguration
+                        {
+                            IgnoreModuleName = new[] { "Pester" }
+                        }
+                    },
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Pester",
+                            RequiredVersion = "5.6.1"
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
+            Assert.Contains("Pester", hostedOperations.LastSkipModules?.IgnoreModuleName ?? Array.Empty<string>());
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPesterForConfiguredTests()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -108,6 +175,13 @@ public sealed class ModulePipelineHostedOperationsTests
                 Install = new ModulePipelineInstallOptions { Enabled = false },
                 Segments = new IConfigurationSegment[]
                 {
+                    new ConfigurationModuleSkipSegment
+                    {
+                        Configuration = new ModuleSkipConfiguration
+                        {
+                            IgnoreModuleName = new[] { "Pester" }
+                        }
+                    },
                     new ConfigurationTestSegment
                     {
                         Configuration = new TestConfiguration
@@ -134,6 +208,7 @@ public sealed class ModulePipelineHostedOperationsTests
             var dependency = Assert.Single(hostedOperations.LastDependencies);
             Assert.Equal("Pester", dependency.Name);
             Assert.Equal("5.7.1", dependency.MinimumVersion);
+            Assert.Null(hostedOperations.LastSkipModules);
         }
         finally
         {
@@ -142,7 +217,7 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
-    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForAutoRepositoryPublish()
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPowerShellGetFallbackForAutoRepositoryPublish()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -163,7 +238,9 @@ public sealed class ModulePipelineHostedOperationsTests
 
             Assert.Single(result);
             Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+            var dependency = Assert.Single(hostedOperations.LastDependencies);
+            Assert.Equal("PowerShellGet", dependency.Name);
+            Assert.Equal("2.2.5", dependency.MinimumVersion);
         }
         finally
         {
@@ -196,6 +273,36 @@ public sealed class ModulePipelineHostedOperationsTests
             var dependency = Assert.Single(hostedOperations.LastDependencies);
             Assert.Equal("PowerShellGet", dependency.Name);
             Assert.Equal("2.2.5", dependency.MinimumVersion);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForExplicitPSResourceGetPublish()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreatePublishToolSpec(root.FullName, moduleName, PublishTool.PSResourceGet);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
         }
         finally
         {
@@ -605,6 +712,7 @@ public sealed class ModulePipelineHostedOperationsTests
         public int DependencyInstallCalls { get; private set; }
         public IReadOnlyList<ModuleDependency> LastDependencies { get; private set; } = Array.Empty<ModuleDependency>();
         public string? LastRepository { get; private set; }
+        public ModuleSkipConfiguration? LastSkipModules { get; private set; }
         public ModuleTestSuiteResult? NextTestSuiteResult { get; set; }
 
         public IReadOnlyList<ModuleDependencyInstallResult> EnsureDependenciesInstalled(
@@ -618,6 +726,7 @@ public sealed class ModulePipelineHostedOperationsTests
             DependencyInstallCalls++;
             LastDependencies = dependencies ?? Array.Empty<ModuleDependency>();
             LastRepository = repository;
+            LastSkipModules = skipModules;
             return LastDependencies
                 .Select(dependency => new ModuleDependencyInstallResult(
                     name: dependency.Name,

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -86,6 +86,124 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPesterForConfiguredTests()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var testsPath = Path.Combine(root.FullName, "Tests");
+            Directory.CreateDirectory(testsPath);
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationTestSegment
+                    {
+                        Configuration = new TestConfiguration
+                        {
+                            TestsPath = testsPath,
+                            When = TestExecutionWhen.AfterMerge
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            var dependency = Assert.Single(hostedOperations.LastDependencies);
+            Assert.Equal("Pester", dependency.Name);
+            Assert.Equal("5.7.1", dependency.MinimumVersion);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForAutoRepositoryPublish()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreatePublishToolSpec(root.FullName, moduleName, PublishTool.Auto);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPowerShellGetForExplicitPowerShellGetPublish()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreatePublishToolSpec(root.FullName, moduleName, PublishTool.PowerShellGet);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            var dependency = Assert.Single(hostedOperations.LastDependencies);
+            Assert.Equal("PowerShellGet", dependency.Name);
+            Assert.Equal("2.2.5", dependency.MinimumVersion);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void ValidateModuleImports_UsesInjectedPowerShellRunner()
     {
         var requests = new List<PowerShellRunRequest>();
@@ -415,6 +533,33 @@ public sealed class ModulePipelineHostedOperationsTests
         method!.Invoke(runner, new object?[] { plan, buildResult, configuration });
     }
 
+    private static ModulePipelineSpec CreatePublishToolSpec(string root, string moduleName, PublishTool tool)
+    {
+        return new ModulePipelineSpec
+        {
+            Build = new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = root,
+                Version = "1.0.0"
+            },
+            Install = new ModulePipelineInstallOptions { Enabled = false },
+            Segments = new IConfigurationSegment[]
+            {
+                new ConfigurationPublishSegment
+                {
+                    Configuration = new PublishConfiguration
+                    {
+                        Enabled = true,
+                        Destination = PublishDestination.PowerShellGallery,
+                        Tool = tool,
+                        ApiKey = "test-api-key"
+                    }
+                }
+            }
+        };
+    }
+
     private static void WriteMinimalModule(string moduleRoot, string moduleName, string version)
     {
         Directory.CreateDirectory(moduleRoot);
@@ -473,19 +618,16 @@ public sealed class ModulePipelineHostedOperationsTests
             DependencyInstallCalls++;
             LastDependencies = dependencies ?? Array.Empty<ModuleDependency>();
             LastRepository = repository;
-            var first = LastDependencies.FirstOrDefault() ?? new ModuleDependency("Unknown", null, null, null);
-
-            return new[]
-            {
-                new ModuleDependencyInstallResult(
-                    name: first.Name,
-                    installedVersion: first.RequiredVersion,
-                    resolvedVersion: first.RequiredVersion,
-                    requestedVersion: first.RequiredVersion,
+            return LastDependencies
+                .Select(dependency => new ModuleDependencyInstallResult(
+                    name: dependency.Name,
+                    installedVersion: dependency.RequiredVersion ?? dependency.MinimumVersion,
+                    resolvedVersion: dependency.RequiredVersion ?? dependency.MinimumVersion,
+                    requestedVersion: dependency.RequiredVersion ?? dependency.MinimumVersion,
                     status: ModuleDependencyInstallStatus.Satisfied,
                     installer: "fake",
-                    message: "ok")
-            };
+                    message: "ok"))
+                .ToArray();
         }
 
         public DocumentationBuildResult BuildDocumentation(

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -205,9 +205,8 @@ public sealed class ModulePipelineHostedOperationsTests
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
             Assert.Equal(2, result.Length);
-            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            Assert.Contains(hostedOperations.LastDependencies, dependency =>
-                dependency.Name == "Microsoft.PowerShell.PSResourceGet");
+            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
             var pester = Assert.Single(hostedOperations.LastDependencies, dependency => dependency.Name == "Pester");
             Assert.Equal("5.7.1", pester.MinimumVersion);
             Assert.Null(hostedOperations.LastSkipModules);
@@ -329,11 +328,9 @@ public sealed class ModulePipelineHostedOperationsTests
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
             Assert.Equal(2, result.Length);
-            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            Assert.Contains(hostedOperations.LastDependencies, dependency =>
-                dependency.Name == "Microsoft.PowerShell.PSResourceGet");
-            Assert.Contains(hostedOperations.LastDependencies, dependency =>
-                dependency.Name == "Pester");
+            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
+            Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
             Assert.Null(hostedOperations.LastRepository);
         }
         finally
@@ -374,7 +371,7 @@ public sealed class ModulePipelineHostedOperationsTests
                             {
                                 Enable = true,
                                 TestPath = testsPath,
-                                AdditionalModules = new[] { "Pester", "PSWriteColor" }
+                                AdditionalModules = new[] { "Az.Accounts", "Pester", "PSWriteColor" }
                             }
                         }
                     }
@@ -391,14 +388,129 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Equal(3, result.Length);
-            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            Assert.Contains(hostedOperations.LastDependencies, dependency =>
-                dependency.Name == "Microsoft.PowerShell.PSResourceGet");
+            Assert.Equal(4, result.Length);
+            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
             var pester = Assert.Single(hostedOperations.LastDependencies, dependency => dependency.Name == "Pester");
             Assert.Equal("5.7.1", pester.MinimumVersion);
+            Assert.Contains(hostedOperations.LastDependencies, dependency => dependency.Name == "Az.Accounts");
             Assert.Contains(hostedOperations.LastDependencies, dependency => dependency.Name == "PSWriteColor");
             Assert.Null(hostedOperations.LastRepository);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_SkipsRepositoryToolForSatisfiedTestsAfterMergeTool()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var testsPath = Path.Combine(root.FullName, "Tests");
+            Directory.CreateDirectory(testsPath);
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationTestSegment
+                    {
+                        Configuration = new TestConfiguration
+                        {
+                            TestsPath = testsPath,
+                            When = TestExecutionWhen.AfterMerge
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Pester"] = "5.7.1"
+                }),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsScriptAnalyzerBootstrapBeforeAnalyzerTool()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationValidationSegment
+                    {
+                        Settings = new ModuleValidationSettings
+                        {
+                            Enable = true,
+                            ScriptAnalyzer = new ScriptAnalyzerValidationSettings
+                            {
+                                Enable = true,
+                                InstallIfUnavailable = true,
+                                Severity = ValidationSeverity.Warning
+                            },
+                            Tests = new TestSuiteValidationSettings { Severity = ValidationSeverity.Off }
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Equal(2, result.Length);
+            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
+            Assert.Equal("PSScriptAnalyzer", Assert.Single(hostedOperations.LastDependencies).Name);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -204,11 +204,12 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Single(result);
+            Assert.Equal(2, result.Length);
             Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            var dependency = Assert.Single(hostedOperations.LastDependencies);
-            Assert.Equal("Pester", dependency.Name);
-            Assert.Equal("5.7.1", dependency.MinimumVersion);
+            Assert.Contains(hostedOperations.LastDependencies, dependency =>
+                dependency.Name == "Microsoft.PowerShell.PSResourceGet");
+            var pester = Assert.Single(hostedOperations.LastDependencies, dependency => dependency.Name == "Pester");
+            Assert.Equal("5.7.1", pester.MinimumVersion);
             Assert.Null(hostedOperations.LastSkipModules);
         }
         finally
@@ -327,9 +328,76 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Single(result);
+            Assert.Equal(2, result.Length);
             Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
+            Assert.Contains(hostedOperations.LastDependencies, dependency =>
+                dependency.Name == "Microsoft.PowerShell.PSResourceGet");
+            Assert.Contains(hostedOperations.LastDependencies, dependency =>
+                dependency.Name == "Pester");
+            Assert.Null(hostedOperations.LastRepository);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsValidationTestSuiteTools()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var testsPath = Path.Combine(root.FullName, "Tests");
+            Directory.CreateDirectory(testsPath);
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationValidationSegment
+                    {
+                        Settings = new ModuleValidationSettings
+                        {
+                            Enable = true,
+                            Tests = new TestSuiteValidationSettings
+                            {
+                                Enable = true,
+                                TestPath = testsPath,
+                                AdditionalModules = new[] { "Pester", "PSWriteColor" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Equal(3, result.Length);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Contains(hostedOperations.LastDependencies, dependency =>
+                dependency.Name == "Microsoft.PowerShell.PSResourceGet");
+            var pester = Assert.Single(hostedOperations.LastDependencies, dependency => dependency.Name == "Pester");
+            Assert.Equal("5.7.1", pester.MinimumVersion);
+            Assert.Contains(hostedOperations.LastDependencies, dependency => dependency.Name == "PSWriteColor");
             Assert.Null(hostedOperations.LastRepository);
         }
         finally
@@ -654,6 +722,73 @@ public sealed class ModulePipelineHostedOperationsTests
             InvokeEnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(runner, spec);
 
             Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RunPreflight_InstallsPSResourceGetForRepositorySourcedTransitiveMetadata()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            ResolveMissingModulesOnline = false
+                        }
+                    },
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Parent.Tools",
+                            ModuleVersion = "1.0.0",
+                            Guid = "11111111-1111-1111-1111-111111111111",
+                            VersionSource = ModuleDependencyVersionSource.PSGallery
+                        }
+                    }
+                }
+            };
+            var hostedOperations = new FakeHostedOperations();
+            var provider = new FakeMetadataProvider(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Parent.Tools"] = new[]
+                    {
+                        new RequiredModuleReference("Child.Tools")
+                    }
+                });
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                provider,
+                hostedOperations);
+
+            InvokeEnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(runner, spec);
+
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
         }
         finally
         {
@@ -1574,12 +1709,14 @@ public sealed class ModulePipelineHostedOperationsTests
         private readonly bool _filterInstalledModules;
         private readonly HashSet<string> _installedModuleNames;
         private readonly IReadOnlyDictionary<string, string> _installedModuleVersions;
+        private readonly IReadOnlyDictionary<string, IReadOnlyList<RequiredModuleReference>> _installedRequiredModules;
         private readonly bool _throwOnResolveLatestOnlineVersions;
 
         public FakeMetadataProvider()
         {
             _installedModuleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _installedModuleVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _installedRequiredModules = new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase);
         }
 
         public FakeMetadataProvider(params string[] installedModuleNames)
@@ -1592,6 +1729,7 @@ public sealed class ModulePipelineHostedOperationsTests
                 static name => name,
                 static name => name.Equals("PowerShellGet", StringComparison.OrdinalIgnoreCase) ? "2.2.5" : "1.0.0",
                 StringComparer.OrdinalIgnoreCase);
+            _installedRequiredModules = new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase);
         }
 
         public FakeMetadataProvider(IReadOnlyDictionary<string, string> installedModuleVersions)
@@ -1599,6 +1737,16 @@ public sealed class ModulePipelineHostedOperationsTests
             _filterInstalledModules = true;
             _installedModuleVersions = installedModuleVersions ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _installedModuleNames = new HashSet<string>(_installedModuleVersions.Keys, StringComparer.OrdinalIgnoreCase);
+            _installedRequiredModules = new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public FakeMetadataProvider(
+            IReadOnlyDictionary<string, string> installedModuleVersions,
+            IReadOnlyDictionary<string, IReadOnlyList<RequiredModuleReference>> installedRequiredModules)
+            : this(installedModuleVersions)
+        {
+            _installedRequiredModules = installedRequiredModules ??
+                new Dictionary<string, IReadOnlyList<RequiredModuleReference>>(StringComparer.OrdinalIgnoreCase);
         }
 
         private FakeMetadataProvider(bool throwOnResolveLatestOnlineVersions)
@@ -1624,7 +1772,9 @@ public sealed class ModulePipelineHostedOperationsTests
                     StringComparer.OrdinalIgnoreCase);
 
         public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)
-            => Array.Empty<RequiredModuleReference>();
+            => _installedRequiredModules.TryGetValue(moduleName, out var modules)
+                ? modules
+                : Array.Empty<RequiredModuleReference>();
 
         public IReadOnlyDictionary<string, (string? Version, string? Guid)> ResolveLatestOnlineVersions(
             IReadOnlyCollection<string> names,

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -455,6 +455,67 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void Run_WithPrecomputedPlanInstallsPSResourceGetBeforeOnlineRequiredModuleResolution()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateOnlineRequiredModuleSpec(root.FullName, moduleName);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            runner.Run(spec, plan);
+
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Run_InstallsPSResourceGetForRepositoryVersionSourceEvenWhenOnlineResolutionIsDisabled()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateOnlineRequiredModuleSpec(
+                root.FullName,
+                moduleName,
+                resolveMissingModulesOnline: false,
+                versionSource: ModuleDependencyVersionSource.PSGallery);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                FakeMetadataProvider.ThrowingOnlineResolver(),
+                hostedOperations);
+
+            Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Run_InstallsPSResourceGetBeforeManifestRequiredModuleOnlineResolution()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -502,6 +563,59 @@ public sealed class ModulePipelineHostedOperationsTests
 
             runner.Run(spec);
 
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_UsesFilteredPackagingModulesForRequiredModuleArtefact()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateRequiredModuleArtefactSpec(root.FullName, moduleName, ModuleSaveTool.Auto, RequiredModulesSource.Download);
+            spec.Segments = new IConfigurationSegment[]
+            {
+                new ConfigurationBuildSegment
+                {
+                    BuildModule = new BuildModuleConfiguration
+                    {
+                        MergeMissing = true
+                    }
+                }
+            }
+            .Concat(spec.Segments)
+            .Concat(new IConfigurationSegment[]
+            {
+                new ConfigurationModuleSegment
+                {
+                    Kind = ModuleDependencyKind.ApprovedModule,
+                    Configuration = new ModuleDependencyConfiguration
+                    {
+                        ModuleName = "Dependency.Tools"
+                    }
+                }
+            })
+            .ToArray();
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Empty(result);
             Assert.Equal(0, hostedOperations.DependencyInstallCalls);
         }
         finally
@@ -978,7 +1092,9 @@ public sealed class ModulePipelineHostedOperationsTests
         string root,
         string moduleName,
         bool refreshPsd1Only = false,
-        bool includeSegmentRequiredModule = true)
+        bool includeSegmentRequiredModule = true,
+        bool? resolveMissingModulesOnline = true,
+        ModuleDependencyVersionSource versionSource = ModuleDependencyVersionSource.Auto)
     {
         var segments = new List<IConfigurationSegment>
         {
@@ -986,7 +1102,7 @@ public sealed class ModulePipelineHostedOperationsTests
             {
                 BuildModule = new BuildModuleConfiguration
                 {
-                    ResolveMissingModulesOnline = true,
+                    ResolveMissingModulesOnline = resolveMissingModulesOnline,
                     RefreshPSD1Only = refreshPsd1Only
                 }
             }
@@ -999,7 +1115,8 @@ public sealed class ModulePipelineHostedOperationsTests
                 Configuration = new ModuleDependencyConfiguration
                 {
                     ModuleName = "Online.Tools",
-                    ModuleVersion = "Latest"
+                    ModuleVersion = "Latest",
+                    VersionSource = versionSource
                 }
             });
         }

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -1266,8 +1266,9 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Single(result);
-            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal(2, result.Length);
+            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
             var dependency = Assert.Single(hostedOperations.LastDependencies);
             Assert.Equal("PowerShellGet", dependency.Name);
             Assert.Equal("2.2.5", dependency.MinimumVersion);

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -400,6 +400,52 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_PreservesExactLocalAutoRequiredModuleArtefactWhenLatestVersionDiffers()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateRequiredModuleArtefactSpec(root.FullName, moduleName, ModuleSaveTool.Auto, RequiredModulesSource.Auto);
+            var requiredModule = spec.Segments
+                .OfType<ConfigurationModuleSegment>()
+                .Single()
+                .Configuration;
+            requiredModule.ModuleVersion = null;
+            requiredModule.RequiredVersion = "1.0.0";
+
+            var moduleLocatorRequests = new List<PowerShellRunRequest>();
+            var powerShellRunner = new RecordingPowerShellRunner(request =>
+            {
+                moduleLocatorRequests.Add(request);
+                return new PowerShellRunResult(0, "PFMODLOC::FOUND::version::path", string.Empty, "pwsh");
+            });
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner,
+                new FakeMetadataProvider(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Dependency.Tools"] = "2.0.0"
+                }),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Empty(result);
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+            Assert.Single(moduleLocatorRequests);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Plan_DoesNotInstallPSResourceGetBeforeOnlineRequiredModuleResolution()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -417,6 +463,73 @@ public sealed class ModulePipelineHostedOperationsTests
                 hostedOperations);
 
             runner.Plan(spec);
+
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RunPreflight_SkipsPublishVersionSourceWhenRequiredModulesAreConcrete()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            ResolveMissingModulesOnline = false
+                        }
+                    },
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Dependency.Tools",
+                            ModuleVersion = "1.0.0",
+                            Guid = "11111111-1111-1111-1111-111111111111"
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Enabled = true,
+                            Destination = PublishDestination.PowerShellGallery,
+                            Tool = PublishTool.Auto,
+                            ApiKey = "test-api-key",
+                            UseAsDependencyVersionSource = true
+                        }
+                    }
+                }
+            };
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            InvokeEnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(runner, spec);
 
             Assert.Equal(0, hostedOperations.DependencyInstallCalls);
         }
@@ -1007,6 +1120,13 @@ public sealed class ModulePipelineHostedOperationsTests
         var method = typeof(ModulePipelineRunner).GetMethod("EnsureBuildDependenciesInstalledIfNeeded", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.True(method is not null, "EnsureBuildDependenciesInstalledIfNeeded method signature may have changed.");
         return (ModuleDependencyInstallResult[])method!.Invoke(runner, new object?[] { plan })!;
+    }
+
+    private static void InvokeEnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(ModulePipelineRunner runner, ModulePipelineSpec spec)
+    {
+        var method = typeof(ModulePipelineRunner).GetMethod("EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(method is not null, "EnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun method signature may have changed.");
+        method!.Invoke(runner, new object?[] { spec });
     }
 
     private static void InvokeRunTestsAfterMerge(ModulePipelineRunner runner, ModulePipelinePlan plan, ModuleBuildResult buildResult, TestConfiguration configuration)

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -74,8 +74,9 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Single(result);
-            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal(2, result.Length);
+            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
             Assert.Equal("Pester", hostedOperations.LastDependencies.Single().Name);
             Assert.Null(hostedOperations.LastRepository);
         }
@@ -141,8 +142,9 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Single(result);
-            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal(2, result.Length);
+            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
             Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
             Assert.Contains("Pester", hostedOperations.LastSkipModules?.IgnoreModuleName ?? Array.Empty<string>());
         }
@@ -532,6 +534,146 @@ public sealed class ModulePipelineHostedOperationsTests
             InvokeEnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(runner, spec);
 
             Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RunPreflight_UsesConfigurationOverrideBeforeManifestRequiredModules()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+            AddRequiredModuleToManifest(root.FullName, moduleName, "Dependency.Tools", "Latest");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            ResolveMissingModulesOnline = false
+                        }
+                    },
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Dependency.Tools",
+                            ModuleVersion = "1.0.0",
+                            Guid = "11111111-1111-1111-1111-111111111111"
+                        }
+                    }
+                }
+            };
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            InvokeEnsureRequiredModuleOnlineResolutionToolInstalledIfNeededForRun(runner, spec);
+
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RunPreflight_RefreshesRepositorySourcedPrecomputedPlans()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateOnlineRequiredModuleSpec(
+                root.FullName,
+                moduleName,
+                resolveMissingModulesOnline: false,
+                versionSource: ModuleDependencyVersionSource.PSGallery);
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Online.Tools"] = "1.0.0"
+                }),
+                new FakeHostedOperations());
+
+            var plan = runner.Plan(spec);
+
+            Assert.True(InvokeShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(runner, spec, plan));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void RunPreflight_DoesNotRefreshExactRequiredVersionPrecomputedPlans()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Dependency.Tools",
+                            RequiredVersion = "1.0.0"
+                        }
+                    }
+                }
+            };
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Dependency.Tools"] = "1.0.0"
+                }),
+                new FakeHostedOperations());
+
+            var plan = runner.Plan(spec);
+
+            Assert.False(InvokeShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(runner, spec, plan));
         }
         finally
         {
@@ -1129,6 +1271,13 @@ public sealed class ModulePipelineHostedOperationsTests
         method!.Invoke(runner, new object?[] { spec });
     }
 
+    private static bool InvokeShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight(ModulePipelineRunner runner, ModulePipelineSpec spec, ModulePipelinePlan plan)
+    {
+        var method = typeof(ModulePipelineRunner).GetMethod("ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(method is not null, "ShouldRefreshPrecomputedPlanAfterOnlineRequiredModulePreflight method signature may have changed.");
+        return (bool)method!.Invoke(runner, new object?[] { spec, plan })!;
+    }
+
     private static void InvokeRunTestsAfterMerge(ModulePipelineRunner runner, ModulePipelinePlan plan, ModuleBuildResult buildResult, TestConfiguration configuration)
     {
         var method = typeof(ModulePipelineRunner).GetMethod("RunTestsAfterMerge", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -1373,6 +1522,7 @@ public sealed class ModulePipelineHostedOperationsTests
     private sealed class FakeHostedOperations : IModulePipelineHostedOperations
     {
         public int DependencyInstallCalls { get; private set; }
+        public List<IReadOnlyList<ModuleDependency>> DependencyCalls { get; } = new();
         public IReadOnlyList<ModuleDependency> LastDependencies { get; private set; } = Array.Empty<ModuleDependency>();
         public string? LastRepository { get; private set; }
         public ModuleSkipConfiguration? LastSkipModules { get; private set; }
@@ -1388,6 +1538,7 @@ public sealed class ModulePipelineHostedOperationsTests
         {
             DependencyInstallCalls++;
             LastDependencies = dependencies ?? Array.Empty<ModuleDependency>();
+            DependencyCalls.Add(LastDependencies);
             LastRepository = repository;
             LastSkipModules = skipModules;
             return LastDependencies

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -142,9 +142,8 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Equal(2, result.Length);
-            Assert.Equal(2, hostedOperations.DependencyInstallCalls);
-            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.DependencyCalls[0]).Name);
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
             Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
             Assert.Contains("Pester", hostedOperations.LastSkipModules?.IgnoreModuleName ?? Array.Empty<string>());
         }
@@ -211,6 +210,127 @@ public sealed class ModulePipelineHostedOperationsTests
             Assert.Equal("Pester", dependency.Name);
             Assert.Equal("5.7.1", dependency.MinimumVersion);
             Assert.Null(hostedOperations.LastSkipModules);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_SkipsRepositoryToolPreflightForSatisfiedDeclaredDependencies()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            InstallMissingModules = true
+                        }
+                    },
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Pester",
+                            RequiredVersion = "1.0.0"
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider("Pester"),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsFeatureToolsFromDefaultSource()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var testsPath = Path.Combine(root.FullName, "Tests");
+            Directory.CreateDirectory(testsPath);
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            InstallMissingModulesRepository = "CompanyDependencies"
+                        }
+                    },
+                    new ConfigurationTestSegment
+                    {
+                        Configuration = new TestConfiguration
+                        {
+                            TestsPath = testsPath,
+                            When = TestExecutionWhen.AfterMerge
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Pester", Assert.Single(hostedOperations.LastDependencies).Name);
+            Assert.Null(hostedOperations.LastRepository);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -278,6 +278,39 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForAutoRepositoryPublishWhenPowerShellGetIsTooOld()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreatePublishToolSpec(root.FullName, moduleName, PublishTool.Auto);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["PowerShellGet"] = "1.0.0.1"
+                }),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForRequiredModuleDownloadArtefact()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -286,7 +319,7 @@ public sealed class ModulePipelineHostedOperationsTests
             const string moduleName = "TestModule";
             WriteMinimalModule(root.FullName, moduleName, "1.0.0");
 
-            var spec = CreateRequiredModuleDownloadArtefactSpec(root.FullName, moduleName, ModuleSaveTool.Auto);
+            var spec = CreateRequiredModuleArtefactSpec(root.FullName, moduleName, ModuleSaveTool.Auto, RequiredModulesSource.Download);
             var hostedOperations = new FakeHostedOperations();
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
@@ -308,7 +341,7 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
-    public void Plan_InstallsPSResourceGetBeforeOnlineRequiredModuleResolution()
+    public void EnsureBuildDependenciesInstalledIfNeeded_PreservesLocalFirstAutoRequiredModuleArtefact()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -316,36 +349,36 @@ public sealed class ModulePipelineHostedOperationsTests
             const string moduleName = "TestModule";
             WriteMinimalModule(root.FullName, moduleName, "1.0.0");
 
-            var spec = new ModulePipelineSpec
-            {
-                Build = new ModuleBuildSpec
-                {
-                    Name = moduleName,
-                    SourcePath = root.FullName,
-                    Version = "1.0.0"
-                },
-                Install = new ModulePipelineInstallOptions { Enabled = false },
-                Segments = new IConfigurationSegment[]
-                {
-                    new ConfigurationBuildSegment
-                    {
-                        BuildModule = new BuildModuleConfiguration
-                        {
-                            ResolveMissingModulesOnline = true
-                        }
-                    },
-                    new ConfigurationModuleSegment
-                    {
-                        Kind = ModuleDependencyKind.RequiredModule,
-                        Configuration = new ModuleDependencyConfiguration
-                        {
-                            ModuleName = "Online.Tools",
-                            ModuleVersion = "Latest"
-                        }
-                    }
-                }
-            };
+            var spec = CreateRequiredModuleArtefactSpec(root.FullName, moduleName, ModuleSaveTool.Auto, RequiredModulesSource.Auto);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
 
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Empty(result);
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_DoesNotInstallPSResourceGetBeforeOnlineRequiredModuleResolution()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateOnlineRequiredModuleSpec(root.FullName, moduleName);
             var hostedOperations = new FakeHostedOperations();
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
@@ -355,8 +388,62 @@ public sealed class ModulePipelineHostedOperationsTests
 
             runner.Plan(spec);
 
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Run_InstallsPSResourceGetBeforeOnlineRequiredModuleResolution()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateOnlineRequiredModuleSpec(root.FullName, moduleName);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                FakeMetadataProvider.ThrowingOnlineResolver(),
+                hostedOperations);
+
+            Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
             Assert.Equal(1, hostedOperations.DependencyInstallCalls);
             Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Run_SkipsOnlineRequiredModuleResolutionToolPreflightForRefreshOnly()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateOnlineRequiredModuleSpec(root.FullName, moduleName, refreshPsd1Only: true);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            runner.Run(spec);
+
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
         }
         finally
         {
@@ -783,7 +870,11 @@ public sealed class ModulePipelineHostedOperationsTests
         };
     }
 
-    private static ModulePipelineSpec CreateRequiredModuleDownloadArtefactSpec(string root, string moduleName, ModuleSaveTool tool)
+    private static ModulePipelineSpec CreateRequiredModuleArtefactSpec(
+        string root,
+        string moduleName,
+        ModuleSaveTool tool,
+        RequiredModulesSource source)
     {
         return new ModulePipelineSpec
         {
@@ -815,9 +906,46 @@ public sealed class ModulePipelineHostedOperationsTests
                         RequiredModules = new ArtefactRequiredModulesConfiguration
                         {
                             Enabled = true,
-                            Source = RequiredModulesSource.Download,
+                            Source = source,
                             Tool = tool
                         }
+                    }
+                }
+            }
+        };
+    }
+
+    private static ModulePipelineSpec CreateOnlineRequiredModuleSpec(
+        string root,
+        string moduleName,
+        bool refreshPsd1Only = false)
+    {
+        return new ModulePipelineSpec
+        {
+            Build = new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = root,
+                Version = "1.0.0"
+            },
+            Install = new ModulePipelineInstallOptions { Enabled = false },
+            Segments = new IConfigurationSegment[]
+            {
+                new ConfigurationBuildSegment
+                {
+                    BuildModule = new BuildModuleConfiguration
+                    {
+                        ResolveMissingModulesOnline = true,
+                        RefreshPSD1Only = refreshPsd1Only
+                    }
+                },
+                new ConfigurationModuleSegment
+                {
+                    Kind = ModuleDependencyKind.RequiredModule,
+                    Configuration = new ModuleDependencyConfiguration
+                    {
+                        ModuleName = "Online.Tools",
+                        ModuleVersion = "Latest"
                     }
                 }
             }
@@ -847,10 +975,13 @@ public sealed class ModulePipelineHostedOperationsTests
     {
         private readonly bool _filterInstalledModules;
         private readonly HashSet<string> _installedModuleNames;
+        private readonly IReadOnlyDictionary<string, string> _installedModuleVersions;
+        private readonly bool _throwOnResolveLatestOnlineVersions;
 
         public FakeMetadataProvider()
         {
             _installedModuleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            _installedModuleVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public FakeMetadataProvider(params string[] installedModuleNames)
@@ -859,6 +990,28 @@ public sealed class ModulePipelineHostedOperationsTests
             _installedModuleNames = new HashSet<string>(
                 installedModuleNames ?? Array.Empty<string>(),
                 StringComparer.OrdinalIgnoreCase);
+            _installedModuleVersions = _installedModuleNames.ToDictionary(
+                static name => name,
+                static name => name.Equals("PowerShellGet", StringComparison.OrdinalIgnoreCase) ? "2.2.5" : "1.0.0",
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public FakeMetadataProvider(IReadOnlyDictionary<string, string> installedModuleVersions)
+        {
+            _filterInstalledModules = true;
+            _installedModuleVersions = installedModuleVersions ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            _installedModuleNames = new HashSet<string>(_installedModuleVersions.Keys, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private FakeMetadataProvider(bool throwOnResolveLatestOnlineVersions)
+            : this()
+        {
+            _throwOnResolveLatestOnlineVersions = throwOnResolveLatestOnlineVersions;
+        }
+
+        public static FakeMetadataProvider ThrowingOnlineResolver()
+        {
+            return new FakeMetadataProvider(throwOnResolveLatestOnlineVersions: true);
         }
 
         public IReadOnlyDictionary<string, InstalledModuleMetadata> GetLatestInstalledModules(IReadOnlyList<string> names)
@@ -868,7 +1021,7 @@ public sealed class ModulePipelineHostedOperationsTests
                 .ToDictionary(
                     static name => name,
                     name => _installedModuleNames.Contains(name)
-                        ? new InstalledModuleMetadata(name, "1.0.0", null, Path.Combine(Path.GetTempPath(), name))
+                        ? new InstalledModuleMetadata(name, _installedModuleVersions[name], null, Path.Combine(Path.GetTempPath(), name))
                         : new InstalledModuleMetadata(name, null, null, null),
                     StringComparer.OrdinalIgnoreCase);
 
@@ -880,7 +1033,12 @@ public sealed class ModulePipelineHostedOperationsTests
             string? repository,
             RepositoryCredential? credential,
             bool prerelease)
-            => new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase);
+        {
+            if (_throwOnResolveLatestOnlineVersions)
+                throw new InvalidOperationException("Online metadata resolution was requested.");
+
+            return new Dictionary<string, (string? Version, string? Guid)>(StringComparer.OrdinalIgnoreCase);
+        }
     }
 
     private sealed class FakeHostedOperations : IModulePipelineHostedOperations

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -261,13 +261,100 @@ public sealed class ModulePipelineHostedOperationsTests
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
                 new ThrowingPowerShellRunner(),
-                new FakeMetadataProvider(Array.Empty<string>()),
+                new FakeMetadataProvider(),
                 hostedOperations);
 
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
             Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForRequiredModuleDownloadArtefact()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateRequiredModuleDownloadArtefactSpec(root.FullName, moduleName, ModuleSaveTool.Auto);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Plan_InstallsPSResourceGetBeforeOnlineRequiredModuleResolution()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            ResolveMissingModulesOnline = true
+                        }
+                    },
+                    new ConfigurationModuleSegment
+                    {
+                        Kind = ModuleDependencyKind.RequiredModule,
+                        Configuration = new ModuleDependencyConfiguration
+                        {
+                            ModuleName = "Online.Tools",
+                            ModuleVersion = "Latest"
+                        }
+                    }
+                }
+            };
+
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            runner.Plan(spec);
+
             Assert.Equal(1, hostedOperations.DependencyInstallCalls);
             Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
         }
@@ -696,6 +783,47 @@ public sealed class ModulePipelineHostedOperationsTests
         };
     }
 
+    private static ModulePipelineSpec CreateRequiredModuleDownloadArtefactSpec(string root, string moduleName, ModuleSaveTool tool)
+    {
+        return new ModulePipelineSpec
+        {
+            Build = new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = root,
+                Version = "1.0.0"
+            },
+            Install = new ModulePipelineInstallOptions { Enabled = false },
+            Segments = new IConfigurationSegment[]
+            {
+                new ConfigurationModuleSegment
+                {
+                    Kind = ModuleDependencyKind.RequiredModule,
+                    Configuration = new ModuleDependencyConfiguration
+                    {
+                        ModuleName = "Dependency.Tools",
+                        ModuleVersion = "1.0.0"
+                    }
+                },
+                new ConfigurationArtefactSegment
+                {
+                    ArtefactType = ArtefactType.Unpacked,
+                    Configuration = new ArtefactConfiguration
+                    {
+                        Enabled = true,
+                        Path = Path.Combine(root, "Artefacts", "Unpacked"),
+                        RequiredModules = new ArtefactRequiredModulesConfiguration
+                        {
+                            Enabled = true,
+                            Source = RequiredModulesSource.Download,
+                            Tool = tool
+                        }
+                    }
+                }
+            }
+        };
+    }
+
     private static void WriteMinimalModule(string moduleRoot, string moduleName, string version)
     {
         Directory.CreateDirectory(moduleRoot);
@@ -739,7 +867,9 @@ public sealed class ModulePipelineHostedOperationsTests
                 .Where(name => !_filterInstalledModules || _installedModuleNames.Contains(name))
                 .ToDictionary(
                     static name => name,
-                    static name => new InstalledModuleMetadata(name, null, null, null),
+                    name => _installedModuleNames.Contains(name)
+                        ? new InstalledModuleMetadata(name, "1.0.0", null, Path.Combine(Path.GetTempPath(), name))
+                        : new InstalledModuleMetadata(name, null, null, null),
                     StringComparer.OrdinalIgnoreCase);
 
         public IReadOnlyList<RequiredModuleReference> GetRequiredModulesForInstalledModule(string moduleName)

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -354,7 +354,7 @@ public sealed class ModulePipelineHostedOperationsTests
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
                 new ThrowingPowerShellRunner(),
-                new FakeMetadataProvider(),
+                new FakeMetadataProvider("Dependency.Tools"),
                 hostedOperations);
 
             var plan = runner.Plan(spec);
@@ -362,6 +362,36 @@ public sealed class ModulePipelineHostedOperationsTests
 
             Assert.Empty(result);
             Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForAutoRequiredModuleArtefactWhenLocalModuleIsMissing()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreateRequiredModuleArtefactSpec(root.FullName, moduleName, ModuleSaveTool.Auto, RequiredModulesSource.Auto);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Single(result);
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
         }
         finally
         {
@@ -406,6 +436,35 @@ public sealed class ModulePipelineHostedOperationsTests
             WriteMinimalModule(root.FullName, moduleName, "1.0.0");
 
             var spec = CreateOnlineRequiredModuleSpec(root.FullName, moduleName);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                FakeMetadataProvider.ThrowingOnlineResolver(),
+                hostedOperations);
+
+            Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Run_InstallsPSResourceGetBeforeManifestRequiredModuleOnlineResolution()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+            AddRequiredModuleToManifest(root.FullName, moduleName, "Manifest.Tools", "Latest");
+
+            var spec = CreateOnlineRequiredModuleSpec(root.FullName, moduleName, includeSegmentRequiredModule: false);
             var hostedOperations = new FakeHostedOperations();
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
@@ -918,8 +977,33 @@ public sealed class ModulePipelineHostedOperationsTests
     private static ModulePipelineSpec CreateOnlineRequiredModuleSpec(
         string root,
         string moduleName,
-        bool refreshPsd1Only = false)
+        bool refreshPsd1Only = false,
+        bool includeSegmentRequiredModule = true)
     {
+        var segments = new List<IConfigurationSegment>
+        {
+            new ConfigurationBuildSegment
+            {
+                BuildModule = new BuildModuleConfiguration
+                {
+                    ResolveMissingModulesOnline = true,
+                    RefreshPSD1Only = refreshPsd1Only
+                }
+            }
+        };
+        if (includeSegmentRequiredModule)
+        {
+            segments.Add(new ConfigurationModuleSegment
+            {
+                Kind = ModuleDependencyKind.RequiredModule,
+                Configuration = new ModuleDependencyConfiguration
+                {
+                    ModuleName = "Online.Tools",
+                    ModuleVersion = "Latest"
+                }
+            });
+        }
+
         return new ModulePipelineSpec
         {
             Build = new ModuleBuildSpec
@@ -929,26 +1013,7 @@ public sealed class ModulePipelineHostedOperationsTests
                 Version = "1.0.0"
             },
             Install = new ModulePipelineInstallOptions { Enabled = false },
-            Segments = new IConfigurationSegment[]
-            {
-                new ConfigurationBuildSegment
-                {
-                    BuildModule = new BuildModuleConfiguration
-                    {
-                        ResolveMissingModulesOnline = true,
-                        RefreshPSD1Only = refreshPsd1Only
-                    }
-                },
-                new ConfigurationModuleSegment
-                {
-                    Kind = ModuleDependencyKind.RequiredModule,
-                    Configuration = new ModuleDependencyConfiguration
-                    {
-                        ModuleName = "Online.Tools",
-                        ModuleVersion = "Latest"
-                    }
-                }
-            }
+            Segments = segments.ToArray()
         };
     }
 
@@ -969,6 +1034,33 @@ public sealed class ModulePipelineHostedOperationsTests
         }) + Environment.NewLine;
 
         File.WriteAllText(Path.Combine(moduleRoot, $"{moduleName}.psd1"), psd1);
+    }
+
+    private static void AddRequiredModuleToManifest(
+        string moduleRoot,
+        string moduleName,
+        string requiredModuleName,
+        string requiredModuleVersion)
+    {
+        var manifestPath = Path.Combine(moduleRoot, $"{moduleName}.psd1");
+        var psd1 = string.Join(Environment.NewLine, new[]
+        {
+            "@{",
+            $"    RootModule = '{moduleName}.psm1'",
+            "    ModuleVersion = '1.0.0'",
+            "    RequiredModules = @(",
+            "        @{",
+            $"            ModuleName = '{requiredModuleName}'",
+            $"            ModuleVersion = '{requiredModuleVersion}'",
+            "        }",
+            "    )",
+            "    FunctionsToExport = @()",
+            "    CmdletsToExport = @()",
+            "    AliasesToExport = @()",
+            "}"
+        }) + Environment.NewLine;
+
+        File.WriteAllText(manifestPath, psd1);
     }
 
     private sealed class FakeMetadataProvider : IModuleDependencyMetadataProvider

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -216,8 +216,10 @@ public sealed class ModulePipelineHostedOperationsTests
         }
     }
 
-    [Fact]
-    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPowerShellGetFallbackForAutoRepositoryPublish()
+    [Theory]
+    [InlineData("Microsoft.PowerShell.PSResourceGet")]
+    [InlineData("PowerShellGet")]
+    public void EnsureBuildDependenciesInstalledIfNeeded_SkipsAutoRepositoryPublishPreflightWhenPublishToolExists(string installedPublishTool)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -230,7 +232,36 @@ public sealed class ModulePipelineHostedOperationsTests
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
                 new ThrowingPowerShellRunner(),
-                new FakeMetadataProvider(),
+                new FakeMetadataProvider(installedPublishTool),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Empty(result);
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForAutoRepositoryPublishWhenNoPublishToolExists()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var spec = CreatePublishToolSpec(root.FullName, moduleName, PublishTool.Auto);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(Array.Empty<string>()),
                 hostedOperations);
 
             var plan = runner.Plan(spec);
@@ -238,9 +269,7 @@ public sealed class ModulePipelineHostedOperationsTests
 
             Assert.Single(result);
             Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            var dependency = Assert.Single(hostedOperations.LastDependencies);
-            Assert.Equal("PowerShellGet", dependency.Name);
-            Assert.Equal("2.2.5", dependency.MinimumVersion);
+            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
         }
         finally
         {
@@ -688,9 +717,26 @@ public sealed class ModulePipelineHostedOperationsTests
 
     private sealed class FakeMetadataProvider : IModuleDependencyMetadataProvider
     {
+        private readonly bool _filterInstalledModules;
+        private readonly HashSet<string> _installedModuleNames;
+
+        public FakeMetadataProvider()
+        {
+            _installedModuleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public FakeMetadataProvider(params string[] installedModuleNames)
+        {
+            _filterInstalledModules = true;
+            _installedModuleNames = new HashSet<string>(
+                installedModuleNames ?? Array.Empty<string>(),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
         public IReadOnlyDictionary<string, InstalledModuleMetadata> GetLatestInstalledModules(IReadOnlyList<string> names)
             => (names ?? Array.Empty<string>())
                 .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Where(name => !_filterInstalledModules || _installedModuleNames.Contains(name))
                 .ToDictionary(
                     static name => name,
                     static name => new InstalledModuleMetadata(name, null, null, null),

--- a/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
+++ b/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
@@ -1,11 +1,18 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace PowerForge.Tests;
 
 public sealed class ModuleTestSuiteServiceTests
 {
+    private const string InstalledVersionsMarker = "PFMOD::ITEM::";
+    private const string PsResourceInstallMarker = "PFPSRG::INSTALL::OK";
+    private const string PowerShellGetInstallMarker = "PFMOD::INSTALL::OK";
+
     [Fact]
     public void Run_PassesNamedBooleanTokenForImportVerbose()
     {
@@ -46,6 +53,41 @@ public sealed class ModuleTestSuiteServiceTests
         }
     }
 
+    [Fact]
+    public void Run_BootstrapsRepositoryToolBeforeInstallingAdditionalModules()
+    {
+        var projectRoot = Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            const string moduleName = "SampleModule";
+            Directory.CreateDirectory(Path.Combine(projectRoot.FullName, "Tests"));
+            File.WriteAllText(Path.Combine(projectRoot.FullName, $"{moduleName}.psm1"), string.Empty);
+            File.WriteAllText(
+                Path.Combine(projectRoot.FullName, $"{moduleName}.psd1"),
+                "@{ RootModule = 'SampleModule.psm1'; ModuleVersion = '1.0.0'; FunctionsToExport = @(); CmdletsToExport = @(); AliasesToExport = @() }");
+
+            var runner = new TestSuiteDependencyRunner();
+            var service = new ModuleTestSuiteService(runner, new NullLogger());
+
+            _ = service.Run(new ModuleTestSuiteSpec
+            {
+                ProjectPath = projectRoot.FullName,
+                AdditionalModules = new[] { "Pester", "PSWriteColor" },
+                SkipImport = true
+            });
+
+            Assert.Equal(
+                new[] { "Microsoft.PowerShell.PSResourceGet", "Pester", "PSWriteColor" },
+                runner.InstallNames);
+        }
+        finally
+        {
+            try { projectRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private sealed class RecordingPowerShellRunner : IPowerShellRunner
     {
         private readonly Func<PowerShellRunRequest, PowerShellRunResult> _run;
@@ -57,5 +99,54 @@ public sealed class ModuleTestSuiteServiceTests
 
         public PowerShellRunResult Run(PowerShellRunRequest request)
             => _run(request);
+    }
+
+    private sealed class TestSuiteDependencyRunner : IPowerShellRunner
+    {
+        public List<string> InstallNames { get; } = new();
+
+        public PowerShellRunResult Run(PowerShellRunRequest request)
+        {
+            Assert.NotNull(request.ScriptPath);
+            var script = File.ReadAllText(request.ScriptPath!);
+
+            if (script.Contains(InstalledVersionsMarker, StringComparison.Ordinal))
+            {
+                var names = DecodeLines(request.Arguments[0]);
+                var lines = names.Select(name =>
+                    InstalledVersionsMarker + Encode(name) + "::" + Encode(string.Empty));
+                return new PowerShellRunResult(0, string.Join(Environment.NewLine, lines), string.Empty, "pwsh.exe");
+            }
+
+            if (script.Contains(PsResourceInstallMarker, StringComparison.Ordinal) ||
+                script.Contains(PowerShellGetInstallMarker, StringComparison.Ordinal))
+            {
+                InstallNames.Add(request.Arguments[0]);
+                return new PowerShellRunResult(0, PsResourceInstallMarker, string.Empty, "pwsh.exe");
+            }
+
+            return new PowerShellRunResult(
+                0,
+                string.Join(Environment.NewLine, new[]
+                {
+                    "PFTEST::PESTER::5.7.1",
+                    "PFTEST::COUNTS::0::0::0::0"
+                }),
+                string.Empty,
+                "pwsh.exe");
+        }
+
+        private static string[] DecodeLines(string value)
+        {
+            var text = Encoding.UTF8.GetString(Convert.FromBase64String(value));
+            return text
+                .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(static line => line.Trim())
+                .Where(static line => line.Length > 0)
+                .ToArray();
+        }
+
+        private static string Encode(string value)
+            => Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty));
     }
 }

--- a/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
+++ b/PowerForge.Tests/ModuleTestSuiteServiceTests.cs
@@ -74,12 +74,12 @@ public sealed class ModuleTestSuiteServiceTests
             _ = service.Run(new ModuleTestSuiteSpec
             {
                 ProjectPath = projectRoot.FullName,
-                AdditionalModules = new[] { "Pester", "PSWriteColor" },
+                AdditionalModules = new[] { "Az.Accounts", "Pester" },
                 SkipImport = true
             });
 
             Assert.Equal(
-                new[] { "Microsoft.PowerShell.PSResourceGet", "Pester", "PSWriteColor" },
+                new[] { "Microsoft.PowerShell.PSResourceGet", "Az.Accounts", "Pester" },
                 runner.InstallNames);
         }
         finally

--- a/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
+++ b/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
@@ -1,0 +1,47 @@
+using System.Text.RegularExpressions;
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class PSPublishModuleManifestContractTests
+{
+    private static readonly string[] OptionalToolModules =
+    {
+        "Pester",
+        "PowerShellGet",
+        "Microsoft.PowerShell.PSResourceGet"
+    };
+
+    [Fact]
+    public void Manifest_does_not_require_feature_specific_tool_modules_at_import_time()
+    {
+        var repoRoot = RepoRootLocator.Find();
+        var manifestPath = Path.Combine(repoRoot, "Module", "PSPublishModule.psd1");
+
+        Assert.True(ManifestEditor.TryGetRequiredModules(manifestPath, out RequiredModuleReference[]? requiredModules));
+
+        var requiredNames = requiredModules!
+            .Select(static module => module.ModuleName)
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .ToArray();
+
+        foreach (var optionalModule in OptionalToolModules)
+        {
+            Assert.DoesNotContain(requiredNames, name => string.Equals(name, optionalModule, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    [Fact]
+    public void Build_recipe_does_not_generate_feature_specific_tool_modules_as_required_modules()
+    {
+        var repoRoot = RepoRootLocator.Find();
+        var buildScriptPath = Path.Combine(repoRoot, "Module", "Build", "Build-Module.ps1");
+        var buildScript = File.ReadAllText(buildScriptPath);
+
+        foreach (var optionalModule in OptionalToolModules)
+        {
+            var pattern = $@"(?im)^\s*New-ConfigurationModule\b[^\r\n]*\b-Type\s+RequiredModule\b[^\r\n]*\b-Name\s+['""]?{Regex.Escape(optionalModule)}['""]?";
+            Assert.DoesNotMatch(pattern, buildScript);
+        }
+    }
+}

--- a/PowerForge/Services/ModuleDependencyInstaller.PSResourceGetBootstrap.cs
+++ b/PowerForge/Services/ModuleDependencyInstaller.PSResourceGetBootstrap.cs
@@ -1,0 +1,225 @@
+using System.IO.Compression;
+using System.Net.Http;
+
+namespace PowerForge;
+
+public sealed partial class ModuleDependencyInstaller
+{
+    private const string PowerShellGalleryPackageTemplate = "https://www.powershellgallery.com/api/v2/package/{0}/{1}";
+
+    private bool CanDirectBootstrapPSResourceGet(
+        ModuleDependency dependency,
+        string? repository,
+        RepositoryCredential? credential)
+        => dependency is not null &&
+           string.Equals(dependency.Name, PSResourceGetModuleName, StringComparison.OrdinalIgnoreCase) &&
+           credential is null &&
+           (string.IsNullOrWhiteSpace(repository) ||
+            string.Equals(repository!.Trim(), "PSGallery", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(repository!.Trim(), "PowerShellGallery", StringComparison.OrdinalIgnoreCase));
+
+    private void InstallPSResourceGetDirect(
+        ModuleDependency dependency,
+        bool prerelease,
+        bool force,
+        TimeSpan timeout)
+    {
+        var version = ResolveDirectPSResourceGetVersion(dependency, prerelease, timeout);
+        var tempRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "psresourceget-bootstrap", Guid.NewGuid().ToString("N"));
+        var packagePath = Path.Combine(tempRoot, $"{PSResourceGetModuleName}.{version}.nupkg");
+        var extractPath = Path.Combine(tempRoot, "extract");
+
+        try
+        {
+            Directory.CreateDirectory(tempRoot);
+            _directPackageDownloader(BuildPowerShellGalleryPackageUri(version), packagePath, timeout);
+            ZipFile.ExtractToDirectory(packagePath, extractPath);
+
+            var sourceDirectory = FindPowerShellModulePayloadDirectory(extractPath, PSResourceGetModuleName);
+            var destinationRoot = _currentUserModuleRootResolver();
+            var destination = Path.Combine(destinationRoot, PSResourceGetModuleName, version);
+
+            if (force && Directory.Exists(destination))
+                Directory.Delete(destination, recursive: true);
+
+            Directory.CreateDirectory(destination);
+            CopyModulePayload(sourceDirectory, destination);
+            _logger.Info($"Installed {PSResourceGetModuleName} {version} directly from PowerShell Gallery to '{destination}'.");
+        }
+        finally
+        {
+            try { Directory.Delete(tempRoot, recursive: true); } catch { /* best effort cleanup */ }
+        }
+    }
+
+    private string ResolveDirectPSResourceGetVersion(
+        ModuleDependency dependency,
+        bool prerelease,
+        TimeSpan timeout)
+    {
+        if (!string.IsNullOrWhiteSpace(dependency.RequiredVersion))
+            return dependency.RequiredVersion!.Trim();
+
+        var minimumVersion = string.IsNullOrWhiteSpace(dependency.MinimumVersion) ? null : dependency.MinimumVersion!.Trim();
+        var maximumVersion = string.IsNullOrWhiteSpace(dependency.MaximumVersion) ? null : dependency.MaximumVersion!.Trim();
+        var versions = _galleryVersionResolver(PSResourceGetModuleName, prerelease, timeout)
+            .Where(version => version is not null && version.IsListed)
+            .Where(version => prerelease || !version.IsPrerelease)
+            .Where(version => VersionMeetsRange(version.VersionText, minimumVersion, maximumVersion))
+            .OrderByDescending(version => version.VersionText, Comparer<string>.Create(CompareVersionStrings))
+            .ToArray();
+
+        var selected = versions.FirstOrDefault();
+        if (selected is null)
+        {
+            var rangeText = minimumVersion is null && maximumVersion is null
+                ? "latest listed stable version"
+                : $"version range '{BuildNuGetRange(minimumVersion, maximumVersion)}'";
+            throw new InvalidOperationException($"Unable to resolve {PSResourceGetModuleName} {rangeText} from PowerShell Gallery.");
+        }
+
+        return selected.VersionText;
+    }
+
+    private static bool VersionMeetsRange(string version, string? minimumVersion, string? maximumVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(minimumVersion) &&
+            CompareVersionStrings(version, minimumVersion) < 0)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(maximumVersion) &&
+            CompareVersionStrings(version, maximumVersion) > 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static Uri BuildPowerShellGalleryPackageUri(string version)
+        => new(string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            PowerShellGalleryPackageTemplate,
+            Uri.EscapeDataString(PSResourceGetModuleName),
+            Uri.EscapeDataString(version)));
+
+    private static string FindPowerShellModulePayloadDirectory(string extractPath, string moduleName)
+    {
+        var manifest = Directory.EnumerateFiles(extractPath, $"{moduleName}.psd1", SearchOption.AllDirectories)
+            .Where(path => !IsPackageMetadataPath(extractPath, path))
+            .OrderBy(static path => path.Length)
+            .FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(manifest))
+            throw new InvalidOperationException($"Downloaded package did not contain '{moduleName}.psd1'.");
+
+        return Path.GetDirectoryName(manifest!)!;
+    }
+
+    private static void CopyModulePayload(string sourceDirectory, string destinationDirectory)
+    {
+        foreach (var directory in Directory.EnumerateDirectories(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            if (IsPackageMetadataPath(sourceDirectory, directory))
+                continue;
+
+            var relative = GetRelativePath(sourceDirectory, directory);
+            Directory.CreateDirectory(Path.Combine(destinationDirectory, relative));
+        }
+
+        foreach (var file in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            if (IsPackageMetadataPath(sourceDirectory, file))
+                continue;
+
+            var relative = GetRelativePath(sourceDirectory, file);
+            var target = Path.Combine(destinationDirectory, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(file, target, overwrite: true);
+        }
+    }
+
+    private static bool IsPackageMetadataPath(string root, string path)
+    {
+        var relative = GetRelativePath(root, path);
+        if (relative.Length == 0)
+            return false;
+
+        var firstSegment = relative.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault();
+        if (firstSegment is null)
+            return false;
+
+        return string.Equals(firstSegment, "_rels", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(firstSegment, "package", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(firstSegment, "[Content_Types].xml", StringComparison.OrdinalIgnoreCase) ||
+               firstSegment.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolveCurrentUserModuleRoot()
+    {
+        var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+        var fromPath = (psModulePath ?? string.Empty)
+            .Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static path => path.Trim())
+            .FirstOrDefault(path =>
+                path.Length > 0 &&
+                path.IndexOf("PowerShell", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                path.IndexOf("Modules", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                path.IndexOf("Program Files", StringComparison.OrdinalIgnoreCase) < 0);
+        if (!string.IsNullOrWhiteSpace(fromPath))
+            return fromPath!;
+
+        if (Path.DirectorySeparatorChar == '\\')
+        {
+            var docs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (string.IsNullOrWhiteSpace(docs))
+                docs = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrWhiteSpace(docs))
+                return Path.Combine(docs!, "PowerShell", "Modules");
+        }
+
+        var home = Environment.GetEnvironmentVariable("HOME");
+        if (string.IsNullOrWhiteSpace(home))
+            home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+            return Path.Combine(home!, ".local", "share", "powershell", "Modules");
+
+        return Path.Combine(Path.GetTempPath(), "PowerForge", "Modules");
+    }
+
+    private static string GetRelativePath(string relativeTo, string path)
+    {
+#if NET472
+        var baseUri = new Uri(AppendDirectorySeparatorChar(Path.GetFullPath(relativeTo)));
+        var pathUri = new Uri(Path.GetFullPath(path));
+        var relativeUri = baseUri.MakeRelativeUri(pathUri);
+        return Uri.UnescapeDataString(relativeUri.ToString()).Replace('/', Path.DirectorySeparatorChar);
+#else
+        return Path.GetRelativePath(relativeTo, path);
+#endif
+    }
+
+#if NET472
+    private static string AppendDirectorySeparatorChar(string path)
+        => path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+#endif
+
+    private static void DownloadPackage(Uri packageUri, string destinationPath, TimeSpan timeout)
+    {
+        using var http = new HttpClient { Timeout = timeout };
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("PowerForge/1.0");
+        using var response = http.GetAsync(packageUri).GetAwaiter().GetResult();
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"PowerShell Gallery package download failed ({(int)response.StatusCode} {response.ReasonPhrase}) for '{packageUri}'.");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(destinationPath))!);
+        using var source = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+        using var destination = File.Create(destinationPath);
+        source.CopyTo(destination);
+    }
+}

--- a/PowerForge/Services/ModuleDependencyInstaller.cs
+++ b/PowerForge/Services/ModuleDependencyInstaller.cs
@@ -9,21 +9,39 @@ namespace PowerForge;
 /// Ensures that a set of PowerShell module dependencies are installed (out-of-process),
 /// preferring PSResourceGet and falling back to PowerShellGet when PSResourceGet is not available.
 /// </summary>
-public sealed class ModuleDependencyInstaller
+public sealed partial class ModuleDependencyInstaller
 {
     private static readonly TimeSpan ModuleLookupTimeout = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan ExactVersionProbeTimeout = TimeSpan.FromSeconds(30);
+    private const string PSResourceGetModuleName = "Microsoft.PowerShell.PSResourceGet";
 
     private readonly IPowerShellRunner _runner;
     private readonly ILogger _logger;
+    private readonly Func<string, bool, TimeSpan?, IReadOnlyList<PowerShellGalleryPackageVersion>> _galleryVersionResolver;
+    private readonly Action<Uri, string, TimeSpan> _directPackageDownloader;
+    private readonly Func<string> _currentUserModuleRootResolver;
 
     /// <summary>
     /// Creates a new installer using the provided runner and logger.
     /// </summary>
     public ModuleDependencyInstaller(IPowerShellRunner runner, ILogger logger)
+        : this(runner, logger, galleryVersionResolver: null, directPackageDownloader: null, currentUserModuleRootResolver: null)
+    {
+    }
+
+    internal ModuleDependencyInstaller(
+        IPowerShellRunner runner,
+        ILogger logger,
+        Func<string, bool, TimeSpan?, IReadOnlyList<PowerShellGalleryPackageVersion>>? galleryVersionResolver,
+        Action<Uri, string, TimeSpan>? directPackageDownloader,
+        Func<string>? currentUserModuleRootResolver)
     {
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _galleryVersionResolver = galleryVersionResolver ?? ((packageId, includePrerelease, timeout) =>
+            new PowerShellGalleryVersionFeedClient(_logger).GetVersions(packageId, includePrerelease, timeout));
+        _directPackageDownloader = directPackageDownloader ?? DownloadPackage;
+        _currentUserModuleRootResolver = currentUserModuleRootResolver ?? ResolveCurrentUserModuleRoot;
     }
 
     /// <summary>
@@ -131,6 +149,29 @@ public sealed class ModuleDependencyInstaller
                     installer: a.Installer,
                     message: a.Message))
             .ToArray();
+    }
+
+    internal bool NeedsInstall(ModuleDependency dependency, bool force)
+    {
+        if (dependency is null || string.IsNullOrWhiteSpace(dependency.Name))
+            return false;
+
+        var before = GetLatestInstalledModuleVersions(new[] { dependency.Name });
+        var installedBefore = before.TryGetValue(dependency.Name, out var version) ? version : null;
+        var decision = Decide(dependency, installedBefore, force);
+        if (!decision.NeedsInstall)
+            return false;
+
+        var requiredVersion = dependency.RequiredVersion;
+        if (!force &&
+            !string.IsNullOrWhiteSpace(installedBefore) &&
+            !string.IsNullOrWhiteSpace(requiredVersion) &&
+            HasInstalledRequiredVersion(dependency.Name, requiredVersion!.Trim()))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     private bool HasInstalledRequiredVersion(string name, string requiredVersion)
@@ -352,8 +393,17 @@ public sealed class ModuleDependencyInstaller
         catch (PowerShellToolNotAvailableException)
         {
             _logger.Warn($"PSResourceGet not available; falling back to PowerShellGet Install-Module for '{dep.Name}'.");
-            InstallWithPowerShellGet(dep, repository, credential, timeout);
-            return "PowerShellGet";
+            try
+            {
+                InstallWithPowerShellGet(dep, repository, credential, timeout);
+                return "PowerShellGet";
+            }
+            catch (PowerShellToolNotAvailableException) when (CanDirectBootstrapPSResourceGet(dep, repository, credential))
+            {
+                _logger.Warn("PowerShellGet not available; installing Microsoft.PowerShell.PSResourceGet directly from PowerShell Gallery.");
+                InstallPSResourceGetDirect(dep, prerelease, force, timeout);
+                return "DirectPowerShellGallery";
+            }
         }
     }
 

--- a/PowerForge/Services/RuntimeToolDependencyService.cs
+++ b/PowerForge/Services/RuntimeToolDependencyService.cs
@@ -9,6 +9,10 @@ namespace PowerForge;
 /// </summary>
 public sealed class RuntimeToolDependencyService
 {
+    private const string PSResourceGetModuleName = "Microsoft.PowerShell.PSResourceGet";
+    private const string PowerShellGetModuleName = "PowerShellGet";
+    private const string PowerShellGetMinimumVersion = "2.2.5";
+
     private readonly IPowerShellRunner _runner;
     private readonly ILogger _logger;
 
@@ -36,13 +40,54 @@ public sealed class RuntimeToolDependencyService
 
         var effective = options ?? new RuntimeToolDependencyOptions();
         var installer = new ModuleDependencyInstaller(_runner, _logger);
-        return installer.EnsureInstalled(
+        var results = new List<ModuleDependencyInstallResult>();
+        var needsRepositoryBootstrap =
+            !IsRepositoryToolAvailable() &&
+            !list.Any(IsRepositoryToolDependency) &&
+            list.Any(dependency => installer.NeedsInstall(dependency, effective.Force));
+
+        if (needsRepositoryBootstrap)
+        {
+            results.AddRange(installer.EnsureInstalled(
+                dependencies: new[] { new ModuleDependency(PSResourceGetModuleName) },
+                force: effective.Force,
+                prerelease: effective.Prerelease,
+                timeoutPerModule: effective.TimeoutPerModule));
+        }
+
+        results.AddRange(installer.EnsureInstalled(
             dependencies: list,
             force: effective.Force,
             repository: effective.Repository,
             credential: effective.Credential,
             prerelease: effective.Prerelease,
             preferPowerShellGet: effective.PreferPowerShellGet,
-            timeoutPerModule: effective.TimeoutPerModule);
+            timeoutPerModule: effective.TimeoutPerModule));
+        return results;
+    }
+
+    private bool IsRepositoryToolAvailable()
+    {
+        var psResourceGet = new PSResourceGetClient(_runner, _logger).GetAvailability();
+        if (psResourceGet.Available)
+            return true;
+
+        var powerShellGet = new PowerShellGetClient(_runner, _logger).GetAvailability();
+        return powerShellGet.Available &&
+               VersionMeetsMinimum(powerShellGet.Version, PowerShellGetMinimumVersion);
+    }
+
+    private static bool IsRepositoryToolDependency(ModuleDependency dependency)
+        => dependency is not null &&
+           (string.Equals(dependency.Name, PSResourceGetModuleName, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(dependency.Name, PowerShellGetModuleName, StringComparison.OrdinalIgnoreCase));
+
+    private static bool VersionMeetsMinimum(string? version, string minimumVersion)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+        if (!Version.TryParse(version!.Trim(), out var actual))
+            return false;
+        return Version.TryParse(minimumVersion, out var minimum) && actual >= minimum;
     }
 }


### PR DESCRIPTION
## Summary
- remove Pester and PowerShellGet from PSPublishModule import-time RequiredModules
- add build-time feature tool preflight for enabled test and PowerShell repository publish segments
- keep normal builds/imports clean unless tests or repository publishing are configured

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "ModulePipelineHostedOperationsTests|PSPublishModuleManifestContractTests|PrivateGalleryBootstrapReadinessTests|ModuleDependencyInstallerExactVersionTests"
- .\Build\Build-Module.ps1 -NoBuild
- generated pipeline config check: RequiredModules=0, Tests=0, Publishes=0 for current PSPublishModule build
- built artifact import check: RequiredModules=0 and Import-IsolatedModule available