### PR TITLE
Add GitHub Packages private feed support

### DIFF
--- a/Docs/PSPublishModule.GitHubPackages.md
+++ b/Docs/PSPublishModule.GitHubPackages.md
@@ -1,0 +1,91 @@
+# PSPublishModule GitHub Packages NuGet Feed
+
+This note describes the private GitHub Packages path for internal .NET packages
+such as `Licensing.Verification`. Use this when a product repository needs a
+runtime package without depending on a sibling local checkout.
+
+## Why
+
+GraphEssentialsX, TestimoX, and future products should restore private runtime
+packages from a feed in CI. Local folders such as `C:\Support\GitHub\Licensing`
+are useful for development proof, but they must not be required by product CI.
+
+GitHub Packages is the preferred private feed for neutral internal packages:
+
+- packages stay private unless the package owner changes visibility
+- repository or team access can be granted from the package settings
+- GitHub Actions can use `GITHUB_TOKEN` when the package grants that repository
+  access
+- cross-repository restores can use an organization secret containing a classic
+  PAT with `read:packages`
+
+## Maintainer Profile
+
+Create a non-secret profile for the organization-scoped NuGet feed:
+
+```powershell
+Set-ModuleRepositoryProfile -Name LicensingGitHub -Provider GitHubPackages -GitHubOwner EvotecIT -RepositoryName github-evotec
+```
+
+The profile resolves to:
+
+```text
+https://nuget.pkg.github.com/EvotecIT/index.json
+```
+
+## Publish
+
+Package from the owning repository, then publish through the saved profile:
+
+```powershell
+dotnet pack .\Licensing.Verification\Licensing.Verification.csproj -c Release -o .\Artifacts\Packages
+Publish-NugetPackage -Path .\Artifacts\Packages -ProfileName LicensingGitHub -SkipDuplicate
+```
+
+`Publish-NugetPackage` uses the supplied `-ApiKey` when provided. For
+GitHub Packages profiles, it can also use `GITHUB_TOKEN` or `GH_TOKEN`.
+
+## Consumer CI Restore
+
+Consumer repositories should add the GitHub Packages source before `dotnet
+restore` and should keep the package version pinned in the project or lock file.
+
+When the package grants the consumer repository GitHub Actions access:
+
+```powershell
+dotnet nuget add source --username EvotecIT --password $env:GITHUB_TOKEN --store-password-in-clear-text --name github-evotec "https://nuget.pkg.github.com/EvotecIT/index.json"
+dotnet restore
+```
+
+When the package is not directly granted to the consumer repository, use a
+private organization secret with a classic PAT that has `read:packages`:
+
+```powershell
+dotnet nuget add source --username EvotecIT --password $env:LICENSING_PACKAGES_TOKEN --store-password-in-clear-text --name github-evotec "https://nuget.pkg.github.com/EvotecIT/index.json"
+dotnet restore
+```
+
+## Recommended Package Source Mapping
+
+Route only private package ids to GitHub Packages so public dependencies still
+restore from nuget.org:
+
+```xml
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="github-evotec" value="https://nuget.pkg.github.com/EvotecIT/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="github-evotec">
+      <package pattern="Licensing.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+```
+
+Do not commit clear-text tokens. Prefer runtime `dotnet nuget add source` in CI
+or a generated temporary `NuGet.config` in the workspace.

