### PR TITLE
Handle PowerShell parameter-set API signatures

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorMemberSignatureWarningsTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorMemberSignatureWarningsTests.cs
@@ -160,10 +160,45 @@ public class WebApiDocsGeneratorMemberSignatureWarningsTests
         }
     }
 
+    [Fact]
+    public void Generate_WarnsForPowerShellDuplicateSyntaxWhenExplicitParameterSetNamesAreDuplicated()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-powershell-duplicate-explicit-parameter-sets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        var helpPath = Path.Combine(root, "PSWriteOffice-help.xml");
+        File.WriteAllText(helpPath, CreatePowerShellDuplicateSyntaxHelpXml(includeExplicitParameterSetNames: true, duplicateExplicitParameterSetName: true));
+
+        var outputPath = Path.Combine(root, "api");
+        var options = new WebApiDocsOptions
+        {
+            Type = ApiDocsType.PowerShell,
+            HelpPath = helpPath,
+            OutputPath = outputPath,
+            Format = "json",
+            BaseUrl = "/api"
+        };
+
+        try
+        {
+            var result = WebApiDocsGenerator.Generate(options);
+            Assert.Contains(result.Warnings, warning => warning.Contains("[PFWEB.APIDOCS.MEMBER.SIGNATURES]", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
     private static string CreatePowerShellDuplicateSyntaxHelpXml(bool includeExplicitParameterSetNames)
+        => CreatePowerShellDuplicateSyntaxHelpXml(includeExplicitParameterSetNames, duplicateExplicitParameterSetName: false);
+
+    private static string CreatePowerShellDuplicateSyntaxHelpXml(bool includeExplicitParameterSetNames, bool duplicateExplicitParameterSetName)
     {
         var firstSetAttribute = includeExplicitParameterSetNames ? " parameterSetName=\"Document\"" : string.Empty;
-        var secondSetAttribute = includeExplicitParameterSetNames ? " parameterSetName=\"PipelineDocument\"" : string.Empty;
+        var secondSetName = duplicateExplicitParameterSetName ? "Document" : "PipelineDocument";
+        var secondSetAttribute = includeExplicitParameterSetNames ? $" parameterSetName=\"{secondSetName}\"" : string.Empty;
 
         return
             $$"""

--- a/PowerForge.Tests/WebApiDocsGeneratorMemberSignatureWarningsTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorMemberSignatureWarningsTests.cs
@@ -97,4 +97,114 @@ public class WebApiDocsGeneratorMemberSignatureWarningsTests
                 Directory.Delete(root, true);
         }
     }
+
+    [Fact]
+    public void Generate_DoesNotWarnForPowerShellParameterSetsWithSameRenderedSyntax()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-powershell-parameter-sets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        var helpPath = Path.Combine(root, "PSWriteOffice-help.xml");
+        File.WriteAllText(helpPath, CreatePowerShellDuplicateSyntaxHelpXml(includeExplicitParameterSetNames: true));
+
+        var outputPath = Path.Combine(root, "api");
+        var options = new WebApiDocsOptions
+        {
+            Type = ApiDocsType.PowerShell,
+            HelpPath = helpPath,
+            OutputPath = outputPath,
+            Format = "json",
+            BaseUrl = "/api"
+        };
+
+        try
+        {
+            var result = WebApiDocsGenerator.Generate(options);
+            Assert.DoesNotContain(result.Warnings, warning => warning.Contains("[PFWEB.APIDOCS.MEMBER.SIGNATURES]", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_WarnsForPowerShellDuplicateSyntaxWhenParameterSetNamesAreGenerated()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-powershell-generated-parameter-sets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        var helpPath = Path.Combine(root, "PSWriteOffice-help.xml");
+        File.WriteAllText(helpPath, CreatePowerShellDuplicateSyntaxHelpXml(includeExplicitParameterSetNames: false));
+
+        var outputPath = Path.Combine(root, "api");
+        var options = new WebApiDocsOptions
+        {
+            Type = ApiDocsType.PowerShell,
+            HelpPath = helpPath,
+            OutputPath = outputPath,
+            Format = "json",
+            BaseUrl = "/api"
+        };
+
+        try
+        {
+            var result = WebApiDocsGenerator.Generate(options);
+            Assert.Contains(result.Warnings, warning => warning.Contains("[PFWEB.APIDOCS.MEMBER.SIGNATURES]", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    private static string CreatePowerShellDuplicateSyntaxHelpXml(bool includeExplicitParameterSetNames)
+    {
+        var firstSetAttribute = includeExplicitParameterSetNames ? " parameterSetName=\"Document\"" : string.Empty;
+        var secondSetAttribute = includeExplicitParameterSetNames ? " parameterSetName=\"PipelineDocument\"" : string.Empty;
+
+        return
+            $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <helpItems schema="maml" xmlns="http://msh" xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10">
+              <command:command>
+                <command:details>
+                  <command:name>Add-OfficeMarkdownTable</command:name>
+                  <maml:description>
+                    <maml:para>Adds a table to a markdown document.</maml:para>
+                  </maml:description>
+                </command:details>
+                <maml:description>
+                  <maml:para>Adds a table to a markdown document.</maml:para>
+                </maml:description>
+                <command:syntax>
+                  <command:syntaxItem{{firstSetAttribute}}>
+                    <command:name>Add-OfficeMarkdownTable</command:name>
+                    <command:parameter required="true" globbing="false" pipelineInput="false" position="named">
+                      <maml:name>Document</maml:name>
+                      <command:parameterValue required="true">MarkdownDoc</command:parameterValue>
+                    </command:parameter>
+                    <command:parameter required="true" globbing="false" pipelineInput="true" position="named">
+                      <maml:name>InputObject</maml:name>
+                      <command:parameterValue required="true">object</command:parameterValue>
+                    </command:parameter>
+                  </command:syntaxItem>
+                  <command:syntaxItem{{secondSetAttribute}}>
+                    <command:name>Add-OfficeMarkdownTable</command:name>
+                    <command:parameter required="true" globbing="false" pipelineInput="true" position="named">
+                      <maml:name>Document</maml:name>
+                      <command:parameterValue required="true">MarkdownDoc</command:parameterValue>
+                    </command:parameter>
+                    <command:parameter required="true" globbing="false" pipelineInput="true" position="named">
+                      <maml:name>InputObject</maml:name>
+                      <command:parameterValue required="true">object</command:parameterValue>
+                    </command:parameter>
+                  </command:syntaxItem>
+                </command:syntax>
+              </command:command>
+            </helpItems>
+            """;
+    }
 }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.DisplayAndValidation.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.DisplayAndValidation.cs
@@ -222,7 +222,7 @@ public static partial class WebApiDocsGenerator
 
         var signature = NormalizeSignatureKey(member.Signature);
         if (!string.IsNullOrWhiteSpace(signature))
-            return signature;
+            return BuildMemberSignatureKeyWithPowerShellParameterSet(member, signature);
 
         var name = string.IsNullOrWhiteSpace(member.DisplayName) ? member.Name : member.DisplayName;
         name = NormalizeSignatureKey(name);
@@ -235,7 +235,25 @@ public static partial class WebApiDocsGenerator
         var parameterTypes = member.Parameters
             .Select(parameter => NormalizeSignatureKey(parameter.Type))
             .ToArray();
-        return $"{name}({string.Join(",", parameterTypes)})";
+        return BuildMemberSignatureKeyWithPowerShellParameterSet(member, $"{name}({string.Join(",", parameterTypes)})");
+    }
+
+    private static string BuildMemberSignatureKeyWithPowerShellParameterSet(ApiMemberModel member, string signatureKey)
+    {
+        if (string.IsNullOrWhiteSpace(signatureKey))
+            return string.Empty;
+
+        if (!string.Equals(member.Kind, "CommandSyntax", StringComparison.OrdinalIgnoreCase))
+            return signatureKey;
+
+        if (!member.HasExplicitParameterSetName)
+            return signatureKey;
+
+        var parameterSetName = NormalizeSignatureKey(member.ParameterSetName);
+        if (string.IsNullOrWhiteSpace(parameterSetName))
+            return signatureKey;
+
+        return $"{signatureKey}|powershell-parameter-set:{parameterSetName}";
     }
 
     private static string BuildMemberSignatureLabel(ApiMemberModel member)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.DisplayAndValidation.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.DisplayAndValidation.cs
@@ -249,7 +249,7 @@ public static partial class WebApiDocsGenerator
         if (!member.HasExplicitParameterSetName)
             return signatureKey;
 
-        var parameterSetName = NormalizeSignatureKey(member.ParameterSetName);
+        var parameterSetName = NormalizeSignatureKey(member.SourceParameterSetName);
         if (string.IsNullOrWhiteSpace(parameterSetName))
             return signatureKey;
 

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
@@ -70,6 +70,7 @@ public static partial class WebApiDocsGenerator
         public string? Summary { get; set; }
         public string? Kind { get; set; }
         public string? ParameterSetName { get; set; }
+        public string? SourceParameterSetName { get; set; }
         public bool HasExplicitParameterSetName { get; set; }
         public bool IncludesCommonParameters { get; set; }
         public string? Signature { get; set; }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
@@ -70,6 +70,7 @@ public static partial class WebApiDocsGenerator
         public string? Summary { get; set; }
         public string? Kind { get; set; }
         public string? ParameterSetName { get; set; }
+        public bool HasExplicitParameterSetName { get; set; }
         public bool IncludesCommonParameters { get; set; }
         public string? Signature { get; set; }
         public string? ReturnType { get; set; }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Parse.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Parse.cs
@@ -179,6 +179,7 @@ public static partial class WebApiDocsGenerator
                         Name = name!,
                         Kind = "CommandSyntax",
                         ParameterSetName = parameterSetName,
+                        SourceParameterSetName = parameterSetName,
                         HasExplicitParameterSetName = !string.IsNullOrWhiteSpace(parameterSetName),
                         IncludesCommonParameters = includesCommonParameters,
                         Returns = returns,

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Parse.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Parse.cs
@@ -173,11 +173,13 @@ public static partial class WebApiDocsGenerator
             {
                 foreach (var syntaxItem in syntax.Elements(commandNs + "syntaxItem"))
                 {
+                    var parameterSetName = ResolvePowerShellParameterSetName(syntaxItem, commandNs, mamlNs, devNs);
                     var member = new ApiMemberModel
                     {
                         Name = name!,
                         Kind = "CommandSyntax",
-                        ParameterSetName = ResolvePowerShellParameterSetName(syntaxItem, commandNs, mamlNs, devNs),
+                        ParameterSetName = parameterSetName,
+                        HasExplicitParameterSetName = !string.IsNullOrWhiteSpace(parameterSetName),
                         IncludesCommonParameters = includesCommonParameters,
                         Returns = returns,
                         ReturnType = type.OutputTypes.Count == 1 ? type.OutputTypes[0] : null


### PR DESCRIPTION
## Summary
- include PowerShell command syntax parameter-set names in duplicate signature warning keys
- keep duplicate-signature warnings for C# members and unnamed PowerShell syntax intact
- add regression coverage for PSWriteOffice-style parameter sets with identical rendered syntax

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter WebApiDocsGeneratorMemberSignatureWarningsTests`
- `dotnet run --project .\PowerForge.Web.Cli\PowerForge.Web.Cli.csproj --framework net10.0 -c Release -- apidocs --type powershell --help-path C:\Support\GitHub\PSWriteOffice\WebsiteArtifacts\apidocs\powershell\PSWriteOffice-help.xml --out <temp> --format json --base-url /api` (287 types, no PFWEB.APIDOCS.MEMBER.SIGNATURES warning)
- `git diff --check`