### PR TITLE
feat(dotnet-publish): support MSI metadata and private feed restore

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
@@ -262,10 +262,10 @@ public sealed class InvokeDotNetPublishCommand : PSCmdlet
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (DictionaryEntry entry in values)
         {
-            var key = entry.Key?.ToString();
-            if (string.IsNullOrWhiteSpace(key))
+            var trimmedKey = (entry.Key?.ToString() ?? string.Empty).Trim();
+            if (trimmedKey.Length == 0)
                 continue;
-            result[key.Trim()] = entry.Value?.ToString() ?? string.Empty;
+            result[trimmedKey] = entry.Value?.ToString() ?? string.Empty;
         }
 
         return result.Count == 0 ? null : result;

--- a/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
@@ -230,7 +230,7 @@ public sealed class InvokeDotNetPublishCommand : PSCmdlet
 
             if (workflow.Plan is not null)
             {
-                WriteObject(workflow.Plan);
+                WriteObject(DotNetPublishPlanRedactor.RedactInPlace(workflow.Plan));
                 if (exitCodeMode) Host.SetShouldExit(0);
                 return;
             }

--- a/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetPublishCommand.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Management.Automation;
 using PowerForge;
 
@@ -95,6 +97,27 @@ public sealed class InvokeDotNetPublishCommand : PSCmdlet
     public DotNetPublishStyle[]? Styles { get; set; }
 
     /// <summary>
+    /// Optional publish output-path override applied to selected targets.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetSettings)]
+    [Parameter(ParameterSetName = ParameterSetConfig)]
+    public string? OutputPath { get; set; }
+
+    /// <summary>
+    /// Optional global MSBuild properties passed to restore, build, publish, and installer steps.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetSettings)]
+    [Parameter(ParameterSetName = ParameterSetConfig)]
+    public Hashtable? MsBuildProperty { get; set; }
+
+    /// <summary>
+    /// Skips installer definitions after selected targets are filtered.
+    /// </summary>
+    [Parameter(ParameterSetName = ParameterSetSettings)]
+    [Parameter(ParameterSetName = ParameterSetConfig)]
+    public SwitchParameter SkipInstallers { get; set; }
+
+    /// <summary>
     /// Disables restore steps for this run.
     /// </summary>
     [Parameter(ParameterSetName = ParameterSetSettings)]
@@ -176,6 +199,9 @@ public sealed class InvokeDotNetPublishCommand : PSCmdlet
                     Runtimes = Runtimes,
                     Frameworks = Frameworks,
                     Styles = Styles,
+                    OutputPath = OutputPath,
+                    MsBuildProperties = ConvertHashtable(MsBuildProperty),
+                    SkipInstallers = SkipInstallers.IsPresent,
                     SkipRestore = SkipRestore.IsPresent,
                     SkipBuild = SkipBuild.IsPresent,
                     JsonOnly = JsonOnly.IsPresent,
@@ -226,5 +252,22 @@ public sealed class InvokeDotNetPublishCommand : PSCmdlet
             WriteError(new ErrorRecord(ex, "InvokeDotNetPublishFailed", ErrorCategory.NotSpecified, null));
             if (exitCodeMode) Host.SetShouldExit(1);
         }
+    }
+
+    private static Dictionary<string, string>? ConvertHashtable(Hashtable? values)
+    {
+        if (values is null || values.Count == 0)
+            return null;
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in values)
+        {
+            var key = entry.Key?.ToString();
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+            result[key.Trim()] = entry.Value?.ToString() ?? string.Empty;
+        }
+
+        return result.Count == 0 ? null : result;
     }
 }

--- a/PowerForge.Cli/Program.Command.DotNet.cs
+++ b/PowerForge.Cli/Program.Command.DotNet.cs
@@ -1,6 +1,7 @@
 using PowerForge;
 using PowerForge.Cli;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -97,7 +98,7 @@ internal static partial class Program
                     if (effectiveStyles.Length > 1 && GetActiveDotNetPublishProfile(spec) is not null)
                         cmdLogger.Warn("Multiple --style values were provided with an active profile; the single-value profile style filter is ignored and target styles drive matrix expansion.");
                     ApplyDotNetPublishSpecOverrides(spec, overrideTargets, effectiveRids, effectiveFrameworks, effectiveStyles);
-                    var plan = runner.Plan(spec, specPath);
+                    var plan = runner.Plan(spec, specPath, enforceRequiredEnvironmentVariables: runPipeline);
                     ApplyDotNetPublishSkipFlags(plan, skipRestore, skipBuild);
 
                     if (validateOnly)
@@ -117,7 +118,7 @@ internal static partial class Program
                                 Config = "dotnetpublish",
                                 ConfigPath = specPath,
                                 Spec = CliJson.SerializeToElement(spec, CliJson.Context.DotNetPublishSpec),
-                                Plan = CliJson.SerializeToElement(plan, CliJson.Context.DotNetPublishPlan),
+                                Plan = SerializeRedactedDotNetPublishPlan(plan),
                                 Logs = LogsToJsonElement(logBuffer)
                             });
                             return validateExitCode;
@@ -156,7 +157,7 @@ internal static partial class Program
                             Config = "dotnetpublish",
                             ConfigPath = specPath,
                             Spec = CliJson.SerializeToElement(spec, CliJson.Context.DotNetPublishSpec),
-                            Plan = CliJson.SerializeToElement(plan, CliJson.Context.DotNetPublishPlan),
+                            Plan = SerializeRedactedDotNetPublishPlan(plan),
                             Result = result is null ? null : CliJson.SerializeToElement(result, CliJson.Context.DotNetPublishResult),
                             Logs = LogsToJsonElement(logBuffer)
                         });
@@ -334,7 +335,7 @@ internal static partial class Program
                         spec.DotNet.ProjectRoot = Path.GetFullPath(projectRoot.Trim().Trim('"'));
 
                     var runner = new DotNetPublishPipelineRunner(cmdLogger);
-                    var plan = runner.Plan(spec, specPath);
+                    var plan = runner.Plan(spec, specPath, enforceRequiredEnvironmentVariables: false);
                     var bundle = (spec.Bundles ?? Array.Empty<DotNetPublishBundle>())
                         .FirstOrDefault(entry => string.Equals(entry.Id, bundleId, StringComparison.OrdinalIgnoreCase));
                     if (bundle is null)
@@ -526,6 +527,30 @@ internal static partial class Program
                 Console.WriteLine(DotNetScaffoldUsage);
                 return 2;
             }
+        }
+    }
+
+    private static System.Text.Json.JsonElement SerializeRedactedDotNetPublishPlan(DotNetPublishPlan plan)
+    {
+        var environmentVariables = new Dictionary<string, string?>(plan.EnvironmentVariables, StringComparer.OrdinalIgnoreCase);
+        var hookEnvironments = (plan.Steps ?? Array.Empty<DotNetPublishStep>())
+            .Select(step => new
+            {
+                Step = step,
+                Environment = new Dictionary<string, string>(step.HookEnvironment, StringComparer.OrdinalIgnoreCase)
+            })
+            .ToArray();
+
+        DotNetPublishPlanRedactor.RedactInPlace(plan);
+        try
+        {
+            return CliJson.SerializeToElement(plan, CliJson.Context.DotNetPublishPlan);
+        }
+        finally
+        {
+            plan.EnvironmentVariables = environmentVariables;
+            foreach (var entry in hookEnvironments)
+                entry.Step.HookEnvironment = entry.Environment;
         }
     }
 }

--- a/PowerForge.PowerShell/Models/DotNetPublishPreparationRequest.cs
+++ b/PowerForge.PowerShell/Models/DotNetPublishPreparationRequest.cs
@@ -14,6 +14,9 @@ internal sealed class DotNetPublishPreparationRequest
     public string[]? Runtimes { get; set; }
     public string[]? Frameworks { get; set; }
     public DotNetPublishStyle[]? Styles { get; set; }
+    public string? OutputPath { get; set; }
+    public Dictionary<string, string>? MsBuildProperties { get; set; }
+    public bool SkipInstallers { get; set; }
     public bool SkipRestore { get; set; }
     public bool SkipBuild { get; set; }
     public bool JsonOnly { get; set; }

