### PR TITLE
Fix generated Markdown help block indentation

### DIFF
--- a/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
+++ b/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
@@ -49,7 +49,7 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
             if (indent < 8)
                 return normalized;
 
-            if (statements.Length == 1 && !ShouldNormalizeSingleStatement(lines, linesToNormalize, indent))
+            if (statements.Length == 1 && !ShouldNormalizeSingleStatement(firstStatement, lines, linesToNormalize, indent))
                 return normalized;
 
             AddIndentedCommentLines(lines, commentLines, linesToNormalize, indent, firstStatement.Extent.EndLineNumber - 1);
@@ -225,8 +225,15 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
         return false;
     }
 
-    private static bool ShouldNormalizeSingleStatement(string[] lines, HashSet<int> lineIndexes, int commonIndent)
+    private static bool ShouldNormalizeSingleStatement(
+        StatementAst statement,
+        string[] lines,
+        HashSet<int> lineIndexes,
+        int commonIndent)
     {
+        if (!IsSingleCommandScriptBlockStatement(statement))
+            return false;
+
         if (!HasNestedIndent(lines, lineIndexes, commonIndent))
             return false;
 
@@ -246,6 +253,17 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
         }
 
         return true;
+    }
+
+    private static bool IsSingleCommandScriptBlockStatement(StatementAst statement)
+    {
+        if (statement is not PipelineAst pipeline || pipeline.PipelineElements.Count != 1)
+            return false;
+
+        if (pipeline.PipelineElements[0] is not CommandAst command)
+            return false;
+
+        return command.CommandElements.Any(static element => element is ScriptBlockExpressionAst);
     }
 
     private static bool IsClosingDelimiterLine(string line)

--- a/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
+++ b/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
@@ -49,7 +49,7 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
             if (indent < 8)
                 return normalized;
 
-            if (statements.Length == 1 && (indent < 12 || !HasNestedIndent(lines, linesToNormalize, indent)))
+            if (statements.Length == 1 && !ShouldNormalizeSingleStatement(lines, linesToNormalize, indent))
                 return normalized;
 
             AddIndentedCommentLines(lines, commentLines, linesToNormalize, indent, firstStatement.Extent.EndLineNumber - 1);
@@ -223,6 +223,35 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
         }
 
         return false;
