### PR TITLE
Fix Apple release review follow-ups

### DIFF
--- a/PSPublishModule/Cmdlets/InvokePowerForgeReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokePowerForgeReleaseCommand.cs
@@ -99,7 +99,6 @@ public sealed partial class InvokePowerForgeReleaseCommand : PSCmdlet
     /// Optional configuration override.
     /// </summary>
     [Parameter]
-    [ValidateSet("Release", "Debug")]
     public string? Configuration { get; set; }
 
     /// <summary>

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -5,6 +5,18 @@ namespace PowerForge.Tests;
 public sealed class PowerForgeProjectCmdletTests
 {
     [Fact]
+    public void InvokePowerForgeRelease_Configuration_DoesNotRestrictAppleBuildConfigurations()
+    {
+        var property = typeof(PSPublishModule.InvokePowerForgeReleaseCommand)
+            .GetProperty(nameof(PSPublishModule.InvokePowerForgeReleaseCommand.Configuration));
+
+        Assert.NotNull(property);
+        Assert.DoesNotContain(
+            property!.GetCustomAttributes(inherit: true),
+            attribute => attribute.GetType().FullName == "System.Management.Automation.ValidateSetAttribute");
+    }
+
+    [Fact]
     public void ExportConfigurationProject_ExistingFileWithoutForce_ReturnsResourceExistsError()
     {
         var tempRoot = CreateTempDirectory();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -1496,6 +1496,117 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_MixedInlineDotNetToolsAndAppleApps_RespectsDotNetPublishProfileOverrideBeforeTargetMatching()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var plannedToolTargets = Array.Empty<string>();
+            var dotNetPublish = new DotNetPublishSpec
+            {
+                Profile = "tools",
+                Profiles = new[]
+                {
+                    new DotNetPublishProfile
+                    {
+                        Name = "tools",
+                        Targets = new[] { "PowerForge" }
+                    },
+                    new DotNetPublishProfile
+                    {
+                        Name = "apple",
+                        Targets = new[] { "Tactra" }
+                    }
+                },
+                Targets = new[]
+                {
+                    new DotNetPublishTarget
+                    {
+                        Name = "Tactra",
+                        ProjectPath = "Tactra.Cli.csproj"
+                    },
+                    new DotNetPublishTarget
+                    {
+                        Name = "PowerForge",
+                        ProjectPath = "PowerForge.Cli.csproj"
+                    }
+                }
+            };
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (dotNetPublish, configPath),
+                planDotNetTools: (_, _, request, _) =>
+                {
+                    plannedToolTargets = request.Targets;
+                    return new DotNetPublishPlan
+                    {
+                        ProjectRoot = root,
+                        Configuration = "Release",
+                        Targets = new[]
+                        {
+                            new DotNetPublishTargetPlan
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.Cli.csproj",
+                                Combinations = Array.Empty<DotNetPublishTargetCombination>()
+                            }
+                        }
+                    };
+                },
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run in plan mode."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run in plan mode."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublishProfile = "apple",
+                        DotNetPublish = dotNetPublish
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    Targets = new[] { "Tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal("apple", dotNetPublish.Profile);
+            Assert.Equal(new[] { "Tactra" }, plannedToolTargets);
+            Assert.NotNull(result.DotNetToolPlan);
+            Assert.Single(result.AppleAppPlan!.Apps);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_MixedDotNetToolsAndAppleApps_RunsSharedTargetInBothSections()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -1038,7 +1038,49 @@ public sealed class PowerForgeReleaseServiceTests
                     Targets = new[] { "MissingApp" }
                 }));
 
-            Assert.Contains("Unknown Apple app target", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("Unknown release target", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("MissingApp", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_RejectsPartiallyUnknownTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<ArgumentException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Targets = new[] { "Tactra", "MissingApp" }
+                }));
+
+            Assert.Contains("Unknown release target", ex.Message, StringComparison.Ordinal);
             Assert.Contains("MissingApp", ex.Message, StringComparison.Ordinal);
         }
         finally