--- a/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
+++ b/PowerForge.PowerShell/Services/DotNetPublishPreparationService.cs
@@ -120,6 +120,9 @@ internal sealed class DotNetPublishPreparationService
         var overrideRuntimes = NormalizeStrings(request.Runtimes);
         var overrideFrameworks = NormalizeStrings(request.Frameworks);
         var overrideStyles = NormalizeStyles(request.Styles);
+        var outputPath = string.IsNullOrWhiteSpace(request.OutputPath)
+            ? null
+            : request.OutputPath!.Trim();
 
         if (overrideTargets.Length > 0)
         {
@@ -174,7 +177,8 @@ internal sealed class DotNetPublishPreparationService
 
         if (overrideRuntimes.Length > 0
             || overrideFrameworks.Length > 0
-            || overrideStyles.Length > 0)
+            || overrideStyles.Length > 0
+            || !string.IsNullOrWhiteSpace(outputPath))
         {
             foreach (var target in spec.Targets ?? Array.Empty<DotNetPublishTarget>())
             {
@@ -194,10 +198,27 @@ internal sealed class DotNetPublishPreparationService
                     target.Publish.Style = overrideStyles[0];
                     target.Publish.Styles = overrideStyles;
                 }
+
+                if (!string.IsNullOrWhiteSpace(outputPath))
+                    target.Publish.OutputPath = outputPath;
             }
         }
 
         spec.DotNet ??= new DotNetPublishDotNetOptions();
+        if (request.MsBuildProperties is { Count: > 0 })
+        {
+            spec.DotNet.MsBuildProperties ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in request.MsBuildProperties)
+            {
+                if (string.IsNullOrWhiteSpace(property.Key))
+                    continue;
+                spec.DotNet.MsBuildProperties[property.Key.Trim()] = property.Value;
+            }
+        }
+
+        if (request.SkipInstallers)
+            spec.Installers = Array.Empty<DotNetPublishInstaller>();
+
         if (request.SkipRestore)
         {
             spec.DotNet.Restore = false;

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetPublishPipelineRunnerEnvironmentTests
+{
+    [Fact]
+    public void Plan_ResolvesDotNetEnvironmentVariableFromFallbackList()
+    {
+        var root = CreateTempRoot();
+        var sourceName = "POWERFORGE_TEST_SOURCE_TOKEN_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var projectPath = CreateProject(root);
+            Environment.SetEnvironmentVariable(sourceName, "token-value");
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                new DotNetPublishSpec
+                {
+                    DotNet = new DotNetPublishDotNetOptions
+                    {
+                        ProjectRoot = root,
+                        Restore = false,
+                        Build = false,
+                        Runtimes = new[] { "win-x64" },
+                        EnvironmentVariables = new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["LICENSING_PACKAGES_TOKEN"] = new()
+                            {
+                                FromEnvironmentVariables = new[] { "MISSING_TOKEN", sourceName },
+                                Required = true
+                            }
+                        }
+                    },
+                    Targets = new[] { NewTarget(projectPath) }
+                },
+                configPath: null);
+
+            Assert.Equal("token-value", plan.EnvironmentVariables["LICENSING_PACKAGES_TOKEN"]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(sourceName, null);
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_ThrowsWhenRequiredDotNetEnvironmentVariableIsMissing()
+    {
+        var root = CreateTempRoot();
+        var sourceName = "POWERFORGE_TEST_MISSING_TOKEN_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var projectPath = CreateProject(root);
+            Environment.SetEnvironmentVariable(sourceName, null);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                new DotNetPublishSpec
+                {
+                    DotNet = new DotNetPublishDotNetOptions
+                    {
+                        ProjectRoot = root,
+                        Restore = false,
+                        Build = false,
+                        Runtimes = new[] { "win-x64" },
+                        EnvironmentVariables = new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["LICENSING_PACKAGES_TOKEN"] = new()
+                            {
+                                FromEnvironmentVariables = new[] { sourceName },
+                                Required = true
+                            }
+                        }
+                    },
+                    Targets = new[] { NewTarget(projectPath) }
+                },
+                configPath: null));
+
+            Assert.Contains("LICENSING_PACKAGES_TOKEN", ex.Message, StringComparison.Ordinal);
+            Assert.Contains(sourceName, ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_AllowsMissingRequiredDotNetEnvironmentVariableWhenNotEnforced()
+    {
+        var root = CreateTempRoot();
+        var sourceName = "POWERFORGE_TEST_PLAN_ONLY_TOKEN_" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var projectPath = CreateProject(root);
+            Environment.SetEnvironmentVariable(sourceName, null);
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                new DotNetPublishSpec
+                {
+                    DotNet = new DotNetPublishDotNetOptions
+                    {
+                        ProjectRoot = root,
+                        Restore = false,
+                        Build = false,
+                        Runtimes = new[] { "win-x64" },
+                        EnvironmentVariables = new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["LICENSING_PACKAGES_TOKEN"] = new()
+                            {
+                                FromEnvironmentVariables = new[] { sourceName },
+                                Required = true
+                            }
+                        }
+                    },
+                    Targets = new[] { NewTarget(projectPath) }
+                },
+                configPath: null,
+                enforceRequiredEnvironmentVariables: false);
+
+            Assert.False(plan.EnvironmentVariables.ContainsKey("LICENSING_PACKAGES_TOKEN"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static DotNetPublishTarget NewTarget(string projectPath)
+        => new()
+        {
+            Name = "app",
+            ProjectPath = projectPath,
+            Publish = new DotNetPublishPublishOptions
+            {
+                Framework = "net10.0",
+                Runtimes = new[] { "win-x64" },
+                UseStaging = false
+            }
+        };
+
+    private static string CreateProject(string root)
+    {
+        var path = Path.Combine(root, "App", "App.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>");
+        return path;
+    }
+
+    private static string CreateTempRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best effort cleanup for transient test roots.
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
@@ -130,6 +130,16 @@ public sealed class DotNetPublishPipelineRunnerEnvironmentTests
         }
     }
 
+    [Fact]
+    public void Plan_PreservesTwoArgumentOverloadForBinaryCompatibility()
+    {
+        var overload = typeof(DotNetPublishPipelineRunner).GetMethod(
+            nameof(DotNetPublishPipelineRunner.Plan),
+            new[] { typeof(DotNetPublishSpec), typeof(string) });
+
+        Assert.NotNull(overload);
+    }
+
     private static DotNetPublishTarget NewTarget(string projectPath)
         => new()
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -163,7 +163,24 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
                     Style = DotNetPublishStyle.Portable,
                     OutputFiles = new[] { msiPath, msiSidecarPath },
                     SignedFiles = new[] { msiPath },
-                    Version = "1.2.3"
+                    Version = "1.2.3",
+                    PackageMetadata = new[]
+                    {
+                        new DotNetPublishMsiPackageMetadata
+                        {
+                            Path = msiPath,
+                            ProductCode = "{11111111-1111-1111-1111-111111111111}",
+                            ProductName = "App",
+                            ProductVersion = "1.2.3",
+                            Manufacturer = "Evotec",
+                            UpgradeCode = "{22222222-2222-2222-2222-222222222222}"
+                        },
+                        new DotNetPublishMsiPackageMetadata
+                        {
+                            Path = msiSidecarPath,
+                            ReadError = "metadata unavailable"
+                        }
+                    }
                 }
             };
             var storePackages = new List<DotNetPublishStorePackageResult>
@@ -201,6 +218,16 @@ public sealed class DotNetPublishPipelineRunnerHardeningTests
             Assert.Equal("Portable", installer.GetProperty("Style").GetString());
             Assert.Equal(1, installer.GetProperty("SignedFiles").GetInt32());
             Assert.False(installer.TryGetProperty("Cleanup", out _));
