### PR TITLE
Add private gallery dependency publishing

### DIFF
--- a/Docs/PSPublishModule.PrivateGalleries.md
+++ b/Docs/PSPublishModule.PrivateGalleries.md
@@ -1,87 +1,265 @@
 # PSPublishModule Private Galleries
 
-This page describes the supported enterprise flow for consuming and publishing
-private PowerShell modules with PSPublishModule. It covers Azure Artifacts,
-JFrog Artifactory, generic NuGet-compatible feeds, GitHub Packages, and the
-related Microsoft Artifact Registry (MAR) intake path for Microsoft-owned
-packages.
+This guide explains how to consume and publish private PowerShell modules with
+PSPublishModule and PowerForge. It is written for the common operator decision:
+"I have a private NuGet-compatible feed. Which command shape should I use?"
 
-For the short maintainer/end-user process used for the Evotec private feed, see
+The short answer:
+
+- Use the generic NuGet-compatible flow when you already know the feed URLs and
+  the feed behaves like a normal NuGet v2/v3 repository.
+- Use the Azure Artifacts preset when the feed is in Azure DevOps and users
+  should authenticate with Entra ID/MFA through the Azure Artifacts Credential
+  Provider.
+- Use the JFrog preset when the feed is Artifactory and you want PSPublishModule
+  to derive the NuGet URLs from `JFrogBaseUri` and `JFrogRepository`.
+- Use profiles for workstation onboarding and repeated install/update commands.
+- Use publish configuration for build/release pipelines.
+
+For the Evotec Azure Artifacts feed runbook, see
 `Docs/PSPublishModule.PrivateGalleryProcess.md`.
 
-## Recommended Azure Artifacts Flow
+## Mental Model
 
-Use Microsoft Entra ID/MFA through Microsoft.PowerShell.PSResourceGet and the
-Azure Artifacts Credential Provider. PSPublishModule stores only non-secret feed
-profile settings such as organization, project, feed, repository name, and tool
-preferences. The Entra token/session cache remains owned by the Azure Artifacts
-Credential Provider.
+PowerShell module publishing still uses NuGet underneath:
 
-When registering Azure Artifacts feeds through PSResourceGet, PSPublishModule
-sets the repository credential provider to `AzArtifacts` when the installed
-PSResourceGet version exposes that parameter, and falls back to PSResourceGet's
-Azure Artifacts URL detection for older versions.
+- `PSResourceGet` usually talks to a NuGet v3 endpoint.
+- `PowerShellGet` usually talks to a NuGet v2 endpoint.
+- A repository can require a push API key, a basic/PAT credential, an external
+  credential provider, or some combination of those.
+- Profiles store repository shape and local behavior only. They must not store
+  PATs, passwords, Entra tokens, or JFrog access tokens.
 
-## Microsoft Artifact Registry (MAR)
+Use `PSResourceGet` unless you have a specific reason to support older
+PowerShellGet-only clients.
 
-MAR is the Microsoft-controlled source for Microsoft-owned PowerShell packages.
-It is a PSResourceGet container-registry repository, not a PowerShellGet
-repository, and it is read-only for consumers. PSPublishModule therefore treats
-MAR as a trusted discovery/intake source and never as a publish target.
+## Which Flow Should I Pick?
 
-Register or validate MAR explicitly:
+| Feed or scenario | Recommended path | Why |
+| --- | --- | --- |
+| Any NuGet v3/v2-compatible feed with known URLs | Generic NuGet-compatible configuration | It is explicit and works for most vendors. |
+| Azure DevOps Artifacts | Azure Artifacts preset/profile | It derives endpoints and uses the Azure Artifacts Credential Provider. |
+| JFrog Artifactory | JFrog preset | It derives Artifactory NuGet URLs and supports PAT/basic, API key, OIDC, and CLI bootstrap options. |
+| GitHub Packages | GitHub Packages profile | It resolves `https://nuget.pkg.github.com/<owner>/index.json`; see `Docs/PSPublishModule.GitHubPackages.md`. |
+| Microsoft-owned modules from MAR | Microsoft Artifact Registry | MAR is read-only discovery/install only, not a publish target. |
+| Missing RequiredModules in a private feed | `-PublishRequiredModules` | Mirrors required dependencies into the target feed before publishing the main module. |
 
-```powershell
-Register-ModuleRepository -MicrosoftArtifactRegistry
-Connect-ModuleRepository -MicrosoftArtifactRegistry
-```
+## Standard NuGet-Compatible Feed
 
-Install Microsoft-owned packages from MAR with the wrapper or native command:
+Use this when the private gallery gives you standard NuGet feed URLs.
 
-```powershell
-Install-PrivateModule -MicrosoftArtifactRegistry -Name Microsoft.PowerShell.SecretManagement
-Install-PSResource -Repository MAR -Name Microsoft.PowerShell.SecretManagement
-```
+Typical examples:
 
-## JFrog Artifactory
+- Sonatype Nexus NuGet repository
+- ProGet NuGet feed
+- GitHub Packages NuGet feed
+- JFrog Artifactory when you prefer to provide the URLs yourself
+- any internal NuGet v2/v3 service
 
-JFrog Artifactory is supported as a NuGet-compatible private PowerShell module
-repository. PSPublishModule can derive the required PowerShellGet and
-PSResourceGet endpoints from the Artifactory base URI and the NuGet repository
-key:
+### Publish With A NuGet API Key
 
-```text
-Base URI:   https://company.jfrog.io/artifactory
-Repository: powershell-virtual
-PSResourceGet endpoint:
-  https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json
-PowerShellGet source/publish endpoint:
-  https://company.jfrog.io/artifactory/api/nuget/powershell-virtual
-```
-
-### JFrog Publisher Configuration With PAT/Basic Auth
-
-Use this when the same JFrog PAT or access token is accepted as the repository
-credential for publishing and for authenticated read/probe operations. This is
-the preferred simple build configuration because it avoids a pre-created local
-profile and avoids duplicating the same PAT as a NuGet API key:
+Use this when the feed expects a NuGet API key for package push:
 
 ```powershell
 New-ConfigurationPublish `
-    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
-    -JFrogRepository 'powershell-virtual' `
-    -RepositoryName 'JFrogPS' `
+    -Type PowerShellGallery `
+    -RepositoryName 'CompanyModules' `
     -Tool PSResourceGet `
-    -RepositoryCredentialUserName 'name@company.com' `
-    -RepositoryCredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
-    -Enabled:$true
+    -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' `
+    -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' `
+    -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' `
+    -FilePath "$env:USERPROFILE\.secrets\company-nuget-api-key.txt" `
+    -Enabled
 ```
 
-The local repository name can be omitted when the Artifactory repository key is
-also an acceptable local PowerShell repository name. Keep it when you want a
-shorter or clearer local alias such as `JFrogPS`.
+Use `-ApiKey` only for local tests. Prefer `-FilePath` or a CI secret expanded
+at runtime.
 
-For CI, prefer an environment variable over a local secret file:
+### Publish With Basic/PAT Credentials
+
+Some feeds use the same username/token for read probes and package push. For a
+generic feed, create a non-secret profile once, then pass the credential at
+publish time:
+
+```powershell
+Set-ModuleRepositoryProfile `
+    -Name 'CompanyNuGet' `
+    -Provider NuGet `
+    -RepositoryName 'CompanyModules' `
+    -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' `
+    -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' `
+    -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' `
+    -Tool PSResourceGet
+
+New-ConfigurationPublish `
+    -ProfileName 'CompanyNuGet' `
+    -RepositoryCredentialUserName 'publisher' `
+    -RepositoryCredentialSecretEnvironmentVariable 'COMPANY_NUGET_TOKEN' `
+    -Enabled
+```
+
+That keeps the URL/profile reusable while keeping the token outside committed
+configuration.
+
+### Connect And Install From A Generic Feed
+
+For users or support engineers:
+
+```powershell
+Connect-ModuleRepository `
+    -Provider NuGet `
+    -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' `
+    -Name 'CompanyModules' `
+    -Tool PSResourceGet `
+    -CredentialUserName 'reader' `
+    -CredentialSecretFilePath "$env:USERPROFILE\.secrets\company-feed-token.txt" `
+    -InstallPrerequisites
+
+Install-PrivateModule `
+    -Name 'Company.Tools' `
+    -Repository 'CompanyModules' `
+    -CredentialUserName 'reader' `
+    -CredentialSecretFilePath "$env:USERPROFILE\.secrets\company-feed-token.txt"
+```
+
+For repeated workstation usage, prefer a profile and `-ProfileName`.
+
+## Azure Artifacts
+
+Use this for Azure DevOps feeds. This is the preferred enterprise flow when
+users should authenticate with Entra ID/MFA instead of PATs.
+
+PSPublishModule stores:
+
+- organization
+- optional project
+- feed
+- local repository name
+- preferred tool/bootstrap settings
+
+It does not store Entra tokens, PATs, or passwords. Authentication stays with
+`Microsoft.PowerShell.PSResourceGet` and the Azure Artifacts Credential Provider.
+
+### Create Or Import A Profile
+
+Create a profile directly:
+
+```powershell
+Set-ModuleRepositoryProfile `
+    -Name 'Company' `
+    -AzureDevOpsOrganization 'contoso' `
+    -AzureDevOpsProject 'Platform' `
+    -AzureArtifactsFeed 'Modules'
+```
+
+One-command workstation onboarding:
+
+```powershell
+Initialize-ModuleRepository `
+    -ProfileName 'Company' `
+    -InstallPrerequisites
+```
+
+Import a managed profile file:
+
+```powershell
+Initialize-ModuleRepository `
+    -Path .\Company.profile.json `
+    -ProfileName 'Company' `
+    -Overwrite `
+    -InstallPrerequisites
+```
+
+### Install And Update
+
+```powershell
+Install-PrivateModule -ProfileName 'Company' -Name 'Company.Tools' -InstallPrerequisites
+Update-PrivateModule  -ProfileName 'Company' -Name 'Company.Tools'
+```
+
+The wrappers refresh repository registration and run the access
+probe/session-prime step before install or update. If the cached credential
+provider session expired, the normal command can prompt the user again.
+
+### Publish A PowerShell Module
+
+Direct preset:
+
+```powershell
+New-ConfigurationPublish `
+    -AzureDevOpsOrganization 'contoso' `
+    -AzureDevOpsProject 'Platform' `
+    -AzureArtifactsFeed 'Modules' `
+    -RepositoryName 'CompanyModules' `
+    -Tool PSResourceGet `
+    -Enabled
+```
+
+Profile-backed:
+
+```powershell
+New-ConfigurationPublish -ProfileName 'Company' -Enabled
+```
+
+The generated configuration resolves the Azure Artifacts v3 endpoint and does
+not store a credential object. The user or automation identity still needs feed
+push permission.
+
+### Publish Plain NuGet Packages
+
+```powershell
+Publish-NugetPackage `
+    -Path .\artifacts `
+    -ProfileName 'Company' `
+    -InstallPrerequisites `
+    -SkipDuplicate
+```
+
+Use this for `.nupkg` files that are not PowerShell module publishing outputs.
+
+### When To Use PATs
+
+PAT/basic credential parameters still exist for legacy or constrained
+environments:
+
+```powershell
+Install-PrivateModule `
+    -Name 'Company.Tools' `
+    -AzureDevOpsOrganization 'contoso' `
+    -AzureDevOpsProject 'Platform' `
+    -AzureArtifactsFeed 'Modules' `
+    -CredentialUserName 'user@contoso.com' `
+    -CredentialSecretFilePath "$env:USERPROFILE\.secrets\azdo.pat"
+```
+
+Treat this as a fallback. Prefer the Azure Artifacts Credential Provider when
+Azure DevOps Services and workstation policy allow it.
+
+## JFrog Artifactory
+
+JFrog Artifactory is a NuGet-compatible private PowerShell module repository.
+You can use it two ways:
+
+- generic NuGet URLs, as shown in the standard NuGet section;
+- JFrog shortcut parameters, which derive URLs for you.
+
+For a SaaS Artifactory instance:
+
+```text
+JFrogBaseUri:    https://company.jfrog.io/artifactory
+JFrogRepository: powershell-virtual
+
+PSResourceGet v3:
+https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json
+
+PowerShellGet v2 source/publish:
+https://company.jfrog.io/artifactory/api/nuget/powershell-virtual
+```
+
+### Option 1: PAT Or Access Token As Repository Credential
+
+Use this when the JFrog PAT/access token is accepted for both read/probe and
+publish operations. This is the simplest local and CI shape.
 
 ```powershell
 New-ConfigurationPublish `
@@ -91,14 +269,10 @@ New-ConfigurationPublish `
     -Tool PSResourceGet `
     -RepositoryCredentialUserName 'name@company.com' `
     -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' `
-    -Enabled:$true
+    -Enabled
 ```
 
-### JFrog Publisher Configuration With Separate NuGet API Key
-
-Use this only when Artifactory requires a NuGet API key for package push in
-addition to a repository credential for registration, probing, or authenticated
-feed access:
+For a quick local test, inline clear text works but should not be committed:
 
 ```powershell
 New-ConfigurationPublish `
@@ -106,19 +280,38 @@ New-ConfigurationPublish `
     -JFrogRepository 'powershell-virtual' `
     -RepositoryName 'JFrogPS' `
     -Tool PSResourceGet `
-    -FilePath 'C:\Support\Important\JFrogNuGetApiKey.txt' `
     -RepositoryCredentialUserName 'name@company.com' `
-    -RepositoryCredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
-    -Enabled:$true
+    -RepositoryCredentialSecret 'temporary-pat' `
+    -Enabled
 ```
 
-### JFrog OIDC / Federated CI Authentication
+### Option 2: Separate NuGet API Key Plus Repository Credential
 
-Use JFrog OIDC token exchange when the build runner can obtain a short-lived
-OIDC token from the CI platform. PSPublishModule runs `jf eot` at publish time,
-parses the returned JFrog username/access token, and passes that credential to
-PSResourceGet or PowerShellGet. The resulting access token is not written into
-the publish configuration.
+Use this only when Artifactory requires a push API key in addition to a
+repository credential for authenticated read/probe operations:
+
+```powershell
+New-ConfigurationPublish `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -RepositoryName 'JFrogPS' `
+    -Tool PSResourceGet `
+    -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" `
+    -RepositoryCredentialUserName 'name@company.com' `
+    -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" `
+    -Enabled
+```
+
+If the feed does not require a separate NuGet API key, do not pass `-FilePath`
+or `-ApiKey`; use repository credentials only.
+
+### Option 3: JFrog OIDC In CI
+
+Use this when the CI runner can obtain a short-lived OIDC token and JFrog is
+configured to exchange it. PSPublishModule calls JFrog CLI at publish time,
+parses the returned username/access token, and passes that credential to the
+repository tooling. The exchanged access token is not written into the publish
+configuration.
 
 ```powershell
 New-ConfigurationPublish `
@@ -129,29 +322,22 @@ New-ConfigurationPublish `
     -JFrogOidcProvider 'azure-oidc' `
     -JFrogOidcProviderType Azure `
     -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' `
-    -Enabled:$true
+    -Enabled
 ```
 
-Provider type choices are:
+Provider type choices:
 
 - `GitHub` for GitHub Actions OIDC.
 - `Azure` for Azure DevOps or Entra-backed JFrog OIDC mappings.
 - `GenericOidc` for other OIDC-compatible CI providers.
 
-`JFrogPlatformUri` can be supplied when the platform URL is not derivable from
-`JFrogBaseUri`. For the common SaaS shape above, PSPublishModule derives
-`https://company.jfrog.io/` from `https://company.jfrog.io/artifactory`.
+Use `-JFrogPlatformUri` when the platform URL cannot be derived from
+`JFrogBaseUri`.
 
-This is the right direction for FAMS/federated-style automation because it uses
-the identity provider to mint a short-lived token and exchanges it for a JFrog
-access token only during the publish run. It still needs a real JFrog OIDC
-integration, identity mapping, feed permission, JFrog CLI on PATH, and live
-publish proof before it should be treated as production-ready.
+### Option 4: JFrog CLI Browser Login For Workstations
 
-### JFrog Browser SSO / Entra Login
-
-If JFrog is connected to Microsoft Entra ID through SAML/OIDC SSO, interactive
-users can use the existing JFrog CLI browser-login bootstrap path:
+Use this as an interactive bootstrap/proof path, not as the default CI publish
+configuration:
 
 ```powershell
 Connect-ModuleRepository `
@@ -166,46 +352,14 @@ Connect-ModuleRepository `
 ```
 
 This runs `jf login` and then probes whether PowerShell repository tooling can
-use the resulting session. Treat it as an interactive workstation/bootstrap
-test, not as the default publish configuration: JFrog CLI browser login is not
-CI-friendly, and PSResourceGet/PowerShellGet may still require an explicit
-repository credential, access token, or OIDC exchange result.
+use the resulting session. If the CLI login succeeds but PSResourceGet still
+cannot read the NuGet feed, the result reports that boundary instead of hiding
+it.
 
-### JFrog Connection And Install Test
+### JFrog Profile For Users
 
-Before handing a feed to publishers or end users, test both authenticated access
-and module install from a clean shell:
-
-```powershell
-Connect-ModuleRepository `
-    -Provider JFrog `
-    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
-    -JFrogRepository 'powershell-virtual' `
-    -Name 'JFrogPS' `
-    -Tool PSResourceGet `
-    -CredentialUserName 'name@company.com' `
-    -CredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
-    -InstallPrerequisites `
-    -Verbose
-
-Install-PrivateModule `
-    -Name 'YourModuleName' `
-    -Repository 'JFrogPS' `
-    -CredentialUserName 'name@company.com' `
-    -CredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt' `
-    -Force
-```
-
-Use a PAT or access token with the minimum Artifactory permissions required for
-the scenario: read for install/update validation, and deploy/publish for module
-release builds. Keep tokens outside committed configuration by using environment
-variables, CI secrets, or local secret files.
-
-### JFrog Profile For Workstation Onboarding
-
-A profile is still useful for managed workstation onboarding because it stores
-the non-secret feed shape once and lets install/update commands reference a
-stable profile name:
+Profiles are useful for workstation onboarding because they store the feed
+shape once:
 
 ```powershell
 Set-ModuleRepositoryProfile `
@@ -218,744 +372,149 @@ Set-ModuleRepositoryProfile `
     -Trusted $true
 
 Install-PrivateModule `
-    -Name 'YourModuleName' `
+    -Name 'Company.Tools' `
     -ProfileName 'JFrogPS' `
     -CredentialUserName 'name@company.com' `
-    -CredentialSecretFilePath 'C:\Support\Important\JFrogArtifactoryPAT.txt'
+    -CredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt"
 ```
 
-Profiles should contain feed metadata only. Do not store PATs, passwords, or
-session tokens in exported profile JSON.
+The profile is non-secret. The credential stays in a prompt, environment
+variable, CI secret, or local secret file.
 
-## Other NuGet-Compatible Private Feeds
+## Publishing Missing RequiredModules
 
-For a private feed that is not one of the provider-specific presets, use the
-generic repository URI parameters. This is also the escape hatch when a vendor
-uses nonstandard NuGet endpoints:
+Private feeds often start empty. If your module manifest contains
+`RequiredModules`, the main module publish can fail because the target feed does
+not yet contain those dependencies.
+
+Use `-PublishRequiredModules` to opt in to mirroring missing dependencies before
+publishing the main module:
 
 ```powershell
 New-ConfigurationPublish `
-    -Type PowerShellGallery `
-    -RepositoryName 'CompanyModules' `
+    -JFrogBaseUri 'https://company.jfrog.io/artifactory' `
+    -JFrogRepository 'powershell-virtual' `
+    -RepositoryName 'JFrogPS' `
     -Tool PSResourceGet `
-    -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' `
-    -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' `
-    -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' `
-    -RepositoryCredentialUserName 'publisher' `
-    -RepositoryCredentialSecretFilePath 'C:\Support\Important\CompanyFeedToken.txt' `
-    -Enabled:$true
+    -RepositoryCredentialUserName 'name@company.com' `
+    -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' `
+    -PublishRequiredModules `
+    -RequiredModuleSourceRepository PSGallery `
+    -Enabled
 ```
 
-If the repository also requires a separate NuGet API key for push, add
-`-FilePath` or `-ApiKey` to the publish configuration.
+Behavior:
 
-For production estates, keep using a central enterprise feed such as Azure
-Artifacts as the only trusted runtime source. The recommended flow is:
+1. PSPublishModule reads the built module manifest.
+2. It checks each `RequiredModules` entry in the target repository.
+3. It skips modules listed in `PSData.ExternalModuleDependencies`.
+4. For missing entries, it finds a compatible version in
+   `RequiredModuleSourceRepository`.
+5. It saves that dependency locally and publishes it to the target repository
+   using the target publish credential.
+6. It verifies the dependency is now present, then publishes the main module.
 
-1. Discover Microsoft-owned packages from MAR.
-2. Review, scan, approve, and version-pin them.
-3. Promote the approved packages into the enterprise feed.
-4. Point production automation only at that enterprise feed.
+This is intentionally opt-in. It changes the target feed by adding dependency
+packages. Use it only when your release process is allowed to promote those
+dependencies.
 
-## Enterprise Rollout Checklist
+If the target repository returns `401 Unauthorized` while checking a dependency,
+that is still a repository credential/read-access problem. Dependency mirroring
+only helps after the target feed can be read and written.
 
-For a managed workstation estate, treat PSPublishModule as the operator-facing
-wrapper and leave identity/session ownership with Microsoft tooling:
+## Microsoft Artifact Registry
 
-1. Publish PSPublishModule to the approved bootstrap channel users already trust
-   (PSGallery mirror, Azure Artifacts, Intune package, or internal software
-   distribution).
-2. Ensure users have Azure DevOps access to the target feed through Entra ID
-   groups. Do not create PATs by default.
-3. Let `Initialize-ModuleRepository -InstallPrerequisites` install or refresh
-   `Microsoft.PowerShell.PSResourceGet` at the version required by the selected
-   bootstrap mode and install the Azure Artifacts Credential Provider on Windows
-   workstations. For locked-down estates, mirror `PSPublishModule.Artefacts`
-   into the same private gallery as PSPublishModule so the provider ZIPs are
-   delivered as a normal PowerShell module dependency. On non-Windows systems,
-   pre-install the credential provider with the official Microsoft installer
-   before onboarding.
-4. Create the profile once with `Set-ModuleRepositoryProfile`. Use the default
-   user scope for one-user machines, or `-Scope Machine` from an elevated/admin
-   deployment when the same non-secret feed definition should be visible to all
-   users on the workstation. The profile contains feed identity only; it does
-   not contain PATs, passwords, or tokens.
-5. For managed rollout, export the non-secret profile with
-   `Export-ModuleRepositoryProfile` and ask users or desktop support to run
-   `Initialize-ModuleRepository -Path <profile.json> -ProfileName <name>
-   -Overwrite -InstallPrerequisites` once. This imports or refreshes the
-   profile, registers the repository, probes access, and, when the first
-   ExistingSession probe cannot use a cached token, invokes the Azure Artifacts
-   Credential Provider interactively so the user can complete Entra/MFA and
-   cache a session token for later install/update/publish commands.
-6. If the profile is already deployed into the profile store, use
-   `Initialize-ModuleRepository -ProfileName <name> -InstallPrerequisites`
-   instead. Add `-SkipConnect` when you only want profile/readiness output
-   without repository registration or probing.
-7. Keep `Set-ModuleRepositoryProfile`, `Test-ModuleRepositoryProfile`, and
-   `Connect-ModuleRepository` available as the advanced/manual flow for admins,
-   diagnostics, and constrained rollouts.
-8. Standardize install/update commands around `Install-PrivateModule
-   -ProfileName <name>` and `Update-PrivateModule -ProfileName <name>`.
-   These commands refresh the repository registration and run the same access
-   probe/session-prime step before installing or updating, so an expired Azure
-   Artifacts Credential Provider session can be renewed from the normal
-   day-to-day command in an interactive shell.
-9. For publishers and CI operators, use the same profile with
-   `New-ConfigurationPublish -ProfileName <name>` and `Publish-NugetPackage
-   -ProfileName <name> -InstallPrerequisites` so package push and package
-   consumption resolve the same feed and can bootstrap the same Azure Artifacts
-   credential-provider path.
-10. Run the opt-in live Pester flow against at least one real feed/module before
-   announcing the feed as production-ready.
+Microsoft Artifact Registry (MAR) is the Microsoft-controlled source for
+Microsoft-owned PowerShell packages. It is read-only for consumers and is a
+PSResourceGet container-registry repository.
 
-The normal user command set should be short:
+Use it for discovery/install, not publishing:
 
 ```powershell
-Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
-Install-PrivateModule -ProfileName Company -Name ModuleA
-Update-PrivateModule -ProfileName Company -Name ModuleA
-```
+Register-ModuleRepository -MicrosoftArtifactRegistry
+Connect-ModuleRepository -MicrosoftArtifactRegistry
 
-## Testing Handoff Scenarios
-
-Use this matrix when handing the feature to desktop, platform, or release
-testing. Keep real organization/project/feed names in the test ticket or secure
-run notes, not in committed repository files.
-
-### 1. Static PR Readiness
-
-Purpose: prove the code and non-live behavior are ready before involving an
-enterprise feed.
-
-Run:
-
-```powershell
-dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net8.0
-Invoke-Pester -Path .\Module\Tests\PrivateGallery.Commands.Tests.ps1 -Output Detailed
-Invoke-Pester -Path .\Module\Tests\PrivateGallery.AzureArtifacts.Live.Tests.ps1 -Output Detailed
-```
-
-Expected:
-
-- Build succeeds.
-- Command tests pass.
-- Live Azure Artifacts tests are skipped when live environment variables are
-  not enabled.
-- Pull request checks are green. The live job may be skipped unless explicitly
-  enabled.
-
-### 2. Managed Profile Package
-
-Purpose: prove administrators can prepare non-secret feed metadata without
-sharing credentials.
-
-Run on an admin/staging workstation:
-
-```powershell
-Initialize-ModuleRepository -ProfileName Company -Organization contoso -Project Platform -Feed Modules -SkipConnect
-Export-ModuleRepositoryProfile -Name Company -Path .\Company.profile.json -Force
-New-ModuleRepositoryBootstrap -ProfileName Company -OutputDirectory .\CompanyGalleryBootstrap -InstallModule ModuleA -Force
-```
-
-Expected:
-
-- The exported profile and bootstrap package contain organization, project,
-  feed, and profile settings only.
-- They do not contain PATs, passwords, Entra tokens, or credential-provider
-  session cache files.
-
-### 3. First User Onboarding On A Compliant Workstation
-
-Purpose: prove a normal user can import the profile, register the repository,
-complete Entra/MFA through Azure Artifacts Credential Provider, and install a
-module without PAT parameters.
-
-Run:
-
-```powershell
-Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
-Install-PrivateModule -ProfileName Company -Name ModuleA -InstallPrerequisites
-Update-PrivateModule -ProfileName Company -Name ModuleA
-```
-
-Expected:
-
-- `Initialize-ModuleRepository` reports `Connection.AccessProbeSucceeded =
-  True`.
-- If no token was cached before the run, `Connection.CredentialProviderSessionPrimeAttempted`
-  is true and the provider prompts with an Entra-capable browser/dialog or
-  device-code flow.
-- Install and update succeed without `-CredentialUserName`,
-  `-CredentialSecret`, or `-CredentialSecretFilePath`.
-
-### 4. Existing Or Expired User Session
-
-Purpose: prove day-to-day commands recover when the profile already exists but
-the user's credential-provider cache is missing or expired.
-
-Run as the same user after deleting/expiring the Azure Artifacts Credential
-Provider session cache, or as a second user on a machine that already has the
-profile:
-
-```powershell
-Install-PrivateModule -ProfileName Company -Name ModuleA -InstallPrerequisites
-Update-PrivateModule -ProfileName Company -Name ModuleA
-```
-
-Expected:
-
-- PSPublishModule refreshes/validates repository registration before the
-  operation.
-- If access fails because there is no usable cached session, PSPublishModule
-  invokes Azure Artifacts Credential Provider and retries after successful
-  sign-in.
-- Authentication remains per-user even when the profile was deployed
-  machine-wide.
-
-### 5. Conditional Access Block
-
-Purpose: prove enterprise policy failures are visible and are not confused with
-missing profile data or PAT requirements.
-
-Run scenario 3 from a device/user that can open the Azure DevOps web UI but is
-not allowed by Conditional Access for the package-tool client.
-
-Expected:
-
-- Browser access to Azure DevOps is not treated as sufficient package-tool
-  proof. The browser uses web session cookies; PSResourceGet/NuGet uses Azure
-  Artifacts Credential Provider and its own token/session cache.
-- The credential provider displays or returns the tenant policy failure, for
-  example a "you cannot get there from here" or device-compliance block.
-- PSPublishModule reports the failed access probe/session-prime result without
-  storing credentials.
-- Remediation is policy/device/runner selection, not switching the managed
-  profile to PAT by default.
-
-### 6. Publisher Flow
-
-Purpose: prove publishers can reuse the same managed profile and still keep
-credentials out of configuration.
-
-Run:
-
-```powershell
-New-ConfigurationPublish -ProfileName Company -Enabled
-Publish-NugetPackage -Path .\artifacts -ProfileName Company -InstallPrerequisites -SkipDuplicate
-```
-
-Expected:
-
-- `New-ConfigurationPublish` resolves the Azure Artifacts v3 URI from the
-  profile.
-- The publish configuration does not contain a credential object.
-- Package push succeeds only for a user or automation identity with feed push
-  permission.
-
-### 7. Disposable Live Validation
-
-Purpose: collect one artifact that proves onboarding, install/update, and
-optional push against a real feed.
-
-Run from a compliant workstation or approved self-hosted runner:
-
-```powershell
-$root = Join-Path $env:TEMP ("PSPublishModule.LiveProof." + [guid]::NewGuid().ToString('N'))
-New-Item -ItemType Directory -Path $root -Force | Out-Null
-$evidence = Join-Path $root 'private-gallery-live.evidence.json'
-$version = "0.0.1-live.$([DateTimeOffset]::UtcNow.ToString('yyyyMMddHHmmss'))"
-
-.\Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 `
-    -Organization contoso `
-    -Project Platform `
-    -Feed Modules `
-    -ModuleName ModuleA `
-    -GenerateDisposablePackage `
-    -DisposablePackageName 'PSPublishModule.PrivateGallery.LiveValidation' `
-    -DisposablePackageVersion $version `
-    -CredentialProviderWaitMinutes 30 `
-    -EvidenceFile $evidence `
-    -Output Detailed `
-    -PassThru
-
-$evidence
-```
-
-Expected:
-
-- Evidence JSON has `Succeeded = true`.
-- `OnboardingInstallUpdate` proves access probe, non-secret bootstrap package,
-  bootstrap script execution, credential-free publish configuration, install,
-  and update.
-- `PublishPackage` is present and successful when disposable package publish is
-  enabled.
-- The evidence reports only whether unattended credential-provider environment
-  variables were configured. It never includes secret values.
-
-### 8. Unattended Runner Or Service Principal
-
-Purpose: prove repeatable CI/release validation without a human device-login
-prompt.
-
-Configure one supported Azure Artifacts Credential Provider secret for the
-runner, such as:
-
-- `PSPUBLISHMODULE_AZDO_ARTIFACTS_EXTERNAL_FEED_ENDPOINTS`
-- `PSPUBLISHMODULE_AZDO_ARTIFACTS_FEED_ENDPOINTS`
-- `PSPUBLISHMODULE_AZDO_VSS_NUGET_EXTERNAL_FEED_ENDPOINTS`
-
-Then run the manual `Private Gallery Live Validation` workflow, or dispatch the
-existing `Test & Build Module` workflow with `privateGalleryLiveValidation =
-true`.
-
-Expected:
-
-- The selected runner has policy permission to access the feed.
-- Live validation succeeds without an interactive prompt.
-- Evidence artifacts are uploaded by the workflow.
-
-### 9. PAT Fallback
-
-Purpose: prove the legacy escape hatch still works for constrained tenants
-where Entra/provider-based authentication cannot be used.
-
-Run with a test-only, low-scope, rotated PAT:
-
-```powershell
 Install-PrivateModule `
-    -Name ModuleA `
-    -AzureDevOpsOrganization contoso `
-    -AzureDevOpsProject Platform `
-    -AzureArtifactsFeed Modules `
-    -CredentialUserName user@contoso.com `
-    -CredentialSecretFilePath "$env:USERPROFILE\.secrets\azdo.pat"
+    -MicrosoftArtifactRegistry `
+    -Name Microsoft.PowerShell.SecretManagement
 ```
 
-Expected:
+For production estates, promote approved Microsoft packages into your enterprise
+feed and point production automation at that enterprise feed.
 
-- Install succeeds when PAT permissions are valid.
-- The test record marks this as fallback coverage, not the default enterprise
-  rollout path.
+## Profiles And Deployment
 
-If you distribute a pre-created profile file, redirect the user profile store
-with `POWERFORGE_MODULE_REPOSITORY_PROFILE_PATH`, redirect the machine profile
-store with `POWERFORGE_MODULE_REPOSITORY_MACHINE_PROFILE_PATH`, or place
-`profiles.json` in the default user or machine profile store. Keep that file
-non-secret and user-writable only when users should be allowed to edit profile
-definitions.
-
-Create a profile once:
-
-```powershell
-Set-ModuleRepositoryProfile `
-    -Name Company `
-    -AzureDevOpsOrganization contoso `
-    -AzureDevOpsProject Platform `
-    -AzureArtifactsFeed Modules
-```
-
-Connect and validate access on a workstation with the one-command onboarding
-wrapper:
-
-```powershell
-Initialize-ModuleRepository -ProfileName Company -InstallPrerequisites
-```
-
-Use `Test-ModuleRepositoryProfile` and `Connect-ModuleRepository` directly when
-you want separate readiness and connection/probe steps. The readiness object
-includes both `RecommendedOnboardingCommand` for the managed one-command path
-and `RecommendedConnectCommand` for the lower-level connection step.
-
-Install or update modules by profile:
-
-```powershell
-Install-PrivateModule -ProfileName Company -Name ModuleA, ModuleB -InstallPrerequisites
-Update-PrivateModule -ProfileName Company -Name ModuleA, ModuleB
-```
-
-Use the same profile in module build/publish configuration:
-
-```powershell
-New-ConfigurationPublish -ProfileName Company -Enabled
-```
-
-Direct NuGet package pushes can also resolve the feed from the profile:
-
-```powershell
-Publish-NugetPackage -Path .\artifacts -ProfileName Company -InstallPrerequisites -SkipDuplicate
-```
-
-## Profile Storage
-
-Profiles are stored under the current user's local application data folder:
+Profiles live here by default:
 
 ```text
-%LOCALAPPDATA%\PowerForge\PrivateGalleries\profiles.json
+User:    %LOCALAPPDATA%\PowerForge\PrivateGalleries\profiles.json
+Machine: %ProgramData%\PowerForge\PrivateGalleries\profiles.json
 ```
 
-Machine-wide profiles are stored under the machine common application data
-folder:
+Commands resolve user profiles first, then machine profiles. This lets desktop
+support deploy a non-secret feed definition once while each user still
+authenticates as themselves.
 
-```text
-%ProgramData%\PowerForge\PrivateGalleries\profiles.json
-```
-
-Commands that consume a profile, such as `Install-PrivateModule -ProfileName
-Company`, `Update-PrivateModule`, `Connect-ModuleRepository`,
-`Initialize-ModuleRepository`, `New-ConfigurationPublish`, and
-`Publish-NugetPackage`, resolve user profiles first and then machine-wide
-profiles. This lets desktop support register feed metadata once for everyone
-without sharing anyone's token cache. Each user still authenticates as
-themselves through the Azure Artifacts Credential Provider and Entra/MFA.
-
-Set `POWERFORGE_MODULE_REPOSITORY_PROFILE_PATH` to redirect user profile
-storage in tests or automation. Set
-`POWERFORGE_MODULE_REPOSITORY_MACHINE_PROFILE_PATH` to redirect the machine-wide
-store for tests or managed desktop deployment tooling.
-
-Profiles intentionally do not store PATs, passwords, or Entra tokens. For Azure
-Artifacts, prefer the default profile settings:
-
-- `Tool = PSResourceGet`
-- `BootstrapMode = ExistingSession`
-- `AuthenticationMode = AzureArtifactsCredentialProvider`
-
-`-InstallPrerequisites` honors these Entra-first defaults by upgrading
-PSResourceGet to the ExistingSession-capable line before it installs or refreshes
-the Azure Artifacts Credential Provider.
-
-### Credential Provider Package Source
-
-PowerForge installs the Azure Artifacts Credential Provider from package ZIPs. It
-does not download and execute Microsoft's installer script at runtime.
-
-The preferred enterprise source is `PSPublishModule.Artefacts`, a companion
-package-carrier module that can be published to PSGallery or mirrored into a
-private PowerShell gallery. During `-InstallPrerequisites`, PSPublishModule looks
-for the module locally first, then tries to install it from the configured
-PowerShell repositories, and only then falls back to Microsoft's public release
-package URLs. This lets isolated networks approve and promote one PowerShell
-module instead of managing separate script downloads from `github.com`.
-The carrier manifest includes architecture-specific Windows netcore packages,
-and PSPublishModule selects the package matching the current Windows process
-architecture.
-
-Build and publish the carrier module from this repository:
+Useful profile commands:
 
 ```powershell
-.\Modules\PSPublishModule.Artefacts\Build\Build-Module.ps1
-```
-
-Then publish the packed module to PSGallery or to the private gallery users
-already trust. Workstations can pre-install it, or PSPublishModule can install it
-on demand from the configured repository when `-InstallPrerequisites` runs:
-
-```powershell
-Install-Module PSPublishModule.Artefacts -Repository CompanyGallery
-Initialize-ModuleRepository -ProfileName Company -InstallPrerequisites
-```
-
-Explicit package variables remain available as the override path for file
-shares, internal HTTP artifact caches, or emergency pinning. Configure these
-machine or user environment variables before running `-InstallPrerequisites`:
-
-```powershell
-$env:POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETCORE_PACKAGE = '\\fileserver\packages\Microsoft.win-x64.NuGet.CredentialProvider.zip'
-$env:POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETFX_PACKAGE = '\\fileserver\packages\Microsoft.NetFx48.NuGet.CredentialProvider.zip'
-$env:POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETCORE_SHA256 = '<sha256>'
-$env:POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETFX_SHA256 = '<sha256>'
-```
-
-The package variables may also point at internal HTTPS mirror URLs. Use
-`POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_PACKAGE` only when the same ZIP
-contains every requested runtime folder. The runtime-specific variables are the
-preferred enterprise shape because Microsoft publishes the .NET and .NET
-Framework credential-provider packages as separate release assets. On Windows,
-prefer Microsoft's self-contained `Microsoft.win-*.NuGet.CredentialProvider.zip`
-packages over `Microsoft.Net8.NuGet.CredentialProvider.zip`; the latter requires
-a separately installed .NET runtime. The `netfx` package is kept for Windows
-PowerShell 5.1/.NET Framework compatibility, but it is not self-contained
-either; it requires a supported .NET Framework runtime. PSPublishModule
-preflights the `netfx` provider and reports the runtime requirement before
-trying another detected provider when one is available.
-
-## Managed Profile Deployment
-
-Profile files are safe to treat as configuration, not credentials. An
-administrator can create the profile on a staging machine, export it, and deploy
-that JSON file with Intune, GPO, configuration management, or a bootstrap script:
-
-```powershell
-Initialize-ModuleRepository -ProfileName Company -Organization contoso -Project Platform -Feed Modules -SkipConnect
-Export-ModuleRepositoryProfile -Name Company -Path .\Company.profile.json -Force
-```
-
-For a machine-wide profile installed once by desktop support or software
-distribution, import or create it with `-Scope Machine`:
-
-```powershell
+Test-ModuleRepositoryProfile -ProfileName 'Company'
+Export-ModuleRepositoryProfile -Name 'Company' -Path .\Company.profile.json -Force
 Import-ModuleRepositoryProfile -Path .\Company.profile.json -Scope Machine -Overwrite
-# or
-Set-ModuleRepositoryProfile -Name Company -Organization contoso -Project Platform -Feed Modules -Scope Machine
+Remove-ModuleRepositoryProfile -Name 'Company'
 ```
 
-After that, any user on the workstation can run `Install-PrivateModule
--ProfileName Company -Name ModuleA`. PSPublishModule reads the shared profile,
-but Azure Artifacts authentication remains per-user. If that user has no cached
-session yet, or the session expired, the normal install/update access probe can
-invoke the Azure Artifacts Credential Provider so the user signs in with their
-own Entra ID/MFA.
-
-On the target workstation, import or refresh the profile and connect in one
-step:
-
-```powershell
-Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
-```
-
-When desktop support, Intune, GPO, or another software distribution system
-needs a single folder to deploy, generate a bootstrap package from the saved
-profile:
+Generate a one-folder onboarding package:
 
 ```powershell
 New-ModuleRepositoryBootstrap `
-    -ProfileName Company `
+    -ProfileName 'Company' `
     -OutputDirectory .\CompanyGalleryBootstrap `
-    -InstallModule ModuleA, ModuleB `
+    -InstallModule 'Company.Tools' `
     -Force
 ```
 
-The package contains `profiles.json` and `Initialize-PrivateGallery.ps1`. The
-script imports PSPublishModule when needed, imports the bundled profile,
-installs missing private-gallery prerequisites unless `-SkipInstallPrerequisites`
-is used, connects with `Initialize-ModuleRepository`, and can install approved
-modules through `Install-PrivateModule -ProfileName <name>`. The package remains
-non-secret: it contains feed identity and bootstrap commands only, not PATs,
-passwords, Entra tokens, or Azure Artifacts Credential Provider session caches.
+The package contains feed metadata and bootstrap scripts only. It must not
+contain PATs, passwords, Entra tokens, JFrog tokens, or credential-provider
+session caches.
 
-The imported profile still does not contain secrets. If the user has not signed
-in before, `Initialize-ModuleRepository` and `Connect-ModuleRepository` can
-prime the Azure Artifacts Credential Provider for the feed URI so the user can
-complete Entra/MFA and cache a session token. PSResourceGet itself calls the
-provider in non-interactive mode after that, so the explicit priming step is
-what gives managed workstation onboarding a real prompt/cache path.
+## Validation Checklist
 
-`Install-PrivateModule -ProfileName <name>` and `Update-PrivateModule
--ProfileName <name>` also perform this access probe/session-prime step before
-installing or updating modules. If the cached session expired after onboarding,
-or a different user receives the same non-secret profile, the first normal
-install/update command can invoke the Azure Artifacts Credential Provider again
-and then continue once Entra/MFA succeeds.
+Before announcing a feed as ready:
 
-## PAT Fallback
+1. Register/connect the repository from a clean shell.
+2. Install a known module through `Install-PrivateModule`.
+3. Update the same module through `Update-PrivateModule`.
+4. Generate publish configuration and confirm secrets are not stored.
+5. Publish a disposable package or module version.
+6. If dependency mirroring is enabled, prove a missing dependency is promoted
+   to the target feed before the main module publish.
 
-PAT/basic credential parameters remain available for legacy or constrained
-environments:
-
-```powershell
-Install-PrivateModule `
-    -Name ModuleA `
-    -AzureDevOpsOrganization contoso `
-    -AzureDevOpsProject Platform `
-    -AzureArtifactsFeed Modules `
-    -CredentialUserName user@contoso.com `
-    -CredentialSecretFilePath "$env:USERPROFILE\.secrets\azdo.pat"
-```
-
-Treat this as a fallback, not the default enterprise path. Rotate tokens outside
-PSPublishModule and prefer Microsoft Entra-backed credential-provider login when
-Azure DevOps Services and client tooling support it.
-
-## Other Private Feeds
-
-The profile model is intentionally provider-shaped. Azure Artifacts and JFrog
-have first-class provider paths; generic NuGet v2/v3 feeds and GitHub Packages
-remain available through explicit repository URI and credential parameters.
-When a feed has its own credential policy, keep it explicit in configuration
-instead of overloading the Azure Artifacts credential-provider behavior.
-
-## Live Azure Artifacts Validation
-
-The local test suite includes an opt-in live smoke test that is skipped unless
-explicitly enabled. Use it against a real Azure Artifacts feed that contains at
-least one module the current user may install/update:
+Azure Artifacts live validation helper:
 
 ```powershell
 .\Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 `
     -Organization contoso `
     -Project Platform `
     -Feed Modules `
-    -ModuleName ModuleA `
-    -CredentialProviderWaitMinutes 30 `
-    -OutputFile .\private-gallery-live.xml `
-    -EvidenceFile .\private-gallery-live.evidence.json
-```
-
-The helper sets the required environment variables for the current process,
-runs the Pester harness, optionally writes an NUnit/JUnit result file, and then
-restores the caller's environment, including any existing
-`POWERFORGE_MODULE_REPOSITORY_PROFILE_PATH` override. The helper throws when
-Pester reports failed tests so release operators get a non-zero script outcome
-instead of a false-green live validation. `-EvidenceFile` writes a non-secret
-JSON evidence summary with the provider, organization, project, feed, module,
-profile name, publish opt-in state, Pester counts, optional result-file
-metadata, and sanitized live assertion details such as bootstrap package
-generation, non-secret package contents, bootstrap script execution, access
-probe success, credential-free publish configuration, install/update execution,
-and optional package-push evidence. When `-EvidenceFile` is used, the helper
-also treats missing or incomplete required assertion details as a validation
-failure so the JSON artifact cannot look successful while omitting the evidence
-operators need. For publish proof, use either `-PublishPackagePath` with a
-prebuilt disposable package or `-GenerateDisposablePackage` to create a unique
-non-secret validation package for the run.
-
-The repository also includes a manual GitHub Actions workflow named
-`Private Gallery Live Validation`. Use it when you want the same proof captured
-as a workflow run with downloadable evidence artifacts. Dispatch it with:
-
-- `organization`, `project`, `feed`, and `moduleName` for the Azure Artifacts
-  feed and an existing module to install/update.
-- `generateDisposablePackage = true` when the run should also push a generated
-  disposable package to the feed.
-- `runnerLabels` set to a JSON array for the runner that owns the enterprise
-  authentication policy, for example `["self-hosted","windows"]`.
-
-For a managed repository, define GitHub variables once and leave the matching
-manual inputs blank during dispatch:
-
-- `PSPUBLISHMODULE_AZDO_ORGANIZATION`
-- `PSPUBLISHMODULE_AZDO_PROJECT` for project-scoped feeds
-- `PSPUBLISHMODULE_AZDO_FEED`
-- `PSPUBLISHMODULE_AZDO_MODULE_NAME`
-- `PSPUBLISHMODULE_AZDO_PROFILE_NAME`
-- `PSPUBLISHMODULE_AZDO_RUNNER_LABELS`
-- `PSPUBLISHMODULE_AZDO_DISPOSABLE_PACKAGE_NAME`
-- `PSPUBLISHMODULE_AZDO_DISPOSABLE_PACKAGE_VERSION`
-
-Workflow inputs override variables when both are provided. The pre-merge
-`Test & Build Module` workflow uses the same variable names for its opt-in
-`PrivateGalleryLiveValidation` job.
-
-Before dispatching a live run, check the repository configuration without
-printing any secret values:
-
-```powershell
-.\Module\Tests\Test-PrivateGalleryGitHubLiveValidationConfiguration.ps1 `
-    -Repository EvotecIT/PSPublishModule `
-    -RequireUnattendedCredentialProviderSecret `
-    -Markdown
-```
-
-Use `-NoFail` for a report-only inventory. Without `-NoFail`, the helper fails
-when required variables are missing or, when
-`-RequireUnattendedCredentialProviderSecret` is used, when none of the supported
-Azure Artifacts Credential Provider secret names is present. The Markdown output
-includes concrete `gh variable set`, `gh secret set`, and `gh workflow run`
-command shapes with placeholders so operators can move from inventory to a live
-validation run without putting secret material in profiles, logs, or docs.
-
-Prefer a self-hosted Windows runner that is allowed to use the Azure Artifacts
-Credential Provider and already has a cached or policy-provided identity for
-the target feed. Hosted runners generally do not have the interactive or cached
-enterprise identity context needed to prove the Entra-first path. In unattended
-validation outside a signed-in workstation, configure the Azure Artifacts
-Credential Provider using its supported endpoint environment variables, such as
-`ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS` for access-token based
-automation or `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS` for managed
-identity/service-principal based automation. PSPublishModule does not write
-those secrets into profiles. The included workflows pass through the matching
-GitHub secrets when they exist:
-
-- `PSPUBLISHMODULE_AZDO_ARTIFACTS_EXTERNAL_FEED_ENDPOINTS` to
-  `ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS`
-- `PSPUBLISHMODULE_AZDO_ARTIFACTS_FEED_ENDPOINTS` to
-  `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS`
-- `PSPUBLISHMODULE_AZDO_VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` to the legacy
-  `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS`
-
-The evidence JSON and step summary report only whether each unattended
-credential-provider endpoint variable was configured, never the secret value.
-The workflow adds a non-secret run summary from the evidence JSON and uploads
-`private-gallery-live.xml` and `private-gallery-live.evidence.json` as the
-`private-gallery-live-validation` artifact.
-
-Because GitHub only exposes brand-new `workflow_dispatch` workflows after the
-workflow file exists on the default branch, pre-merge validation can also run
-through the existing `Test & Build Module` workflow (`BuildModule.yml`). Dispatch
-that workflow against the feature branch and set:
-
-- `privateGalleryLiveValidation = true`
-- `privateGalleryOrganization`, `privateGalleryProject`, `privateGalleryFeed`,
-  and `privateGalleryModuleName`
-- `privateGalleryGenerateDisposablePackage = true` when package-push proof is
-  required
-- `privateGalleryRunnerLabels` to the approved runner JSON array
-
-That gated job uses the same validation helper, writes the same step summary,
-and uploads the same evidence artifact. Normal push and pull request runs do not
-run the live Azure Artifacts job.
-
-To run the harness directly, set:
-
-```powershell
-$env:PSPUBLISHMODULE_AZDO_LIVE = '1'
-$env:PSPUBLISHMODULE_AZDO_ORGANIZATION = 'contoso'
-$env:PSPUBLISHMODULE_AZDO_PROJECT = 'Platform'
-$env:PSPUBLISHMODULE_AZDO_FEED = 'Modules'
-$env:PSPUBLISHMODULE_AZDO_MODULE_NAME = 'ModuleA'
-
-Invoke-Pester -Path .\Module\Tests\PrivateGallery.AzureArtifacts.Live.Tests.ps1 -Output Detailed
-```
-
-The live test creates a temporary profile store, exports a non-secret managed
-profile file, imports/connects it with `Initialize-ModuleRepository`, verifies
-profile-backed publish configuration, then calls `Install-PrivateModule` and
-`Update-PrivateModule` through the saved profile.
-
-Recommended production-readiness evidence:
-
-- `Initialize-ModuleRepository -Path <profile.json> -ProfileName <name>
-  -Overwrite -InstallPrerequisites` succeeds on a clean user workstation and
-  reports `Connection.AccessProbeSucceeded = True`. If no cached token existed
-  before the first probe, `Connection.CredentialProviderSessionPrimeAttempted`
-  shows whether PSPublishModule invoked the provider to prime the Entra-backed
-  session before retrying.
-- `Install-PrivateModule -ProfileName <name> -Name <known module>` succeeds with
-  no PAT or explicit credential parameters.
-- `Update-PrivateModule -ProfileName <name> -Name <known module>` succeeds for
-  an installed private module.
-- `New-ConfigurationPublish -ProfileName <name> -Enabled` produces a repository
-  configuration with an Azure Artifacts v3 URI and no stored credential.
-- `Publish-NugetPackage -ProfileName <name>` succeeds for a disposable package
-  when package-push validation is intentionally enabled with
-  `-PublishPackagePath` or `-GenerateDisposablePackage`.
-
-To prove a real package push as well, opt in separately. This mutates the target
-feed, so it is intentionally not part of the default live smoke. The simplest
-operator path is to let the helper create a disposable package with a timestamp
-version:
-
-```powershell
-.\Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 `
-    -Organization contoso `
-    -Project Platform `
-    -Feed Modules `
-    -ModuleName ModuleA `
+    -ModuleName Company.Tools `
     -GenerateDisposablePackage `
-    -OutputFile .\private-gallery-live-publish.xml `
-    -EvidenceFile .\private-gallery-live-publish.evidence.json
+    -EvidenceFile .\private-gallery-live.evidence.json `
+    -Output Detailed `
+    -PassThru
 ```
 
-You can also supply a prebuilt package:
+JFrog SSO/credential evidence helper:
 
 ```powershell
-.\Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 `
-    -Organization contoso `
-    -Project Platform `
-    -Feed Modules `
-    -ModuleName ModuleA `
-    -PublishPackagePath 'C:\Temp\Company.Tools.1.0.0.nupkg' `
-    -OutputFile .\private-gallery-live-publish.xml `
-    -EvidenceFile .\private-gallery-live-publish.evidence.json
+.\Module\Tests\Invoke-PrivateGalleryJFrogSsoValidation.ps1 `
+    -JFrogBaseUri https://company.jfrog.io/artifactory `
+    -Repository powershell-virtual `
+    -ModuleName Company.Tools `
+    -RunJFrogCliLogin `
+    -EvidenceFile .\jfrog-sso.evidence.json `
+    -MarkdownFile .\jfrog-sso.evidence.md
 ```
+
+Keep real organization, feed, repository, and module names in secure run notes
+or test tickets when they are not safe for committed docs.

--- a/Docs/PSPublishModule.PrivateGalleries.md
+++ b/Docs/PSPublishModule.PrivateGalleries.md
@@ -403,6 +403,10 @@ New-ConfigurationPublish `
     -Enabled
 ```
 
+Dependency mirroring requires `PSResourceGet`. If a configuration uses
+`-PublishRequiredModules -Tool PowerShellGet`, the publish run fails early with
+a clear error instead of silently skipping dependency mirroring.
+
 Behavior:
 
 1. PSPublishModule reads the built module manifest.

--- a/Module/Docs/About/README.md
+++ b/Module/Docs/About/README.md
@@ -8,4 +8,4 @@ This folder is generated from `about_*.help.txt` and `about_*.txt` source files.
 
 - [about_ModuleDependencies](about_ModuleDependencies.md) - Explains how module dependencies are declared, resolved, installed, and packaged in PSPublishModule builds.
 - [about_ModuleLifecycleActions](about_ModuleLifecycleActions.md) - Explains module build lifecycle actions, their stage ordering, and the JSON context passed to action scripts.
-- [about_PrivateGalleries](about_PrivateGalleries.md) - Explains the enterprise private gallery profile flow for Azure Artifacts and PSPublishModule.
+- [about_PrivateGalleries](about_PrivateGalleries.md) - Explains how PSPublishModule consumes and publishes private PowerShell modules from NuGet-compatible feeds, Azure Artifacts, JFrog Artifactory, GitHub Packages, and Microsoft Artifact Registry.

--- a/Module/Docs/About/about_PrivateGalleries.md
+++ b/Module/Docs/About/about_PrivateGalleries.md
@@ -166,6 +166,10 @@ Opt in to dependency mirroring:
 New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled
 ```
 
