### PR TITLE
Fix JFrog publish configuration docs

### DIFF
--- a/Module/Docs/New-ConfigurationPublish.md
+++ b/Module/Docs/New-ConfigurationPublish.md
@@ -21,7 +21,7 @@ New-ConfigurationPublish -Type <PublishDestination> -ApiKey <string> [-UserName 
 
 ### JFrog
 ```powershell
-New-ConfigurationPublish -JFrogBaseUri <string> -JFrogRepository <string> [-Type <PublishDestination>] [-FilePath <string>] [-ApiKey <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-JFrogPlatformUri <string>] [-JFrogOidcProvider <string>] [-JFrogOidcTokenId <string>] [-JFrogOidcTokenIdEnvironmentVariable <string>] [-JFrogOidcProviderType <JFrogOidcProviderType>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -JFrogBaseUri <string> -JFrogRepository <string> [-Type <PublishDestination>] [-FilePath <string>] [-ApiKey <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-JFrogPlatformUri <string>] [-JFrogOidcProvider <string>] [-JFrogOidcTokenId <string>] [-JFrogOidcTokenIdEnvironmentVariable <string>] [-JFrogOidcProviderType <JFrogOidcProviderType>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ### AzureArtifacts
@@ -535,7 +535,7 @@ Repository publish URI (PowerShellGet PublishLocation).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
 Aliases: None
 Possible values:
 
@@ -551,7 +551,7 @@ Repository source URI (PowerShellGet SourceLocation).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
 Aliases: None
 Possible values:
 
@@ -583,7 +583,7 @@ Repository base URI (used for both source and publish unless overridden).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
 Aliases: None
 Possible values:
 

--- a/Module/Docs/New-ConfigurationPublish.md
+++ b/Module/Docs/New-ConfigurationPublish.md
@@ -11,12 +11,17 @@ Provides a way to configure publishing to PowerShell Gallery, GitHub, JFrog Arti
 ## SYNTAX
 ### ApiFromFile (Default)
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> -FilePath <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-JFrogBaseUri <string>] [-JFrogRepository <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> -FilePath <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ### ApiKey
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> -ApiKey <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-JFrogBaseUri <string>] [-JFrogRepository <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> -ApiKey <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
+```
+
+### JFrog
+```powershell
+New-ConfigurationPublish -JFrogBaseUri <string> -JFrogRepository <string> [-Type <PublishDestination>] [-FilePath <string>] [-ApiKey <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-JFrogPlatformUri <string>] [-JFrogOidcProvider <string>] [-JFrogOidcTokenId <string>] [-JFrogOidcTokenIdEnvironmentVariable <string>] [-JFrogOidcProviderType <JFrogOidcProviderType>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ### AzureArtifacts
@@ -27,11 +32,6 @@ New-ConfigurationPublish -AzureDevOpsOrganization <string> -AzureArtifactsFeed <
 ### Profile
 ```powershell
 New-ConfigurationPublish -ProfileName <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-Force] [-ID <string>] [<CommonParameters>]