+            var packageMetadata = installer.GetProperty("PackageMetadata");
+            Assert.Equal(2, packageMetadata.GetArrayLength());
+            var firstPackage = packageMetadata[0];
+            Assert.Equal("Artifacts/Msi/app/output/App.msi", firstPackage.GetProperty("Path").GetString());
+            Assert.Equal("{11111111-1111-1111-1111-111111111111}", firstPackage.GetProperty("ProductCode").GetString());
+            Assert.Equal("App", firstPackage.GetProperty("ProductName").GetString());
+            Assert.Equal("1.2.3", firstPackage.GetProperty("ProductVersion").GetString());
+            Assert.Equal("Evotec", firstPackage.GetProperty("Manufacturer").GetString());
+            Assert.Equal("{22222222-2222-2222-2222-222222222222}", firstPackage.GetProperty("UpgradeCode").GetString());
+            Assert.Equal("metadata unavailable", packageMetadata[1].GetProperty("ReadError").GetString());
 
             var store = FindManifestEntry(doc, "Category", "StorePackage");
             Assert.Equal("app.store", store.GetProperty("StorePackageId").GetString());

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
@@ -114,6 +114,13 @@ public sealed class DotNetPublishPipelineRunnerServicePackageTests
             var installContent = File.ReadAllText(result.InstallScriptPath!);
             Assert.Contains("PowerForge.Svc", installContent, StringComparison.Ordinal);
             Assert.Contains("Svc.exe", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string]$ServiceName", installContent, StringComparison.Ordinal);
+            Assert.Contains("[string]$ConfigPath", installContent, StringComparison.Ordinal);
+            Assert.Contains("[string]$Account", installContent, StringComparison.Ordinal);
+            Assert.Contains("[switch]$PreserveExistingServiceBinPath", installContent, StringComparison.Ordinal);
+            Assert.Contains("Set-CommandLineOption", installContent, StringComparison.Ordinal);
+            Assert.Contains("$preservedBinaryPathName", installContent, StringComparison.Ordinal);
+            Assert.Contains("--config", installContent, StringComparison.Ordinal);
             Assert.DoesNotContain("{{", installContent, StringComparison.Ordinal);
 
             var uninstallContent = File.ReadAllText(result.UninstallScriptPath!);

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerStorePackageTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerStorePackageTests.cs
@@ -338,6 +338,67 @@ public sealed class DotNetPublishPipelineRunnerStorePackageTests
     }
 
     [Fact]
+    public void Run_StorePackage_PassesPlanEnvironmentVariablesToBuild()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var packagingProject = CreateFakeStorePackagingProject(root, writeEnvironmentProbe: true);
+            var outputDir = Path.Combine(root, "Artifacts", "Store", "app.store");
+            var probePath = Path.Combine(outputDir, "StoreEnv.txt");
+
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Configuration = "Release",
+                Restore = true,
+                Build = false,
+                EnvironmentVariables = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["POWERFORGE_STORE_TEST_TOKEN"] = "store-secret"
+                },
+                StorePackages = new[]
+                {
+                    new DotNetPublishStorePackagePlan
+                    {
+                        Id = "app.store",
+                        PrepareFromTarget = "app",
+                        PackagingProjectPath = packagingProject,
+                        OutputPath = outputDir,
+                        BuildMode = DotNetPublishStoreBuildMode.StoreUpload,
+                        Bundle = DotNetPublishStoreBundleMode.Always
+                    }
+                },
+                Steps = new[]
+                {
+                    new DotNetPublishStep
+                    {
+                        Key = "store.package:app.store:app:net8.0-windows10.0.19041.0:win-x64:FrameworkDependent",
+                        Kind = DotNetPublishStepKind.StorePackage,
+                        Title = "Store package",
+                        StorePackageId = "app.store",
+                        TargetName = "app",
+                        Framework = "net8.0-windows10.0.19041.0",
+                        Runtime = "win-x64",
+                        Style = DotNetPublishStyle.FrameworkDependent,
+                        StorePackageProjectPath = packagingProject,
+                        StorePackageOutputPath = outputDir
+                    }
+                }
+            };
+
+            var result = new DotNetPublishPipelineRunner(new NullLogger()).Run(plan, progress: null);
+
+            Assert.True(result.Succeeded, result.ErrorMessage);
+            Assert.Equal("store-secret", File.ReadAllText(probePath).Trim());
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Run_StorePackage_FallsBackToDefaultAppPackagesDirectory()
     {
         var root = CreateTempRoot();
@@ -761,13 +822,20 @@ public sealed class DotNetPublishPipelineRunnerStorePackageTests
         return fullPath;
     }
 
-    private static string CreateFakeStorePackagingProject(string root, bool writeToDefaultAppPackages = false, bool writeOutputs = true)
+    private static string CreateFakeStorePackagingProject(
+        string root,
+        bool writeToDefaultAppPackages = false,
+        bool writeOutputs = true,
+        bool writeEnvironmentProbe = false)
     {
         var path = Path.Combine(root, "Store", "FakeStore.csproj");
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var outputRootExpression = writeToDefaultAppPackages
             ? "$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', 'AppPackages'))"
             : "$(AppxPackageDir)";
+        var environmentProbeTarget = writeEnvironmentProbe ? """
+    <WriteLinesToFile File="$([System.IO.Path]::Combine('$(PowerForgeStoreOutputRoot)', 'StoreEnv.txt'))" Lines="$(POWERFORGE_STORE_TEST_TOKEN)" Overwrite="true" />
+""" : string.Empty;
         var outputTarget = writeOutputs ? """
   <Target Name="PowerForgeFakeStoreOutputs" AfterTargets="Build">
     <PropertyGroup>
@@ -780,6 +848,7 @@ public sealed class DotNetPublishPipelineRunnerStorePackageTests
     <WriteLinesToFile File="$(PowerForgeBundlePath)" Lines="bundle" Overwrite="true" />
     <WriteLinesToFile File="$(PowerForgeUploadPath)" Lines="upload" Overwrite="true" />
     <WriteLinesToFile File="$(PowerForgeSymbolsPath)" Lines="symbols" Overwrite="true" />
+ENVIRONMENT_PROBE_TOKEN
   </Target>
 """ : """
   <Target Name="PowerForgeFakeStoreOutputs" AfterTargets="Build">
@@ -794,7 +863,8 @@ public sealed class DotNetPublishPipelineRunnerStorePackageTests
 OUTPUT_TARGET_TOKEN
 </Project>
 """.Replace("OUTPUT_TARGET_TOKEN", outputTarget, StringComparison.Ordinal)
-    .Replace("OUTPUT_ROOT_TOKEN", outputRootExpression, StringComparison.Ordinal), new UTF8Encoding(false));
+    .Replace("OUTPUT_ROOT_TOKEN", outputRootExpression, StringComparison.Ordinal)
+    .Replace("ENVIRONMENT_PROBE_TOKEN", environmentProbeTarget, StringComparison.Ordinal), new UTF8Encoding(false));
         return path;
     }
 

--- a/PowerForge.Tests/DotNetPublishPlanRedactorTests.cs
+++ b/PowerForge.Tests/DotNetPublishPlanRedactorTests.cs
@@ -1,0 +1,47 @@
+namespace PowerForge.Tests;
+
+public sealed class DotNetPublishPlanRedactorTests
+{
+    [Fact]
+    public void RedactInPlace_ReplacesResolvedEnvironmentVariableValues()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            EnvironmentVariables = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["LICENSING_PACKAGES_TOKEN"] = "token-value",
+                ["LICENSING_PACKAGES_USERNAME"] = "EvotecIT",
+                ["OPTIONAL_EMPTY"] = null
+            }
+        };
+
+        var redacted = DotNetPublishPlanRedactor.RedactInPlace(plan);
+
+        Assert.Same(plan, redacted);
+        Assert.Equal("<redacted>", plan.EnvironmentVariables["LICENSING_PACKAGES_TOKEN"]);
+        Assert.Equal("<redacted>", plan.EnvironmentVariables["LICENSING_PACKAGES_USERNAME"]);
+        Assert.Null(plan.EnvironmentVariables["OPTIONAL_EMPTY"]);
+    }
+
+    [Fact]
+    public void RedactInPlace_ReplacesHookEnvironmentValues()
+    {
+        var plan = new DotNetPublishPlan
+        {
+            Steps = new[]
+            {
+                new DotNetPublishStep
+                {
+                    HookEnvironment = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["HOOK_TOKEN"] = "secret"
+                    }
+                }
+            }
+        };
+
+        DotNetPublishPlanRedactor.RedactInPlace(plan);
+
+        Assert.Equal("<redacted>", plan.Steps[0].HookEnvironment["HOOK_TOKEN"]);
+    }
+}

--- a/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPreparationServiceTests.cs
@@ -67,6 +67,12 @@ public sealed class DotNetPublishPreparationServiceTests
                 Runtimes = new[] { "linux-x64" },
                 Frameworks = new[] { "net10.0" },
                 Styles = new[] { DotNetPublishStyle.PortableCompat },