--- a/Module/Tests/PrivateGallery.Commands.Tests.ps1
+++ b/Module/Tests/PrivateGallery.Commands.Tests.ps1
@@ -640,6 +640,9 @@ Describe 'Private gallery command metadata' {
         $profile.Parameters.Keys | Should -Contain 'RepositoryUri'
         $profile.Parameters.Keys | Should -Contain 'JFrogBaseUri'
         $profile.Parameters.Keys | Should -Contain 'JFrogRepository'
+        $profile.Parameters.Keys | Should -Contain 'GitHubOwner'
+        $profile.Parameters['GitHubOwner'].Aliases | Should -Contain 'Owner'
+        $profile.Parameters['GitHubOwner'].Aliases | Should -Contain 'Namespace'
         $profile.Parameters.Keys | Should -Contain 'Scope'
 
         $exportProfile = $module.ExportedCmdlets['Export-ModuleRepositoryProfile']
@@ -706,6 +709,21 @@ Describe 'Private gallery command metadata' {
         $profile.RepositoryUri | Should -Be 'https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json'
         $profile.RepositorySourceUri | Should -Be 'https://company.jfrog.io/artifactory/api/nuget/powershell-virtual'
         $profile.JFrogRepository | Should -Be 'powershell-virtual'
+        $profile.BootstrapMode | Should -Be ([PowerForge.PrivateGalleryBootstrapMode]::CredentialPrompt)
+        $profile.AuthenticationMode | Should -Be 'CredentialPrompt'
+    }
+
+    It 'saves GitHub Packages profiles with owner-scoped NuGet endpoints' {
+        $profile = Set-ModuleRepositoryProfile -Name 'Licensing' -Provider GitHubPackages -GitHubOwner 'EvotecIT' -RepositoryName 'github-evotec'
+
+        $profile.Name | Should -Be 'Licensing'
+        $profile.Provider.ToString() | Should -Be 'GitHubPackages'
+        $profile.GitHubOwner | Should -Be 'EvotecIT'
+        $profile.Repository | Should -Be 'EvotecIT'
+        $profile.RepositoryName | Should -Be 'github-evotec'
+        $profile.RepositoryUri | Should -Be 'https://nuget.pkg.github.com/EvotecIT/index.json'
+        $profile.RepositorySourceUri | Should -Be $profile.RepositoryUri
+        $profile.RepositoryPublishUri | Should -Be $profile.RepositoryUri
         $profile.BootstrapMode | Should -Be ([PowerForge.PrivateGalleryBootstrapMode]::CredentialPrompt)
         $profile.AuthenticationMode | Should -Be 'CredentialPrompt'
     }
@@ -1026,6 +1044,42 @@ Describe 'Private gallery command metadata' {
         $result.Source | Should -Be 'https://pkgs.dev.azure.com/contoso/Platform/_packaging/Modules/nuget/v3/index.json'
         $result.Pushed | Should -Contain $packagePath
         $result.Failed | Should -BeNullOrEmpty
+    }
+
+    It 'uses GitHub token environment variables for GitHub Packages NuGet publishing' {
+        Set-ModuleRepositoryProfile -Name 'LicensingPackages' -Provider GitHubPackages -GitHubOwner 'EvotecIT' -RepositoryName 'github-evotec' | Out-Null
+        $packageRoot = Join-Path $script:PrivateGalleryProfileRoot 'github-packages'
+        New-Item -ItemType Directory -Path $packageRoot -Force | Out-Null
+        $packagePath = Join-Path $packageRoot 'Licensing.Verification.1.0.0.nupkg'
+        Set-Content -LiteralPath $packagePath -Value 'placeholder' -NoNewline
+        $previousToken = $env:GITHUB_TOKEN
+        $previousGhToken = $env:GH_TOKEN
+
+        try {
+            $env:GITHUB_TOKEN = 'test-token'
+            Remove-Item Env:\GH_TOKEN -ErrorAction SilentlyContinue
+
+            $result = Publish-NugetPackage -Path $packageRoot -ProfileName 'LicensingPackages' -SkipDuplicate -WhatIf
+
+            $result.Success | Should -BeTrue
+            $result.ProfileName | Should -Be 'LicensingPackages'
+            $result.RepositoryName | Should -Be 'github-evotec'
+            $result.Source | Should -Be 'https://nuget.pkg.github.com/EvotecIT/index.json'
+            $result.Pushed | Should -Contain $packagePath
+            $result.Failed | Should -BeNullOrEmpty
+        } finally {
+            if ($null -eq $previousToken) {
+                Remove-Item Env:\GITHUB_TOKEN -ErrorAction SilentlyContinue
+            } else {
+                $env:GITHUB_TOKEN = $previousToken
+            }
+
+            if ($null -eq $previousGhToken) {
+                Remove-Item Env:\GH_TOKEN -ErrorAction SilentlyContinue
+            } else {
+                $env:GH_TOKEN = $previousGhToken
+            }
+        }
     }
 
     It 'requires an API key when publishing packages to saved JFrog profiles' {

--- a/PSPublishModule/Cmdlets/PublishNugetPackageCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishNugetPackageCommand.cs
@@ -42,6 +42,8 @@ public sealed class PublishNugetPackageCommand : PSCmdlet
     private const string ParameterSetSource = "Source";
     private const string ParameterSetProfile = "Profile";
     private const string AzureArtifactsApiKeyPlaceholder = "AzureArtifacts";
+    private const string GitHubTokenEnvironmentVariable = "GITHUB_TOKEN";
+    private const string GitHubCliTokenEnvironmentVariable = "GH_TOKEN";
 
     /// <summary>Directory to search for NuGet packages.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetSource)]
@@ -49,7 +51,7 @@ public sealed class PublishNugetPackageCommand : PSCmdlet
     [ValidateNotNullOrEmpty]
     public string[] Path { get; set; } = Array.Empty<string>();
 
-    /// <summary>API key used to authenticate against the NuGet feed. For Azure Artifacts profiles this defaults to a non-secret placeholder used by NuGet clients.</summary>
+    /// <summary>API key used to authenticate against the NuGet feed. For Azure Artifacts profiles this defaults to a non-secret placeholder used by NuGet clients; for GitHub Packages profiles this defaults from GITHUB_TOKEN or GH_TOKEN.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetSource)]
     [Parameter(ParameterSetName = ParameterSetProfile)]
     [ValidateNotNullOrEmpty]
@@ -111,7 +113,8 @@ public sealed class PublishNugetPackageCommand : PSCmdlet
                     profile.RepositorySourceUri,
                     profile.RepositoryPublishUri,
                     profile.JFrogBaseUri,
-                    profile.JFrogRepository);
+                    profile.JFrogRepository,
+                    profile.GitHubOwner);
 
                 source = endpoint.PSResourceGetUri;
                 repositoryName = endpoint.RepositoryName;
