### PR TITLE
Add JFrog private gallery auth modes

### DIFF
--- a/Docs/PSPublishModule.PrivateGalleries.md
+++ b/Docs/PSPublishModule.PrivateGalleries.md
@@ -1,8 +1,10 @@
 # PSPublishModule Private Galleries
 
-This page describes the supported enterprise flow for consuming private modules
-from Azure Artifacts with PSPublishModule and the related Microsoft Artifact
-Registry (MAR) intake path for Microsoft-owned packages.
+This page describes the supported enterprise flow for consuming and publishing
+private PowerShell modules with PSPublishModule. It covers Azure Artifacts,
+JFrog Artifactory, generic NuGet-compatible feeds, GitHub Packages, and the
+related Microsoft Artifact Registry (MAR) intake path for Microsoft-owned
+packages.
 
 For the short maintainer/end-user process used for the Evotec private feed, see
 `Docs/PSPublishModule.PrivateGalleryProcess.md`.
@@ -40,6 +42,212 @@ Install Microsoft-owned packages from MAR with the wrapper or native command:
 Install-PrivateModule -MicrosoftArtifactRegistry -Name Microsoft.PowerShell.SecretManagement
 Install-PSResource -Repository MAR -Name Microsoft.PowerShell.SecretManagement
 ```
+
+## JFrog Artifactory
+
+JFrog Artifactory is supported as a NuGet-compatible private PowerShell module
+repository. PSPublishModule can derive the required PowerShellGet and
+PSResourceGet endpoints from the Artifactory base URI and the NuGet repository
+key:
+
+```text
+Base URI:   https://company.jfrog.io/artifactory
+Repository: powershell-virtual
+PSResourceGet endpoint:
+  https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json
+PowerShellGet source/publish endpoint:
+  https://company.jfrog.io/artifactory/api/nuget/powershell-virtual
+```
+
+### JFrog Publisher Configuration With PAT/Basic Auth
+
+Use this when the same JFrog PAT or access token is accepted as the repository
+credential for publishing and for authenticated read/probe operations. This is
+the preferred simple build configuration because it avoids a pre-created local
+profile and avoids duplicating the same PAT as a NuGet API key:
+
+```powershell
+New-ConfigurationPublish `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -RepositoryName 'JFrogPS' `
+    -Tool PSResourceGet `
+    -RepositoryCredentialUserName 'name@company.com' `
+    -RepositoryCredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
+    -Enabled:$true
+```
+
+The local repository name can be omitted when the Artifactory repository key is
+also an acceptable local PowerShell repository name. Keep it when you want a
+shorter or clearer local alias such as `JFrogPS`.
+
+For CI, prefer an environment variable over a local secret file:
+
+```powershell
+New-ConfigurationPublish `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -RepositoryName 'JFrogPS' `
+    -Tool PSResourceGet `
+    -RepositoryCredentialUserName 'name@company.com' `
+    -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' `
+    -Enabled:$true
+```
+
+### JFrog Publisher Configuration With Separate NuGet API Key
+
+Use this only when Artifactory requires a NuGet API key for package push in
+addition to a repository credential for registration, probing, or authenticated
+feed access:
+
+```powershell
+New-ConfigurationPublish `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -RepositoryName 'JFrogPS' `
+    -Tool PSResourceGet `
+    -FilePath 'C:\Support\Important\JFrogNuGetApiKey.txt' `
+    -RepositoryCredentialUserName 'name@company.com' `
+    -RepositoryCredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
+    -Enabled:$true
+```
+
+### JFrog OIDC / Federated CI Authentication
+
+Use JFrog OIDC token exchange when the build runner can obtain a short-lived
+OIDC token from the CI platform. PSPublishModule runs `jf eot` at publish time,
+parses the returned JFrog username/access token, and passes that credential to
+PSResourceGet or PowerShellGet. The resulting access token is not written into
+the publish configuration.
+
+```powershell
+New-ConfigurationPublish `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -RepositoryName 'JFrogPS' `
+    -Tool PSResourceGet `
+    -JFrogOidcProvider 'azure-oidc' `
+    -JFrogOidcProviderType Azure `
+    -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' `
+    -Enabled:$true
+```
+
+Provider type choices are:
+
+- `GitHub` for GitHub Actions OIDC.
+- `Azure` for Azure DevOps or Entra-backed JFrog OIDC mappings.
+- `GenericOidc` for other OIDC-compatible CI providers.
+
+`JFrogPlatformUri` can be supplied when the platform URL is not derivable from
+`JFrogBaseUri`. For the common SaaS shape above, PSPublishModule derives
+`https://company.jfrog.io/` from `https://company.jfrog.io/artifactory`.
+
+This is the right direction for FAMS/federated-style automation because it uses
+the identity provider to mint a short-lived token and exchanges it for a JFrog
+access token only during the publish run. It still needs a real JFrog OIDC
+integration, identity mapping, feed permission, JFrog CLI on PATH, and live
+publish proof before it should be treated as production-ready.
+
+### JFrog Browser SSO / Entra Login
+
+If JFrog is connected to Microsoft Entra ID through SAML/OIDC SSO, interactive
+users can use the existing JFrog CLI browser-login bootstrap path:
+
+```powershell
+Connect-ModuleRepository `
+    -Provider JFrog `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -Name 'JFrogPS' `
+    -Tool PSResourceGet `
+    -BootstrapMode JFrogCli `
+    -InstallPrerequisites `
+    -Verbose
+```
+
+This runs `jf login` and then probes whether PowerShell repository tooling can
+use the resulting session. Treat it as an interactive workstation/bootstrap
+test, not as the default publish configuration: JFrog CLI browser login is not
+CI-friendly, and PSResourceGet/PowerShellGet may still require an explicit
+repository credential, access token, or OIDC exchange result.
+
+### JFrog Connection And Install Test
+
+Before handing a feed to publishers or end users, test both authenticated access
+and module install from a clean shell:
+
+```powershell
+Connect-ModuleRepository `
+    -Provider JFrog `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -Name 'JFrogPS' `
+    -Tool PSResourceGet `
+    -CredentialUserName 'name@company.com' `
+    -CredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
+    -InstallPrerequisites `
+    -Verbose
+
+Install-PrivateModule `
+    -Name 'YourModuleName' `
+    -Repository 'JFrogPS' `
+    -CredentialUserName 'name@company.com' `
+    -CredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
+    -Force
+```
+
+Use a PAT or access token with the minimum Artifactory permissions required for
+the scenario: read for install/update validation, and deploy/publish for module
+release builds. Keep tokens outside committed configuration by using environment
+variables, CI secrets, or local secret files.
+
+### JFrog Profile For Workstation Onboarding
+
+A profile is still useful for managed workstation onboarding because it stores
+the non-secret feed shape once and lets install/update commands reference a
+stable profile name:
+
+```powershell
+Set-ModuleRepositoryProfile `
+    -Name 'JFrogPS' `
+    -Provider JFrog `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -RepositoryName 'JFrogPS' `
+    -Tool PSResourceGet `
+    -Trusted $true
+
+Install-PrivateModule `
+    -Name 'YourModuleName' `
+    -ProfileName 'JFrogPS' `
+    -CredentialUserName 'name@company.com' `
+    -CredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt'
+```
+
+Profiles should contain feed metadata only. Do not store PATs, passwords, or
+session tokens in exported profile JSON.
+
+## Other NuGet-Compatible Private Feeds
+
+For a private feed that is not one of the provider-specific presets, use the
+generic repository URI parameters. This is also the escape hatch when a vendor
+uses nonstandard NuGet endpoints:
+
+```powershell
+New-ConfigurationPublish `
+    -Type PowerShellGallery `
+    -RepositoryName 'CompanyModules' `
+    -Tool PSResourceGet `
+    -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' `
+    -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' `
+    -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' `
+    -RepositoryCredentialUserName 'publisher' `
+    -RepositoryCredentialSecretFilePath 'C:\Support\Important\CompanyFeedToken.txt' `
+    -Enabled:$true
+```
+
+If the repository also requires a separate NuGet API key for push, add
+`-FilePath` or `-ApiKey` to the publish configuration.
 
 For production estates, keep using a central enterprise feed such as Azure
 Artifacts as the only trusted runtime source. The recommended flow is:
@@ -503,10 +711,11 @@ Azure DevOps Services and client tooling support it.
 
 ## Other Private Feeds
 
-The profile model is intentionally provider-shaped, but the only implemented
-managed provider is currently Azure Artifacts. JFrog and generic NuGet v3 feeds
-should be added as explicit providers/adapters with their own credential policy
-instead of overloading Azure Artifacts behavior.
+The profile model is intentionally provider-shaped. Azure Artifacts and JFrog
+have first-class provider paths; generic NuGet v2/v3 feeds and GitHub Packages
+remain available through explicit repository URI and credential parameters.
+When a feed has its own credential policy, keep it explicit in configuration
+instead of overloading the Azure Artifacts credential-provider behavior.
 
 ## Live Azure Artifacts Validation
 

--- a/Module/Docs/New-ConfigurationPublish.md
+++ b/Module/Docs/New-ConfigurationPublish.md
@@ -6,27 +6,32 @@ schema: 2.0.0
 ---
 # New-ConfigurationPublish
 ## SYNOPSIS
-Provides a way to configure publishing to PowerShell Gallery, GitHub, or private galleries such as Azure Artifacts.
+Provides a way to configure publishing to PowerShell Gallery, GitHub, JFrog Artifactory, or other private PowerShell module repositories.
 
 ## SYNTAX
 ### ApiFromFile (Default)
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> -FilePath <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> -FilePath <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-JFrogBaseUri <string>] [-JFrogRepository <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ### ApiKey
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> -ApiKey <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> -ApiKey <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-JFrogBaseUri <string>] [-JFrogRepository <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ### AzureArtifacts
 ```powershell
