### PR TITLE
Add opt-in isolated module resolution preference

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,7 @@
 ### What's Changed
 - Added `Import-IsolatedModule` with a built-in `ExchangeOnlineManagement` profile that loads EXO binary assemblies through a module-scoped AssemblyLoadContext, allowing EXO's OData 7.22 dependency line to coexist with Az.Storage's OData 7.6 line in the same PowerShell 7 process.
 - Added a built-in `MicrosoftTeams` profile for `Import-IsolatedModule` that loads the Teams connect, Teams cmdlet, policy administration, and ConfigAPI binary surfaces through `MicrosoftTeams.ALC`.
+- Added `Import-IsolatedModule -PreferIsolatedModulePath` so downstream modules that import a profiled module by name can opt into resolving the generated isolated copy first for the current PowerShell process.
 - Added opt-in module-scoped `UseAssemblyLoadContext` / `NETAssemblyLoadContext` loading for binary modules. The PowerShell Core export bridge uses the private `PSModuleInfo.AddExportedCmdlet` method when available and falls back to a warning if a future PowerShell version removes it.
 - Preserved binary module aliases in the module-scoped AssemblyLoadContext export bridge so forced re-imports keep DSL aliases available.
 - Updated core PSPublishModule/PowerForge package references used by the release build.

--- a/Docs/PSPublishModule.ModuleIsolation.md
+++ b/Docs/PSPublishModule.ModuleIsolation.md
@@ -220,7 +220,9 @@ The switch prepends the generated profile work path to process-scoped `PSModuleP
 the isolated import succeeds. In the Exchange example, a later
 `Import-Module ExchangeOnlineManagement` by name can resolve the generated copy under
 `%TEMP%\PowerForge\IsolatedModules\ExchangeOnlineManagement\<guid>` before the original
-installed module.
+installed module. Profiles that use an ALC-specific manifest name, such as
+`MicrosoftTeams.ALC.psd1`, also write a module-name manifest in the generated copy so
+PowerShell name-based resolution still points at the patched ALC root module.
 
 Use this only when you need that resolution behavior. It is intentionally opt-in because it
 changes module-name resolution for the whole current PowerShell process:

--- a/Docs/PSPublishModule.ModuleIsolation.md
+++ b/Docs/PSPublishModule.ModuleIsolation.md
@@ -189,6 +189,47 @@ Non-manifest file paths are resolved to their parent directory. The service then
 find a manifest for validation and patching from the profile's configured manifest path,
 then from a single `.psd1` in the module base, then from `<moduleBase>\<moduleBaseName>.psd1`.
 
+## Preferred Module Resolution
+
+By default, `Import-IsolatedModule` imports the generated wrapper but does not change
+`PSModulePath`. That keeps the isolated import narrow: commands are available in the
+current runspace, but later module-name resolution can still find the originally installed
+module first.
+
+Use `-PreferIsolatedModulePath` when a downstream module imports the profiled module by
+name and should bind to the generated isolated copy:
+
+```powershell
+Import-Module Az.Storage
+
+$exo = Import-IsolatedModule `
+    -Profile ExchangeOnlineManagement `
+    -PreferIsolatedModulePath `
+    -PassThru
+
+Connect-ExchangeOnline -ShowBanner:$false
+
+Import-Module Contoso.ExchangeWorker
+Invoke-ContosoExchangeWorker
+
+$exo |
+    Format-List ProfileName, IsolatedModuleResolutionPath, PreferIsolatedModulePath
+```
+
+The switch prepends the generated profile work path to process-scoped `PSModulePath` after
+the isolated import succeeds. In the Exchange example, a later
+`Import-Module ExchangeOnlineManagement` by name can resolve the generated copy under
+`%TEMP%\PowerForge\IsolatedModules\ExchangeOnlineManagement\<guid>` before the original
+installed module.
+
+Use this only when you need that resolution behavior. It is intentionally opt-in because it
+changes module-name resolution for the whole current PowerShell process:
+
+- `Get-Module -ListAvailable <profile module>` may show the generated copy first,
+- the most recently prepended isolated import wins when several generated copies exist,
+- explicit file-path imports still use the path provided by the caller,
+- the change is process-scoped and ends when the PowerShell process exits.
+
 ## Validation Behavior
 
 `Import-IsolatedModule` fails before importing when a required contract is missing.