@@ -119,6 +122,10 @@ public sealed class PublishNugetPackageCommand : PSCmdlet
                 if (string.IsNullOrWhiteSpace(apiKey) && endpoint.Provider == PrivateGalleryProvider.AzureArtifacts)
                 {
                     apiKey = AzureArtifactsApiKeyPlaceholder;
+                }
+                else if (string.IsNullOrWhiteSpace(apiKey) && endpoint.Provider == PrivateGalleryProvider.GitHubPackages)
+                {
+                    apiKey = ResolveGitHubPackagesApiKey();
                 }
                 else if (string.IsNullOrWhiteSpace(apiKey))
                 {
@@ -154,6 +161,19 @@ public sealed class PublishNugetPackageCommand : PSCmdlet
             .Where(path => !string.IsNullOrWhiteSpace(path))
             .Select(path => SessionState.Path.GetUnresolvedProviderPathFromPSPath(path!))
         .ToArray();
+
+    private static string ResolveGitHubPackagesApiKey()
+    {
+        var token = Environment.GetEnvironmentVariable(GitHubTokenEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(token))
+            return token!;
+
+        token = Environment.GetEnvironmentVariable(GitHubCliTokenEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(token))
+            return token!;
+
+        throw new ArgumentException("ApiKey is required for GitHub Packages profiles unless GITHUB_TOKEN or GH_TOKEN is set.", nameof(ApiKey));
+    }
 
     private static PublishNugetPackageResult ToCmdletResult(
         PowerForge.NuGetPackagePublishResult result,

--- a/PSPublishModule/Cmdlets/SetModuleRepositoryProfileCommand.cs
+++ b/PSPublishModule/Cmdlets/SetModuleRepositoryProfileCommand.cs
@@ -85,6 +85,11 @@ public sealed class SetModuleRepositoryProfileCommand : PSCmdlet
     [Parameter]
     public string? JFrogRepository { get; set; }
 
+    /// <summary>GitHub user or organization namespace for GitHub Packages. Defaults from Repository when omitted.</summary>
+    [Parameter]
+    [Alias("Owner", "Namespace")]
+    public string? GitHubOwner { get; set; }
+
     /// <summary>Registration strategy saved in the profile. Defaults to PSResourceGet for Entra-first Azure Artifacts use.</summary>
     [Parameter]
     public RepositoryRegistrationTool Tool { get; set; } = RepositoryRegistrationTool.PSResourceGet;
@@ -127,6 +132,7 @@ public sealed class SetModuleRepositoryProfileCommand : PSCmdlet
             RepositoryPublishUri = RepositoryPublishUri ?? string.Empty,
             JFrogBaseUri = JFrogBaseUri ?? string.Empty,
             JFrogRepository = JFrogRepository ?? string.Empty,
+            GitHubOwner = GitHubOwner ?? string.Empty,
             Tool = Tool,
             BootstrapMode = BootstrapMode,
             Trusted = Trusted,

--- a/PSPublishModule/Services/ModuleRepositoryProfileReadinessMapper.cs
+++ b/PSPublishModule/Services/ModuleRepositoryProfileReadinessMapper.cs
@@ -26,7 +26,8 @@ internal static class ModuleRepositoryProfileReadinessMapper
             profile.RepositorySourceUri,
             profile.RepositoryPublishUri,
             profile.JFrogBaseUri,
-            profile.JFrogRepository);
+            profile.JFrogRepository,
+            profile.GitHubOwner);
 
         var existingSessionReady = endpoint.Provider == PrivateGalleryProvider.AzureArtifacts &&
                                    PrivateGalleryVersionPolicy.IsExistingSessionBootstrapReady(status);