+Dependency mirroring requires PSResourceGet. If a configuration uses
+PublishRequiredModules with Tool PowerShellGet, the publish run fails early
+with a clear error instead of silently skipping dependency mirroring.
+
 The publish flow checks RequiredModules in the target feed, skips modules
 listed in PSData.ExternalModuleDependencies, saves a compatible dependency
 from RequiredModuleSourceRepository, publishes it to the target, verifies it

--- a/Module/Docs/About/about_PrivateGalleries.md
+++ b/Module/Docs/About/about_PrivateGalleries.md
@@ -6,406 +6,269 @@ schema: 1.0.0
 
 ## Short Description
 
-Explains the enterprise private gallery profile flow for Azure Artifacts and PSPublishModule.
+Explains how PSPublishModule consumes and publishes private PowerShell modules
+from NuGet-compatible feeds, Azure Artifacts, JFrog Artifactory, GitHub
+Packages, and Microsoft Artifact Registry.
 
 ## Long Description
 
-PSPublishModule supports an Entra-first private gallery workflow for Azure Artifacts feeds.
-The intended enterprise flow is:
+PSPublishModule treats private PowerShell galleries as NuGet-compatible
+repositories with a small set of reusable command shapes:
 
-1. Save or import non-secret feed settings in a local PSPublishModule profile.
-2. Let Microsoft.PowerShell.PSResourceGet and the Azure Artifacts Credential Provider own Entra ID, MFA,
-device login, and token/session caching.
-3. Use Initialize-ModuleRepository as the one-command workstation onboarding entry point.
-4. Use the saved profile for install, update, and publish configuration commands.
+- generic NuGet-compatible feeds when you know the source/publish URLs
+- Azure Artifacts profiles for Entra ID/MFA and the Azure Artifacts
+Credential Provider
+- JFrog Artifactory shortcuts that derive the NuGet URLs for you
+- GitHub Packages profiles for GitHub-hosted NuGet feeds
+- Microsoft Artifact Registry for read-only Microsoft package intake
 
-Profiles are created with Initialize-ModuleRepository or Set-ModuleRepositoryProfile. A profile stores feed
-identity and local behavior:
+Use PSResourceGet unless you have a specific reason to support an older
+PowerShellGet-only feed. Profiles store repository shape and local behavior
+only. They do not store PATs, passwords, Entra tokens, JFrog tokens, or
+credential-provider session caches.
 
-- Azure DevOps organization
-- optional Azure DevOps project
-- Azure Artifacts feed
-- local repository name
-- preferred repository tool
-- bootstrap mode
-- repository trust and priority settings
+STANDARD NUGET-COMPATIBLE FEEDS
 
-Profiles intentionally do not store PATs, passwords, or Entra tokens. The default Azure Artifacts profile uses:
+Use the generic NuGet-compatible path for feeds such as Nexus, ProGet,
+GitHub Packages, internal NuGet servers, or JFrog when you prefer to provide
+the URLs yourself.
+
+If the feed expects a NuGet API key for push:
 
 ```powershell
-Tool           = PSResourceGet
-BootstrapMode  = ExistingSession
-Authentication = AzureArtifactsCredentialProvider
+New-ConfigurationPublish -Type PowerShellGallery -RepositoryName 'CompanyModules' -Tool PSResourceGet -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' -FilePath "$env:USERPROFILE\.secrets\company-nuget-api-key.txt" -Enabled
 ```
 
-When PSResourceGet registration supports it, PSPublishModule configures Azure Artifacts repositories with
-CredentialProvider = AzArtifacts. Older PSResourceGet versions fall back to their built-in Azure Artifacts URL
-detection.
-Install-prerequisite flows honor the selected bootstrap mode. For the default ExistingSession profile, they
-upgrade PSResourceGet to the ExistingSession-capable line before installing or refreshing the Azure Artifacts
-Credential Provider.
+If the feed uses basic/PAT credentials, create a non-secret profile and pass
+the credential when publishing:
+
+```powershell
+Set-ModuleRepositoryProfile -Name 'CompanyNuGet' -Provider NuGet -RepositoryName 'CompanyModules' -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' -Tool PSResourceGet
+```
+
+```powershell
+New-ConfigurationPublish -ProfileName 'CompanyNuGet' -RepositoryCredentialUserName 'publisher' -RepositoryCredentialSecretEnvironmentVariable 'COMPANY_NUGET_TOKEN' -Enabled
+```
+
+AZURE ARTIFACTS
+
+Azure Artifacts is the preferred enterprise flow when users should
+authenticate through Entra ID/MFA instead of PATs. PSPublishModule stores
+the organization, project, feed, repository name, and tool/bootstrap
+preference. Authentication remains owned by PSResourceGet and the Azure
+Artifacts Credential Provider.
+
+Create a profile:
+
+```powershell
+Set-ModuleRepositoryProfile -Name 'Company' -AzureDevOpsOrganization 'contoso' -AzureDevOpsProject 'Platform' -AzureArtifactsFeed 'Modules'
+```
+
+Onboard a workstation:
+
+```powershell
+Initialize-ModuleRepository -ProfileName 'Company' -InstallPrerequisites
+```
+
+Install and update modules:
+
+```powershell
+Install-PrivateModule -ProfileName 'Company' -Name 'Company.Tools' -InstallPrerequisites
+Update-PrivateModule  -ProfileName 'Company' -Name 'Company.Tools'
+```
+
+Publish a module:
+
+```powershell
+New-ConfigurationPublish -AzureDevOpsOrganization 'contoso' -AzureDevOpsProject 'Platform' -AzureArtifactsFeed 'Modules' -RepositoryName 'CompanyModules' -Tool PSResourceGet -Enabled
+```
+
+Or use the saved profile:
+
+```powershell
+New-ConfigurationPublish -ProfileName 'Company' -Enabled
+```
+
+Push plain NuGet packages through the same profile:
+
+```powershell
+Publish-NugetPackage -Path .\artifacts -ProfileName 'Company' -InstallPrerequisites -SkipDuplicate
+```
+
+PAT/basic parameters remain available for constrained environments, but
+they are a fallback. Prefer the Azure Artifacts Credential Provider when
+Azure DevOps Services and workstation policy allow it.
+
+JFROG ARTIFACTORY
+
+JFrog can be configured as a generic NuGet feed, or with JFrog shortcut
+parameters. Given:
+
+```powershell
+JFrogBaseUri    = https://company.jfrog.io/artifactory
+JFrogRepository = powershell-virtual
+```
+
+PSPublishModule derives:
+
+PSResourceGet v3:
+https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json
+
+PowerShellGet v2 source/publish:
+https://company.jfrog.io/artifactory/api/nuget/powershell-virtual
+
+For PAT/access-token publishing where the same token can read and push:
+
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
+```
+
+For local testing, inline clear text works but must not be committed:
+
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled
+```
+
+If Artifactory requires a separate NuGet API key for package push, add
+FilePath or ApiKey:
+
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
+```
+
+For federated CI, use JFrog OIDC token exchange. PSPublishModule calls
+JFrog CLI at publish time and passes the exchanged short-lived credential
+to repository tooling:
+
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled
+```
+
+For interactive workstation proof, use JFrog CLI bootstrap mode:
+
+```powershell
+Connect-ModuleRepository -Provider JFrog -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -Name 'JFrogPS' -Tool PSResourceGet -BootstrapMode JFrogCli -InstallPrerequisites -Verbose
+```
+
+This runs jf login and then probes whether PowerShell repository tooling can
+use that session. It is useful for troubleshooting, but it is not the default
+CI publish shape.
+
+PUBLISHING MISSING REQUIREDMODULES
+
+Private feeds often start empty. If a module manifest contains
+RequiredModules, publishing the main module can fail because the dependency
+is not yet in the target feed.
+
+Opt in to dependency mirroring:
+
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled
+```
+
+The publish flow checks RequiredModules in the target feed, skips modules
+listed in PSData.ExternalModuleDependencies, saves a compatible dependency
+from RequiredModuleSourceRepository, publishes it to the target, verifies it
+is present, and then publishes the main module.
+
+This changes the target feed, so it is explicit. If the target repository
+returns 401 Unauthorized while checking a dependency, fix repository
+credentials first. Dependency mirroring only helps after the target feed can
+be read and written.
+
+MICROSOFT ARTIFACT REGISTRY
+
+Microsoft Artifact Registry is a read-only PSResourceGet
+container-registry repository for Microsoft-owned PowerShell packages.
+
+```powershell
+Register-ModuleRepository -MicrosoftArtifactRegistry
+Connect-ModuleRepository -MicrosoftArtifactRegistry
+Install-PrivateModule -MicrosoftArtifactRegistry -Name Microsoft.PowerShell.SecretManagement
+```
+
+Do not use MAR as a publish target. For production estates, promote approved
+Microsoft packages into your enterprise feed.
 
 PROFILE STORAGE
 
-Profile data is stored under the current user's local application data folder:
+User profiles:
 
 ```powershell
 %LOCALAPPDATA%\PowerForge\PrivateGalleries\profiles.json
 ```
 
-Machine-wide profile data is stored under the machine common application data folder:
+Machine profiles:
 
 ```powershell
 %ProgramData%\PowerForge\PrivateGalleries\profiles.json
 ```
 
-Commands that consume a profile read user profiles first and then machine-wide profiles. This lets desktop
-support register feed metadata once for all users without sharing credentials. Each user still authenticates as
-themselves through the Azure Artifacts Credential Provider and Entra/MFA.
+Commands read user profiles first, then machine profiles. This allows
+desktop support to deploy non-secret feed metadata while each user still
+authenticates as themselves.
 
-Set POWERFORGE_MODULE_REPOSITORY_PROFILE_PATH when tests, managed desktop rollout tooling, or ephemeral build
-agents need to redirect user profile storage. Set POWERFORGE_MODULE_REPOSITORY_MACHINE_PROFILE_PATH to redirect
-the machine-wide profile store for tests or managed deployment tooling.
-
-ENTERPRISE ROLLOUT CHECKLIST
-
-For a managed workstation estate, keep PSPublishModule as the wrapper and leave identity/session ownership with
-Microsoft tooling:
-
-1. Publish PSPublishModule through the approved bootstrap channel users already trust.
-2. Grant Azure DevOps feed access through Entra ID groups. Do not create PATs by default.
-3. Use Initialize-ModuleRepository -InstallPrerequisites to install or refresh PSResourceGet at the version
-required by the selected bootstrap mode and install the Azure Artifacts Credential Provider on Windows
-workstations. For locked-down estates, mirror PSPublishModule.Artefacts into the same private gallery as
-PSPublishModule so the provider ZIPs are delivered as a normal PowerShell module dependency. Pre-install
-the credential provider on non-Windows systems with Microsoft's installer. On Windows, prefer Microsoft's
-self-contained Microsoft.win-*.NuGet.CredentialProvider.zip packages over Microsoft.Net8.NuGet.CredentialProvider.zip
-when mirroring packages manually, because the Net8 package requires a separately installed .NET runtime.
-The netfx package is kept for Windows PowerShell 5.1/.NET Framework compatibility, but it is not
-self-contained either; it requires a supported .NET Framework runtime.
-4. Create the feed profile once with Set-ModuleRepositoryProfile. Use -Scope Machine from an elevated/admin
-deployment when the same non-secret feed definition should be visible to all users on the workstation.
-5. For managed rollout, export the non-secret profile with Export-ModuleRepositoryProfile and ask users or
-desktop support to run Initialize-ModuleRepository -Path <profile.json> -ProfileName <name> -Overwrite
--InstallPrerequisites once. This imports or refreshes the profile, registers the repository, probes
-access, and, when the first ExistingSession probe cannot use a cached token, invokes the Azure Artifacts
-Credential Provider interactively so the user can complete Entra/MFA and cache a session token.
-6. If the profile is already deployed into the profile store, use
+Useful commands:
 
 ```powershell
-Initialize-ModuleRepository -ProfileName <name> -InstallPrerequisites instead. Add -SkipConnect when you
-```
-
-only want profile/readiness output without repository registration or probing.
-7. Keep Set-ModuleRepositoryProfile, Test-ModuleRepositoryProfile, and Connect-ModuleRepository available as
-the advanced/manual flow for admins, diagnostics, and constrained rollouts.
-8. Standardize user commands around Install-PrivateModule -ProfileName <name> and
-
-```powershell
-Update-PrivateModule -ProfileName <name>. These commands refresh repository registration and perform the
-```
-
-same access probe/session-prime step before install/update, so an expired Azure Artifacts Credential
-Provider session can be renewed from the normal day-to-day command in an interactive shell.
-9. Use the same profile for New-ConfigurationPublish -ProfileName <name> and
-
-```powershell
-Publish-NugetPackage -ProfileName <name> -InstallPrerequisites so publishing and consuming resolve the
-```
-
-same feed and can bootstrap the same Azure Artifacts credential-provider path.
-10. Run the opt-in live Pester flow against a real feed/module before announcing the feed as production-ready.
-
-RECOMMENDED WORKSTATION FLOW
-
-Create and connect a profile directly:
-
-```powershell
-Initialize-ModuleRepository -ProfileName Company -Organization contoso -Project Platform -Feed Modules -InstallPrerequisites
-```
-
-Import a managed profile file and connect the workstation:
-
-```powershell
-Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
-```
-
-Use Test-ModuleRepositoryProfile and Connect-ModuleRepository directly when separate readiness and
-connection/probe steps are desired. The readiness object includes RecommendedOnboardingCommand for the managed
-one-command path and RecommendedConnectCommand for the lower-level connection step.
-
-Install or update modules:
-
-```powershell
-Install-PrivateModule -ProfileName Company -Name ModuleA, ModuleB -InstallPrerequisites
-Update-PrivateModule -ProfileName Company -Name ModuleA, ModuleB
-```
-
-Use the same profile in publish configuration:
-
-```powershell
-New-ConfigurationPublish -ProfileName Company -Enabled
-```
-
-Direct NuGet package pushes can also resolve the feed from the profile:
-
-```powershell
-Publish-NugetPackage -Path .\artifacts -ProfileName Company -InstallPrerequisites -SkipDuplicate
-```
-
-MANAGED PROFILE DEPLOYMENT
-
-Profile files are configuration, not credentials. An administrator can create the profile once, export it, and
-deploy the JSON file with Intune, GPO, configuration management, or a bootstrap script:
-
-```powershell
-Export-ModuleRepositoryProfile -Name Company -Path .\Company.profile.json -Force
-```
-
-For a machine-wide profile installed once by desktop support or software distribution, import or create it with
--Scope Machine:
-
-```powershell
+Test-ModuleRepositoryProfile -ProfileName 'Company'
+Export-ModuleRepositoryProfile -Name 'Company' -Path .\Company.profile.json -Force
 Import-ModuleRepositoryProfile -Path .\Company.profile.json -Scope Machine -Overwrite
-Set-ModuleRepositoryProfile -Name Company -Organization contoso -Project Platform -Feed Modules -Scope Machine
+New-ModuleRepositoryBootstrap -ProfileName 'Company' -OutputDirectory .\CompanyGalleryBootstrap -InstallModule 'Company.Tools' -Force
 ```
 
-After that, any user on the workstation can run Install-PrivateModule -ProfileName Company -Name ModuleA.
-PSPublishModule reads the shared profile, but Azure Artifacts authentication remains per-user. If that user has
-no cached session yet, or the session expired, the normal install/update access probe can invoke the Azure
-Artifacts Credential Provider so the user signs in with their own Entra ID/MFA.
+VALIDATION
 
-For a deployable one-folder workstation package, use:
+Before calling a feed ready:
+
+1. Register/connect the repository from a clean shell.
+2. Install a known module with Install-PrivateModule.
+3. Update the module with Update-PrivateModule.
+4. Generate publish configuration and confirm secrets are not stored.
+5. Publish a disposable package or module version.
+6. If PublishRequiredModules is enabled, prove a missing dependency is
+promoted before the main module publish.
+
+Azure Artifacts live validation:
 
 ```powershell
-New-ModuleRepositoryBootstrap -ProfileName Company -OutputDirectory .\CompanyGalleryBootstrap -InstallModule ModuleA, ModuleB -Force
+.\Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 -Organization contoso -Project Platform -Feed Modules -ModuleName Company.Tools -GenerateDisposablePackage -EvidenceFile .\private-gallery-live.evidence.json -Output Detailed -PassThru
 ```
 
-The generated package contains profiles.json and Initialize-PrivateGallery.ps1. The script imports PSPublishModule
-when needed, imports the bundled profile, installs missing private-gallery prerequisites unless
--SkipInstallPrerequisites is used, connects with Initialize-ModuleRepository, and can install approved modules
-through Install-PrivateModule -ProfileName <name>. The package remains non-secret: it contains feed identity and
-bootstrap commands only, not PATs, passwords, Entra tokens, or Azure Artifacts Credential Provider session caches.
-
-On the target workstation, import or refresh the profile and connect in one step:
+JFrog SSO/credential validation:
 
 ```powershell
-Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
+.\Module\Tests\Invoke-PrivateGalleryJFrogSsoValidation.ps1 -JFrogBaseUri https://company.jfrog.io/artifactory -Repository powershell-virtual -ModuleName Company.Tools -RunJFrogCliLogin -EvidenceFile .\jfrog-sso.evidence.json -MarkdownFile .\jfrog-sso.evidence.md
 ```
-
-The imported profile still does not contain PATs, passwords, or tokens. If the user has not signed in before,
-Initialize-ModuleRepository and Connect-ModuleRepository can prime the Azure Artifacts Credential Provider
-session for the feed URI. PSResourceGet calls the provider non-interactively after that, so the explicit priming
-step is what gives managed workstation onboarding a real Entra/MFA prompt/cache path.
-
-CREDENTIAL PROVIDER PACKAGE SOURCE
-
-PowerForge installs the Azure Artifacts Credential Provider from package ZIPs. It does not download and execute
-Microsoft's installer script at runtime.
-
-The preferred enterprise source is PSPublishModule.Artefacts, a companion package-carrier module that can be
-published to PSGallery or mirrored into a private PowerShell gallery. During -InstallPrerequisites,
-PSPublishModule looks for the module locally first, then tries to install it from the configured PowerShell
-repositories, and only then falls back to Microsoft's public release package URLs. This lets isolated networks
-approve and promote one PowerShell module instead of managing separate script downloads from github.com.
-The carrier manifest includes architecture-specific Windows netcore packages, and PSPublishModule selects the
-package matching the current Windows process architecture.
-
-```powershell
-.\Modules\PSPublishModule.Artefacts\Build\Build-Module.ps1
-Install-Module PSPublishModule.Artefacts -Repository CompanyGallery
-Initialize-ModuleRepository -ProfileName Company -InstallPrerequisites
-```
-
-Explicit package variables remain available as the override path for file shares, internal HTTP artifact caches,
-or emergency pinning. Configure these machine or user environment variables before running -InstallPrerequisites:
-
-```powershell
-POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETCORE_PACKAGE
-POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETFX_PACKAGE
-POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETCORE_SHA256
-POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETFX_SHA256
-```
-
-The package variables may point at local paths, UNC paths, or internal HTTPS mirror URLs. Use
-POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_PACKAGE only when the same ZIP contains every requested runtime
-folder. The runtime-specific variables are the preferred enterprise shape because Microsoft publishes the .NET
-and .NET Framework credential-provider packages as separate release assets.
-
-```powershell
-Install-PrivateModule -ProfileName <name> and Update-PrivateModule -ProfileName <name> also perform this access
-```
-
-probe/session-prime step before installing or updating modules. If the cached session expired after onboarding,
-or a different user receives the same non-secret profile, the first normal install/update command can invoke the
-Azure Artifacts Credential Provider again and then continue once Entra/MFA succeeds.
-
-PRODUCTION READINESS EVIDENCE
-
-Before calling a feed ready for users, prove:
-
-- Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 succeeds against the real feed/module
-and writes a non-secret evidence JSON file with -EvidenceFile. The evidence should include bootstrap package
-generation, non-secret package contents, bootstrap script execution, the access probe,
-credential-free publish configuration, install/update, and optional package-push checks.
-Missing or incomplete required evidence details make the helper fail so the JSON cannot look successful
-while omitting the proof operators need. For package-push proof, use -GenerateDisposablePackage or pass
-a prebuilt disposable package with -PublishPackagePath.
-- The manual GitHub Actions workflow named Private Gallery Live Validation succeeds on a runner that owns
-the enterprise Azure Artifacts credential-provider policy. Prefer runnerLabels = ["self-hosted","windows"]
-or another approved self-hosted runner because hosted runners usually cannot prove cached Entra-backed
-feed access. For managed repository defaults, define GitHub variables once and leave matching manual
-inputs blank during dispatch:
-
-```powershell
-PSPUBLISHMODULE_AZDO_ORGANIZATION
-PSPUBLISHMODULE_AZDO_PROJECT
-PSPUBLISHMODULE_AZDO_FEED
-PSPUBLISHMODULE_AZDO_MODULE_NAME
-PSPUBLISHMODULE_AZDO_PROFILE_NAME
-PSPUBLISHMODULE_AZDO_RUNNER_LABELS
-PSPUBLISHMODULE_AZDO_DISPOSABLE_PACKAGE_NAME
-PSPUBLISHMODULE_AZDO_DISPOSABLE_PACKAGE_VERSION
-```
-
-Workflow inputs override variables when both are provided. For unattended validation, configure the Azure
-Artifacts Credential Provider with
-ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS for access-token based automation or
-ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS for managed identity/service-principal based automation. Do
-not put those secrets in PSPublishModule profiles. The included workflows pass through these GitHub
-secrets when present:
-
-```powershell
-PSPUBLISHMODULE_AZDO_ARTIFACTS_EXTERNAL_FEED_ENDPOINTS -> ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS
-PSPUBLISHMODULE_AZDO_ARTIFACTS_FEED_ENDPOINTS -> ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS
-PSPUBLISHMODULE_AZDO_VSS_NUGET_EXTERNAL_FEED_ENDPOINTS -> VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
-```
-
-The evidence JSON and step summary report only whether each unattended credential-provider endpoint
-variable was configured, never the secret value. The workflow writes a non-secret run summary and uploads
-the XML/evidence JSON artifacts for release records.
-- Before dispatching a live run, check the repository configuration without printing any secret values:
-
-```powershell
-.\Module\Tests\Test-PrivateGalleryGitHubLiveValidationConfiguration.ps1 `
--Repository EvotecIT/PSPublishModule `
--RequireUnattendedCredentialProviderSecret `
--Markdown
-```
-
-Use -NoFail for a report-only inventory. Without -NoFail, the helper fails when required variables are
-missing or, when -RequireUnattendedCredentialProviderSecret is used, when none of the supported Azure
-Artifacts Credential Provider secret names is present. The Markdown output includes suggested gh variable
-set, gh secret set, and gh workflow run command shapes with placeholders so operators can move from inventory
-to a live run without putting secret material in profiles, logs, or docs.
-- Before the new standalone workflow exists on the default branch, dispatch the existing Test & Build Module
-workflow against the feature branch with privateGalleryLiveValidation = true. That gated job uses the same
-helper, summary, and artifact path and does not run during normal push or pull request builds.
-- Initialize-ModuleRepository -Path <profile.json> -ProfileName <name> -Overwrite -InstallPrerequisites
-succeeds on a clean workstation and reports Connection.AccessProbeSucceeded = True. If no cached token
-existed before the first probe, Connection.CredentialProviderSessionPrimeAttempted shows whether
-PSPublishModule invoked the provider to prime the Entra-backed session before retrying.
-- Install-PrivateModule -ProfileName <name> -Name <known module> succeeds with no PAT or explicit
-credential parameters.
-- Update-PrivateModule -ProfileName <name> -Name <known module> succeeds for an installed private module.
-- New-ConfigurationPublish -ProfileName <name> -Enabled produces an Azure Artifacts v3 URI and no stored
-credential.
-- Publish-NugetPackage -ProfileName <name> succeeds for a disposable package when package-push validation
-is intentionally enabled with -GenerateDisposablePackage or -PublishPackagePath.
-
-PAT FALLBACK
-
-PAT/basic credential parameters remain available for legacy or constrained environments, but they are not the
-preferred enterprise path. Prefer the Azure Artifacts Credential Provider whenever Azure DevOps Services and
-workstation policy allow it.
-
-JFROG AND OTHER PRIVATE FEEDS
-
-JFrog and generic NuGet feeds use the same profile surface, but they do not use the Azure Artifacts
-Credential Provider. A JFrog profile can be created with:
-
-```powershell
-Set-ModuleRepositoryProfile -Name CompanyJfrog -Provider JFrog -Repository powershell-virtual -JFrogBaseUri https://company.jfrog.io/artifactory
-```
-
-For credential-based usage, pass CredentialUserName plus CredentialSecret/CredentialSecretFilePath, or prompt
-interactively. If the JFrog instance is SAML/SSO-backed, the web login may be used to obtain or refresh a
-JFrog token, but PowerShellGet and PSResourceGet still need NuGet-compatible authentication unless the local
-environment provides a working bridge.
-
-PSPublishModule also supports an explicit experimental JFrog CLI bridge mode:
-
-```powershell
-Initialize-ModuleRepository -ProfileName CompanyJfrog -Provider JFrog -Repository powershell-virtual -JFrogBaseUri https://company.jfrog.io/artifactory -BootstrapMode JFrogCli -InstallPrerequisites
-```
-
-This mode runs jf login interactively and then retries the repository probe. If JFrog CLI login succeeds but
-PSResourceGet still cannot read the NuGet feed, the connection result reports JFrogCliLoginSucceeded = True
-and AccessProbeSucceeded = False with a message explaining that the JFrog CLI session was not consumed by
-PowerShellGet/PSResourceGet. That gives support a precise error boundary instead of silently falling back.
-
-To prove whether JFrog CLI browser login can bridge to PSResourceGet on a real workstation, run:
-
-```powershell
-.\Module\Tests\Invoke-PrivateGalleryJFrogSsoValidation.ps1 -JFrogBaseUri https://company.jfrog.io/artifactory -Repository powershell-virtual -ModuleName ModuleA -RunJFrogCliLogin -EvidenceFile .\jfrog-sso.evidence.json -MarkdownFile .\jfrog-sso.evidence.md
-```
-
-The helper writes non-secret JSON/Markdown evidence showing whether jf login succeeded, whether PSResourceGet
-could find the module without explicit credentials, and whether the explicit credential fallback works when
-CredentialUserName plus CredentialSecret/CredentialSecretFilePath are supplied.
 
 ## Examples
 
 
 ```powershell
+PS> New-ConfigurationPublish -Type PowerShellGallery -RepositoryName CompanyModules -Tool PSResourceGet -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' -FilePath "$env:USERPROFILE\.secrets\company-nuget-api-key.txt" -Enabled
+```
+
+Configures a standard NuGet-compatible private feed that uses a NuGet API key for package push.
+
+```powershell
 PS> Initialize-ModuleRepository -ProfileName Company -Organization contoso -Project Platform -Feed Modules -InstallPrerequisites
 ```
 
-Saves an Entra-first Azure Artifacts profile named Company, installs missing prerequisites if needed, registers
-the repository, and validates authenticated feed access.
+Creates and connects an Azure Artifacts profile with Entra/MFA-capable credential-provider authentication.
 
 ```powershell
-PS> Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
+PS> New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
 ```
 
-Imports or refreshes a managed profile file, then registers and probes the repository.
+Configures JFrog Artifactory publishing with PAT/access-token authentication provided from an environment variable.
 
 ```powershell
-PS> Connect-ModuleRepository -ProfileName Company -InstallPrerequisites
+PS> New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled
 ```
 