@@ -1120,6 +1162,442 @@ public sealed class PowerForgeReleaseServiceTests
             Assert.Null(result.DotNetToolPlan);
             Assert.Single(result.AppleAppPlan!.Apps);
             Assert.Single(archiveRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedExternalDotNetToolsAndAppleApps_AllowsAppleOnlyTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("External DotNet config should not load for an Apple-only target."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublishConfigPath = "missing-dotnet-publish.json"
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Targets = new[] { "com.evotecit.tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.DotNetToolPlan);
+            Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Single(archiveRequests);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedExternalDotNetToolsAndAppleApps_SkipsExistingDotNetConfigForAppleBundleIdTarget()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            File.WriteAllText(Path.Combine(root, "dotnet-publish.json"), "{ invalid json");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublishConfigPath = "dotnet-publish.json"
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    Targets = new[] { "com.evotecit.tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.DotNetToolPlan);
+            Assert.Single(result.AppleAppPlan!.Apps);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedExternalDotNetToolsAndAppleApps_RunsSharedTargetInBothSections()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var dotNetConfigPath = Path.Combine(root, "dotnet-publish.json");
+            File.WriteAllText(dotNetConfigPath, """
+{
+  "Targets": [
+    {
+      "Name": "Tactra",
+      "ProjectPath": "Tactra.Cli.csproj"
+    }
+  ]
+}
+""");
+            var plannedToolTargets = Array.Empty<string>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => (new DotNetPublishSpec
+                {
+                    Targets = new[]
+                    {
+                        new DotNetPublishTarget
+                        {
+                            Name = "Tactra",
+                            ProjectPath = "Tactra.Cli.csproj"
+                        }
+                    }
+                }, dotNetConfigPath),
+                planDotNetTools: (_, _, request, _) =>
+                {
+                    plannedToolTargets = request.Targets;
+                    return new DotNetPublishPlan
+                    {
+                        ProjectRoot = root,
+                        Configuration = "Release",
+                        Targets = new[]
+                        {
+                            new DotNetPublishTargetPlan
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.Cli.csproj",
+                                Combinations = Array.Empty<DotNetPublishTargetCombination>()
+                            }
+                        }
+                    };
+                },
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run in plan mode."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run in plan mode."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublishConfigPath = "dotnet-publish.json"
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    Targets = new[] { "Tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal(new[] { "Tactra" }, plannedToolTargets);
+            Assert.NotNull(result.DotNetToolPlan);
+            Assert.Single(result.AppleAppPlan!.Apps);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedExternalDotNetToolsAndAppleApps_RespectsDotNetPublishProfileTargetFilter()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var dotNetConfigPath = Path.Combine(root, "dotnet-publish.json");
+            File.WriteAllText(dotNetConfigPath, """
+{
+  "Profile": "tools",
+  "Profiles": [
+    {
+      "Name": "tools",
+      "Targets": [ "PowerForge" ]
+    }
+  ],
+  "Targets": [
+    {
+      "Name": "Tactra",
+      "ProjectPath": "Tactra.Cli.csproj"
+    },
+    {
+      "Name": "PowerForge",
+      "ProjectPath": "PowerForge.Cli.csproj"
+    }
+  ]
+}
+""");
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => (new DotNetPublishSpec
+                {
+                    Profile = "tools",
+                    Profiles = new[]
+                    {
+                        new DotNetPublishProfile
+                        {
+                            Name = "tools",
+                            Targets = new[] { "PowerForge" }
+                        }
+                    },
+                    Targets = new[]
+                    {
+                        new DotNetPublishTarget
+                        {
+                            Name = "Tactra",
+                            ProjectPath = "Tactra.Cli.csproj"
+                        },
+                        new DotNetPublishTarget
+                        {
+                            Name = "PowerForge",
+                            ProjectPath = "PowerForge.Cli.csproj"
+                        }
+                    }
+                }, dotNetConfigPath),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run for a target excluded by the active profile."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run in plan mode."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run in plan mode."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublishConfigPath = "dotnet-publish.json"
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    Targets = new[] { "Tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.DotNetToolPlan);
+            Assert.Single(result.AppleAppPlan!.Apps);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedDotNetToolsAndAppleApps_RunsSharedTargetInBothSections()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var archiveRequests = new List<AppleAppArchiveRequest>();
+            var plannedToolTargets = Array.Empty<string>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (new DotNetPublishSpec
+                {
+                    Targets = new[]
+                    {
+                        new DotNetPublishTarget
+                        {
+                            Name = "Tactra",
+                            ProjectPath = "Tactra.Cli.csproj"
+                        }
+                    }
+                }, configPath),
+                planDotNetTools: (_, _, request, _) =>
+                {
+                    plannedToolTargets = request.Targets;
+                    return new DotNetPublishPlan
+                    {
+                        ProjectRoot = root,
+                        Configuration = "Release",
+                        Targets = new[]
+                        {
+                            new DotNetPublishTargetPlan
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.Cli.csproj",
+                                Combinations = Array.Empty<DotNetPublishTargetCombination>()
+                            }
+                        }
+                    };
+                },
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run in plan mode."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: request =>
+                {
+                    archiveRequests.Add(request);
+                    return new AppleAppArchiveResult
+                    {
+                        ArchivePath = request.ArchivePath!,
+                        Destination = request.Destination!,
+                        ProcessResult = new ProcessRunResult(0, "archive-ok", string.Empty, "xcodebuild", TimeSpan.FromSeconds(1), false)
+                    };
+                },
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublish = new DotNetPublishSpec
+                        {
+                            Targets = new[]
+                            {
+                                new DotNetPublishTarget
+                                {
+                                    Name = "Tactra",
+                                    ProjectPath = "Tactra.Cli.csproj"
+                                }
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    Targets = new[] { "Tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal(new[] { "Tactra" }, plannedToolTargets);
+            Assert.NotNull(result.DotNetToolPlan);
+            Assert.Single(result.AppleAppPlan!.Apps);
+            Assert.Empty(archiveRequests);
         }
         finally
         {
@@ -1428,6 +1906,394 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_MixedPackagesAndAppleApps_ValidatesAppleBeforePublishingPackages()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run before Apple validation succeeds."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run after validation failure."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var ex = Assert.Throws<FileNotFoundException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        RootPath = "."
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Missing.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                }));
+
+            Assert.Contains("Missing.xcodeproj", ex.FileName, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_AllowsCustomXcodeConfiguration()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Configuration = "AppStore",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal("AppStore", result.AppleAppPlan!.Configuration);
+            Assert.Equal("AppStore", Assert.Single(result.AppleAppPlan.Apps).Configuration);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_AllowsCustomRequestConfigurationForAppleOnlyTarget()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run for an Apple-only target."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run for an Apple-only target."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run for an Apple-only target."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run for an Apple-only target."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run in plan mode."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Module = new PowerForgeModuleReleaseOptions
+                    {
+                        RepositoryRoot = ".",
+                        ScriptPath = "Missing-Build-Module.ps1"
+                    },
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        RootPath = "."
+                    },
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        Targets = new[]
+                        {
+                            new PowerForgeToolReleaseTarget
+                            {
+                                Name = "PowerForge",
+                                ProjectPath = "PowerForge.Cli.csproj"
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    Configuration = "AppStore",
+                    PlanOnly = true,
+                    Targets = new[] { "com.evotecit.tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.ModulePlan);
+            Assert.Null(result.Packages);
+            Assert.Null(result.ToolPlan);
+            Assert.Equal("AppStore", result.AppleAppPlan!.Configuration);
+            Assert.Equal("AppStore", Assert.Single(result.AppleAppPlan.Apps).Configuration);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_UsesModuleVersionForResolvedVersion()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var buildScript = Path.Combine(root, "Module", "Build", "Build-Module.ps1");
+            Directory.CreateDirectory(Path.GetDirectoryName(buildScript)!);
+            File.WriteAllText(buildScript, "# test build script");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Module = new PowerForgeModuleReleaseOptions
+                    {
+                        RepositoryRoot = ".",
+                        ModuleVersion = "2.3.4"
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                UseResolvedVersion = true
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal("2.3.4", result.ModulePlan!.ModuleVersion);
+            Assert.Equal("2.3.4", Assert.Single(result.AppleAppPlan!.Apps).MarketingVersion);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_TargetFilterUsesConfiguredModuleVersionWithoutRunningModule()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var buildScript = Path.Combine(root, "Module", "Build", "Build-Module.ps1");
+            Directory.CreateDirectory(Path.GetDirectoryName(buildScript)!);
+            File.WriteAllText(buildScript, "# test build script");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Module = new PowerForgeModuleReleaseOptions
+                    {
+                        RepositoryRoot = ".",
+                        ModuleVersion = "2.3.4"
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                BundleId = "com.evotecit.tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                UseResolvedVersion = true
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true,
+                    Targets = new[] { "com.evotecit.tactra" }
+                });
+
+            Assert.True(result.Success);
+            Assert.Null(result.ModulePlan);
+            Assert.Equal("2.3.4", Assert.Single(result.AppleAppPlan!.Apps).MarketingVersion);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedModuleDotNetToolsAndAppleApps_DoesNotApplyModuleVersionToTools()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var buildScript = Path.Combine(root, "Module", "Build", "Build-Module.ps1");
+            Directory.CreateDirectory(Path.GetDirectoryName(buildScript)!);
+            File.WriteAllText(buildScript, "# test build script");
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, configPath) => (new DotNetPublishSpec
+                {
+                    Targets = new[]
+                    {
+                        new DotNetPublishTarget
+                        {
+                            Name = "PowerForge",
+                            ProjectPath = "PowerForge.Cli.csproj"
+                        }
+                    }
+                }, configPath),
+                planDotNetTools: (_, _, _, _) => new DotNetPublishPlan
+                {
+                    ProjectRoot = root,
+                    Configuration = "Release",
+                    MsBuildProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Version"] = "9.9.9",
+                        ["PackageVersion"] = "9.9.9"
+                    },
+                    Targets = new[]
+                    {
+                        new DotNetPublishTargetPlan
+                        {
+                            Name = "PowerForge",
+                            ProjectPath = "PowerForge.Cli.csproj",
+                            Combinations = Array.Empty<DotNetPublishTargetCombination>()
+                        }
+                    }
+                },
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run in plan mode."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run in plan mode."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Module = new PowerForgeModuleReleaseOptions
+                    {
+                        RepositoryRoot = ".",
+                        ModuleVersion = "2.3.4"
+                    },
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        DotNetPublish = new DotNetPublishSpec
+                        {
+                            Targets = new[]
+                            {
+                                new DotNetPublishTarget
+                                {
+                                    Name = "PowerForge",
+                                    ProjectPath = "PowerForge.Cli.csproj"
+                                }
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                UseResolvedVersion = true
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.Equal("9.9.9", result.DotNetToolPlan!.MsBuildProperties["Version"]);
+            Assert.Equal("9.9.9", result.DotNetToolPlan.MsBuildProperties["PackageVersion"]);
+            Assert.Equal("2.3.4", Assert.Single(result.AppleAppPlan!.Apps).MarketingVersion);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_RejectsSkipBuildWhenArchiveIsEnabled()
     {
         var root = CreateSandbox();
@@ -1532,6 +2398,150 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_RejectsMissingReuseArchiveBeforeUpload()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var ex = Assert.Throws<FileNotFoundException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        Upload = true,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                }));
+
+            Assert.Contains("Tactra.xcarchive", ex.FileName, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedPackagesAndAppleApps_ValidatesMissingReuseArchiveBeforePublishingPackages()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run before Apple archive reuse validation succeeds."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Archive should not run when archive reuse validation fails."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run when archive reuse validation fails."));
+
+            var ex = Assert.Throws<FileNotFoundException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Packages = new ProjectBuildConfiguration
+                    {
+                        RootPath = "."
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        Upload = true,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                }));
+
+            Assert.Contains("Tactra.xcarchive", ex.FileName, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_PlanOnly_AllowsMissingReuseArchive()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        Upload = true,
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal(Path.Combine(root, "Artifacts", "Apple", "Archives", "iOS", "Tactra.xcarchive"),
+                Assert.Single(result.AppleAppPlan!.Apps).ArchivePath);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_RejectsExistingNonProjectDirectoryBeforeArchive()
     {
         var root = CreateSandbox();
@@ -1567,6 +2577,48 @@ public sealed class PowerForgeReleaseServiceTests
             Assert.Contains(".xcodeproj", ex.Message, StringComparison.Ordinal);
             Assert.Contains(".xcworkspace", ex.Message, StringComparison.Ordinal);
             Assert.Contains(source.FullName, ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_NormalizesTrailingSeparatorProjectPath()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var projectPath = CreateXcodeProject(root, "Tactra.xcodeproj");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj" + Path.DirectorySeparatorChar,
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.Equal(projectPath, Assert.Single(result.AppleAppPlan!.Apps).ProjectPath);
         }
         finally
         {

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -155,6 +155,7 @@ internal sealed class PowerForgeReleaseService
         {
             if (UsesDotNetToolWorkflow(spec.Tools!))
             {
+                ApplyDotNetPublishProfileOverride(spec.Tools!);
                 var inlineMatches = ResolveOptionalDotNetToolTargetMatches(spec.Tools!.DotNetPublish, selectedTargets);
                 var selectedTargetsAreAppleOnly = runAppleApps &&
                                                   selectedTargets.Length > 0 &&
@@ -1770,6 +1771,14 @@ internal sealed class PowerForgeReleaseService
         return File.Exists(configPath);
     }
 
+    private static void ApplyDotNetPublishProfileOverride(PowerForgeToolReleaseSpec tools)
+    {
+        if (tools.DotNetPublish is null || string.IsNullOrWhiteSpace(tools.DotNetPublishProfile))
+            return;
+
+        tools.DotNetPublish.Profile = tools.DotNetPublishProfile!.Trim();
+    }
+
     private static (DotNetPublishSpec Spec, string SourceConfigPath) LoadDotNetToolsSpec(PowerForgeToolReleaseSpec tools, string releaseConfigPath)
     {
         if (tools.DotNetPublish is not null && !string.IsNullOrWhiteSpace(tools.DotNetPublishConfigPath))
@@ -1777,8 +1786,7 @@ internal sealed class PowerForgeReleaseService
 
         if (tools.DotNetPublish is not null)
         {
-            if (!string.IsNullOrWhiteSpace(tools.DotNetPublishProfile))
-                tools.DotNetPublish.Profile = tools.DotNetPublishProfile!.Trim();
+            ApplyDotNetPublishProfileOverride(tools);
 
             return (tools.DotNetPublish, releaseConfigPath);
         }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -146,18 +146,64 @@ internal sealed class PowerForgeReleaseService
             ? ResolveAppleTargetMatches(spec.AppleApps!, selectedTargets)
             : Array.Empty<string>();
         var toolTargetMatches = Array.Empty<string>();
-        var selectedTargetsAreAppleOnly = runAppleApps &&
-                                          selectedTargets.Length > 0 &&
-                                          appleTargetMatches.Length == selectedTargets.Length;
-        if (selectedTargetsAreAppleOnly)
+        var runWorkspaceValidation = spec.WorkspaceValidation is not null && !request.SkipWorkspaceValidation;
+        var publishUnifiedGitHub = ShouldPublishUnifiedGitHub(spec, request);
+        DotNetPublishSpec? dotNetSpecForTools = null;
+        string? dotNetSourcePathForTools = null;
+
+        if (runTools)
+        {
+            if (UsesDotNetToolWorkflow(spec.Tools!))
+            {
+                var inlineMatches = ResolveOptionalDotNetToolTargetMatches(spec.Tools!.DotNetPublish, selectedTargets);
+                var selectedTargetsAreAppleOnly = runAppleApps &&
+                                                  selectedTargets.Length > 0 &&
+                                                  appleTargetMatches.Length == selectedTargets.Length &&
+                                                  inlineMatches.Length == 0;
+                var externalConfigExists = DotNetToolsConfigExists(spec.Tools!, configPath);
+                var appleTargetsNeedDotNetDisambiguation = selectedTargetsAreAppleOnly &&
+                                                           AppleTargetSelectionUsesNameOrScheme(spec.AppleApps!, selectedTargets);
+                var shouldLoadDotNetSpec = selectedTargets.Length == 0 ||
+                                           inlineMatches.Length > 0 ||
+                                           !selectedTargetsAreAppleOnly ||
+                                           externalConfigExists && appleTargetsNeedDotNetDisambiguation;
+                if (shouldLoadDotNetSpec)
+                {
+                    var dotNetSource = _loadDotNetToolsSpec(spec.Tools!, configPath);
+                    dotNetSpecForTools = dotNetSource.Spec;
+                    dotNetSourcePathForTools = dotNetSource.SourceConfigPath;
+                    toolTargetMatches = ResolveDotNetToolTargetMatches(dotNetSpecForTools, selectedTargets);
+                }
+                else
+                {
+                    toolTargetMatches = inlineMatches;
+                }
+            }
+            else
+            {
+                toolTargetMatches = ResolveLegacyToolTargetMatches(spec.Tools!, selectedTargets);
+            }
+        }
+
+        ValidateSelectedTargets(selectedTargets, toolTargetMatches, appleTargetMatches, runTools, runAppleApps);
+        var hasTargetAwareSelection = selectedTargets.Length > 0 &&
+                                      (toolTargetMatches.Length > 0 || appleTargetMatches.Length > 0);
+        if (hasTargetAwareSelection)
         {
             runModule = false;
             runPackages = false;
-            runTools = false;
         }
-        var configurationOverride = NormalizeConfiguration(request.Configuration);
-        var runWorkspaceValidation = spec.WorkspaceValidation is not null && !request.SkipWorkspaceValidation;
-        var publishUnifiedGitHub = ShouldPublishUnifiedGitHub(spec, request);
+
+        var willRunTools = runTools && ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches);
+        var willRunAppleApps = runAppleApps && ShouldRunSectionForTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches);
+        var hasNonAppleConfigurationConsumer = runWorkspaceValidation || runModule || runPackages || willRunTools;
+        var configurationOverride = hasNonAppleConfigurationConsumer
+            ? NormalizeConfiguration(request.Configuration)
+            : null;
+        var appleConfigurationOverride = NormalizeAppleConfiguration(request.Configuration);
+
+        if (willRunTools)
+            ApplyToolRequestOverrides(spec.Tools!, request, configurationOverride);
 
         if (!runModule && !runPackages && !runTools && !runAppleApps && !runWorkspaceValidation)
         {
@@ -212,6 +258,21 @@ internal sealed class PowerForgeReleaseService
             }
         }
 
+        var earlyAppleReleaseVersion = ResolveAppleSharedReleaseVersion(spec, request, result);
+        if (willRunAppleApps)
+        {
+            var selectedAppleTargets = GetSectionSelectedTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches);
+            _ = PrepareAppleRelease(
+                spec.AppleApps!,
+                configPath,
+                appleConfigurationOverride,
+                earlyAppleReleaseVersion,
+                request.SkipBuild,
+                selectedAppleTargets,
+                allowUnresolvedResolvedVersion: true,
+                validateReusableArchives: !request.PlanOnly && !request.ValidateOnly);
+        }
+
         if (runPackages)
         {
             ApplyPackageRequestOverrides(spec.Packages!, request, configurationOverride);
@@ -235,41 +296,20 @@ internal sealed class PowerForgeReleaseService
         }
 
         var sharedReleaseVersion = ResolveSharedReleaseVersion(spec, result);
-        DotNetPublishSpec? dotNetSpecForTools = null;
-        string? dotNetSourcePathForTools = null;
-        if (runTools)
-        {
-            ApplyToolRequestOverrides(spec.Tools!, request, configurationOverride);
-            if (UsesDotNetToolWorkflow(spec.Tools!))
-            {
-                var dotNetSource = _loadDotNetToolsSpec(spec.Tools!, configPath);
-                dotNetSpecForTools = dotNetSource.Spec;
-                dotNetSourcePathForTools = dotNetSource.SourceConfigPath;
-                toolTargetMatches = ResolveDotNetToolTargetMatches(dotNetSpecForTools, selectedTargets);
-            }
-            else
-            {
-                toolTargetMatches = ResolveLegacyToolTargetMatches(spec.Tools!, selectedTargets);
-            }
-
-            ValidateMixedSelectedTargets(selectedTargets, toolTargetMatches, appleTargetMatches, runTools, runAppleApps);
-        }
-        else if (runAppleApps)
-        {
-            ValidateMixedSelectedTargets(selectedTargets, Array.Empty<string>(), appleTargetMatches, runTools, runAppleApps);
-        }
 
         PowerForgeAppleReleasePlan? applePlan = null;
-        if (runAppleApps && ShouldRunSectionForTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches))
+        if (willRunAppleApps)
         {
             var selectedAppleTargets = GetSectionSelectedTargets(selectedTargets, appleTargetMatches, runTools, toolTargetMatches);
+            var appleReleaseVersion = ResolveAppleSharedReleaseVersion(spec, request, result);
             applePlan = PrepareAppleRelease(
                 spec.AppleApps!,
                 configPath,
-                configurationOverride,
-                sharedReleaseVersion,
+                appleConfigurationOverride,
+                appleReleaseVersion,
                 request.SkipBuild,
-                selectedAppleTargets);
+                selectedAppleTargets,
+                validateReusableArchives: !request.PlanOnly && !request.ValidateOnly);
             result.AppleAppPlan = applePlan;
         }
 
@@ -279,7 +319,7 @@ internal sealed class PowerForgeReleaseService
             {
                 if (dotNetSpecForTools is not null &&
                     dotNetSourcePathForTools is not null &&
-                    ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches))
+                    willRunTools)
                 {
                     var dotNetTargets = GetSectionSelectedTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches);
                     var dotNetPlan = WithRequestTargets(
@@ -320,7 +360,7 @@ internal sealed class PowerForgeReleaseService
             }
             else
             {
-                if (ShouldRunSectionForTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches))
+                if (willRunTools)
                 {
                     var legacyToolTargets = GetSectionSelectedTargets(selectedTargets, toolTargetMatches, runAppleApps, appleTargetMatches);
                     var toolPlan = WithRequestTargets(
@@ -455,10 +495,46 @@ internal sealed class PowerForgeReleaseService
         if (selectedTargets.Length == 0)
             return Array.Empty<string>();
 
+        var activeTargets = ResolveDotNetProfileTargetNames(spec);
         return selectedTargets
-            .Where(selected => (spec.Targets ?? Array.Empty<DotNetPublishTarget>())
-                .Any(target => string.Equals(target.Name?.Trim(), selected, StringComparison.OrdinalIgnoreCase)))
+            .Where(selected => activeTargets.Contains(selected))
             .ToArray();
+    }
+
+    private static string[] ResolveOptionalDotNetToolTargetMatches(DotNetPublishSpec? spec, string[] selectedTargets)
+    {
+        return spec is null ? Array.Empty<string>() : ResolveDotNetToolTargetMatches(spec, selectedTargets);
+    }
+
+    private static HashSet<string> ResolveDotNetProfileTargetNames(DotNetPublishSpec spec)
+    {
+        var targetNames = (spec.Targets ?? Array.Empty<DotNetPublishTarget>())
+            .Where(target => target is not null && !string.IsNullOrWhiteSpace(target.Name))
+            .Select(target => target.Name!.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var profiles = (spec.Profiles ?? Array.Empty<DotNetPublishProfile>())
+            .Where(profile => profile is not null && !string.IsNullOrWhiteSpace(profile.Name))
+            .ToArray();
+        if (profiles.Length == 0)
+            return targetNames;
+
+        var profileName = !string.IsNullOrWhiteSpace(spec.Profile)
+            ? spec.Profile!.Trim()
+            : profiles.FirstOrDefault(profile => profile.Default)?.Name;
+        if (string.IsNullOrWhiteSpace(profileName))
+            return targetNames;
+
+        var profile = profiles.FirstOrDefault(profile => profile.Name!.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        var profileTargets = profile?.Targets ?? Array.Empty<string>();
+        if (profile is null || profileTargets.Length == 0)
+            return targetNames;
+
+        return profileTargets
+            .Where(target => !string.IsNullOrWhiteSpace(target))
+            .Select(target => target.Trim())
+            .Where(targetNames.Contains)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private static string[] ResolveAppleTargetMatches(PowerForgeAppleReleaseOptions options, string[] selectedTargets)
@@ -475,14 +551,27 @@ internal sealed class PowerForgeReleaseService
             .ToArray();
     }
 
-    private static void ValidateMixedSelectedTargets(
+    private static bool AppleTargetSelectionUsesNameOrScheme(PowerForgeAppleReleaseOptions options, string[] selectedTargets)
+    {
+        if (selectedTargets.Length == 0)
+            return false;
+
+        var apps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
+            .Where(app => app.Enabled)
+            .ToArray();
+
+        return selectedTargets.Any(selected =>
+            apps.Any(app => AppleAppNameOrSchemeMatchesTarget(app, selected)));
+    }
+
+    private static void ValidateSelectedTargets(
         string[] selectedTargets,
         string[] toolTargetMatches,
         string[] appleTargetMatches,
         bool runTools,
         bool runAppleApps)
     {
-        if (!runTools || !runAppleApps || selectedTargets.Length == 0)
+        if ((!runTools && !runAppleApps) || selectedTargets.Length == 0)
             return;
 
         var knownTargets = toolTargetMatches
@@ -584,7 +673,9 @@ internal sealed class PowerForgeReleaseService
         string? configurationOverride,
         string? sharedReleaseVersion,
         bool skipBuild,
-        string[]? selectedTargetNames)
+        string[]? selectedTargetNames,
+        bool allowUnresolvedResolvedVersion = false,
+        bool validateReusableArchives = true)
     {
         if (options.SyncScreenshots)
             throw new NotSupportedException("AppleApps.SyncScreenshots is not supported by the unified release workflow yet. Use Sync-AppStoreConnectScreenshots or project-specific screenshot sync scripts for now.");
@@ -593,7 +684,7 @@ internal sealed class PowerForgeReleaseService
 
         var configDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
         var projectRoot = ResolveOutputPath(configDirectory, string.IsNullOrWhiteSpace(options.ProjectRoot) ? "." : options.ProjectRoot!);
-        var configuration = configurationOverride ?? NormalizeConfiguration(options.Configuration) ?? "Release";
+        var configuration = configurationOverride ?? NormalizeAppleConfiguration(options.Configuration) ?? "Release";
         var archiveRoot = ResolveOutputPath(projectRoot, string.IsNullOrWhiteSpace(options.ArchiveRoot) ? Path.Combine("Artifacts", "Apple", "Archives") : options.ArchiveRoot!);
         var exportRoot = ResolveOutputPath(projectRoot, string.IsNullOrWhiteSpace(options.ExportRoot) ? Path.Combine("Artifacts", "Apple", "Exports") : options.ExportRoot!);
         var screenshotConfigPath = string.IsNullOrWhiteSpace(options.ScreenshotConfigPath)
@@ -619,13 +710,19 @@ internal sealed class PowerForgeReleaseService
 
         var apps = configuredApps
             .Where(app => selectedTargets.Length == 0 || selectedTargets.Any(selected => AppleAppMatchesTarget(app, selected)))
-            .Select(app => PrepareAppleAppPlan(app, options, projectRoot, archiveRoot, exportRoot, configuration, sharedReleaseVersion))
+            .Select(app => PrepareAppleAppPlan(app, options, projectRoot, archiveRoot, exportRoot, configuration, sharedReleaseVersion, allowUnresolvedResolvedVersion))
             .ToArray();
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
         if (!options.Archive && apps.Any(app => app.VersionUpdateRequested))
             throw new InvalidOperationException("Apple app version updates require AppleApps.Archive=true. Set Archive=true to build a fresh archive after updating versions, or remove version update fields when reusing an existing archive.");
+        if (validateReusableArchives && !options.Archive && options.Upload)
+        {
+            var missingArchive = apps.FirstOrDefault(app => !Directory.Exists(app.ArchivePath));
+            if (missingArchive is not null)
+                throw new FileNotFoundException($"Apple app archive was not found for upload-only release: {missingArchive.ArchivePath}", missingArchive.ArchivePath);
+        }
 
         return new PowerForgeAppleReleasePlan
         {
@@ -654,7 +751,8 @@ internal sealed class PowerForgeReleaseService
         string archiveRoot,
         string exportRoot,
         string configuration,
-        string? sharedReleaseVersion)
+        string? sharedReleaseVersion,
+        bool allowUnresolvedResolvedVersion)
     {
         if (string.IsNullOrWhiteSpace(app.ProjectPath))
             throw new InvalidOperationException("Apple app ProjectPath is required.");
@@ -684,7 +782,7 @@ internal sealed class PowerForgeReleaseService
             : null;
         if (versionUpdateRequested && isWorkspace)
             throw new InvalidOperationException($"Apple app '{name}' uses a .xcworkspace ProjectPath. Unified Apple version updates require a .xcodeproj ProjectPath or project.pbxproj path.");
-        if (versionUpdateRequested && string.IsNullOrWhiteSpace(marketingVersion))
+        if (versionUpdateRequested && string.IsNullOrWhiteSpace(marketingVersion) && !(allowUnresolvedResolvedVersion && app.UseResolvedVersion))
             throw new InvalidOperationException($"Apple app '{name}' requires MarketingVersion unless UseResolvedVersion is enabled with a resolvable release version.");
 
         var buildNumber = versionUpdateRequested
@@ -784,28 +882,29 @@ internal sealed class PowerForgeReleaseService
 
     private static string NormalizeAppleArchiveProjectPath(string projectPath, string appName)
     {
-        if (Directory.Exists(projectPath))
+        var normalizedProjectPath = TrimTrailingDirectorySeparators(projectPath);
+        if (Directory.Exists(normalizedProjectPath))
         {
-            var extension = Path.GetExtension(projectPath);
+            var extension = Path.GetExtension(normalizedProjectPath);
             if (string.Equals(extension, ".xcodeproj", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(extension, ".xcworkspace", StringComparison.OrdinalIgnoreCase))
             {
-                return projectPath;
+                return normalizedProjectPath;
             }
 
-            throw new InvalidOperationException($"Apple app '{appName}' ProjectPath must point to a .xcodeproj or .xcworkspace directory for archive automation: {projectPath}");
+            throw new InvalidOperationException($"Apple app '{appName}' ProjectPath must point to a .xcodeproj or .xcworkspace directory for archive automation: {normalizedProjectPath}");
         }
 
-        if (File.Exists(projectPath) &&
-            string.Equals(Path.GetExtension(projectPath), ".xcodeproj", StringComparison.OrdinalIgnoreCase))
+        if (File.Exists(normalizedProjectPath) &&
+            string.Equals(Path.GetExtension(normalizedProjectPath), ".xcodeproj", StringComparison.OrdinalIgnoreCase))
         {
-            return projectPath;
+            return normalizedProjectPath;
         }
 
-        if (File.Exists(projectPath) &&
-            string.Equals(Path.GetFileName(projectPath), "project.pbxproj", StringComparison.OrdinalIgnoreCase))
+        if (File.Exists(normalizedProjectPath) &&
+            string.Equals(Path.GetFileName(normalizedProjectPath), "project.pbxproj", StringComparison.OrdinalIgnoreCase))
         {
-            var projectDirectory = Path.GetDirectoryName(projectPath);
+            var projectDirectory = Path.GetDirectoryName(normalizedProjectPath);
             if (!string.IsNullOrWhiteSpace(projectDirectory) &&
                 string.Equals(Path.GetExtension(projectDirectory), ".xcodeproj", StringComparison.OrdinalIgnoreCase))
             {
@@ -814,6 +913,19 @@ internal sealed class PowerForgeReleaseService
         }
 
         throw new InvalidOperationException($"Apple app '{appName}' ProjectPath must point to a .xcodeproj or .xcworkspace for archive automation. project.pbxproj paths are only supported when they are inside a .xcodeproj directory.");
+    }
+
+    private static string TrimTrailingDirectorySeparators(string path)
+    {
+        var trimmed = Path.GetFullPath(path.Trim());
+        var root = Path.GetPathRoot(trimmed) ?? string.Empty;
+        while (trimmed.Length > root.Length &&
+               (trimmed[trimmed.Length - 1] == Path.DirectorySeparatorChar || trimmed[trimmed.Length - 1] == Path.AltDirectorySeparatorChar))
+        {
+            trimmed = trimmed.Substring(0, trimmed.Length - 1);
+        }
+
+        return trimmed;
     }
 
     private static bool AppleAppMatchesTarget(AppleAppConfiguration app, string targetName)
@@ -825,6 +937,16 @@ internal sealed class PowerForgeReleaseService
         return string.Equals(app.Name?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase) ||
                string.Equals(app.Scheme?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase) ||
                string.Equals(app.BundleId?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool AppleAppNameOrSchemeMatchesTarget(AppleAppConfiguration app, string targetName)
+    {
+        var trimmed = targetName.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return false;
+
+        return string.Equals(app.Name?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(app.Scheme?.Trim(), trimmed, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string[] NormalizeStrings(IEnumerable<string>? values)
@@ -923,6 +1045,21 @@ internal sealed class PowerForgeReleaseService
             .ToArray();
 
         return distinctVersions.Length == 1 ? distinctVersions[0] : null;
+    }
+
+    private static string? ResolveAppleSharedReleaseVersion(
+        PowerForgeReleaseSpec spec,
+        PowerForgeReleaseRequest request,
+        PowerForgeReleaseResult result)
+    {
+        var sharedReleaseVersion = ResolveSharedReleaseVersion(spec, result);
+        if (!string.IsNullOrWhiteSpace(sharedReleaseVersion))
+            return sharedReleaseVersion;
+
+        var moduleVersion = result.ModulePlan?.ModuleVersion
+            ?? request.ModuleVersion
+            ?? spec.Module?.ModuleVersion;
+        return string.IsNullOrWhiteSpace(moduleVersion) ? null : moduleVersion;
     }
 
     private static void ApplySharedReleaseVersion(DotNetPublishPlan plan, string? sharedReleaseVersion)
@@ -1619,6 +1756,18 @@ internal sealed class PowerForgeReleaseService
     private static bool UsesDotNetToolWorkflow(PowerForgeToolReleaseSpec spec)
     {
         return spec.DotNetPublish is not null || !string.IsNullOrWhiteSpace(spec.DotNetPublishConfigPath);
+    }
+
+    private static bool DotNetToolsConfigExists(PowerForgeToolReleaseSpec tools, string releaseConfigPath)
+    {
+        if (string.IsNullOrWhiteSpace(tools.DotNetPublishConfigPath))
+            return false;
+
+        var releaseConfigDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
+        var configPath = Path.GetFullPath(Path.IsPathRooted(tools.DotNetPublishConfigPath)
+            ? tools.DotNetPublishConfigPath!
+            : Path.Combine(releaseConfigDirectory, tools.DotNetPublishConfigPath!));
+        return File.Exists(configPath);
     }
 
     private static (DotNetPublishSpec Spec, string SourceConfigPath) LoadDotNetToolsSpec(PowerForgeToolReleaseSpec tools, string releaseConfigPath)
@@ -2926,6 +3075,11 @@ internal sealed class PowerForgeReleaseService
         }
 
         return normalized;
+    }
+
+    private static string? NormalizeAppleConfiguration(string? configuration)
+    {
+        return string.IsNullOrWhiteSpace(configuration) ? null : configuration!.Trim();
     }
 
     private static void ApplyPackageRequestOverrides(

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -241,7 +241,7 @@
       "additionalProperties": false,
       "properties": {
         "ProjectRoot": { "type": [ "string", "null" ] },
-        "Configuration": { "type": "string", "enum": [ "Release", "Debug" ] },
+        "Configuration": { "type": "string" },
         "ArchiveRoot": { "type": [ "string", "null" ] },
         "ExportRoot": { "type": [ "string", "null" ] },
         "TeamId": { "type": [ "string", "null" ] },


### PR DESCRIPTION
## Summary
- validate selected Apple release targets before package/tool side effects
- keep shared tool and Apple target filters from hiding either matching lane
- support custom Apple Xcode configurations, module-derived resolved versions, upload-only archive validation, and trailing project path separators
- add focused PowerForge release regression coverage for the merged PR review follow-ups

## Testing
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter FullyQualifiedName~PowerForgeReleaseServiceTests (clean detached worktree): 59 passed
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj (clean detached worktree): build passed, then existing unrelated WebLinkService/WebPipelineRunner link assertions failed and the test host crashed with a PowerShell runspace AccessViolation