+    }
+
+    private static bool ShouldNormalizeSingleStatement(string[] lines, HashSet<int> lineIndexes, int commonIndent)
+    {
+        if (!HasNestedIndent(lines, lineIndexes, commonIndent))
+            return false;
+
+        if (commonIndent >= 12)
+            return true;
+
+        foreach (var lineIndex in lineIndexes)
+        {
+            if (lineIndex < 0 || lineIndex >= lines.Length || string.IsNullOrWhiteSpace(lines[lineIndex]))
+                continue;
+
+            if (CountLeadingWhitespace(lines[lineIndex]) != commonIndent)
+                continue;
+
+            if (!IsClosingDelimiterLine(lines[lineIndex]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsClosingDelimiterLine(string line)
+    {
+        var trimmed = line.Trim();
+        return trimmed == "}" || trimmed == ")" || trimmed == "]";
     }
 
     private static void AddIndentedCommentLines(

--- a/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
+++ b/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
@@ -237,9 +237,6 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
         if (!HasNestedIndent(lines, lineIndexes, commonIndent))
             return false;
 
-        if (commonIndent >= 12)
-            return true;
-
         foreach (var lineIndex in lineIndexes)
         {
             if (lineIndex < 0 || lineIndex >= lines.Length || string.IsNullOrWhiteSpace(lines[lineIndex]))
@@ -269,7 +266,15 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
     private static bool IsClosingDelimiterLine(string line)
     {
         var trimmed = line.Trim();
-        return trimmed == "}" || trimmed == ")" || trimmed == "]";
+        if (trimmed.Length == 0 || (trimmed[0] != '}' && trimmed[0] != ')' && trimmed[0] != ']'))
+            return false;
+
+        if (trimmed.Length == 1)
+            return true;
+
+        var remainder = trimmed.Substring(1).TrimStart();
+        return remainder.StartsWith("-", StringComparison.Ordinal)
+            || remainder.StartsWith("|", StringComparison.Ordinal);
     }
 
     private static void AddIndentedCommentLines(

--- a/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
+++ b/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
@@ -27,7 +27,7 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
             var commentLines = GetCommentLines(tokens);
 
             var statements = ast.EndBlock?.Statements.ToArray() ?? Array.Empty<StatementAst>();
-            if (statements.Length <= 1)
+            if (statements.Length == 0)
                 return normalized;
 
             var firstStatementIndex = FindFirstUsableStatementIndex(statements, errorLines);
@@ -47,6 +47,9 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
 
             var indent = GetCommonIndent(lines, linesToNormalize);
             if (indent < 8)
+                return normalized;
+
+            if (statements.Length == 1 && (indent < 12 || !HasNestedIndent(lines, linesToNormalize, indent)))
                 return normalized;
 
             AddIndentedCommentLines(lines, commentLines, linesToNormalize, indent, firstStatement.Extent.EndLineNumber - 1);
@@ -206,6 +209,20 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
         }
 
         return common == int.MaxValue ? 0 : common;
+    }
+
+    private static bool HasNestedIndent(string[] lines, HashSet<int> lineIndexes, int commonIndent)
+    {
+        foreach (var lineIndex in lineIndexes)
+        {
+            if (lineIndex < 0 || lineIndex >= lines.Length || string.IsNullOrWhiteSpace(lines[lineIndex]))
+                continue;
+
+            if (CountLeadingWhitespace(lines[lineIndex]) > commonIndent)
+                return true;
+        }
+
+        return false;
     }
 
     private static void AddIndentedCommentLines(

--- a/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
+++ b/PowerForge.PowerShell/Services/PowerShellMarkdownExampleIndentClassifier.cs
@@ -25,6 +25,7 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
             var ast = Parser.ParseInput(normalized, out var tokens, out var errors);
             var errorLines = GetErrorLines(errors);
             var commentLines = GetCommentLines(tokens);
+            var hereStringLines = GetHereStringLines(tokens);
 
             var statements = ast.EndBlock?.Statements.ToArray() ?? Array.Empty<StatementAst>();
             if (statements.Length == 0)
@@ -49,7 +50,7 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
             if (indent < 8)
                 return normalized;
 
-            if (statements.Length == 1 && !ShouldNormalizeSingleStatement(firstStatement, lines, linesToNormalize, indent))
+            if (statements.Length == 1 && !ShouldNormalizeSingleStatement(firstStatement, lines, linesToNormalize, commentLines, hereStringLines, indent))
                 return normalized;
 
             AddIndentedCommentLines(lines, commentLines, linesToNormalize, indent, firstStatement.Extent.EndLineNumber - 1);
@@ -89,6 +90,25 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
         foreach (var token in tokens)
         {
             if (token.Kind != TokenKind.Comment)
+                continue;
+
+            var start = Math.Max(1, token.Extent.StartLineNumber);
+            var end = Math.Max(start, token.Extent.EndLineNumber);
+            for (var line = start; line <= end; line++)
+            {
+                lines.Add(line - 1);
+            }
+        }
+
+        return lines;
+    }
+
+    private static HashSet<int> GetHereStringLines(Token[] tokens)
+    {
+        var lines = new HashSet<int>();
+        foreach (var token in tokens)
+        {
+            if (token.Kind != TokenKind.HereStringExpandable && token.Kind != TokenKind.HereStringLiteral)
                 continue;
 
             var start = Math.Max(1, token.Extent.StartLineNumber);
@@ -229,6 +249,8 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
         StatementAst statement,
         string[] lines,
         HashSet<int> lineIndexes,
+        HashSet<int> commentLines,
+        HashSet<int> hereStringLines,
         int commonIndent)
     {
         if (!IsSingleCommandScriptBlockStatement(statement))
@@ -245,6 +267,12 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
             if (CountLeadingWhitespace(lines[lineIndex]) != commonIndent)
                 continue;
 
+            if (hereStringLines.Contains(lineIndex))
+                return false;
+
+            if (commentLines.Contains(lineIndex))
+                continue;
+
             if (!IsClosingDelimiterLine(lines[lineIndex]))
                 return false;
         }
@@ -254,6 +282,9 @@ internal sealed class PowerShellMarkdownExampleIndentClassifier : IMarkdownExamp
 
     private static bool IsSingleCommandScriptBlockStatement(StatementAst statement)
     {
+        if (statement is AssignmentStatementAst assignment)
+            return IsSingleCommandScriptBlockStatement(assignment.Right);
+
         if (statement is not PipelineAst pipeline || pipeline.PipelineElements.Count != 1)
             return false;
 

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -110,6 +110,38 @@ ForEach-Object {
     }
 
     [Fact]
+    public void RenderCommandMarkdown_NormalizesGeneratedIndentationInSingleBlockCommand()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "New-DemoReport",
+            Synopsis = "Creates a demo report.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+New-DemoReport -Path .\Examples\Documents\Report.pdf {
+                Add-DemoHeading -Text 'Service Review'
+                Add-DemoParagraph -Text 'All services are healthy.'
+            }
+""",
+                    Remarks = "Creates a generated report."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> New-DemoReport -Path .\\Examples\\Documents\\Report.pdf {\r\n    Add-DemoHeading -Text 'Service Review'", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\n    Add-DemoParagraph -Text 'All services are healthy.'\r\n}", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n                Add-DemoHeading", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n            }", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderCommandMarkdown_IgnoresQuotedDelimitersWhenPreservingSingleBlockIndentation()
     {
         var command = new DocumentationCommandHelp

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -172,6 +172,36 @@ New-DemoReport -Path .\Examples\Documents\Report.pdf {
     }
 
     [Fact]
+    public void RenderCommandMarkdown_PreservesAuthoredPipelineContinuationInSingleStatement()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Get-DemoReport",
+            Synopsis = "Gets a demo report.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+Get-Demo |
+            Where-Object {
+                $_.Ready
+            }
+""",
+                    Remarks = "Keeps authored pipeline continuation formatting."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> Get-Demo |\r\n            Where-Object {", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\n                $_.Ready\r\n            }", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderCommandMarkdown_IgnoresQuotedDelimitersWhenPreservingSingleBlockIndentation()
     {
         var command = new DocumentationCommandHelp

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -268,6 +268,97 @@ ForEach-Object -Begin {
     }
 
     [Fact]
+    public void RenderCommandMarkdown_PreservesHereStringContentInSingleBlockCommand()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Invoke-DemoBlock",
+            Synopsis = "Invokes a demo block.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+Invoke-DemoBlock {
+            $template = @'
+        }
+'@
+        }
+""",
+                    Remarks = "Keeps template content unchanged."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> Invoke-DemoBlock {\r\n            $template = @'\r\n        }\r\n'@\r\n        }", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderCommandMarkdown_NormalizesGeneratedCommentsInSingleBlockCommand()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "New-DemoReport",
+            Synopsis = "Creates a demo report.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+New-DemoReport -Path .\Examples\Documents\Report.pdf {
+        # setup
+            Add-DemoHeading -Text 'Service Review'
+        }
+""",
+                    Remarks = "Normalizes generated block comments."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> New-DemoReport -Path .\\Examples\\Documents\\Report.pdf {\r\n# setup\r\n    Add-DemoHeading -Text 'Service Review'\r\n}", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n        # setup", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n            Add-DemoHeading", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderCommandMarkdown_NormalizesGeneratedAssignmentSingleBlockCommand()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "New-DemoPlan",
+            Synopsis = "Creates a demo plan.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+$plan = New-DemoPlan {
+            Add-DemoStep -Title 'Service Review'
+        }
+""",
+                    Remarks = "Normalizes generated assignment block formatting."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> $plan = New-DemoPlan {\r\n    Add-DemoStep -Title 'Service Review'\r\n}", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n            Add-DemoStep", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n        }", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderCommandMarkdown_IgnoresQuotedDelimitersWhenPreservingSingleBlockIndentation()
     {
         var command = new DocumentationCommandHelp

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -142,6 +142,36 @@ New-DemoReport -Path .\Examples\Documents\Report.pdf {
     }
 
     [Fact]
+    public void RenderCommandMarkdown_NormalizesGeneratedEightSpaceClosingIndentationInSingleBlockCommand()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "New-DemoReport",
+            Synopsis = "Creates a demo report.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+New-DemoReport -Path .\Examples\Documents\Report.pdf {
+            Add-DemoHeading -Text 'Service Review'
+        }
+""",
+                    Remarks = "Creates a generated report."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> New-DemoReport -Path .\\Examples\\Documents\\Report.pdf {\r\n    Add-DemoHeading -Text 'Service Review'\r\n}", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n            Add-DemoHeading", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n        }", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderCommandMarkdown_IgnoresQuotedDelimitersWhenPreservingSingleBlockIndentation()
     {
         var command = new DocumentationCommandHelp

--- a/PowerForge.Tests/MarkdownHelpWriterTests.cs
+++ b/PowerForge.Tests/MarkdownHelpWriterTests.cs
@@ -202,6 +202,72 @@ Get-Demo |
     }
 
     [Fact]
+    public void RenderCommandMarkdown_PreservesAuthoredDeepSingleBlockIndentation()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Invoke-DemoBlock",
+            Synopsis = "Invokes a demo block.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+Invoke-DemoBlock {
+            ForEach-Object {
+                if ($_.Ready) {
+                    $_.Name
+                }
+            }
+            }
+""",
+                    Remarks = "Keeps authored deep block formatting."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> Invoke-DemoBlock {\r\n            ForEach-Object {", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\n                if ($_.Ready) {\r\n                    $_.Name", exampleSection, StringComparison.Ordinal);
+        Assert.Contains("\r\n            }\r\n            }", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderCommandMarkdown_NormalizesGeneratedChainedScriptBlockParameters()
+    {
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Invoke-DemoBlock",
+            Synopsis = "Invokes a demo block.",
+            Examples = new List<DocumentationExampleHelp>
+            {
+                new()
+                {
+                    Introduction = "PS> ",
+                    Code = """
+ForEach-Object -Begin {
+            $started = $true
+        } -Process {
+            $_.Name
+        }
+""",
+                    Remarks = "Normalizes generated script-block parameter formatting."
+                }
+            }
+        };
+
+        var markdown = RenderCommandMarkdown(command);
+        var exampleSection = markdown.Substring(markdown.IndexOf("### EXAMPLE 1", StringComparison.Ordinal));
+
+        Assert.Contains("PS> ForEach-Object -Begin {\r\n    $started = $true\r\n} -Process {\r\n    $_.Name\r\n}", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n            $started", exampleSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r\n        } -Process", exampleSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderCommandMarkdown_IgnoresQuotedDelimitersWhenPreservingSingleBlockIndentation()
     {
         var command = new DocumentationCommandHelp


### PR DESCRIPTION
## Summary
- Normalize generated Markdown help examples for single multiline PowerShell commands whose script-block body retains MAML/XML incidental indentation.
- Keep the existing parser-backed classifier conservative: no command-name hardcoding, and flat authored single-block indentation remains preserved.
- Add a regression test for the generated-help shape that affected PSWriteOffice `New-Office* { ... }` examples.

## Validation
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter FullyQualifiedName~MarkdownHelpWriterTests`
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~Markdown|FullyQualifiedName~Documentation"`
- `dotnet build PowerForge\PowerForge.csproj -c Release -f net472`
- `dotnet build PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release -f net472`
- `dotnet build PSPublishModule\PSPublishModule.csproj -c Release -f net472`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Module\Build\Build-Module.ps1`
- `git diff --check`

## Downstream proof
- Rebuilt PSWriteOffice docs using locally installed PSPublishModule `3.0.25.1` from this branch.
- PSWriteOffice rendered PowerShell-fence scan for `^ {12,}\S` returned `COUNT=0` after regeneration.
- Spot checks show DSL bodies at normal indentation in `Docs\Add-OfficeMarkdownHeading.md`, `Docs\New-OfficePdf.md`, and `Docs\Add-OfficePowerPointShape.md`.