@@ -51,6 +52,7 @@ internal static class ModuleRepositoryProfileReadinessMapper
             RepositoryPublishUri = endpoint.PowerShellGetPublishUri,
             JFrogBaseUri = endpoint.JFrogBaseUri ?? string.Empty,
             JFrogRepository = endpoint.JFrogRepository ?? string.Empty,
+            GitHubOwner = endpoint.GitHubOwner ?? string.Empty,
             PowerShellGetSourceUri = endpoint.PowerShellGetSourceUri,
             PowerShellGetPublishUri = endpoint.PowerShellGetPublishUri,
             PSResourceGetUri = endpoint.PSResourceGetUri,

--- a/PSPublishModule/Services/ModuleRepositoryProfileReadinessResult.cs
+++ b/PSPublishModule/Services/ModuleRepositoryProfileReadinessResult.cs
@@ -77,6 +77,9 @@ public sealed class ModuleRepositoryProfileReadinessResult
     /// <summary>JFrog NuGet repository key, when applicable.</summary>
     public string JFrogRepository { get; set; } = string.Empty;
 
+    /// <summary>GitHub user or organization namespace, when applicable.</summary>
+    public string GitHubOwner { get; set; } = string.Empty;
+
     /// <summary>Resolved NuGet v2 source URI used by PowerShellGet.</summary>
     public string PowerShellGetSourceUri { get; set; } = string.Empty;
 

--- a/PSPublishModule/Services/ModuleRepositoryProfileResult.cs
+++ b/PSPublishModule/Services/ModuleRepositoryProfileResult.cs
@@ -44,6 +44,9 @@ public sealed class ModuleRepositoryProfileResult
     /// <summary>JFrog NuGet repository key, when applicable.</summary>
     public string JFrogRepository { get; set; } = string.Empty;
 
+    /// <summary>GitHub user or organization namespace, when applicable.</summary>
+    public string GitHubOwner { get; set; } = string.Empty;
+
     /// <summary>Registration tool selected for this profile.</summary>
     public RepositoryRegistrationTool Tool { get; set; } = RepositoryRegistrationTool.PSResourceGet;
 