+                OutputPath = "Artifacts/Portable/{target}/{rid}",
+                MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["UseLocalHtmlForgeX"] = "true"
+                },
+                SkipInstallers = true,
                 SkipRestore = true,
                 SkipBuild = true,
                 JsonOnly = true
@@ -80,13 +86,14 @@ public sealed class DotNetPublishPreparationServiceTests
             Assert.Equal("App", context.Spec.Targets[0].Name);
             Assert.Single(context.Spec.Profiles[0].Targets);
             Assert.Equal("App", context.Spec.Profiles[0].Targets[0]);
-            Assert.Single(context.Spec.Installers);
-            Assert.Equal("AppInstaller", context.Spec.Installers[0].Id);
             Assert.Equal(new[] { "linux-x64" }, context.Spec.Targets[0].Publish.Runtimes);
             Assert.Equal("net10.0", context.Spec.Targets[0].Publish.Framework);
             Assert.Equal(new[] { "net10.0" }, context.Spec.Targets[0].Publish.Frameworks);
             Assert.Equal(DotNetPublishStyle.PortableCompat, context.Spec.Targets[0].Publish.Style);
             Assert.Equal(new[] { DotNetPublishStyle.PortableCompat }, context.Spec.Targets[0].Publish.Styles);
+            Assert.Equal("Artifacts/Portable/{target}/{rid}", context.Spec.Targets[0].Publish.OutputPath);
+            Assert.Equal("true", context.Spec.DotNet.MsBuildProperties!["UseLocalHtmlForgeX"]);
+            Assert.Empty(context.Spec.Installers);
             Assert.False(context.Spec.DotNet.Restore);
             Assert.False(context.Spec.DotNet.Build);
             Assert.True(context.Spec.DotNet.NoRestoreInPublish);

--- a/PowerForge.Tests/DotNetPublishWorkflowServiceTests.cs
+++ b/PowerForge.Tests/DotNetPublishWorkflowServiceTests.cs
@@ -44,9 +44,10 @@ public sealed class DotNetPublishWorkflowServiceTests
         };
         var service = new DotNetPublishWorkflowService(
             logger,
-            planPublish: (spec, sourceLabel) =>
+            planPublish: (spec, sourceLabel, enforceRequiredEnvironmentVariables) =>
             {
                 Assert.Equal("config.json", sourceLabel);
+                Assert.False(enforceRequiredEnvironmentVariables);
                 return expectedPlan;
             });
 
@@ -68,7 +69,11 @@ public sealed class DotNetPublishWorkflowServiceTests
         var expectedProgress = new TestProgressReporter();
         var service = new DotNetPublishWorkflowService(
             new NullLogger(),
-            planPublish: (_, _) => new DotNetPublishPlan(),
+            planPublish: (_, _, enforceRequiredEnvironmentVariables) =>
+            {
+                Assert.True(enforceRequiredEnvironmentVariables);
+                return new DotNetPublishPlan();
+            },
             runPublish: (plan, progress) =>
             {
                 Assert.NotNull(plan);

--- a/PowerForge.Tests/MsiPackageMetadataReaderTests.cs
+++ b/PowerForge.Tests/MsiPackageMetadataReaderTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+
+namespace PowerForge.Tests;
+
+public sealed class MsiPackageMetadataReaderTests
+{
+    [Fact]
+    public void ReadProperties_ThrowsWhenMsiFileDoesNotExist()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"), "missing.msi");
+
+        var ex = Assert.Throws<FileNotFoundException>(
+            () => MsiPackageMetadataReader.ReadProperties(path, new[] { "ProductCode" }));
+
+        Assert.Equal(path, ex.FileName);
+    }
+}

--- a/PowerForge/Models/DotNetPublish/DotNetPublishMsiPackageMetadata.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishMsiPackageMetadata.cs
@@ -1,0 +1,28 @@
+namespace PowerForge;
+
+/// <summary>
+/// Windows Installer package identity read from a built MSI file.
+/// </summary>
+public sealed class DotNetPublishMsiPackageMetadata
+{
+    /// <summary>MSI file path this metadata describes.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Windows Installer ProductCode property.</summary>
+    public string? ProductCode { get; set; }
+
+    /// <summary>Windows Installer ProductName property.</summary>
+    public string? ProductName { get; set; }
+
+    /// <summary>Windows Installer ProductVersion property.</summary>
+    public string? ProductVersion { get; set; }
+
+    /// <summary>Windows Installer Manufacturer property.</summary>
+    public string? Manufacturer { get; set; }
+
+    /// <summary>Windows Installer UpgradeCode property.</summary>
+    public string? UpgradeCode { get; set; }
+
+    /// <summary>Error captured when package metadata could not be read.</summary>
+    public string? ReadError { get; set; }
+}

--- a/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
@@ -47,6 +47,9 @@ public sealed class DotNetPublishPlan
     /// <summary>Resolved MSBuild properties.</summary>
     public Dictionary<string, string> MsBuildProperties { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Resolved environment variables passed to dotnet commands.</summary>
+    public Dictionary<string, string?> EnvironmentVariables { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Resolved targets (paths + publish options).</summary>
     public DotNetPublishTargetPlan[] Targets { get; set; } = Array.Empty<DotNetPublishTargetPlan>();
 

--- a/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
@@ -256,6 +256,9 @@ public sealed class DotNetPublishMsiBuildResult
     /// <summary>MSI files signed by <c>msi.sign</c> step.</summary>
     public string[] SignedFiles { get; set; } = Array.Empty<string>();
 
+    /// <summary>Package identity metadata read from detected MSI output files.</summary>
+    public DotNetPublishMsiPackageMetadata[] PackageMetadata { get; set; } = Array.Empty<DotNetPublishMsiPackageMetadata>();
+
     /// <summary>Resolved MSI version used for build (when version policy is enabled).</summary>
     public string? Version { get; set; }
 

--- a/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
@@ -1027,6 +1027,43 @@ public sealed class DotNetPublishDotNetOptions
     /// Optional MSBuild properties passed to build/publish (as <c>/p:Name=Value</c>).
     /// </summary>
     public Dictionary<string, string>? MsBuildProperties { get; set; }
+
+    /// <summary>
+    /// Optional environment variables supplied to dotnet restore/build/publish commands.
+    /// Use this for private package feeds that rely on NuGet.config environment-variable expansion.
+    /// </summary>
+    public Dictionary<string, DotNetPublishEnvironmentVariable>? EnvironmentVariables { get; set; }
+}
+
+/// <summary>
+/// Environment variable definition for dotnet restore/build/publish commands.
+/// </summary>
+public sealed class DotNetPublishEnvironmentVariable
+{
+    /// <summary>
+    /// Literal value to assign. Prefer <see cref="FromEnvironmentVariables"/> for secrets.
+    /// </summary>
+    public string? Value { get; set; }
+
+    /// <summary>
+    /// Single source environment variable used when <see cref="Value"/> is not set.
+    /// </summary>
+    public string? FromEnvironmentVariable { get; set; }
+
+    /// <summary>
+    /// Ordered source environment variable fallback list used when <see cref="Value"/> is not set.
+    /// </summary>
+    public string[] FromEnvironmentVariables { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// When true, planning fails if no literal or source environment value can be resolved.
+    /// </summary>
+    public bool Required { get; set; }
+
+    /// <summary>
+    /// Indicates that the value is sensitive and should not be written to logs.
+    /// </summary>
+    public bool Secret { get; set; } = true;
 }
 
 /// <summary>

--- a/PowerForge/Scripts/DotNetPublish/Install-Service.Template.ps1
+++ b/PowerForge/Scripts/DotNetPublish/Install-Service.Template.ps1
@@ -1,13 +1,19 @@
 ﻿#requires -Version 5.1
 [CmdletBinding()]
 param(
+    [string]$ServiceName = '{{ServiceName}}',
+    [string]$DisplayName = '{{DisplayName}}',
+    [string]$Description = '{{Description}}',
+    [string]$ConfigPath,
+    [string]$Account = 'LocalSystem',
+    [string]$Password,
+    [string]$BackupPath,
+    [switch]$UpgradeMode,
+    [switch]$PreserveExistingServiceBinPath,
     [switch]$Start
 )
 $ErrorActionPreference = 'Stop'
 
-$serviceName = '{{ServiceName}}'
-$displayName = '{{DisplayName}}'
-$description = '{{Description}}'
 $binaryRelative = '{{ExecutableRelativePath}}'
 $arguments = '{{Arguments}}'
 
@@ -16,6 +22,52 @@ $exePath = Join-Path -Path $packageRoot -ChildPath $binaryRelative
 
 if (-not (Test-Path -LiteralPath $exePath)) {
     throw "Service binary not found: $exePath"
+}
+
+function Set-CommandLineOption {
+    param(
+        [Parameter(Mandatory)]
+        [string]$CommandLine,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    $escapedValue = $Value.Replace('"', '\"')
+    $pattern = '(?i)(^|\s)' + [regex]::Escape($Name) + '\s+(".*?"|\S+)'
+    if ($CommandLine -match $pattern) {
+        return [regex]::Replace($CommandLine, $pattern, '$1' + $Name + ' "' + $escapedValue + '"', 1)
+    }
+
+    return ($CommandLine + ' ' + $Name + ' "' + $escapedValue + '"').Trim()
+}
+
+$binaryPathName = '"' + $exePath + '"'
+if (-not [string]::IsNullOrWhiteSpace($arguments)) {
+    $binaryPathName += ' ' + $arguments
+}
+
+if ($UpgradeMode -and $PreserveExistingServiceBinPath -and -not [string]::IsNullOrWhiteSpace($BackupPath) -and (Test-Path -LiteralPath $BackupPath)) {
+    $preservedBinaryPathName = (Get-Content -LiteralPath $BackupPath -Raw).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($preservedBinaryPathName)) {
+        $binaryPathName = $preservedBinaryPathName
+    }
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ConfigPath)) {
+    $resolvedConfigPath = $ConfigPath
+    if (-not [System.IO.Path]::IsPathRooted($resolvedConfigPath)) {
+        $resolvedConfigPath = Join-Path -Path $packageRoot -ChildPath $resolvedConfigPath
+    }
+
+    $binaryPathName = Set-CommandLineOption -CommandLine $binaryPathName -Name '--config' -Value $resolvedConfigPath
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ServiceName)) {
+    $binaryPathName = Set-CommandLineOption -CommandLine $binaryPathName -Name '--service-name' -Value $ServiceName
 }
 
 $existing = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
@@ -27,15 +79,28 @@ if ($existing) {
     Start-Sleep -Seconds 1
 }
 
-$binaryPathName = '"' + $exePath + '"'
-if (-not [string]::IsNullOrWhiteSpace($arguments)) {
-    $binaryPathName += ' ' + $arguments
+$newServiceParams = @{
+    Name           = $ServiceName
+    BinaryPathName = $binaryPathName
+    DisplayName    = $DisplayName
+    Description    = $Description
+    StartupType    = 'Automatic'
 }
 
-New-Service -Name $serviceName -BinaryPathName $binaryPathName -DisplayName $displayName -Description $description -StartupType Automatic | Out-Null
+if (-not [string]::IsNullOrWhiteSpace($Account) -and $Account -ne 'LocalSystem') {
+    if ([string]::IsNullOrWhiteSpace($Password)) {
+        $credential = Get-Credential -UserName $Account -Message 'Enter password for service account'
+    } else {
+        $securePassword = ConvertTo-SecureString -String $Password -AsPlainText -Force
+        $credential = [pscredential]::new($Account, $securePassword)
+    }
+    $newServiceParams.Credential = $credential
+}
+
+New-Service @newServiceParams | Out-Null
 
 if ($Start) {
-    Start-Service -Name $serviceName
+    Start-Service -Name $ServiceName
 }
 
-Get-Service -Name $serviceName
+Get-Service -Name $ServiceName

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -521,7 +521,8 @@ public sealed partial class DotNetPublishPipelineRunner
                 OutputFiles = ToManifestOutputFiles(projectRoot, files),
                 Files = files.Length,
                 TotalBytes = SumFileBytes(files),
-                SignedFiles = build.SignedFiles is { Length: > 0 } ? build.SignedFiles.Length : null
+                SignedFiles = build.SignedFiles is { Length: > 0 } ? build.SignedFiles.Length : null,
+                PackageMetadata = ToManifestPackageMetadata(projectRoot, build.PackageMetadata)
             });
         }
 
