### PR TITLE
test(dotnet-publish): preserve artifact result display

### DIFF
--- a/PowerForge.Tests/DotNetPublishArtifactResultTests.cs
+++ b/PowerForge.Tests/DotNetPublishArtifactResultTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetPublishArtifactResultTests
+{
+    [Fact]
+    public void ToString_UsesZipPath_WhenAvailable()
+    {
+        var artifact = new DotNetPublishArtefactResult
+        {
+            Target = "TestimoX.CLI",
+            Framework = "net10.0-windows",
+            Runtime = "win-x64",
+            Style = DotNetPublishStyle.PortableCompat,
+            OutputDir = @"C:\repo\Artifacts\DotNetPublish\TestimoX.CLI",
+            ZipPath = @"C:\repo\Artifacts\DotNetPublish\TestimoX.CLI.zip"
+        };
+
+        Assert.Equal(
+            @"TestimoX.CLI (net10.0-windows, win-x64, PortableCompat) -> C:\repo\Artifacts\DotNetPublish\TestimoX.CLI.zip",
+            artifact.ToString());
+    }
+
+    [Fact]
+    public void ToString_FallsBackToOutputDirectory_WhenZipIsNotAvailable()
+    {
+        var artifact = new DotNetPublishArtefactResult
+        {
+            Target = "TestimoX.Service",
+            Framework = "net10.0-windows",
+            Runtime = "win-x64",
+            Style = DotNetPublishStyle.PortableCompat,
+            OutputDir = @"C:\repo\Artifacts\DotNetPublish\TestimoX.Service"
+        };
+
+        Assert.Equal(
+            @"TestimoX.Service (net10.0-windows, win-x64, PortableCompat) -> C:\repo\Artifacts\DotNetPublish\TestimoX.Service",
+            artifact.ToString());
+    }
+}

--- a/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishResult.cs
@@ -159,6 +159,23 @@ public sealed class DotNetPublishArtefactResult
 
     /// <summary>Number of publish output files that were signed.</summary>
     public int SignedFiles { get; set; }
+
+    /// <summary>
+    /// Returns a concise artifact summary suitable for PowerShell collection display.
+    /// </summary>
+    public override string ToString()
+    {
+        var target = string.IsNullOrWhiteSpace(Target) ? "<unknown>" : Target;
+        var framework = string.IsNullOrWhiteSpace(Framework) ? "<framework>" : Framework;
+        var runtime = string.IsNullOrWhiteSpace(Runtime) ? "<runtime>" : Runtime;
+        var output = string.IsNullOrWhiteSpace(ZipPath)
+            ? OutputDir
+            : ZipPath;
+
+        return string.IsNullOrWhiteSpace(output)
+            ? $"{target} ({framework}, {runtime}, {Style})"
+            : $"{target} ({framework}, {runtime}, {Style}) -> {output}";
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- preserve the useful `DotNetPublishArtefactResult.ToString()` behavior found in the saved dirty-main snapshot
- add focused tests for zip-path and output-directory display fallback

## Validation
- `dotnet.exe test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~DotNetPublishArtifactResultTests" --nologo`
- `git diff --cached --check`