-```
-
-### JFrog
-```powershell
-New-ConfigurationPublish -JFrogBaseUri <string> -JFrogRepository <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-JFrogPlatformUri <string>] [-JFrogOidcProvider <string>] [-JFrogOidcTokenId <string>] [-JFrogOidcTokenIdEnvironmentVariable <string>] [-JFrogOidcProviderType <JFrogOidcProviderType>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -74,17 +74,23 @@ New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -J
 
 ### EXAMPLE 5
 ```powershell
-New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled
 ```
 
 
 ### EXAMPLE 6
 ```powershell
-New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
 ```
 
 
 ### EXAMPLE 7
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
+```
+
+
+### EXAMPLE 8
 ```powershell
 New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled
 ```
@@ -97,7 +103,7 @@ API key to be used for publishing in clear text. For JFrog, use this only when t
 
 ```yaml
 Type: String
-Parameter Sets: ApiKey, Profile, JFrog
+Parameter Sets: ApiKey, JFrog, Profile
 Aliases: None
 Possible values:
 
@@ -177,7 +183,7 @@ Enable publishing to the chosen destination.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -193,7 +199,7 @@ When true, registers/updates the repository before publishing. Default: true.
 
 ```yaml
 Type: Boolean
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -209,7 +215,7 @@ API key to be used for publishing in clear text in a file. For JFrog, use this o
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, Profile, JFrog
+Parameter Sets: ApiFromFile, JFrog, Profile
 Aliases: None
 Possible values:
 
@@ -225,7 +231,7 @@ Allow publishing lower version of a module on a PowerShell repository.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -257,7 +263,7 @@ Optional ID of the artefact used for publishing.
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -273,7 +279,7 @@ JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. Po
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, JFrog
+Parameter Sets: JFrog
 Aliases: None
 Possible values:
 
@@ -369,7 +375,7 @@ JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoi
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, JFrog
+Parameter Sets: JFrog
 Aliases: None
 Possible values:
 
@@ -417,7 +423,7 @@ Repository API version for PSResourceGet registration (v2/v3).
 
 ```yaml
 Type: RepositoryApiVersion
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values: Auto, V2, V3, ContainerRegistry
 
@@ -433,7 +439,7 @@ Repository credential secret (password/token) in clear text. For JFrog PAT/basic
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -449,7 +455,7 @@ Environment variable containing the repository credential secret (password/token
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -465,7 +471,7 @@ Repository credential secret (password/token) in a clear-text file. For JFrog PA
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -481,7 +487,7 @@ Repository credential username (basic auth). For JFrog PAT/basic-auth flows, thi
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -497,7 +503,7 @@ Repository name override (GitHub or PowerShell repository name).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -513,7 +519,7 @@ Repository priority for PSResourceGet (lower is higher priority).
 
 ```yaml
 Type: Nullable`1
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -561,7 +567,7 @@ Whether to mark the repository as trusted (avoids prompts). Default: true.
 
 ```yaml
 Type: Boolean
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -593,7 +599,7 @@ Publishing tool/provider used for repository publishing. Ignored for GitHub publ
 
 ```yaml
 Type: PublishTool
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values: Auto, PSResourceGet, PowerShellGet
 
@@ -609,7 +615,7 @@ Choose between PowerShellGallery and GitHub.
 
 ```yaml
 Type: PublishDestination
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
 Aliases: None
 Possible values: PowerShellGallery, GitHub
 
@@ -625,7 +631,7 @@ When set, unregisters the repository after publish if it was created by this run
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -641,7 +647,7 @@ Use this PowerShell repository as the source for resolving Auto/Latest dependenc
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 

--- a/Module/Tests/PrivateGallery.Commands.Tests.ps1
+++ b/Module/Tests/PrivateGallery.Commands.Tests.ps1
@@ -1035,6 +1035,16 @@ Describe 'Private gallery command metadata' {
         $publish.Configuration.Repository.Credential.Secret | Should -Be 'token'
     }
 
+    It 'keeps direct JFrog parameters composable with repository URI overrides' {
+        $publish = New-ConfigurationPublish -Type PowerShellGallery -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryUri 'https://custom.example/v3/index.json' -RepositorySourceUri 'https://custom.example/v2/source' -RepositoryPublishUri 'https://custom.example/v2/publish' -RepositoryCredentialUserName 'publisher' -RepositoryCredentialSecret 'token' -Enabled
+
+        $publish.Configuration.Repository.Uri | Should -Be 'https://custom.example/v3/index.json'
+        $publish.Configuration.Repository.SourceUri | Should -Be 'https://custom.example/v2/source'
+        $publish.Configuration.Repository.PublishUri | Should -Be 'https://custom.example/v2/publish'
+        $publish.Configuration.Repository.Credential.UserName | Should -Be 'publisher'
+        $publish.Configuration.Repository.Credential.Secret | Should -Be 'token'
+    }
+
     It 'requires publish auth when enabling saved JFrog profiles for publish configuration' {
         Set-ModuleRepositoryProfile -Name 'JFrogCompanyNoAuth' -Provider JFrog -Repository 'powershell-virtual' -JFrogBaseUri 'https://company.jfrog.io/artifactory' | Out-Null
 

--- a/Module/Tests/PrivateGallery.Commands.Tests.ps1
+++ b/Module/Tests/PrivateGallery.Commands.Tests.ps1
@@ -1022,6 +1022,19 @@ Describe 'Private gallery command metadata' {
         $publish.Configuration.Repository.Credential.Secret | Should -Be 'token'
     }
 
+    It 'uses direct JFrog parameters with a clear-text repository PAT without requiring FilePath' {
+        $publish = New-ConfigurationPublish -Type PowerShellGallery -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryCredentialUserName 'publisher' -RepositoryCredentialSecret 'token' -Enabled
+
+        $publish.Configuration.ApiKey | Should -Be ''
+        $publish.Configuration.RepositoryName | Should -Be 'powershell-virtual'
+        $publish.Configuration.Tool | Should -Be ([PowerForge.PublishTool]::Auto)
+        $publish.Configuration.Repository.Uri | Should -Be 'https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json'
+        $publish.Configuration.Repository.SourceUri | Should -Be 'https://company.jfrog.io/artifactory/api/nuget/powershell-virtual'
+        $publish.Configuration.Repository.PublishUri | Should -Be 'https://company.jfrog.io/artifactory/api/nuget/powershell-virtual'
+        $publish.Configuration.Repository.Credential.UserName | Should -Be 'publisher'
+        $publish.Configuration.Repository.Credential.Secret | Should -Be 'token'
+    }
+
     It 'requires publish auth when enabling saved JFrog profiles for publish configuration' {
         Set-ModuleRepositoryProfile -Name 'JFrogCompanyNoAuth' -Provider JFrog -Repository 'powershell-virtual' -JFrogBaseUri 'https://company.jfrog.io/artifactory' | Out-Null
 

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -1780,12 +1780,12 @@ PATs, passwords, Entra tokens, or Azure Artifacts Credential Provider session ca
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Destination JSON file path.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -6343,12 +6343,12 @@ across targets or configurations before uploading to App Store Connect.</maml:pa
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Get-XcodeProjectVersion</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -6558,13 +6558,13 @@ session-scoped and intentionally opt-in because it changes module-name resolutio
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Profile</maml:name>
           <maml:description>
             <maml:para>Supported built-in profiles are ExchangeOnlineManagement, MicrosoftTeams, and&#xD;
 MicrosoftGraphAuthentication. Profile names are resolved case-insensitively.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -6824,12 +6824,12 @@ Provider.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Source JSON file path.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7004,12 +7004,12 @@ authenticated access through the selected bootstrap mode.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
           <maml:name>ProfileName</maml:name>
           <maml:description>
             <maml:para>Saved repository profile name. When used with Path, selects one imported profile from the file. When used with Azure Artifacts feed details, creates that profile name.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7120,24 +7120,24 @@ authenticated access through the selected bootstrap mode.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Source JSON profile file exported with Export-ModuleRepositoryProfile.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
           <maml:name>ProfileName</maml:name>
           <maml:description>
             <maml:para>Saved repository profile name. When used with Path, selects one imported profile from the file. When used with Azure Artifacts feed details, creates that profile name.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7326,12 +7326,12 @@ authenticated access through the selected bootstrap mode.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
           <maml:name>ProfileName</maml:name>
           <maml:description>
             <maml:para>Saved repository profile name. When used with Path, selects one imported profile from the file. When used with Azure Artifacts feed details, creates that profile name.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7880,12 +7880,12 @@ authenticated access through the selected bootstrap mode.</maml:para>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Install-AppleApp</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>AppPath</maml:name>
           <maml:description>
             <maml:para>Path to the built .app bundle.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -8622,12 +8622,12 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="None">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module name to source scripts from (highest installed version is used by default).</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -8652,12 +8652,12 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Destination folder to copy scripts into (created if missing).</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -8781,12 +8781,12 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Destination folder to copy scripts into (created if missing).</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -9090,12 +9090,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -9279,12 +9279,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -9347,12 +9347,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>Repository</maml:name>
           <maml:description>
             <maml:para>Name of an already registered repository, or provider repository/feed id when a private-gallery provider is selected.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -9500,12 +9500,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -9587,12 +9587,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -18484,12 +18484,12 @@ the local date (yyyy.MM.dd) unless a primary project version is available.</maml
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to the Xcode project or workspace.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -18897,12 +18897,12 @@ the local date (yyyy.MM.dd) unless a primary project version is available.</maml
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to the Xcode project or workspace.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -19618,13 +19618,13 @@ configuration for future read-only checks and publish/review commands.</maml:par
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -19743,13 +19743,13 @@ Relative paths resolve from the pipeline project root.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -33967,30 +33967,6 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogBaseUri</maml:name>
-          <maml:description>
-            <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogRepository</maml:name>
-          <maml:description>
-            <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OverwriteTagName</maml:name>
           <maml:description>
@@ -34297,30 +34273,6 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogBaseUri</maml:name>
-          <maml:description>
-            <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogRepository</maml:name>
-          <maml:description>
-            <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OverwriteTagName</maml:name>
           <maml:description>
@@ -34541,367 +34493,14 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
-      <command:syntaxItem parameterSetName="AzureArtifacts">
-        <maml:name>New-ConfigurationPublish</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>AzureArtifactsFeed</maml:name>
-          <maml:description>
-            <maml:para>Azure Artifacts feed name for the private gallery preset.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>AzureDevOpsOrganization</maml:name>
-          <maml:description>
-            <maml:para>Azure DevOps organization name for the Azure Artifacts preset.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>AzureDevOpsProject</maml:name>
-          <maml:description>
-            <maml:para>Optional Azure DevOps project name for project-scoped feeds.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Enabled</maml:name>
-          <maml:description>
-            <maml:para>Enable publishing to the chosen destination.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>EnsureRepositoryRegistered</maml:name>
-          <maml:description>
-            <maml:para>When true, registers/updates the repository before publishing. Default: true.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
-          <dev:type>
-            <maml:name>Boolean</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Force</maml:name>
-          <maml:description>
-            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>ID</maml:name>
-          <maml:description>
-            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryApiVersion</maml:name>
-          <maml:description>
-            <maml:para>Repository API version for PSResourceGet registration (v2/v3).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">RepositoryApiVersion</command:parameterValue>
-          <command:parameterValueGroup>
-            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">V2</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">V3</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">ContainerRegistry</command:parameterValue>
-          </command:parameterValueGroup>
-          <dev:type>
-            <maml:name>RepositoryApiVersion</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecret</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
-          <maml:description>
-            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialUserName</maml:name>
-          <maml:description>
-            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryName</maml:name>
-          <maml:description>
-            <maml:para>Repository name override (GitHub or PowerShell repository name).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryPriority</maml:name>
-          <maml:description>
-            <maml:para>Repository priority for PSResourceGet (lower is higher priority).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
-          <dev:type>
-            <maml:name>Nullable`1</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryTrusted</maml:name>
-          <maml:description>
-            <maml:para>Whether to mark the repository as trusted (avoids prompts). Default: true.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
-          <dev:type>
-            <maml:name>Boolean</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Tool</maml:name>
-          <maml:description>
-            <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">PublishTool</command:parameterValue>
-          <command:parameterValueGroup>
-            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">PSResourceGet</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">PowerShellGet</command:parameterValue>
-          </command:parameterValueGroup>
-          <dev:type>
-            <maml:name>PublishTool</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>UnregisterRepositoryAfterPublish</maml:name>
-          <maml:description>
-            <maml:para>When set, unregisters the repository after publish if it was created by this run.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>UseAsDependencyVersionSource</maml:name>
-          <maml:description>
-            <maml:para>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem parameterSetName="Profile">
-        <maml:name>New-ConfigurationPublish</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>ApiKey</maml:name>
-          <maml:description>
-            <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Enabled</maml:name>
-          <maml:description>
-            <maml:para>Enable publishing to the chosen destination.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>FilePath</maml:name>
-          <maml:description>
-            <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Force</maml:name>
-          <maml:description>
-            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>ID</maml:name>
-          <maml:description>
-            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="Profile">
-          <maml:name>ProfileName</maml:name>
-          <maml:description>
-            <maml:para>Saved private gallery profile name for Azure Artifacts publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecret</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
-          <maml:description>
-            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialUserName</maml:name>
-          <maml:description>
-            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
       <command:syntaxItem parameterSetName="JFrog">
         <maml:name>New-ConfigurationPublish</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>ApiKey</maml:name>
           <maml:description>
             <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -34932,12 +34531,12 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>FilePath</maml:name>
           <maml:description>
             <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -35177,6 +34776,22 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Choose between PowerShellGallery and GitHub.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PublishDestination</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">PowerShellGallery</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GitHub</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>PublishDestination</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>UnregisterRepositoryAfterPublish</maml:name>
           <maml:description>
             <maml:para>When set, unregisters the repository after publish if it was created by this run.</maml:para>
@@ -35196,6 +34811,359 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="AzureArtifacts">
+        <maml:name>New-ConfigurationPublish</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AzureArtifactsFeed</maml:name>
+          <maml:description>
+            <maml:para>Azure Artifacts feed name for the private gallery preset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AzureDevOpsOrganization</maml:name>
+          <maml:description>
+            <maml:para>Azure DevOps organization name for the Azure Artifacts preset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AzureDevOpsProject</maml:name>
+          <maml:description>
+            <maml:para>Optional Azure DevOps project name for project-scoped feeds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Enabled</maml:name>
+          <maml:description>
+            <maml:para>Enable publishing to the chosen destination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnsureRepositoryRegistered</maml:name>
+          <maml:description>
+            <maml:para>When true, registers/updates the repository before publishing. Default: true.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ID</maml:name>
+          <maml:description>
+            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryApiVersion</maml:name>
+          <maml:description>
+            <maml:para>Repository API version for PSResourceGet registration (v2/v3).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">RepositoryApiVersion</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">V2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">V3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ContainerRegistry</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>RepositoryApiVersion</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecret</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialUserName</maml:name>
+          <maml:description>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryName</maml:name>
+          <maml:description>
+            <maml:para>Repository name override (GitHub or PowerShell repository name).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryPriority</maml:name>
+          <maml:description>
+            <maml:para>Repository priority for PSResourceGet (lower is higher priority).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryTrusted</maml:name>
+          <maml:description>
+            <maml:para>Whether to mark the repository as trusted (avoids prompts). Default: true.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Tool</maml:name>
+          <maml:description>
+            <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PublishTool</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSResourceGet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PowerShellGet</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>PublishTool</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UnregisterRepositoryAfterPublish</maml:name>
+          <maml:description>
+            <maml:para>When set, unregisters the repository after publish if it was created by this run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseAsDependencyVersionSource</maml:name>
+          <maml:description>
+            <maml:para>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Profile">
+        <maml:name>New-ConfigurationPublish</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Enabled</maml:name>
+          <maml:description>
+            <maml:para>Enable publishing to the chosen destination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ID</maml:name>
+          <maml:description>
+            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="Profile">
+          <maml:name>ProfileName</maml:name>
+          <maml:description>
+            <maml:para>Saved private gallery profile name for Azure Artifacts publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecret</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialUserName</maml:name>
+          <maml:description>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -35700,6 +35668,13 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
       <command:example>
         <maml:title>Publish to JFrog Artifactory with PAT/basic authentication</maml:title>
         <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Publish to JFrog Artifactory with a clear-text PAT for local testing</maml:title>
+        <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -37106,13 +37081,13 @@ sync with the build recipe.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -37146,13 +37121,13 @@ Relative paths resolve from the pipeline project root.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -37697,12 +37672,12 @@ Invoke-ModuleBuild documentation generation into markdown pages under Docs\About
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>TopicName</maml:name>
           <maml:description>
             <maml:para>Topic name. The about_ prefix is added automatically when missing.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -37875,12 +37850,12 @@ Credential Provider session caches.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>OutputDirectory</maml:name>
           <maml:description>
             <maml:para>Destination directory for the generated bootstrap package.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -38719,12 +38694,12 @@ PowerForge.PowerForgeProjectConfigurationScaffoldResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="Path,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="Path,FullName">
           <maml:name>ArchivePath</maml:name>
           <maml:description>
             <maml:para>Path to the .xcarchive to upload.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -39196,12 +39171,12 @@ PowerForge.PowerForgeProjectConfigurationScaffoldResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to the Xcode project or workspace.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -39637,12 +39612,12 @@ PowerForge.PowerForgeProjectConfigurationScaffoldResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Screenshot file path.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -40235,12 +40210,12 @@ This makes repeated publishing runs idempotent when the package already exists.<
       </command:syntaxItem>
       <command:syntaxItem parameterSetName="Profile">
         <maml:name>Publish-NugetPackage</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>ApiKey</maml:name>
           <maml:description>
             <maml:para>API key used to authenticate against the NuGet feed. For Azure Artifacts profiles this defaults to a non-secret placeholder used by NuGet clients; for GitHub Packages profiles this defaults from GITHUB_TOKEN or GH_TOKEN.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -41937,12 +41912,12 @@ repository and does not clear Azure Artifacts Credential Provider token caches.<
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Remove-ModuleRepositoryProfile</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Profile name to remove.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -43244,12 +43219,12 @@ Credential Provider so Entra ID/MFA is handled by the provider instead of storin
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Profile name used by connect, install, update, and publish commands.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -43943,12 +43918,12 @@ Connect metadata and build selection belong to higher-level Apple release comman
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -45628,12 +45603,12 @@ System.Management.Automation.PSModuleInfo</maml:name>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Start-AppleApp</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>BundleIdentifier</maml:name>
           <maml:description>
             <maml:para>Bundle identifier to launch.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -45968,12 +45943,12 @@ PowerForge.ModuleVersionStepResult</maml:name>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Sync-AppStoreConnectScreenshots</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>ConfigPath</maml:name>
           <maml:description>
             <maml:para>Path to the screenshot sync JSON configuration file.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -46245,12 +46220,12 @@ PowerForge.ModuleVersionStepResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -46499,12 +46474,12 @@ PowerForge.AppleAppReleaseDriftReport</maml:name>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Test-AppStoreConnectScreenshotSyncConfig</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
           <maml:name>ConfigPath</maml:name>
           <maml:description>
             <maml:para>Path to the screenshot sync JSON configuration file.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -46648,12 +46623,12 @@ generated wrapper.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Profile</maml:name>
           <maml:description>
             <maml:para>Name of the built-in isolation profile to validate.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -47708,12 +47683,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -47885,12 +47860,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -47953,12 +47928,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>Repository</maml:name>
           <maml:description>
             <maml:para>Name of an already registered repository, or provider repository/feed id when a private-gallery provider is selected.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -48094,12 +48069,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -48169,12 +48144,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -1780,12 +1780,12 @@ PATs, passwords, Entra tokens, or Azure Artifacts Credential Provider session ca
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Destination JSON file path.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -6343,12 +6343,12 @@ across targets or configurations before uploading to App Store Connect.</maml:pa
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Get-XcodeProjectVersion</maml:name>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -6558,13 +6558,13 @@ session-scoped and intentionally opt-in because it changes module-name resolutio
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Profile</maml:name>
           <maml:description>
             <maml:para>Supported built-in profiles are ExchangeOnlineManagement, MicrosoftTeams, and&#xD;
 MicrosoftGraphAuthentication. Profile names are resolved case-insensitively.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -6824,12 +6824,12 @@ Provider.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Source JSON file path.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7004,12 +7004,12 @@ authenticated access through the selected bootstrap mode.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
           <maml:name>ProfileName</maml:name>
           <maml:description>
             <maml:para>Saved repository profile name. When used with Path, selects one imported profile from the file. When used with Azure Artifacts feed details, creates that profile name.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7120,12 +7120,12 @@ authenticated access through the selected bootstrap mode.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Source JSON profile file exported with Export-ModuleRepositoryProfile.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7326,12 +7326,12 @@ authenticated access through the selected bootstrap mode.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Name,Profile">
           <maml:name>ProfileName</maml:name>
           <maml:description>
             <maml:para>Saved repository profile name. When used with Path, selects one imported profile from the file. When used with Azure Artifacts feed details, creates that profile name.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -7880,12 +7880,12 @@ authenticated access through the selected bootstrap mode.</maml:para>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Install-AppleApp</maml:name>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>AppPath</maml:name>
           <maml:description>
             <maml:para>Path to the built .app bundle.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -8622,12 +8622,12 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="None">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module name to source scripts from (highest installed version is used by default).</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -8652,12 +8652,12 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Destination folder to copy scripts into (created if missing).</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -8781,12 +8781,12 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Destination folder to copy scripts into (created if missing).</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -9090,12 +9090,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -9279,12 +9279,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -9500,12 +9500,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -9587,12 +9587,12 @@ the requested modules.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to install.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -18484,12 +18484,12 @@ the local date (yyyy.MM.dd) unless a primary project version is available.</maml
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to the Xcode project or workspace.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -18897,12 +18897,12 @@ the local date (yyyy.MM.dd) unless a primary project version is available.</maml
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to the Xcode project or workspace.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -19618,13 +19618,13 @@ configuration for future read-only checks and publish/review commands.</maml:par
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -19743,13 +19743,13 @@ Relative paths resolve from the pipeline project root.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -34747,6 +34747,30 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryPublishUri</maml:name>
+          <maml:description>
+            <maml:para>Repository publish URI (PowerShellGet PublishLocation).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositorySourceUri</maml:name>
+          <maml:description>
+            <maml:para>Repository source URI (PowerShellGet SourceLocation).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryTrusted</maml:name>
           <maml:description>
             <maml:para>Whether to mark the repository as trusted (avoids prompts). Default: true.</maml:para>
@@ -34754,6 +34778,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
             <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryUri</maml:name>
+          <maml:description>
+            <maml:para>Repository base URI (used for both source and publish unless overridden).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -37081,13 +37117,13 @@ sync with the build recipe.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -37121,13 +37157,13 @@ Relative paths resolve from the pipeline project root.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.&#xD;
 Relative paths resolve from the pipeline project root.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -37672,12 +37708,12 @@ Invoke-ModuleBuild documentation generation into markdown pages under Docs\About
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>TopicName</maml:name>
           <maml:description>
             <maml:para>Topic name. The about_ prefix is added automatically when missing.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -37850,12 +37886,12 @@ Credential Provider session caches.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="1" aliases="None">
           <maml:name>OutputDirectory</maml:name>
           <maml:description>
             <maml:para>Destination directory for the generated bootstrap package.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -38694,12 +38730,12 @@ PowerForge.PowerForgeProjectConfigurationScaffoldResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="Path,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByPropertyName)" position="0" aliases="Path,FullName">
           <maml:name>ArchivePath</maml:name>
           <maml:description>
             <maml:para>Path to the .xcarchive to upload.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -39171,12 +39207,12 @@ PowerForge.PowerForgeProjectConfigurationScaffoldResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="Path,FullName">
           <maml:name>ProjectPath</maml:name>
           <maml:description>
             <maml:para>Path to the Xcode project or workspace.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -39612,12 +39648,12 @@ PowerForge.PowerForgeProjectConfigurationScaffoldResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Screenshot file path.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -41912,12 +41948,12 @@ repository and does not clear Azure Artifacts Credential Provider token caches.<
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Remove-ModuleRepositoryProfile</maml:name>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Profile name to remove.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -43219,12 +43255,12 @@ Credential Provider so Entra ID/MFA is handled by the provider instead of storin
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProfileName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Profile name used by connect, install, update, and publish commands.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -43918,12 +43954,12 @@ Connect metadata and build selection belong to higher-level Apple release comman
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -45603,12 +45639,12 @@ System.Management.Automation.PSModuleInfo</maml:name>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Start-AppleApp</maml:name>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>BundleIdentifier</maml:name>
           <maml:description>
             <maml:para>Bundle identifier to launch.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -45943,12 +45979,12 @@ PowerForge.ModuleVersionStepResult</maml:name>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Sync-AppStoreConnectScreenshots</maml:name>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>ConfigPath</maml:name>
           <maml:description>
             <maml:para>Path to the screenshot sync JSON configuration file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -46220,12 +46256,12 @@ PowerForge.ModuleVersionStepResult</maml:name>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="ProjectPath,FullName">
           <maml:name>Path</maml:name>
           <maml:description>
             <maml:para>Path to a .xcodeproj directory or project.pbxproj file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -46474,12 +46510,12 @@ PowerForge.AppleAppReleaseDriftReport</maml:name>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Test-AppStoreConnectScreenshotSyncConfig</maml:name>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="FullName">
           <maml:name>ConfigPath</maml:name>
           <maml:description>
             <maml:para>Path to the screenshot sync JSON configuration file.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -46623,12 +46659,12 @@ generated wrapper.</maml:para>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="0" aliases="None">
           <maml:name>Profile</maml:name>
           <maml:description>
             <maml:para>Name of the built-in isolation profile to validate.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -47683,12 +47719,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -47860,12 +47896,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -48069,12 +48105,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />
@@ -48144,12 +48180,12 @@ are provided, the repository registration is refreshed before the update is atte
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
+        <command:parameter required="true" variableLength="true" globbing="true" pipelineInput="False" position="0" aliases="ModuleName">
           <maml:name>Name</maml:name>
           <maml:description>
             <maml:para>Module names to update.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
             <maml:name>String[]</maml:name>
             <maml:uri />

--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -116,16 +116,19 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     /// <summary>Repository base URI (used for both source and publish unless overridden).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryUri { get; set; }
 
     /// <summary>Repository source URI (PowerShellGet SourceLocation).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositorySourceUri { get; set; }
 
     /// <summary>Repository publish URI (PowerShellGet PublishLocation).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryPublishUri { get; set; }
 
     /// <summary>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</summary>

--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -40,6 +40,10 @@ namespace PSPublishModule;
 /// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</code>
 /// </example>
 /// <example>
+/// <summary>Publish to JFrog Artifactory with a clear-text PAT for local testing</summary>
+/// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled</code>
+/// </example>
+/// <example>
 /// <summary>Publish to JFrog Artifactory with a separate NuGet API key</summary>
 /// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</code>
 /// </example>
@@ -57,6 +61,7 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     /// <summary>Choose between PowerShellGallery and GitHub.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "ApiKey")]
     [Parameter(Mandatory = true, ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public PowerForge.PublishDestination Type { get; set; }
 
     /// <summary>Azure DevOps organization name for the Azure Artifacts preset.</summary>
@@ -124,14 +129,10 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     public string? RepositoryPublishUri { get; set; }
 
     /// <summary>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</summary>
-    [Parameter(ParameterSetName = "ApiKey")]
-    [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(Mandatory = true, ParameterSetName = "JFrog")]
     public string? JFrogBaseUri { get; set; }
 
     /// <summary>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</summary>
-    [Parameter(ParameterSetName = "ApiKey")]
-    [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(Mandatory = true, ParameterSetName = "JFrog")]
     public string? JFrogRepository { get; set; }
 
@@ -287,6 +288,9 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
 
         if (ParameterSetName == "JFrog")
         {
+            if (MyInvocation.BoundParameters.ContainsKey(nameof(Type)) && Type != PowerForge.PublishDestination.PowerShellGallery)
+                throw new ArgumentException("JFrog publishing targets PowerShell repositories. Omit Type or use PowerShellGallery.", nameof(Type));
+
             type = PowerForge.PublishDestination.PowerShellGallery;
         }
 

--- a/PowerForge.PowerShell/Services/DocumentationEngine.cs
+++ b/PowerForge.PowerShell/Services/DocumentationEngine.cs
@@ -301,7 +301,12 @@ public sealed class DocumentationEngine
                 throw new FileNotFoundException("Documentation help extraction did not produce output JSON.", jsonPath);
 
             using var stream = File.OpenRead(jsonPath);
-            var serializer = new DataContractJsonSerializer(typeof(DocumentationExtractionPayload));
+            var serializer = new DataContractJsonSerializer(
+                typeof(DocumentationExtractionPayload),
+                new DataContractJsonSerializerSettings
+                {
+                    UseSimpleDictionaryFormat = true
+                });
             var payload = serializer.ReadObject(stream) as DocumentationExtractionPayload;
             return payload ?? new DocumentationExtractionPayload();
         }

--- a/PowerForge.Tests/DocumentationEngineSafetyTests.cs
+++ b/PowerForge.Tests/DocumentationEngineSafetyTests.cs
@@ -150,6 +150,49 @@ public sealed class DocumentationEngineSafetyTests
         }
     }
 
+    [Fact]
+    public void ExtractHelpPayload_ReadsSimpleDictionaryParameterSetRequired()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var manifestPath = Path.Combine(root.FullName, "TestModule.psd1");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '1.0.0'; RootModule = 'TestModule.psm1' }");
+
+            const string json = """
+{
+  "moduleName": "TestModule",
+  "commands": [
+    {
+      "name": "New-Thing",
+      "parameters": [
+        {
+          "name": "Path",
+          "parameterSetRequired": {
+            "__AllParameterSets": true,
+            "OptionalSet": false
+          }
+        }
+      ]
+    }
+  ]
+}
+""";
+
+            var engine = new DocumentationEngine(new RawJsonPowerShellRunner(json), new NullLogger());
+
+            var payload = engine.ExtractHelpPayload(root.FullName, manifestPath);
+
+            var parameter = Assert.Single(Assert.Single(payload.Commands).Parameters);
+            Assert.True(parameter.ParameterSetRequired["__AllParameterSets"]);
+            Assert.False(parameter.ParameterSetRequired["OptionalSet"]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private sealed class PayloadPowerShellRunner : IPowerShellRunner
     {
         private readonly DocumentationExtractionPayload _payload;
@@ -165,6 +208,24 @@ public sealed class DocumentationEngineSafetyTests
             using var stream = File.Create(jsonPath);
             var serializer = new DataContractJsonSerializer(typeof(DocumentationExtractionPayload));
             serializer.WriteObject(stream, _payload);
+            return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh");
+        }
+    }
+
+    private sealed class RawJsonPowerShellRunner : IPowerShellRunner
+    {
+        private readonly string _json;
+
+        public RawJsonPowerShellRunner(string json)
+        {
+            _json = json;
+        }
+
+        public PowerShellRunResult Run(PowerShellRunRequest request)
+        {
+            var jsonPath = request.Arguments[2];
+            Directory.CreateDirectory(Path.GetDirectoryName(jsonPath)!);
+            File.WriteAllText(jsonPath, _json);
             return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh");
         }
     }