@@ -552,6 +553,7 @@ public sealed partial class DotNetPublishPipelineRunner
         public DotNetPublishServicePackageResult? ServicePackage { get; set; }
         public DotNetPublishStateTransferResult? StateTransfer { get; set; }
         public int? SignedFiles { get; set; }
+        public DotNetPublishMsiPackageMetadata[]? PackageMetadata { get; set; }
     }
 
     private static bool HasCleanup(DotNetPublishCleanupResult? cleanup)
@@ -577,6 +579,29 @@ public sealed partial class DotNetPublishPipelineRunner
             .ToArray();
 
         return outputFiles.Length == 0 ? null : outputFiles;
+    }
+
+    private static DotNetPublishMsiPackageMetadata[]? ToManifestPackageMetadata(
+        string projectRoot,
+        IEnumerable<DotNetPublishMsiPackageMetadata>? packages)
+    {
+        var metadata = (packages ?? Array.Empty<DotNetPublishMsiPackageMetadata>())
+            .Where(package => package is not null && !string.IsNullOrWhiteSpace(package.Path))
+            .Select(package => new DotNetPublishMsiPackageMetadata
+            {
+                Path = Path.IsPathRooted(package.Path)
+                    ? ToManifestRelativePath(projectRoot, package.Path)
+                    : package.Path.Replace('\\', '/'),
+                ProductCode = EmptyToNull(package.ProductCode),
+                ProductName = EmptyToNull(package.ProductName),
+                ProductVersion = EmptyToNull(package.ProductVersion),
+                Manufacturer = EmptyToNull(package.Manufacturer),
+                UpgradeCode = EmptyToNull(package.UpgradeCode),
+                ReadError = EmptyToNull(package.ReadError)
+            })
+            .ToArray();
+
+        return metadata.Length == 0 ? null : metadata;
     }
 
     private static IEnumerable<string> EnumerateStorePackageFiles(DotNetPublishStorePackageResult store)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -141,7 +141,7 @@ public sealed partial class DotNetPublishPipelineRunner
             _logger.Info($"MSI output directory for '{installerId}' -> {configuredOutputDir}");
         if (!string.IsNullOrWhiteSpace(configuredOutputName))
             _logger.Info($"MSI output name for '{installerId}' -> {configuredOutputName}.msi");
-        RunDotnet(plan.ProjectRoot, args);
+        RunDotnet(plan.ProjectRoot, args, plan.EnvironmentVariables);
 
         if (versionResolution.Patch.HasValue && !string.IsNullOrWhiteSpace(versionResolution.StatePath))
             WriteMsiVersionState(versionResolution.StatePath!, versionResolution.Patch.Value, versionResolution.Version!);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 
@@ -154,6 +155,7 @@ public sealed partial class DotNetPublishPipelineRunner
             foreach (var output in outputs)
                 _logger.Info($"  -> {output}");
         }
+        var packageMetadata = ReadMsiPackageMetadata(outputs);
 
         return new DotNetPublishMsiBuildResult
         {
@@ -164,6 +166,7 @@ public sealed partial class DotNetPublishPipelineRunner
             Style = style.Value,
             ProjectPath = installerProjectPath,
             OutputFiles = outputs,
+            PackageMetadata = packageMetadata,
             Version = versionResolution.Version,
             VersionPropertyName = versionResolution.PropertyName,
             VersionPatch = versionResolution.Patch,
@@ -172,6 +175,38 @@ public sealed partial class DotNetPublishPipelineRunner
             ClientLicensePropertyName = licenseResolution.PropertyName,
             ClientId = licenseResolution.ClientId
         };