@@ -365,4 +406,6 @@ patching rules without duplicating loader code.
   namespaced or renamed.
 - Generated module copies are process-local working artifacts and can remain locked until
   the PowerShell process exits.
+- `-PreferIsolatedModulePath` changes process-scoped `PSModulePath` only after a successful
+  import and does not prevent explicit imports of another module path.
 - Assembly isolation does not isolate service authentication state or remote service state.

--- a/Module/Docs/Import-IsolatedModule.md
+++ b/Module/Docs/Import-IsolatedModule.md
@@ -11,7 +11,7 @@ Imports a known PowerShell module through a curated AssemblyLoadContext isolatio
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Import-IsolatedModule [-Profile] <string> [-Name <string>] [-Path <string>] [-WorkRoot <string>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+Import-IsolatedModule [-Profile] <string> [-Name <string>] [-Path <string>] [-WorkRoot <string>] [-PassThru] [-PreferIsolatedModulePath] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -114,6 +114,21 @@ Creates the generated module copy under the supplied root and inspects the gener
 
 ### EXAMPLE 7
 ```powershell
+Import-Module Az.Storage
+$result = Import-IsolatedModule -Profile ExchangeOnlineManagement -PreferIsolatedModulePath -PassThru
+Connect-ExchangeOnline -ShowBanner:$false
+Import-Module Contoso.ExchangeWorker
+Invoke-ContosoExchangeWorker
+$result | Format-List IsolatedModuleResolutionPath, PreferIsolatedModulePath
+Disconnect-ExchangeOnline -Confirm:$false
+```
+
+Prepends the generated isolated module parent path to PSModulePath for the current process. This is
+useful when a downstream module imports ExchangeOnlineManagement by name and should bind to the
+isolated copy instead of the original installed module.
+
+### EXAMPLE 8
+```powershell
 Import-IsolatedModule -Profile ExchangeOnlineManagement -WhatIf
 ```
 
@@ -161,6 +176,25 @@ as module bases. File paths are resolved to their parent directory.
 
 ```yaml
 Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -PreferIsolatedModulePath
+When set, Import-IsolatedModule prepends the generated module parent directory to PSModulePath after
+the isolated import succeeds. Later Import-Module calls and RequiredModules resolution in the same
+PowerShell process can then find the isolated copy before the original installed module. This is
+session-scoped and intentionally opt-in because it changes module-name resolution for the process.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -4944,6 +4944,21 @@ as module bases. File paths are resolved to their parent directory.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferIsolatedModulePath</maml:name>
+          <maml:description>
+            <maml:para>When set, Import-IsolatedModule prepends the generated module parent directory to PSModulePath after&#xD;
+the isolated import succeeds. Later Import-Module calls and RequiredModules resolution in the same&#xD;
+PowerShell process can then find the isolated copy before the original installed module. This is&#xD;
+session-scoped and intentionally opt-in because it changes module-name resolution for the process.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Profile</maml:name>
           <maml:description>
@@ -5009,6 +5024,21 @@ as module bases. File paths are resolved to their parent directory.</maml:para>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PreferIsolatedModulePath</maml:name>
+        <maml:description>
+          <maml:para>When set, Import-IsolatedModule prepends the generated module parent directory to PSModulePath after&#xD;
+the isolated import succeeds. Later Import-Module calls and RequiredModules resolution in the same&#xD;
+PowerShell process can then find the isolated copy before the original installed module. This is&#xD;
+session-scoped and intentionally opt-in because it changes module-name resolution for the process.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -5138,6 +5168,21 @@ Get-ChildItem -LiteralPath $result.WorkPath -Recurse | Select-Object -First 20 F
 Get-Content -LiteralPath $result.IsolatedScriptPath -TotalCount 40</dev:code>
         <dev:remarks>
           <maml:para>Creates the generated module copy under the supplied root and inspects the generated wrapper.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Prefer the generated isolated copy for later module imports</maml:title>
+        <dev:code>Import-Module Az.Storage&#xD;
+$result = Import-IsolatedModule -Profile ExchangeOnlineManagement -PreferIsolatedModulePath -PassThru&#xD;
+Connect-ExchangeOnline -ShowBanner:$false&#xD;
+Import-Module Contoso.ExchangeWorker&#xD;
+Invoke-ContosoExchangeWorker&#xD;
+$result | Format-List IsolatedModuleResolutionPath, PreferIsolatedModulePath&#xD;
+Disconnect-ExchangeOnline -Confirm:$false</dev:code>
+        <dev:remarks>
+          <maml:para>Prepends the generated isolated module parent path to PSModulePath for the current process. This is&#xD;
+useful when a downstream module imports ExchangeOnlineManagement by name and should bind to the&#xD;
+isolated copy instead of the original installed module.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>

--- a/PSPublishModule/Cmdlets/ImportIsolatedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/ImportIsolatedModuleCommand.cs
@@ -75,6 +75,15 @@ namespace PSPublishModule;
 /// </para>
 /// </example>
 /// <example>
+/// <summary>Prefer the generated isolated copy for later module imports</summary>
+/// <code>Import-Module Az.Storage&#xA;$result = Import-IsolatedModule -Profile ExchangeOnlineManagement -PreferIsolatedModulePath -PassThru&#xA;Connect-ExchangeOnline -ShowBanner:$false&#xA;Import-Module Contoso.ExchangeWorker&#xA;Invoke-ContosoExchangeWorker&#xA;$result | Format-List IsolatedModuleResolutionPath, PreferIsolatedModulePath&#xA;Disconnect-ExchangeOnline -Confirm:$false</code>
+/// <para>
+/// Prepends the generated isolated module parent path to PSModulePath for the current process. This is
+/// useful when a downstream module imports ExchangeOnlineManagement by name and should bind to the
+/// isolated copy instead of the original installed module.
+/// </para>
+/// </example>
+/// <example>
 /// <summary>Preview an import without creating the isolated module copy</summary>
 /// <code>Import-IsolatedModule -Profile ExchangeOnlineManagement -WhatIf</code>
 /// <para>
@@ -140,6 +149,18 @@ public sealed class ImportIsolatedModuleCommand : PSCmdlet
     [Parameter]
     public SwitchParameter PassThru { get; set; }
 
+    /// <summary>Prefer the generated isolated module copy for later module-name resolution in the current process.</summary>
+    /// <remarks>
+    /// <para>
+    /// When set, Import-IsolatedModule prepends the generated module parent directory to PSModulePath after
+    /// the isolated import succeeds. Later Import-Module calls and RequiredModules resolution in the same
+    /// PowerShell process can then find the isolated copy before the original installed module. This is
+    /// session-scoped and intentionally opt-in because it changes module-name resolution for the process.
+    /// </para>
+    /// </remarks>
+    [Parameter]
+    public SwitchParameter PreferIsolatedModulePath { get; set; }
+
     /// <summary>Imports the isolated module profile into the current session.</summary>
     protected override void ProcessRecord()
     {
@@ -153,7 +174,8 @@ public sealed class ImportIsolatedModuleCommand : PSCmdlet
                 ProfileName = Profile,
                 ModuleName = Name,
                 Path = ResolveOptionalPath(Path),
-                WorkRoot = ResolveOptionalPath(WorkRoot)
+                WorkRoot = ResolveOptionalPath(WorkRoot),
+                PreferIsolatedModulePath = PreferIsolatedModulePath.IsPresent
             };
 
             var result = new IsolatedModuleImportService().Import(request);

--- a/PowerForge.PowerShell/Models/ModuleIsolation/IsolatedModuleImportRequest.cs
+++ b/PowerForge.PowerShell/Models/ModuleIsolation/IsolatedModuleImportRequest.cs
@@ -16,4 +16,7 @@ public sealed class IsolatedModuleImportRequest
 
     /// <summary>Optional root folder for generated isolated module copies.</summary>
     public string? WorkRoot { get; set; }
+
+    /// <summary>Prepend the generated module parent path to PSModulePath after a successful import.</summary>
+    public bool PreferIsolatedModulePath { get; set; }
 }

--- a/PowerForge.PowerShell/Models/ModuleIsolation/IsolatedModuleImportResult.cs
+++ b/PowerForge.PowerShell/Models/ModuleIsolation/IsolatedModuleImportResult.cs
@@ -26,6 +26,12 @@ public sealed class IsolatedModuleImportResult
     /// <summary>Root folder containing the generated copy.</summary>
     public string WorkPath { get; set; } = string.Empty;
 
+    /// <summary>Whether the generated module parent path was requested as the preferred PSModulePath entry.</summary>
+    public bool PreferIsolatedModulePath { get; set; }
+
+    /// <summary>PSModulePath entry prepended when <see cref="PreferIsolatedModulePath"/> is enabled.</summary>
+    public string IsolatedModuleResolutionPath { get; set; } = string.Empty;
+
     /// <summary>Load-context name used by the generated wrapper.</summary>
     public string ContextName { get; set; } = string.Empty;
 

--- a/PowerForge.PowerShell/Services/ModuleIsolation/IsolatedModuleImportService.cs
+++ b/PowerForge.PowerShell/Services/ModuleIsolation/IsolatedModuleImportService.cs
@@ -14,6 +14,10 @@ namespace PowerForge;
 /// </summary>
 public sealed partial class IsolatedModuleImportService
 {
+    private static readonly StringComparison PathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
     private readonly ModuleIsolationProfileRegistry _profiles;
     private readonly ModuleIsolationScriptPatcher _patcher;
 
@@ -78,6 +82,12 @@ public sealed partial class IsolatedModuleImportService
     {
         var plan = Prepare(request);
         ImportGeneratedModule(plan.IsolatedImportPath);
+        var moduleResolutionPath = string.Empty;
+        if (request.PreferIsolatedModulePath)
+        {
+            moduleResolutionPath = plan.WorkPath;
+            PrependModuleResolutionPath(moduleResolutionPath);
+        }
 
         return new IsolatedModuleImportResult
         {
@@ -88,6 +98,8 @@ public sealed partial class IsolatedModuleImportService
             IsolatedManifestPath = plan.IsolatedManifestPath,
             IsolatedImportPath = plan.IsolatedImportPath,
             WorkPath = plan.WorkPath,
+            PreferIsolatedModulePath = request.PreferIsolatedModulePath,
+            IsolatedModuleResolutionPath = moduleResolutionPath,
             ContextName = plan.Profile.ContextName,
             BinaryImportCount = plan.Profile.BinaryImports.Length,
             TypeAcceleratorNamespaceCount = plan.Profile.TypeAcceleratorNamespaces.Length
@@ -327,6 +339,42 @@ public sealed partial class IsolatedModuleImportService
 
         _ = ps.Invoke<PSModuleInfo>();
         ThrowIfPowerShellFailed(ps.Streams.Error, $"Failed to import isolated module '{isolatedImportPath}'.");
+    }
+
+    internal static string PrependModuleResolutionPath(string moduleResolutionPath)
+    {
+        if (string.IsNullOrWhiteSpace(moduleResolutionPath))
+            throw new ArgumentException("Module resolution path is required.", nameof(moduleResolutionPath));
+
+        var normalizedPath = Path.GetFullPath(moduleResolutionPath.Trim().Trim('"'));
+        var current = Environment.GetEnvironmentVariable("PSModulePath", EnvironmentVariableTarget.Process) ?? string.Empty;
+        var entries = current
+            .Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static entry => entry.Trim())
+            .Where(static entry => !string.IsNullOrWhiteSpace(entry))
+            .ToList();
+
+        if (!entries.Any(entry => PathsEqual(entry, normalizedPath)))
+        {
+            entries.Insert(0, normalizedPath);
+            Environment.SetEnvironmentVariable("PSModulePath", string.Join(Path.PathSeparator.ToString(), entries), EnvironmentVariableTarget.Process);
+        }
+
+        return normalizedPath;
+    }
+
+    private static bool PathsEqual(string first, string second)
+    {
+        try
+        {
+            return string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), PathComparison);
+        }
+        catch (Exception) when (
+            first.Length > 0 &&
+            second.Length > 0)
+        {
+            return string.Equals(first.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), second.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), PathComparison);
+        }
     }
 
     private static void ThrowIfPowerShellFailed(PSDataCollection<ErrorRecord> errors, string message)

--- a/PowerForge.PowerShell/Services/ModuleIsolation/IsolatedModuleImportService.cs
+++ b/PowerForge.PowerShell/Services/ModuleIsolation/IsolatedModuleImportService.cs
@@ -249,7 +249,22 @@ public sealed partial class IsolatedModuleImportService
         var patched = PatchManifestText(source, sourceManifestPath, scriptRelativePath, profile.RemoveManifestNestedModules);
         Directory.CreateDirectory(Path.GetDirectoryName(isolatedManifestPath) ?? ".");
         File.WriteAllText(isolatedManifestPath, patched, Encoding.UTF8);
+        WriteDiscoverableManifest(profile, source, sourceManifestPath, isolatedModuleBase, isolatedManifestPath, isolatedScriptPath);
         return isolatedManifestPath;
+    }
+
+    private static void WriteDiscoverableManifest(ModuleIsolationProfile profile, string source, string sourceManifestPath, string isolatedModuleBase, string isolatedManifestPath, string isolatedScriptPath)
+    {
+        var discoverableManifestPath = Path.Combine(isolatedModuleBase, profile.ModuleName + ".psd1");
+        if (PathsEqual(discoverableManifestPath, isolatedManifestPath))
+            return;
+
+        var scriptRelativePath = GetRelativePath(isolatedModuleBase, isolatedScriptPath).Replace('\\', '/');
+        if (!scriptRelativePath.StartsWith(".", StringComparison.Ordinal))
+            scriptRelativePath = "./" + scriptRelativePath;
+
+        var patched = PatchManifestText(source, sourceManifestPath, scriptRelativePath, profile.RemoveManifestNestedModules);
+        File.WriteAllText(discoverableManifestPath, patched, Encoding.UTF8);
     }
 
     private static string ResolveProfileManifestPath(string moduleBase, ModuleIsolationProfile profile)

--- a/PowerForge.Tests/IsolatedModuleImportServiceTests.cs
+++ b/PowerForge.Tests/IsolatedModuleImportServiceTests.cs
@@ -112,6 +112,13 @@ public sealed class IsolatedModuleImportServiceTests
             var manifest = File.ReadAllText(plan.IsolatedManifestPath);
             Assert.Contains("RootModule = './MicrosoftTeams.ALC.psm1'", manifest, StringComparison.Ordinal);
             Assert.Contains("FunctionsToExport = @('Get-Team')", manifest, StringComparison.Ordinal);
+
+            var discoverableManifestPath = Path.Combine(plan.IsolatedModuleBase, "MicrosoftTeams.psd1");
+            Assert.True(File.Exists(discoverableManifestPath));
+            var discoverableManifest = File.ReadAllText(discoverableManifestPath);
+            Assert.Contains("RootModule = './MicrosoftTeams.ALC.psm1'", discoverableManifest, StringComparison.Ordinal);
+            Assert.Contains("FunctionsToExport = @('Get-Team')", discoverableManifest, StringComparison.Ordinal);
+            Assert.DoesNotContain("RootModule = './MicrosoftTeams.psm1'", discoverableManifest, StringComparison.Ordinal);
         }
         finally
         {
@@ -196,6 +203,13 @@ public sealed class IsolatedModuleImportServiceTests
             Assert.Contains("RootModule = './Microsoft.Graph.Authentication.ALC.psm1'", manifest, StringComparison.Ordinal);
             Assert.Contains("NestedModules = @()", manifest, StringComparison.Ordinal);
             Assert.DoesNotContain("Microsoft.Graph.Authentication.Core.dll')", manifest, StringComparison.Ordinal);
+
+            var discoverableManifestPath = Path.Combine(plan.IsolatedModuleBase, "Microsoft.Graph.Authentication.psd1");
+            Assert.True(File.Exists(discoverableManifestPath));
+            var discoverableManifest = File.ReadAllText(discoverableManifestPath);
+            Assert.Contains("RootModule = './Microsoft.Graph.Authentication.ALC.psm1'", discoverableManifest, StringComparison.Ordinal);
+            Assert.Contains("NestedModules = @()", discoverableManifest, StringComparison.Ordinal);
+            Assert.DoesNotContain("RootModule = './Microsoft.Graph.Authentication.psm1'", discoverableManifest, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/IsolatedModuleImportServiceTests.cs
+++ b/PowerForge.Tests/IsolatedModuleImportServiceTests.cs
@@ -306,6 +306,40 @@ public sealed class IsolatedModuleImportServiceTests
         }
     }
 
+    [Fact]
+    public void PrependModuleResolutionPath_AddsPathOnceAtFront()
+    {
+        var original = Environment.GetEnvironmentVariable("PSModulePath", EnvironmentVariableTarget.Process);
+        var root = CreateTempDirectory();
+        try
+        {
+            var first = Path.Combine(root, "first");
+            var second = Path.Combine(root, "second");
+            var isolated = Path.Combine(root, "isolated");
+            Directory.CreateDirectory(first);
+            Directory.CreateDirectory(second);
+            Directory.CreateDirectory(isolated);
+            Environment.SetEnvironmentVariable("PSModulePath", string.Join(Path.PathSeparator.ToString(), first, second), EnvironmentVariableTarget.Process);
+
+            var normalized = IsolatedModuleImportService.PrependModuleResolutionPath(isolated);
+            IsolatedModuleImportService.PrependModuleResolutionPath(isolated);
+
+            var entries = (Environment.GetEnvironmentVariable("PSModulePath", EnvironmentVariableTarget.Process) ?? string.Empty)
+                .Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.Equal(Path.GetFullPath(isolated), normalized);
+            Assert.Equal(Path.GetFullPath(isolated), entries[0]);
+            Assert.Single(entries, entry => string.Equals(Path.GetFullPath(entry), Path.GetFullPath(isolated), PlatformPathComparison));
+            Assert.Contains(entries, entry => string.Equals(Path.GetFullPath(entry), Path.GetFullPath(first), PlatformPathComparison));
+            Assert.Contains(entries, entry => string.Equals(Path.GetFullPath(entry), Path.GetFullPath(second), PlatformPathComparison));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PSModulePath", original, EnvironmentVariableTarget.Process);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static string CreateExchangeLikeScript()
         => string.Join(Environment.NewLine, new[]
         {
@@ -402,4 +436,7 @@ public sealed class IsolatedModuleImportServiceTests
         Directory.CreateDirectory(path);
         return path;
     }
+
+    private static StringComparison PlatformPathComparison =>
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 }


### PR DESCRIPTION
## Summary

- add `Import-IsolatedModule -PreferIsolatedModulePath` as an opt-in process-scoped resolution preference
- prepend the generated isolated module work path to `PSModulePath` only after the isolated import succeeds
- expose the selected resolution path in `-PassThru` output and document the downstream-module workflow

## Why

Some consumer modules call `Import-Module ExchangeOnlineManagement` internally after the caller already connected through an isolated Exchange profile. By default, those nested imports can resolve the original installed module again and bypass the isolated copy. This switch gives callers an explicit way to prefer the generated isolated module path for later name-based imports in the same PowerShell process, without changing default behavior.

## Validation

- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "IsolatedModuleImportServiceTests|ModuleIsolationScriptPatcherTests|ModuleIsolationProfileRegistryTests"`
- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release -f net472 --nologo`
- `.\Module\Build\Build-Module.ps1 -NoDotnetBuild`
- `pwsh -NoLogo -NoProfile -File .\Module\PSPublishModule.Tests.ps1`
- no-auth smoke: `Import-IsolatedModule -Profile ExchangeOnlineManagement -PreferIsolatedModulePath -PassThru`, then a later `Import-Module ExchangeOnlineManagement` resolved from the generated isolated work path