-Runs the lower-level connection/probe step for an already saved profile.
-
-```powershell
-PS> Test-ModuleRepositoryProfile -ProfileName Company
-```
-
-Checks saved profile and local prerequisite readiness without changing repository registrations.
-
-```powershell
-PS> Export-ModuleRepositoryProfile -Name Company -Path .\Company.profile.json -Force
-```
-
-Exports the non-secret Company profile for managed rollout.
-
-```powershell
-PS> Import-ModuleRepositoryProfile -Path .\Company.profile.json -Overwrite
-```
-
-Imports or refreshes managed profile settings on a workstation without connecting.
-
-```powershell
-PS> Install-PrivateModule -ProfileName Company -Name ModuleA -InstallPrerequisites
-```
-
-Installs ModuleA from the saved private gallery profile.
-
-```powershell
-PS> Publish-NugetPackage -Path .\artifacts -ProfileName Company -SkipDuplicate
-```
-
-Pushes local NuGet packages to the saved Azure Artifacts feed using credential-provider authentication.
+Configures JFrog publishing and opts in to pushing missing RequiredModules from PSGallery into the private target feed before publishing the main module.
 
 ## Notes
 
+The longer maintainer guide is Docs\PSPublishModule.PrivateGalleries.md.
 This file is source content for generated module documentation.