--- a/PSPublishModule/Services/ModuleRepositoryProfileResultMapper.cs
+++ b/PSPublishModule/Services/ModuleRepositoryProfileResultMapper.cs
@@ -23,6 +23,7 @@ internal static class ModuleRepositoryProfileResultMapper
             RepositoryPublishUri = profile.RepositoryPublishUri,
             JFrogBaseUri = profile.JFrogBaseUri,
             JFrogRepository = profile.JFrogRepository,
+            GitHubOwner = profile.GitHubOwner,
             Tool = profile.Tool,
             BootstrapMode = profile.BootstrapMode,
             Trusted = profile.Trusted,

--- a/PowerForge.PowerShell/Models/ModuleRepositoryProfile.cs
+++ b/PowerForge.PowerShell/Models/ModuleRepositoryProfile.cs
@@ -16,6 +16,7 @@ internal sealed class ModuleRepositoryProfile
     public string RepositoryPublishUri { get; set; } = string.Empty;
     public string JFrogBaseUri { get; set; } = string.Empty;
     public string JFrogRepository { get; set; } = string.Empty;
+    public string GitHubOwner { get; set; } = string.Empty;
     public RepositoryRegistrationTool Tool { get; set; } = RepositoryRegistrationTool.PSResourceGet;
     public PrivateGalleryBootstrapMode BootstrapMode { get; set; } = PrivateGalleryBootstrapMode.ExistingSession;
     public bool Trusted { get; set; } = true;

--- a/PowerForge.PowerShell/Services/ModuleRepositoryProfileStore.cs
+++ b/PowerForge.PowerShell/Services/ModuleRepositoryProfileStore.cs
@@ -227,7 +227,8 @@ internal sealed class ModuleRepositoryProfileStore
             profile.RepositorySourceUri,
             profile.RepositoryPublishUri,
             profile.JFrogBaseUri,