+    }
+
+    private DotNetPublishMsiPackageMetadata[] ReadMsiPackageMetadata(IEnumerable<string> outputs)
+    {
+        var reader = new MsiPackageMetadataReader();
+        var metadata = new List<DotNetPublishMsiPackageMetadata>();
+        foreach (var output in outputs ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(output))
+                continue;
+
+            try
+            {
+                metadata.Add(reader.Read(output));
+            }
+            catch (Exception ex) when (ex is COMException
+                                           or InvalidOperationException
+                                           or PlatformNotSupportedException
+                                           or FileNotFoundException
+                                           or UnauthorizedAccessException)
+            {
+                var message = ex.GetBaseException().Message;
+                _logger.Warn($"MSI metadata could not be read for '{output}': {message}");
+                metadata.Add(new DotNetPublishMsiPackageMetadata
+                {
+                    Path = Path.GetFullPath(output),
+                    ReadError = message
+                });
+            }
+        }
+
+        return metadata.ToArray();
     }
 
     private string ResolveOrPrepareInstallerProjectPath(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -30,7 +30,14 @@ public sealed partial class DotNetPublishPipelineRunner
     /// Optional path to the JSON config file. When provided, relative paths are resolved against its directory,
     /// unless <see cref="DotNetPublishDotNetOptions.ProjectRoot"/> is set.
     /// </param>
-    public DotNetPublishPlan Plan(DotNetPublishSpec spec, string? configPath)
+    /// <param name="enforceRequiredEnvironmentVariables">
+    /// When true, missing required dotnet environment variables fail planning. Plan-only and validate-only callers
+    /// can set this to false so configuration inspection does not require private feed credentials.
+    /// </param>
+    public DotNetPublishPlan Plan(
+        DotNetPublishSpec spec,
+        string? configPath,
+        bool enforceRequiredEnvironmentVariables = true)
     {
         if (spec is null) throw new ArgumentNullException(nameof(spec));
         spec = ResolveProfile(spec);
@@ -520,6 +527,9 @@ public sealed partial class DotNetPublishPipelineRunner
             NoRestoreInPublish = spec.DotNet.NoRestoreInPublish,
             NoBuildInPublish = spec.DotNet.NoBuildInPublish,
             MsBuildProperties = msbuildProps,
+            EnvironmentVariables = ResolveDotNetEnvironmentVariables(
+                spec.DotNet.EnvironmentVariables,
+                enforceRequiredEnvironmentVariables),
             Targets = targets.ToArray(),
             Bundles = bundles,
             Installers = installers,
@@ -665,8 +675,127 @@ public sealed partial class DotNetPublishPipelineRunner
             Runtimes = (dotNet.Runtimes ?? Array.Empty<string>()).ToArray(),
             MsBuildProperties = dotNet.MsBuildProperties is null
                 ? null
-                : new Dictionary<string, string>(dotNet.MsBuildProperties, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(dotNet.MsBuildProperties, StringComparer.OrdinalIgnoreCase),
+            EnvironmentVariables = CloneEnvironmentVariables(dotNet.EnvironmentVariables)
         };
+    }
+
+    private static Dictionary<string, DotNetPublishEnvironmentVariable>? CloneEnvironmentVariables(
+        Dictionary<string, DotNetPublishEnvironmentVariable>? environmentVariables)
+    {
+        if (environmentVariables is null)
+            return null;
+
+        var clone = new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in environmentVariables)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key))
+                continue;
+
+            var value = entry.Value ?? new DotNetPublishEnvironmentVariable();
+            clone[entry.Key.Trim()] = new DotNetPublishEnvironmentVariable
+            {
+                Value = value.Value,
+                FromEnvironmentVariable = value.FromEnvironmentVariable,
+                FromEnvironmentVariables = (value.FromEnvironmentVariables ?? Array.Empty<string>()).ToArray(),
+                Required = value.Required,
+                Secret = value.Secret
+            };
+        }
+
+        return clone;
+    }
+
+    private static Dictionary<string, string?> ResolveDotNetEnvironmentVariables(
+        Dictionary<string, DotNetPublishEnvironmentVariable>? environmentVariables,
+        bool enforceRequired)
+    {
+        var resolved = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in environmentVariables ?? new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase))
+        {
+            var targetName = (entry.Key ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(targetName))
+                continue;
+
+            var definition = entry.Value ?? new DotNetPublishEnvironmentVariable();
+            var value = definition.Value;
+            var sources = BuildEnvironmentSourceList(targetName, definition);
+
+            if (value is null)
+            {
+                foreach (var source in sources)
+                {
+                    var candidate = GetEnvironmentVariable(source);
+                    if (!string.IsNullOrWhiteSpace(candidate))
+                    {
+                        value = candidate;
+                        break;
+                    }
+                }
+            }
+
+            if (enforceRequired && definition.Required && string.IsNullOrWhiteSpace(value))
+            {
+                var sourceList = sources.Length == 0
+                    ? targetName
+                    : string.Join(", ", sources);
+                throw new InvalidOperationException(
+                    $"Required dotnet environment variable '{targetName}' could not be resolved. " +
+                    $"Set one of: {sourceList}.");
+            }
+
+            if (value is not null)
+                resolved[targetName] = value;
+        }
+
+        return resolved;
+    }
+
+    private static string[] BuildEnvironmentSourceList(string targetName, DotNetPublishEnvironmentVariable definition)
+    {
+        var sources = new List<string>();
+        if (!string.IsNullOrWhiteSpace(definition.FromEnvironmentVariable))
+            sources.Add(definition.FromEnvironmentVariable!.Trim());
+
+        foreach (var source in definition.FromEnvironmentVariables ?? Array.Empty<string>())
+        {
+            if (!string.IsNullOrWhiteSpace(source))
+                sources.Add(source.Trim());
+        }
+
+        if (sources.Count == 0)
+            sources.Add(targetName);
+
+        return sources
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string? GetEnvironmentVariable(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        if (!string.IsNullOrWhiteSpace(value))
+            return value;
+
+        try
+        {
+            value = Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.User);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+        catch
+        {
+            // Non-Windows platforms may not support user-scoped environment variables.
+        }
+
+        try
+        {
+            return Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.Machine);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static DotNetPublishOutputs CloneOutputs(DotNetPublishOutputs outputs)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -30,6 +30,17 @@ public sealed partial class DotNetPublishPipelineRunner
     /// Optional path to the JSON config file. When provided, relative paths are resolved against its directory,
     /// unless <see cref="DotNetPublishDotNetOptions.ProjectRoot"/> is set.
     /// </param>
+    public DotNetPublishPlan Plan(DotNetPublishSpec spec, string? configPath)
+        => Plan(spec, configPath, enforceRequiredEnvironmentVariables: true);
+
+    /// <summary>
+    /// Resolves paths/defaults from <paramref name="spec"/> and produces an ordered execution plan.
+    /// </summary>
+    /// <param name="spec">Publish spec.</param>
+    /// <param name="configPath">
+    /// Optional path to the JSON config file. When provided, relative paths are resolved against its directory,
+    /// unless <see cref="DotNetPublishDotNetOptions.ProjectRoot"/> is set.
+    /// </param>
     /// <param name="enforceRequiredEnvironmentVariables">
     /// When true, missing required dotnet environment variables fail planning. Plan-only and validate-only callers
     /// can set this to false so configuration inspection does not require private feed credentials.
@@ -37,7 +48,7 @@ public sealed partial class DotNetPublishPipelineRunner
     public DotNetPublishPlan Plan(
         DotNetPublishSpec spec,
         string? configPath,
-        bool enforceRequiredEnvironmentVariables = true)
+        bool enforceRequiredEnvironmentVariables)
     {
         if (spec is null) throw new ArgumentNullException(nameof(spec));
         spec = ResolveProfile(spec);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.SigningAndProcess.cs
@@ -277,9 +277,12 @@ public sealed partial class DotNetPublishPipelineRunner
         return sb.ToString();
     }
 
-    private void RunDotnet(string workingDir, IReadOnlyList<string> args)
+    private void RunDotnet(
+        string workingDir,
+        IReadOnlyList<string> args,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null)
     {
-        var result = RunProcess("dotnet", workingDir, args);
+        var result = RunProcess("dotnet", workingDir, args, environmentVariables);
         if (result.ExitCode != 0)
         {
             var stderr = (result.StdErr ?? string.Empty).TrimEnd();
@@ -308,9 +311,13 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
-    private static (int ExitCode, string StdOut, string StdErr) RunProcess(string fileName, string workingDir, IReadOnlyList<string> args)
+    private static (int ExitCode, string StdOut, string StdErr) RunProcess(
+        string fileName,
+        string workingDir,
+        IReadOnlyList<string> args,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null)
     {
-        var result = RunProcessCore(fileName, workingDir, args, timeout: null);
+        var result = RunProcessCore(fileName, workingDir, args, timeout: null, environmentVariables);
         return (result.ExitCode, result.StdOut, result.StdErr);
     }
 
@@ -319,13 +326,14 @@ public sealed partial class DotNetPublishPipelineRunner
         string workingDir,
         IReadOnlyList<string> args,
         TimeSpan timeout)
-        => RunProcessCore(fileName, workingDir, args, timeout);
+        => RunProcessCore(fileName, workingDir, args, timeout, environmentVariables: null);
 
     private static (int ExitCode, string StdOut, string StdErr, bool TimedOut) RunProcessCore(
         string fileName,
         string workingDir,
         IReadOnlyList<string> args,
-        TimeSpan? timeout)
+        TimeSpan? timeout,
+        IReadOnlyDictionary<string, string?>? environmentVariables)
     {
         var psi = new ProcessStartInfo
         {
@@ -337,6 +345,20 @@ public sealed partial class DotNetPublishPipelineRunner
             CreateNoWindow = true
         };
         ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+        if (environmentVariables is not null)
+        {
+            foreach (var variable in environmentVariables)
+            {
+                if (string.IsNullOrWhiteSpace(variable.Key))
+                    continue;
+
+                if (variable.Value is null)
+                    psi.EnvironmentVariables.Remove(variable.Key);
+                else
+                    psi.EnvironmentVariables[variable.Key] = variable.Value;
+            }
+        }
 
 #if NET472
         psi.Arguments = BuildWindowsArgumentString(args);

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -36,7 +36,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 var label = string.IsNullOrWhiteSpace(framework) ? runtimeValue : $"{runtimeValue}, {framework}";
                 _logger.Info($"Restore ({label}) -> {request.ProjectPath}");
 
-                RunDotnet(workDir, BuildRestoreArguments(plan, request.ProjectPath, runtimeValue, framework));
+                RunDotnet(workDir, BuildRestoreArguments(plan, request.ProjectPath, runtimeValue, framework), plan.EnvironmentVariables);
             }
 
             return;
@@ -46,14 +46,14 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(plan.SolutionPath))
         {
             _logger.Info($"Restore -> {plan.SolutionPath}");
-            RunDotnet(workDir, new[] { "restore", plan.SolutionPath!, "--nologo" }.Concat(props).ToArray());
+            RunDotnet(workDir, new[] { "restore", plan.SolutionPath!, "--nologo" }.Concat(props).ToArray(), plan.EnvironmentVariables);
             return;
         }
 
         foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
         {
             _logger.Info($"Restore -> {p}");
-            RunDotnet(workDir, new[] { "restore", p, "--nologo" }.Concat(props).ToArray());
+            RunDotnet(workDir, new[] { "restore", p, "--nologo" }.Concat(props).ToArray(), plan.EnvironmentVariables);
         }
     }
 