-New-ConfigurationPublish -AzureDevOpsOrganization <string> -AzureArtifactsFeed <string> [-AzureDevOpsProject <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -AzureDevOpsOrganization <string> -AzureArtifactsFeed <string> [-AzureDevOpsProject <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ### Profile
 ```powershell
-New-ConfigurationPublish -ProfileName <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-Enabled] [-Force] [-ID <string>] [<CommonParameters>]
+New-ConfigurationPublish -ProfileName <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-Force] [-ID <string>] [<CommonParameters>]
+```
+
+### JFrog
+```powershell
+New-ConfigurationPublish -JFrogBaseUri <string> -JFrogRepository <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-JFrogPlatformUri <string>] [-JFrogOidcProvider <string>] [-JFrogOidcTokenId <string>] [-JFrogOidcTokenIdEnvironmentVariable <string>] [-JFrogOidcProviderType <JFrogOidcProviderType>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,9 +39,12 @@ This cmdlet emits publish configuration consumed by Invoke-ModuleBuild / Build-M
 Use -Type to choose a destination. For repository publishing, -Tool selects the provider
 (PowerShellGet/PSResourceGet/Auto).
 
-For private repositories (for example Azure DevOps Artifacts / private NuGet v3 feeds), provide repository URIs
-and (optionally) credentials, or use the Azure Artifacts preset parameters to resolve those URIs automatically.
+For private repositories (for example Azure DevOps Artifacts, JFrog Artifactory, GitHub Packages, or private NuGet v3 feeds), provide repository URIs
+and (optionally) credentials, or use provider-specific preset parameters to resolve those URIs automatically.
 To avoid secrets in source control, pass API keys/tokens via -FilePath or environment-specific tooling.
+
+JFrog Artifactory can be configured directly with -JFrogBaseUri and -JFrogRepository.
+For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -ApiKey only when the feed requires a separate NuGet API key for package push.
 
 ## EXAMPLES
 
@@ -58,14 +66,38 @@ New-ConfigurationPublish -ProfileName 'Company' -Enabled
 ```
 
 
+### EXAMPLE 4
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
+```
+
+
+### EXAMPLE 5
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
+```
+
+
+### EXAMPLE 6
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
+```
+
+
+### EXAMPLE 7
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled
+```
+
+
 ## PARAMETERS
 
 ### -ApiKey
-API key to be used for publishing in clear text.
+API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.
 
 ```yaml
 Type: String
-Parameter Sets: ApiKey, Profile
+Parameter Sets: ApiKey, Profile, JFrog
 Aliases: None
 Possible values:
 
@@ -145,7 +177,7 @@ Enable publishing to the chosen destination.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
 Aliases: None
 Possible values:
 
@@ -161,7 +193,7 @@ When true, registers/updates the repository before publishing. Default: true.
 
 ```yaml
 Type: Boolean
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values:
 
@@ -173,11 +205,11 @@ Accept wildcard characters: True
 ```
 
 ### -FilePath
-API key to be used for publishing in clear text in a file.
+API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, Profile
+Parameter Sets: ApiFromFile, Profile, JFrog
 Aliases: None
 Possible values:
 
@@ -193,7 +225,7 @@ Allow publishing lower version of a module on a PowerShell repository.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
 Aliases: None
 Possible values:
 
@@ -225,11 +257,123 @@ Optional ID of the artefact used for publishing.
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
 Aliases: None
 Possible values:
 
 Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -JFrogBaseUri
+JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.
+
+```yaml
+Type: String
+Parameter Sets: ApiFromFile, ApiKey, JFrog
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -JFrogOidcProvider
+JFrog OIDC provider name configured in Artifactory. Enables runtime token exchange through JFrog CLI.
+
+```yaml
+Type: String
+Parameter Sets: JFrog
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -JFrogOidcProviderType
+JFrog OIDC provider implementation passed to JFrog CLI. Use Azure for Azure DevOps or Entra-backed OIDC mappings.
+
+```yaml
+Type: JFrogOidcProviderType
+Parameter Sets: JFrog
+Aliases: None
+Possible values: GitHub, Azure, GenericOidc
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -JFrogOidcTokenId
+CI-issued OIDC token value used by JFrog CLI token exchange. Prefer JFrogOidcTokenIdEnvironmentVariable in CI.
+
+```yaml
+Type: String
+Parameter Sets: JFrog
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -JFrogOidcTokenIdEnvironmentVariable
+Environment variable containing the CI-issued OIDC token value used by JFrog CLI token exchange.
+
+```yaml
+Type: String
+Parameter Sets: JFrog
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -JFrogPlatformUri
+JFrog Platform URL used for JFrog CLI OIDC token exchange. Defaults from JFrogBaseUri when omitted.
+
+```yaml
+Type: String
+Parameter Sets: JFrog
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -JFrogRepository
+JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.
+
+```yaml
+Type: String
+Parameter Sets: ApiFromFile, ApiKey, JFrog
+Aliases: None
+Possible values:
+
+Required: True
 Position: named
 Default value: None
 Accept pipeline input: False
@@ -273,7 +417,7 @@ Repository API version for PSResourceGet registration (v2/v3).
 
 ```yaml
 Type: RepositoryApiVersion
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values: Auto, V2, V3, ContainerRegistry
 
@@ -285,11 +429,27 @@ Accept wildcard characters: True
 ```
 
 ### -RepositoryCredentialSecret
-Repository credential secret (password/token) in clear text.
+Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -RepositoryCredentialSecretEnvironmentVariable
+Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.
+
+```yaml
+Type: String
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
 Aliases: None
 Possible values:
 
@@ -301,11 +461,11 @@ Accept wildcard characters: True
 ```
 
 ### -RepositoryCredentialSecretFilePath
-Repository credential secret (password/token) in a clear-text file.
+Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
 Aliases: None
 Possible values:
 
@@ -317,11 +477,11 @@ Accept wildcard characters: True
 ```
 
 ### -RepositoryCredentialUserName
-Repository credential username (basic auth).
+Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
 Aliases: None
 Possible values:
 
@@ -337,7 +497,7 @@ Repository name override (GitHub or PowerShell repository name).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values:
 
@@ -353,7 +513,7 @@ Repository priority for PSResourceGet (lower is higher priority).
 
 ```yaml
 Type: Nullable`1
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values:
 
@@ -401,7 +561,7 @@ Whether to mark the repository as trusted (avoids prompts). Default: true.
 
 ```yaml
 Type: Boolean
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values:
 
@@ -433,7 +593,7 @@ Publishing tool/provider used for repository publishing. Ignored for GitHub publ
 
 ```yaml
 Type: PublishTool
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values: Auto, PSResourceGet, PowerShellGet
 
@@ -465,7 +625,7 @@ When set, unregisters the repository after publish if it was created by this run
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values:
 
@@ -481,7 +641,7 @@ Use this PowerShell repository as the source for resolving Auto/Latest dependenc
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts
+Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
 Aliases: None
 Possible values:
 

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -29810,16 +29810,18 @@ without hardcoding them into source files.</maml:para>
       <command:verb>New</command:verb>
       <command:noun>ConfigurationPublish</command:noun>
       <maml:description>
-        <maml:para>Provides a way to configure publishing to PowerShell Gallery, GitHub, or private galleries such as Azure Artifacts.</maml:para>
+        <maml:para>Provides a way to configure publishing to PowerShell Gallery, GitHub, JFrog Artifactory, or other private PowerShell module repositories.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
       <maml:para>This cmdlet emits publish configuration consumed by Invoke-ModuleBuild / Build-Module.&#xD;
 Use -Type to choose a destination. For repository publishing, -Tool selects the provider&#xD;
 (PowerShellGet/PSResourceGet/Auto).</maml:para>
-      <maml:para>For private repositories (for example Azure DevOps Artifacts / private NuGet v3 feeds), provide repository URIs&#xD;
-and (optionally) credentials, or use the Azure Artifacts preset parameters to resolve those URIs automatically.&#xD;
+      <maml:para>For private repositories (for example Azure DevOps Artifacts, JFrog Artifactory, GitHub Packages, or private NuGet v3 feeds), provide repository URIs&#xD;
+and (optionally) credentials, or use provider-specific preset parameters to resolve those URIs automatically.&#xD;
 To avoid secrets in source control, pass API keys/tokens via -FilePath or environment-specific tooling.</maml:para>
+      <maml:para>JFrog Artifactory can be configured directly with -JFrogBaseUri and -JFrogRepository.&#xD;
+For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -ApiKey only when the feed requires a separate NuGet API key for package push.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="ApiFromFile">
@@ -29863,7 +29865,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>FilePath</maml:name>
           <maml:description>
-            <maml:para>API key to be used for publishing in clear text in a file.</maml:para>
+            <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -29908,6 +29910,30 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogBaseUri</maml:name>
+          <maml:description>
+            <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogRepository</maml:name>
+          <maml:description>
+            <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OverwriteTagName</maml:name>
           <maml:description>
@@ -29941,7 +29967,19 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecret</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text.</maml:para>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -29953,7 +29991,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecretFilePath</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file.</maml:para>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -29965,7 +30003,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialUserName</maml:name>
           <maml:description>
-            <maml:para>Repository credential username (basic auth).</maml:para>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30121,7 +30159,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>ApiKey</maml:name>
           <maml:description>
-            <maml:para>API key to be used for publishing in clear text.</maml:para>
+            <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30202,6 +30240,30 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogBaseUri</maml:name>
+          <maml:description>
+            <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogRepository</maml:name>
+          <maml:description>
+            <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OverwriteTagName</maml:name>
           <maml:description>
@@ -30235,7 +30297,19 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecret</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text.</maml:para>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30247,7 +30321,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecretFilePath</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file.</maml:para>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30259,7 +30333,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialUserName</maml:name>
           <maml:description>
-            <maml:para>Repository credential username (basic auth).</maml:para>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30517,7 +30591,19 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecret</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text.</maml:para>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30529,7 +30615,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecretFilePath</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file.</maml:para>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30541,7 +30627,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialUserName</maml:name>
           <maml:description>
-            <maml:para>Repository credential username (basic auth).</maml:para>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30633,7 +30719,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>ApiKey</maml:name>
           <maml:description>
-            <maml:para>API key to be used for publishing in clear text.</maml:para>
+            <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30657,7 +30743,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>FilePath</maml:name>
           <maml:description>
-            <maml:para>API key to be used for publishing in clear text in a file.</maml:para>
+            <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30705,7 +30791,19 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecret</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text.</maml:para>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30717,7 +30815,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialSecretFilePath</maml:name>
           <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file.</maml:para>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -30729,11 +30827,318 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryCredentialUserName</maml:name>
           <maml:description>
-            <maml:para>Repository credential username (basic auth).</maml:para>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="JFrog">
+        <maml:name>New-ConfigurationPublish</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Enabled</maml:name>
+          <maml:description>
+            <maml:para>Enable publishing to the chosen destination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnsureRepositoryRegistered</maml:name>
+          <maml:description>
+            <maml:para>When true, registers/updates the repository before publishing. Default: true.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ID</maml:name>
+          <maml:description>
+            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogBaseUri</maml:name>
+          <maml:description>
+            <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogOidcProvider</maml:name>
+          <maml:description>
+            <maml:para>JFrog OIDC provider name configured in Artifactory. Enables runtime token exchange through JFrog CLI.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogOidcProviderType</maml:name>
+          <maml:description>
+            <maml:para>JFrog OIDC provider implementation passed to JFrog CLI. Use Azure for Azure DevOps or Entra-backed OIDC mappings.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">JFrogOidcProviderType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">GitHub</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Azure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GenericOidc</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>JFrogOidcProviderType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogOidcTokenId</maml:name>
+          <maml:description>
+            <maml:para>CI-issued OIDC token value used by JFrog CLI token exchange. Prefer JFrogOidcTokenIdEnvironmentVariable in CI.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogOidcTokenIdEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the CI-issued OIDC token value used by JFrog CLI token exchange.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogPlatformUri</maml:name>
+          <maml:description>
+            <maml:para>JFrog Platform URL used for JFrog CLI OIDC token exchange. Defaults from JFrogBaseUri when omitted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>JFrogRepository</maml:name>
+          <maml:description>
+            <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryApiVersion</maml:name>
+          <maml:description>
+            <maml:para>Repository API version for PSResourceGet registration (v2/v3).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">RepositoryApiVersion</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">V2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">V3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ContainerRegistry</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>RepositoryApiVersion</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecret</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialUserName</maml:name>
+          <maml:description>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryName</maml:name>
+          <maml:description>
+            <maml:para>Repository name override (GitHub or PowerShell repository name).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryPriority</maml:name>
+          <maml:description>
+            <maml:para>Repository priority for PSResourceGet (lower is higher priority).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryTrusted</maml:name>
+          <maml:description>
+            <maml:para>Whether to mark the repository as trusted (avoids prompts). Default: true.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Tool</maml:name>
+          <maml:description>
+            <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PublishTool</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSResourceGet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PowerShellGet</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>PublishTool</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UnregisterRepositoryAfterPublish</maml:name>
+          <maml:description>
+            <maml:para>When set, unregisters the repository after publish if it was created by this run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseAsDependencyVersionSource</maml:name>
+          <maml:description>
+            <maml:para>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -30744,7 +31149,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
       <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>ApiKey</maml:name>
         <maml:description>
-          <maml:para>API key to be used for publishing in clear text.</maml:para>
+          <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -30828,7 +31233,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
       <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>FilePath</maml:name>
         <maml:description>
-          <maml:para>API key to be used for publishing in clear text in a file.</maml:para>
+          <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -30867,6 +31272,95 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
           <maml:para>Optional ID of the artefact used for publishing.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JFrogBaseUri</maml:name>
+        <maml:description>
+          <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JFrogOidcProvider</maml:name>
+        <maml:description>
+          <maml:para>JFrog OIDC provider name configured in Artifactory. Enables runtime token exchange through JFrog CLI.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JFrogOidcProviderType</maml:name>
+        <maml:description>
+          <maml:para>JFrog OIDC provider implementation passed to JFrog CLI. Use Azure for Azure DevOps or Entra-backed OIDC mappings.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">JFrogOidcProviderType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">GitHub</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Azure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GenericOidc</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>JFrogOidcProviderType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JFrogOidcTokenId</maml:name>
+        <maml:description>
+          <maml:para>CI-issued OIDC token value used by JFrog CLI token exchange. Prefer JFrogOidcTokenIdEnvironmentVariable in CI.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JFrogOidcTokenIdEnvironmentVariable</maml:name>
+        <maml:description>
+          <maml:para>Environment variable containing the CI-issued OIDC token value used by JFrog CLI token exchange.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JFrogPlatformUri</maml:name>
+        <maml:description>
+          <maml:para>JFrog Platform URL used for JFrog CLI OIDC token exchange. Defaults from JFrogBaseUri when omitted.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>JFrogRepository</maml:name>
+        <maml:description>
+          <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
           <maml:uri />
@@ -30918,7 +31412,19 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>RepositoryCredentialSecret</maml:name>
         <maml:description>
-          <maml:para>Repository credential secret (password/token) in clear text.</maml:para>
+          <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+        <maml:description>
+          <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -30930,7 +31436,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>RepositoryCredentialSecretFilePath</maml:name>
         <maml:description>
-          <maml:para>Repository credential secret (password/token) in a clear-text file.</maml:para>
+          <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -30942,7 +31448,7 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>RepositoryCredentialUserName</maml:name>
         <maml:description>
-          <maml:para>Repository credential username (basic auth).</maml:para>
+          <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -31130,6 +31636,34 @@ To avoid secrets in source control, pass API keys/tokens via -FilePath or enviro
       <command:example>
         <maml:title>Publish to Azure Artifacts (private feed preset)</maml:title>
         <dev:code>New-ConfigurationPublish -ProfileName 'Company' -Enabled</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Publish to JFrog Artifactory with PAT/basic authentication</maml:title>
+        <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Publish to JFrog Artifactory with a separate NuGet API key</maml:title>
+        <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Publish to JFrog Artifactory with a PAT/access token stored in an environment variable</maml:title>
+        <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Publish to JFrog Artifactory with CI OIDC token exchange</maml:title>
+        <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>

--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -5,7 +5,7 @@ using PowerForge;
 namespace PSPublishModule;
 
 /// <summary>
-/// Provides a way to configure publishing to PowerShell Gallery, GitHub, or private galleries such as Azure Artifacts.
+/// Provides a way to configure publishing to PowerShell Gallery, GitHub, JFrog Artifactory, or other private PowerShell module repositories.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -14,9 +14,13 @@ namespace PSPublishModule;
 /// (PowerShellGet/PSResourceGet/Auto).
 /// </para>
 /// <para>
-/// For private repositories (for example Azure DevOps Artifacts / private NuGet v3 feeds), provide repository URIs
-/// and (optionally) credentials, or use the Azure Artifacts preset parameters to resolve those URIs automatically.
+/// For private repositories (for example Azure DevOps Artifacts, JFrog Artifactory, GitHub Packages, or private NuGet v3 feeds), provide repository URIs
+/// and (optionally) credentials, or use provider-specific preset parameters to resolve those URIs automatically.
 /// To avoid secrets in source control, pass API keys/tokens via <c>-FilePath</c> or environment-specific tooling.
+/// </para>
+/// <para>
+/// JFrog Artifactory can be configured directly with <c>-JFrogBaseUri</c> and <c>-JFrogRepository</c>.
+/// For PAT/basic-auth feeds, use repository credentials only. Add <c>-FilePath</c> or <c>-ApiKey</c> only when the feed requires a separate NuGet API key for package push.
 /// </para>
 /// </remarks>
 /// <example>
@@ -30,6 +34,22 @@ namespace PSPublishModule;
 /// <example>
 /// <summary>Publish to Azure Artifacts (private feed preset)</summary>
 /// <code>New-ConfigurationPublish -ProfileName 'Company' -Enabled</code>
+/// </example>
+/// <example>
+/// <summary>Publish to JFrog Artifactory with PAT/basic authentication</summary>
+/// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</code>
+/// </example>
+/// <example>
+/// <summary>Publish to JFrog Artifactory with a separate NuGet API key</summary>
+/// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</code>
+/// </example>
+/// <example>
+/// <summary>Publish to JFrog Artifactory with a PAT/access token stored in an environment variable</summary>
+/// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled</code>
+/// </example>
+/// <example>
+/// <summary>Publish to JFrog Artifactory with CI OIDC token exchange</summary>
+/// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled</code>
 /// </example>
 [Cmdlet(VerbsCommon.New, "ConfigurationPublish", DefaultParameterSetName = "ApiFromFile")]
 public sealed class NewConfigurationPublishCommand : PSCmdlet
@@ -57,14 +77,16 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [ValidateNotNullOrEmpty]
     public string ProfileName { get; set; } = string.Empty;
 
-    /// <summary>API key to be used for publishing in clear text in a file.</summary>
+    /// <summary>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string FilePath { get; set; } = string.Empty;
 
-    /// <summary>API key to be used for publishing in clear text.</summary>
+    /// <summary>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string ApiKey { get; set; } = string.Empty;
 
     /// <summary>GitHub username (required for GitHub publishing).</summary>
@@ -76,12 +98,14 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryName { get; set; }
 
     /// <summary>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public PowerForge.PublishTool Tool { get; set; } = PowerForge.PublishTool.Auto;
 
     /// <summary>Repository base URI (used for both source and publish unless overridden).</summary>
@@ -99,62 +123,111 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "ApiFromFile")]
     public string? RepositoryPublishUri { get; set; }
 
+    /// <summary>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(Mandatory = true, ParameterSetName = "JFrog")]
+    public string? JFrogBaseUri { get; set; }
+
+    /// <summary>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(Mandatory = true, ParameterSetName = "JFrog")]
+    public string? JFrogRepository { get; set; }
+
     /// <summary>Whether to mark the repository as trusted (avoids prompts). Default: true.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public bool RepositoryTrusted { get; set; } = true;
 
     /// <summary>Repository priority for PSResourceGet (lower is higher priority).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public int? RepositoryPriority { get; set; }
 
     /// <summary>Repository API version for PSResourceGet registration (v2/v3).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public PowerForge.RepositoryApiVersion RepositoryApiVersion { get; set; } = PowerForge.RepositoryApiVersion.Auto;
 
     /// <summary>When true, registers/updates the repository before publishing. Default: true.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public bool EnsureRepositoryRegistered { get; set; } = true;
 
     /// <summary>When set, unregisters the repository after publish if it was created by this run.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public SwitchParameter UnregisterRepositoryAfterPublish { get; set; }
 
-    /// <summary>Repository credential username (basic auth).</summary>
+    /// <summary>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryCredentialUserName { get; set; }
 
-    /// <summary>Repository credential secret (password/token) in clear text.</summary>
+    /// <summary>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryCredentialSecret { get; set; }
 
-    /// <summary>Repository credential secret (password/token) in a clear-text file.</summary>
+    /// <summary>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryCredentialSecretFilePath { get; set; }
+
+    /// <summary>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
+    public string? RepositoryCredentialSecretEnvironmentVariable { get; set; }
+
+    /// <summary>JFrog Platform URL used for JFrog CLI OIDC token exchange. Defaults from JFrogBaseUri when omitted.</summary>
+    [Parameter(ParameterSetName = "JFrog")]
+    public string? JFrogPlatformUri { get; set; }
+
+    /// <summary>JFrog OIDC provider name configured in Artifactory. Enables runtime token exchange through JFrog CLI.</summary>
+    [Parameter(ParameterSetName = "JFrog")]
+    public string? JFrogOidcProvider { get; set; }
+
+    /// <summary>CI-issued OIDC token value used by JFrog CLI token exchange. Prefer JFrogOidcTokenIdEnvironmentVariable in CI.</summary>
+    [Parameter(ParameterSetName = "JFrog")]
+    public string? JFrogOidcTokenId { get; set; }
+
+    /// <summary>Environment variable containing the CI-issued OIDC token value used by JFrog CLI token exchange.</summary>
+    [Parameter(ParameterSetName = "JFrog")]
+    public string? JFrogOidcTokenIdEnvironmentVariable { get; set; }
+
+    /// <summary>JFrog OIDC provider implementation passed to JFrog CLI. Use Azure for Azure DevOps or Entra-backed OIDC mappings.</summary>
+    [Parameter(ParameterSetName = "JFrog")]
+    public PowerForge.JFrogOidcProviderType JFrogOidcProviderType { get; set; } = PowerForge.JFrogOidcProviderType.GitHub;
 
     /// <summary>Enable publishing to the chosen destination.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public SwitchParameter Enabled { get; set; }
 
     /// <summary>Override tag name used for GitHub publishing.</summary>
@@ -167,6 +240,7 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public SwitchParameter Force { get; set; }
 
     /// <summary>Optional ID of the artefact used for publishing.</summary>
@@ -174,6 +248,7 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
     [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? ID { get; set; }
 
     /// <summary>Publish GitHub release as a release even if module prerelease is set.</summary>
@@ -190,6 +265,7 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "JFrog")]
     public SwitchParameter UseAsDependencyVersionSource { get; set; }
 
     /// <summary>Emits publish configuration for the build pipeline.</summary>
@@ -208,6 +284,11 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
         var repositoryUri = RepositoryUri;
         var repositorySourceUri = RepositorySourceUri;
         var repositoryPublishUri = RepositoryPublishUri;
+
+        if (ParameterSetName == "JFrog")
+        {
+            type = PowerForge.PublishDestination.PowerShellGallery;
+        }
 
         if (ParameterSetName == "Profile")
         {
@@ -238,7 +319,8 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
                 var repositoryCredentialSpecified =
                     !string.IsNullOrWhiteSpace(RepositoryCredentialUserName) &&
                     (!string.IsNullOrWhiteSpace(RepositoryCredentialSecret) ||
-                     !string.IsNullOrWhiteSpace(RepositoryCredentialSecretFilePath));
+                     !string.IsNullOrWhiteSpace(RepositoryCredentialSecretFilePath) ||
+                     !string.IsNullOrWhiteSpace(RepositoryCredentialSecretEnvironmentVariable));
 
                 if (apiKeySpecified && filePathSpecified)
                     throw new ArgumentException("Specify either ApiKey or FilePath for profile-based private gallery publishing, not both.", nameof(FilePath));
@@ -268,6 +350,8 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
             RepositoryUri = repositoryUri,
             RepositorySourceUri = repositorySourceUri,
             RepositoryPublishUri = repositoryPublishUri,
+            JFrogBaseUri = JFrogBaseUri,
+            JFrogRepository = JFrogRepository,
             RepositoryTrusted = repositoryTrusted,
             RepositoryPriority = repositoryPriority,
             RepositoryApiVersion = repositoryApiVersion,
@@ -278,6 +362,13 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
             RepositoryCredentialSecretSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryCredentialSecret)),
             RepositoryCredentialSecretFilePath = RepositoryCredentialSecretFilePath,
             RepositoryCredentialSecretFilePathSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryCredentialSecretFilePath)),
+            RepositoryCredentialSecretEnvironmentVariable = RepositoryCredentialSecretEnvironmentVariable,
+            RepositoryCredentialSecretEnvironmentVariableSpecified = MyInvocation.BoundParameters.ContainsKey(nameof(RepositoryCredentialSecretEnvironmentVariable)),
+            JFrogPlatformUri = JFrogPlatformUri,
+            JFrogOidcProvider = JFrogOidcProvider,
+            JFrogOidcTokenId = JFrogOidcTokenId,
+            JFrogOidcTokenIdEnvironmentVariable = JFrogOidcTokenIdEnvironmentVariable,
+            JFrogOidcProviderType = JFrogOidcProviderType,
             Enabled = Enabled.IsPresent,
             OverwriteTagName = OverwriteTagName,
             Force = Force.IsPresent,

--- a/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
@@ -1,36 +1,128 @@
 namespace PowerForge;
 
+/// <summary>
+/// Captures the normalized <c>New-ConfigurationPublish</c> parameter values before they are mapped
+/// into a reusable publish configuration segment.
+/// </summary>
 internal sealed class PublishConfigurationRequest
 {
+    /// <summary>PowerShell parameter set that produced the request.</summary>
     public string ParameterSetName { get; set; } = string.Empty;
+
+    /// <summary>Publish destination selected by the caller.</summary>
     public PublishDestination Type { get; set; }
+
+    /// <summary>Azure DevOps organization used by the Azure Artifacts shortcut.</summary>
     public string AzureDevOpsOrganization { get; set; } = string.Empty;
+
+    /// <summary>Optional Azure DevOps project used by project-scoped Azure Artifacts feeds.</summary>
     public string? AzureDevOpsProject { get; set; }
+
+    /// <summary>Azure Artifacts feed name used by the Azure Artifacts shortcut.</summary>
     public string AzureArtifactsFeed { get; set; } = string.Empty;
+
+    /// <summary>Path to a file containing the publish API key.</summary>
     public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>Inline publish API key. For JFrog this is only needed when the feed requires a separate NuGet API key.</summary>
     public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>GitHub owner or user name used by GitHub release publishing.</summary>
     public string? UserName { get; set; }
+
+    /// <summary>PowerShell repository name or GitHub repository name, depending on the destination.</summary>
     public string? RepositoryName { get; set; }
+
+    /// <summary>PowerShell repository publishing tool requested by the caller.</summary>
     public PublishTool Tool { get; set; } = PublishTool.Auto;
+
+    /// <summary>Repository URI used for both source and publish operations unless source/publish URIs are provided separately.</summary>
     public string? RepositoryUri { get; set; }
+
+    /// <summary>PowerShellGet source URI for repositories that expose separate source and publish endpoints.</summary>
     public string? RepositorySourceUri { get; set; }
+
+    /// <summary>PowerShellGet publish URI for repositories that expose separate source and publish endpoints.</summary>
     public string? RepositoryPublishUri { get; set; }
+
+    /// <summary>JFrog Artifactory base URI used with <see cref="JFrogRepository"/> to derive repository endpoints.</summary>
+    public string? JFrogBaseUri { get; set; }
+
+    /// <summary>JFrog NuGet repository key used with <see cref="JFrogBaseUri"/> to derive repository endpoints.</summary>
+    public string? JFrogRepository { get; set; }
+
+    /// <summary>Whether the generated repository configuration should be trusted when registered.</summary>
     public bool RepositoryTrusted { get; set; } = true;
+
+    /// <summary>PSResourceGet repository priority. Lower values have higher priority.</summary>
     public int? RepositoryPriority { get; set; }
+
+    /// <summary>PSResourceGet repository API version used during registration.</summary>
     public RepositoryApiVersion RepositoryApiVersion { get; set; } = RepositoryApiVersion.Auto;
+
+    /// <summary>Whether the repository should be registered or updated before publishing.</summary>
     public bool EnsureRepositoryRegistered { get; set; } = true;
+
+    /// <summary>Whether a repository created by the publish run should be unregistered afterward.</summary>
     public bool UnregisterRepositoryAfterPublish { get; set; }
+
+    /// <summary>User name for repository basic authentication.</summary>
     public string? RepositoryCredentialUserName { get; set; }
+
+    /// <summary>Inline repository credential secret.</summary>
     public string? RepositoryCredentialSecret { get; set; }
+
+    /// <summary>Whether the repository credential secret parameter was explicitly supplied.</summary>
     public bool RepositoryCredentialSecretSpecified { get; set; }
+
+    /// <summary>Path to a file containing the repository credential secret.</summary>
     public string? RepositoryCredentialSecretFilePath { get; set; }
+
+    /// <summary>Whether the repository credential secret file parameter was explicitly supplied.</summary>
     public bool RepositoryCredentialSecretFilePathSpecified { get; set; }
+
+    /// <summary>Environment variable containing the repository credential secret.</summary>
+    public string? RepositoryCredentialSecretEnvironmentVariable { get; set; }
+
+    /// <summary>Whether the repository credential secret environment variable parameter was explicitly supplied.</summary>
+    public bool RepositoryCredentialSecretEnvironmentVariableSpecified { get; set; }
+
+    /// <summary>JFrog Platform URL used for runtime OIDC token exchange.</summary>
+    public string? JFrogPlatformUri { get; set; }
+
+    /// <summary>JFrog OIDC provider name configured in Artifactory.</summary>
+    public string? JFrogOidcProvider { get; set; }
+
+    /// <summary>CI-issued OIDC token value passed to JFrog CLI token exchange.</summary>
+    public string? JFrogOidcTokenId { get; set; }
+
+    /// <summary>Environment variable containing the CI-issued OIDC token value for JFrog CLI token exchange.</summary>
+    public string? JFrogOidcTokenIdEnvironmentVariable { get; set; }
+
+    /// <summary>JFrog OIDC provider implementation passed to JFrog CLI.</summary>
+    public JFrogOidcProviderType JFrogOidcProviderType { get; set; } = JFrogOidcProviderType.GitHub;
+
+    /// <summary>Whether the generated publish configuration segment is enabled.</summary>
     public bool Enabled { get; set; }
+
+    /// <summary>Optional GitHub release tag override.</summary>
     public string? OverwriteTagName { get; set; }
+
+    /// <summary>Whether repository publishing should skip the remote version guard.</summary>
     public bool Force { get; set; }
+
+    /// <summary>Optional publish segment identifier used by artefact selection.</summary>
     public string? ID { get; set; }
+
+    /// <summary>Whether GitHub release publishing should avoid marking prerelease module versions as prereleases.</summary>
     public bool DoNotMarkAsPreRelease { get; set; }
+
+    /// <summary>Whether GitHub should generate release notes automatically.</summary>
     public bool GenerateReleaseNotes { get; set; }
+
+    /// <summary>Whether this repository should be used as a dependency-version source.</summary>
     public bool UseAsDependencyVersionSource { get; set; }
+
+    /// <summary>Whether verbose logging was requested by the cmdlet invocation.</summary>
     public bool Verbose { get; set; }
 }

--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -14,26 +14,80 @@ internal sealed class PublishConfigurationFactory
 
         var isAzureArtifacts = string.Equals(request.ParameterSetName, "AzureArtifacts", StringComparison.Ordinal);
         var destination = isAzureArtifacts ? PublishDestination.PowerShellGallery : request.Type;
+        if (string.Equals(request.ParameterSetName, "JFrog", StringComparison.Ordinal) &&
+            !string.IsNullOrWhiteSpace(request.ApiKey) &&
+            !string.IsNullOrWhiteSpace(request.FilePath))
+        {
+            throw new ArgumentException("Specify either ApiKey or FilePath for JFrog publishing, not both.", nameof(request));
+        }
+
         var apiKeyToUse = request.ParameterSetName switch
         {
             "ApiFromFile" => File.ReadAllText(request.FilePath).Trim(),
             "AzureArtifacts" => AzureArtifactsApiKeyPlaceholder,
+            "JFrog" when !string.IsNullOrWhiteSpace(request.FilePath) => File.ReadAllText(request.FilePath).Trim(),
             _ => request.ApiKey
         };
 
         if (destination == PublishDestination.GitHub && string.IsNullOrWhiteSpace(request.UserName))
             throw new ArgumentException("UserName is required for GitHub. Please fix New-ConfigurationPublish and provide UserName", nameof(request));
 
+        var repositoryName = request.RepositoryName;
+        var repositoryUri = request.RepositoryUri;
+        var repositorySourceUri = request.RepositorySourceUri;
+        var repositoryPublishUri = request.RepositoryPublishUri;
+        var repositoryApiVersion = request.RepositoryApiVersion;
+        var hasJFrogShortcut =
+            !string.IsNullOrWhiteSpace(request.JFrogBaseUri) ||
+            !string.IsNullOrWhiteSpace(request.JFrogRepository);
+
+        if (isAzureArtifacts && hasJFrogShortcut)
+            throw new ArgumentException("JFrogBaseUri/JFrogRepository cannot be combined with the Azure Artifacts preset.", nameof(request));
+
+        if (hasJFrogShortcut)
+        {
+            var endpoint = PrivateGalleryRepositoryEndpoints.Create(
+                PrivateGalleryProvider.JFrog,
+                repositoryName: repositoryName,
+                repositoryUri: repositoryUri,
+                repositorySourceUri: repositorySourceUri,
+                repositoryPublishUri: repositoryPublishUri,
+                jfrogBaseUri: request.JFrogBaseUri,
+                jfrogRepository: request.JFrogRepository);
+
+            repositoryName = endpoint.RepositoryName;
+            repositoryUri = endpoint.PSResourceGetUri;
+            repositorySourceUri = endpoint.PowerShellGetSourceUri;
+            repositoryPublishUri = endpoint.PowerShellGetPublishUri;
+            if (repositoryApiVersion == RepositoryApiVersion.Auto)
+                repositoryApiVersion = RepositoryApiVersion.V3;
+        }
+
         var repositorySecret = ResolveSecret(
             request.RepositoryCredentialSecretSpecified,
             request.RepositoryCredentialSecret,
             request.RepositoryCredentialSecretFilePathSpecified,
-            request.RepositoryCredentialSecretFilePath);
+            request.RepositoryCredentialSecretFilePath,
+            request.RepositoryCredentialSecretEnvironmentVariableSpecified,
+            request.RepositoryCredentialSecretEnvironmentVariable);
+        var hasJfrogOidcProvider = !string.IsNullOrWhiteSpace(request.JFrogOidcProvider);
+        var hasJfrogOidcOptions =
+            hasJfrogOidcProvider ||
+            !string.IsNullOrWhiteSpace(request.JFrogOidcTokenId) ||
+            !string.IsNullOrWhiteSpace(request.JFrogOidcTokenIdEnvironmentVariable) ||
+            !string.IsNullOrWhiteSpace(request.JFrogPlatformUri) ||
+            request.JFrogOidcProviderType != JFrogOidcProviderType.GitHub;
+
+        if (hasJfrogOidcOptions && !hasJFrogShortcut)
+            throw new ArgumentException("JFrog OIDC parameters require JFrogBaseUri/JFrogRepository or the JFrog parameter set.", nameof(request));
+
+        if (hasJfrogOidcOptions && !hasJfrogOidcProvider)
+            throw new ArgumentException("JFrogOidcProvider is required when using JFrog OIDC publishing.", nameof(request));
 
         var anyRepositoryUriProvided =
-            !string.IsNullOrWhiteSpace(request.RepositoryUri) ||
-            !string.IsNullOrWhiteSpace(request.RepositorySourceUri) ||
-            !string.IsNullOrWhiteSpace(request.RepositoryPublishUri);
+            !string.IsNullOrWhiteSpace(repositoryUri) ||
+            !string.IsNullOrWhiteSpace(repositorySourceUri) ||
+            !string.IsNullOrWhiteSpace(repositoryPublishUri);
 
         var resolvedAzureArtifactsRepositoryName = string.IsNullOrWhiteSpace(request.RepositoryName)
             ? request.AzureArtifactsFeed?.Trim()
@@ -62,22 +116,45 @@ internal sealed class PublishConfigurationFactory
 
         if (!isAzureArtifacts && anyRepositoryUriProvided)
         {
-            var resolvedRepositoryName = request.RepositoryName?.Trim();
+            var resolvedRepositoryName = repositoryName?.Trim();
             if (string.IsNullOrWhiteSpace(resolvedRepositoryName))
                 throw new ArgumentException("RepositoryName is required when RepositoryUri/RepositorySourceUri/RepositoryPublishUri is provided.", nameof(request));
             if (string.Equals(resolvedRepositoryName, PowerShellGalleryRepositoryName, StringComparison.OrdinalIgnoreCase))
                 throw new ArgumentException("RepositoryName cannot be 'PSGallery' when RepositoryUri/RepositorySourceUri/RepositoryPublishUri is provided.", nameof(request));
         }
 
+        var repositorySecretSourceSpecified =
+            request.RepositoryCredentialSecretSpecified ||
+            request.RepositoryCredentialSecretFilePathSpecified ||
+            request.RepositoryCredentialSecretEnvironmentVariableSpecified;
+        if (repositorySecretSourceSpecified && string.IsNullOrWhiteSpace(repositorySecret))
+            throw new ArgumentException("Repository credential secret could not be resolved. Check RepositoryCredentialSecret, RepositoryCredentialSecretFilePath, or RepositoryCredentialSecretEnvironmentVariable.", nameof(request));
+
         var hasRepoCredentialSecret = !string.IsNullOrWhiteSpace(repositorySecret);
         if (hasRepoCredentialSecret && string.IsNullOrWhiteSpace(request.RepositoryCredentialUserName))
-            throw new ArgumentException("RepositoryCredentialUserName is required when RepositoryCredentialSecret/RepositoryCredentialSecretFilePath is provided.", nameof(request));
+            throw new ArgumentException("RepositoryCredentialUserName is required when RepositoryCredentialSecret, RepositoryCredentialSecretFilePath, or RepositoryCredentialSecretEnvironmentVariable is provided.", nameof(request));
+
+        if (hasRepoCredentialSecret && hasJfrogOidcOptions)
+            throw new ArgumentException("Repository credential secrets cannot be combined with JFrog OIDC publishing. Use either static credentials or JFrogOidcProvider.", nameof(request));
 
         PublishRepositoryConfiguration? repository = null;
         var hasRepoCredential = !string.IsNullOrWhiteSpace(request.RepositoryCredentialUserName) && hasRepoCredentialSecret;
+        var runtimeCredentialProvider = hasJfrogOidcProvider
+            ? new RepositoryCredentialProviderConfiguration
+            {
+                Kind = RepositoryCredentialProviderKind.JFrogOidc,
+                UserName = request.RepositoryCredentialUserName,
+                JFrogPlatformUri = ResolveJfrogPlatformUri(request.JFrogPlatformUri, request.JFrogBaseUri),
+                JFrogOidcProvider = request.JFrogOidcProvider?.Trim(),
+                JFrogOidcTokenId = string.IsNullOrWhiteSpace(request.JFrogOidcTokenId) ? null : request.JFrogOidcTokenId!.Trim(),
+                JFrogOidcTokenIdEnvironmentVariable = string.IsNullOrWhiteSpace(request.JFrogOidcTokenIdEnvironmentVariable) ? null : request.JFrogOidcTokenIdEnvironmentVariable!.Trim(),
+                JFrogOidcProviderType = request.JFrogOidcProviderType
+            }
+            : null;
         var hasRepoOptions = isAzureArtifacts ||
                              anyRepositoryUriProvided ||
                              hasRepoCredential ||
+                             runtimeCredentialProvider is not null ||
                              request.RepositoryPriority is not null ||
                              request.RepositoryApiVersion != RepositoryApiVersion.Auto ||
                              !request.EnsureRepositoryRegistered ||
@@ -103,19 +180,19 @@ internal sealed class PublishConfigurationFactory
                     }
                     : null);
 
-            request.RepositoryName = repository.Name;
+            repositoryName = repository.Name;
         }
         else if (hasRepoOptions)
         {
             repository = new PublishRepositoryConfiguration
             {
-                Name = request.RepositoryName,
-                Uri = request.RepositoryUri,
-                SourceUri = request.RepositorySourceUri,
-                PublishUri = request.RepositoryPublishUri,
+                Name = repositoryName,
+                Uri = repositoryUri,
+                SourceUri = repositorySourceUri,
+                PublishUri = repositoryPublishUri,
                 Trusted = request.RepositoryTrusted,
                 Priority = request.RepositoryPriority,
-                ApiVersion = request.RepositoryApiVersion,
+                ApiVersion = repositoryApiVersion,
                 EnsureRegistered = request.EnsureRepositoryRegistered,
                 UnregisterAfterUse = request.UnregisterRepositoryAfterPublish,
                 Credential = hasRepoCredential
@@ -124,7 +201,8 @@ internal sealed class PublishConfigurationFactory
                         UserName = request.RepositoryCredentialUserName,
                         Secret = repositorySecret
                     }
-                    : null
+                    : null,
+                CredentialProvider = runtimeCredentialProvider
             };
         }
 
@@ -138,7 +216,7 @@ internal sealed class PublishConfigurationFactory
                 ID = request.ID,
                 Enabled = request.Enabled,
                 UserName = request.UserName,
-                RepositoryName = request.RepositoryName,
+                RepositoryName = repositoryName,
                 Repository = repository,
                 Force = request.Force,
                 OverwriteTagName = request.OverwriteTagName,
@@ -150,15 +228,43 @@ internal sealed class PublishConfigurationFactory
         };
     }
 
-    private static string ResolveSecret(bool secretSpecified, string? secret, bool secretFileSpecified, string? secretFilePath)
+    private static string ResolveSecret(
+        bool secretSpecified,
+        string? secret,
+        bool secretFileSpecified,
+        string? secretFilePath,
+        bool secretEnvironmentVariableSpecified,
+        string? secretEnvironmentVariable)
     {
         if (secretFileSpecified && !string.IsNullOrWhiteSpace(secretFilePath))
             return File.ReadAllText(secretFilePath!.Trim()).Trim();
+
+        if (secretEnvironmentVariableSpecified && !string.IsNullOrWhiteSpace(secretEnvironmentVariable))
+            return Environment.GetEnvironmentVariable(secretEnvironmentVariable!.Trim())?.Trim() ?? string.Empty;
 
         if (secretSpecified && !string.IsNullOrWhiteSpace(secret))
             return secret!.Trim();
 
         return string.Empty;
+    }
+
+    private static string? ResolveJfrogPlatformUri(string? explicitPlatformUri, string? jfrogBaseUri)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitPlatformUri))
+            return explicitPlatformUri!.Trim().TrimEnd('/') + "/";
+
+        if (string.IsNullOrWhiteSpace(jfrogBaseUri))
+            return null;
+
+        var candidate = jfrogBaseUri!.Trim();
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri))
+            return candidate.TrimEnd('/') + "/";
+
+        var path = uri.AbsolutePath.TrimEnd('/');
+        if (path.Equals("/artifactory", StringComparison.OrdinalIgnoreCase))
+            return uri.GetLeftPart(UriPartial.Authority).TrimEnd('/') + "/";
+
+        return candidate.TrimEnd('/') + "/";
     }
 
     private static bool IsMicrosoftArtifactRegistryPublishTarget(PublishConfigurationRequest request)

--- a/PowerForge.Tests/ModulePublishConfigurationReaderTests.cs
+++ b/PowerForge.Tests/ModulePublishConfigurationReaderTests.cs
@@ -31,6 +31,14 @@ public sealed class ModulePublishConfigurationReaderTests
                   "Credential": {
                     "UserName": "user",
                     "Secret": "secret"
+                  },
+                  "CredentialProvider": {
+                    "Kind": "JFrogOidc",
+                    "UserName": "fallback-user",
+                    "JFrogPlatformUri": "https://company.jfrog.io/",
+                    "JFrogOidcProvider": "azure-oidc",
+                    "JFrogOidcTokenIdEnvironmentVariable": "JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID",
+                    "JFrogOidcProviderType": "Azure"
                   }
                 }
               }
@@ -66,6 +74,13 @@ public sealed class ModulePublishConfigurationReaderTests
         Assert.NotNull(repositoryPublish.Repository.Credential);
         Assert.Equal("user", repositoryPublish.Repository.Credential!.UserName);
         Assert.Equal("secret", repositoryPublish.Repository.Credential.Secret);
+        Assert.NotNull(repositoryPublish.Repository.CredentialProvider);
+        Assert.Equal(RepositoryCredentialProviderKind.JFrogOidc, repositoryPublish.Repository.CredentialProvider!.Kind);
+        Assert.Equal("fallback-user", repositoryPublish.Repository.CredentialProvider.UserName);
+        Assert.Equal("https://company.jfrog.io/", repositoryPublish.Repository.CredentialProvider.JFrogPlatformUri);
+        Assert.Equal("azure-oidc", repositoryPublish.Repository.CredentialProvider.JFrogOidcProvider);
+        Assert.Equal("JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID", repositoryPublish.Repository.CredentialProvider.JFrogOidcTokenIdEnvironmentVariable);
+        Assert.Equal(JFrogOidcProviderType.Azure, repositoryPublish.Repository.CredentialProvider.JFrogOidcProviderType);
 
         var gitHubPublish = configs[1];
         Assert.Equal(PublishDestination.GitHub, gitHubPublish.Destination);

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -166,8 +166,119 @@ public sealed class ModulePublisherRepositoryVersionTests
         }
     }
 
+    [Fact]
+    public void Publish_AllowsRuntimeCredentialProviderWithoutApiKeyOrStaticCredential()
+    {
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        var calls = new List<string>();
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "PSPublishModule.psd1");
+            File.WriteAllText(
+                manifestPath,
+                """
+                @{
+                    ModuleVersion = '3.0.13'
+                    GUID = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
+                    RootModule = 'PSPublishModule.psm1'
+                    RequiredModules = @(
+                        @{ ModuleName = 'DependencyModule'; ModuleVersion = '1.0.0' }
+                    )
+                }
+                """);
+            File.WriteAllText(Path.Combine(stagingRoot, "PSPublishModule.psm1"), string.Empty);
+
+            var runner = new StubPowerShellRunner(request =>
+            {
+                var script = File.ReadAllText(request.ScriptPath!);
+                if (script.Contains("Register-PSResourceRepository", StringComparison.Ordinal))
+                {
+                    calls.Add("register");
+                    return new PowerShellRunResult(0, "PFPSRG::REPO::CREATED::0", string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Find-PSResource", StringComparison.Ordinal))
+                {
+                    calls.Add("find");
+                    Assert.Equal("oidc-user@example.com", request.Arguments[4]);
+                    Assert.Equal("jfrog-access-token", request.Arguments[5]);
+
+                    var names = DecodeLines(request.Arguments[0]);
+                    if (names.Contains("PSPublishModule", StringComparer.OrdinalIgnoreCase))
+                        return new PowerShellRunResult(0, VisibleRepositoryItem("PSPublishModule", "3.0.12"), string.Empty, "pwsh.exe");
+                    if (names.Contains("DependencyModule", StringComparer.OrdinalIgnoreCase))
+                        return new PowerShellRunResult(0, VisibleRepositoryItem("DependencyModule", "1.2.3"), string.Empty, "pwsh.exe");
+
+                    return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Publish-PSResource", StringComparison.Ordinal))
+                {
+                    calls.Add("publish");
+                    Assert.Equal("oidc-user@example.com", request.Arguments[7]);
+                    Assert.Equal("jfrog-access-token", request.Arguments[8]);
+                    return new PowerShellRunResult(0, "PFPSRG::PUBLISH::OK", string.Empty, "pwsh.exe");
+                }
+
+                throw new InvalidOperationException("Unexpected PowerShell script invocation.");
+            });
+            var processRunner = new StubProcessRunner(_ => new ProcessRunResult(
+                0,
+                """{"access_token":"jfrog-access-token","username":"oidc-user@example.com"}""",
+                string.Empty,
+                "jf.exe",
+                TimeSpan.FromMilliseconds(10),
+                timedOut: false));
+            var publisher = new ModulePublisher(new NullLogger(), runner, client: null, processRunner: processRunner);
+
+            var publish = new PublishConfiguration
+            {
+                Destination = PublishDestination.PowerShellGallery,
+                Enabled = true,
+                Tool = PublishTool.PSResourceGet,
+                RepositoryName = "JFrogPS",
+                Repository = new PublishRepositoryConfiguration
+                {
+                    Name = "JFrogPS",
+                    Uri = "https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json",
+                    EnsureRegistered = true,
+                    CredentialProvider = new RepositoryCredentialProviderConfiguration
+                    {
+                        Kind = RepositoryCredentialProviderKind.JFrogOidc,
+                        JFrogPlatformUri = "https://company.jfrog.io/",
+                        JFrogOidcProvider = "azure-oidc",
+                        JFrogOidcProviderType = JFrogOidcProviderType.Azure,
+                        JFrogOidcTokenId = "ci-jwt"
+                    }
+                }
+            };
+            var plan = CreatePlan();
+            var buildResult = new ModuleBuildResult(
+                stagingPath: stagingRoot,
+                manifestPath: manifestPath,
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var result = publisher.Publish(publish, plan, buildResult, Array.Empty<ArtefactBuildResult>());
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(new[] { "register", "find", "find", "publish" }, calls);
+            var processRequest = Assert.Single(processRunner.Requests);
+            Assert.Equal(new[] { "eot", "azure-oidc", "--url=https://company.jfrog.io/", "--oidc-provider-type=Azure" }, processRequest.Arguments);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+                Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
     private static string Encode(string value)
         => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+
+    private static string[] DecodeLines(string value)
+        => Encoding.UTF8.GetString(Convert.FromBase64String(value))
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     private static string VisibleRepositoryItem(string name, string version)
         => string.Join("::", new[]
@@ -257,6 +368,24 @@ public sealed class ModulePublisherRepositoryVersionTests
         public PowerShellRunResult Run(PowerShellRunRequest request)
         {
             return _run(request);
+        }
+    }
+
+    private sealed class StubProcessRunner : IProcessRunner
+    {
+        private readonly Func<ProcessRunRequest, ProcessRunResult> _run;
+
+        public StubProcessRunner(Func<ProcessRunRequest, ProcessRunResult> run)
+        {
+            _run = run;
+        }
+
+        public List<ProcessRunRequest> Requests { get; } = new();
+
+        public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_run(request));
         }
     }
 

--- a/PowerForge.Tests/PublishConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/PublishConfigurationFactoryTests.cs
@@ -98,6 +98,154 @@ public sealed class PublishConfigurationFactoryTests
     }
 
     [Fact]
+    public void Create_builds_jfrog_repository_configuration_from_shortcut()
+    {
+        var secretPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(secretPath, " pat ");
+        try
+        {
+            var factory = new PublishConfigurationFactory();
+
+            var segment = factory.Create(new PublishConfigurationRequest
+            {
+                ParameterSetName = "ApiFromFile",
+                Type = PublishDestination.PowerShellGallery,
+                FilePath = secretPath,
+                RepositoryName = "JFrogPS",
+                Tool = PublishTool.PSResourceGet,
+                JFrogBaseUri = "https://company.jfrog.io/artifactory",
+                JFrogRepository = "powershell-virtual",
+                RepositoryCredentialUserName = "name@company.com",
+                RepositoryCredentialSecretFilePath = secretPath,
+                RepositoryCredentialSecretFilePathSpecified = true,
+                Enabled = true
+            });
+
+            Assert.Equal("pat", segment.Configuration.ApiKey);
+            Assert.Equal("JFrogPS", segment.Configuration.RepositoryName);
+
+            var repository = Assert.IsType<PublishRepositoryConfiguration>(segment.Configuration.Repository);
+            Assert.Equal("JFrogPS", repository.Name);
+            Assert.Equal(RepositoryApiVersion.V3, repository.ApiVersion);
+            Assert.Equal("https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json", repository.Uri);
+            Assert.Equal("https://company.jfrog.io/artifactory/api/nuget/powershell-virtual", repository.SourceUri);
+            Assert.Equal("https://company.jfrog.io/artifactory/api/nuget/powershell-virtual", repository.PublishUri);
+
+            var credential = Assert.IsType<RepositoryCredential>(repository.Credential);
+            Assert.Equal("name@company.com", credential.UserName);
+            Assert.Equal("pat", credential.Secret);
+        }
+        finally
+        {
+            if (File.Exists(secretPath))
+                File.Delete(secretPath);
+        }
+    }
+
+    [Fact]
+    public void Create_builds_jfrog_repository_configuration_without_api_key()
+    {
+        var secretPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(secretPath, " pat ");
+        try
+        {
+            var factory = new PublishConfigurationFactory();
+
+            var segment = factory.Create(new PublishConfigurationRequest
+            {
+                ParameterSetName = "JFrog",
+                Type = PublishDestination.PowerShellGallery,
+                RepositoryName = "JFrogPS",
+                Tool = PublishTool.PSResourceGet,
+                JFrogBaseUri = "https://company.jfrog.io/artifactory",
+                JFrogRepository = "powershell-virtual",
+                RepositoryCredentialUserName = "name@company.com",
+                RepositoryCredentialSecretFilePath = secretPath,
+                RepositoryCredentialSecretFilePathSpecified = true,
+                Enabled = true
+            });
+
+            Assert.Equal(string.Empty, segment.Configuration.ApiKey);
+            Assert.Equal("JFrogPS", segment.Configuration.RepositoryName);
+
+            var repository = Assert.IsType<PublishRepositoryConfiguration>(segment.Configuration.Repository);
+            Assert.Equal("https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json", repository.Uri);
+
+            var credential = Assert.IsType<RepositoryCredential>(repository.Credential);
+            Assert.Equal("name@company.com", credential.UserName);
+            Assert.Equal("pat", credential.Secret);
+        }
+        finally
+        {
+            if (File.Exists(secretPath))
+                File.Delete(secretPath);
+        }
+    }
+
+    [Fact]
+    public void Create_reads_repository_credential_secret_from_environment()
+    {
+        var envName = "POWERFORGE_TEST_JFROG_PAT_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            Environment.SetEnvironmentVariable(envName, " env-pat ");
+            var factory = new PublishConfigurationFactory();
+
+            var segment = factory.Create(new PublishConfigurationRequest
+            {
+                ParameterSetName = "JFrog",
+                Type = PublishDestination.PowerShellGallery,
+                RepositoryName = "JFrogPS",
+                Tool = PublishTool.PSResourceGet,
+                JFrogBaseUri = "https://company.jfrog.io/artifactory",
+                JFrogRepository = "powershell-virtual",
+                RepositoryCredentialUserName = "name@company.com",
+                RepositoryCredentialSecretEnvironmentVariable = envName,
+                RepositoryCredentialSecretEnvironmentVariableSpecified = true,
+                Enabled = true
+            });
+
+            var repository = Assert.IsType<PublishRepositoryConfiguration>(segment.Configuration.Repository);
+            var credential = Assert.IsType<RepositoryCredential>(repository.Credential);
+            Assert.Equal("name@company.com", credential.UserName);
+            Assert.Equal("env-pat", credential.Secret);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envName, null);
+        }
+    }
+
+    [Fact]
+    public void Create_builds_jfrog_oidc_runtime_credential_provider()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var segment = factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "JFrog",
+            Type = PublishDestination.PowerShellGallery,
+            RepositoryName = "JFrogPS",
+            Tool = PublishTool.PSResourceGet,
+            JFrogBaseUri = "https://company.jfrog.io/artifactory",
+            JFrogRepository = "powershell-virtual",
+            JFrogOidcProvider = "azure-oidc",
+            JFrogOidcProviderType = JFrogOidcProviderType.Azure,
+            JFrogOidcTokenIdEnvironmentVariable = "JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID",
+            Enabled = true
+        });
+
+        var repository = Assert.IsType<PublishRepositoryConfiguration>(segment.Configuration.Repository);
+        Assert.Null(repository.Credential);
+        var provider = Assert.IsType<RepositoryCredentialProviderConfiguration>(repository.CredentialProvider);
+        Assert.Equal(RepositoryCredentialProviderKind.JFrogOidc, provider.Kind);
+        Assert.Equal("https://company.jfrog.io/", provider.JFrogPlatformUri);
+        Assert.Equal("azure-oidc", provider.JFrogOidcProvider);
+        Assert.Equal("JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID", provider.JFrogOidcTokenIdEnvironmentVariable);
+        Assert.Equal(JFrogOidcProviderType.Azure, provider.JFrogOidcProviderType);
+    }
+
+    [Fact]
     public void Create_throws_when_custom_repository_uses_psgallery_name()
     {
         var factory = new PublishConfigurationFactory();

--- a/PowerForge.Tests/RepositoryPublisherTests.cs
+++ b/PowerForge.Tests/RepositoryPublisherTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class RepositoryPublisherTests
+{
+    [Fact]
+    public void Publish_exchanges_jfrog_oidc_token_before_psresourceget_publish()
+    {
+        var tokenEnvName = "POWERFORGE_TEST_JFROG_OIDC_" + Guid.NewGuid().ToString("N");
+        var toolDir = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            Directory.CreateDirectory(toolDir);
+            File.WriteAllText(Path.Combine(toolDir, Path.DirectorySeparatorChar == '\\' ? "jf.exe" : "jf"), string.Empty);
+            Environment.SetEnvironmentVariable("PATH", toolDir + Path.PathSeparator + originalPath);
+            Environment.SetEnvironmentVariable(tokenEnvName, "ci-jwt");
+
+            var powerShellRunner = new StubPowerShellRunner(_ => new PowerShellRunResult(0, "PFPSRG::PUBLISH::OK", string.Empty, "pwsh.exe"));
+            var processRunner = new StubProcessRunner(_ => new ProcessRunResult(
+                0,
+                """{"access_token":"jfrog-access-token","username":"oidc-user@example.com"}""",
+                string.Empty,
+                "jf.exe",
+                TimeSpan.FromMilliseconds(10),
+                timedOut: false));
+            var publisher = new RepositoryPublisher(new NullLogger(), powerShellRunner, processRunner);
+
+            publisher.Publish(new RepositoryPublishRequest
+            {
+                Path = @"C:\staging\module",
+                IsNupkg = false,
+                RepositoryName = "JFrogPS",
+                ApiKey = null,
+                Tool = PublishTool.PSResourceGet,
+                Repository = new PublishRepositoryConfiguration
+                {
+                    Name = "JFrogPS",
+                    EnsureRegistered = false,
+                    CredentialProvider = new RepositoryCredentialProviderConfiguration
+                    {
+                        Kind = RepositoryCredentialProviderKind.JFrogOidc,
+                        JFrogPlatformUri = "https://company.jfrog.io/",
+                        JFrogOidcProvider = "azure-oidc",
+                        JFrogOidcProviderType = JFrogOidcProviderType.Azure,
+                        JFrogOidcTokenIdEnvironmentVariable = tokenEnvName
+                    }
+                }
+            });
+
+            var processRequest = Assert.Single(processRunner.Requests);
+            Assert.Equal(new[] { "eot", "azure-oidc", "--url=https://company.jfrog.io/", "--oidc-provider-type=Azure" }, processRequest.Arguments);
+            Assert.Equal("ci-jwt", processRequest.EnvironmentVariables?["JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID"]);
+
+            var powerShellRequest = Assert.Single(powerShellRunner.Requests);
+            Assert.Equal("oidc-user@example.com", powerShellRequest.Arguments[7]);
+            Assert.Equal("jfrog-access-token", powerShellRequest.Arguments[8]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(tokenEnvName, null);
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            if (Directory.Exists(toolDir))
+                Directory.Delete(toolDir, recursive: true);
+        }
+    }
+
+    private sealed class StubPowerShellRunner : IPowerShellRunner
+    {
+        private readonly Func<PowerShellRunRequest, PowerShellRunResult> _run;
+
+        public StubPowerShellRunner(Func<PowerShellRunRequest, PowerShellRunResult> run)
+        {
+            _run = run;
+        }
+
+        public List<PowerShellRunRequest> Requests { get; } = new();
+
+        public PowerShellRunResult Run(PowerShellRunRequest request)
+        {
+            Requests.Add(request);
+            return _run(request);
+        }
+    }
+
+    private sealed class StubProcessRunner : IProcessRunner
+    {
+        private readonly Func<ProcessRunRequest, ProcessRunResult> _run;
+
+        public StubProcessRunner(Func<ProcessRunRequest, ProcessRunResult> run)
+        {
+            _run = run;
+        }
+
+        public List<ProcessRunRequest> Requests { get; } = new();
+
+        public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_run(request));
+        }
+    }
+}

--- a/PowerForge/Models/Configuration/ConfigurationEnums.cs
+++ b/PowerForge/Models/Configuration/ConfigurationEnums.cs
@@ -101,6 +101,30 @@ public enum PrivateGalleryCredentialSource
 }
 
 /// <summary>
+/// Runtime credential provider used when repository credentials must be resolved at publish time.
+/// </summary>
+public enum RepositoryCredentialProviderKind
+{
+    /// <summary>No runtime credential provider is configured.</summary>
+    None,
+    /// <summary>Exchange a CI-issued OIDC token for a JFrog access token with JFrog CLI.</summary>
+    JFrogOidc
+}
+
+/// <summary>
+/// JFrog OIDC provider implementation passed to <c>jf exchange-oidc-token</c>.
+/// </summary>
+public enum JFrogOidcProviderType
+{
+    /// <summary>GitHub Actions OIDC provider.</summary>
+    GitHub,
+    /// <summary>Azure DevOps / Azure OIDC provider.</summary>
+    Azure,
+    /// <summary>Generic OIDC-compatible provider.</summary>
+    GenericOidc
+}
+
+/// <summary>
 /// Profile store scope used by private gallery profile commands.
 /// </summary>
 public enum ModuleRepositoryProfileScope

--- a/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
@@ -121,4 +121,48 @@ public sealed class PublishRepositoryConfiguration
     /// Optional credential used for repository operations (Find/Publish).
     /// </summary>
     public RepositoryCredential? Credential { get; set; }
+
+    /// <summary>
+    /// Optional runtime credential provider used when credentials should be resolved immediately before publishing.
+    /// </summary>
+    public RepositoryCredentialProviderConfiguration? CredentialProvider { get; set; }
+}
+
+/// <summary>
+/// Describes a runtime repository credential source.
+/// </summary>
+public sealed class RepositoryCredentialProviderConfiguration
+{
+    /// <summary>Credential provider kind.</summary>
+    public RepositoryCredentialProviderKind Kind { get; set; } = RepositoryCredentialProviderKind.None;
+
+    /// <summary>
+    /// Optional fallback username when the provider does not return one.
+    /// </summary>
+    public string? UserName { get; set; }
+
+    /// <summary>
+    /// JFrog Platform URL used by <c>jf exchange-oidc-token --url</c>, for example https://company.jfrog.io/.
+    /// </summary>
+    public string? JFrogPlatformUri { get; set; }
+
+    /// <summary>
+    /// JFrog OIDC provider name configured in Artifactory.
+    /// </summary>
+    public string? JFrogOidcProvider { get; set; }
+
+    /// <summary>
+    /// Optional CI-issued OIDC token value. Prefer <see cref="JFrogOidcTokenIdEnvironmentVariable"/> for CI use.
+    /// </summary>
+    public string? JFrogOidcTokenId { get; set; }
+
+    /// <summary>
+    /// Environment variable containing the CI-issued OIDC token value.
+    /// </summary>
+    public string? JFrogOidcTokenIdEnvironmentVariable { get; set; }
+
+    /// <summary>
+    /// JFrog OIDC provider implementation.
+    /// </summary>
+    public JFrogOidcProviderType JFrogOidcProviderType { get; set; } = JFrogOidcProviderType.GitHub;
 }

--- a/PowerForge/Services/ModulePublishConfigurationReader.cs
+++ b/PowerForge/Services/ModulePublishConfigurationReader.cs
@@ -87,6 +87,17 @@ public sealed class ModulePublishConfigurationReader
                 : new RepositoryCredential {
                     UserName = repository.Credential.UserName,
                     Secret = repository.Credential.Secret
+                },
+            CredentialProvider = repository.CredentialProvider is null
+                ? null
+                : new RepositoryCredentialProviderConfiguration {
+                    Kind = repository.CredentialProvider.Kind,
+                    UserName = repository.CredentialProvider.UserName,
+                    JFrogPlatformUri = repository.CredentialProvider.JFrogPlatformUri,
+                    JFrogOidcProvider = repository.CredentialProvider.JFrogOidcProvider,
+                    JFrogOidcTokenId = repository.CredentialProvider.JFrogOidcTokenId,
+                    JFrogOidcTokenIdEnvironmentVariable = repository.CredentialProvider.JFrogOidcTokenIdEnvironmentVariable,
+                    JFrogOidcProviderType = repository.CredentialProvider.JFrogOidcProviderType
                 }
         };
     }

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -34,11 +34,13 @@ public sealed class ModulePublisher
     {
     }
 
-    internal ModulePublisher(ILogger logger, IPowerShellRunner runner, HttpClient? client)
+    internal ModulePublisher(ILogger logger, IPowerShellRunner runner, HttpClient? client, IProcessRunner? processRunner = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         if (runner is null) throw new ArgumentNullException(nameof(runner));
-        _repositoryPublisher = new RepositoryPublisher(_logger, runner);
+        _repositoryPublisher = processRunner is null
+            ? new RepositoryPublisher(_logger, runner)
+            : new RepositoryPublisher(_logger, runner, processRunner);
         _psResourceGet = new PSResourceGetClient(runner, _logger);
         _powerShellGet = new PowerShellGetClient(runner, _logger);
         _gitHub = new GitHubReleasePublisher(_logger);
@@ -92,11 +94,12 @@ public sealed class ModulePublisher
         var hasCredential = credential is not null &&
                             !string.IsNullOrWhiteSpace(credential.UserName) &&
                             !string.IsNullOrWhiteSpace(credential.Secret);
+        var hasRuntimeCredentialProvider = repoConfig?.CredentialProvider is { Kind: not RepositoryCredentialProviderKind.None };
 
         if (isPsGallery && string.IsNullOrWhiteSpace(publish.ApiKey))
             throw new InvalidOperationException("Publish API key is required for repository publishing to PSGallery.");
 
-        if (!isPsGallery && string.IsNullOrWhiteSpace(publish.ApiKey) && !hasCredential)
+        if (!isPsGallery && string.IsNullOrWhiteSpace(publish.ApiKey) && !hasCredential && !hasRuntimeCredentialProvider)
             throw new InvalidOperationException("Publish API key or credential is required for repository publishing.");
 
         var tool = publish.Tool;
@@ -124,10 +127,12 @@ public sealed class ModulePublisher
         PublishRepositoryConfiguration? repoConfig,
         bool includeScriptFolders)
     {
-        var credential = repoConfig?.Credential;
+        var credential = _repositoryPublisher.ResolveCredentialForRepository(repoConfig);
         string? temporaryPublishPath = null;
         var repositoryCreated = false;
-        PublishRepositoryConfiguration? repositoryForPublish = repoConfig;
+        PublishRepositoryConfiguration? repositoryForPublish = repoConfig is null
+            ? null
+            : CloneRepositoryForPublish(repoConfig, credential);
         var versionText = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
 
         try
@@ -142,7 +147,7 @@ public sealed class ModulePublisher
             if (repoConfig is not null && repoConfig.EnsureRegistered && HasRepositoryUris(repoConfig))
             {
                 repositoryCreated = EnsureRepositoryRegistered(tool, repositoryName, repoConfig);
-                repositoryForPublish = CloneRegisteredRepository(repoConfig);
+                repositoryForPublish = CloneRegisteredRepository(repoConfig, credential);
             }
 
             if (!publish.Force)
@@ -598,7 +603,14 @@ public sealed class ModulePublisher
         _psResourceGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
     }
 
-    private static PublishRepositoryConfiguration CloneRegisteredRepository(PublishRepositoryConfiguration repo)
+    private static PublishRepositoryConfiguration CloneRegisteredRepository(PublishRepositoryConfiguration repo, RepositoryCredential? credential)
+        => CloneRepositoryForPublish(repo, credential, ensureRegistered: false, unregisterAfterUse: false);
+
+    private static PublishRepositoryConfiguration CloneRepositoryForPublish(
+        PublishRepositoryConfiguration repo,
+        RepositoryCredential? credential,
+        bool ensureRegistered = false,
+        bool unregisterAfterUse = false)
         => new()
         {
             Name = repo.Name,
@@ -608,10 +620,25 @@ public sealed class ModulePublisher
             Trusted = repo.Trusted,
             Priority = repo.Priority,
             ApiVersion = repo.ApiVersion,
-            EnsureRegistered = false,
-            UnregisterAfterUse = false,
-            Credential = repo.Credential
+            EnsureRegistered = ensureRegistered,
+            UnregisterAfterUse = unregisterAfterUse,
+            Credential = credential,
+            CredentialProvider = credential is null ? CloneCredentialProvider(repo.CredentialProvider) : null
         };
+
+    private static RepositoryCredentialProviderConfiguration? CloneCredentialProvider(RepositoryCredentialProviderConfiguration? provider)
+        => provider is null
+            ? null
+            : new RepositoryCredentialProviderConfiguration
+            {
+                Kind = provider.Kind,
+                UserName = provider.UserName,
+                JFrogPlatformUri = provider.JFrogPlatformUri,
+                JFrogOidcProvider = provider.JFrogOidcProvider,
+                JFrogOidcTokenId = provider.JFrogOidcTokenId,
+                JFrogOidcTokenIdEnvironmentVariable = provider.JFrogOidcTokenIdEnvironmentVariable,
+                JFrogOidcProviderType = provider.JFrogOidcProviderType
+            };
 
     private static (string RepositoryName, PublishRepositoryConfiguration? Repository) ResolveRepository(PublishConfiguration publish)
     {

--- a/PowerForge/Services/RepositoryPublisher.cs
+++ b/PowerForge/Services/RepositoryPublisher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.Json;
 
 namespace PowerForge;
 
@@ -11,6 +12,7 @@ public sealed class RepositoryPublisher
     private readonly ILogger _logger;
     private readonly PSResourceGetClient _psResourceGet;
     private readonly PowerShellGetClient _powerShellGet;
+    private readonly IProcessRunner _processRunner;
 
     /// <summary>
     /// Creates a new publisher using the provided logger and the default out-of-process PowerShell runner.
@@ -24,9 +26,18 @@ public sealed class RepositoryPublisher
     /// Creates a new publisher using the provided logger and runner.
     /// </summary>
     public RepositoryPublisher(ILogger logger, IPowerShellRunner runner)
+        : this(logger, runner, new ProcessRunner())
+    {
+    }
+
+    /// <summary>
+    /// Creates a new publisher using the provided logger, PowerShell runner, and external process runner.
+    /// </summary>
+    public RepositoryPublisher(ILogger logger, IPowerShellRunner runner, IProcessRunner processRunner)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         if (runner is null) throw new ArgumentNullException(nameof(runner));
+        _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
         _psResourceGet = new PSResourceGetClient(runner, _logger);
         _powerShellGet = new PowerShellGetClient(runner, _logger);
     }
@@ -57,7 +68,7 @@ public sealed class RepositoryPublisher
                                   !string.IsNullOrWhiteSpace(request.RepositoryName);
 
         var repoConfig = request.Repository;
-        var credential = repoConfig?.Credential;
+        var credential = ResolveRepositoryCredential(repoConfig);
 
         var tool = request.Tool;
         if (tool == PublishTool.Auto)
@@ -216,5 +227,168 @@ public sealed class RepositoryPublisher
         }
 
         _psResourceGet.UnregisterRepository(repositoryName, timeout: TimeSpan.FromMinutes(2));
+    }
+
+    internal RepositoryCredential? ResolveCredentialForRepository(PublishRepositoryConfiguration? repoConfig)
+        => ResolveRepositoryCredential(repoConfig);
+
+    private RepositoryCredential? ResolveRepositoryCredential(PublishRepositoryConfiguration? repoConfig)
+    {
+        if (repoConfig?.CredentialProvider is null ||
+            repoConfig.CredentialProvider.Kind == RepositoryCredentialProviderKind.None)
+        {
+            return repoConfig?.Credential;
+        }
+
+        if (repoConfig.Credential is not null)
+            throw new InvalidOperationException("Repository configuration cannot use both static credentials and a runtime credential provider.");
+
+        return repoConfig.CredentialProvider.Kind switch
+        {
+            RepositoryCredentialProviderKind.JFrogOidc => ExchangeJFrogOidcToken(repoConfig.CredentialProvider),
+            _ => throw new InvalidOperationException($"Repository credential provider '{repoConfig.CredentialProvider.Kind}' is not supported.")
+        };
+    }
+
+    private RepositoryCredential ExchangeJFrogOidcToken(RepositoryCredentialProviderConfiguration provider)
+    {
+        if (string.IsNullOrWhiteSpace(provider.JFrogOidcProvider))
+            throw new InvalidOperationException("JFrogOidcProvider is required for JFrog OIDC credential exchange.");
+
+        var executable = ResolveOnPath(Path.DirectorySeparatorChar == '\\' ? "jf.exe" : "jf") ??
+                         ResolveOnPath("jf");
+        if (string.IsNullOrWhiteSpace(executable))
+            throw new InvalidOperationException("JFrog CLI executable 'jf' was not found on PATH. Install JFrog CLI before using JFrog OIDC publishing.");
+
+        var tokenId = ResolveJfrogOidcTokenId(provider);
+        var environment = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(tokenId))
+            environment["JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID"] = tokenId;
+
+        var arguments = new List<string>
+        {
+            "eot",
+            provider.JFrogOidcProvider!.Trim()
+        };
+
+        if (!string.IsNullOrWhiteSpace(provider.JFrogPlatformUri))
+            arguments.Add("--url=" + provider.JFrogPlatformUri!.Trim());
+
+        arguments.Add("--oidc-provider-type=" + provider.JFrogOidcProviderType);
+
+        _logger.Info("Exchanging JFrog OIDC token for a short-lived repository credential.");
+        var result = _processRunner.RunAsync(
+            new ProcessRunRequest(
+                executable!,
+                Environment.CurrentDirectory,
+                arguments,
+                TimeSpan.FromMinutes(2),
+                environmentVariables: environment.Count == 0 ? null : environment,
+                captureOutput: true,
+                captureError: true)).GetAwaiter().GetResult();
+
+        if (!result.Succeeded)
+        {
+            var detail = string.IsNullOrWhiteSpace(result.StdErr) ? result.StdOut : result.StdErr;
+            throw new InvalidOperationException($"JFrog OIDC token exchange failed with exit code {result.ExitCode}. {detail}".Trim());
+        }
+
+        var credential = ParseJfrogOidcCredential(result.StdOut, provider.UserName);
+        if (string.IsNullOrWhiteSpace(credential.Secret))
+            throw new InvalidOperationException("JFrog OIDC token exchange succeeded but did not return an access token.");
+
+        if (string.IsNullOrWhiteSpace(credential.UserName))
+            throw new InvalidOperationException("JFrog OIDC token exchange succeeded but did not return a username. Provide RepositoryCredentialUserName as a fallback.");
+
+        return credential;
+    }
+
+    private static string? ResolveJfrogOidcTokenId(RepositoryCredentialProviderConfiguration provider)
+    {
+        if (!string.IsNullOrWhiteSpace(provider.JFrogOidcTokenIdEnvironmentVariable))
+        {
+            var value = Environment.GetEnvironmentVariable(provider.JFrogOidcTokenIdEnvironmentVariable!.Trim());
+            if (!string.IsNullOrWhiteSpace(value))
+                return value.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(provider.JFrogOidcTokenId)
+            ? null
+            : provider.JFrogOidcTokenId!.Trim();
+    }
+
+    private static RepositoryCredential ParseJfrogOidcCredential(string stdout, string? fallbackUserName)
+    {
+        var trimmed = stdout?.Trim() ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(trimmed) && trimmed.StartsWith("{", StringComparison.Ordinal))
+        {
+            using var document = JsonDocument.Parse(trimmed);
+            var root = document.RootElement;
+            return new RepositoryCredential
+            {
+                UserName = TryGetJsonString(root, "username") ?? fallbackUserName,
+                Secret = TryGetJsonString(root, "access_token")
+            };
+        }
+
+        string? accessToken = null;
+        string? userName = null;
+        foreach (var line in SplitLines(trimmed))
+        {
+            var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2)
+                continue;
+
+            if (parts[0].Equals("access_token", StringComparison.OrdinalIgnoreCase))
+                accessToken = parts[1];
+            else if (parts[0].Equals("username", StringComparison.OrdinalIgnoreCase))
+                userName = parts[1];
+        }
+
+        return new RepositoryCredential
+        {
+            UserName = userName ?? fallbackUserName,
+            Secret = accessToken
+        };
+    }
+
+    private static string? TryGetJsonString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static IEnumerable<string> SplitLines(string value)
+        => value.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries);
+
+    private static string? ResolveOnPath(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return null;
+
+        if (Path.IsPathRooted(fileName) && File.Exists(fileName))
+            return fileName;
+
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        foreach (var entry in path.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
+
+            try
+            {
+                var candidate = Path.Combine(entry.Trim(), fileName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+            catch
+            {
+                // Ignore malformed PATH entries.
+            }
+        }
+
+        return null;
     }
 }

--- a/PowerForgeStudio.Orchestrator/Queue/ReleasePublishExecutionService.cs
+++ b/PowerForgeStudio.Orchestrator/Queue/ReleasePublishExecutionService.cs
@@ -535,9 +535,9 @@ public sealed partial class ReleasePublishExecutionService
             return FailedReceipt(repository.RootPath, repository.Name, ReleaseBuildAdapterKind.ModuleBuild.ToString(), "Module publish", destination, "No publishable module package path was captured from the build artefacts.");
         }
 
-        if (string.IsNullOrWhiteSpace(publishConfig.ApiKey))
+        if (string.IsNullOrWhiteSpace(publishConfig.ApiKey) && !HasRepositoryAuthentication(publishConfig.Repository))
         {
-            return FailedReceipt(repository.RootPath, repository.Name, ReleaseBuildAdapterKind.ModuleBuild.ToString(), "Module publish", destination, "Module publish is enabled but no API key was resolved.");
+            return FailedReceipt(repository.RootPath, repository.Name, ReleaseBuildAdapterKind.ModuleBuild.ToString(), "Module publish", destination, "Module publish is enabled but no API key or repository credential was resolved.");
         }
 
         try
@@ -548,7 +548,7 @@ public sealed partial class ReleasePublishExecutionService
                     IsNupkg = false,
                     RepositoryName = destination,
                     Tool = publishConfig.Tool,
-                    ApiKey = publishConfig.ApiKey,
+                    ApiKey = string.IsNullOrWhiteSpace(publishConfig.ApiKey) ? null : publishConfig.ApiKey,
                     Repository = publishConfig.Repository,
                     SkipDependenciesCheck = true,
                     SkipModuleManifestValidate = false
@@ -616,6 +616,18 @@ public sealed partial class ReleasePublishExecutionService
             execution.Succeeded ? ReleasePublishReceiptStatus.Published : ReleasePublishReceiptStatus.Failed,
             execution.Succeeded ? $"GitHub release {tag} published." : execution.ErrorMessage!,
             packageDetails.ZipAssets.FirstOrDefault());
+    }
+
+    private static bool HasRepositoryAuthentication(PublishRepositoryConfiguration? repository)
+    {
+        if (repository?.Credential is { } credential &&
+            !string.IsNullOrWhiteSpace(credential.UserName) &&
+            !string.IsNullOrWhiteSpace(credential.Secret))
+        {
+            return true;
+        }
+
+        return repository?.CredentialProvider is { Kind: not RepositoryCredentialProviderKind.None };
     }
 }
 

--- a/PowerForgeStudio.Tests/PowerForgeStudioReleasePublishExecutionServiceTests.cs
+++ b/PowerForgeStudio.Tests/PowerForgeStudioReleasePublishExecutionServiceTests.cs
@@ -572,6 +572,150 @@ public sealed class PowerForgeStudioReleasePublishExecutionServiceTests
         }
     }
 
+    [Fact]
+    public async Task ExecuteAsync_ModuleRepositoryPublish_AllowsRepositoryCredentialProviderWithoutApiKey()
+    {
+        var repositoryRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForgeStudio.Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var buildDirectory = Directory.CreateDirectory(Path.Combine(repositoryRoot, "Build")).FullName;
+        File.WriteAllText(Path.Combine(buildDirectory, "Build-Module.ps1"), "# build");
+
+        var packageDirectory = Directory.CreateDirectory(Path.Combine(repositoryRoot, "Artifacts", "Packed", "PSPublishModule")).FullName;
+        var manifestPath = Path.Combine(packageDirectory, "PSPublishModule.psd1");
+        File.WriteAllText(
+            manifestPath,
+            """
+            @{
+                RootModule = 'PSPublishModule.psm1'
+                ModuleVersion = '2.0.0'
+            }
+            """);
+
+        var signingResult = new ReleaseSigningExecutionResult(
+            RootPath: repositoryRoot,
+            Succeeded: true,
+            Summary: "Signing completed.",
+            SourceCheckpointStateJson: null,
+            Receipts: [
+                new ReleaseSigningReceipt(
+                    RootPath: repositoryRoot,
+                    RepositoryName: "PSPublishModule",
+                    AdapterKind: ReleaseBuildAdapterKind.ModuleBuild.ToString(),
+                    ArtifactPath: packageDirectory,
+                    ArtifactKind: "Directory",
+                    Status: ReleaseSigningReceiptStatus.Signed,
+                    Summary: "Package directory signed.",
+                    SignedAtUtc: DateTimeOffset.UtcNow),
+                new ReleaseSigningReceipt(
+                    RootPath: repositoryRoot,
+                    RepositoryName: "PSPublishModule",
+                    AdapterKind: ReleaseBuildAdapterKind.ModuleBuild.ToString(),
+                    ArtifactPath: manifestPath,
+                    ArtifactKind: "File",
+                    Status: ReleaseSigningReceiptStatus.Signed,
+                    Summary: "Manifest signed.",
+                    SignedAtUtc: DateTimeOffset.UtcNow)
+            ]);
+
+        var queueItem = new ReleaseQueueItem(
+            RootPath: repositoryRoot,
+            RepositoryName: "PSPublishModule",
+            RepositoryKind: ReleaseRepositoryKind.Module,
+            WorkspaceKind: ReleaseWorkspaceKind.PrimaryRepository,
+            QueueOrder: 1,
+            Stage: ReleaseQueueStage.Publish,
+            Status: ReleaseQueueItemStatus.ReadyToRun,
+            Summary: "Ready for publish.",
+            CheckpointKey: "publish.ready",
+            CheckpointStateJson: JsonSerializer.Serialize(signingResult),
+            UpdatedAtUtc: DateTimeOffset.UtcNow);
+
+        RepositoryPublishRequest? captured = null;
+        var moduleRunner = new StubPowerShellRunner((request) => {
+                if (request.InvocationMode != PowerShellInvocationMode.Command || string.IsNullOrWhiteSpace(request.CommandText))
+                    return new PowerShellRunResult(1, string.Empty, "Unexpected invocation.", "pwsh");
+
+                if (request.CommandText.Contains("$targetJson =", StringComparison.Ordinal))
+                {
+                    var match = Regex.Match(request.CommandText, "\\$targetJson = '([^']+)'");
+                    if (!match.Success)
+                        return new PowerShellRunResult(1, string.Empty, "Export path missing.", "pwsh");
+
+                    File.WriteAllText(
+                        match.Groups[1].Value,
+                        """
+                        {
+                          "Segments": [
+                            {
+                              "Type": "GalleryNuget",
+                              "Configuration": {
+                                "Destination": "PowerShellGallery",
+                                "Enabled": true,
+                                "Tool": "PSResourceGet",
+                                "ApiKey": "",
+                                "RepositoryName": "JFrogPS",
+                                "Repository": {
+                                  "Name": "JFrogPS",
+                                  "Uri": "https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json",
+                                  "CredentialProvider": {
+                                    "Kind": "JFrogOidc",
+                                    "JFrogPlatformUri": "https://company.jfrog.io/",
+                                    "JFrogOidcProvider": "azure-oidc",
+                                    "JFrogOidcProviderType": "Azure"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                        """);
+
+                    return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh");
+                }
+
+                return new PowerShellRunResult(1, string.Empty, "Unexpected command.", "pwsh");
+            });
+        var service = new ReleasePublishExecutionService(
+            new RepositoryCatalogScanner(),
+            new ModuleBuildHostService(moduleRunner),
+            new ProjectBuildHostService(),
+            new ProjectBuildCommandHostService(),
+            new ProjectBuildPublishHostService(),
+            (request, _) => Task.FromResult(new DotNetNuGetPushResult(0, "published", string.Empty, "dotnet", TimeSpan.Zero, timedOut: false, errorMessage: null)),
+            publishRepositoryAsync: (request, _) => {
+                captured = request;
+                return Task.FromResult(new RepositoryPublishResult(
+                    path: request.Path,
+                    isNupkg: request.IsNupkg,
+                    repositoryName: request.RepositoryName ?? "JFrogPS",
+                    tool: request.Tool,
+                    repositoryCreated: false,
+                    repositoryUnregistered: false));
+            });
+
+        try
+        {
+            using var _ = new EnvironmentScope()
+                .Set("RELEASE_OPS_STUDIO_ENABLE_PUBLISH", "true");
+
+            var result = await service.ExecuteAsync(queueItem);
+
+            Assert.True(result.Succeeded);
+            Assert.NotNull(captured);
+            Assert.Equal(packageDirectory, captured!.Path);
+            Assert.Equal("JFrogPS", captured.RepositoryName);
+            Assert.Null(captured.ApiKey);
+            Assert.NotNull(captured.Repository?.CredentialProvider);
+            Assert.Equal(RepositoryCredentialProviderKind.JFrogOidc, captured.Repository!.CredentialProvider!.Kind);
+            Assert.Equal("azure-oidc", captured.Repository.CredentialProvider.JFrogOidcProvider);
+            var receipt = Assert.Single(result.Receipts);
+            Assert.Equal(ReleasePublishReceiptStatus.Published, receipt.Status);
+        }
+        finally
+        {
+            try { Directory.Delete(repositoryRoot, recursive: true); } catch { }
+        }
+    }
+
     private sealed class StubPowerShellRunner : IPowerShellRunner
     {
         private readonly Func<PowerShellRunRequest, PowerShellRunResult> _execute;


### PR DESCRIPTION
## Summary
- add direct JFrog private gallery publish configuration with PAT/basic, environment-secret, separate NuGet API key, and runtime OIDC credential-provider modes
- exchange JFrog OIDC tokens at publish time through `jf eot` and pass the returned username/access token to PSResourceGet/PowerShellGet without storing the exchanged token in config
- update private-gallery docs and generated `New-ConfigurationPublish` help with PAT, env-token, OIDC/federated CI, and browser SSO guidance

## Validation
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~PublishConfigurationFactoryTests|FullyQualifiedName~RepositoryPublisherTests"`
- `git diff --cached --check`

## Notes
- Live JFrog publish/install proof still requires a real Artifactory repository, JFrog CLI, provider mapping, and credentials/OIDC token in the target environment.