### PR TITLE
fix(dotnet-publish): allow uninstall service name override

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerServicePackageTests.cs
@@ -124,6 +124,8 @@ public sealed class DotNetPublishPipelineRunnerServicePackageTests
             Assert.DoesNotContain("{{", installContent, StringComparison.Ordinal);
 
             var uninstallContent = File.ReadAllText(result.UninstallScriptPath!);
+            Assert.Contains("[string]$ServiceName", uninstallContent, StringComparison.Ordinal);
+            Assert.Contains("PowerForge.Svc", uninstallContent, StringComparison.Ordinal);
             Assert.DoesNotContain("{{", uninstallContent, StringComparison.Ordinal);
 
             var metadata = File.ReadAllText(result.MetadataPath);

--- a/PowerForge/Scripts/DotNetPublish/Uninstall-Service.Template.ps1
+++ b/PowerForge/Scripts/DotNetPublish/Uninstall-Service.Template.ps1
@@ -1,11 +1,12 @@
 ﻿#requires -Version 5.1
 [CmdletBinding()]
 param(
+    [string]$ServiceName = '{{ServiceName}}',
     [switch]$Force
 )
 $ErrorActionPreference = 'Stop'
 
-$serviceName = '{{ServiceName}}'
+$serviceName = $ServiceName
 
 $existing = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 if ($existing) {


### PR DESCRIPTION
## Summary
- allow generated `Uninstall-Service.ps1` to accept a runtime `-ServiceName` override
- keep generated uninstall behavior aligned with generated install scripts for dynamically named smoke-test services
- add a focused service package contract assertion

## Validation
- `dotnet.exe test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~DotNetPublishPipelineRunnerServicePackageTests" --nologo`
- `git diff --check`