@@ -196,14 +196,14 @@ public sealed partial class DotNetPublishPipelineRunner
         if (!string.IsNullOrWhiteSpace(plan.SolutionPath))
         {
             _logger.Info($"Clean -> {plan.SolutionPath}");
-            RunDotnet(workDir, new[] { "clean", plan.SolutionPath!, "-c", plan.Configuration, "--nologo" });
+            RunDotnet(workDir, new[] { "clean", plan.SolutionPath!, "-c", plan.Configuration, "--nologo" }, plan.EnvironmentVariables);
             return;
         }
 
         foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
         {
             _logger.Info($"Clean -> {p}");
-            RunDotnet(workDir, new[] { "clean", p, "-c", plan.Configuration, "--nologo" });
+            RunDotnet(workDir, new[] { "clean", p, "-c", plan.Configuration, "--nologo" }, plan.EnvironmentVariables);
         }
     }
 
@@ -223,7 +223,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (plan.Restore) args.Add("--no-restore");
                 args.AddRange(props);
 
-                RunDotnet(workDir, args);
+                RunDotnet(workDir, args, plan.EnvironmentVariables);
             }
 
             return;
@@ -235,14 +235,14 @@ public sealed partial class DotNetPublishPipelineRunner
             var args = new List<string> { "build", plan.SolutionPath!, "-c", plan.Configuration, "--nologo" };
             if (plan.Restore) args.Add("--no-restore");
             args.AddRange(props);
-            RunDotnet(workDir, args);
+            RunDotnet(workDir, args, plan.EnvironmentVariables);
             return;
         }
 
         foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
         {
             _logger.Info($"Build -> {p}");
-            RunDotnet(workDir, new[] { "build", p, "-c", plan.Configuration, "--nologo" }.Concat(props).ToArray());
+            RunDotnet(workDir, new[] { "build", p, "-c", plan.Configuration, "--nologo" }.Concat(props).ToArray(), plan.EnvironmentVariables);
         }
     }
 
@@ -313,7 +313,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var publishArgs = BuildPublishArguments(plan, target, tfm, rid, style, publishDir);
 
         _logger.Info($"Publishing {target.Name} ({rid}) -> {publishDir}");
-        RunDotnet(plan.ProjectRoot, publishArgs);
+        RunDotnet(plan.ProjectRoot, publishArgs, plan.EnvironmentVariables);
 
         var cleanup = ApplyCleanup(publishDir, target.Publish);
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Store.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Store.cs
@@ -166,7 +166,7 @@ public sealed partial class DotNetPublishPipelineRunner
             $"Store package build starting for '{storePackageId}' ({target}, {framework}, {runtime}, {style.Value}) -> {Path.GetFileName(projectPath)} using {Path.GetFileName(buildExecutable)}");
 
         var preBuildFiles = storePackage.ClearOutput ? SnapshotStoreFiles(searchRoots) : null;
-        var result = RunProcess(buildExecutable!, plan.ProjectRoot, args);
+        var result = RunProcess(buildExecutable!, plan.ProjectRoot, args, plan.EnvironmentVariables);
         if (result.ExitCode != 0)
         {
             var stderr = (result.StdErr ?? string.Empty).TrimEnd();

--- a/PowerForge/Services/DotNetPublishPlanRedactor.cs
+++ b/PowerForge/Services/DotNetPublishPlanRedactor.cs
@@ -1,0 +1,37 @@
+namespace PowerForge;
+
+/// <summary>
+/// Removes sensitive values from dotnet publish plans before they are displayed or serialized for humans.
+/// </summary>
+public static class DotNetPublishPlanRedactor
+{
+    private const string RedactedValue = "<redacted>";
+
+    /// <summary>
+    /// Replaces resolved environment variable values in a plan with a redaction marker.
+    /// </summary>
+    /// <param name="plan">Plan to redact.</param>
+    /// <returns>The same plan instance after redaction.</returns>
+    public static DotNetPublishPlan RedactInPlace(DotNetPublishPlan plan)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        Redact(plan.EnvironmentVariables);
+        foreach (var step in plan.Steps ?? Array.Empty<DotNetPublishStep>())
+            Redact(step.HookEnvironment);
+
+        return plan;
+    }
+
+    private static void Redact(System.Collections.IDictionary? variables)
+    {
+        if (variables is null || variables.Count == 0)
+            return;
+
+        foreach (var key in variables.Keys.Cast<object>().ToArray())
+        {
+            if (variables[key] is not null)
+                variables[key] = RedactedValue;
+        }
+    }
+}