-            profile.JFrogRepository);
+            profile.JFrogRepository,
+            profile.GitHubOwner);
 
         return new ModuleRepositoryProfile
         {
@@ -243,6 +244,7 @@ internal sealed class ModuleRepositoryProfileStore
             RepositoryPublishUri = endpoint.PowerShellGetPublishUri,
             JFrogBaseUri = endpoint.JFrogBaseUri ?? string.Empty,
             JFrogRepository = endpoint.JFrogRepository ?? string.Empty,
+            GitHubOwner = endpoint.GitHubOwner ?? string.Empty,
             Tool = profile.Tool,
             BootstrapMode = ResolveBootstrapMode(endpoint.Provider, profile.BootstrapMode),
             Trusted = profile.Trusted,

--- a/PowerForge.PowerShell/Services/PrivateGalleryService.cs
+++ b/PowerForge.PowerShell/Services/PrivateGalleryService.cs
@@ -23,8 +23,8 @@ internal sealed class PrivateGalleryService
 
     public void EnsureProviderSupported(PrivateGalleryProvider provider)
     {
-        if (provider is not (PrivateGalleryProvider.AzureArtifacts or PrivateGalleryProvider.JFrog or PrivateGalleryProvider.NuGet))
-            throw new ArgumentException($"Provider '{provider}' is not supported. Supported values: AzureArtifacts, JFrog, NuGet.", nameof(provider));
+        if (provider is not (PrivateGalleryProvider.AzureArtifacts or PrivateGalleryProvider.JFrog or PrivateGalleryProvider.GitHubPackages or PrivateGalleryProvider.NuGet))
+            throw new ArgumentException($"Provider '{provider}' is not supported. Supported values: AzureArtifacts, JFrog, GitHubPackages, NuGet.", nameof(provider));
     }
 
     public IReadOnlyList<ModuleDependency> BuildDependencies(IEnumerable<string> names)
@@ -228,8 +228,7 @@ internal sealed class PrivateGalleryService
         var result = new ModuleRepositoryRegistrationResult
         {
             RepositoryName = endpoint.RepositoryName,
-            Provider = endpoint.Provider == PrivateGalleryProvider.JFrog ? "JFrog" :
-                endpoint.Provider == PrivateGalleryProvider.NuGet ? "NuGet" : "AzureArtifacts",
+            Provider = endpoint.Provider.ToString(),
             BootstrapModeRequested = bootstrapModeRequested,
             BootstrapModeUsed = bootstrapModeUsed,
             CredentialSource = credentialSource,

--- a/PowerForge.Tests/ModuleRepositoryProfileStoreTests.cs
+++ b/PowerForge.Tests/ModuleRepositoryProfileStoreTests.cs
@@ -132,6 +132,39 @@ public sealed class ModuleRepositoryProfileStoreTests
     }
 
     [Fact]
+    public void SaveProfile_NormalizesGitHubPackagesProfileWithTokenDefaults()
+    {
+        var path = CreateTempFilePath();
+        try
+        {
+            var store = new ModuleRepositoryProfileStore(path);
+
+            var saved = store.SaveProfile(new ModuleRepositoryProfile
+            {
+                Name = " Licensing ",
+                Provider = PrivateGalleryProvider.GitHubPackages,
+                GitHubOwner = " EvotecIT ",
+                RepositoryName = " evotec-github "
+            });
+
+            Assert.Equal("Licensing", saved.Name);
+            Assert.Equal(PrivateGalleryProvider.GitHubPackages, saved.Provider);
+            Assert.Equal("EvotecIT", saved.GitHubOwner);
+            Assert.Equal("EvotecIT", saved.Repository);
+            Assert.Equal("evotec-github", saved.RepositoryName);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", saved.RepositoryUri);
+            Assert.Equal(saved.RepositoryUri, saved.RepositorySourceUri);
+            Assert.Equal(saved.RepositoryUri, saved.RepositoryPublishUri);
+            Assert.Equal(PrivateGalleryBootstrapMode.CredentialPrompt, saved.BootstrapMode);
+            Assert.Equal("CredentialPrompt", saved.AuthenticationMode);
+        }
+        finally
+        {
+            TryDelete(Path.GetDirectoryName(path));
+        }
+    }
+
+    [Fact]
     public void GetProfile_ReturnsCaseInsensitiveProfile()
     {
         var path = CreateTempFilePath();

--- a/PowerForge.Tests/PrivateGalleryRepositoryEndpointsTests.cs
+++ b/PowerForge.Tests/PrivateGalleryRepositoryEndpointsTests.cs
@@ -68,6 +68,46 @@ public sealed class PrivateGalleryRepositoryEndpointsTests
     }
 
     [Fact]
+    public void Create_GitHubPackagesOwner_ReturnsGitHubNuGetServiceIndex()
+    {
+        var endpoint = PrivateGalleryRepositoryEndpoints.Create(
+            PrivateGalleryProvider.GitHubPackages,
+            repositoryName: "Licensing",
+            gitHubOwner: "EvotecIT");
+
+        Assert.Equal(PrivateGalleryProvider.GitHubPackages, endpoint.Provider);
+        Assert.Equal("Licensing", endpoint.RepositoryName);
+        Assert.Equal("EvotecIT", endpoint.Repository);
+        Assert.Equal("EvotecIT", endpoint.GitHubOwner);
+        Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", endpoint.PSResourceGetUri);
+        Assert.Equal(endpoint.PSResourceGetUri, endpoint.PowerShellGetSourceUri);
+        Assert.Equal(endpoint.PSResourceGetUri, endpoint.PowerShellGetPublishUri);
+    }
+
+    [Fact]
+    public void Create_GitHubAliasUsesRepositoryAsOwnerWhenOwnerIsOmitted()
+    {
+        var endpoint = PrivateGalleryRepositoryEndpoints.Create(
+            PrivateGalleryProvider.GitHub,
+            repository: "EvotecIT");
+
+        Assert.Equal(PrivateGalleryProvider.GitHubPackages, endpoint.Provider);
+        Assert.Equal("EvotecIT", endpoint.RepositoryName);
+        Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", endpoint.PSResourceGetUri);
+    }
+
+    [Fact]
+    public void Create_GitHubPackagesRejectsMultiSegmentOwner()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => PrivateGalleryRepositoryEndpoints.Create(
+            PrivateGalleryProvider.GitHubPackages,
+            repositoryName: "Licensing",
+            gitHubOwner: "EvotecIT/Licensing"));
+
+        Assert.Contains("single GitHub user or organization", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Create_GenericNuGet_RequiresExplicitRepositoryUri()
     {
         var ex = Assert.Throws<ArgumentException>(() => PrivateGalleryRepositoryEndpoints.Create(
@@ -90,12 +130,14 @@ public sealed class PrivateGalleryRepositoryEndpointsTests
 
     [Theory]
     [InlineData(PrivateGalleryProvider.JFrog)]
+    [InlineData(PrivateGalleryProvider.GitHubPackages)]
     [InlineData(PrivateGalleryProvider.NuGet)]
     public void Create_RejectsResolvedPowerShellGalleryName(PrivateGalleryProvider provider)
     {
         var ex = Assert.Throws<ArgumentException>(() => PrivateGalleryRepositoryEndpoints.Create(
             provider,
             repositoryName: "PSGallery",
+            repository: "EvotecIT",
             repositoryUri: "https://example.test/v3/index.json"));
 
         Assert.Contains("PSGallery", ex.Message, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge/Models/Configuration/ConfigurationEnums.cs
+++ b/PowerForge/Models/Configuration/ConfigurationEnums.cs
@@ -55,7 +55,11 @@ public enum PrivateGalleryProvider
     /// <summary>JFrog Artifactory NuGet/PowerShell repository.</summary>
     JFrog = 1,
     /// <summary>Generic NuGet-backed PowerShell repository.</summary>
-    NuGet = 2
+    NuGet = 2,
+    /// <summary>GitHub Packages NuGet registry scoped to a GitHub user or organization.</summary>
+    GitHubPackages = 3,
+    /// <summary>Alias for GitHub Packages NuGet registry.</summary>
+    GitHub = 3
 }
 
 /// <summary>

--- a/PowerForge/Services/PrivateGalleryRepositoryEndpoints.cs
+++ b/PowerForge/Services/PrivateGalleryRepositoryEndpoints.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace PowerForge;
 
@@ -8,7 +9,7 @@ namespace PowerForge;
 public static class PrivateGalleryRepositoryEndpoints
 {
     /// <summary>
-    /// Resolves Azure Artifacts, JFrog, or generic NuGet private-gallery inputs into concrete repository endpoints.
+    /// Resolves Azure Artifacts, JFrog, GitHub Packages, or generic NuGet private-gallery inputs into concrete repository endpoints.
     /// </summary>
     public static PrivateGalleryRepositoryEndpoint Create(
         PrivateGalleryProvider provider,
@@ -21,7 +22,8 @@ public static class PrivateGalleryRepositoryEndpoints
         string? repositorySourceUri = null,
         string? repositoryPublishUri = null,
         string? jfrogBaseUri = null,
-        string? jfrogRepository = null)
+        string? jfrogRepository = null,
+        string? gitHubOwner = null)
     {
         if (provider == PrivateGalleryProvider.AzureArtifacts)
         {
@@ -87,8 +89,34 @@ public static class PrivateGalleryRepositoryEndpoints
                 remoteRepository);
         }
 
+        if (provider == PrivateGalleryProvider.GitHubPackages)
+        {
+            var owner = NormalizeGitHubOwner(gitHubOwner) ?? NormalizeGitHubOwner(repository);
+            if (string.IsNullOrWhiteSpace(owner))
+                throw new ArgumentException("GitHubOwner or Repository is required for GitHub Packages.", nameof(gitHubOwner));
+
+            var githubName = ResolveRepositoryName(repositoryName, owner);
+            if (string.IsNullOrWhiteSpace(githubName))
+                throw new ArgumentException("RepositoryName is required for GitHub Packages when no owner is provided.", nameof(repositoryName));
+
+            var serviceIndex = NormalizeOptional(repositoryUri) ?? $"https://nuget.pkg.github.com/{Uri.EscapeDataString(owner!)}/index.json";
+            var sourceUri = NormalizeOptional(repositorySourceUri) ?? serviceIndex;
+
+            return new PrivateGalleryRepositoryEndpoint(
+                PrivateGalleryProvider.GitHubPackages,
+                githubName!,
+                null,
+                null,
+                owner!,
+                sourceUri,
+                NormalizeOptional(repositoryPublishUri) ?? sourceUri,
+                serviceIndex,
+                null,
+                null);
+        }
+
         if (provider != PrivateGalleryProvider.NuGet)
-            throw new ArgumentException($"Provider '{provider}' is not supported. Supported values: AzureArtifacts, JFrog, NuGet.", nameof(provider));
+            throw new ArgumentException($"Provider '{provider}' is not supported. Supported values: AzureArtifacts, JFrog, GitHubPackages, NuGet.", nameof(provider));
 
         var genericName = ResolveRepositoryName(repositoryName, repository);
         if (string.IsNullOrWhiteSpace(genericName))
@@ -124,6 +152,18 @@ public static class PrivateGalleryRepositoryEndpoints
             return null;
 
         return value!.Trim().Trim('/');
+    }
+
+    private static string? NormalizeGitHubOwner(string? value)
+    {
+        var owner = NormalizeOptional(value);
+        if (owner is null)
+            return null;
+
+        if (owner.Contains('/') || owner.Contains('\\') || owner.Any(char.IsWhiteSpace))
+            throw new ArgumentException("GitHub owner must be a single GitHub user or organization name.", nameof(value));
+
+        return owner;
     }
 }
 
@@ -188,4 +228,7 @@ public sealed class PrivateGalleryRepositoryEndpoint
 
     /// <summary>JFrog NuGet repository key when the provider is JFrog.</summary>
     public string? JFrogRepository { get; }
+
+    /// <summary>GitHub user or organization namespace when the provider is GitHub Packages.</summary>
+    public string? GitHubOwner => Provider == PrivateGalleryProvider.GitHubPackages ? Repository : null;
 }


### PR DESCRIPTION
## Summary
- add GitHub Packages as a first-class private NuGet provider for repository profiles
- persist and report GitHub owner metadata, and resolve owner-scoped NuGet endpoints
- let `Publish-NugetPackage -ProfileName` use `GITHUB_TOKEN`/`GH_TOKEN` for GitHub Packages profiles
- document the private feed publish/restore flow for packages such as `Licensing.Verification`

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "PrivateGalleryRepositoryEndpointsTests|ModuleRepositoryProfileStoreTests|PrivateGalleryServiceTests"`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net8.0`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472`
- `pwsh -NoProfile -Command '$env:PSPUBLISHMODULE_TEST_MANIFEST_PATH=(Resolve-Path ".\PSPublishModule\bin\Release\net8.0\PSPublishModule.dll").Path; Invoke-Pester -Path ".\Module\Tests\PrivateGallery.Commands.Tests.ps1" -Output Detailed'`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore`
- `dotnet test .\PowerForge.Net472SmokeTests\PowerForge.Net472SmokeTests.csproj -c Release --no-restore`
- `git diff --check`

## Notes
- `dotnet test .\PSPublishModule.sln -c Release` was started but hung in the broad solution lane after unrelated project output; I stopped that test process tree and validated the touched shared/module surfaces separately.
- `node .\Build\linecount.js . 800` currently fails on many pre-existing oversized files in the repo; this PR does not try to turn the private-feed provider slice into a broad decomposition pass.