### PR TITLE
Add unified Apple app release targets

### DIFF
--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -119,10 +119,6 @@ that need one release file to describe iPhone, iPad, macOS, and store-delivery l
     "ExportRoot": "Artifacts/Apple/Exports",
     "TeamId": "8ZPGZ79T7J",
     "Upload": false,
-    "ScreenshotConfigPaths": [
-      "scripts/appstoreconnect-screenshots-ios.json",
-      "scripts/appstoreconnect-screenshots-macos.json"
-    ],
     "Apps": [
       {
         "Name": "Tactra iPhone",
@@ -153,26 +149,28 @@ that need one release file to describe iPhone, iPad, macOS, and store-delivery l
 Plan first:
 
 ```powershell
-Invoke-PowerForgeRelease -ConfigPath '.\powerforge.release.json' -ToolsOnly -Plan
+Invoke-PowerForgeRelease -ConfigPath '.\powerforge.release.json' -Plan
 ```
 
 Archive without uploading:
 
 ```powershell
-Invoke-PowerForgeRelease -ConfigPath '.\powerforge.release.json' -ToolsOnly
+Invoke-PowerForgeRelease -ConfigPath '.\powerforge.release.json'
 ```
 
 Upload to App Store Connect by setting `AppleApps.Upload` to `true`, or by keeping a
 separate release config for the store lane. The unified flow reuses the same archive
 and `xcodebuild -exportArchive` helpers as `New-AppleAppArchive` and
 `Publish-AppleAppArchive`; it does not duplicate signing or upload behavior.
+`-ToolsOnly` intentionally runs downloadable tool targets only and skips `AppleApps`.
 
 ## Current Boundary
 
 These helpers automate signed binary archive/upload and provide low-level screenshot
 upload primitives. App Store localized text metadata, build selection for review, and
 release submission still need dedicated App Store Connect write support before they
-should be automated here.
+should be automated here. Unified `AppleApps` screenshot sync is not wired yet; keep
+using `Sync-AppStoreConnectScreenshots` or project-specific screenshot scripts for now.
 
 ## Screenshot Upload Flow
 

--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -101,6 +101,72 @@ Get-AppStoreConnectBuild -IssuerId $issuerId -KeyId $keyId -PrivateKeyPath $keyP
 Test-AppleAppReleaseDrift -IssuerId $issuerId -KeyId $keyId -PrivateKeyPath $keyPath -Path '.\Tactra.xcodeproj' -AppId $appId -Platform iOS
 ```
 
+## Unified Release Flow
+
+Apple app archive/upload targets can also live in the same `powerforge.release.json`
+used for modules, NuGet packages, downloadable tools, Winget manifests, and GitHub
+release assets. This is the preferred shape for apps such as Tactra or BayManager
+that need one release file to describe iPhone, iPad, macOS, and store-delivery lanes.
+
+```json
+{
+  "$schema": "./Schemas/powerforge.release.schema.json",
+  "SchemaVersion": 1,
+  "AppleApps": {
+    "ProjectRoot": ".",
+    "Configuration": "Release",
+    "ArchiveRoot": "Artifacts/Apple/Archives",
+    "ExportRoot": "Artifacts/Apple/Exports",
+    "TeamId": "8ZPGZ79T7J",
+    "Upload": false,
+    "ScreenshotConfigPaths": [
+      "scripts/appstoreconnect-screenshots-ios.json",
+      "scripts/appstoreconnect-screenshots-macos.json"
+    ],
+    "Apps": [
+      {
+        "Name": "Tactra iPhone",
+        "BundleId": "com.evotecit.tactra",
+        "Platform": "iOS",
+        "ProjectPath": "Tactra.xcodeproj",
+        "Scheme": "Tactra"
+      },
+      {
+        "Name": "Tactra iPad",
+        "BundleId": "com.evotecit.tactra",
+        "Platform": "iPadOS",
+        "ProjectPath": "Tactra.xcodeproj",
+        "Scheme": "Tactra"
+      },
+      {
+        "Name": "Tactra Mac",
+        "BundleId": "com.evotecit.tactra.mac",
+        "Platform": "macOS",
+        "ProjectPath": "Tactra.xcodeproj",
+        "Scheme": "TactraMac"
+      }
+    ]
+  }
+}
+```
+
+Plan first:
+
+```powershell
+Invoke-PowerForgeRelease -ConfigPath '.\powerforge.release.json' -ToolsOnly -Plan
+```
+
+Archive without uploading:
+
+```powershell
+Invoke-PowerForgeRelease -ConfigPath '.\powerforge.release.json' -ToolsOnly
+```
+
+Upload to App Store Connect by setting `AppleApps.Upload` to `true`, or by keeping a
+separate release config for the store lane. The unified flow reuses the same archive
+and `xcodebuild -exportArchive` helpers as `New-AppleAppArchive` and
+`Publish-AppleAppArchive`; it does not duplicate signing or upload behavior.
+
 ## Current Boundary
 
 These helpers automate signed binary archive/upload and provide low-level screenshot

--- a/PowerForge.Tests/AppleAppArchiveServiceTests.cs
+++ b/PowerForge.Tests/AppleAppArchiveServiceTests.cs
@@ -145,6 +145,33 @@ public sealed class AppleAppArchiveServiceTests
     }
 
     [Fact]
+    public async Task UploadArchiveAsync_omits_allow_provisioning_updates_when_disabled()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcarchive"));
+            var runner = new CapturingProcessRunner();
+            var service = new AppleAppArchiveService(runner);
+
+            var result = await service.UploadArchiveAsync(new AppleAppArchiveUploadRequest
+            {
+                ArchivePath = archive.FullName,
+                ExportPath = Path.Combine(root.FullName, "export"),
+                AllowProvisioningUpdates = false
+            });
+
+            Assert.True(result.Succeeded);
+            var request = Assert.Single(runner.Requests);
+            Assert.DoesNotContain("-allowProvisioningUpdates", request.Arguments);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task UploadArchiveAsync_defaults_export_options_plist_inside_export_path()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -351,7 +351,7 @@ public sealed class PowerForgeReleaseServiceTests
         var root = CreateSandbox();
         try
         {
-            Directory.CreateDirectory(Path.Combine(root, "Tactra.xcodeproj"));
+            CreateXcodeProject(root, "Tactra.xcodeproj");
 
             var service = new PowerForgeReleaseService(new NullLogger());
             var result = service.Execute(
@@ -388,8 +388,7 @@ public sealed class PowerForgeReleaseServiceTests
                 new PowerForgeReleaseRequest
                 {
                     ConfigPath = Path.Combine(root, "powerforge.release.json"),
-                    PlanOnly = true,
-                    ToolsOnly = true
+                    PlanOnly = true
                 });
 
             Assert.True(result.Success);
@@ -424,7 +423,7 @@ public sealed class PowerForgeReleaseServiceTests
         var root = CreateSandbox();
         try
         {
-            Directory.CreateDirectory(Path.Combine(root, "Tactra.xcodeproj"));
+            CreateXcodeProject(root, "Tactra.xcodeproj");
             var archiveRequests = new List<AppleAppArchiveRequest>();
             var uploadRequests = new List<AppleAppArchiveUploadRequest>();
 
@@ -484,8 +483,7 @@ public sealed class PowerForgeReleaseServiceTests
                 },
                 new PowerForgeReleaseRequest
                 {
-                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
-                    ToolsOnly = true
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
                 });
 
             Assert.True(result.Success);
@@ -503,6 +501,232 @@ public sealed class PowerForgeReleaseServiceTests
             Assert.True(appResult.Success);
             Assert.NotNull(appResult.Archive);
             Assert.NotNull(appResult.Upload);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_ToolsOnly_DoesNotRunAppleApps()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archiveCalled = false;
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => new PowerForgeToolReleasePlan
+                {
+                    ProjectRoot = root,
+                    Configuration = "Release"
+                },
+                runTools: _ => new PowerForgeToolReleaseResult
+                {
+                    Success = true
+                },
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ =>
+                {
+                    archiveCalled = true;
+                    throw new InvalidOperationException("Apple apps should not run.");
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec(),
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    ToolsOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.False(archiveCalled);
+            Assert.Null(result.AppleAppPlan);
+            Assert.Empty(result.AppleApps);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RejectsScreenshotSyncUntilUnifiedSupportExists()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<NotSupportedException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        SyncScreenshots = true,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                }));
+
+            Assert.Contains("SyncScreenshots is not supported", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_ValidatesProjectPathBeforeReportingSuccess()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<FileNotFoundException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Missing.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                }));
+
+            Assert.Contains("Missing.xcodeproj", ex.FileName, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_UpdatesXcodeVersionBeforeArchive()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var xcodeproj = CreateXcodeProject(root, "Tactra.xcodeproj", "1.0.0", "7");
+            var pbxproj = Path.Combine(xcodeproj, "project.pbxproj");
+            var archiveCalled = false;
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveCalled = true;
+                    var content = File.ReadAllText(pbxproj);
+                    Assert.Contains("MARKETING_VERSION = 2.1.0;", content, StringComparison.Ordinal);
+                    Assert.Contains("CURRENT_PROJECT_VERSION = 8;", content, StringComparison.Ordinal);
+
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Upload = false,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                MarketingVersion = "2.1.0",
+                                BuildNumberPolicy = AppleBuildNumberPolicy.IncrementExisting
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.True(result.Success);
+            Assert.True(archiveCalled);
+            var appResult = Assert.Single(result.AppleApps);
+            Assert.NotNull(appResult.VersionUpdate);
+            Assert.Equal("1.0.0", appResult.VersionUpdate!.Before.MarketingVersion);
+            Assert.Equal("7", appResult.VersionUpdate.Before.BuildNumber);
+            Assert.Equal("2.1.0", appResult.VersionUpdate.After.MarketingVersion);
+            Assert.Equal("8", appResult.VersionUpdate.After.BuildNumber);
+            Assert.NotNull(appResult.Archive);
+            Assert.Null(appResult.Upload);
         }
         finally
         {
@@ -3847,6 +4071,25 @@ public sealed class PowerForgeReleaseServiceTests
         var path = Path.Combine(Path.GetTempPath(), "PowerForge.ReleaseTests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private static string CreateXcodeProject(
+        string root,
+        string name,
+        string marketingVersion = "1.0.0",
+        string buildNumber = "1")
+    {
+        var xcodeproj = Path.Combine(root, name);
+        Directory.CreateDirectory(xcodeproj);
+        File.WriteAllText(
+            Path.Combine(xcodeproj, "project.pbxproj"),
+            $"""
+                MARKETING_VERSION = {marketingVersion};
+                CURRENT_PROJECT_VERSION = {buildNumber};
+                """,
+            new UTF8Encoding(false));
+
+        return xcodeproj;
     }
 
     private static void TryDelete(string path)

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -927,6 +927,249 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_HonorsTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Phone.xcodeproj");
+            CreateXcodeProject(root, "Mac.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra iPhone",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Phone.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            },
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra Mac",
+                                BundleId = "com.evotecit.tactra.mac",
+                                ProjectPath = "Mac.xcodeproj",
+                                Scheme = "TactraMac",
+                                Platform = ApplePlatform.macOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Targets = new[] { "Tactra Mac" }
+                });
+
+            Assert.True(result.Success);
+            var app = Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Equal("Tactra Mac", app.Name);
+            Assert.Equal(ApplePlatform.macOS, app.Platform);
+            Assert.Single(archiveRequests);
+            Assert.Equal(Path.Combine(root, "Mac.xcodeproj"), archiveRequests[0].ProjectPath);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RejectsUnknownTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<ArgumentException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Targets = new[] { "MissingApp" }
+                }));
+
+            Assert.Contains("Unknown Apple app target", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("MissingApp", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RejectsExistingNonProjectDirectoryBeforeArchive()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var source = Directory.CreateDirectory(Path.Combine(root, "Source"));
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Source",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                }));
+
+            Assert.Contains(".xcodeproj", ex.Message, StringComparison.Ordinal);
+            Assert.Contains(".xcworkspace", ex.Message, StringComparison.Ordinal);
+            Assert.Contains(source.FullName, ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_WritesUnifiedManifestSection()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archivePath = Path.Combine(root, "Artifacts", "Apple", "Archives", "iOS", "Tactra.xcarchive");
+            var exportPath = Path.Combine(root, "Artifacts", "Apple", "Exports", "iOS", "Tactra");
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request => new AppleAppArchiveResult
+                {
+                    ArchivePath = archivePath,
+                    Destination = request.Destination!,
+                    ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                },
+                uploadAppleApp: request => new AppleAppArchiveUploadResult
+                {
+                    ArchivePath = request.ArchivePath,
+                    ExportPath = exportPath,
+                    ExportOptionsPlistPath = Path.Combine(exportPath, "ExportOptions.plist"),
+                    ProcessResult = new ProcessRunResult(0, "upload-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                });
+
+            var summaryManifest = Path.Combine(root, "release-manifest.json");
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Outputs = new PowerForgeReleaseOutputsOptions
+                    {
+                        ManifestJsonPath = summaryManifest
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Upload = true,
+                        TeamId = "TEAMID",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal(summaryManifest, result.ReleaseManifestPath);
+            Assert.True(File.Exists(summaryManifest));
+            var manifestJson = File.ReadAllText(summaryManifest);
+            Assert.Contains("\"appleApps\"", manifestJson, StringComparison.Ordinal);
+            Assert.Contains("\"Tactra\"", manifestJson, StringComparison.Ordinal);
+            Assert.Contains("\"com.evotecit.tactra\"", manifestJson, StringComparison.Ordinal);
+            Assert.Contains("\"ArchivePath\"", manifestJson, StringComparison.Ordinal);
+            Assert.Contains("\"ExportPath\"", manifestJson, StringComparison.Ordinal);
+            Assert.Contains("\"Succeeded\": true", manifestJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_PlanOnly_InstallerPropertyOverridesFlowIntoDotNetInstallerPlan()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -1046,6 +1046,311 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_MixedDotNetToolsAndAppleApps_AllowsAppleOnlyTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+            var dotNetSpec = new DotNetPublishSpec
+            {
+                Targets = new[]
+                {
+                    new DotNetPublishTarget
+                    {
+                        Name = "PowerForge",
+                        ProjectPath = "PowerForge.Cli.csproj"
+                    }
+                }
+            };
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (dotNetSpec, configPath),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublish = dotNetSpec
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Targets = new[] { "com.evotecit.tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.DotNetToolPlan);
+            Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Single(archiveRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedLegacyToolsAndAppleApps_AllowsAppleOnlyTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "EmailIMO.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run for an Apple-only target."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run for an Apple-only target."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        Targets = new[]
+                        {
+                            new PowerForgeToolReleaseTarget
+                            {
+                                Name = "emailimo backend macOS arm64"
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "EmailIMO Mac",
+                                BundleId = "com.codebybedizen.emailimo",
+                                ProjectPath = "EmailIMO.xcodeproj",
+                                Scheme = "EmailIMO",
+                                Platform = ApplePlatform.macOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Targets = new[] { "EmailIMO Mac" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.ToolPlan);
+            var app = Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Equal("EmailIMO Mac", app.Name);
+            Assert.Single(archiveRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedLegacyToolsAndAppleApps_AllowsToolOnlyTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "EmailIMO.xcodeproj");
+            var plannedTargets = Array.Empty<string>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, request) =>
+                {
+                    plannedTargets = request.Targets;
+                    return new PowerForgeToolReleasePlan
+                    {
+                        ProjectRoot = root,
+                        Configuration = "Release",
+                        Targets = new[]
+                        {
+                            new PowerForgeToolReleaseTargetPlan
+                            {
+                                Name = "emailimo backend macOS arm64",
+                                ProjectPath = "Backend.csproj",
+                                OutputName = "EmailImo.Backend",
+                                Version = "1.0.0",
+                                ArtifactRootPath = root,
+                                Combinations = Array.Empty<PowerForgeToolReleaseCombinationPlan>()
+                            }
+                        }
+                    };
+                },
+                runTools: _ => throw new InvalidOperationException("Tools should not run in plan mode."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple apps should not run for a tool-only target."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        Targets = new[]
+                        {
+                            new PowerForgeToolReleaseTarget
+                            {
+                                Name = "emailimo backend macOS arm64"
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "EmailIMO Mac",
+                                BundleId = "com.codebybedizen.emailimo",
+                                ProjectPath = "EmailIMO.xcodeproj",
+                                Scheme = "EmailIMO",
+                                Platform = ApplePlatform.macOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    Targets = new[] { "emailimo backend macOS arm64" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal(new[] { "emailimo backend macOS arm64" }, plannedTargets);
+            Assert.NotNull(result.ToolPlan);
+            Assert.Null(result.AppleAppPlan);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RejectsSkipBuildWhenArchiveIsEnabled()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    throw new InvalidOperationException("Archive should not run when SkipBuild is set.");
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    SkipBuild = true
+                }));
+
+            Assert.Contains("SkipBuild", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("AppleApps.Archive", ex.Message, StringComparison.Ordinal);
+            Assert.Empty(archiveRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_RejectsExistingNonProjectDirectoryBeforeArchive()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -467,6 +467,7 @@ public sealed class PowerForgeReleaseServiceTests
                         Upload = true,
                         TeamId = "TEAMID",
                         XcodeBuildExecutable = "xcodebuild-test",
+                        AllowProvisioningUpdates = false,
                         SigningStyle = "automatic",
                         ManageAppVersionAndBuildNumber = true,
                         Apps = new[]
@@ -495,6 +496,7 @@ public sealed class PowerForgeReleaseServiceTests
             var uploadRequest = Assert.Single(uploadRequests);
             Assert.Equal("TEAMID", uploadRequest.TeamId);
             Assert.Equal("xcodebuild-test", uploadRequest.XcodeBuildExecutable);
+            Assert.False(uploadRequest.AllowProvisioningUpdates);
             Assert.True(uploadRequest.ManageAppVersionAndBuildNumber);
 
             var appResult = Assert.Single(result.AppleApps);
@@ -1053,24 +1055,13 @@ public sealed class PowerForgeReleaseServiceTests
         {
             CreateXcodeProject(root, "Tactra.xcodeproj");
             var archiveRequests = new List<AppleAppArchiveRequest>();
-            var dotNetSpec = new DotNetPublishSpec
-            {
-                Targets = new[]
-                {
-                    new DotNetPublishTarget
-                    {
-                        Name = "PowerForge",
-                        ProjectPath = "PowerForge.Cli.csproj"
-                    }
-                }
-            };
 
             var service = new PowerForgeReleaseService(
                 new NullLogger(),
                 executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
                 planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
                 runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
-                loadDotNetToolsSpec: (_, configPath) => (dotNetSpec, configPath),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet config should not load for an Apple-only target."),
                 planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
                 runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
                 publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
@@ -1091,7 +1082,17 @@ public sealed class PowerForgeReleaseServiceTests
                 {
                     Tools = new PowerForgeToolReleaseSpec
                     {
-                        DotNetPublish = dotNetSpec
+                        DotNetPublish = new DotNetPublishSpec
+                        {
+                            Targets = new[]
+                            {
+                                new DotNetPublishTarget
+                                {
+                                    Name = "PowerForge",
+                                    ProjectPath = "PowerForge.Cli.csproj"
+                                }
+                            }
+                        }
                     },
                     AppleApps = new PowerForgeAppleReleaseOptions
                     {
@@ -1204,6 +1205,82 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_MixedModulePackagesAndAppleApps_AllowsAppleOnlyTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run for an Apple-only target."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Module = new PowerForgeModuleReleaseOptions
+                    {
+                        RepositoryRoot = ".",
+                        ScriptPath = "Missing-Build-Module.ps1"
+                    },
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        RootPath = "."
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Targets = new[] { "com.evotecit.tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.ModulePlan);
+            Assert.Null(result.Packages);
+            Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Single(archiveRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_MixedLegacyToolsAndAppleApps_AllowsToolOnlyTargetFilter()
     {
         var root = CreateSandbox();
@@ -1292,6 +1369,65 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_MixedToolsAndAppleApps_ValidatesAppleBeforePublishingTools()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tool planning should not run before Apple validation succeeds."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run before Apple validation succeeds."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run after validation failure."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var ex = Assert.Throws<FileNotFoundException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        Targets = new[]
+                        {
+                            new PowerForgeToolReleaseTarget
+                            {
+                                Name = "PowerForge"
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Missing.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                }));
+
+            Assert.Contains("Missing.xcodeproj", ex.FileName, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_RejectsSkipBuildWhenArchiveIsEnabled()
     {
         var root = CreateSandbox();
@@ -1343,6 +1479,51 @@ public sealed class PowerForgeReleaseServiceTests
             Assert.Contains("SkipBuild", ex.Message, StringComparison.Ordinal);
             Assert.Contains("AppleApps.Archive", ex.Message, StringComparison.Ordinal);
             Assert.Empty(archiveRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RejectsVersionUpdatesWhenArchiveIsDisabled()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        Upload = true,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                MarketingVersion = "1.2.3"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                }));
+
+            Assert.Contains("version updates", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("AppleApps.Archive=true", ex.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -735,6 +735,198 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_NormalizesPbxprojPathForArchive()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var xcodeproj = CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Upload = false,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = Path.Combine("Tactra.xcodeproj", "project.pbxproj"),
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.True(result.Success);
+            var app = Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Equal(xcodeproj, app.ProjectPath);
+            Assert.False(app.IsWorkspace);
+
+            var archiveRequest = Assert.Single(archiveRequests);
+            Assert.Equal(xcodeproj, archiveRequest.ProjectPath);
+            Assert.False(archiveRequest.IsWorkspace);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RejectsWorkspaceVersionUpdatesBeforeArchive()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "Tactra.xcworkspace"));
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra Workspace",
+                                ProjectPath = "Tactra.xcworkspace",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                MarketingVersion = "2.1.0"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                }));
+
+            Assert.Contains(".xcworkspace", ex.Message, StringComparison.Ordinal);
+            Assert.Contains(".xcodeproj", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_StopsAfterFirstAppFailure()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "First.xcodeproj");
+            CreateXcodeProject(root, "Second.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+            var uploadRequests = new List<AppleAppArchiveUploadRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(65, string.Empty, "archive-failed", "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: request =>
+                {
+                    uploadRequests.Add(request);
+                    throw new InvalidOperationException("Upload should not run after archive failure.");
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Upload = true,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "First",
+                                ProjectPath = "First.xcodeproj",
+                                Scheme = "First",
+                                Platform = ApplePlatform.iOS
+                            },
+                            new AppleAppConfiguration
+                            {
+                                Name = "Second",
+                                ProjectPath = "Second.xcodeproj",
+                                Scheme = "Second",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.False(result.Success);
+            Assert.Contains("First", result.ErrorMessage, StringComparison.Ordinal);
+            var appResult = Assert.Single(result.AppleApps);
+            Assert.Equal("First", appResult.Plan.Name);
+            Assert.False(appResult.Success);
+            Assert.Single(archiveRequests);
+            Assert.Empty(uploadRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_PlanOnly_InstallerPropertyOverridesFlowIntoDotNetInstallerPlan()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -346,6 +346,171 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_PlanOnly_BuildsAppleAppArchiveUploadPlan()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "Tactra.xcodeproj"));
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        ArchiveRoot = "Artifacts/Apple/Archives",
+                        ExportRoot = "Artifacts/Apple/Exports",
+                        Upload = true,
+                        TeamId = "8ZPGZ79T7J",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra iPhone",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            },
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra Mac",
+                                BundleId = "com.evotecit.tactra.mac",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "TactraMac",
+                                Platform = ApplePlatform.macOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    ToolsOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.AppleAppPlan);
+            Assert.True(result.AppleAppPlan!.Archive);
+            Assert.True(result.AppleAppPlan.Upload);
+            Assert.Equal("Release", result.AppleAppPlan.Configuration);
+
+            var phone = result.AppleAppPlan.Apps[0];
+            Assert.Equal("Tactra iPhone", phone.Name);
+            Assert.Equal(ApplePlatform.iOS, phone.Platform);
+            Assert.Equal("generic/platform=iOS", phone.Destination);
+            Assert.Equal(Path.Combine(root, "Tactra.xcodeproj"), phone.ProjectPath);
+            Assert.Equal(Path.Combine(root, "Artifacts", "Apple", "Archives", "iOS", "Tactra-iPhone.xcarchive"), phone.ArchivePath);
+            Assert.Equal(Path.Combine(root, "Artifacts", "Apple", "Exports", "iOS", "Tactra-iPhone"), phone.ExportPath);
+            Assert.True(phone.Upload);
+            Assert.Equal("8ZPGZ79T7J", phone.TeamId);
+
+            var mac = result.AppleAppPlan.Apps[1];
+            Assert.Equal("generic/platform=macOS", mac.Destination);
+            Assert.Equal(Path.Combine(root, "Artifacts", "Apple", "Archives", "macOS", "Tactra-Mac.xcarchive"), mac.ArchivePath);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RunsArchiveAndUploadThroughSharedService()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "Tactra.xcodeproj"));
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+            var uploadRequests = new List<AppleAppArchiveUploadRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: request =>
+                {
+                    uploadRequests.Add(request);
+                    return new AppleAppArchiveUploadResult
+                    {
+                        ArchivePath = request.ArchivePath,
+                        ExportPath = request.ExportPath!,
+                        ExportOptionsPlistPath = Path.Combine(request.ExportPath!, "ExportOptions.plist"),
+                        ProcessResult = new ProcessRunResult(0, "upload-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Upload = true,
+                        TeamId = "TEAMID",
+                        XcodeBuildExecutable = "xcodebuild-test",
+                        SigningStyle = "automatic",
+                        ManageAppVersionAndBuildNumber = true,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iPadOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    ToolsOnly = true
+                });
+
+            Assert.True(result.Success);
+            var archiveRequest = Assert.Single(archiveRequests);
+            Assert.Equal("xcodebuild-test", archiveRequest.XcodeBuildExecutable);
+            Assert.Equal(ApplePlatform.iPadOS, archiveRequest.Platform);
+            Assert.Equal("generic/platform=iOS", archiveRequest.Destination);
+
+            var uploadRequest = Assert.Single(uploadRequests);
+            Assert.Equal("TEAMID", uploadRequest.TeamId);
+            Assert.Equal("xcodebuild-test", uploadRequest.XcodeBuildExecutable);
+            Assert.True(uploadRequest.ManageAppVersionAndBuildNumber);
+
+            var appResult = Assert.Single(result.AppleApps);
+            Assert.True(appResult.Success);
+            Assert.NotNull(appResult.Archive);
+            Assert.NotNull(appResult.Upload);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_PlanOnly_InstallerPropertyOverridesFlowIntoDotNetInstallerPlan()
     {
         var root = CreateSandbox();
@@ -3636,20 +3801,27 @@ public sealed class PowerForgeReleaseServiceTests
         var method = typeof(PowerForgeToolReleaseService).GetMethod("RunProcess", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         Assert.NotNull(method);
 
-        var tempScript = Path.Combine(Path.GetTempPath(), $"powerforge-toolrelease-{Guid.NewGuid():N}.cmd");
+        var isWindows = OperatingSystem.IsWindows();
+        var tempScript = Path.Combine(Path.GetTempPath(), $"powerforge-toolrelease-{Guid.NewGuid():N}.{(isWindows ? "cmd" : "sh")}");
         try
         {
-            File.WriteAllText(tempScript, "@echo stdout-line\r\n@echo stderr-line 1>&2\r\n", new UTF8Encoding(false));
+            File.WriteAllText(
+                tempScript,
+                isWindows
+                    ? "@echo stdout-line\r\n@echo stderr-line 1>&2\r\n"
+                    : "#!/bin/sh\necho stdout-line\necho stderr-line >&2\n",
+                new UTF8Encoding(false));
 
             var psi = new ProcessStartInfo
             {
-                FileName = "cmd.exe",
+                FileName = isWindows ? "cmd.exe" : "/bin/sh",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
-            psi.ArgumentList.Add("/c");
+            if (isWindows)
+                psi.ArgumentList.Add("/c");
             psi.ArgumentList.Add(tempScript);
 
             var result = method!.Invoke(null, new object?[] { psi });

--- a/PowerForge/Models/AppleAppArchiveModels.cs
+++ b/PowerForge/Models/AppleAppArchiveModels.cs
@@ -89,6 +89,9 @@ public sealed class AppleAppArchiveUploadRequest
     /// <summary>Controls whether App Store Connect manages app version and build numbers during upload.</summary>
     public bool ManageAppVersionAndBuildNumber { get; set; }
 
+    /// <summary>Controls whether xcodebuild may update provisioning profiles during export/upload.</summary>
+    public bool AllowProvisioningUpdates { get; set; } = true;
+
     /// <summary>Controls whether debug symbols are uploaded.</summary>
     public bool UploadSymbols { get; set; } = true;
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -371,6 +371,14 @@ internal sealed class PowerForgeAppleAppReleaseTargetPlan
     public string? TeamId { get; set; }
 
     public bool Upload { get; set; }
+
+    public bool VersionUpdateRequested { get; set; }
+
+    public string? MarketingVersion { get; set; }
+
+    public string? BuildNumber { get; set; }
+
+    public AppleBuildNumberPolicy BuildNumberPolicy { get; set; } = AppleBuildNumberPolicy.KeepExisting;
 }
 
 internal sealed class PowerForgeAppleAppReleaseResult
@@ -380,6 +388,8 @@ internal sealed class PowerForgeAppleAppReleaseResult
     public AppleAppArchiveResult? Archive { get; set; }
 
     public AppleAppArchiveUploadResult? Upload { get; set; }
+
+    public XcodeProjectVersionUpdateResult? VersionUpdate { get; set; }
 
     public bool Success { get; set; }
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -18,6 +18,8 @@ internal sealed class PowerForgeReleaseSpec
 
     public PowerForgeToolReleaseSpec? Tools { get; set; }
 
+    public PowerForgeAppleReleaseOptions? AppleApps { get; set; }
+
     public PowerForgeWorkspaceValidationOptions? WorkspaceValidation { get; set; }
 
     public PowerForgeReleaseOutputsOptions Outputs { get; set; } = new();
@@ -194,6 +196,10 @@ internal sealed class PowerForgeReleaseResult
 
     public DotNetPublishResult? DotNetTools { get; set; }
 
+    public PowerForgeAppleReleasePlan? AppleAppPlan { get; set; }
+
+    public PowerForgeAppleAppReleaseResult[] AppleApps { get; set; } = Array.Empty<PowerForgeAppleAppReleaseResult>();
+
     public WorkspaceValidationPlan? WorkspaceValidationPlan { get; set; }
 
     public WorkspaceValidationResult? WorkspaceValidation { get; set; }
@@ -266,6 +272,118 @@ internal sealed class PowerForgeReleaseStagingOptions
     public string? MetadataNameTemplate { get; set; }
 
     public string? OtherNameTemplate { get; set; }
+}
+
+internal sealed class PowerForgeAppleReleaseOptions
+{
+    public string? ProjectRoot { get; set; }
+
+    public string? Configuration { get; set; }
+
+    public string? ArchiveRoot { get; set; }
+
+    public string? ExportRoot { get; set; }
+
+    public string? TeamId { get; set; }
+
+    public string XcodeBuildExecutable { get; set; } = "xcodebuild";
+
+    public bool Archive { get; set; } = true;
+
+    public bool Upload { get; set; }
+
+    public bool AllowProvisioningUpdates { get; set; } = true;
+
+    public bool ManageAppVersionAndBuildNumber { get; set; }
+
+    public bool UploadSymbols { get; set; } = true;
+
+    public bool GenerateAppStoreInformation { get; set; } = true;
+
+    public string? SigningStyle { get; set; }
+
+    public string? ScreenshotConfigPath { get; set; }
+
+    public string[] ScreenshotConfigPaths { get; set; } = Array.Empty<string>();
+
+    public bool SyncScreenshots { get; set; }
+
+    public bool ReplaceScreenshots { get; set; }
+
+    public AppleAppConfiguration[] Apps { get; set; } = Array.Empty<AppleAppConfiguration>();
+}
+
+internal sealed class PowerForgeAppleReleasePlan
+{
+    public string ProjectRoot { get; set; } = string.Empty;
+
+    public string Configuration { get; set; } = "Release";
+
+    public bool Archive { get; set; }
+
+    public bool Upload { get; set; }
+
+    public bool SyncScreenshots { get; set; }
+
+    public string? ScreenshotConfigPath { get; set; }
+
+    public string[] ScreenshotConfigPaths { get; set; } = Array.Empty<string>();
+
+    public bool ReplaceScreenshots { get; set; }
+
+    public string XcodeBuildExecutable { get; set; } = "xcodebuild";
+
+    public bool AllowProvisioningUpdates { get; set; } = true;
+
+    public bool ManageAppVersionAndBuildNumber { get; set; }
+
+    public bool UploadSymbols { get; set; } = true;
+
+    public bool GenerateAppStoreInformation { get; set; } = true;
+
+    public string SigningStyle { get; set; } = "automatic";
+
+    public PowerForgeAppleAppReleaseTargetPlan[] Apps { get; set; } = Array.Empty<PowerForgeAppleAppReleaseTargetPlan>();
+}
+
+internal sealed class PowerForgeAppleAppReleaseTargetPlan
+{
+    public string Name { get; set; } = string.Empty;
+
+    public string? BundleId { get; set; }
+
+    public ApplePlatform Platform { get; set; }
+
+    public string ProjectPath { get; set; } = string.Empty;
+
+    public bool IsWorkspace { get; set; }
+
+    public string Scheme { get; set; } = string.Empty;
+
+    public string Configuration { get; set; } = "Release";
+
+    public string Destination { get; set; } = string.Empty;
+
+    public string ArchivePath { get; set; } = string.Empty;
+
+    public string ExportPath { get; set; } = string.Empty;
+
+    public string? TeamId { get; set; }
+
+    public bool Upload { get; set; }
+}
+
+internal sealed class PowerForgeAppleAppReleaseResult
+{
+    public PowerForgeAppleAppReleaseTargetPlan Plan { get; set; } = new();
+
+    public AppleAppArchiveResult? Archive { get; set; }
+
+    public AppleAppArchiveUploadResult? Upload { get; set; }
+
+    public bool Success { get; set; }
+
+    public string? ErrorMessage { get; set; }
 }
 
 internal sealed class PowerForgeReleaseGitHubOptions

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -115,9 +115,11 @@ public sealed class AppleAppArchiveService
             "-exportPath",
             exportPath,
             "-exportOptionsPlist",
-            plistPath,
-            "-allowProvisioningUpdates"
+            plistPath
         };
+        if (request.AllowProvisioningUpdates)
+            args.Add("-allowProvisioningUpdates");
+
         args.AddRange(request.AdditionalArguments ?? Array.Empty<string>());
 
         var result = await _processRunner.RunAsync(

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -295,7 +295,7 @@ internal sealed class PowerForgeReleaseService
 
         if (runAppleApps)
         {
-            var applePlan = PrepareAppleRelease(spec.AppleApps!, configPath, configurationOverride, sharedReleaseVersion);
+            var applePlan = PrepareAppleRelease(spec.AppleApps!, configPath, configurationOverride, sharedReleaseVersion, request.Targets);
             result.AppleAppPlan = applePlan;
 
             if (!request.PlanOnly && !request.ValidateOnly)
@@ -422,7 +422,8 @@ internal sealed class PowerForgeReleaseService
         PowerForgeAppleReleaseOptions options,
         string releaseConfigPath,
         string? configurationOverride,
-        string? sharedReleaseVersion)
+        string? sharedReleaseVersion,
+        string[]? selectedTargetNames)
     {
         if (options.SyncScreenshots)
             throw new NotSupportedException("AppleApps.SyncScreenshots is not supported by the unified release workflow yet. Use Sync-AppStoreConnectScreenshots or project-specific screenshot sync scripts for now.");
@@ -440,8 +441,21 @@ internal sealed class PowerForgeReleaseService
             .Select(path => ResolveOutputPath(projectRoot, path))
             .ToArray();
 
-        var apps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
+        var selectedTargets = NormalizeStrings(selectedTargetNames);
+        var configuredApps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
             .Where(app => app.Enabled)
+            .ToArray();
+        if (selectedTargets.Length > 0)
+        {
+            var missing = selectedTargets
+                .Where(selected => configuredApps.All(app => !AppleAppMatchesTarget(app, selected)))
+                .ToArray();
+            if (missing.Length > 0)
+                throw new ArgumentException($"Unknown Apple app target(s): {string.Join(", ", missing)}", nameof(selectedTargetNames));
+        }
+
+        var apps = configuredApps
+            .Where(app => selectedTargets.Length == 0 || selectedTargets.Any(selected => AppleAppMatchesTarget(app, selected)))
             .Select(app => PrepareAppleAppPlan(app, options, projectRoot, archiveRoot, exportRoot, configuration, sharedReleaseVersion))
             .ToArray();
 
@@ -605,7 +619,22 @@ internal sealed class PowerForgeReleaseService
     private static string NormalizeAppleArchiveProjectPath(string projectPath, string appName)
     {
         if (Directory.Exists(projectPath))
+        {
+            var extension = Path.GetExtension(projectPath);
+            if (string.Equals(extension, ".xcodeproj", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(extension, ".xcworkspace", StringComparison.OrdinalIgnoreCase))
+            {
+                return projectPath;
+            }
+
+            throw new InvalidOperationException($"Apple app '{appName}' ProjectPath must point to a .xcodeproj or .xcworkspace directory for archive automation: {projectPath}");
+        }
+
+        if (File.Exists(projectPath) &&
+            string.Equals(Path.GetExtension(projectPath), ".xcodeproj", StringComparison.OrdinalIgnoreCase))
+        {
             return projectPath;
+        }
 
         if (File.Exists(projectPath) &&
             string.Equals(Path.GetFileName(projectPath), "project.pbxproj", StringComparison.OrdinalIgnoreCase))
@@ -620,6 +649,24 @@ internal sealed class PowerForgeReleaseService
 
         throw new InvalidOperationException($"Apple app '{appName}' ProjectPath must point to a .xcodeproj or .xcworkspace for archive automation. project.pbxproj paths are only supported when they are inside a .xcodeproj directory.");
     }
+
+    private static bool AppleAppMatchesTarget(AppleAppConfiguration app, string targetName)
+    {
+        var trimmed = targetName.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return false;
+
+        return string.Equals(app.Name?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(app.Scheme?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(app.BundleId?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string[] NormalizeStrings(IEnumerable<string>? values)
+        => (values ?? Array.Empty<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
 
     private static string? ResolveAppleBuildNumber(
         AppleAppConfiguration app,
@@ -2440,6 +2487,7 @@ internal sealed class PowerForgeReleaseService
             packages = BuildPackageManifestSection(result.Packages),
             legacyTools = BuildLegacyToolsManifestSection(result.Tools),
             dotNetTools = BuildDotNetToolsManifestSection(result.DotNetTools),
+            appleApps = BuildAppleAppsManifestSection(result.AppleAppPlan, result.AppleApps),
             githubReleases = result.ToolGitHubReleases,
             unifiedGithubRelease = result.UnifiedGitHubRelease
         };
@@ -2447,6 +2495,91 @@ internal sealed class PowerForgeReleaseService
         Directory.CreateDirectory(Path.GetDirectoryName(manifestPath)!);
         var json = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine;
         File.WriteAllText(manifestPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static object? BuildAppleAppsManifestSection(
+        PowerForgeAppleReleasePlan? plan,
+        PowerForgeAppleAppReleaseResult[] results)
+    {
+        if (plan is null && (results is null || results.Length == 0))
+            return null;
+
+        return new
+        {
+            plan = plan is null ? null : new
+            {
+                plan.ProjectRoot,
+                plan.Configuration,
+                plan.Archive,
+                plan.Upload,
+                plan.SyncScreenshots,
+                plan.ScreenshotConfigPath,
+                plan.ScreenshotConfigPaths,
+                plan.ReplaceScreenshots,
+                plan.XcodeBuildExecutable,
+                plan.AllowProvisioningUpdates,
+                plan.ManageAppVersionAndBuildNumber,
+                plan.UploadSymbols,
+                plan.GenerateAppStoreInformation,
+                plan.SigningStyle,
+                apps = plan.Apps.Select(app => new
+                {
+                    app.Name,
+                    app.BundleId,
+                    Platform = app.Platform.ToString(),
+                    app.ProjectPath,
+                    app.IsWorkspace,
+                    app.Scheme,
+                    app.Configuration,
+                    app.Destination,
+                    app.ArchivePath,
+                    app.ExportPath,
+                    app.TeamId,
+                    app.Upload,
+                    app.VersionUpdateRequested,
+                    app.MarketingVersion,
+                    app.BuildNumber,
+                    BuildNumberPolicy = app.BuildNumberPolicy.ToString()
+                }).ToArray()
+            },
+            results = (results ?? Array.Empty<PowerForgeAppleAppReleaseResult>()).Select(result => new
+            {
+                app = result.Plan.Name,
+                result.Success,
+                result.ErrorMessage,
+                versionUpdate = result.VersionUpdate is null ? null : new
+                {
+                    result.VersionUpdate.ProjectFilePath,
+                    result.VersionUpdate.Changed,
+                    result.VersionUpdate.WhatIf,
+                    before = new
+                    {
+                        result.VersionUpdate.Before.MarketingVersion,
+                        result.VersionUpdate.Before.BuildNumber
+                    },
+                    after = new
+                    {
+                        result.VersionUpdate.After.MarketingVersion,
+                        result.VersionUpdate.After.BuildNumber
+                    }
+                },
+                archive = result.Archive is null ? null : new
+                {
+                    result.Archive.ArchivePath,
+                    result.Archive.Destination,
+                    result.Archive.Succeeded,
+                    ExitCode = result.Archive.ProcessResult.ExitCode
+                },
+                upload = result.Upload is null ? null : new
+                {
+                    result.Upload.ArchivePath,
+                    result.Upload.ExportPath,
+                    result.Upload.ExportOptionsPlistPath,
+                    result.Upload.Succeeded,
+                    ExitCode = result.Upload.ProcessResult.ExitCode
+                }
+            }).ToArray()
+        };
     }
 
     private static void WriteReleaseChecksums(PowerForgeReleaseResult result, string checksumsPath)

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -140,7 +140,7 @@ internal sealed class PowerForgeReleaseService
         var runModule = spec.Module is not null && (!request.PackagesOnly && !request.ToolsOnly || request.ModuleOnly);
         var runPackages = spec.Packages is not null && !request.ModuleOnly && !request.ToolsOnly;
         var runTools = spec.Tools is not null && !request.ModuleOnly && !request.PackagesOnly;
-        var runAppleApps = spec.AppleApps is not null && !request.ModuleOnly && !request.PackagesOnly;
+        var runAppleApps = spec.AppleApps is not null && !request.ModuleOnly && !request.PackagesOnly && !request.ToolsOnly;
         var configurationOverride = NormalizeConfiguration(request.Configuration);
         var runWorkspaceValidation = spec.WorkspaceValidation is not null && !request.SkipWorkspaceValidation;
         var publishUnifiedGitHub = ShouldPublishUnifiedGitHub(spec, request);
@@ -295,7 +295,7 @@ internal sealed class PowerForgeReleaseService
 
         if (runAppleApps)
         {
-            var applePlan = PrepareAppleRelease(spec.AppleApps!, configPath, configurationOverride);
+            var applePlan = PrepareAppleRelease(spec.AppleApps!, configPath, configurationOverride, sharedReleaseVersion);
             result.AppleAppPlan = applePlan;
 
             if (!request.PlanOnly && !request.ValidateOnly)
@@ -421,8 +421,12 @@ internal sealed class PowerForgeReleaseService
     private static PowerForgeAppleReleasePlan PrepareAppleRelease(
         PowerForgeAppleReleaseOptions options,
         string releaseConfigPath,
-        string? configurationOverride)
+        string? configurationOverride,
+        string? sharedReleaseVersion)
     {
+        if (options.SyncScreenshots)
+            throw new NotSupportedException("AppleApps.SyncScreenshots is not supported by the unified release workflow yet. Use Sync-AppStoreConnectScreenshots or project-specific screenshot sync scripts for now.");
+
         var configDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
         var projectRoot = ResolveOutputPath(configDirectory, string.IsNullOrWhiteSpace(options.ProjectRoot) ? "." : options.ProjectRoot!);
         var configuration = configurationOverride ?? NormalizeConfiguration(options.Configuration) ?? "Release";
@@ -438,7 +442,7 @@ internal sealed class PowerForgeReleaseService
 
         var apps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
             .Where(app => app.Enabled)
-            .Select(app => PrepareAppleAppPlan(app, options, projectRoot, archiveRoot, exportRoot, configuration))
+            .Select(app => PrepareAppleAppPlan(app, options, projectRoot, archiveRoot, exportRoot, configuration, sharedReleaseVersion))
             .ToArray();
 
         if (apps.Length == 0)
@@ -470,7 +474,8 @@ internal sealed class PowerForgeReleaseService
         string projectRoot,
         string archiveRoot,
         string exportRoot,
-        string configuration)
+        string configuration,
+        string? sharedReleaseVersion)
     {
         if (string.IsNullOrWhiteSpace(app.ProjectPath))
             throw new InvalidOperationException("Apple app ProjectPath is required.");
@@ -478,6 +483,9 @@ internal sealed class PowerForgeReleaseService
             throw new InvalidOperationException($"Apple app '{app.Name ?? app.ProjectPath}' requires Scheme for archive automation.");
 
         var projectPath = ResolveOutputPath(projectRoot, app.ProjectPath);
+        if (!File.Exists(projectPath) && !Directory.Exists(projectPath))
+            throw new FileNotFoundException($"Apple app project or workspace was not found: {projectPath}", projectPath);
+
         var isWorkspace = projectPath.EndsWith(".xcworkspace", StringComparison.OrdinalIgnoreCase);
         var name = string.IsNullOrWhiteSpace(app.Name) ? app.Scheme!.Trim() : app.Name!.Trim();
         var safeName = SanitizeStageEntryName(name).Replace(' ', '-');
@@ -487,6 +495,19 @@ internal sealed class PowerForgeReleaseService
         var destination = AppleAppArchiveService.GetGenericDestination(platform);
         var archivePath = Path.Combine(archiveRoot, platform.ToString(), $"{safeName}.xcarchive");
         var exportPath = Path.Combine(exportRoot, platform.ToString(), safeName);
+        var versionUpdateRequested = app.UseResolvedVersion ||
+                                     !string.IsNullOrWhiteSpace(app.MarketingVersion) ||
+                                     !string.IsNullOrWhiteSpace(app.BuildNumber) ||
+                                     app.BuildNumberPolicy != AppleBuildNumberPolicy.KeepExisting;
+        var marketingVersion = versionUpdateRequested
+            ? app.UseResolvedVersion ? sharedReleaseVersion : app.MarketingVersion
+            : null;
+        if (versionUpdateRequested && string.IsNullOrWhiteSpace(marketingVersion))
+            throw new InvalidOperationException($"Apple app '{name}' requires MarketingVersion unless UseResolvedVersion is enabled with a resolvable release version.");
+
+        var buildNumber = versionUpdateRequested
+            ? ResolveAppleBuildNumber(app, projectPath, new XcodeProjectVersionEditor())
+            : null;
 
         return new PowerForgeAppleAppReleaseTargetPlan
         {
@@ -501,7 +522,11 @@ internal sealed class PowerForgeReleaseService
             ArchivePath = archivePath,
             ExportPath = exportPath,
             TeamId = options.TeamId,
-            Upload = options.Upload
+            Upload = options.Upload,
+            VersionUpdateRequested = versionUpdateRequested,
+            MarketingVersion = marketingVersion?.Trim(),
+            BuildNumber = buildNumber,
+            BuildNumberPolicy = app.BuildNumberPolicy
         };
     }
 
@@ -515,6 +540,11 @@ internal sealed class PowerForgeReleaseService
                 Plan = app,
                 Success = true
             };
+
+            if (app.VersionUpdateRequested)
+            {
+                result.VersionUpdate = new XcodeProjectVersionEditor().Update(app.ProjectPath, app.MarketingVersion!, app.BuildNumber);
+            }
 
             if (plan.Archive)
             {
@@ -565,6 +595,34 @@ internal sealed class PowerForgeReleaseService
         }
 
         return results.ToArray();
+    }
+
+    private static string? ResolveAppleBuildNumber(
+        AppleAppConfiguration app,
+        string projectPath,
+        XcodeProjectVersionEditor editor)
+    {
+        if (!string.IsNullOrWhiteSpace(app.BuildNumber))
+            return app.BuildNumber!.Trim();
+
+        return app.BuildNumberPolicy switch
+        {
+            AppleBuildNumberPolicy.KeepExisting => null,
+            AppleBuildNumberPolicy.Explicit => throw new InvalidOperationException("AppleApps.Apps.BuildNumber is required when BuildNumberPolicy is Explicit."),
+            AppleBuildNumberPolicy.IncrementExisting => IncrementExistingAppleBuildNumber(editor.Read(projectPath)),
+            _ => throw new InvalidOperationException($"Unsupported Apple build number policy: {app.BuildNumberPolicy}.")
+        };
+    }
+
+    private static string IncrementExistingAppleBuildNumber(XcodeProjectVersionInfo info)
+    {
+        if (info.BuildNumber is null)
+            throw new InvalidOperationException($"Cannot increment Apple build number because CURRENT_PROJECT_VERSION is missing or inconsistent in '{info.ProjectFilePath}'.");
+
+        if (!long.TryParse(info.BuildNumber, out var current))
+            throw new InvalidOperationException($"Cannot increment Apple build number '{info.BuildNumber}' in '{info.ProjectFilePath}'. Only integer build numbers are supported.");
+
+        return (current + 1).ToString(System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static (WorkspaceValidationSpec Spec, string ConfigPath) LoadWorkspaceValidationSpec(

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -137,10 +137,15 @@ internal sealed class PowerForgeReleaseService
         var configPath = Path.GetFullPath(request.ConfigPath.Trim().Trim('"'));
         var configDirectory = Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory();
         var selectedToolOutputs = ResolveSelectedToolOutputs(request);
+        var selectedTargets = NormalizeStrings(request.Targets);
         var runModule = spec.Module is not null && (!request.PackagesOnly && !request.ToolsOnly || request.ModuleOnly);
         var runPackages = spec.Packages is not null && !request.ModuleOnly && !request.ToolsOnly;
         var runTools = spec.Tools is not null && !request.ModuleOnly && !request.PackagesOnly;
         var runAppleApps = spec.AppleApps is not null && !request.ModuleOnly && !request.PackagesOnly && !request.ToolsOnly;
+        var appleTargetMatches = runAppleApps
+            ? ResolveAppleTargetMatches(spec.AppleApps!, selectedTargets)
+            : Array.Empty<string>();
+        var toolTargetMatches = Array.Empty<string>();
         var configurationOverride = NormalizeConfiguration(request.Configuration);
         var runWorkspaceValidation = spec.WorkspaceValidation is not null && !request.SkipWorkspaceValidation;
         var publishUnifiedGitHub = ShouldPublishUnifiedGitHub(spec, request);
@@ -228,74 +233,103 @@ internal sealed class PowerForgeReleaseService
             if (UsesDotNetToolWorkflow(spec.Tools!))
             {
                 var (dotNetSpec, dotNetSourcePath) = _loadDotNetToolsSpec(spec.Tools!, configPath);
-                var dotNetPlan = _planDotNetTools(dotNetSpec, dotNetSourcePath, request, selectedToolOutputs);
-                ApplySharedReleaseVersion(dotNetPlan, sharedReleaseVersion);
-                ApplyDotNetPublishSkipFlags(dotNetPlan, request.SkipRestore, request.SkipBuild);
-                result.DotNetToolPlan = dotNetPlan;
-
-                if (!request.PlanOnly && !request.ValidateOnly)
+                toolTargetMatches = ResolveDotNetToolTargetMatches(dotNetSpec, selectedTargets);
+                ValidateMixedSelectedTargets(selectedTargets, toolTargetMatches, appleTargetMatches, runTools, runAppleApps);
+                if (ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches))
                 {
-                    var dotNetTools = _runDotNetTools(dotNetPlan);
-                    FilterDotNetToolResult(dotNetTools, selectedToolOutputs);
-                    result.DotNetTools = dotNetTools;
-                    if (!dotNetTools.Succeeded)
-                    {
-                        result.Success = false;
-                        result.ErrorMessage = dotNetTools.ErrorMessage ?? "DotNet tool release workflow failed.";
-                        return result;
-                    }
+                    var dotNetTargets = GetSectionSelectedTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches);
+                    var dotNetPlan = WithRequestTargets(
+                        request,
+                        dotNetTargets,
+                        () => _planDotNetTools(dotNetSpec, dotNetSourcePath, request, selectedToolOutputs));
+                    ApplySharedReleaseVersion(dotNetPlan, sharedReleaseVersion);
+                    ApplyDotNetPublishSkipFlags(dotNetPlan, request.SkipRestore, request.SkipBuild);
+                    result.DotNetToolPlan = dotNetPlan;
 
-                    var publishToolGitHub = request.PublishToolGitHub ?? spec.Tools!.GitHub.Publish;
-                    if (publishToolGitHub)
+                    if (!request.PlanOnly && !request.ValidateOnly)
                     {
-                        var releases = PublishDotNetToolGitHubReleases(spec, configDirectory, dotNetPlan, dotNetTools, sharedReleaseVersion);
-                        result.ToolGitHubReleases = releases;
-                        var failures = releases.Where(entry => !entry.Success).ToArray();
-                        if (failures.Length > 0)
+                        var dotNetTools = _runDotNetTools(dotNetPlan);
+                        FilterDotNetToolResult(dotNetTools, selectedToolOutputs);
+                        result.DotNetTools = dotNetTools;
+                        if (!dotNetTools.Succeeded)
                         {
                             result.Success = false;
-                            result.ErrorMessage = failures[0].ErrorMessage ?? "Tool GitHub release publishing failed.";
+                            result.ErrorMessage = dotNetTools.ErrorMessage ?? "DotNet tool release workflow failed.";
                             return result;
+                        }
+
+                        var publishToolGitHub = request.PublishToolGitHub ?? spec.Tools!.GitHub.Publish;
+                        if (publishToolGitHub)
+                        {
+                            var releases = PublishDotNetToolGitHubReleases(spec, configDirectory, dotNetPlan, dotNetTools, sharedReleaseVersion);
+                            result.ToolGitHubReleases = releases;
+                            var failures = releases.Where(entry => !entry.Success).ToArray();
+                            if (failures.Length > 0)
+                            {
+                                result.Success = false;
+                                result.ErrorMessage = failures[0].ErrorMessage ?? "Tool GitHub release publishing failed.";
+                                return result;
+                            }
                         }
                     }
                 }
             }
             else
             {
-                var toolPlan = _planTools(spec.Tools!, configPath, request);
-                result.ToolPlan = toolPlan;
-
-                if (!request.PlanOnly && !request.ValidateOnly)
+                toolTargetMatches = ResolveLegacyToolTargetMatches(spec.Tools!, selectedTargets);
+                ValidateMixedSelectedTargets(selectedTargets, toolTargetMatches, appleTargetMatches, runTools, runAppleApps);
+                if (ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches))
                 {
-                    var tools = _runTools(toolPlan);
-                    result.Tools = tools;
-                    if (!tools.Success)
-                    {
-                        result.Success = false;
-                        result.ErrorMessage = tools.ErrorMessage ?? "Tool release workflow failed.";
-                        return result;
-                    }
+                    var legacyToolTargets = GetSectionSelectedTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches);
+                    var toolPlan = WithRequestTargets(
+                        request,
+                        legacyToolTargets,
+                        () => _planTools(spec.Tools!, configPath, request));
+                    result.ToolPlan = toolPlan;
 
-                    var publishToolGitHub = request.PublishToolGitHub ?? spec.Tools!.GitHub.Publish;
-                    if (publishToolGitHub)
+                    if (!request.PlanOnly && !request.ValidateOnly)
                     {
-                        var releases = PublishLegacyToolGitHubReleases(spec, configDirectory, tools);
-                        result.ToolGitHubReleases = releases;
-                        var failures = releases.Where(entry => !entry.Success).ToArray();
-                        if (failures.Length > 0)
+                        var tools = _runTools(toolPlan);
+                        result.Tools = tools;
+                        if (!tools.Success)
                         {
                             result.Success = false;
-                            result.ErrorMessage = failures[0].ErrorMessage ?? "Tool GitHub release publishing failed.";
+                            result.ErrorMessage = tools.ErrorMessage ?? "Tool release workflow failed.";
                             return result;
+                        }
+
+                        var publishToolGitHub = request.PublishToolGitHub ?? spec.Tools!.GitHub.Publish;
+                        if (publishToolGitHub)
+                        {
+                            var releases = PublishLegacyToolGitHubReleases(spec, configDirectory, tools);
+                            result.ToolGitHubReleases = releases;
+                            var failures = releases.Where(entry => !entry.Success).ToArray();
+                            if (failures.Length > 0)
+                            {
+                                result.Success = false;
+                                result.ErrorMessage = failures[0].ErrorMessage ?? "Tool GitHub release publishing failed.";
+                                return result;
+                            }
                         }
                     }
                 }
             }
         }
-
-        if (runAppleApps)
+        else if (runAppleApps)
         {
-            var applePlan = PrepareAppleRelease(spec.AppleApps!, configPath, configurationOverride, sharedReleaseVersion, request.Targets);
+            ValidateMixedSelectedTargets(selectedTargets, Array.Empty<string>(), appleTargetMatches, runTools, runAppleApps);
+        }
+
+        if (runAppleApps && ShouldRunSectionForTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches))
+        {
+            var selectedAppleTargets = GetSectionSelectedTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches);
+            var applePlan = PrepareAppleRelease(
+                spec.AppleApps!,
+                configPath,
+                configurationOverride,
+                sharedReleaseVersion,
+                request.SkipBuild,
+                selectedAppleTargets);
             result.AppleAppPlan = applePlan;
 
             if (!request.PlanOnly && !request.ValidateOnly)
@@ -333,6 +367,105 @@ internal sealed class PowerForgeReleaseService
         }
 
         return result;
+    }
+
+    private static TResult WithRequestTargets<TResult>(PowerForgeReleaseRequest request, string[] targets, Func<TResult> action)
+    {
+        var originalTargets = request.Targets;
+        request.Targets = targets;
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            request.Targets = originalTargets;
+        }
+    }
+
+    private static bool ShouldRunSectionForTargets(
+        string[] selectedTargets,
+        string[] sectionTargetMatches,
+        bool hasOtherTargetSection,
+        string[] otherSectionTargetMatches)
+    {
+        if (selectedTargets.Length == 0 || sectionTargetMatches.Length > 0)
+            return true;
+
+        return !hasOtherTargetSection || otherSectionTargetMatches.Length == 0;
+    }
+
+    private static string[] GetSectionSelectedTargets(
+        string[] selectedTargets,
+        string[] sectionTargetMatches,
+        bool hasOtherTargetSection,
+        string[] otherSectionTargetMatches)
+    {
+        if (selectedTargets.Length == 0)
+            return Array.Empty<string>();
+
+        if (sectionTargetMatches.Length > 0)
+            return sectionTargetMatches;
+
+        return hasOtherTargetSection && otherSectionTargetMatches.Length > 0
+            ? Array.Empty<string>()
+            : selectedTargets;
+    }
+
+    private static string[] ResolveLegacyToolTargetMatches(PowerForgeToolReleaseSpec tools, string[] selectedTargets)
+    {
+        if (selectedTargets.Length == 0)
+            return Array.Empty<string>();
+
+        return selectedTargets
+            .Where(selected => (tools.Targets ?? Array.Empty<PowerForgeToolReleaseTarget>())
+                .Any(target => string.Equals(target.Name?.Trim(), selected, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+    }
+
+    private static string[] ResolveDotNetToolTargetMatches(DotNetPublishSpec spec, string[] selectedTargets)
+    {
+        if (selectedTargets.Length == 0)
+            return Array.Empty<string>();
+
+        return selectedTargets
+            .Where(selected => (spec.Targets ?? Array.Empty<DotNetPublishTarget>())
+                .Any(target => string.Equals(target.Name?.Trim(), selected, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+    }
+
+    private static string[] ResolveAppleTargetMatches(PowerForgeAppleReleaseOptions options, string[] selectedTargets)
+    {
+        if (selectedTargets.Length == 0)
+            return Array.Empty<string>();
+
+        var apps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
+            .Where(app => app.Enabled)
+            .ToArray();
+
+        return selectedTargets
+            .Where(selected => apps.Any(app => AppleAppMatchesTarget(app, selected)))
+            .ToArray();
+    }
+
+    private static void ValidateMixedSelectedTargets(
+        string[] selectedTargets,
+        string[] toolTargetMatches,
+        string[] appleTargetMatches,
+        bool runTools,
+        bool runAppleApps)
+    {
+        if (!runTools || !runAppleApps || selectedTargets.Length == 0)
+            return;
+
+        var knownTargets = toolTargetMatches
+            .Concat(appleTargetMatches)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missing = selectedTargets
+            .Where(selected => !knownTargets.Contains(selected))
+            .ToArray();
+        if (missing.Length > 0)
+            throw new ArgumentException($"Unknown release target(s): {string.Join(", ", missing)}", nameof(PowerForgeReleaseRequest.Targets));
     }
 
     private static (WorkspaceValidationService Service, WorkspaceValidationSpec Spec, string ConfigPath, WorkspaceValidationRequest Request, WorkspaceValidationPlan Plan) PrepareWorkspaceValidation(
@@ -423,10 +556,13 @@ internal sealed class PowerForgeReleaseService
         string releaseConfigPath,
         string? configurationOverride,
         string? sharedReleaseVersion,
+        bool skipBuild,
         string[]? selectedTargetNames)
     {
         if (options.SyncScreenshots)
             throw new NotSupportedException("AppleApps.SyncScreenshots is not supported by the unified release workflow yet. Use Sync-AppStoreConnectScreenshots or project-specific screenshot sync scripts for now.");
+        if (skipBuild && options.Archive)
+            throw new InvalidOperationException("PowerForge release SkipBuild is not supported when AppleApps.Archive is enabled. Set AppleApps.Archive=false to reuse an existing Apple archive explicitly.");
 
         var configDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
         var projectRoot = ResolveOutputPath(configDirectory, string.IsNullOrWhiteSpace(options.ProjectRoot) ? "." : options.ProjectRoot!);

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -482,12 +482,13 @@ internal sealed class PowerForgeReleaseService
         if (string.IsNullOrWhiteSpace(app.Scheme))
             throw new InvalidOperationException($"Apple app '{app.Name ?? app.ProjectPath}' requires Scheme for archive automation.");
 
-        var projectPath = ResolveOutputPath(projectRoot, app.ProjectPath);
-        if (!File.Exists(projectPath) && !Directory.Exists(projectPath))
-            throw new FileNotFoundException($"Apple app project or workspace was not found: {projectPath}", projectPath);
-
-        var isWorkspace = projectPath.EndsWith(".xcworkspace", StringComparison.OrdinalIgnoreCase);
         var name = string.IsNullOrWhiteSpace(app.Name) ? app.Scheme!.Trim() : app.Name!.Trim();
+        var requestedProjectPath = ResolveOutputPath(projectRoot, app.ProjectPath);
+        if (!File.Exists(requestedProjectPath) && !Directory.Exists(requestedProjectPath))
+            throw new FileNotFoundException($"Apple app project or workspace was not found: {requestedProjectPath}", requestedProjectPath);
+
+        var projectPath = NormalizeAppleArchiveProjectPath(requestedProjectPath, name);
+        var isWorkspace = projectPath.EndsWith(".xcworkspace", StringComparison.OrdinalIgnoreCase);
         var safeName = SanitizeStageEntryName(name).Replace(' ', '-');
         if (string.IsNullOrWhiteSpace(safeName))
             safeName = "AppleApp";
@@ -502,6 +503,8 @@ internal sealed class PowerForgeReleaseService
         var marketingVersion = versionUpdateRequested
             ? app.UseResolvedVersion ? sharedReleaseVersion : app.MarketingVersion
             : null;
+        if (versionUpdateRequested && isWorkspace)
+            throw new InvalidOperationException($"Apple app '{name}' uses a .xcworkspace ProjectPath. Unified Apple version updates require a .xcodeproj ProjectPath or project.pbxproj path.");
         if (versionUpdateRequested && string.IsNullOrWhiteSpace(marketingVersion))
             throw new InvalidOperationException($"Apple app '{name}' requires MarketingVersion unless UseResolvedVersion is enabled with a resolvable release version.");
 
@@ -566,7 +569,7 @@ internal sealed class PowerForgeReleaseService
                     result.Success = false;
                     result.ErrorMessage = $"xcodebuild archive failed for '{app.Name}' with exit code {archive.ProcessResult.ExitCode}.";
                     results.Add(result);
-                    continue;
+                    return results.ToArray();
                 }
             }
 
@@ -588,6 +591,8 @@ internal sealed class PowerForgeReleaseService
                 {
                     result.Success = false;
                     result.ErrorMessage = $"xcodebuild exportArchive upload failed for '{app.Name}' with exit code {upload.ProcessResult.ExitCode}.";
+                    results.Add(result);
+                    return results.ToArray();
                 }
             }
 
@@ -595,6 +600,25 @@ internal sealed class PowerForgeReleaseService
         }
 
         return results.ToArray();
+    }
+
+    private static string NormalizeAppleArchiveProjectPath(string projectPath, string appName)
+    {
+        if (Directory.Exists(projectPath))
+            return projectPath;
+
+        if (File.Exists(projectPath) &&
+            string.Equals(Path.GetFileName(projectPath), "project.pbxproj", StringComparison.OrdinalIgnoreCase))
+        {
+            var projectDirectory = Path.GetDirectoryName(projectPath);
+            if (!string.IsNullOrWhiteSpace(projectDirectory) &&
+                string.Equals(Path.GetExtension(projectDirectory), ".xcodeproj", StringComparison.OrdinalIgnoreCase))
+            {
+                return projectDirectory;
+            }
+        }
+
+        throw new InvalidOperationException($"Apple app '{appName}' ProjectPath must point to a .xcodeproj or .xcworkspace for archive automation. project.pbxproj paths are only supported when they are inside a .xcodeproj directory.");
     }
 
     private static string? ResolveAppleBuildNumber(

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -146,6 +146,15 @@ internal sealed class PowerForgeReleaseService
             ? ResolveAppleTargetMatches(spec.AppleApps!, selectedTargets)
             : Array.Empty<string>();
         var toolTargetMatches = Array.Empty<string>();
+        var selectedTargetsAreAppleOnly = runAppleApps &&
+                                          selectedTargets.Length > 0 &&
+                                          appleTargetMatches.Length == selectedTargets.Length;
+        if (selectedTargetsAreAppleOnly)
+        {
+            runModule = false;
+            runPackages = false;
+            runTools = false;
+        }
         var configurationOverride = NormalizeConfiguration(request.Configuration);
         var runWorkspaceValidation = spec.WorkspaceValidation is not null && !request.SkipWorkspaceValidation;
         var publishUnifiedGitHub = ShouldPublishUnifiedGitHub(spec, request);
@@ -226,22 +235,57 @@ internal sealed class PowerForgeReleaseService
         }
 
         var sharedReleaseVersion = ResolveSharedReleaseVersion(spec, result);
-
+        DotNetPublishSpec? dotNetSpecForTools = null;
+        string? dotNetSourcePathForTools = null;
         if (runTools)
         {
             ApplyToolRequestOverrides(spec.Tools!, request, configurationOverride);
             if (UsesDotNetToolWorkflow(spec.Tools!))
             {
-                var (dotNetSpec, dotNetSourcePath) = _loadDotNetToolsSpec(spec.Tools!, configPath);
-                toolTargetMatches = ResolveDotNetToolTargetMatches(dotNetSpec, selectedTargets);
-                ValidateMixedSelectedTargets(selectedTargets, toolTargetMatches, appleTargetMatches, runTools, runAppleApps);
-                if (ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches))
+                var dotNetSource = _loadDotNetToolsSpec(spec.Tools!, configPath);
+                dotNetSpecForTools = dotNetSource.Spec;
+                dotNetSourcePathForTools = dotNetSource.SourceConfigPath;
+                toolTargetMatches = ResolveDotNetToolTargetMatches(dotNetSpecForTools, selectedTargets);
+            }
+            else
+            {
+                toolTargetMatches = ResolveLegacyToolTargetMatches(spec.Tools!, selectedTargets);
+            }
+
+            ValidateMixedSelectedTargets(selectedTargets, toolTargetMatches, appleTargetMatches, runTools, runAppleApps);
+        }
+        else if (runAppleApps)
+        {
+            ValidateMixedSelectedTargets(selectedTargets, Array.Empty<string>(), appleTargetMatches, runTools, runAppleApps);
+        }
+
+        PowerForgeAppleReleasePlan? applePlan = null;
+        if (runAppleApps && ShouldRunSectionForTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches))
+        {
+            var selectedAppleTargets = GetSectionSelectedTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches);
+            applePlan = PrepareAppleRelease(
+                spec.AppleApps!,
+                configPath,
+                configurationOverride,
+                sharedReleaseVersion,
+                request.SkipBuild,
+                selectedAppleTargets);
+            result.AppleAppPlan = applePlan;
+        }
+
+        if (runTools)
+        {
+            if (UsesDotNetToolWorkflow(spec.Tools!))
+            {
+                if (dotNetSpecForTools is not null &&
+                    dotNetSourcePathForTools is not null &&
+                    ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches))
                 {
                     var dotNetTargets = GetSectionSelectedTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches);
                     var dotNetPlan = WithRequestTargets(
                         request,
                         dotNetTargets,
-                        () => _planDotNetTools(dotNetSpec, dotNetSourcePath, request, selectedToolOutputs));
+                        () => _planDotNetTools(dotNetSpecForTools, dotNetSourcePathForTools, request, selectedToolOutputs));
                     ApplySharedReleaseVersion(dotNetPlan, sharedReleaseVersion);
                     ApplyDotNetPublishSkipFlags(dotNetPlan, request.SkipRestore, request.SkipBuild);
                     result.DotNetToolPlan = dotNetPlan;
@@ -276,8 +320,6 @@ internal sealed class PowerForgeReleaseService
             }
             else
             {
-                toolTargetMatches = ResolveLegacyToolTargetMatches(spec.Tools!, selectedTargets);
-                ValidateMixedSelectedTargets(selectedTargets, toolTargetMatches, appleTargetMatches, runTools, runAppleApps);
                 if (ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches))
                 {
                     var legacyToolTargets = GetSectionSelectedTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches);
@@ -315,23 +357,8 @@ internal sealed class PowerForgeReleaseService
                 }
             }
         }
-        else if (runAppleApps)
+        if (applePlan is not null)
         {
-            ValidateMixedSelectedTargets(selectedTargets, Array.Empty<string>(), appleTargetMatches, runTools, runAppleApps);
-        }
-
-        if (runAppleApps && ShouldRunSectionForTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches))
-        {
-            var selectedAppleTargets = GetSectionSelectedTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches);
-            var applePlan = PrepareAppleRelease(
-                spec.AppleApps!,
-                configPath,
-                configurationOverride,
-                sharedReleaseVersion,
-                request.SkipBuild,
-                selectedAppleTargets);
-            result.AppleAppPlan = applePlan;
-
             if (!request.PlanOnly && !request.ValidateOnly)
             {
                 var appleResults = RunAppleRelease(applePlan);
@@ -597,6 +624,8 @@ internal sealed class PowerForgeReleaseService
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
+        if (!options.Archive && apps.Any(app => app.VersionUpdateRequested))
+            throw new InvalidOperationException("Apple app version updates require AppleApps.Archive=true. Set Archive=true to build a fresh archive after updating versions, or remove version update fields when reusing an existing archive.");
 
         return new PowerForgeAppleReleasePlan
         {
@@ -734,7 +763,8 @@ internal sealed class PowerForgeReleaseService
                     SigningStyle = plan.SigningStyle,
                     ManageAppVersionAndBuildNumber = plan.ManageAppVersionAndBuildNumber,
                     UploadSymbols = plan.UploadSymbols,
-                    GenerateAppStoreInformation = plan.GenerateAppStoreInformation
+                    GenerateAppStoreInformation = plan.GenerateAppStoreInformation,
+                    AllowProvisioningUpdates = plan.AllowProvisioningUpdates
                 });
                 result.Upload = upload;
                 if (!upload.Succeeded)

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -52,6 +52,8 @@ internal sealed class PowerForgeReleaseService
     private readonly Func<DotNetPublishPlan, DotNetPublishResult> _runDotNetTools;
     private readonly Func<GitHubReleasePublishRequest, GitHubReleasePublishResult> _publishGitHubRelease;
     private readonly Func<PowerForgeWingetSubmissionPlan, PowerForgeWingetSubmissionResult> _submitWinget;
+    private readonly Func<AppleAppArchiveRequest, AppleAppArchiveResult> _archiveAppleApp;
+    private readonly Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult> _uploadAppleApp;
 
     /// <summary>
     /// Creates a new unified release service.
@@ -66,7 +68,9 @@ internal sealed class PowerForgeReleaseService
             (spec, configPath, request, selectedOutputs) => PlanDotNetTools(logger, spec, configPath, request, selectedOutputs),
             plan => new DotNetPublishPipelineRunner(logger).Run(plan, progress: null),
             publishRequest => new GitHubReleasePublisher(logger).PublishRelease(publishRequest),
-            plan => new WingetSubmissionService(logger).Run(plan))
+            plan => new WingetSubmissionService(logger).Run(plan),
+            request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult(),
+            request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult())
     {
     }
 
@@ -85,7 +89,9 @@ internal sealed class PowerForgeReleaseService
             (spec, configPath, request, selectedOutputs) => PlanDotNetTools(logger, spec, configPath, request, selectedOutputs),
             plan => new DotNetPublishPipelineRunner(logger).Run(plan, progress: null),
             publishGitHubRelease,
-            plan => new WingetSubmissionService(logger).Run(plan))
+            plan => new WingetSubmissionService(logger).Run(plan),
+            request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult(),
+            request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult())
     {
     }
 
@@ -98,7 +104,9 @@ internal sealed class PowerForgeReleaseService
         Func<DotNetPublishSpec, string, PowerForgeReleaseRequest, ISet<PowerForgeReleaseToolOutputKind>, DotNetPublishPlan> planDotNetTools,
         Func<DotNetPublishPlan, DotNetPublishResult> runDotNetTools,
         Func<GitHubReleasePublishRequest, GitHubReleasePublishResult> publishGitHubRelease,
-        Func<PowerForgeWingetSubmissionPlan, PowerForgeWingetSubmissionResult>? submitWinget = null)
+        Func<PowerForgeWingetSubmissionPlan, PowerForgeWingetSubmissionResult>? submitWinget = null,
+        Func<AppleAppArchiveRequest, AppleAppArchiveResult>? archiveAppleApp = null,
+        Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -109,6 +117,8 @@ internal sealed class PowerForgeReleaseService
         _runDotNetTools = runDotNetTools ?? throw new ArgumentNullException(nameof(runDotNetTools));
         _publishGitHubRelease = publishGitHubRelease ?? throw new ArgumentNullException(nameof(publishGitHubRelease));
         _submitWinget = submitWinget ?? (plan => new WingetSubmissionService(logger).Run(plan));
+        _archiveAppleApp = archiveAppleApp ?? (request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult());
+        _uploadAppleApp = uploadAppleApp ?? (request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult());
     }
 
     /// <summary>
@@ -130,17 +140,18 @@ internal sealed class PowerForgeReleaseService
         var runModule = spec.Module is not null && (!request.PackagesOnly && !request.ToolsOnly || request.ModuleOnly);
         var runPackages = spec.Packages is not null && !request.ModuleOnly && !request.ToolsOnly;
         var runTools = spec.Tools is not null && !request.ModuleOnly && !request.PackagesOnly;
+        var runAppleApps = spec.AppleApps is not null && !request.ModuleOnly && !request.PackagesOnly;
         var configurationOverride = NormalizeConfiguration(request.Configuration);
         var runWorkspaceValidation = spec.WorkspaceValidation is not null && !request.SkipWorkspaceValidation;
         var publishUnifiedGitHub = ShouldPublishUnifiedGitHub(spec, request);
 
-        if (!runModule && !runPackages && !runTools && !runWorkspaceValidation)
+        if (!runModule && !runPackages && !runTools && !runAppleApps && !runWorkspaceValidation)
         {
             return new PowerForgeReleaseResult
             {
                 Success = false,
                 ConfigPath = configPath,
-                ErrorMessage = "Release config does not enable any selected WorkspaceValidation, Module, Packages, or Tools sections."
+                ErrorMessage = "Release config does not enable any selected WorkspaceValidation, Module, Packages, Tools, or AppleApps sections."
             };
         }
 
@@ -282,6 +293,25 @@ internal sealed class PowerForgeReleaseService
             }
         }
 
+        if (runAppleApps)
+        {
+            var applePlan = PrepareAppleRelease(spec.AppleApps!, configPath, configurationOverride);
+            result.AppleAppPlan = applePlan;
+
+            if (!request.PlanOnly && !request.ValidateOnly)
+            {
+                var appleResults = RunAppleRelease(applePlan);
+                result.AppleApps = appleResults;
+                var failure = appleResults.FirstOrDefault(entry => !entry.Success);
+                if (failure is not null)
+                {
+                    result.Success = false;
+                    result.ErrorMessage = failure.ErrorMessage ?? $"Apple app release failed for '{failure.Plan.Name}'.";
+                    return result;
+                }
+            }
+        }
+
         if (!request.PlanOnly && !request.ValidateOnly)
         {
             PopulateReleaseOutputs(spec, request, configDirectory, result, sharedReleaseVersion);
@@ -386,6 +416,155 @@ internal sealed class PowerForgeReleaseService
         };
 
         return (buildRequest, plan, artifactPaths);
+    }
+
+    private static PowerForgeAppleReleasePlan PrepareAppleRelease(
+        PowerForgeAppleReleaseOptions options,
+        string releaseConfigPath,
+        string? configurationOverride)
+    {
+        var configDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
+        var projectRoot = ResolveOutputPath(configDirectory, string.IsNullOrWhiteSpace(options.ProjectRoot) ? "." : options.ProjectRoot!);
+        var configuration = configurationOverride ?? NormalizeConfiguration(options.Configuration) ?? "Release";
+        var archiveRoot = ResolveOutputPath(projectRoot, string.IsNullOrWhiteSpace(options.ArchiveRoot) ? Path.Combine("Artifacts", "Apple", "Archives") : options.ArchiveRoot!);
+        var exportRoot = ResolveOutputPath(projectRoot, string.IsNullOrWhiteSpace(options.ExportRoot) ? Path.Combine("Artifacts", "Apple", "Exports") : options.ExportRoot!);
+        var screenshotConfigPath = string.IsNullOrWhiteSpace(options.ScreenshotConfigPath)
+            ? null
+            : ResolveOutputPath(projectRoot, options.ScreenshotConfigPath!);
+        var screenshotConfigPaths = (options.ScreenshotConfigPaths ?? Array.Empty<string>())
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => ResolveOutputPath(projectRoot, path))
+            .ToArray();
+
+        var apps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
+            .Where(app => app.Enabled)
+            .Select(app => PrepareAppleAppPlan(app, options, projectRoot, archiveRoot, exportRoot, configuration))
+            .ToArray();
+
+        if (apps.Length == 0)
+            throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
+
+        return new PowerForgeAppleReleasePlan
+        {
+            ProjectRoot = projectRoot,
+            Configuration = configuration,
+            Archive = options.Archive,
+            Upload = options.Upload,
+            SyncScreenshots = options.SyncScreenshots,
+            ScreenshotConfigPath = screenshotConfigPath,
+            ScreenshotConfigPaths = screenshotConfigPaths,
+            ReplaceScreenshots = options.ReplaceScreenshots,
+            XcodeBuildExecutable = string.IsNullOrWhiteSpace(options.XcodeBuildExecutable) ? "xcodebuild" : options.XcodeBuildExecutable.Trim(),
+            AllowProvisioningUpdates = options.AllowProvisioningUpdates,
+            ManageAppVersionAndBuildNumber = options.ManageAppVersionAndBuildNumber,
+            UploadSymbols = options.UploadSymbols,
+            GenerateAppStoreInformation = options.GenerateAppStoreInformation,
+            SigningStyle = string.IsNullOrWhiteSpace(options.SigningStyle) ? "automatic" : options.SigningStyle!.Trim(),
+            Apps = apps
+        };
+    }
+
+    private static PowerForgeAppleAppReleaseTargetPlan PrepareAppleAppPlan(
+        AppleAppConfiguration app,
+        PowerForgeAppleReleaseOptions options,
+        string projectRoot,
+        string archiveRoot,
+        string exportRoot,
+        string configuration)
+    {
+        if (string.IsNullOrWhiteSpace(app.ProjectPath))
+            throw new InvalidOperationException("Apple app ProjectPath is required.");
+        if (string.IsNullOrWhiteSpace(app.Scheme))
+            throw new InvalidOperationException($"Apple app '{app.Name ?? app.ProjectPath}' requires Scheme for archive automation.");
+
+        var projectPath = ResolveOutputPath(projectRoot, app.ProjectPath);
+        var isWorkspace = projectPath.EndsWith(".xcworkspace", StringComparison.OrdinalIgnoreCase);
+        var name = string.IsNullOrWhiteSpace(app.Name) ? app.Scheme!.Trim() : app.Name!.Trim();
+        var safeName = SanitizeStageEntryName(name).Replace(' ', '-');
+        if (string.IsNullOrWhiteSpace(safeName))
+            safeName = "AppleApp";
+        var platform = app.Platform;
+        var destination = AppleAppArchiveService.GetGenericDestination(platform);
+        var archivePath = Path.Combine(archiveRoot, platform.ToString(), $"{safeName}.xcarchive");
+        var exportPath = Path.Combine(exportRoot, platform.ToString(), safeName);
+
+        return new PowerForgeAppleAppReleaseTargetPlan
+        {
+            Name = name,
+            BundleId = app.BundleId,
+            Platform = platform,
+            ProjectPath = projectPath,
+            IsWorkspace = isWorkspace,
+            Scheme = app.Scheme!.Trim(),
+            Configuration = configuration,
+            Destination = destination,
+            ArchivePath = archivePath,
+            ExportPath = exportPath,
+            TeamId = options.TeamId,
+            Upload = options.Upload
+        };
+    }
+
+    private PowerForgeAppleAppReleaseResult[] RunAppleRelease(PowerForgeAppleReleasePlan plan)
+    {
+        var results = new List<PowerForgeAppleAppReleaseResult>();
+        foreach (var app in plan.Apps)
+        {
+            var result = new PowerForgeAppleAppReleaseResult
+            {
+                Plan = app,
+                Success = true
+            };
+
+            if (plan.Archive)
+            {
+                var archive = _archiveAppleApp(new AppleAppArchiveRequest
+                {
+                    ProjectPath = app.ProjectPath,
+                    IsWorkspace = app.IsWorkspace,
+                    Scheme = app.Scheme,
+                    Configuration = app.Configuration,
+                    Platform = app.Platform,
+                    Destination = app.Destination,
+                    ArchivePath = app.ArchivePath,
+                    XcodeBuildExecutable = plan.XcodeBuildExecutable,
+                    AllowProvisioningUpdates = plan.AllowProvisioningUpdates
+                });
+                result.Archive = archive;
+                if (!archive.Succeeded)
+                {
+                    result.Success = false;
+                    result.ErrorMessage = $"xcodebuild archive failed for '{app.Name}' with exit code {archive.ProcessResult.ExitCode}.";
+                    results.Add(result);
+                    continue;
+                }
+            }
+
+            if (plan.Upload && result.Success)
+            {
+                var upload = _uploadAppleApp(new AppleAppArchiveUploadRequest
+                {
+                    ArchivePath = app.ArchivePath,
+                    ExportPath = app.ExportPath,
+                    TeamId = app.TeamId,
+                    XcodeBuildExecutable = plan.XcodeBuildExecutable,
+                    SigningStyle = plan.SigningStyle,
+                    ManageAppVersionAndBuildNumber = plan.ManageAppVersionAndBuildNumber,
+                    UploadSymbols = plan.UploadSymbols,
+                    GenerateAppStoreInformation = plan.GenerateAppStoreInformation
+                });
+                result.Upload = upload;
+                if (!upload.Succeeded)
+                {
+                    result.Success = false;
+                    result.ErrorMessage = $"xcodebuild exportArchive upload failed for '{app.Name}' with exit code {upload.ProcessResult.ExitCode}.";
+                }
+            }
+
+            results.Add(result);
+        }
+
+        return results.ToArray();
     }
 
     private static (WorkspaceValidationSpec Spec, string ConfigPath) LoadWorkspaceValidationSpec(

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -235,6 +235,36 @@
           }
         }
       }
+    },
+    "AppleApps": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ProjectRoot": { "type": [ "string", "null" ] },
+        "Configuration": { "type": "string", "enum": [ "Release", "Debug" ] },
+        "ArchiveRoot": { "type": [ "string", "null" ] },
+        "ExportRoot": { "type": [ "string", "null" ] },
+        "TeamId": { "type": [ "string", "null" ] },
+        "XcodeBuildExecutable": { "type": "string" },
+        "Archive": { "type": "boolean" },
+        "Upload": { "type": "boolean" },
+        "AllowProvisioningUpdates": { "type": "boolean" },
+        "ManageAppVersionAndBuildNumber": { "type": "boolean" },
+        "UploadSymbols": { "type": "boolean" },
+        "GenerateAppStoreInformation": { "type": "boolean" },
+        "SigningStyle": { "type": [ "string", "null" ] },
+        "ScreenshotConfigPath": { "type": [ "string", "null" ] },
+        "ScreenshotConfigPaths": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "SyncScreenshots": { "type": "boolean" },
+        "ReplaceScreenshots": { "type": "boolean" },
+        "Apps": {
+          "type": "array",
+          "items": { "$ref": "powerforge.segments.schema.json#/$defs/AppleAppConfiguration" }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add AppleApps targets to the unified PowerForge release spec/result model
- plan and run Apple app archive/upload targets through the existing Apple archive services
- document the unified release config shape and cover the flow with focused tests

## Tests
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --no-restore --filter PowerForgeReleaseServiceTests