--- a/PowerForge/Services/DotNetPublishWorkflowService.cs
+++ b/PowerForge/Services/DotNetPublishWorkflowService.cs
@@ -7,20 +7,21 @@ namespace PowerForge;
 internal sealed class DotNetPublishWorkflowService
 {
     private readonly ILogger _logger;
-    private readonly Func<DotNetPublishSpec, string?, DotNetPublishPlan> _planPublish;
+    private readonly Func<DotNetPublishSpec, string?, bool, DotNetPublishPlan> _planPublish;
     private readonly Func<DotNetPublishPlan, IDotNetPublishProgressReporter?, DotNetPublishResult> _runPublish;
     private readonly Func<DotNetPublishPlan, IDotNetPublishProgressReporter?> _createProgressReporter;
     private readonly Action<DotNetPublishSpec, string> _writeSpecJson;
 
     public DotNetPublishWorkflowService(
         ILogger logger,
-        Func<DotNetPublishSpec, string?, DotNetPublishPlan>? planPublish = null,
+        Func<DotNetPublishSpec, string?, bool, DotNetPublishPlan>? planPublish = null,
         Func<DotNetPublishPlan, IDotNetPublishProgressReporter?, DotNetPublishResult>? runPublish = null,
         Func<DotNetPublishPlan, IDotNetPublishProgressReporter?>? createProgressReporter = null,
         Action<DotNetPublishSpec, string>? writeSpecJson = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _planPublish = planPublish ?? ((spec, sourceLabel) => new DotNetPublishPipelineRunner(_logger).Plan(spec, sourceLabel));
+        _planPublish = planPublish ?? ((spec, sourceLabel, enforceRequiredEnvironmentVariables) =>
+            new DotNetPublishPipelineRunner(_logger).Plan(spec, sourceLabel, enforceRequiredEnvironmentVariables));
         _runPublish = runPublish ?? ((plan, progress) => new DotNetPublishPipelineRunner(_logger).Run(plan, progress));
         _createProgressReporter = createProgressReporter ?? (_ => null);
         _writeSpecJson = writeSpecJson ?? WriteSpecJson;
@@ -47,7 +48,8 @@ internal sealed class DotNetPublishWorkflowService
             };
         }
 
-        var plan = _planPublish(context.Spec, context.SourceLabel);
+        var enforceRequiredEnvironmentVariables = !context.PlanOnly && !context.ValidateOnly;
+        var plan = _planPublish(context.Spec, context.SourceLabel, enforceRequiredEnvironmentVariables);
         if (context.PlanOnly || context.ValidateOnly)
         {
             if (context.ValidateOnly)

--- a/PowerForge/Services/MsiPackageMetadataReader.cs
+++ b/PowerForge/Services/MsiPackageMetadataReader.cs
@@ -1,0 +1,143 @@
+using System.Runtime.InteropServices;
+
+namespace PowerForge;
+
+internal sealed class MsiPackageMetadataReader
+{
+    private static readonly string[] DefaultPropertyNames =
+    {
+        "ProductCode",
+        "ProductName",
+        "ProductVersion",
+        "Manufacturer",
+        "UpgradeCode"
+    };
+
+    public DotNetPublishMsiPackageMetadata Read(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("MSI path must not be empty.", nameof(path));
+
+        var fullPath = System.IO.Path.GetFullPath(path);
+        var values = ReadProperties(fullPath, DefaultPropertyNames);
+
+        return new DotNetPublishMsiPackageMetadata
+        {
+            Path = fullPath,
+            ProductCode = GetValue(values, "ProductCode"),
+            ProductName = GetValue(values, "ProductName"),
+            ProductVersion = GetValue(values, "ProductVersion"),
+            Manufacturer = GetValue(values, "Manufacturer"),
+            UpgradeCode = GetValue(values, "UpgradeCode")
+        };
+    }
+
+    internal static IReadOnlyDictionary<string, string> ReadProperties(string path, IEnumerable<string> propertyNames)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("MSI path must not be empty.", nameof(path));
+        if (!File.Exists(path))
+            throw new FileNotFoundException("MSI file not found.", path);
+
+        var names = (propertyNames ?? Array.Empty<string>())
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (names.Length == 0)
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+#if !NET472
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("Windows Installer automation is only available on Windows.");
+#endif
+        var installerType = Type.GetTypeFromProgID("WindowsInstaller.Installer");
+        if (installerType is null)
+            throw new PlatformNotSupportedException("Windows Installer automation is not available on this platform.");
+
+        object? installer = null;
+        object? database = null;
+        object? view = null;
+        try
+        {
+            installer = Activator.CreateInstance(installerType)
+                ?? throw new InvalidOperationException("Could not create WindowsInstaller.Installer.");
+            database = InvokeComMethod(installer, "OpenDatabase", path, 0);
+            if (database is null)
+                throw new InvalidOperationException($"Could not open MSI database: {path}");
+
+            var conditions = names
+                .Select(name => $"`Property` = '{name.Replace("'", "''")}'");
+            var query = "SELECT `Property`, `Value` FROM `Property` WHERE " + string.Join(" OR ", conditions);
+            view = InvokeComMethod(database, "OpenView", query);
+            if (view is null)
+                throw new InvalidOperationException($"Could not open MSI property view: {path}");
+            InvokeComMethod(view, "Execute");
+
+            var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            while (InvokeComMethod(view, "Fetch") is { } record)
+            {
+                try
+                {
+                    var key = ReadRecordString(record, 1);
+                    if (!string.IsNullOrWhiteSpace(key))
+                    {
+                        key = key!.Trim();
+                        values[key] = ReadRecordString(record, 2) ?? string.Empty;
+                    }
+                }
+                finally
+                {
+                    ReleaseComObject(record);
+                }
+            }
+
+            return values;
+        }
+        finally
+        {
+            ReleaseComObject(view);
+            ReleaseComObject(database);
+            ReleaseComObject(installer);
+        }
+    }
+
+    private static string? GetValue(IReadOnlyDictionary<string, string> values, string key)
+        => values.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : null;
+
+    private static object? InvokeComMethod(object target, string name, params object?[] args)
+    {
+        return target.GetType().InvokeMember(
+            name,
+            System.Reflection.BindingFlags.InvokeMethod,
+            binder: null,
+            target,
+            args.Length == 0 ? null : args);
+    }
+
+    private static string? ReadRecordString(object record, int index)
+    {
+        return record.GetType().InvokeMember(
+            "StringData",
+            System.Reflection.BindingFlags.GetProperty,
+            binder: null,
+            target: record,
+            args: new object[] { index }) as string;
+    }
+
+    private static void ReleaseComObject(object? value)
+    {
+        if (value is null)
+            return;
+
+#if NET472
+        if (Marshal.IsComObject(value))
+            Marshal.ReleaseComObject(value);
+#else
+        if (OperatingSystem.IsWindows() && Marshal.IsComObject(value))
+            Marshal.ReleaseComObject(value);
+#endif
+    }
+}

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -102,6 +102,20 @@
       "type": "string",
       "enum": ["FixedMajorMinorDatePatch", "UtcShortYearMonthDayMinute"]
     },
+    "DotNetPublishEnvironmentVariable": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Value": { "type": ["string", "null"] },
+        "FromEnvironmentVariable": { "type": ["string", "null"] },
+        "FromEnvironmentVariables": {
+          "type": ["array", "null"],
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "Required": { "type": "boolean" },
+        "Secret": { "type": "boolean" }
+      }
+    },
     "DotNetPublishMsiVersionOptions": {
       "type": "object",
       "additionalProperties": false,
@@ -1092,6 +1106,10 @@
         "MsBuildProperties": {
           "type": ["object", "null"],
           "additionalProperties": { "type": "string" }
+        },
+        "EnvironmentVariables": {
+          "type": ["object", "null"],
+          "additionalProperties": { "$ref": "#/$defs/DotNetPublishEnvironmentVariable" }
         }
       }
     },


### PR DESCRIPTION
## Summary
- read MSI package identity metadata after MSI build outputs are detected
- pass configured DotNet.EnvironmentVariables into restore, build, publish, clean, and MSI build dotnet invocations
- redact resolved environment and hook values before emitting plan output from Invoke-DotNetPublish
- keep TestimoX/private-feed restore behavior in PowerForge instead of consumer scripts

## Validation
- dotnet.exe test PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~DotNetPublishPipelineRunnerEnvironmentTests|FullyQualifiedName~DotNetPublishPlanRedactorTests|FullyQualifiedName~DotNetPublishWorkflowServiceTests|FullyQualifiedName~DotNetPublishPipelineRunnerHardeningTests|FullyQualifiedName~DotNetPublishPreparationServiceTests"
- dotnet.exe build PSPublishModule.sln -c Release --nologo
- pwsh.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Module\Build\Build-Module.ps1
- git diff --check

## Notes
- Module build succeeded and installed PSPublishModule 3.0.27.8 locally.
- Build-generated docs/help/manifest and sample lockfile noise were intentionally left out of this PR.
- Module build reported existing installed-module binary conflict advisories; no compile/test failures.