--- a/Module/Docs/New-ConfigurationPublish.md
+++ b/Module/Docs/New-ConfigurationPublish.md
@@ -11,27 +11,27 @@ Provides a way to configure publishing to PowerShell Gallery, GitHub, JFrog Arti
 ## SYNTAX
 ### ApiFromFile (Default)
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> -FilePath <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-JFrogBaseUri <string>] [-JFrogRepository <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> -FilePath <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [<CommonParameters>]
 ```
 
 ### ApiKey
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> -ApiKey <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-JFrogBaseUri <string>] [-JFrogRepository <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [<CommonParameters>]
-```
-
-### AzureArtifacts
-```powershell
-New-ConfigurationPublish -AzureDevOpsOrganization <string> -AzureArtifactsFeed <string> [-AzureDevOpsProject <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
-```
-
-### Profile
-```powershell
-New-ConfigurationPublish -ProfileName <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-Force] [-ID <string>] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> -ApiKey <string> [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [<CommonParameters>]
 ```
 
 ### JFrog
 ```powershell
-New-ConfigurationPublish -JFrogBaseUri <string> -JFrogRepository <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-JFrogPlatformUri <string>] [-JFrogOidcProvider <string>] [-JFrogOidcTokenId <string>] [-JFrogOidcTokenIdEnvironmentVariable <string>] [-JFrogOidcProviderType <JFrogOidcProviderType>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [<CommonParameters>]
+New-ConfigurationPublish -JFrogBaseUri <string> -JFrogRepository <string> [-Type <PublishDestination>] [-FilePath <string>] [-ApiKey <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-JFrogPlatformUri <string>] [-JFrogOidcProvider <string>] [-JFrogOidcTokenId <string>] [-JFrogOidcTokenIdEnvironmentVariable <string>] [-JFrogOidcProviderType <JFrogOidcProviderType>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [<CommonParameters>]
+```
+
+### AzureArtifacts
+```powershell
+New-ConfigurationPublish -AzureDevOpsOrganization <string> -AzureArtifactsFeed <string> [-AzureDevOpsProject <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-Force] [-ID <string>] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [<CommonParameters>]
+```
+
+### Profile
+```powershell
+New-ConfigurationPublish -ProfileName <string> [-FilePath <string>] [-ApiKey <string>] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-Force] [-ID <string>] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -74,19 +74,31 @@ New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -J
 
 ### EXAMPLE 5
 ```powershell
-New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled
 ```
 
 
 ### EXAMPLE 6
 ```powershell
-New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
 ```
 
 
 ### EXAMPLE 7
 ```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
+```
+
+
+### EXAMPLE 8
+```powershell
 New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled
+```
+
+
+### EXAMPLE 9
+```powershell
+New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled
 ```
 
 
@@ -97,7 +109,7 @@ API key to be used for publishing in clear text. For JFrog, use this only when t
 
 ```yaml
 Type: String
-Parameter Sets: ApiKey, Profile, JFrog
+Parameter Sets: ApiKey, JFrog, Profile
 Aliases: None
 Possible values:
 
@@ -177,7 +189,7 @@ Enable publishing to the chosen destination.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -193,7 +205,7 @@ When true, registers/updates the repository before publishing. Default: true.
 
 ```yaml
 Type: Boolean
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -209,7 +221,7 @@ API key to be used for publishing in clear text in a file. For JFrog, use this o
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, Profile, JFrog
+Parameter Sets: ApiFromFile, JFrog, Profile
 Aliases: None
 Possible values:
 
@@ -225,7 +237,7 @@ Allow publishing lower version of a module on a PowerShell repository.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -257,7 +269,7 @@ Optional ID of the artefact used for publishing.
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -273,7 +285,7 @@ JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. Po
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, JFrog
+Parameter Sets: JFrog
 Aliases: None
 Possible values:
 
@@ -369,7 +381,7 @@ JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoi
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, JFrog
+Parameter Sets: JFrog
 Aliases: None
 Possible values:
 
@@ -412,12 +424,28 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -PublishRequiredModules
+When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -RepositoryApiVersion
 Repository API version for PSResourceGet registration (v2/v3).
 
 ```yaml
 Type: RepositoryApiVersion
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values: Auto, V2, V3, ContainerRegistry
 
@@ -433,7 +461,7 @@ Repository credential secret (password/token) in clear text. For JFrog PAT/basic
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -449,7 +477,7 @@ Environment variable containing the repository credential secret (password/token
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -465,7 +493,7 @@ Repository credential secret (password/token) in a clear-text file. For JFrog PA
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -481,7 +509,7 @@ Repository credential username (basic auth). For JFrog PAT/basic-auth flows, thi
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, Profile, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -497,7 +525,7 @@ Repository name override (GitHub or PowerShell repository name).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -513,7 +541,7 @@ Repository priority for PSResourceGet (lower is higher priority).
 
 ```yaml
 Type: Nullable`1
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -529,7 +557,7 @@ Repository publish URI (PowerShellGet PublishLocation).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
 Aliases: None
 Possible values:
 
@@ -545,7 +573,7 @@ Repository source URI (PowerShellGet SourceLocation).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
 Aliases: None
 Possible values:
 
@@ -561,7 +589,7 @@ Whether to mark the repository as trusted (avoids prompts). Default: true.
 
 ```yaml
 Type: Boolean
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -577,7 +605,23 @@ Repository base URI (used for both source and publish unless overridden).
 
 ```yaml
 Type: String
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -RequiredModuleSourceRepository
+Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.
+
+```yaml
+Type: String
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
 Aliases: None
 Possible values:
 
@@ -593,7 +637,7 @@ Publishing tool/provider used for repository publishing. Ignored for GitHub publ
 
 ```yaml
 Type: PublishTool
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values: Auto, PSResourceGet, PowerShellGet
 
@@ -609,7 +653,7 @@ Choose between PowerShellGallery and GitHub.
 
 ```yaml
 Type: PublishDestination
-Parameter Sets: ApiFromFile, ApiKey
+Parameter Sets: ApiFromFile, ApiKey, JFrog
 Aliases: None
 Possible values: PowerShellGallery, GitHub
 
@@ -625,7 +669,7 @@ When set, unregisters the repository after publish if it was created by this run
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 
@@ -641,7 +685,7 @@ Use this PowerShell repository as the source for resolving Auto/Latest dependenc
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ApiFromFile, ApiKey, AzureArtifacts, JFrog
+Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts
 Aliases: None
 Possible values:
 

--- a/Module/Docs/New-ConfigurationPublish.md
+++ b/Module/Docs/New-ConfigurationPublish.md
@@ -425,7 +425,7 @@ Accept wildcard characters: True
 ```
 
 ### -PublishRequiredModules
-When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.
+When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.
 
 ```yaml
 Type: SwitchParameter

--- a/Module/Help/About/about_PrivateGalleries.help.txt
+++ b/Module/Help/About/about_PrivateGalleries.help.txt
@@ -129,6 +129,10 @@ LONG DESCRIPTION
 
         New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled
 
+    Dependency mirroring requires PSResourceGet. If a configuration uses
+    PublishRequiredModules with Tool PowerShellGet, the publish run fails early
+    with a clear error instead of silently skipping dependency mirroring.
+
     The publish flow checks RequiredModules in the target feed, skips modules
     listed in PSData.ExternalModuleDependencies, saves a compatible dependency
     from RequiredModuleSourceRepository, publishes it to the target, verifies it

--- a/Module/Help/About/about_PrivateGalleries.help.txt
+++ b/Module/Help/About/about_PrivateGalleries.help.txt
@@ -2,325 +2,213 @@ TOPIC
     about_PrivateGalleries
 
 SHORT DESCRIPTION
-    Explains the enterprise private gallery profile flow for Azure Artifacts and PSPublishModule.
+    Explains how PSPublishModule consumes and publishes private PowerShell modules
+    from NuGet-compatible feeds, Azure Artifacts, JFrog Artifactory, GitHub
+    Packages, and Microsoft Artifact Registry.
 
 LONG DESCRIPTION
-    PSPublishModule supports an Entra-first private gallery workflow for Azure Artifacts feeds.
-    The intended enterprise flow is:
+    PSPublishModule treats private PowerShell galleries as NuGet-compatible
+    repositories with a small set of reusable command shapes:
 
-        1. Save or import non-secret feed settings in a local PSPublishModule profile.
-        2. Let Microsoft.PowerShell.PSResourceGet and the Azure Artifacts Credential Provider own Entra ID, MFA,
-           device login, and token/session caching.
-        3. Use Initialize-ModuleRepository as the one-command workstation onboarding entry point.
-        4. Use the saved profile for install, update, and publish configuration commands.
+        - generic NuGet-compatible feeds when you know the source/publish URLs
+        - Azure Artifacts profiles for Entra ID/MFA and the Azure Artifacts
+          Credential Provider
+        - JFrog Artifactory shortcuts that derive the NuGet URLs for you
+        - GitHub Packages profiles for GitHub-hosted NuGet feeds
+        - Microsoft Artifact Registry for read-only Microsoft package intake
 
-    Profiles are created with Initialize-ModuleRepository or Set-ModuleRepositoryProfile. A profile stores feed
-    identity and local behavior:
+    Use PSResourceGet unless you have a specific reason to support an older
+    PowerShellGet-only feed. Profiles store repository shape and local behavior
+    only. They do not store PATs, passwords, Entra tokens, JFrog tokens, or
+    credential-provider session caches.
 
-        - Azure DevOps organization
-        - optional Azure DevOps project
-        - Azure Artifacts feed
-        - local repository name
-        - preferred repository tool
-        - bootstrap mode
-        - repository trust and priority settings
+    STANDARD NUGET-COMPATIBLE FEEDS
 
-    Profiles intentionally do not store PATs, passwords, or Entra tokens. The default Azure Artifacts profile uses:
+    Use the generic NuGet-compatible path for feeds such as Nexus, ProGet,
+    GitHub Packages, internal NuGet servers, or JFrog when you prefer to provide
+    the URLs yourself.
 
-        Tool           = PSResourceGet
-        BootstrapMode  = ExistingSession
-        Authentication = AzureArtifactsCredentialProvider
+    If the feed expects a NuGet API key for push:
 
-    When PSResourceGet registration supports it, PSPublishModule configures Azure Artifacts repositories with
-    CredentialProvider = AzArtifacts. Older PSResourceGet versions fall back to their built-in Azure Artifacts URL
-    detection.
-    Install-prerequisite flows honor the selected bootstrap mode. For the default ExistingSession profile, they
-    upgrade PSResourceGet to the ExistingSession-capable line before installing or refreshing the Azure Artifacts
-    Credential Provider.
+        New-ConfigurationPublish -Type PowerShellGallery -RepositoryName 'CompanyModules' -Tool PSResourceGet -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' -FilePath "$env:USERPROFILE\.secrets\company-nuget-api-key.txt" -Enabled
+
+    If the feed uses basic/PAT credentials, create a non-secret profile and pass
+    the credential when publishing:
+
+        Set-ModuleRepositoryProfile -Name 'CompanyNuGet' -Provider NuGet -RepositoryName 'CompanyModules' -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' -RepositorySourceUri 'https://packages.company.test/nuget/v3/index.json' -RepositoryPublishUri 'https://packages.company.test/nuget/v3/index.json' -Tool PSResourceGet
+
+        New-ConfigurationPublish -ProfileName 'CompanyNuGet' -RepositoryCredentialUserName 'publisher' -RepositoryCredentialSecretEnvironmentVariable 'COMPANY_NUGET_TOKEN' -Enabled
+
+    AZURE ARTIFACTS
+
+    Azure Artifacts is the preferred enterprise flow when users should
+    authenticate through Entra ID/MFA instead of PATs. PSPublishModule stores
+    the organization, project, feed, repository name, and tool/bootstrap
+    preference. Authentication remains owned by PSResourceGet and the Azure
+    Artifacts Credential Provider.
+
+    Create a profile:
+
+        Set-ModuleRepositoryProfile -Name 'Company' -AzureDevOpsOrganization 'contoso' -AzureDevOpsProject 'Platform' -AzureArtifactsFeed 'Modules'
+
+    Onboard a workstation:
+
+        Initialize-ModuleRepository -ProfileName 'Company' -InstallPrerequisites
+
+    Install and update modules:
+
+        Install-PrivateModule -ProfileName 'Company' -Name 'Company.Tools' -InstallPrerequisites
+        Update-PrivateModule  -ProfileName 'Company' -Name 'Company.Tools'
+
+    Publish a module:
+
+        New-ConfigurationPublish -AzureDevOpsOrganization 'contoso' -AzureDevOpsProject 'Platform' -AzureArtifactsFeed 'Modules' -RepositoryName 'CompanyModules' -Tool PSResourceGet -Enabled
+
+    Or use the saved profile:
+
+        New-ConfigurationPublish -ProfileName 'Company' -Enabled
+
+    Push plain NuGet packages through the same profile:
+
+        Publish-NugetPackage -Path .\artifacts -ProfileName 'Company' -InstallPrerequisites -SkipDuplicate
+
+    PAT/basic parameters remain available for constrained environments, but
+    they are a fallback. Prefer the Azure Artifacts Credential Provider when
+    Azure DevOps Services and workstation policy allow it.
+
+    JFROG ARTIFACTORY
+
+    JFrog can be configured as a generic NuGet feed, or with JFrog shortcut
+    parameters. Given:
+
+        JFrogBaseUri    = https://company.jfrog.io/artifactory
+        JFrogRepository = powershell-virtual
+
+    PSPublishModule derives:
+
+        PSResourceGet v3:
+        https://company.jfrog.io/artifactory/api/nuget/v3/powershell-virtual/index.json
+
+        PowerShellGet v2 source/publish:
+        https://company.jfrog.io/artifactory/api/nuget/powershell-virtual
+
+    For PAT/access-token publishing where the same token can read and push:
+
+        New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
+
+    For local testing, inline clear text works but must not be committed:
+
+        New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled
+
+    If Artifactory requires a separate NuGet API key for package push, add
+    FilePath or ApiKey:
+
+        New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled
+
+    For federated CI, use JFrog OIDC token exchange. PSPublishModule calls
+    JFrog CLI at publish time and passes the exchanged short-lived credential
+    to repository tooling:
+
+        New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled
+
+    For interactive workstation proof, use JFrog CLI bootstrap mode:
+
+        Connect-ModuleRepository -Provider JFrog -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -Name 'JFrogPS' -Tool PSResourceGet -BootstrapMode JFrogCli -InstallPrerequisites -Verbose
+
+    This runs jf login and then probes whether PowerShell repository tooling can
+    use that session. It is useful for troubleshooting, but it is not the default
+    CI publish shape.
+
+    PUBLISHING MISSING REQUIREDMODULES
+
+    Private feeds often start empty. If a module manifest contains
+    RequiredModules, publishing the main module can fail because the dependency
+    is not yet in the target feed.
+
+    Opt in to dependency mirroring:
+
+        New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled
+
+    The publish flow checks RequiredModules in the target feed, skips modules
+    listed in PSData.ExternalModuleDependencies, saves a compatible dependency
+    from RequiredModuleSourceRepository, publishes it to the target, verifies it
+    is present, and then publishes the main module.
+
+    This changes the target feed, so it is explicit. If the target repository
+    returns 401 Unauthorized while checking a dependency, fix repository
+    credentials first. Dependency mirroring only helps after the target feed can
+    be read and written.
+
+    MICROSOFT ARTIFACT REGISTRY
+
+    Microsoft Artifact Registry is a read-only PSResourceGet
+    container-registry repository for Microsoft-owned PowerShell packages.
+
+        Register-ModuleRepository -MicrosoftArtifactRegistry
+        Connect-ModuleRepository -MicrosoftArtifactRegistry
+        Install-PrivateModule -MicrosoftArtifactRegistry -Name Microsoft.PowerShell.SecretManagement
+
+    Do not use MAR as a publish target. For production estates, promote approved
+    Microsoft packages into your enterprise feed.
 
     PROFILE STORAGE
 
-    Profile data is stored under the current user's local application data folder:
+    User profiles:
 
         %LOCALAPPDATA%\PowerForge\PrivateGalleries\profiles.json
 
-    Machine-wide profile data is stored under the machine common application data folder:
+    Machine profiles:
 
         %ProgramData%\PowerForge\PrivateGalleries\profiles.json
 
-    Commands that consume a profile read user profiles first and then machine-wide profiles. This lets desktop
-    support register feed metadata once for all users without sharing credentials. Each user still authenticates as
-    themselves through the Azure Artifacts Credential Provider and Entra/MFA.
+    Commands read user profiles first, then machine profiles. This allows
+    desktop support to deploy non-secret feed metadata while each user still
+    authenticates as themselves.
 
-    Set POWERFORGE_MODULE_REPOSITORY_PROFILE_PATH when tests, managed desktop rollout tooling, or ephemeral build
-    agents need to redirect user profile storage. Set POWERFORGE_MODULE_REPOSITORY_MACHINE_PROFILE_PATH to redirect
-    the machine-wide profile store for tests or managed deployment tooling.
+    Useful commands:
 
-    ENTERPRISE ROLLOUT CHECKLIST
-
-    For a managed workstation estate, keep PSPublishModule as the wrapper and leave identity/session ownership with
-    Microsoft tooling:
-
-        1. Publish PSPublishModule through the approved bootstrap channel users already trust.
-        2. Grant Azure DevOps feed access through Entra ID groups. Do not create PATs by default.
-        3. Use Initialize-ModuleRepository -InstallPrerequisites to install or refresh PSResourceGet at the version
-           required by the selected bootstrap mode and install the Azure Artifacts Credential Provider on Windows
-           workstations. For locked-down estates, mirror PSPublishModule.Artefacts into the same private gallery as
-           PSPublishModule so the provider ZIPs are delivered as a normal PowerShell module dependency. Pre-install
-           the credential provider on non-Windows systems with Microsoft's installer. On Windows, prefer Microsoft's
-           self-contained Microsoft.win-*.NuGet.CredentialProvider.zip packages over Microsoft.Net8.NuGet.CredentialProvider.zip
-           when mirroring packages manually, because the Net8 package requires a separately installed .NET runtime.
-           The netfx package is kept for Windows PowerShell 5.1/.NET Framework compatibility, but it is not
-           self-contained either; it requires a supported .NET Framework runtime.
-        4. Create the feed profile once with Set-ModuleRepositoryProfile. Use -Scope Machine from an elevated/admin
-           deployment when the same non-secret feed definition should be visible to all users on the workstation.
-        5. For managed rollout, export the non-secret profile with Export-ModuleRepositoryProfile and ask users or
-           desktop support to run Initialize-ModuleRepository -Path <profile.json> -ProfileName <name> -Overwrite
-           -InstallPrerequisites once. This imports or refreshes the profile, registers the repository, probes
-           access, and, when the first ExistingSession probe cannot use a cached token, invokes the Azure Artifacts
-           Credential Provider interactively so the user can complete Entra/MFA and cache a session token.
-        6. If the profile is already deployed into the profile store, use
-           Initialize-ModuleRepository -ProfileName <name> -InstallPrerequisites instead. Add -SkipConnect when you
-           only want profile/readiness output without repository registration or probing.
-        7. Keep Set-ModuleRepositoryProfile, Test-ModuleRepositoryProfile, and Connect-ModuleRepository available as
-           the advanced/manual flow for admins, diagnostics, and constrained rollouts.
-        8. Standardize user commands around Install-PrivateModule -ProfileName <name> and
-           Update-PrivateModule -ProfileName <name>. These commands refresh repository registration and perform the
-           same access probe/session-prime step before install/update, so an expired Azure Artifacts Credential
-           Provider session can be renewed from the normal day-to-day command in an interactive shell.
-        9. Use the same profile for New-ConfigurationPublish -ProfileName <name> and
-           Publish-NugetPackage -ProfileName <name> -InstallPrerequisites so publishing and consuming resolve the
-           same feed and can bootstrap the same Azure Artifacts credential-provider path.
-        10. Run the opt-in live Pester flow against a real feed/module before announcing the feed as production-ready.
-
-    RECOMMENDED WORKSTATION FLOW
-
-    Create and connect a profile directly:
-
-        Initialize-ModuleRepository -ProfileName Company -Organization contoso -Project Platform -Feed Modules -InstallPrerequisites
-
-    Import a managed profile file and connect the workstation:
-
-        Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
-
-    Use Test-ModuleRepositoryProfile and Connect-ModuleRepository directly when separate readiness and
-    connection/probe steps are desired. The readiness object includes RecommendedOnboardingCommand for the managed
-    one-command path and RecommendedConnectCommand for the lower-level connection step.
-
-    Install or update modules:
-
-        Install-PrivateModule -ProfileName Company -Name ModuleA, ModuleB -InstallPrerequisites
-        Update-PrivateModule -ProfileName Company -Name ModuleA, ModuleB
-
-    Use the same profile in publish configuration:
-
-        New-ConfigurationPublish -ProfileName Company -Enabled
-
-    Direct NuGet package pushes can also resolve the feed from the profile:
-
-        Publish-NugetPackage -Path .\artifacts -ProfileName Company -InstallPrerequisites -SkipDuplicate
-
-    MANAGED PROFILE DEPLOYMENT
-
-    Profile files are configuration, not credentials. An administrator can create the profile once, export it, and
-    deploy the JSON file with Intune, GPO, configuration management, or a bootstrap script:
-
-        Export-ModuleRepositoryProfile -Name Company -Path .\Company.profile.json -Force
-
-    For a machine-wide profile installed once by desktop support or software distribution, import or create it with
-    -Scope Machine:
-
+        Test-ModuleRepositoryProfile -ProfileName 'Company'
+        Export-ModuleRepositoryProfile -Name 'Company' -Path .\Company.profile.json -Force
         Import-ModuleRepositoryProfile -Path .\Company.profile.json -Scope Machine -Overwrite
-        Set-ModuleRepositoryProfile -Name Company -Organization contoso -Project Platform -Feed Modules -Scope Machine
+        New-ModuleRepositoryBootstrap -ProfileName 'Company' -OutputDirectory .\CompanyGalleryBootstrap -InstallModule 'Company.Tools' -Force
 
-    After that, any user on the workstation can run Install-PrivateModule -ProfileName Company -Name ModuleA.
-    PSPublishModule reads the shared profile, but Azure Artifacts authentication remains per-user. If that user has
-    no cached session yet, or the session expired, the normal install/update access probe can invoke the Azure
-    Artifacts Credential Provider so the user signs in with their own Entra ID/MFA.
+    VALIDATION
 
-    For a deployable one-folder workstation package, use:
+    Before calling a feed ready:
 
-        New-ModuleRepositoryBootstrap -ProfileName Company -OutputDirectory .\CompanyGalleryBootstrap -InstallModule ModuleA, ModuleB -Force
+        1. Register/connect the repository from a clean shell.
+        2. Install a known module with Install-PrivateModule.
+        3. Update the module with Update-PrivateModule.
+        4. Generate publish configuration and confirm secrets are not stored.
+        5. Publish a disposable package or module version.
+        6. If PublishRequiredModules is enabled, prove a missing dependency is
+           promoted before the main module publish.
 
-    The generated package contains profiles.json and Initialize-PrivateGallery.ps1. The script imports PSPublishModule
-    when needed, imports the bundled profile, installs missing private-gallery prerequisites unless
-    -SkipInstallPrerequisites is used, connects with Initialize-ModuleRepository, and can install approved modules
-    through Install-PrivateModule -ProfileName <name>. The package remains non-secret: it contains feed identity and
-    bootstrap commands only, not PATs, passwords, Entra tokens, or Azure Artifacts Credential Provider session caches.
+    Azure Artifacts live validation:
 
-    On the target workstation, import or refresh the profile and connect in one step:
+        .\Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 -Organization contoso -Project Platform -Feed Modules -ModuleName Company.Tools -GenerateDisposablePackage -EvidenceFile .\private-gallery-live.evidence.json -Output Detailed -PassThru
 
-        Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
+    JFrog SSO/credential validation:
 
-    The imported profile still does not contain PATs, passwords, or tokens. If the user has not signed in before,
-    Initialize-ModuleRepository and Connect-ModuleRepository can prime the Azure Artifacts Credential Provider
-    session for the feed URI. PSResourceGet calls the provider non-interactively after that, so the explicit priming
-    step is what gives managed workstation onboarding a real Entra/MFA prompt/cache path.
-
-    CREDENTIAL PROVIDER PACKAGE SOURCE
-
-    PowerForge installs the Azure Artifacts Credential Provider from package ZIPs. It does not download and execute
-    Microsoft's installer script at runtime.
-
-    The preferred enterprise source is PSPublishModule.Artefacts, a companion package-carrier module that can be
-    published to PSGallery or mirrored into a private PowerShell gallery. During -InstallPrerequisites,
-    PSPublishModule looks for the module locally first, then tries to install it from the configured PowerShell
-    repositories, and only then falls back to Microsoft's public release package URLs. This lets isolated networks
-    approve and promote one PowerShell module instead of managing separate script downloads from github.com.
-    The carrier manifest includes architecture-specific Windows netcore packages, and PSPublishModule selects the
-    package matching the current Windows process architecture.
-
-        .\Modules\PSPublishModule.Artefacts\Build\Build-Module.ps1
-        Install-Module PSPublishModule.Artefacts -Repository CompanyGallery
-        Initialize-ModuleRepository -ProfileName Company -InstallPrerequisites
-
-    Explicit package variables remain available as the override path for file shares, internal HTTP artifact caches,
-    or emergency pinning. Configure these machine or user environment variables before running -InstallPrerequisites:
-
-        POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETCORE_PACKAGE
-        POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETFX_PACKAGE
-        POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETCORE_SHA256
-        POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_NETFX_SHA256
-
-    The package variables may point at local paths, UNC paths, or internal HTTPS mirror URLs. Use
-    POWERFORGE_AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_PACKAGE only when the same ZIP contains every requested runtime
-    folder. The runtime-specific variables are the preferred enterprise shape because Microsoft publishes the .NET
-    and .NET Framework credential-provider packages as separate release assets.
-
-    Install-PrivateModule -ProfileName <name> and Update-PrivateModule -ProfileName <name> also perform this access
-    probe/session-prime step before installing or updating modules. If the cached session expired after onboarding,
-    or a different user receives the same non-secret profile, the first normal install/update command can invoke the
-    Azure Artifacts Credential Provider again and then continue once Entra/MFA succeeds.
-
-    PRODUCTION READINESS EVIDENCE
-
-    Before calling a feed ready for users, prove:
-
-        - Module\Tests\Invoke-PrivateGalleryAzureArtifactsLiveValidation.ps1 succeeds against the real feed/module
-          and writes a non-secret evidence JSON file with -EvidenceFile. The evidence should include bootstrap package
-          generation, non-secret package contents, bootstrap script execution, the access probe,
-          credential-free publish configuration, install/update, and optional package-push checks.
-          Missing or incomplete required evidence details make the helper fail so the JSON cannot look successful
-          while omitting the proof operators need. For package-push proof, use -GenerateDisposablePackage or pass
-          a prebuilt disposable package with -PublishPackagePath.
-        - The manual GitHub Actions workflow named Private Gallery Live Validation succeeds on a runner that owns
-          the enterprise Azure Artifacts credential-provider policy. Prefer runnerLabels = ["self-hosted","windows"]
-          or another approved self-hosted runner because hosted runners usually cannot prove cached Entra-backed
-          feed access. For managed repository defaults, define GitHub variables once and leave matching manual
-          inputs blank during dispatch:
-              PSPUBLISHMODULE_AZDO_ORGANIZATION
-              PSPUBLISHMODULE_AZDO_PROJECT
-              PSPUBLISHMODULE_AZDO_FEED
-              PSPUBLISHMODULE_AZDO_MODULE_NAME
-              PSPUBLISHMODULE_AZDO_PROFILE_NAME
-              PSPUBLISHMODULE_AZDO_RUNNER_LABELS
-              PSPUBLISHMODULE_AZDO_DISPOSABLE_PACKAGE_NAME
-              PSPUBLISHMODULE_AZDO_DISPOSABLE_PACKAGE_VERSION
-          Workflow inputs override variables when both are provided. For unattended validation, configure the Azure
-          Artifacts Credential Provider with
-          ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS for access-token based automation or
-          ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS for managed identity/service-principal based automation. Do
-          not put those secrets in PSPublishModule profiles. The included workflows pass through these GitHub
-          secrets when present:
-              PSPUBLISHMODULE_AZDO_ARTIFACTS_EXTERNAL_FEED_ENDPOINTS -> ARTIFACTS_CREDENTIALPROVIDER_EXTERNAL_FEED_ENDPOINTS
-              PSPUBLISHMODULE_AZDO_ARTIFACTS_FEED_ENDPOINTS -> ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS
-              PSPUBLISHMODULE_AZDO_VSS_NUGET_EXTERNAL_FEED_ENDPOINTS -> VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
-          The evidence JSON and step summary report only whether each unattended credential-provider endpoint
-          variable was configured, never the secret value. The workflow writes a non-secret run summary and uploads
-          the XML/evidence JSON artifacts for release records.
-        - Before dispatching a live run, check the repository configuration without printing any secret values:
-              .\Module\Tests\Test-PrivateGalleryGitHubLiveValidationConfiguration.ps1 `
-                  -Repository EvotecIT/PSPublishModule `
-                  -RequireUnattendedCredentialProviderSecret `
-                  -Markdown
-          Use -NoFail for a report-only inventory. Without -NoFail, the helper fails when required variables are
-          missing or, when -RequireUnattendedCredentialProviderSecret is used, when none of the supported Azure
-          Artifacts Credential Provider secret names is present. The Markdown output includes suggested gh variable
-          set, gh secret set, and gh workflow run command shapes with placeholders so operators can move from inventory
-          to a live run without putting secret material in profiles, logs, or docs.
-        - Before the new standalone workflow exists on the default branch, dispatch the existing Test & Build Module
-          workflow against the feature branch with privateGalleryLiveValidation = true. That gated job uses the same
-          helper, summary, and artifact path and does not run during normal push or pull request builds.
-        - Initialize-ModuleRepository -Path <profile.json> -ProfileName <name> -Overwrite -InstallPrerequisites
-          succeeds on a clean workstation and reports Connection.AccessProbeSucceeded = True. If no cached token
-          existed before the first probe, Connection.CredentialProviderSessionPrimeAttempted shows whether
-          PSPublishModule invoked the provider to prime the Entra-backed session before retrying.
-        - Install-PrivateModule -ProfileName <name> -Name <known module> succeeds with no PAT or explicit
-          credential parameters.
-        - Update-PrivateModule -ProfileName <name> -Name <known module> succeeds for an installed private module.
-        - New-ConfigurationPublish -ProfileName <name> -Enabled produces an Azure Artifacts v3 URI and no stored
-          credential.
-        - Publish-NugetPackage -ProfileName <name> succeeds for a disposable package when package-push validation
-          is intentionally enabled with -GenerateDisposablePackage or -PublishPackagePath.
-
-    PAT FALLBACK
-
-    PAT/basic credential parameters remain available for legacy or constrained environments, but they are not the
-    preferred enterprise path. Prefer the Azure Artifacts Credential Provider whenever Azure DevOps Services and
-    workstation policy allow it.
-
-    JFROG AND OTHER PRIVATE FEEDS
-
-    JFrog and generic NuGet feeds use the same profile surface, but they do not use the Azure Artifacts
-    Credential Provider. A JFrog profile can be created with:
-
-        Set-ModuleRepositoryProfile -Name CompanyJfrog -Provider JFrog -Repository powershell-virtual -JFrogBaseUri https://company.jfrog.io/artifactory
-
-    For credential-based usage, pass CredentialUserName plus CredentialSecret/CredentialSecretFilePath, or prompt
-    interactively. If the JFrog instance is SAML/SSO-backed, the web login may be used to obtain or refresh a
-    JFrog token, but PowerShellGet and PSResourceGet still need NuGet-compatible authentication unless the local
-    environment provides a working bridge.
-
-    PSPublishModule also supports an explicit experimental JFrog CLI bridge mode:
-
-        Initialize-ModuleRepository -ProfileName CompanyJfrog -Provider JFrog -Repository powershell-virtual -JFrogBaseUri https://company.jfrog.io/artifactory -BootstrapMode JFrogCli -InstallPrerequisites
-
-    This mode runs jf login interactively and then retries the repository probe. If JFrog CLI login succeeds but
-    PSResourceGet still cannot read the NuGet feed, the connection result reports JFrogCliLoginSucceeded = True
-    and AccessProbeSucceeded = False with a message explaining that the JFrog CLI session was not consumed by
-    PowerShellGet/PSResourceGet. That gives support a precise error boundary instead of silently falling back.
-
-    To prove whether JFrog CLI browser login can bridge to PSResourceGet on a real workstation, run:
-
-        .\Module\Tests\Invoke-PrivateGalleryJFrogSsoValidation.ps1 -JFrogBaseUri https://company.jfrog.io/artifactory -Repository powershell-virtual -ModuleName ModuleA -RunJFrogCliLogin -EvidenceFile .\jfrog-sso.evidence.json -MarkdownFile .\jfrog-sso.evidence.md
-
-    The helper writes non-secret JSON/Markdown evidence showing whether jf login succeeded, whether PSResourceGet
-    could find the module without explicit credentials, and whether the explicit credential fallback works when
-    CredentialUserName plus CredentialSecret/CredentialSecretFilePath are supplied.
+        .\Module\Tests\Invoke-PrivateGalleryJFrogSsoValidation.ps1 -JFrogBaseUri https://company.jfrog.io/artifactory -Repository powershell-virtual -ModuleName Company.Tools -RunJFrogCliLogin -EvidenceFile .\jfrog-sso.evidence.json -MarkdownFile .\jfrog-sso.evidence.md
 
 EXAMPLES
+    PS> New-ConfigurationPublish -Type PowerShellGallery -RepositoryName CompanyModules -Tool PSResourceGet -RepositoryUri 'https://packages.company.test/nuget/v3/index.json' -FilePath "$env:USERPROFILE\.secrets\company-nuget-api-key.txt" -Enabled
+
+    Configures a standard NuGet-compatible private feed that uses a NuGet API key for package push.
+
     PS> Initialize-ModuleRepository -ProfileName Company -Organization contoso -Project Platform -Feed Modules -InstallPrerequisites
 
-    Saves an Entra-first Azure Artifacts profile named Company, installs missing prerequisites if needed, registers
-    the repository, and validates authenticated feed access.
+    Creates and connects an Azure Artifacts profile with Entra/MFA-capable credential-provider authentication.
 
-    PS> Initialize-ModuleRepository -Path .\Company.profile.json -ProfileName Company -Overwrite -InstallPrerequisites
+    PS> New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -Enabled
 
-    Imports or refreshes a managed profile file, then registers and probes the repository.
+    Configures JFrog Artifactory publishing with PAT/access-token authentication provided from an environment variable.
 
-    PS> Connect-ModuleRepository -ProfileName Company -InstallPrerequisites
+    PS> New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled
 
-    Runs the lower-level connection/probe step for an already saved profile.
-
-    PS> Test-ModuleRepositoryProfile -ProfileName Company
-
-    Checks saved profile and local prerequisite readiness without changing repository registrations.
-
-    PS> Export-ModuleRepositoryProfile -Name Company -Path .\Company.profile.json -Force
-
-    Exports the non-secret Company profile for managed rollout.
-
-    PS> Import-ModuleRepositoryProfile -Path .\Company.profile.json -Overwrite
-
-    Imports or refreshes managed profile settings on a workstation without connecting.
-
-    PS> Install-PrivateModule -ProfileName Company -Name ModuleA -InstallPrerequisites
-
-    Installs ModuleA from the saved private gallery profile.
-
-    PS> Publish-NugetPackage -Path .\artifacts -ProfileName Company -SkipDuplicate
-
-    Pushes local NuGet packages to the saved Azure Artifacts feed using credential-provider authentication.
+    Configures JFrog publishing and opts in to pushing missing RequiredModules from PSGallery into the private target feed before publishing the main module.
 
 NOTES
+    The longer maintainer guide is Docs\PSPublishModule.PrivateGalleries.md.
     This file is source content for generated module documentation.

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -33982,7 +33982,7 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>PublishRequiredModules</maml:name>
           <maml:description>
-            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -34312,7 +34312,7 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>PublishRequiredModules</maml:name>
           <maml:description>
-            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -34707,7 +34707,7 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>PublishRequiredModules</maml:name>
           <maml:description>
-            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -35013,7 +35013,7 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>PublishRequiredModules</maml:name>
           <maml:description>
-            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -35255,7 +35255,7 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>PublishRequiredModules</maml:name>
           <maml:description>
-            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -35575,7 +35575,7 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>PublishRequiredModules</maml:name>
         <maml:description>
-          <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+          <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -33967,30 +33967,6 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogBaseUri</maml:name>
-          <maml:description>
-            <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogRepository</maml:name>
-          <maml:description>
-            <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OverwriteTagName</maml:name>
           <maml:description>
@@ -33999,6 +33975,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublishRequiredModules</maml:name>
+          <maml:description>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -34133,6 +34121,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <maml:name>RepositoryUri</maml:name>
           <maml:description>
             <maml:para>Repository base URI (used for both source and publish unless overridden).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequiredModuleSourceRepository</maml:name>
+          <maml:description>
+            <maml:para>Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -34297,30 +34297,6 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogBaseUri</maml:name>
-          <maml:description>
-            <maml:para>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>JFrogRepository</maml:name>
-          <maml:description>
-            <maml:para>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OverwriteTagName</maml:name>
           <maml:description>
@@ -34329,6 +34305,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublishRequiredModules</maml:name>
+          <maml:description>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -34472,6 +34460,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequiredModuleSourceRepository</maml:name>
+          <maml:description>
+            <maml:para>Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>Tool</maml:name>
           <maml:description>
             <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
@@ -34532,359 +34532,6 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <maml:name>UserName</maml:name>
           <maml:description>
             <maml:para>GitHub username (required for GitHub publishing).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem parameterSetName="AzureArtifacts">
-        <maml:name>New-ConfigurationPublish</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>AzureArtifactsFeed</maml:name>
-          <maml:description>
-            <maml:para>Azure Artifacts feed name for the private gallery preset.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>AzureDevOpsOrganization</maml:name>
-          <maml:description>
-            <maml:para>Azure DevOps organization name for the Azure Artifacts preset.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>AzureDevOpsProject</maml:name>
-          <maml:description>
-            <maml:para>Optional Azure DevOps project name for project-scoped feeds.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Enabled</maml:name>
-          <maml:description>
-            <maml:para>Enable publishing to the chosen destination.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>EnsureRepositoryRegistered</maml:name>
-          <maml:description>
-            <maml:para>When true, registers/updates the repository before publishing. Default: true.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
-          <dev:type>
-            <maml:name>Boolean</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Force</maml:name>
-          <maml:description>
-            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>ID</maml:name>
-          <maml:description>
-            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryApiVersion</maml:name>
-          <maml:description>
-            <maml:para>Repository API version for PSResourceGet registration (v2/v3).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">RepositoryApiVersion</command:parameterValue>
-          <command:parameterValueGroup>
-            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">V2</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">V3</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">ContainerRegistry</command:parameterValue>
-          </command:parameterValueGroup>
-          <dev:type>
-            <maml:name>RepositoryApiVersion</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecret</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
-          <maml:description>
-            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialUserName</maml:name>
-          <maml:description>
-            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryName</maml:name>
-          <maml:description>
-            <maml:para>Repository name override (GitHub or PowerShell repository name).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryPriority</maml:name>
-          <maml:description>
-            <maml:para>Repository priority for PSResourceGet (lower is higher priority).</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
-          <dev:type>
-            <maml:name>Nullable`1</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryTrusted</maml:name>
-          <maml:description>
-            <maml:para>Whether to mark the repository as trusted (avoids prompts). Default: true.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
-          <dev:type>
-            <maml:name>Boolean</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Tool</maml:name>
-          <maml:description>
-            <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">PublishTool</command:parameterValue>
-          <command:parameterValueGroup>
-            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">PSResourceGet</command:parameterValue>
-            <command:parameterValue required="false" variableLength="false">PowerShellGet</command:parameterValue>
-          </command:parameterValueGroup>
-          <dev:type>
-            <maml:name>PublishTool</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>UnregisterRepositoryAfterPublish</maml:name>
-          <maml:description>
-            <maml:para>When set, unregisters the repository after publish if it was created by this run.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>UseAsDependencyVersionSource</maml:name>
-          <maml:description>
-            <maml:para>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem parameterSetName="Profile">
-        <maml:name>New-ConfigurationPublish</maml:name>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>ApiKey</maml:name>
-          <maml:description>
-            <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Enabled</maml:name>
-          <maml:description>
-            <maml:para>Enable publishing to the chosen destination.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>FilePath</maml:name>
-          <maml:description>
-            <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>Force</maml:name>
-          <maml:description>
-            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>ID</maml:name>
-          <maml:description>
-            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="Profile">
-          <maml:name>ProfileName</maml:name>
-          <maml:description>
-            <maml:para>Saved private gallery profile name for Azure Artifacts publishing.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecret</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
-          <maml:description>
-            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
-          <maml:description>
-            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
-          </maml:description>
-          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
-          <maml:name>RepositoryCredentialUserName</maml:name>
-          <maml:description>
-            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -35058,6 +34705,324 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublishRequiredModules</maml:name>
+          <maml:description>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryApiVersion</maml:name>
+          <maml:description>
+            <maml:para>Repository API version for PSResourceGet registration (v2/v3).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">RepositoryApiVersion</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">V2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">V3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ContainerRegistry</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>RepositoryApiVersion</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecret</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialUserName</maml:name>
+          <maml:description>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryName</maml:name>
+          <maml:description>
+            <maml:para>Repository name override (GitHub or PowerShell repository name).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryPriority</maml:name>
+          <maml:description>
+            <maml:para>Repository priority for PSResourceGet (lower is higher priority).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryPublishUri</maml:name>
+          <maml:description>
+            <maml:para>Repository publish URI (PowerShellGet PublishLocation).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositorySourceUri</maml:name>
+          <maml:description>
+            <maml:para>Repository source URI (PowerShellGet SourceLocation).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryTrusted</maml:name>
+          <maml:description>
+            <maml:para>Whether to mark the repository as trusted (avoids prompts). Default: true.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryUri</maml:name>
+          <maml:description>
+            <maml:para>Repository base URI (used for both source and publish unless overridden).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequiredModuleSourceRepository</maml:name>
+          <maml:description>
+            <maml:para>Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Tool</maml:name>
+          <maml:description>
+            <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PublishTool</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Auto</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSResourceGet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PowerShellGet</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>PublishTool</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Choose between PowerShellGallery and GitHub.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PublishDestination</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">PowerShellGallery</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GitHub</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>PublishDestination</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UnregisterRepositoryAfterPublish</maml:name>
+          <maml:description>
+            <maml:para>When set, unregisters the repository after publish if it was created by this run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseAsDependencyVersionSource</maml:name>
+          <maml:description>
+            <maml:para>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="AzureArtifacts">
+        <maml:name>New-ConfigurationPublish</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AzureArtifactsFeed</maml:name>
+          <maml:description>
+            <maml:para>Azure Artifacts feed name for the private gallery preset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AzureDevOpsOrganization</maml:name>
+          <maml:description>
+            <maml:para>Azure DevOps organization name for the Azure Artifacts preset.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AzureDevOpsProject</maml:name>
+          <maml:description>
+            <maml:para>Optional Azure DevOps project name for project-scoped feeds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Enabled</maml:name>
+          <maml:description>
+            <maml:para>Enable publishing to the chosen destination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnsureRepositoryRegistered</maml:name>
+          <maml:description>
+            <maml:para>When true, registers/updates the repository before publishing. Default: true.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ID</maml:name>
+          <maml:description>
+            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublishRequiredModules</maml:name>
+          <maml:description>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>RepositoryApiVersion</maml:name>
           <maml:description>
             <maml:para>Repository API version for PSResourceGet registration (v2/v3).</maml:para>
@@ -35160,6 +35125,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequiredModuleSourceRepository</maml:name>
+          <maml:description>
+            <maml:para>Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>Tool</maml:name>
           <maml:description>
             <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
@@ -35196,6 +35173,153 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Profile">
+        <maml:name>New-ConfigurationPublish</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>API key to be used for publishing in clear text. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Enabled</maml:name>
+          <maml:description>
+            <maml:para>Enable publishing to the chosen destination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>API key to be used for publishing in clear text in a file. For JFrog, use this only when the feed requires a separate NuGet API key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Force</maml:name>
+          <maml:description>
+            <maml:para>Allow publishing lower version of a module on a PowerShell repository.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ID</maml:name>
+          <maml:description>
+            <maml:para>Optional ID of the artefact used for publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="Profile">
+          <maml:name>ProfileName</maml:name>
+          <maml:description>
+            <maml:para>Saved private gallery profile name for Azure Artifacts publishing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublishRequiredModules</maml:name>
+          <maml:description>
+            <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecret</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in clear text. For JFrog PAT/basic-auth flows, this is the PAT or access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretEnvironmentVariable</maml:name>
+          <maml:description>
+            <maml:para>Environment variable containing the repository credential secret (password/token). For JFrog PAT/access-token flows, this can be JFROG_ACCESS_TOKEN or a CI secret variable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialSecretFilePath</maml:name>
+          <maml:description>
+            <maml:para>Repository credential secret (password/token) in a clear-text file. For JFrog PAT/basic-auth flows, prefer this over inline token values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RepositoryCredentialUserName</maml:name>
+          <maml:description>
+            <maml:para>Repository credential username (basic auth). For JFrog PAT/basic-auth flows, this is the JFrog user name or email.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequiredModuleSourceRepository</maml:name>
+          <maml:description>
+            <maml:para>Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -35449,6 +35573,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PublishRequiredModules</maml:name>
+        <maml:description>
+          <maml:para>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>RepositoryApiVersion</maml:name>
         <maml:description>
           <maml:para>Repository API version for PSResourceGet registration (v2/v3).</maml:para>
@@ -35587,6 +35723,18 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequiredModuleSourceRepository</maml:name>
+        <maml:description>
+          <maml:para>Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>Tool</maml:name>
         <maml:description>
           <maml:para>Publishing tool/provider used for repository publishing. Ignored for GitHub publishing.</maml:para>
@@ -35705,6 +35853,13 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
         </dev:remarks>
       </command:example>
       <command:example>
+        <maml:title>Publish to JFrog Artifactory with a clear-text PAT for local testing</maml:title>
+        <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
         <maml:title>Publish to JFrog Artifactory with a separate NuGet API key</maml:title>
         <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</dev:code>
         <dev:remarks>
@@ -35721,6 +35876,13 @@ For PAT/basic-auth feeds, use repository credentials only. Add -FilePath or -Api
       <command:example>
         <maml:title>Publish to JFrog Artifactory with CI OIDC token exchange</maml:title>
         <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Publish missing RequiredModules into a private repository before publishing the module</maml:title>
+        <dev:code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>

--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -276,7 +276,7 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "JFrog")]
     public SwitchParameter UseAsDependencyVersionSource { get; set; }
 
-    /// <summary>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</summary>
+    /// <summary>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module. Requires PSResourceGet.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(ParameterSetName = "AzureArtifacts")]

--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -40,6 +40,10 @@ namespace PSPublishModule;
 /// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</code>
 /// </example>
 /// <example>
+/// <summary>Publish to JFrog Artifactory with a clear-text PAT for local testing</summary>
+/// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecret 'temporary-pat' -Enabled</code>
+/// </example>
+/// <example>
 /// <summary>Publish to JFrog Artifactory with a separate NuGet API key</summary>
 /// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -FilePath "$env:USERPROFILE\.secrets\jfrog-nuget-api-key.txt" -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretFilePath "$env:USERPROFILE\.secrets\jfrog-pat.txt" -Enabled</code>
 /// </example>
@@ -51,12 +55,17 @@ namespace PSPublishModule;
 /// <summary>Publish to JFrog Artifactory with CI OIDC token exchange</summary>
 /// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -JFrogOidcProvider 'azure-oidc' -JFrogOidcProviderType Azure -JFrogOidcTokenIdEnvironmentVariable 'JFROG_CLI_OIDC_EXCHANGE_TOKEN_ID' -Enabled</code>
 /// </example>
+/// <example>
+/// <summary>Publish missing RequiredModules into a private repository before publishing the module</summary>
+/// <code>New-ConfigurationPublish -JFrogBaseUri 'https://company.jfrog.io/artifactory' -JFrogRepository 'powershell-virtual' -RepositoryName 'JFrogPS' -Tool PSResourceGet -RepositoryCredentialUserName 'name@company.com' -RepositoryCredentialSecretEnvironmentVariable 'JFROG_ACCESS_TOKEN' -PublishRequiredModules -RequiredModuleSourceRepository PSGallery -Enabled</code>
+/// </example>
 [Cmdlet(VerbsCommon.New, "ConfigurationPublish", DefaultParameterSetName = "ApiFromFile")]
 public sealed class NewConfigurationPublishCommand : PSCmdlet
 {
     /// <summary>Choose between PowerShellGallery and GitHub.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "ApiKey")]
     [Parameter(Mandatory = true, ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public PowerForge.PublishDestination Type { get; set; }
 
     /// <summary>Azure DevOps organization name for the Azure Artifacts preset.</summary>
@@ -111,27 +120,26 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     /// <summary>Repository base URI (used for both source and publish unless overridden).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryUri { get; set; }
 
     /// <summary>Repository source URI (PowerShellGet SourceLocation).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositorySourceUri { get; set; }
 
     /// <summary>Repository publish URI (PowerShellGet PublishLocation).</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "JFrog")]
     public string? RepositoryPublishUri { get; set; }
 
     /// <summary>JFrog Artifactory base URI, for example https://company.jfrog.io/artifactory. PowerShellGet and PSResourceGet URLs are derived automatically.</summary>
-    [Parameter(ParameterSetName = "ApiKey")]
-    [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(Mandatory = true, ParameterSetName = "JFrog")]
     public string? JFrogBaseUri { get; set; }
 
     /// <summary>JFrog NuGet repository key used to derive PowerShellGet and PSResourceGet endpoints, for example powershell-virtual.</summary>
-    [Parameter(ParameterSetName = "ApiKey")]
-    [Parameter(ParameterSetName = "ApiFromFile")]
     [Parameter(Mandatory = true, ParameterSetName = "JFrog")]
     public string? JFrogRepository { get; set; }
 
@@ -268,6 +276,22 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "JFrog")]
     public SwitchParameter UseAsDependencyVersionSource { get; set; }
 
+    /// <summary>When set, publishes missing manifest RequiredModules to the target repository before publishing the main module.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
+    public SwitchParameter PublishRequiredModules { get; set; }
+
+    /// <summary>Repository used as the source for publishing missing RequiredModules. Defaults to PSGallery.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    [Parameter(ParameterSetName = "AzureArtifacts")]
+    [Parameter(ParameterSetName = "Profile")]
+    [Parameter(ParameterSetName = "JFrog")]
+    public string? RequiredModuleSourceRepository { get; set; }
+
     /// <summary>Emits publish configuration for the build pipeline.</summary>
     protected override void ProcessRecord()
     {
@@ -376,6 +400,8 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
             DoNotMarkAsPreRelease = DoNotMarkAsPreRelease.IsPresent,
             GenerateReleaseNotes = GenerateReleaseNotes.IsPresent,
             UseAsDependencyVersionSource = UseAsDependencyVersionSource.IsPresent,
+            PublishRequiredModules = PublishRequiredModules.IsPresent,
+            RequiredModuleSourceRepository = RequiredModuleSourceRepository,
             Verbose = MyInvocation.BoundParameters.ContainsKey("Verbose")
         });
 

--- a/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
@@ -123,6 +123,12 @@ internal sealed class PublishConfigurationRequest
     /// <summary>Whether this repository should be used as a dependency-version source.</summary>
     public bool UseAsDependencyVersionSource { get; set; }
 
+    /// <summary>Whether missing manifest RequiredModules should be published to the target repository first.</summary>
+    public bool PublishRequiredModules { get; set; }
+
+    /// <summary>Repository used as the source for publishing missing RequiredModules.</summary>
+    public string? RequiredModuleSourceRepository { get; set; }
+
     /// <summary>Whether verbose logging was requested by the cmdlet invocation.</summary>
     public bool Verbose { get; set; }
 }

--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -223,6 +223,10 @@ internal sealed class PublishConfigurationFactory
                 DoNotMarkAsPreRelease = request.DoNotMarkAsPreRelease,
                 GenerateReleaseNotes = request.GenerateReleaseNotes,
                 UseAsDependencyVersionSource = request.UseAsDependencyVersionSource,
+                PublishRequiredModules = request.PublishRequiredModules,
+                RequiredModuleSourceRepository = string.IsNullOrWhiteSpace(request.RequiredModuleSourceRepository)
+                    ? "PSGallery"
+                    : request.RequiredModuleSourceRepository!.Trim(),
                 Verbose = request.Verbose
             }
         };

--- a/PowerForge.Tests/ModulePublishConfigurationReaderTests.cs
+++ b/PowerForge.Tests/ModulePublishConfigurationReaderTests.cs
@@ -23,6 +23,8 @@ public sealed class ModulePublishConfigurationReaderTests
                 "ApiKey": "gallery-key",
                 "Enabled": true,
                 "RepositoryName": "PSGallery",
+                "PublishRequiredModules": true,
+                "RequiredModuleSourceRepository": "InternalUpstream",
                 "Repository": {
                   "Name": "PSGallery",
                   "Uri": "https://www.powershellgallery.com/api/v2",
@@ -68,6 +70,8 @@ public sealed class ModulePublishConfigurationReaderTests
         Assert.Equal(PublishTool.PSResourceGet, repositoryPublish.Tool);
         Assert.Equal("gallery-key", repositoryPublish.ApiKey);
         Assert.Equal("PSGallery", repositoryPublish.RepositoryName);
+        Assert.True(repositoryPublish.PublishRequiredModules);
+        Assert.Equal("InternalUpstream", repositoryPublish.RequiredModuleSourceRepository);
         Assert.NotNull(repositoryPublish.Repository);
         Assert.Equal("PSGallery", repositoryPublish.Repository!.Name);
         Assert.Equal("https://www.powershellgallery.com/api/v2", repositoryPublish.Repository.Uri);

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -665,6 +665,66 @@ public sealed class ModulePublisherRepositoryVersionTests
         }
     }
 
+    [Fact]
+    public void Publish_RejectsRequiredModulePublishingToPSGallery()
+    {
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "PSPublishModule.psd1");
+            File.WriteAllText(
+                manifestPath,
+                """
+                @{
+                    ModuleVersion = '3.0.13'
+                    GUID = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
+                    RootModule = 'PSPublishModule.psm1'
+                    RequiredModules = @(@{ ModuleName = 'InternalDependency'; ModuleVersion = '1.0.0' })
+                }
+                """);
+            File.WriteAllText(Path.Combine(stagingRoot, "PSPublishModule.psm1"), string.Empty);
+
+            var runner = new StubPowerShellRunner(request =>
+            {
+                var script = File.ReadAllText(request.ScriptPath!);
+                if (script.Contains("Find-PSResource", StringComparison.Ordinal))
+                    return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh.exe");
+
+                if (script.Contains("Publish-PSResource", StringComparison.Ordinal))
+                    throw new InvalidOperationException("Publish-PSResource should not run when dependency mirroring targets PSGallery.");
+
+                return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh.exe");
+            });
+            var publisher = new ModulePublisher(new NullLogger(), runner);
+
+            var publish = new PublishConfiguration
+            {
+                Destination = PublishDestination.PowerShellGallery,
+                Enabled = true,
+                Tool = PublishTool.PSResourceGet,
+                ApiKey = "target-api-key",
+                Force = true,
+                PublishRequiredModules = true,
+                RequiredModuleSourceRepository = "InternalUpstream"
+            };
+            var buildResult = new ModuleBuildResult(
+                stagingPath: stagingRoot,
+                manifestPath: manifestPath,
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                publisher.Publish(publish, CreatePlan(), buildResult, Array.Empty<ArtefactBuildResult>()));
+
+            Assert.Contains("Refusing to mirror dependencies to PSGallery", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+                Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
     private static string Encode(string value)
         => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -319,6 +319,7 @@ public sealed class ModulePublisherRepositoryVersionTests
         var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
         var calls = new List<string>();
         var dependencyPublished = false;
+        var otherDependencyPublished = false;
         try
         {
             Directory.CreateDirectory(stagingRoot);
@@ -331,7 +332,8 @@ public sealed class ModulePublisherRepositoryVersionTests
                     GUID = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
                     RootModule = 'PSPublishModule.psm1'
                     RequiredModules = @(
-                        @{ ModuleName = 'DependencyModule'; ModuleVersion = '1.0.0'; MaximumVersion = '1.5.0' }
+                        @{ ModuleName = 'DependencyModule'; ModuleVersion = '1.0.0'; MaximumVersion = '1.5.0' },
+                        @{ ModuleName = 'OtherDependency'; ModuleVersion = '1.0.0'; MaximumVersion = '1.5.0' }
                     )
                 }
                 """);
@@ -358,6 +360,7 @@ public sealed class ModulePublisherRepositoryVersionTests
                         repositories.Contains("CompanyGallery", StringComparer.OrdinalIgnoreCase))
                     {
                         calls.Add("find-target-dependency");
+                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
                         Assert.Equal("publisher", request.Arguments[4]);
                         Assert.Equal("target-token", request.Arguments[5]);
                         if (!dependencyPublished)
@@ -376,13 +379,36 @@ public sealed class ModulePublisherRepositoryVersionTests
                             "pwsh.exe");
                     }
 
+                    if (names.Contains("OtherDependency", StringComparer.OrdinalIgnoreCase) &&
+                        repositories.Contains("CompanyGallery", StringComparer.OrdinalIgnoreCase))
+                    {
+                        calls.Add("find-target-other-dependency");
+                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
+                        Assert.Equal("publisher", request.Arguments[4]);
+                        Assert.Equal("target-token", request.Arguments[5]);
+                        if (otherDependencyPublished)
+                        {
+                            return new PowerShellRunResult(
+                                0,
+                                VisibleRepositoryItem("OtherDependency", "1.2.3"),
+                                string.Empty,
+                                "pwsh.exe");
+                        }
+
+                        return new PowerShellRunResult(
+                            1,
+                            string.Empty,
+                            "Package with name 'OtherDependency' could not be found in repository 'CompanyGallery'.",
+                            "pwsh.exe");
+                    }
+
                     if (names.Contains("DependencyModule", StringComparer.OrdinalIgnoreCase) &&
-                        repositories.Contains("PSGallery", StringComparer.OrdinalIgnoreCase))
+                        repositories.Contains("InternalUpstream", StringComparer.OrdinalIgnoreCase))
                     {
                         calls.Add("find-source-dependency");
                         Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
-                        Assert.Equal(string.Empty, request.Arguments[4]);
-                        Assert.Equal(string.Empty, request.Arguments[5]);
+                        Assert.Equal("publisher", request.Arguments[4]);
+                        Assert.Equal("target-token", request.Arguments[5]);
                         return new PowerShellRunResult(
                             0,
                             string.Join(Environment.NewLine, new[]
@@ -394,30 +420,59 @@ public sealed class ModulePublisherRepositoryVersionTests
                             "pwsh.exe");
                     }
 
+                    if (names.Contains("OtherDependency", StringComparer.OrdinalIgnoreCase) &&
+                        repositories.Contains("InternalUpstream", StringComparer.OrdinalIgnoreCase))
+                    {
+                        calls.Add("find-source-other-dependency");
+                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
+                        Assert.Equal("publisher", request.Arguments[4]);
+                        Assert.Equal("target-token", request.Arguments[5]);
+                        return new PowerShellRunResult(
+                            0,
+                            string.Join(Environment.NewLine, new[]
+                            {
+                                VisibleRepositoryItem("OtherDependency", "1.2.3"),
+                                VisibleRepositoryItem("OtherDependency", "1.6.0")
+                            }),
+                            string.Empty,
+                            "pwsh.exe");
+                    }
+
                     return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh.exe");
                 }
 
                 if (script.Contains("Save-PSResource", StringComparison.Ordinal))
                 {
-                    calls.Add("save-dependency");
-                    Assert.Equal("DependencyModule", request.Arguments[0]);
+                    var savedName = request.Arguments[0];
+                    calls.Add(savedName.Equals("DependencyModule", StringComparison.OrdinalIgnoreCase)
+                        ? "save-dependency"
+                        : "save-other-dependency");
+                    Assert.Contains(savedName, new[] { "DependencyModule", "OtherDependency" });
                     Assert.Equal("1.2.3", request.Arguments[1]);
-                    Assert.Equal("PSGallery", request.Arguments[2]);
+                    Assert.Equal("InternalUpstream", request.Arguments[2]);
                     Assert.Equal("0", request.Arguments[6]);
-                    Assert.Equal(string.Empty, request.Arguments[9]);
-                    Assert.Equal(string.Empty, request.Arguments[10]);
+                    Assert.Equal("publisher", request.Arguments[9]);
+                    Assert.Equal("target-token", request.Arguments[10]);
 
                     var transitiveModulePath = Path.Combine(request.Arguments[3], "DependencySupport", "1.0.0");
                     Directory.CreateDirectory(transitiveModulePath);
                     File.WriteAllText(Path.Combine(transitiveModulePath, "DependencySupport.psd1"), "@{ ModuleVersion = '1.0.0'; RootModule = 'DependencySupport.psm1' }");
                     File.WriteAllText(Path.Combine(transitiveModulePath, "DependencySupport.psm1"), string.Empty);
 
-                    var savedModulePath = Path.Combine(request.Arguments[3], "DependencyModule", "1.2.3");
+                    var savedModulePath = Path.Combine(request.Arguments[3], savedName, "1.2.3");
                     Directory.CreateDirectory(savedModulePath);
-                    File.WriteAllText(Path.Combine(savedModulePath, "DependencyModule.psd1"), "@{ ModuleVersion = '1.2.3'; RootModule = 'DependencyModule.psm1' }");
-                    File.WriteAllText(Path.Combine(savedModulePath, "DependencyModule.psm1"), string.Empty);
+                    File.WriteAllText(Path.Combine(savedModulePath, $"{savedName}.psd1"), $"@{{ ModuleVersion = '1.2.3'; RootModule = '{savedName}.psm1' }}");
+                    File.WriteAllText(Path.Combine(savedModulePath, $"{savedName}.psm1"), string.Empty);
 
-                    return new PowerShellRunResult(0, SaveRepositoryItem("DependencyModule", "1.2.3"), string.Empty, "pwsh.exe");
+                    return new PowerShellRunResult(
+                        0,
+                        string.Join(Environment.NewLine, new[]
+                        {
+                            SaveRepositoryItem(savedName, "1.2.3"),
+                            SaveRepositoryItem("DependencySupport", "1.0.0")
+                        }),
+                        string.Empty,
+                        "pwsh.exe");
                 }
 
                 if (script.Contains("Publish-PSResource", StringComparison.Ordinal))
@@ -431,6 +486,11 @@ public sealed class ModulePublisherRepositoryVersionTests
                     {
                         calls.Add("publish-dependency");
                         dependencyPublished = true;
+                    }
+                    else if (request.Arguments[0].Contains("OtherDependency", StringComparison.OrdinalIgnoreCase))
+                    {
+                        calls.Add("publish-other-dependency");
+                        otherDependencyPublished = true;
                     }
                     else if (request.Arguments[0].Contains("DependencySupport", StringComparison.OrdinalIgnoreCase))
                     {
@@ -456,7 +516,7 @@ public sealed class ModulePublisherRepositoryVersionTests
                 ApiKey = "target-api-key",
                 RepositoryName = "CompanyGallery",
                 PublishRequiredModules = true,
-                RequiredModuleSourceRepository = "PSGallery",
+                RequiredModuleSourceRepository = "InternalUpstream",
                 Repository = new PublishRepositoryConfiguration
                 {
                     Name = "CompanyGallery",
@@ -486,6 +546,11 @@ public sealed class ModulePublisherRepositoryVersionTests
                     "publish-transitive-dependency",
                     "publish-dependency",
                     "find-target-dependency",
+                    "find-target-other-dependency",
+                    "find-source-other-dependency",
+                    "save-other-dependency",
+                    "publish-other-dependency",
+                    "find-target-other-dependency",
                     "publish-main"
                 },
                 calls);

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -359,16 +359,37 @@ public sealed class ModulePublisherRepositoryVersionTests
                     if (names.Contains("DependencyModule", StringComparer.OrdinalIgnoreCase) &&
                         repositories.Contains("CompanyGallery", StringComparer.OrdinalIgnoreCase))
                     {
-                        calls.Add("find-target-dependency");
-                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
+                        Assert.Equal("0", request.Arguments[3]);
                         Assert.Equal("publisher", request.Arguments[4]);
                         Assert.Equal("target-token", request.Arguments[5]);
+                        if (string.Equals(request.Arguments[1], "[1.2.3]", StringComparison.Ordinal))
+                        {
+                            calls.Add("find-target-dependency-package");
+                            Assert.Equal("[1.2.3]", request.Arguments[1]);
+                            if (!dependencyPublished)
+                            {
+                                return new PowerShellRunResult(
+                                    1,
+                                    string.Empty,
+                                    "Package with name 'DependencyModule' could not be found in repository 'CompanyGallery'.",
+                                    "pwsh.exe");
+                            }
+
+                            return new PowerShellRunResult(
+                                0,
+                                VisibleRepositoryItem("DependencyModule", "1.2.3"),
+                                string.Empty,
+                                "pwsh.exe");
+                        }
+
+                        calls.Add("find-target-dependency");
+                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
                         if (!dependencyPublished)
                         {
                             return new PowerShellRunResult(
-                                1,
+                                0,
+                                VisibleRepositoryItem("DependencyModule", "2.0.0", "preview1"),
                                 string.Empty,
-                                "Package with name 'DependencyModule' could not be found in repository 'CompanyGallery'.",
                                 "pwsh.exe");
                         }
 
@@ -382,10 +403,31 @@ public sealed class ModulePublisherRepositoryVersionTests
                     if (names.Contains("OtherDependency", StringComparer.OrdinalIgnoreCase) &&
                         repositories.Contains("CompanyGallery", StringComparer.OrdinalIgnoreCase))
                     {
-                        calls.Add("find-target-other-dependency");
-                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
+                        Assert.Equal("0", request.Arguments[3]);
                         Assert.Equal("publisher", request.Arguments[4]);
                         Assert.Equal("target-token", request.Arguments[5]);
+                        if (string.Equals(request.Arguments[1], "[1.2.3]", StringComparison.Ordinal))
+                        {
+                            calls.Add("find-target-other-dependency-package");
+                            Assert.Equal("[1.2.3]", request.Arguments[1]);
+                            if (!otherDependencyPublished)
+                            {
+                                return new PowerShellRunResult(
+                                    1,
+                                    string.Empty,
+                                    "Package with name 'OtherDependency' could not be found in repository 'CompanyGallery'.",
+                                    "pwsh.exe");
+                            }
+
+                            return new PowerShellRunResult(
+                                0,
+                                VisibleRepositoryItem("OtherDependency", "1.2.3"),
+                                string.Empty,
+                                "pwsh.exe");
+                        }
+
+                        calls.Add("find-target-other-dependency");
+                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
                         if (otherDependencyPublished)
                         {
                             return new PowerShellRunResult(
@@ -402,13 +444,29 @@ public sealed class ModulePublisherRepositoryVersionTests
                             "pwsh.exe");
                     }
 
+                    if (names.Contains("DependencySupport", StringComparer.OrdinalIgnoreCase) &&
+                        repositories.Contains("CompanyGallery", StringComparer.OrdinalIgnoreCase))
+                    {
+                        calls.Add("find-target-transitive-dependency");
+                        Assert.Equal("[1.0.0]", request.Arguments[1]);
+                        Assert.Equal("0", request.Arguments[3]);
+                        Assert.Equal("publisher", request.Arguments[4]);
+                        Assert.Equal("target-token", request.Arguments[5]);
+                        return new PowerShellRunResult(
+                            0,
+                            VisibleRepositoryItem("DependencySupport", "1.0.0"),
+                            string.Empty,
+                            "pwsh.exe");
+                    }
+
                     if (names.Contains("DependencyModule", StringComparer.OrdinalIgnoreCase) &&
                         repositories.Contains("InternalUpstream", StringComparer.OrdinalIgnoreCase))
                     {
                         calls.Add("find-source-dependency");
                         Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
-                        Assert.Equal("publisher", request.Arguments[4]);
-                        Assert.Equal("target-token", request.Arguments[5]);
+                        Assert.Equal("0", request.Arguments[3]);
+                        Assert.Equal(string.Empty, request.Arguments[4]);
+                        Assert.Equal(string.Empty, request.Arguments[5]);
                         return new PowerShellRunResult(
                             0,
                             string.Join(Environment.NewLine, new[]
@@ -425,8 +483,9 @@ public sealed class ModulePublisherRepositoryVersionTests
                     {
                         calls.Add("find-source-other-dependency");
                         Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
-                        Assert.Equal("publisher", request.Arguments[4]);
-                        Assert.Equal("target-token", request.Arguments[5]);
+                        Assert.Equal("0", request.Arguments[3]);
+                        Assert.Equal(string.Empty, request.Arguments[4]);
+                        Assert.Equal(string.Empty, request.Arguments[5]);
                         return new PowerShellRunResult(
                             0,
                             string.Join(Environment.NewLine, new[]
@@ -451,8 +510,8 @@ public sealed class ModulePublisherRepositoryVersionTests
                     Assert.Equal("1.2.3", request.Arguments[1]);
                     Assert.Equal("InternalUpstream", request.Arguments[2]);
                     Assert.Equal("0", request.Arguments[6]);
-                    Assert.Equal("publisher", request.Arguments[9]);
-                    Assert.Equal("target-token", request.Arguments[10]);
+                    Assert.Equal(string.Empty, request.Arguments[9]);
+                    Assert.Equal(string.Empty, request.Arguments[10]);
 
                     var transitiveModulePath = Path.Combine(request.Arguments[3], "DependencySupport", "1.0.0");
                     Directory.CreateDirectory(transitiveModulePath);
@@ -543,12 +602,14 @@ public sealed class ModulePublisherRepositoryVersionTests
                     "find-target-dependency",
                     "find-source-dependency",
                     "save-dependency",
-                    "publish-transitive-dependency",
+                    "find-target-transitive-dependency",
+                    "find-target-dependency-package",
                     "publish-dependency",
                     "find-target-dependency",
                     "find-target-other-dependency",
                     "find-source-other-dependency",
                     "save-other-dependency",
+                    "find-target-other-dependency-package",
                     "publish-other-dependency",
                     "find-target-other-dependency",
                     "publish-main"
@@ -611,7 +672,7 @@ public sealed class ModulePublisherRepositoryVersionTests
         => Encoding.UTF8.GetString(Convert.FromBase64String(value))
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-    private static string VisibleRepositoryItem(string name, string version)
+    private static string VisibleRepositoryItem(string name, string version, string? preRelease = null)
         => string.Join("::", new[]
         {
             "PFPSRG::ITEM",
@@ -621,7 +682,7 @@ public sealed class ModulePublisherRepositoryVersionTests
             Encode("Przemyslaw Klys"),
             Encode(name),
             Encode(Guid.Empty.ToString()),
-            Encode(string.Empty)
+            Encode(preRelease ?? string.Empty)
         });
 
     private static string SaveRepositoryItem(string name, string version)

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -360,9 +360,18 @@ public sealed class ModulePublisherRepositoryVersionTests
                         calls.Add("find-target-dependency");
                         Assert.Equal("publisher", request.Arguments[4]);
                         Assert.Equal("target-token", request.Arguments[5]);
+                        if (!dependencyPublished)
+                        {
+                            return new PowerShellRunResult(
+                                1,
+                                string.Empty,
+                                "Package with name 'DependencyModule' could not be found in repository 'CompanyGallery'.",
+                                "pwsh.exe");
+                        }
+
                         return new PowerShellRunResult(
                             0,
-                            dependencyPublished ? VisibleRepositoryItem("DependencyModule", "1.2.3") : string.Empty,
+                            VisibleRepositoryItem("DependencyModule", "1.2.3"),
                             string.Empty,
                             "pwsh.exe");
                     }
@@ -371,6 +380,7 @@ public sealed class ModulePublisherRepositoryVersionTests
                         repositories.Contains("PSGallery", StringComparer.OrdinalIgnoreCase))
                     {
                         calls.Add("find-source-dependency");
+                        Assert.Equal("[1.0.0,1.5.0]", request.Arguments[1]);
                         Assert.Equal(string.Empty, request.Arguments[4]);
                         Assert.Equal(string.Empty, request.Arguments[5]);
                         return new PowerShellRunResult(
@@ -393,8 +403,14 @@ public sealed class ModulePublisherRepositoryVersionTests
                     Assert.Equal("DependencyModule", request.Arguments[0]);
                     Assert.Equal("1.2.3", request.Arguments[1]);
                     Assert.Equal("PSGallery", request.Arguments[2]);
+                    Assert.Equal("0", request.Arguments[6]);
                     Assert.Equal(string.Empty, request.Arguments[9]);
                     Assert.Equal(string.Empty, request.Arguments[10]);
+
+                    var transitiveModulePath = Path.Combine(request.Arguments[3], "DependencySupport", "1.0.0");
+                    Directory.CreateDirectory(transitiveModulePath);
+                    File.WriteAllText(Path.Combine(transitiveModulePath, "DependencySupport.psd1"), "@{ ModuleVersion = '1.0.0'; RootModule = 'DependencySupport.psm1' }");
+                    File.WriteAllText(Path.Combine(transitiveModulePath, "DependencySupport.psm1"), string.Empty);
 
                     var savedModulePath = Path.Combine(request.Arguments[3], "DependencyModule", "1.2.3");
                     Directory.CreateDirectory(savedModulePath);
@@ -415,6 +431,10 @@ public sealed class ModulePublisherRepositoryVersionTests
                     {
                         calls.Add("publish-dependency");
                         dependencyPublished = true;
+                    }
+                    else if (request.Arguments[0].Contains("DependencySupport", StringComparison.OrdinalIgnoreCase))
+                    {
+                        calls.Add("publish-transitive-dependency");
                     }
                     else
                     {
@@ -463,11 +483,54 @@ public sealed class ModulePublisherRepositoryVersionTests
                     "find-target-dependency",
                     "find-source-dependency",
                     "save-dependency",
+                    "publish-transitive-dependency",
                     "publish-dependency",
                     "find-target-dependency",
                     "publish-main"
                 },
                 calls);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+                Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Publish_RejectsRequiredModulePublishingWithPowerShellGet()
+    {
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "PSPublishModule.psd1");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '3.0.13'; GUID = 'eb76426a-1992-40a5-82cd-6480f883ef4d'; RootModule = 'PSPublishModule.psm1' }");
+            File.WriteAllText(Path.Combine(stagingRoot, "PSPublishModule.psm1"), string.Empty);
+
+            var publisher = new ModulePublisher(
+                new NullLogger(),
+                new StubPowerShellRunner(new PowerShellRunResult(0, string.Empty, string.Empty, "powershell.exe")));
+
+            var publish = new PublishConfiguration
+            {
+                Destination = PublishDestination.PowerShellGallery,
+                Enabled = true,
+                Tool = PublishTool.PowerShellGet,
+                ApiKey = "target-api-key",
+                RepositoryName = "CompanyGallery",
+                PublishRequiredModules = true,
+                RequiredModuleSourceRepository = "PSGallery"
+            };
+            var buildResult = new ModuleBuildResult(
+                stagingPath: stagingRoot,
+                manifestPath: manifestPath,
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                publisher.Publish(publish, CreatePlan(), buildResult, Array.Empty<ArtefactBuildResult>()));
+
+            Assert.Contains("PublishRequiredModules requires PSResourceGet", exception.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -313,6 +313,169 @@ public sealed class ModulePublisherRepositoryVersionTests
         }
     }
 
+    [Fact]
+    public void Publish_PublishesMissingRequiredModulesWhenEnabled()
+    {
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        var calls = new List<string>();
+        var dependencyPublished = false;
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "PSPublishModule.psd1");
+            File.WriteAllText(
+                manifestPath,
+                """
+                @{
+                    ModuleVersion = '3.0.13'
+                    GUID = 'eb76426a-1992-40a5-82cd-6480f883ef4d'
+                    RootModule = 'PSPublishModule.psm1'
+                    RequiredModules = @(
+                        @{ ModuleName = 'DependencyModule'; ModuleVersion = '1.0.0'; MaximumVersion = '1.5.0' }
+                    )
+                }
+                """);
+            File.WriteAllText(Path.Combine(stagingRoot, "PSPublishModule.psm1"), string.Empty);
+
+            var runner = new StubPowerShellRunner(request =>
+            {
+                var script = File.ReadAllText(request.ScriptPath!);
+                if (script.Contains("Find-PSResource", StringComparison.Ordinal))
+                {
+                    var names = DecodeLines(request.Arguments[0]);
+                    var repositories = DecodeLines(request.Arguments[2]);
+
+                    if (names.Contains("PSPublishModule", StringComparer.OrdinalIgnoreCase))
+                    {
+                        calls.Add("find-main");
+                        Assert.Equal("CompanyGallery", Assert.Single(repositories));
+                        Assert.Equal("publisher", request.Arguments[4]);
+                        Assert.Equal("target-token", request.Arguments[5]);
+                        return new PowerShellRunResult(0, VisibleRepositoryItem("PSPublishModule", "3.0.12"), string.Empty, "pwsh.exe");
+                    }
+
+                    if (names.Contains("DependencyModule", StringComparer.OrdinalIgnoreCase) &&
+                        repositories.Contains("CompanyGallery", StringComparer.OrdinalIgnoreCase))
+                    {
+                        calls.Add("find-target-dependency");
+                        Assert.Equal("publisher", request.Arguments[4]);
+                        Assert.Equal("target-token", request.Arguments[5]);
+                        return new PowerShellRunResult(
+                            0,
+                            dependencyPublished ? VisibleRepositoryItem("DependencyModule", "1.2.3") : string.Empty,
+                            string.Empty,
+                            "pwsh.exe");
+                    }
+
+                    if (names.Contains("DependencyModule", StringComparer.OrdinalIgnoreCase) &&
+                        repositories.Contains("PSGallery", StringComparer.OrdinalIgnoreCase))
+                    {
+                        calls.Add("find-source-dependency");
+                        Assert.Equal(string.Empty, request.Arguments[4]);
+                        Assert.Equal(string.Empty, request.Arguments[5]);
+                        return new PowerShellRunResult(
+                            0,
+                            string.Join(Environment.NewLine, new[]
+                            {
+                                VisibleRepositoryItem("DependencyModule", "1.2.3"),
+                                VisibleRepositoryItem("DependencyModule", "1.6.0")
+                            }),
+                            string.Empty,
+                            "pwsh.exe");
+                    }
+
+                    return new PowerShellRunResult(0, string.Empty, string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Save-PSResource", StringComparison.Ordinal))
+                {
+                    calls.Add("save-dependency");
+                    Assert.Equal("DependencyModule", request.Arguments[0]);
+                    Assert.Equal("1.2.3", request.Arguments[1]);
+                    Assert.Equal("PSGallery", request.Arguments[2]);
+                    Assert.Equal(string.Empty, request.Arguments[9]);
+                    Assert.Equal(string.Empty, request.Arguments[10]);
+
+                    var savedModulePath = Path.Combine(request.Arguments[3], "DependencyModule", "1.2.3");
+                    Directory.CreateDirectory(savedModulePath);
+                    File.WriteAllText(Path.Combine(savedModulePath, "DependencyModule.psd1"), "@{ ModuleVersion = '1.2.3'; RootModule = 'DependencyModule.psm1' }");
+                    File.WriteAllText(Path.Combine(savedModulePath, "DependencyModule.psm1"), string.Empty);
+
+                    return new PowerShellRunResult(0, SaveRepositoryItem("DependencyModule", "1.2.3"), string.Empty, "pwsh.exe");
+                }
+
+                if (script.Contains("Publish-PSResource", StringComparison.Ordinal))
+                {
+                    Assert.Equal("CompanyGallery", request.Arguments[2]);
+                    Assert.Equal("target-api-key", request.Arguments[3]);
+                    Assert.Equal("publisher", request.Arguments[7]);
+                    Assert.Equal("target-token", request.Arguments[8]);
+
+                    if (request.Arguments[0].Contains("DependencyModule", StringComparison.OrdinalIgnoreCase))
+                    {
+                        calls.Add("publish-dependency");
+                        dependencyPublished = true;
+                    }
+                    else
+                    {
+                        calls.Add("publish-main");
+                    }
+
+                    return new PowerShellRunResult(0, "PFPSRG::PUBLISH::OK", string.Empty, "pwsh.exe");
+                }
+
+                throw new InvalidOperationException("Unexpected PowerShell script invocation.");
+            });
+            var publisher = new ModulePublisher(new NullLogger(), runner);
+
+            var publish = new PublishConfiguration
+            {
+                Destination = PublishDestination.PowerShellGallery,
+                Enabled = true,
+                Tool = PublishTool.PSResourceGet,
+                ApiKey = "target-api-key",
+                RepositoryName = "CompanyGallery",
+                PublishRequiredModules = true,
+                RequiredModuleSourceRepository = "PSGallery",
+                Repository = new PublishRepositoryConfiguration
+                {
+                    Name = "CompanyGallery",
+                    Credential = new RepositoryCredential
+                    {
+                        UserName = "publisher",
+                        Secret = "target-token"
+                    }
+                }
+            };
+            var plan = CreatePlan();
+            var buildResult = new ModuleBuildResult(
+                stagingPath: stagingRoot,
+                manifestPath: manifestPath,
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var result = publisher.Publish(publish, plan, buildResult, Array.Empty<ArtefactBuildResult>());
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(
+                new[]
+                {
+                    "find-main",
+                    "find-target-dependency",
+                    "find-source-dependency",
+                    "save-dependency",
+                    "publish-dependency",
+                    "find-target-dependency",
+                    "publish-main"
+                },
+                calls);
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+                Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
     private static string Encode(string value)
         => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
 
@@ -331,6 +494,14 @@ public sealed class ModulePublisherRepositoryVersionTests
             Encode(name),
             Encode(Guid.Empty.ToString()),
             Encode(string.Empty)
+        });
+
+    private static string SaveRepositoryItem(string name, string version)
+        => string.Join("::", new[]
+        {
+            "PFPSRG::SAVE::ITEM",
+            Encode(name),
+            Encode(version)
         });
 
     private static ModulePipelinePlan CreatePlan()

--- a/PowerForge.Tests/ModulePublisherRequiredModulesTests.cs
+++ b/PowerForge.Tests/ModulePublisherRequiredModulesTests.cs
@@ -93,6 +93,51 @@ public sealed class ModulePublisherRequiredModulesTests
     }
 
     [Fact]
+    public void SelectRequiredModuleVersionForPublish_PicksHighestMatchingVersion()
+    {
+        var required = new RequiredModuleReference(
+            moduleName: "Microsoft.Graph.Authentication",
+            moduleVersion: "2.0.0",
+            maximumVersion: "2.10.0");
+
+        var selected = RequiredModuleRepositoryPublisher.SelectRequiredModuleVersionForPublish(
+            required,
+            new[]
+            {
+                new PSResourceInfo("Microsoft.Graph.Authentication", "1.0.0", "PSGallery", null, null),
+                new PSResourceInfo("Microsoft.Graph.Authentication", "2.2.0", "PSGallery", null, null),
+                new PSResourceInfo("Microsoft.Graph.Authentication", "2.9.1", "PSGallery", null, null),
+                new PSResourceInfo("Microsoft.Graph.Authentication", "2.11.0", "PSGallery", null, null)
+            });
+
+        Assert.NotNull(selected);
+        Assert.Equal("2.9.1", selected!.Version);
+    }
+
+    [Fact]
+    public void FindSavedModulePath_ReturnsVersionFolderContainingManifest()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var modulePath = Path.Combine(root.FullName, "Microsoft.Graph.Authentication", "2.9.1");
+            Directory.CreateDirectory(modulePath);
+            File.WriteAllText(Path.Combine(modulePath, "Microsoft.Graph.Authentication.psd1"), "@{ ModuleVersion = '2.9.1' }");
+
+            var selected = RequiredModuleRepositoryPublisher.FindSavedModulePath(
+                root.FullName,
+                "Microsoft.Graph.Authentication",
+                "2.9.1");
+
+            Assert.Equal(modulePath, selected);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void GetRequiredModulesForPublish_UsesExistingManifestEvenWhenRequiredModulesAreEmpty()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePublisherRequiredModulesTests.cs
+++ b/PowerForge.Tests/ModulePublisherRequiredModulesTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -114,6 +115,25 @@ public sealed class ModulePublisherRequiredModulesTests
         Assert.Equal("2.9.1", selected!.Version);
     }
 
+    [Fact]
+    public void SelectRequiredModuleVersionForPublish_PrefersStableWhenPrereleaseIsNotRequired()
+    {
+        var required = new RequiredModuleReference(
+            moduleName: "DependencyModule",
+            moduleVersion: "1.0.0");
+
+        var selected = RequiredModuleRepositoryPublisher.SelectRequiredModuleVersionForPublish(
+            required,
+            new[]
+            {
+                new PSResourceInfo("DependencyModule", "1.9.0", "PSGallery", null, null),
+                new PSResourceInfo("DependencyModule", "2.0.0", "PSGallery", null, null, preRelease: "preview1")
+            });
+
+        Assert.NotNull(selected);
+        Assert.Equal("1.9.0", ModulePublisher.GetRepositoryVersionText(selected!));
+    }
+
     [Theory]
     [InlineData("1.2.3", null, null, "[1.2.3]")]
     [InlineData(null, "1.0.0", "1.5.0", "[1.0.0,1.5.0]")]
@@ -160,7 +180,7 @@ public sealed class ModulePublisherRequiredModulesTests
     }
 
     [Fact]
-    public void FindSavedModulePathsForPublish_ReturnsDependenciesBeforePrimaryModule()
+    public void FindSavedModulePackagesForPublish_ReturnsSavedDependenciesBeforePrimaryModule()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -172,12 +192,17 @@ public sealed class ModulePublisherRequiredModulesTests
             File.WriteAllText(Path.Combine(dependencyPath, "DependencySupport.psd1"), "@{ ModuleVersion = '1.0.0' }");
             File.WriteAllText(Path.Combine(primaryPath, "DependencyModule.psd1"), "@{ ModuleVersion = '1.2.3' }");
 
-            var paths = RequiredModuleRepositoryPublisher.FindSavedModulePathsForPublish(
+            var paths = RequiredModuleRepositoryPublisher.FindSavedModulePackagesForPublish(
                 root.FullName,
+                new[]
+                {
+                    new PSResourceInfo("DependencyModule", "1.2.3", "PSGallery", null, null),
+                    new PSResourceInfo("DependencySupport", "1.0.0", "PSGallery", null, null)
+                },
                 "DependencyModule",
                 "1.2.3");
 
-            Assert.Equal(new[] { dependencyPath, primaryPath }, paths);
+            Assert.Equal(new[] { dependencyPath, primaryPath }, paths.Select(path => path.Path));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePublisherRequiredModulesTests.cs
+++ b/PowerForge.Tests/ModulePublisherRequiredModulesTests.cs
@@ -114,6 +114,28 @@ public sealed class ModulePublisherRequiredModulesTests
         Assert.Equal("2.9.1", selected!.Version);
     }
 
+    [Theory]
+    [InlineData("1.2.3", null, null, "[1.2.3]")]
+    [InlineData(null, "1.0.0", "1.5.0", "[1.0.0,1.5.0]")]
+    [InlineData(null, "1.0.0", null, "[1.0.0,)")]
+    [InlineData(null, null, "1.5.0", "(,1.5.0]")]
+    public void BuildPSResourceGetVersionRange_UsesRequiredModuleConstraint(
+        string? requiredVersion,
+        string? moduleVersion,
+        string? maximumVersion,
+        string expected)
+    {
+        var required = new RequiredModuleReference(
+            moduleName: "DependencyModule",
+            requiredVersion: requiredVersion,
+            moduleVersion: moduleVersion,
+            maximumVersion: maximumVersion);
+
+        var range = RequiredModuleRepositoryPublisher.BuildPSResourceGetVersionRange(required);
+
+        Assert.Equal(expected, range);
+    }
+
     [Fact]
     public void FindSavedModulePath_ReturnsVersionFolderContainingManifest()
     {
@@ -130,6 +152,32 @@ public sealed class ModulePublisherRequiredModulesTests
                 "2.9.1");
 
             Assert.Equal(modulePath, selected);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FindSavedModulePathsForPublish_ReturnsDependenciesBeforePrimaryModule()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var dependencyPath = Path.Combine(root.FullName, "DependencySupport", "1.0.0");
+            var primaryPath = Path.Combine(root.FullName, "DependencyModule", "1.2.3");
+            Directory.CreateDirectory(dependencyPath);
+            Directory.CreateDirectory(primaryPath);
+            File.WriteAllText(Path.Combine(dependencyPath, "DependencySupport.psd1"), "@{ ModuleVersion = '1.0.0' }");
+            File.WriteAllText(Path.Combine(primaryPath, "DependencyModule.psd1"), "@{ ModuleVersion = '1.2.3' }");
+
+            var paths = RequiredModuleRepositoryPublisher.FindSavedModulePathsForPublish(
+                root.FullName,
+                "DependencyModule",
+                "1.2.3");
+
+            Assert.Equal(new[] { dependencyPath, primaryPath }, paths);
         }
         finally
         {

--- a/PowerForge.Tests/PublishConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/PublishConfigurationFactoryTests.cs
@@ -380,4 +380,43 @@ public sealed class PublishConfigurationFactoryTests
         Assert.Contains("ContainerRegistry", ex.Message, StringComparison.Ordinal);
         Assert.Contains("Azure Artifacts", ex.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Create_sets_required_module_publish_source()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var segment = factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "ApiKey",
+            Type = PublishDestination.PowerShellGallery,
+            ApiKey = "token",
+            RepositoryName = "CompanyGallery",
+            Enabled = true,
+            PublishRequiredModules = true,
+            RequiredModuleSourceRepository = "InternalUpstream"
+        });
+
+        Assert.True(segment.Configuration.PublishRequiredModules);
+        Assert.Equal("InternalUpstream", segment.Configuration.RequiredModuleSourceRepository);
+    }
+
+    [Fact]
+    public void Create_defaults_required_module_publish_source_to_psgallery()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var segment = factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "ApiKey",
+            Type = PublishDestination.PowerShellGallery,
+            ApiKey = "token",
+            RepositoryName = "CompanyGallery",
+            Enabled = true,
+            PublishRequiredModules = true
+        });
+
+        Assert.True(segment.Configuration.PublishRequiredModules);
+        Assert.Equal("PSGallery", segment.Configuration.RequiredModuleSourceRepository);
+    }
 }

--- a/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
@@ -63,6 +63,15 @@ public sealed class PublishConfiguration
     /// <summary>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</summary>
     public bool UseAsDependencyVersionSource { get; set; }
 
+    /// <summary>
+    /// When true, missing manifest RequiredModules are saved from <see cref="RequiredModuleSourceRepository"/>
+    /// and published to the target repository before the main module is published.
+    /// </summary>
+    public bool PublishRequiredModules { get; set; }
+
+    /// <summary>Repository used as the source when <see cref="PublishRequiredModules"/> mirrors dependencies.</summary>
+    public string? RequiredModuleSourceRepository { get; set; } = "PSGallery";
+
     /// <summary>Verbose mode requested.</summary>
     public bool Verbose { get; set; }
 }

--- a/PowerForge/Services/ModulePublishConfigurationReader.cs
+++ b/PowerForge/Services/ModulePublishConfigurationReader.cs
@@ -60,6 +60,8 @@ public sealed class ModulePublishConfigurationReader
             RepositoryName = configuration.RepositoryName,
             Repository = CloneRepository(configuration.Repository),
             Force = configuration.Force,
+            PublishRequiredModules = configuration.PublishRequiredModules,
+            RequiredModuleSourceRepository = configuration.RequiredModuleSourceRepository,
             OverwriteTagName = configuration.OverwriteTagName,
             DoNotMarkAsPreRelease = configuration.DoNotMarkAsPreRelease,
             GenerateReleaseNotes = configuration.GenerateReleaseNotes,

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -17,6 +17,8 @@ public sealed class ModulePublisher
     private readonly PowerShellGetClient _powerShellGet;
     private readonly GitHubReleasePublisher _gitHub;
     private readonly PowerShellGalleryVersionFeedClient _powerShellGalleryFeed;
+    private readonly RequiredModuleRepositoryPublisher _requiredModuleRepositoryPublisher;
+    private readonly RequiredModuleRepositoryValidator _requiredModuleRepositoryValidator;
 
     /// <summary>
     /// Creates a new publisher using the provided logger and the default out-of-process PowerShell runner.
@@ -42,6 +44,8 @@ public sealed class ModulePublisher
             ? new RepositoryPublisher(_logger, runner)
             : new RepositoryPublisher(_logger, runner, processRunner);
         _psResourceGet = new PSResourceGetClient(runner, _logger);
+        _requiredModuleRepositoryPublisher = new RequiredModuleRepositoryPublisher(_logger, _psResourceGet, _repositoryPublisher);
+        _requiredModuleRepositoryValidator = new RequiredModuleRepositoryValidator(_logger, _psResourceGet, _requiredModuleRepositoryPublisher);
         _powerShellGet = new PowerShellGetClient(runner, _logger);
         _gitHub = new GitHubReleasePublisher(_logger);
         _powerShellGalleryFeed = new PowerShellGalleryVersionFeedClient(_logger, client);
@@ -159,7 +163,13 @@ public sealed class ModulePublisher
 
             if (tool != PublishTool.PowerShellGet)
             {
-                ValidateRequiredModulesForRepositoryPublish(repositoryName, credential, plan, buildResult);
+                _requiredModuleRepositoryValidator.Validate(
+                    publish,
+                    repositoryName,
+                    credential,
+                    repositoryForPublish,
+                    plan,
+                    buildResult);
             }
 
             _repositoryPublisher.Publish(
@@ -255,83 +265,6 @@ public sealed class ModulePublisher
         {
             // best effort
         }
-    }
-
-    private void ValidateRequiredModulesForRepositoryPublish(
-        string repositoryName,
-        RepositoryCredential? credential,
-        ModulePipelinePlan plan,
-        ModuleBuildResult buildResult)
-    {
-        var requiredModules = GetRequiredModulesForPublish(buildResult, plan);
-        if (requiredModules.Length == 0)
-            return;
-        var externalModuleDependencies = GetExternalModulesForPublish(buildResult, plan);
-
-        var missing = new List<string>();
-
-        foreach (var requiredModule in requiredModules)
-        {
-            if (ShouldSkipRepositoryDependencyValidation(requiredModule, externalModuleDependencies))
-            {
-                _logger.Info($"Skipping repository dependency verification for required module '{requiredModule.ModuleName}' because it is listed in ExternalModuleDependencies.");
-                continue;
-            }
-
-            IReadOnlyList<string> versions;
-            try
-            {
-                versions = _psResourceGet.Find(
-                        new PSResourceFindOptions(
-                            names: new[] { requiredModule.ModuleName },
-                            version: null,
-                            prerelease: true,
-                            repositories: new[] { repositoryName },
-                            credential: credential),
-                        timeout: TimeSpan.FromMinutes(2))
-                    .Where(r => string.Equals(r.Name, requiredModule.ModuleName, StringComparison.OrdinalIgnoreCase))
-                    .Select(r => r.Version)
-                    .Where(v => !string.IsNullOrWhiteSpace(v))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to verify required dependency '{requiredModule.ModuleName}' in repository '{repositoryName}' before publish. {ex.Message}");
-            }
-
-            if (!HasMatchingRequiredModuleVersion(requiredModule, versions))
-            {
-                missing.Add($"{requiredModule.ModuleName} [{FormatRequiredModuleConstraint(requiredModule)}]");
-            }
-        }
-
-        if (missing.Count > 0)
-        {
-            throw new InvalidOperationException(
-                $"Required module dependency check failed for repository '{repositoryName}'. Missing or incompatible: {string.Join(", ", missing)}.");
-        }
-    }
-
-    private static HashSet<string> GetExternalModulesForPublish(
-        ModuleBuildResult buildResult,
-        ModulePipelinePlan plan)
-    {
-        if (!string.IsNullOrWhiteSpace(buildResult.ManifestPath) &&
-            File.Exists(buildResult.ManifestPath) &&
-            ModuleManifestValueReader.ReadPsDataStringOrArray(buildResult.ManifestPath, "ExternalModuleDependencies") is { Length: > 0 } manifestExternalModules)
-        {
-            return manifestExternalModules
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .Select(n => n.Trim())
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        }
-
-        return (plan.ExternalModuleDependencies ?? Array.Empty<string>())
-            .Where(n => !string.IsNullOrWhiteSpace(n))
-            .Select(n => n.Trim())
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     internal static RequiredModuleReference[] GetRequiredModulesForPublish(

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -167,13 +167,16 @@ public sealed class ModulePublisher
 
             var modulePath = Path.GetFullPath(temporaryPublishPath);
 
-            _requiredModuleRepositoryValidator.Validate(
-                publish,
-                repositoryName,
-                credential,
-                repositoryForPublish,
-                plan,
-                buildResult);
+            if (tool != PublishTool.PowerShellGet)
+            {
+                _requiredModuleRepositoryValidator.Validate(
+                    publish,
+                    repositoryName,
+                    credential,
+                    repositoryForPublish,
+                    plan,
+                    buildResult);
+            }
 
             _repositoryPublisher.Publish(
                 new RepositoryPublishRequest

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -131,6 +131,12 @@ public sealed class ModulePublisher
         PublishRepositoryConfiguration? repoConfig,
         bool includeScriptFolders)
     {
+        if (publish.PublishRequiredModules && tool == PublishTool.PowerShellGet)
+        {
+            throw new InvalidOperationException(
+                "PublishRequiredModules requires PSResourceGet because dependency mirroring saves and republishes dependency graphs before publishing the main module. Use Tool = PSResourceGet or disable PublishRequiredModules.");
+        }
+
         var credential = _repositoryPublisher.ResolveCredentialForRepository(repoConfig);
         string? temporaryPublishPath = null;
         var repositoryCreated = false;
@@ -161,16 +167,13 @@ public sealed class ModulePublisher
 
             var modulePath = Path.GetFullPath(temporaryPublishPath);
 
-            if (tool != PublishTool.PowerShellGet)
-            {
-                _requiredModuleRepositoryValidator.Validate(
-                    publish,
-                    repositoryName,
-                    credential,
-                    repositoryForPublish,
-                    plan,
-                    buildResult);
-            }
+            _requiredModuleRepositoryValidator.Validate(
+                publish,
+                repositoryName,
+                credential,
+                repositoryForPublish,
+                plan,
+                buildResult);
 
             _repositoryPublisher.Publish(
                 new RepositoryPublishRequest

--- a/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
@@ -46,7 +46,7 @@ internal sealed class RequiredModuleRepositoryPublisher
         var sourceItems = _psResourceGet.Find(
                 new PSResourceFindOptions(
                     names: new[] { moduleName },
-                    version: null,
+                    version: BuildPSResourceGetVersionRange(requiredModule),
                     prerelease: true,
                     repositories: new[] { sourceRepository },
                     credential: sourceCredential),
@@ -74,7 +74,7 @@ internal sealed class RequiredModuleRepositoryPublisher
                     repository: sourceRepository,
                     prerelease: true,
                     trustRepository: true,
-                    skipDependencyCheck: true,
+                    skipDependencyCheck: false,
                     acceptLicense: true,
                     quiet: true,
                     credential: sourceCredential),
@@ -84,19 +84,22 @@ internal sealed class RequiredModuleRepositoryPublisher
             if (savedModulePath is null)
                 throw new InvalidOperationException($"Save-PSResource completed for required module '{moduleName}' {selectedVersion}, but the saved module manifest was not found under '{tempRoot}'.");
 
-            _repositoryPublisher.Publish(
-                new RepositoryPublishRequest
-                {
-                    Path = savedModulePath,
-                    IsNupkg = false,
-                    RepositoryName = targetRepositoryNameValue,
-                    Tool = PublishTool.PSResourceGet,
-                    ApiKey = string.IsNullOrWhiteSpace(targetApiKey) ? null : targetApiKey,
-                    Repository = targetRepository,
-                    DestinationPath = null,
-                    SkipDependenciesCheck = true,
-                    SkipModuleManifestValidate = false
-                });
+            foreach (var modulePath in FindSavedModulePathsForPublish(tempRoot, moduleName, selectedVersion))
+            {
+                _repositoryPublisher.Publish(
+                    new RepositoryPublishRequest
+                    {
+                        Path = modulePath,
+                        IsNupkg = false,
+                        RepositoryName = targetRepositoryNameValue,
+                        Tool = PublishTool.PSResourceGet,
+                        ApiKey = string.IsNullOrWhiteSpace(targetApiKey) ? null : targetApiKey,
+                        Repository = targetRepository,
+                        DestinationPath = null,
+                        SkipDependenciesCheck = true,
+                        SkipModuleManifestValidate = false
+                    });
+            }
 
             _logger.Info($"Published required module '{moduleName}' {selectedVersion} to repository '{targetRepositoryNameValue}'.");
         }
@@ -112,6 +115,31 @@ internal sealed class RequiredModuleRepositoryPublisher
                 // best effort cleanup
             }
         }
+    }
+
+    internal static string? BuildPSResourceGetVersionRange(RequiredModuleReference requiredModule)
+    {
+        if (requiredModule is null)
+            return null;
+
+        if (!string.IsNullOrWhiteSpace(requiredModule.RequiredVersion))
+            return $"[{requiredModule.RequiredVersion!.Trim()}]";
+
+        var minimum = string.IsNullOrWhiteSpace(requiredModule.ModuleVersion)
+            ? null
+            : requiredModule.ModuleVersion!.Trim();
+        var maximum = string.IsNullOrWhiteSpace(requiredModule.MaximumVersion)
+            ? null
+            : requiredModule.MaximumVersion!.Trim();
+
+        if (minimum is not null && maximum is not null)
+            return $"[{minimum},{maximum}]";
+        if (minimum is not null)
+            return $"[{minimum},)";
+        if (maximum is not null)
+            return $"(,{maximum}]";
+
+        return null;
     }
 
     internal static PSResourceInfo? SelectRequiredModuleVersionForPublish(
@@ -176,6 +204,32 @@ internal sealed class RequiredModuleRepositoryPublisher
 
         return manifests[0];
     }
+
+    internal static IReadOnlyList<string> FindSavedModulePathsForPublish(string rootPath, string primaryModuleName, string primaryVersionText)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath) || !Directory.Exists(rootPath))
+            return Array.Empty<string>();
+
+        var manifests = Directory
+            .EnumerateFiles(rootPath, "*.psd1", SearchOption.AllDirectories)
+            .Select(Path.GetDirectoryName)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var primary = FindSavedModulePath(rootPath, primaryModuleName, primaryVersionText);
+        var dependencies = manifests
+            .Where(path => primary is null || !string.Equals(path, primary, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (primary is not null)
+            dependencies.Add(primary);
+
+        return dependencies;
+    }
+
 
     private static int CompareRepositoryVersions(string? left, string? right)
     {

--- a/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
@@ -284,7 +284,21 @@ internal sealed class RequiredModuleRepositoryPublisher
         return dependencies;
     }
 
-    internal sealed record SavedRequiredModulePackage(string Name, string Version, string Path);
+    internal sealed class SavedRequiredModulePackage
+    {
+        public SavedRequiredModulePackage(string name, string version, string path)
+        {
+            Name = name;
+            Version = version;
+            Path = path;
+        }
+
+        public string Name { get; }
+
+        public string Version { get; }
+
+        public string Path { get; }
+    }
 
     private static int CompareRepositoryVersions(string? left, string? right)
     {
@@ -325,7 +339,7 @@ internal sealed class RequiredModuleRepositoryPublisher
     }
 
     private static bool IsPrereleaseVersion(string? value)
-        => !string.IsNullOrWhiteSpace(value) && value!.IndexOf('-', StringComparison.Ordinal) >= 0;
+        => !string.IsNullOrWhiteSpace(value) && value!.IndexOf('-') >= 0;
 
     private static int ComparePreRelease(string left, string right)
     {

--- a/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+/// <summary>
+/// Mirrors manifest RequiredModules from a source repository into the target publish repository.
+/// </summary>
+internal sealed class RequiredModuleRepositoryPublisher
+{
+    private readonly ILogger _logger;
+    private readonly PSResourceGetClient _psResourceGet;
+    private readonly RepositoryPublisher _repositoryPublisher;
+
+    public RequiredModuleRepositoryPublisher(
+        ILogger logger,
+        PSResourceGetClient psResourceGet,
+        RepositoryPublisher repositoryPublisher)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _psResourceGet = psResourceGet ?? throw new ArgumentNullException(nameof(psResourceGet));
+        _repositoryPublisher = repositoryPublisher ?? throw new ArgumentNullException(nameof(repositoryPublisher));
+    }
+
+    public void PublishRequiredModule(
+        RequiredModuleReference requiredModule,
+        string sourceRepositoryName,
+        string targetRepositoryName,
+        string? targetApiKey,
+        PublishRepositoryConfiguration? targetRepository,
+        RepositoryCredential? sourceCredential)
+    {
+        if (requiredModule is null) throw new ArgumentNullException(nameof(requiredModule));
+        if (string.IsNullOrWhiteSpace(requiredModule.ModuleName)) throw new ArgumentException("Required module name is required.", nameof(requiredModule));
+        if (string.IsNullOrWhiteSpace(sourceRepositoryName)) throw new ArgumentException("Source repository name is required.", nameof(sourceRepositoryName));
+        if (string.IsNullOrWhiteSpace(targetRepositoryName)) throw new ArgumentException("Target repository name is required.", nameof(targetRepositoryName));
+
+        var moduleName = requiredModule.ModuleName.Trim();
+        var sourceRepository = sourceRepositoryName.Trim();
+        var targetRepositoryNameValue = targetRepositoryName.Trim();
+
+        _logger.Info($"Publishing missing required module '{moduleName}' from repository '{sourceRepository}' to repository '{targetRepositoryNameValue}'.");
+
+        var sourceItems = _psResourceGet.Find(
+                new PSResourceFindOptions(
+                    names: new[] { moduleName },
+                    version: null,
+                    prerelease: true,
+                    repositories: new[] { sourceRepository },
+                    credential: sourceCredential),
+                timeout: TimeSpan.FromMinutes(2))
+            .Where(r => string.Equals(r.Name, moduleName, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        var selected = SelectRequiredModuleVersionForPublish(requiredModule, sourceItems);
+        if (selected is null)
+        {
+            throw new InvalidOperationException(
+                $"Required module '{moduleName}' is missing in repository '{targetRepositoryNameValue}', and no matching version was found in source repository '{sourceRepository}'. Constraint: {ModulePublisher.FormatRequiredModuleConstraint(requiredModule)}.");
+        }
+
+        var selectedVersion = ModulePublisher.GetRepositoryVersionText(selected);
+        var tempRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "required-modules", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(tempRoot);
+            _psResourceGet.Save(
+                new PSResourceSaveOptions(
+                    name: moduleName,
+                    destinationPath: tempRoot,
+                    version: selectedVersion,
+                    repository: sourceRepository,
+                    prerelease: true,
+                    trustRepository: true,
+                    skipDependencyCheck: true,
+                    acceptLicense: true,
+                    quiet: true,
+                    credential: sourceCredential),
+                timeout: TimeSpan.FromMinutes(10));
+
+            var savedModulePath = FindSavedModulePath(tempRoot, moduleName, selectedVersion);
+            if (savedModulePath is null)
+                throw new InvalidOperationException($"Save-PSResource completed for required module '{moduleName}' {selectedVersion}, but the saved module manifest was not found under '{tempRoot}'.");
+
+            _repositoryPublisher.Publish(
+                new RepositoryPublishRequest
+                {
+                    Path = savedModulePath,
+                    IsNupkg = false,
+                    RepositoryName = targetRepositoryNameValue,
+                    Tool = PublishTool.PSResourceGet,
+                    ApiKey = string.IsNullOrWhiteSpace(targetApiKey) ? null : targetApiKey,
+                    Repository = targetRepository,
+                    DestinationPath = null,
+                    SkipDependenciesCheck = true,
+                    SkipModuleManifestValidate = false
+                });
+
+            _logger.Info($"Published required module '{moduleName}' {selectedVersion} to repository '{targetRepositoryNameValue}'.");
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(tempRoot))
+                    Directory.Delete(tempRoot, recursive: true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+    }
+
+    internal static PSResourceInfo? SelectRequiredModuleVersionForPublish(
+        RequiredModuleReference requiredModule,
+        IReadOnlyList<PSResourceInfo> candidates)
+    {
+        if (requiredModule is null || candidates is null || candidates.Count == 0)
+            return null;
+
+        PSResourceInfo? selected = null;
+        foreach (var candidate in candidates)
+        {
+            if (candidate is null ||
+                !string.Equals(candidate.Name, requiredModule.ModuleName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var versionText = ModulePublisher.GetRepositoryVersionText(candidate);
+            if (!ModulePublisher.DoesVersionMatchRequiredModule(requiredModule, versionText))
+                continue;
+
+            if (selected is null ||
+                CompareRepositoryVersions(versionText, ModulePublisher.GetRepositoryVersionText(selected)) > 0)
+            {
+                selected = candidate;
+            }
+        }
+
+        return selected;
+    }
+
+    internal static string? FindSavedModulePath(string rootPath, string moduleName, string versionText)
+    {
+        if (string.IsNullOrWhiteSpace(rootPath) ||
+            string.IsNullOrWhiteSpace(moduleName) ||
+            !Directory.Exists(rootPath))
+        {
+            return null;
+        }
+
+        var manifestFileName = moduleName.Trim() + ".psd1";
+        var manifests = Directory
+            .EnumerateFiles(rootPath, "*.psd1", SearchOption.AllDirectories)
+            .Where(path => string.Equals(Path.GetFileName(path), manifestFileName, StringComparison.OrdinalIgnoreCase))
+            .Select(Path.GetDirectoryName)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path!)
+            .ToArray();
+
+        if (manifests.Length == 0)
+            return null;
+
+        var normalizedVersion = (versionText ?? string.Empty).Trim();
+        if (!string.IsNullOrWhiteSpace(normalizedVersion))
+        {
+            var versionMatch = manifests.FirstOrDefault(path =>
+                string.Equals(Path.GetFileName(path), normalizedVersion, StringComparison.OrdinalIgnoreCase));
+            if (versionMatch is not null)
+                return versionMatch;
+        }
+
+        return manifests[0];
+    }
+
+    private static int CompareRepositoryVersions(string? left, string? right)
+    {
+        if (TryParseVersion(left, out var leftVersion, out var leftPreRelease) &&
+            TryParseVersion(right, out var rightVersion, out var rightPreRelease))
+        {
+            var versionComparison = leftVersion.CompareTo(rightVersion);
+            if (versionComparison != 0)
+                return versionComparison;
+
+            if (leftPreRelease is null && rightPreRelease is null) return 0;
+            if (leftPreRelease is null) return 1;
+            if (rightPreRelease is null) return -1;
+
+            return ComparePreRelease(leftPreRelease, rightPreRelease);
+        }
+
+        return StringComparer.OrdinalIgnoreCase.Compare(left, right);
+    }
+
+    private static bool TryParseVersion(string? value, out Version version, out string? preRelease)
+    {
+        version = new Version(0, 0);
+        preRelease = null;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var text = value!.Trim();
+        var dash = text.IndexOf('-');
+        var versionText = dash >= 0 ? text.Substring(0, dash) : text;
+        preRelease = dash >= 0 ? text.Substring(dash + 1) : null;
+
+        if (!Version.TryParse(versionText, out var parsed))
+            return false;
+
+        version = parsed;
+        return true;
+    }
+
+    private static int ComparePreRelease(string left, string right)
+    {
+        var leftParts = left.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+        var rightParts = right.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+        var length = Math.Max(leftParts.Length, rightParts.Length);
+        for (var i = 0; i < length; i++)
+        {
+            if (i >= leftParts.Length) return -1;
+            if (i >= rightParts.Length) return 1;
+
+            var leftNumber = int.TryParse(leftParts[i], out var leftValue);
+            var rightNumber = int.TryParse(rightParts[i], out var rightValue);
+            if (leftNumber && rightNumber)
+            {
+                var comparison = leftValue.CompareTo(rightValue);
+                if (comparison != 0)
+                    return comparison;
+            }
+            else
+            {
+                var comparison = StringComparer.OrdinalIgnoreCase.Compare(leftParts[i], rightParts[i]);
+                if (comparison != 0)
+                    return comparison;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
@@ -30,7 +30,8 @@ internal sealed class RequiredModuleRepositoryPublisher
         string targetRepositoryName,
         string? targetApiKey,
         PublishRepositoryConfiguration? targetRepository,
-        RepositoryCredential? sourceCredential)
+        RepositoryCredential? sourceCredential,
+        ISet<string>? mirroredPackages = null)
     {
         if (requiredModule is null) throw new ArgumentNullException(nameof(requiredModule));
         if (string.IsNullOrWhiteSpace(requiredModule.ModuleName)) throw new ArgumentException("Required module name is required.", nameof(requiredModule));
@@ -47,7 +48,7 @@ internal sealed class RequiredModuleRepositoryPublisher
                 new PSResourceFindOptions(
                     names: new[] { moduleName },
                     version: BuildPSResourceGetVersionRange(requiredModule),
-                    prerelease: true,
+                    prerelease: AllowsPrerelease(requiredModule),
                     repositories: new[] { sourceRepository },
                     credential: sourceCredential),
                 timeout: TimeSpan.FromMinutes(2))
@@ -66,13 +67,13 @@ internal sealed class RequiredModuleRepositoryPublisher
         try
         {
             Directory.CreateDirectory(tempRoot);
-            _psResourceGet.Save(
+            var savedItems = _psResourceGet.Save(
                 new PSResourceSaveOptions(
                     name: moduleName,
                     destinationPath: tempRoot,
                     version: selectedVersion,
                     repository: sourceRepository,
-                    prerelease: true,
+                    prerelease: IsPrereleaseVersion(selectedVersion),
                     trustRepository: true,
                     skipDependencyCheck: false,
                     acceptLicense: true,
@@ -84,12 +85,19 @@ internal sealed class RequiredModuleRepositoryPublisher
             if (savedModulePath is null)
                 throw new InvalidOperationException($"Save-PSResource completed for required module '{moduleName}' {selectedVersion}, but the saved module manifest was not found under '{tempRoot}'.");
 
-            foreach (var modulePath in FindSavedModulePathsForPublish(tempRoot, moduleName, selectedVersion))
+            foreach (var package in FindSavedModulePackagesForPublish(tempRoot, savedItems, moduleName, selectedVersion))
             {
+                var packageKey = $"{package.Name}|{package.Version}";
+                if (mirroredPackages is not null && !mirroredPackages.Add(packageKey))
+                {
+                    _logger.Info($"Skipping already mirrored required module package '{package.Name}' {package.Version}.");
+                    continue;
+                }
+
                 _repositoryPublisher.Publish(
                     new RepositoryPublishRequest
                     {
-                        Path = modulePath,
+                        Path = package.Path,
                         IsNupkg = false,
                         RepositoryName = targetRepositoryNameValue,
                         Tool = PublishTool.PSResourceGet,
@@ -150,6 +158,7 @@ internal sealed class RequiredModuleRepositoryPublisher
             return null;
 
         PSResourceInfo? selected = null;
+        var allowPrerelease = AllowsPrerelease(requiredModule);
         foreach (var candidate in candidates)
         {
             if (candidate is null ||
@@ -159,6 +168,9 @@ internal sealed class RequiredModuleRepositoryPublisher
             }
 
             var versionText = ModulePublisher.GetRepositoryVersionText(candidate);
+            if (!allowPrerelease && IsPrereleaseVersion(versionText))
+                continue;
+
             if (!ModulePublisher.DoesVersionMatchRequiredModule(requiredModule, versionText))
                 continue;
 
@@ -172,6 +184,16 @@ internal sealed class RequiredModuleRepositoryPublisher
         return selected;
     }
 
+    internal static bool AllowsPrerelease(RequiredModuleReference requiredModule)
+    {
+        if (requiredModule is null)
+            return false;
+
+        return IsPrereleaseVersion(requiredModule.RequiredVersion) ||
+               IsPrereleaseVersion(requiredModule.ModuleVersion) ||
+               IsPrereleaseVersion(requiredModule.MaximumVersion);
+    }
+
     internal static string? FindSavedModulePath(string rootPath, string moduleName, string versionText)
     {
         if (string.IsNullOrWhiteSpace(rootPath) ||
@@ -182,6 +204,14 @@ internal sealed class RequiredModuleRepositoryPublisher
         }
 
         var manifestFileName = moduleName.Trim() + ".psd1";
+        var normalizedVersion = (versionText ?? string.Empty).Trim();
+        if (!string.IsNullOrWhiteSpace(normalizedVersion))
+        {
+            var expectedPath = Path.Combine(rootPath, moduleName.Trim(), normalizedVersion);
+            if (File.Exists(Path.Combine(expectedPath, manifestFileName)))
+                return expectedPath;
+        }
+
         var manifests = Directory
             .EnumerateFiles(rootPath, "*.psd1", SearchOption.AllDirectories)
             .Where(path => string.Equals(Path.GetFileName(path), manifestFileName, StringComparison.OrdinalIgnoreCase))
@@ -193,7 +223,6 @@ internal sealed class RequiredModuleRepositoryPublisher
         if (manifests.Length == 0)
             return null;
 
-        var normalizedVersion = (versionText ?? string.Empty).Trim();
         if (!string.IsNullOrWhiteSpace(normalizedVersion))
         {
             var versionMatch = manifests.FirstOrDefault(path =>
@@ -205,23 +234,48 @@ internal sealed class RequiredModuleRepositoryPublisher
         return manifests[0];
     }
 
-    internal static IReadOnlyList<string> FindSavedModulePathsForPublish(string rootPath, string primaryModuleName, string primaryVersionText)
+    internal static IReadOnlyList<SavedRequiredModulePackage> FindSavedModulePackagesForPublish(
+        string rootPath,
+        IReadOnlyList<PSResourceInfo> savedItems,
+        string primaryModuleName,
+        string primaryVersionText)
     {
         if (string.IsNullOrWhiteSpace(rootPath) || !Directory.Exists(rootPath))
-            return Array.Empty<string>();
+            return Array.Empty<SavedRequiredModulePackage>();
 
-        var manifests = Directory
-            .EnumerateFiles(rootPath, "*.psd1", SearchOption.AllDirectories)
-            .Select(Path.GetDirectoryName)
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .Select(path => path!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        var packages = (savedItems ?? Array.Empty<PSResourceInfo>())
+            .Where(item => item is not null && !string.IsNullOrWhiteSpace(item.Name))
+            .Select(item =>
+            {
+                var version = ModulePublisher.GetRepositoryVersionText(item);
+                var path = FindSavedModulePath(rootPath, item.Name, version);
+                return path is null
+                    ? null
+                    : new SavedRequiredModulePackage(item.Name.Trim(), version, path);
+            })
+            .Where(package => package is not null)
+            .Select(package => package!)
+            .GroupBy(package => $"{package.Name}|{package.Version}", StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToList();
 
-        var primary = FindSavedModulePath(rootPath, primaryModuleName, primaryVersionText);
-        var dependencies = manifests
-            .Where(path => primary is null || !string.Equals(path, primary, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+        var primary = packages.FirstOrDefault(package =>
+            string.Equals(package.Name, primaryModuleName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(package.Version, primaryVersionText, StringComparison.OrdinalIgnoreCase));
+        if (primary is null)
+        {
+            var primaryPath = FindSavedModulePath(rootPath, primaryModuleName, primaryVersionText);
+            if (primaryPath is not null)
+            {
+                primary = new SavedRequiredModulePackage(primaryModuleName.Trim(), primaryVersionText.Trim(), primaryPath);
+                packages.Add(primary);
+            }
+        }
+
+        var dependencies = packages
+            .Where(package => primary is null || !string.Equals(package.Path, primary.Path, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(package => package.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(package => package.Version, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         if (primary is not null)
@@ -230,6 +284,7 @@ internal sealed class RequiredModuleRepositoryPublisher
         return dependencies;
     }
 
+    internal sealed record SavedRequiredModulePackage(string Name, string Version, string Path);
 
     private static int CompareRepositoryVersions(string? left, string? right)
     {
@@ -268,6 +323,9 @@ internal sealed class RequiredModuleRepositoryPublisher
         version = parsed;
         return true;
     }
+
+    private static bool IsPrereleaseVersion(string? value)
+        => !string.IsNullOrWhiteSpace(value) && value!.IndexOf('-', StringComparison.Ordinal) >= 0;
 
     private static int ComparePreRelease(string left, string right)
     {

--- a/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryPublisher.cs
@@ -31,6 +31,7 @@ internal sealed class RequiredModuleRepositoryPublisher
         string? targetApiKey,
         PublishRepositoryConfiguration? targetRepository,
         RepositoryCredential? sourceCredential,
+        RepositoryCredential? targetCredential,
         ISet<string>? mirroredPackages = null)
     {
         if (requiredModule is null) throw new ArgumentNullException(nameof(requiredModule));
@@ -88,9 +89,16 @@ internal sealed class RequiredModuleRepositoryPublisher
             foreach (var package in FindSavedModulePackagesForPublish(tempRoot, savedItems, moduleName, selectedVersion))
             {
                 var packageKey = $"{package.Name}|{package.Version}";
-                if (mirroredPackages is not null && !mirroredPackages.Add(packageKey))
+                if (mirroredPackages is not null && mirroredPackages.Contains(packageKey))
                 {
                     _logger.Info($"Skipping already mirrored required module package '{package.Name}' {package.Version}.");
+                    continue;
+                }
+
+                if (TargetRepositoryContainsPackage(targetRepositoryNameValue, targetCredential, package))
+                {
+                    _logger.Info($"Skipping required module package '{package.Name}' {package.Version} because it already exists in repository '{targetRepositoryNameValue}'.");
+                    mirroredPackages?.Add(packageKey);
                     continue;
                 }
 
@@ -107,6 +115,7 @@ internal sealed class RequiredModuleRepositoryPublisher
                         SkipDependenciesCheck = true,
                         SkipModuleManifestValidate = false
                     });
+                mirroredPackages?.Add(packageKey);
             }
 
             _logger.Info($"Published required module '{moduleName}' {selectedVersion} to repository '{targetRepositoryNameValue}'.");
@@ -338,8 +347,40 @@ internal sealed class RequiredModuleRepositoryPublisher
         return true;
     }
 
-    private static bool IsPrereleaseVersion(string? value)
+    internal static bool IsPrereleaseVersion(string? value)
         => !string.IsNullOrWhiteSpace(value) && value!.IndexOf('-') >= 0;
+
+    private bool TargetRepositoryContainsPackage(
+        string targetRepositoryName,
+        RepositoryCredential? targetCredential,
+        SavedRequiredModulePackage package)
+    {
+        try
+        {
+            var versions = _psResourceGet.Find(
+                    new PSResourceFindOptions(
+                        names: new[] { package.Name },
+                        version: $"[{package.Version}]",
+                        prerelease: IsPrereleaseVersion(package.Version),
+                        repositories: new[] { targetRepositoryName },
+                        credential: targetCredential),
+                    timeout: TimeSpan.FromMinutes(2))
+                .Where(r => string.Equals(r.Name, package.Name, StringComparison.OrdinalIgnoreCase))
+                .Select(ModulePublisher.GetRepositoryVersionText)
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .ToArray();
+
+            return versions.Any(version => string.Equals(version, package.Version, StringComparison.OrdinalIgnoreCase));
+        }
+        catch (Exception ex)
+        {
+            if (ModulePublisher.IsRepositoryPackageNotFound(package.Name, ex))
+                return false;
+
+            throw new InvalidOperationException(
+                $"Failed to verify saved dependency '{package.Name}' {package.Version} in repository '{targetRepositoryName}' before mirroring. {ex.Message}");
+        }
+    }
 
     private static int ComparePreRelease(string left, string right)
     {

--- a/PowerForge/Services/RequiredModuleRepositoryValidator.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryValidator.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+/// <summary>
+/// Verifies manifest RequiredModules against a publish repository and optionally mirrors missing modules.
+/// </summary>
+internal sealed class RequiredModuleRepositoryValidator
+{
+    private readonly ILogger _logger;
+    private readonly PSResourceGetClient _psResourceGet;
+    private readonly RequiredModuleRepositoryPublisher _publisher;
+
+    public RequiredModuleRepositoryValidator(
+        ILogger logger,
+        PSResourceGetClient psResourceGet,
+        RequiredModuleRepositoryPublisher publisher)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _psResourceGet = psResourceGet ?? throw new ArgumentNullException(nameof(psResourceGet));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+    }
+
+    public void Validate(
+        PublishConfiguration publish,
+        string repositoryName,
+        RepositoryCredential? credential,
+        PublishRepositoryConfiguration? repositoryForPublish,
+        ModulePipelinePlan plan,
+        ModuleBuildResult buildResult)
+    {
+        if (publish is null) throw new ArgumentNullException(nameof(publish));
+        if (string.IsNullOrWhiteSpace(repositoryName)) throw new ArgumentException("Repository name is required.", nameof(repositoryName));
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+        if (buildResult is null) throw new ArgumentNullException(nameof(buildResult));
+
+        var requiredModules = ModulePublisher.GetRequiredModulesForPublish(buildResult, plan);
+        if (requiredModules.Length == 0)
+            return;
+
+        var externalModuleDependencies = GetExternalModulesForPublish(buildResult, plan);
+        var missing = new List<string>();
+        var sourceRepositoryName = ResolveRequiredModuleSourceRepository(publish);
+
+        foreach (var requiredModule in requiredModules)
+        {
+            if (ModulePublisher.ShouldSkipRepositoryDependencyValidation(requiredModule, externalModuleDependencies))
+            {
+                _logger.Info($"Skipping repository dependency verification for required module '{requiredModule.ModuleName}' because it is listed in ExternalModuleDependencies.");
+                continue;
+            }
+
+            var versions = FindRequiredModuleVersionsInRepository(repositoryName, credential, requiredModule);
+
+            if (!ModulePublisher.HasMatchingRequiredModuleVersion(requiredModule, versions))
+            {
+                if (publish.PublishRequiredModules)
+                {
+                    _publisher.PublishRequiredModule(
+                        requiredModule,
+                        sourceRepositoryName,
+                        repositoryName,
+                        publish.ApiKey,
+                        repositoryForPublish,
+                        sourceCredential: null);
+
+                    versions = FindRequiredModuleVersionsInRepository(repositoryName, credential, requiredModule);
+                    if (ModulePublisher.HasMatchingRequiredModuleVersion(requiredModule, versions))
+                        continue;
+                }
+
+                missing.Add($"{requiredModule.ModuleName} [{ModulePublisher.FormatRequiredModuleConstraint(requiredModule)}]");
+            }
+        }
+
+        if (missing.Count > 0)
+        {
+            var message = $"Required module dependency check failed for repository '{repositoryName}'. Missing or incompatible: {string.Join(", ", missing)}.";
+            if (!publish.PublishRequiredModules)
+                message += $" Enable PublishRequiredModules to mirror missing dependencies from '{sourceRepositoryName}' before publish.";
+
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private IReadOnlyList<string> FindRequiredModuleVersionsInRepository(
+        string repositoryName,
+        RepositoryCredential? credential,
+        RequiredModuleReference requiredModule)
+    {
+        try
+        {
+            return _psResourceGet.Find(
+                    new PSResourceFindOptions(
+                        names: new[] { requiredModule.ModuleName },
+                        version: null,
+                        prerelease: true,
+                        repositories: new[] { repositoryName },
+                        credential: credential),
+                    timeout: TimeSpan.FromMinutes(2))
+                .Where(r => string.Equals(r.Name, requiredModule.ModuleName, StringComparison.OrdinalIgnoreCase))
+                .Select(ModulePublisher.GetRepositoryVersionText)
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to verify required dependency '{requiredModule.ModuleName}' in repository '{repositoryName}' before publish. {ex.Message}");
+        }
+    }
+
+    private static string ResolveRequiredModuleSourceRepository(PublishConfiguration publish)
+        => string.IsNullOrWhiteSpace(publish.RequiredModuleSourceRepository)
+            ? "PSGallery"
+            : publish.RequiredModuleSourceRepository!.Trim();
+
+    private static HashSet<string> GetExternalModulesForPublish(
+        ModuleBuildResult buildResult,
+        ModulePipelinePlan plan)
+    {
+        if (!string.IsNullOrWhiteSpace(buildResult.ManifestPath) &&
+            File.Exists(buildResult.ManifestPath) &&
+            ModuleManifestValueReader.ReadPsDataStringOrArray(buildResult.ManifestPath, "ExternalModuleDependencies") is { Length: > 0 } manifestExternalModules)
+        {
+            return manifestExternalModules
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Select(n => n.Trim())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return (plan.ExternalModuleDependencies ?? Array.Empty<string>())
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/PowerForge/Services/RequiredModuleRepositoryValidator.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryValidator.cs
@@ -41,6 +41,13 @@ internal sealed class RequiredModuleRepositoryValidator
         if (requiredModules.Length == 0)
             return;
 
+        if (publish.PublishRequiredModules &&
+            string.Equals(repositoryName, "PSGallery", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "PublishRequiredModules is only supported for private repository targets. Refusing to mirror dependencies to PSGallery.");
+        }
+
         var externalModuleDependencies = GetExternalModulesForPublish(buildResult, plan);
         var missing = new List<string>();
         var sourceRepositoryName = ResolveRequiredModuleSourceRepository(publish);

--- a/PowerForge/Services/RequiredModuleRepositoryValidator.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryValidator.cs
@@ -44,6 +44,8 @@ internal sealed class RequiredModuleRepositoryValidator
         var externalModuleDependencies = GetExternalModulesForPublish(buildResult, plan);
         var missing = new List<string>();
         var sourceRepositoryName = ResolveRequiredModuleSourceRepository(publish);
+        var sourceCredential = ResolveRequiredModuleSourceCredential(sourceRepositoryName, credential);
+        var mirroredPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var requiredModule in requiredModules)
         {
@@ -69,7 +71,8 @@ internal sealed class RequiredModuleRepositoryValidator
                         repositoryName,
                         publish.ApiKey,
                         repositoryForPublish,
-                        sourceCredential: null);
+                        sourceCredential,
+                        mirroredPackages);
 
                     versions = FindRequiredModuleVersionsInRepository(
                         repositoryName,
@@ -105,7 +108,7 @@ internal sealed class RequiredModuleRepositoryValidator
             return _psResourceGet.Find(
                     new PSResourceFindOptions(
                         names: new[] { requiredModule.ModuleName },
-                        version: null,
+                        version: RequiredModuleRepositoryPublisher.BuildPSResourceGetVersionRange(requiredModule),
                         prerelease: true,
                         repositories: new[] { repositoryName },
                         credential: credential),
@@ -134,6 +137,19 @@ internal sealed class RequiredModuleRepositoryValidator
         => string.IsNullOrWhiteSpace(publish.RequiredModuleSourceRepository)
             ? "PSGallery"
             : publish.RequiredModuleSourceRepository!.Trim();
+
+    private static RepositoryCredential? ResolveRequiredModuleSourceCredential(
+        string sourceRepositoryName,
+        RepositoryCredential? targetCredential)
+    {
+        if (targetCredential is null)
+            return null;
+
+        if (string.Equals(sourceRepositoryName, "PSGallery", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return targetCredential;
+    }
 
     private static HashSet<string> GetExternalModulesForPublish(
         ModuleBuildResult buildResult,

--- a/PowerForge/Services/RequiredModuleRepositoryValidator.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryValidator.cs
@@ -53,7 +53,11 @@ internal sealed class RequiredModuleRepositoryValidator
                 continue;
             }
 
-            var versions = FindRequiredModuleVersionsInRepository(repositoryName, credential, requiredModule);
+            var versions = FindRequiredModuleVersionsInRepository(
+                repositoryName,
+                credential,
+                requiredModule,
+                treatNotFoundAsEmpty: publish.PublishRequiredModules);
 
             if (!ModulePublisher.HasMatchingRequiredModuleVersion(requiredModule, versions))
             {
@@ -67,7 +71,11 @@ internal sealed class RequiredModuleRepositoryValidator
                         repositoryForPublish,
                         sourceCredential: null);
 
-                    versions = FindRequiredModuleVersionsInRepository(repositoryName, credential, requiredModule);
+                    versions = FindRequiredModuleVersionsInRepository(
+                        repositoryName,
+                        credential,
+                        requiredModule,
+                        treatNotFoundAsEmpty: false);
                     if (ModulePublisher.HasMatchingRequiredModuleVersion(requiredModule, versions))
                         continue;
                 }
@@ -89,7 +97,8 @@ internal sealed class RequiredModuleRepositoryValidator
     private IReadOnlyList<string> FindRequiredModuleVersionsInRepository(
         string repositoryName,
         RepositoryCredential? credential,
-        RequiredModuleReference requiredModule)
+        RequiredModuleReference requiredModule,
+        bool treatNotFoundAsEmpty)
     {
         try
         {
@@ -109,6 +118,13 @@ internal sealed class RequiredModuleRepositoryValidator
         }
         catch (Exception ex)
         {
+            if (treatNotFoundAsEmpty &&
+                ModulePublisher.IsRepositoryPackageNotFound(requiredModule.ModuleName, ex))
+            {
+                _logger.Info($"Required dependency '{requiredModule.ModuleName}' is not present in repository '{repositoryName}' and will be mirrored.");
+                return Array.Empty<string>();
+            }
+
             throw new InvalidOperationException(
                 $"Failed to verify required dependency '{requiredModule.ModuleName}' in repository '{repositoryName}' before publish. {ex.Message}");
         }

--- a/PowerForge/Services/RequiredModuleRepositoryValidator.cs
+++ b/PowerForge/Services/RequiredModuleRepositoryValidator.cs
@@ -44,7 +44,7 @@ internal sealed class RequiredModuleRepositoryValidator
         var externalModuleDependencies = GetExternalModulesForPublish(buildResult, plan);
         var missing = new List<string>();
         var sourceRepositoryName = ResolveRequiredModuleSourceRepository(publish);
-        var sourceCredential = ResolveRequiredModuleSourceCredential(sourceRepositoryName, credential);
+        var sourceCredential = ResolveRequiredModuleSourceCredential(sourceRepositoryName, repositoryName, credential);
         var mirroredPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var requiredModule in requiredModules)
@@ -72,6 +72,7 @@ internal sealed class RequiredModuleRepositoryValidator
                         publish.ApiKey,
                         repositoryForPublish,
                         sourceCredential,
+                        credential,
                         mirroredPackages);
 
                     versions = FindRequiredModuleVersionsInRepository(
@@ -109,13 +110,14 @@ internal sealed class RequiredModuleRepositoryValidator
                     new PSResourceFindOptions(
                         names: new[] { requiredModule.ModuleName },
                         version: RequiredModuleRepositoryPublisher.BuildPSResourceGetVersionRange(requiredModule),
-                        prerelease: true,
+                        prerelease: RequiredModuleRepositoryPublisher.AllowsPrerelease(requiredModule),
                         repositories: new[] { repositoryName },
                         credential: credential),
                     timeout: TimeSpan.FromMinutes(2))
                 .Where(r => string.Equals(r.Name, requiredModule.ModuleName, StringComparison.OrdinalIgnoreCase))
                 .Select(ModulePublisher.GetRepositoryVersionText)
                 .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Where(v => RequiredModuleRepositoryPublisher.AllowsPrerelease(requiredModule) || !RequiredModuleRepositoryPublisher.IsPrereleaseVersion(v))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
         }
@@ -140,6 +142,7 @@ internal sealed class RequiredModuleRepositoryValidator
 
     private static RepositoryCredential? ResolveRequiredModuleSourceCredential(
         string sourceRepositoryName,
+        string targetRepositoryName,
         RepositoryCredential? targetCredential)
     {
         if (targetCredential is null)
@@ -148,7 +151,9 @@ internal sealed class RequiredModuleRepositoryValidator
         if (string.Equals(sourceRepositoryName, "PSGallery", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        return targetCredential;
+        return string.Equals(sourceRepositoryName, targetRepositoryName, StringComparison.OrdinalIgnoreCase)
+            ? targetCredential
+            : null;
     }
 
     private static HashSet<string> GetExternalModulesForPublish(


### PR DESCRIPTION
## Summary
- add opt-in publishing of missing manifest RequiredModules into the target private gallery before publishing the main module
- support JFrog/private-gallery dependency probing and publishing with explicit source repository selection
- rewrite the private galleries guide and regenerate module help/docs for standard NuGet, Azure Artifacts, JFrog, MAR, and dependency mirroring flows

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ModulePublisherRepositoryVersionTests|FullyQualifiedName~ModulePublisherRequiredModulesTests|FullyQualifiedName~PublishConfigurationFactoryTests" --nologo
- .\Module\Build\Build-Module.ps1 -NoSign
- git -c core.whitespace=trailing-space,space-before-tab,cr-at-eol diff --cached --check
- parsed Module\en-US\PSPublishModule-help.xml as XML

## Notes
- Build completed with existing local binary conflict advisories and the existing mixed-line-ending warning for PSPublishModule.Tests.ps1.