--- a/PowerForge.Tests/DocumentationGenerationTests.cs
+++ b/PowerForge.Tests/DocumentationGenerationTests.cs
@@ -257,14 +257,23 @@ EXAMPLES
                                 Name = "FilePath",
                                 Type = "String",
                                 Required = true,
-                                ParameterSets = new List<string> { "ApiFromFile", "JFrog" }
+                                ParameterSets = new List<string> { "ApiFromFile", "JFrog" },
+                                ParameterSetRequired =
+                                {
+                                    ["ApiFromFile"] = true,
+                                    ["JFrog"] = false
+                                }
                             },
                             new()
                             {
                                 Name = "JFrogBaseUri",
                                 Type = "String",
                                 Required = true,
-                                ParameterSets = new List<string> { "JFrog" }
+                                ParameterSets = new List<string> { "JFrog" },
+                                ParameterSetRequired =
+                                {
+                                    ["JFrog"] = true
+                                }
                             }
                         }
                     }
@@ -283,6 +292,88 @@ EXAMPLES
             Assert.Equal("true", apiFilePath.Attribute("required")?.Value);
             Assert.Equal("false", jfrogFilePath.Attribute("required")?.Value);
             Assert.Equal("true", jfrogBaseUri.Attribute("required")?.Value);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void MamlHelpWriter_TreatsAllParameterSetsRequiredMetadataAsShared()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-maml-help-writer-all-required-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var payload = new DocumentationExtractionPayload
+            {
+                ModuleName = "TestModule",
+                Commands = new List<DocumentationCommandHelp>
+                {
+                    new()
+                    {
+                        Name = "New-Thing",
+                        CommandType = "Cmdlet",
+                        Synopsis = "Creates a thing.",
+                        Description = "Creates a thing.",
+                        Syntax = new List<DocumentationSyntaxHelp>
+                        {
+                            new() { Name = "ExplicitVersion", Text = "New-Thing [-Path] <String> -Version <String>" },
+                            new() { Name = "ResolvedVersion", Text = "New-Thing [-Path] <String> -FromManifest" }
+                        },
+                        Parameters = new List<DocumentationParameterHelp>
+                        {
+                            new()
+                            {
+                                Name = "Path",
+                                Type = "String",
+                                Required = true,
+                                ParameterSets = new List<string> { "__AllParameterSets" },
+                                ParameterSetRequired =
+                                {
+                                    ["__AllParameterSets"] = true
+                                }
+                            },
+                            new()
+                            {
+                                Name = "Version",
+                                Type = "String",
+                                Required = true,
+                                ParameterSets = new List<string> { "ExplicitVersion" },
+                                ParameterSetRequired =
+                                {
+                                    ["ExplicitVersion"] = true
+                                }
+                            },
+                            new()
+                            {
+                                Name = "FromManifest",
+                                Type = "SwitchParameter",
+                                Required = true,
+                                ParameterSets = new List<string> { "ResolvedVersion" },
+                                ParameterSetRequired =
+                                {
+                                    ["ResolvedVersion"] = true
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var path = new MamlHelpWriter().WriteExternalHelpFile(payload, "TestModule", root);
+            var doc = XDocument.Load(path);
+            XNamespace commandNs = "http://schemas.microsoft.com/maml/dev/command/2004/10";
+            XNamespace mamlNs = "http://schemas.microsoft.com/maml/2004/10";
+
+            var explicitPath = FindSyntaxParameter(doc, commandNs, mamlNs, "ExplicitVersion", "Path");
+            var resolvedPath = FindSyntaxParameter(doc, commandNs, mamlNs, "ResolvedVersion", "Path");
+
+            Assert.Equal("true", explicitPath.Attribute("required")?.Value);
+            Assert.Equal("true", resolvedPath.Attribute("required")?.Value);
         }
         finally
         {

--- a/PowerForge.Tests/DocumentationGenerationTests.cs
+++ b/PowerForge.Tests/DocumentationGenerationTests.cs
@@ -227,6 +227,71 @@ EXAMPLES
     }
 
     [Fact]
+    public void MamlHelpWriter_UsesParameterSetSpecificRequiredFlagsInSyntax()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-maml-help-writer-set-required-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var payload = new DocumentationExtractionPayload
+            {
+                ModuleName = "TestModule",
+                Commands = new List<DocumentationCommandHelp>
+                {
+                    new()
+                    {
+                        Name = "New-Thing",
+                        CommandType = "Cmdlet",
+                        Synopsis = "Creates a thing.",
+                        Description = "Creates a thing.",
+                        Syntax = new List<DocumentationSyntaxHelp>
+                        {
+                            new() { Name = "ApiFromFile", IsDefault = true, Text = "New-Thing -FilePath <String>" },
+                            new() { Name = "JFrog", Text = "New-Thing -JFrogBaseUri <String> [-FilePath <String>]" }
+                        },
+                        Parameters = new List<DocumentationParameterHelp>
+                        {
+                            new()
+                            {
+                                Name = "FilePath",
+                                Type = "String",
+                                Required = true,
+                                ParameterSets = new List<string> { "ApiFromFile", "JFrog" }
+                            },
+                            new()
+                            {
+                                Name = "JFrogBaseUri",
+                                Type = "String",
+                                Required = true,
+                                ParameterSets = new List<string> { "JFrog" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var path = new MamlHelpWriter().WriteExternalHelpFile(payload, "TestModule", root);
+            var doc = XDocument.Load(path);
+            XNamespace commandNs = "http://schemas.microsoft.com/maml/dev/command/2004/10";
+            XNamespace mamlNs = "http://schemas.microsoft.com/maml/2004/10";
+
+            var apiFilePath = FindSyntaxParameter(doc, commandNs, mamlNs, "ApiFromFile", "FilePath");
+            var jfrogFilePath = FindSyntaxParameter(doc, commandNs, mamlNs, "JFrog", "FilePath");
+            var jfrogBaseUri = FindSyntaxParameter(doc, commandNs, mamlNs, "JFrog", "JFrogBaseUri");
+
+            Assert.Equal("true", apiFilePath.Attribute("required")?.Value);
+            Assert.Equal("false", jfrogFilePath.Attribute("required")?.Value);
+            Assert.Equal("true", jfrogBaseUri.Attribute("required")?.Value);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void AboutTopicWriter_PrefersHelpTxt_AndGeneratesIndex()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-about-writer-" + Guid.NewGuid().ToString("N"));
@@ -1332,5 +1397,20 @@ Write-Output $exampleObject
             if (i == 0 || text[i - 1] != '\r') return true;
         }
         return false;
+    }
+
+    private static XElement FindSyntaxParameter(
+        XDocument doc,
+        XNamespace commandNs,
+        XNamespace mamlNs,
+        string parameterSetName,
+        string parameterName)
+    {
+        var syntaxItem = doc.Descendants(commandNs + "syntaxItem")
+            .Single(item => string.Equals(item.Attribute("parameterSetName")?.Value, parameterSetName, StringComparison.Ordinal));
+
+        return syntaxItem
+            .Elements(commandNs + "parameter")
+            .Single(parameter => string.Equals(parameter.Element(mamlNs + "name")?.Value, parameterName, StringComparison.Ordinal));
     }
 }

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -133,6 +133,7 @@ try {
       $possibleValues = @()
 
       $required = $false
+      $parameterSetRequired = @{}
       $named = $true
       $pos = $null
       $pipeByValue = $false
@@ -145,6 +146,8 @@ try {
           foreach ($setEntry in @($pmeta.ParameterSets.GetEnumerator())) {
             $psm = $setEntry.Value
             if ($psm) {
+              $setName = [string]$setEntry.Key
+              if ($setName) { $parameterSetRequired[$setName] = [bool]$psm.IsMandatory }
               if ($psm.IsMandatory) { $required = $true }
               $pPos = [int]$psm.Position
               if ($pPos -ne -2147483648) {
@@ -245,6 +248,7 @@ try {
         aliases = @($aliases)
         possibleValues = @($possibleValues)
         required = [bool]$required
+        parameterSetRequired = $parameterSetRequired
         position = $positionText
         defaultValue = $defaultValue
         pipelineInput = $pipelineInput

--- a/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
+++ b/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
@@ -211,6 +211,10 @@ internal sealed class DocumentationParameterHelp
     [DataMember(Name = "required")]
     public bool Required { get; set; }
 
+    /// <summary>Required flag by parameter set name for syntax rendering.</summary>
+    [DataMember(Name = "parameterSetRequired")]
+    public Dictionary<string, bool> ParameterSetRequired { get; set; } = new();
+
     /// <summary>Position information (Named/0/1/...).</summary>
     [DataMember(Name = "position")]
     public string Position { get; set; } = string.Empty;

--- a/PowerForge/Services/Documentation/MamlHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MamlHelpWriter.cs
@@ -123,7 +123,7 @@ internal sealed class MamlHelpWriter
             var parameters = (cmd.Parameters ?? Enumerable.Empty<DocumentationParameterHelp>())
                 .Where(p => ParameterInSet(p, setName))
                 .ToArray();
-            WriteSyntaxItem(writer, commandName, setName, parameters);
+            WriteSyntaxItem(writer, commandName, setName, parameters, set.Text);
         }
 
         writer.WriteEndElement(); // syntax
@@ -133,7 +133,8 @@ internal sealed class MamlHelpWriter
         XmlWriter writer,
         string commandName,
         string? setName,
-        IEnumerable<DocumentationParameterHelp>? parameters)
+        IEnumerable<DocumentationParameterHelp>? parameters,
+        string? syntaxText = null)
     {
         writer.WriteStartElement("command", "syntaxItem", CommandNs);
         if (setName is not null)
@@ -147,7 +148,7 @@ internal sealed class MamlHelpWriter
         foreach (var p in (parameters ?? Enumerable.Empty<DocumentationParameterHelp>())
                      .Where(p => p is not null && !string.IsNullOrWhiteSpace(p.Name)))
         {
-            WriteParameter(writer, p, includeParameterValue: true);
+            WriteParameter(writer, p, includeParameterValue: true, setName: setName, syntaxText: syntaxText);
         }
 
         writer.WriteEndElement(); // syntaxItem
@@ -292,7 +293,7 @@ internal sealed class MamlHelpWriter
         writer.WriteEndElement(); // alertSet
     }
 
-    private static void WriteParameter(XmlWriter writer, DocumentationParameterHelp p, bool includeParameterValue)
+    private static void WriteParameter(XmlWriter writer, DocumentationParameterHelp p, bool includeParameterValue, string? setName = null, string? syntaxText = null)
     {
         var aliases = (p.Aliases ?? Enumerable.Empty<string>())
             .Where(a => !string.IsNullOrWhiteSpace(a))
@@ -304,9 +305,10 @@ internal sealed class MamlHelpWriter
 
         var typeName = string.IsNullOrWhiteSpace(p.Type) ? "Object" : p.Type.Trim();
         var isArray = typeName.EndsWith("[]", StringComparison.Ordinal);
+        var required = ParameterRequiredInSet(p, setName, syntaxText);
 
         writer.WriteStartElement("command", "parameter", CommandNs);
-        writer.WriteAttributeString("required", p.Required ? "true" : "false");
+        writer.WriteAttributeString("required", required ? "true" : "false");
         writer.WriteAttributeString("variableLength", isArray ? "true" : "false");
         writer.WriteAttributeString("globbing", p.AcceptWildcardCharacters ? "true" : "false");
         writer.WriteAttributeString("pipelineInput", string.IsNullOrWhiteSpace(p.PipelineInput) ? "False" : p.PipelineInput.Trim());
@@ -321,7 +323,7 @@ internal sealed class MamlHelpWriter
         if (includeParameterValue)
         {
             writer.WriteStartElement("command", "parameterValue", CommandNs);
-            writer.WriteAttributeString("required", p.Required ? "true" : "false");
+            writer.WriteAttributeString("required", required ? "true" : "false");
             writer.WriteAttributeString("variableLength", "false");
             writer.WriteString(typeName);
             writer.WriteEndElement(); // parameterValue
@@ -463,6 +465,74 @@ internal sealed class MamlHelpWriter
             if (sn.Equals(setName, StringComparison.OrdinalIgnoreCase)) return true;
         }
         return false;
+    }
+
+    private static bool ParameterRequiredInSet(DocumentationParameterHelp p, string? setName, string? syntaxText)
+    {
+        if (p is null) return false;
+        if (string.IsNullOrWhiteSpace(setName)) return p.Required;
+
+        var setRequired = p.ParameterSetRequired;
+        if (setRequired is null || setRequired.Count == 0)
+            return TryResolveRequiredFromSyntax(syntaxText, p.Name) ?? p.Required;
+
+        var normalizedSetName = setName!.Trim();
+        foreach (var entry in setRequired)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key)) continue;
+            if (entry.Key.Trim().Equals(normalizedSetName, StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        foreach (var entry in setRequired)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key)) continue;
+            if (entry.Key.Trim().Equals("(All)", StringComparison.OrdinalIgnoreCase))
+                return entry.Value;
+        }
+
+        return TryResolveRequiredFromSyntax(syntaxText, p.Name) ?? p.Required;
+    }
+
+    private static bool? TryResolveRequiredFromSyntax(string? syntaxText, string? parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(syntaxText) || string.IsNullOrWhiteSpace(parameterName))
+            return null;
+
+        var name = parameterName!.Trim();
+        var text = syntaxText!;
+        var depth = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            if (ch == '[')
+            {
+                depth++;
+                continue;
+            }
+
+            if (ch == ']')
+            {
+                if (depth > 0) depth--;
+                continue;
+            }
+
+            if (ch != '-') continue;
+            if (i > 0 && IsParameterNameCharacter(text[i - 1])) continue;
+            if (i + 1 + name.Length > text.Length) continue;
+            if (!text.AsSpan(i + 1, name.Length).Equals(name.AsSpan(), StringComparison.OrdinalIgnoreCase)) continue;
+
+            var after = i + 1 + name.Length;
+            if (after < text.Length && IsParameterNameCharacter(text[after])) continue;
+            return depth == 0;
+        }
+
+        return null;
+    }
+
+    private static bool IsParameterNameCharacter(char ch)
+    {
+        return char.IsLetterOrDigit(ch) || ch == '_' || ch == '-';
     }
 
     private static string NormalizePosition(string? position)

--- a/PowerForge/Services/Documentation/MamlHelpWriter.cs
+++ b/PowerForge/Services/Documentation/MamlHelpWriter.cs
@@ -462,6 +462,7 @@ internal sealed class MamlHelpWriter
             if (string.IsNullOrWhiteSpace(s)) continue;
             var sn = s.Trim();
             if (sn.Equals("(All)", StringComparison.OrdinalIgnoreCase)) return true;
+            if (sn.Equals("__AllParameterSets", StringComparison.OrdinalIgnoreCase)) return true;
             if (sn.Equals(setName, StringComparison.OrdinalIgnoreCase)) return true;
         }
         return false;
@@ -487,7 +488,9 @@ internal sealed class MamlHelpWriter
         foreach (var entry in setRequired)
         {
             if (string.IsNullOrWhiteSpace(entry.Key)) continue;
-            if (entry.Key.Trim().Equals("(All)", StringComparison.OrdinalIgnoreCase))
+            var key = entry.Key.Trim();
+            if (key.Equals("(All)", StringComparison.OrdinalIgnoreCase) ||
+                key.Equals("__AllParameterSets", StringComparison.OrdinalIgnoreCase))
                 return entry.Value;
         }
 


### PR DESCRIPTION
## Summary
- fix JFrog parameter set binding so direct JFrog settings do not force FilePath
- document clear-text PAT testing via RepositoryCredentialSecret
- regenerate markdown/external help and make MAML required flags parameter-set aware

## Validation
- .\Module\Build\Build-Module.ps1 -NoSign
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~DocumentationGenerationTests|FullyQualifiedName~PublishConfigurationFactoryTests" --nologo
- Invoke-Pester -Path .\Module\Tests\PrivateGallery.Commands.Tests.ps1 -FullName "*direct JFrog parameters with a clear-text repository PAT*" -Output Detailed
- git -c core.whitespace=trailing-space,space-before-tab,cr-at-eol diff --check
- verified generated external help marks JFrogBaseUri/JFrogRepository required and ApiKey/FilePath/Type optional