### PR TITLE
Add App Store Connect API key support for Apple releases

### DIFF
--- a/PowerForge.Cli/Program.Command.Release.cs
+++ b/PowerForge.Cli/Program.Command.Release.cs
@@ -212,6 +212,19 @@ internal static partial class Program
                     cmdLogger.Info($"Run report: {result.DotNetTools.RunReportPath}");
             }
 
+            if (result.AppleAppPlan is not null)
+            {
+                var appCount = result.AppleAppPlan.Apps?.Length ?? 0;
+                var uploadLabel = result.AppleAppPlan.Upload ? "upload enabled" : "upload disabled";
+                cmdLogger.Success($"Apple apps: {(planOnly || validateOnly ? "planned" : "completed")} ({appCount} app(s), {uploadLabel}).");
+                foreach (var app in result.AppleAppPlan.Apps ?? Array.Empty<PowerForgeAppleAppReleaseTargetPlan>())
+                {
+                    cmdLogger.Info($" -> {app.Name} {app.Platform}: {app.ArchivePath}");
+                    if (result.AppleAppPlan.Upload)
+                        cmdLogger.Info($"    export: {app.ExportPath}");
+                }
+            }
+
             foreach (var release in result.ToolGitHubReleases)
             {
                 if (release.Success)

--- a/PowerForge.Tests/AppleAppArchiveServiceTests.cs
+++ b/PowerForge.Tests/AppleAppArchiveServiceTests.cs
@@ -129,6 +129,35 @@ public sealed class AppleAppArchiveServiceTests
     }
 
     [Fact]
+    public async Task CreateArchiveAsync_rejects_api_key_auth_without_provisioning_updates()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var keyPath = Path.Combine(root.FullName, "AuthKey_ABC123DEFG.p8");
+            await File.WriteAllTextAsync(keyPath, "private-key");
+            var service = new AppleAppArchiveService(new CapturingProcessRunner());
+
+            await Assert.ThrowsAsync<ArgumentException>(() => service.CreateArchiveAsync(new AppleAppArchiveRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "Tactra",
+                ArchivePath = Path.Combine(root.FullName, "Tactra.xcarchive"),
+                AllowProvisioningUpdates = false,
+                AppStoreConnectApiKeyPath = keyPath,
+                AppStoreConnectApiKeyId = "ABC123DEFG",
+                AppStoreConnectApiIssuerId = "issuer-id"
+            }));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task UploadArchiveAsync_writes_export_options_and_runs_export_archive()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -259,6 +288,33 @@ public sealed class AppleAppArchiveServiceTests
                 ArchivePath = archive.FullName,
                 ExportPath = Path.Combine(root.FullName, "export"),
                 AppStoreConnectApiKeyId = "ABC123DEFG"
+            }));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task UploadArchiveAsync_rejects_api_key_auth_without_provisioning_updates()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcarchive"));
+            var keyPath = Path.Combine(root.FullName, "AuthKey_ABC123DEFG.p8");
+            await File.WriteAllTextAsync(keyPath, "private-key");
+            var service = new AppleAppArchiveService(new CapturingProcessRunner());
+
+            await Assert.ThrowsAsync<ArgumentException>(() => service.UploadArchiveAsync(new AppleAppArchiveUploadRequest
+            {
+                ArchivePath = archive.FullName,
+                ExportPath = Path.Combine(root.FullName, "export"),
+                AllowProvisioningUpdates = false,
+                AppStoreConnectApiKeyPath = keyPath,
+                AppStoreConnectApiKeyId = "ABC123DEFG",
+                AppStoreConnectApiIssuerId = "issuer-id"
             }));
         }
         finally

--- a/PowerForge.Tests/AppleAppArchiveServiceTests.cs
+++ b/PowerForge.Tests/AppleAppArchiveServiceTests.cs
@@ -91,6 +91,44 @@ public sealed class AppleAppArchiveServiceTests
     }
 
     [Fact]
+    public async Task CreateArchiveAsync_passes_app_store_connect_api_key_arguments()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var keyPath = Path.Combine(root.FullName, "AuthKey_ABC123DEFG.p8");
+            await File.WriteAllTextAsync(keyPath, "private-key");
+            var runner = new CapturingProcessRunner();
+            var service = new AppleAppArchiveService(runner);
+
+            var result = await service.CreateArchiveAsync(new AppleAppArchiveRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "Tactra",
+                ArchivePath = Path.Combine(root.FullName, "Tactra.xcarchive"),
+                AppStoreConnectApiKeyPath = keyPath,
+                AppStoreConnectApiKeyId = "ABC123DEFG",
+                AppStoreConnectApiIssuerId = "issuer-id"
+            });
+
+            Assert.True(result.Succeeded);
+            var request = Assert.Single(runner.Requests);
+            Assert.Contains("-authenticationKeyPath", request.Arguments);
+            Assert.Contains(keyPath, request.Arguments);
+            Assert.Contains("-authenticationKeyID", request.Arguments);
+            Assert.Contains("ABC123DEFG", request.Arguments);
+            Assert.Contains("-authenticationKeyIssuerID", request.Arguments);
+            Assert.Contains("issuer-id", request.Arguments);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task UploadArchiveAsync_writes_export_options_and_runs_export_archive()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -164,6 +202,64 @@ public sealed class AppleAppArchiveServiceTests
             Assert.True(result.Succeeded);
             var request = Assert.Single(runner.Requests);
             Assert.DoesNotContain("-allowProvisioningUpdates", request.Arguments);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task UploadArchiveAsync_passes_app_store_connect_api_key_arguments()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcarchive"));
+            var keyPath = Path.Combine(root.FullName, "AuthKey_ABC123DEFG.p8");
+            await File.WriteAllTextAsync(keyPath, "private-key");
+            var runner = new CapturingProcessRunner();
+            var service = new AppleAppArchiveService(runner);
+
+            var result = await service.UploadArchiveAsync(new AppleAppArchiveUploadRequest
+            {
+                ArchivePath = archive.FullName,
+                ExportPath = Path.Combine(root.FullName, "export"),
+                AppStoreConnectApiKeyPath = keyPath,
+                AppStoreConnectApiKeyId = "ABC123DEFG",
+                AppStoreConnectApiIssuerId = "issuer-id"
+            });
+
+            Assert.True(result.Succeeded);
+            var request = Assert.Single(runner.Requests);
+            Assert.Contains("-authenticationKeyPath", request.Arguments);
+            Assert.Contains(keyPath, request.Arguments);
+            Assert.Contains("-authenticationKeyID", request.Arguments);
+            Assert.Contains("ABC123DEFG", request.Arguments);
+            Assert.Contains("-authenticationKeyIssuerID", request.Arguments);
+            Assert.Contains("issuer-id", request.Arguments);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task UploadArchiveAsync_rejects_partial_app_store_connect_api_key_configuration()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcarchive"));
+            var service = new AppleAppArchiveService(new CapturingProcessRunner());
+
+            await Assert.ThrowsAsync<ArgumentException>(() => service.UploadArchiveAsync(new AppleAppArchiveUploadRequest
+            {
+                ArchivePath = archive.FullName,
+                ExportPath = Path.Combine(root.FullName, "export"),
+                AppStoreConnectApiKeyId = "ABC123DEFG"
+            }));
         }
         finally
         {

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -470,6 +470,9 @@ public sealed class PowerForgeReleaseServiceTests
                         AllowProvisioningUpdates = false,
                         SigningStyle = "automatic",
                         ManageAppVersionAndBuildNumber = true,
+                        AppStoreConnectApiKeyPath = "secrets/AuthKey_ABC123DEFG.p8",
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
                         Apps = new[]
                         {
                             new AppleAppConfiguration
@@ -492,12 +495,18 @@ public sealed class PowerForgeReleaseServiceTests
             Assert.Equal("xcodebuild-test", archiveRequest.XcodeBuildExecutable);
             Assert.Equal(ApplePlatform.iPadOS, archiveRequest.Platform);
             Assert.Equal("generic/platform=iOS", archiveRequest.Destination);
+            Assert.EndsWith(Path.Combine("secrets", "AuthKey_ABC123DEFG.p8"), archiveRequest.AppStoreConnectApiKeyPath, StringComparison.Ordinal);
+            Assert.Equal("ABC123DEFG", archiveRequest.AppStoreConnectApiKeyId);
+            Assert.Equal("issuer-id", archiveRequest.AppStoreConnectApiIssuerId);
 
             var uploadRequest = Assert.Single(uploadRequests);
             Assert.Equal("TEAMID", uploadRequest.TeamId);
             Assert.Equal("xcodebuild-test", uploadRequest.XcodeBuildExecutable);
             Assert.False(uploadRequest.AllowProvisioningUpdates);
             Assert.True(uploadRequest.ManageAppVersionAndBuildNumber);
+            Assert.EndsWith(Path.Combine("secrets", "AuthKey_ABC123DEFG.p8"), uploadRequest.AppStoreConnectApiKeyPath, StringComparison.Ordinal);
+            Assert.Equal("ABC123DEFG", uploadRequest.AppStoreConnectApiKeyId);
+            Assert.Equal("issuer-id", uploadRequest.AppStoreConnectApiIssuerId);
 
             var appResult = Assert.Single(result.AppleApps);
             Assert.True(appResult.Success);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -424,6 +424,8 @@ public sealed class PowerForgeReleaseServiceTests
         try
         {
             CreateXcodeProject(root, "Tactra.xcodeproj");
+            Directory.CreateDirectory(Path.Combine(root, "secrets"));
+            File.WriteAllText(Path.Combine(root, "secrets", "AuthKey_ABC123DEFG.p8"), "private-key");
             var archiveRequests = new List<AppleAppArchiveRequest>();
             var uploadRequests = new List<AppleAppArchiveUploadRequest>();
 
@@ -467,7 +469,7 @@ public sealed class PowerForgeReleaseServiceTests
                         Upload = true,
                         TeamId = "TEAMID",
                         XcodeBuildExecutable = "xcodebuild-test",
-                        AllowProvisioningUpdates = false,
+                        AllowProvisioningUpdates = true,
                         SigningStyle = "automatic",
                         ManageAppVersionAndBuildNumber = true,
                         AppStoreConnectApiKeyPath = "secrets/AuthKey_ABC123DEFG.p8",
@@ -502,7 +504,7 @@ public sealed class PowerForgeReleaseServiceTests
             var uploadRequest = Assert.Single(uploadRequests);
             Assert.Equal("TEAMID", uploadRequest.TeamId);
             Assert.Equal("xcodebuild-test", uploadRequest.XcodeBuildExecutable);
-            Assert.False(uploadRequest.AllowProvisioningUpdates);
+            Assert.True(uploadRequest.AllowProvisioningUpdates);
             Assert.True(uploadRequest.ManageAppVersionAndBuildNumber);
             Assert.EndsWith(Path.Combine("secrets", "AuthKey_ABC123DEFG.p8"), uploadRequest.AppStoreConnectApiKeyPath, StringComparison.Ordinal);
             Assert.Equal("ABC123DEFG", uploadRequest.AppStoreConnectApiKeyId);
@@ -2071,6 +2073,133 @@ public sealed class PowerForgeReleaseServiceTests
                 }));
 
             Assert.Contains("Missing.xcodeproj", ex.FileName, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedToolsAndAppleApps_ValidatesPartialApiKeyBeforePublishingTools()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tool planning should not run before Apple API-key validation succeeds."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run before Apple API-key validation succeeds."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run after validation failure."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        Targets = new[]
+                        {
+                            new PowerForgeToolReleaseTarget
+                            {
+                                Name = "PowerForge"
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                }));
+
+            Assert.Contains("AppStoreConnectApiKeyPath", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_MixedToolsAndAppleApps_ValidatesApiKeyProvisioningUpdatesBeforePublishingTools()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Tool planning should not run before Apple API-key validation succeeds."),
+                runTools: _ => throw new InvalidOperationException("Tools should not run before Apple API-key validation succeeds."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Apple archive should not run after validation failure."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."));
+
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    Tools = new PowerForgeToolReleaseSpec
+                    {
+                        Targets = new[]
+                        {
+                            new PowerForgeToolReleaseTarget
+                            {
+                                Name = "PowerForge"
+                            }
+                        }
+                    },
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        AllowProvisioningUpdates = false,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                }));
+
+            Assert.Contains("AllowProvisioningUpdates=true", ex.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge/Models/AppleAppArchiveModels.cs
+++ b/PowerForge/Models/AppleAppArchiveModels.cs
@@ -35,6 +35,15 @@ public sealed class AppleAppArchiveRequest
     /// <summary>Allows Xcode to create or update signing assets during archive.</summary>
     public bool AllowProvisioningUpdates { get; set; } = true;
 
+    /// <summary>Path to an App Store Connect API private key used by xcodebuild archive authentication.</summary>
+    public string? AppStoreConnectApiKeyPath { get; set; }
+
+    /// <summary>App Store Connect API key identifier used by xcodebuild archive authentication.</summary>
+    public string? AppStoreConnectApiKeyId { get; set; }
+
+    /// <summary>App Store Connect API issuer identifier used by xcodebuild archive authentication.</summary>
+    public string? AppStoreConnectApiIssuerId { get; set; }
+
     /// <summary>Additional structured arguments appended to the archive command.</summary>
     public string[] AdditionalArguments { get; set; } = Array.Empty<string>();
 
@@ -97,6 +106,15 @@ public sealed class AppleAppArchiveUploadRequest
 
     /// <summary>Controls whether xcodebuild generates App Store information.</summary>
     public bool GenerateAppStoreInformation { get; set; } = true;
+
+    /// <summary>Path to an App Store Connect API private key used by xcodebuild upload authentication.</summary>
+    public string? AppStoreConnectApiKeyPath { get; set; }
+
+    /// <summary>App Store Connect API key identifier used by xcodebuild upload authentication.</summary>
+    public string? AppStoreConnectApiKeyId { get; set; }
+
+    /// <summary>App Store Connect API issuer identifier used by xcodebuild upload authentication.</summary>
+    public string? AppStoreConnectApiIssuerId { get; set; }
 
     /// <summary>xcodebuild executable name or path.</summary>
     public string XcodeBuildExecutable { get; set; } = "xcodebuild";

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -302,6 +302,12 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public string? SigningStyle { get; set; }
 
+    public string? AppStoreConnectApiKeyPath { get; set; }
+
+    public string? AppStoreConnectApiKeyId { get; set; }
+
+    public string? AppStoreConnectApiIssuerId { get; set; }
+
     public string? ScreenshotConfigPath { get; set; }
 
     public string[] ScreenshotConfigPaths { get; set; } = Array.Empty<string>();
@@ -342,6 +348,12 @@ internal sealed class PowerForgeAppleReleasePlan
     public bool GenerateAppStoreInformation { get; set; } = true;
 
     public string SigningStyle { get; set; } = "automatic";
+
+    public string? AppStoreConnectApiKeyPath { get; set; }
+
+    public string? AppStoreConnectApiKeyId { get; set; }
+
+    public string? AppStoreConnectApiIssuerId { get; set; }
 
     public PowerForgeAppleAppReleaseTargetPlan[] Apps { get; set; } = Array.Empty<PowerForgeAppleAppReleaseTargetPlan>();
 }

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -169,7 +169,7 @@ public sealed class AppleAppArchiveService
             throw new FileNotFoundException($"App Store Connect API key file was not found: {keyPath}", keyPath);
 
         args.Add("-authenticationKeyPath");
-        args.Add(keyPath);
+        args.Add(keyPath!);
         args.Add("-authenticationKeyID");
         args.Add(keyId!);
         args.Add("-authenticationKeyIssuerID");

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -63,6 +63,11 @@ public sealed class AppleAppArchiveService
         if (request.AllowProvisioningUpdates)
             args.Add("-allowProvisioningUpdates");
 
+        AddAppStoreConnectAuthenticationArguments(
+            request.AppStoreConnectApiKeyPath,
+            request.AppStoreConnectApiKeyId,
+            request.AppStoreConnectApiIssuerId,
+            args);
         args.Add("archive");
         args.AddRange(request.AdditionalArguments ?? Array.Empty<string>());
 
@@ -120,6 +125,11 @@ public sealed class AppleAppArchiveService
         if (request.AllowProvisioningUpdates)
             args.Add("-allowProvisioningUpdates");
 
+        AddAppStoreConnectAuthenticationArguments(
+            request.AppStoreConnectApiKeyPath,
+            request.AppStoreConnectApiKeyId,
+            request.AppStoreConnectApiIssuerId,
+            args);
         args.AddRange(request.AdditionalArguments ?? Array.Empty<string>());
 
         var result = await _processRunner.RunAsync(
@@ -137,6 +147,33 @@ public sealed class AppleAppArchiveService
             ExportOptionsPlistPath = plistPath,
             ProcessResult = result
         };
+    }
+
+    private static void AddAppStoreConnectAuthenticationArguments(
+        string? appStoreConnectApiKeyPath,
+        string? appStoreConnectApiKeyId,
+        string? appStoreConnectApiIssuerId,
+        List<string> args)
+    {
+        var keyPath = string.IsNullOrWhiteSpace(appStoreConnectApiKeyPath)
+            ? null
+            : Path.GetFullPath(appStoreConnectApiKeyPath!);
+        var keyId = string.IsNullOrWhiteSpace(appStoreConnectApiKeyId) ? null : appStoreConnectApiKeyId!.Trim();
+        var issuerId = string.IsNullOrWhiteSpace(appStoreConnectApiIssuerId) ? null : appStoreConnectApiIssuerId!.Trim();
+        var configuredCount = (keyPath is null ? 0 : 1) + (keyId is null ? 0 : 1) + (issuerId is null ? 0 : 1);
+        if (configuredCount == 0)
+            return;
+        if (configuredCount != 3)
+            throw new ArgumentException("App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        if (!File.Exists(keyPath))
+            throw new FileNotFoundException($"App Store Connect API key file was not found: {keyPath}", keyPath);
+
+        args.Add("-authenticationKeyPath");
+        args.Add(keyPath);
+        args.Add("-authenticationKeyID");
+        args.Add(keyId!);
+        args.Add("-authenticationKeyIssuerID");
+        args.Add(issuerId!);
     }
 
     /// <summary>

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -67,6 +67,7 @@ public sealed class AppleAppArchiveService
             request.AppStoreConnectApiKeyPath,
             request.AppStoreConnectApiKeyId,
             request.AppStoreConnectApiIssuerId,
+            request.AllowProvisioningUpdates,
             args);
         args.Add("archive");
         args.AddRange(request.AdditionalArguments ?? Array.Empty<string>());
@@ -129,6 +130,7 @@ public sealed class AppleAppArchiveService
             request.AppStoreConnectApiKeyPath,
             request.AppStoreConnectApiKeyId,
             request.AppStoreConnectApiIssuerId,
+            request.AllowProvisioningUpdates,
             args);
         args.AddRange(request.AdditionalArguments ?? Array.Empty<string>());
 
@@ -153,6 +155,7 @@ public sealed class AppleAppArchiveService
         string? appStoreConnectApiKeyPath,
         string? appStoreConnectApiKeyId,
         string? appStoreConnectApiIssuerId,
+        bool allowProvisioningUpdates,
         List<string> args)
     {
         var keyPath = string.IsNullOrWhiteSpace(appStoreConnectApiKeyPath)
@@ -165,6 +168,8 @@ public sealed class AppleAppArchiveService
             return;
         if (configuredCount != 3)
             throw new ArgumentException("App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        if (!allowProvisioningUpdates)
+            throw new ArgumentException("App Store Connect API-key authentication requires AllowProvisioningUpdates=true so xcodebuild can use the credentials.");
         if (!File.Exists(keyPath))
             throw new FileNotFoundException($"App Store Connect API key file was not found: {keyPath}", keyPath);
 

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -741,6 +741,9 @@ internal sealed class PowerForgeReleaseService
             UploadSymbols = options.UploadSymbols,
             GenerateAppStoreInformation = options.GenerateAppStoreInformation,
             SigningStyle = string.IsNullOrWhiteSpace(options.SigningStyle) ? "automatic" : options.SigningStyle!.Trim(),
+            AppStoreConnectApiKeyPath = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyPath) ? null : ResolveOutputPath(projectRoot, options.AppStoreConnectApiKeyPath!),
+            AppStoreConnectApiKeyId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyId) ? null : options.AppStoreConnectApiKeyId!.Trim(),
+            AppStoreConnectApiIssuerId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiIssuerId) ? null : options.AppStoreConnectApiIssuerId!.Trim(),
             Apps = apps
         };
     }
@@ -839,7 +842,10 @@ internal sealed class PowerForgeReleaseService
                     Destination = app.Destination,
                     ArchivePath = app.ArchivePath,
                     XcodeBuildExecutable = plan.XcodeBuildExecutable,
-                    AllowProvisioningUpdates = plan.AllowProvisioningUpdates
+                    AllowProvisioningUpdates = plan.AllowProvisioningUpdates,
+                    AppStoreConnectApiKeyPath = plan.AppStoreConnectApiKeyPath,
+                    AppStoreConnectApiKeyId = plan.AppStoreConnectApiKeyId,
+                    AppStoreConnectApiIssuerId = plan.AppStoreConnectApiIssuerId
                 });
                 result.Archive = archive;
                 if (!archive.Succeeded)
@@ -863,6 +869,9 @@ internal sealed class PowerForgeReleaseService
                     ManageAppVersionAndBuildNumber = plan.ManageAppVersionAndBuildNumber,
                     UploadSymbols = plan.UploadSymbols,
                     GenerateAppStoreInformation = plan.GenerateAppStoreInformation,
+                    AppStoreConnectApiKeyPath = plan.AppStoreConnectApiKeyPath,
+                    AppStoreConnectApiKeyId = plan.AppStoreConnectApiKeyId,
+                    AppStoreConnectApiIssuerId = plan.AppStoreConnectApiIssuerId,
                     AllowProvisioningUpdates = plan.AllowProvisioningUpdates
                 });
                 result.Upload = upload;
@@ -2845,6 +2854,7 @@ internal sealed class PowerForgeReleaseService
                 plan.UploadSymbols,
                 plan.GenerateAppStoreInformation,
                 plan.SigningStyle,
+                AppStoreConnectApiKeyConfigured = !string.IsNullOrWhiteSpace(plan.AppStoreConnectApiKeyPath),
                 apps = plan.Apps.Select(app => new
                 {
                     app.Name,

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -724,6 +724,19 @@ internal sealed class PowerForgeReleaseService
             if (missingArchive is not null)
                 throw new FileNotFoundException($"Apple app archive was not found for upload-only release: {missingArchive.ArchivePath}", missingArchive.ArchivePath);
         }
+        var appStoreConnectApiKeyPath = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyPath) ? null : ResolveOutputPath(projectRoot, options.AppStoreConnectApiKeyPath!);
+        var appStoreConnectApiKeyId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyId) ? null : options.AppStoreConnectApiKeyId!.Trim();
+        var appStoreConnectApiIssuerId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiIssuerId) ? null : options.AppStoreConnectApiIssuerId!.Trim();
+        var appStoreConnectApiConfiguredCount = (appStoreConnectApiKeyPath is null ? 0 : 1) + (appStoreConnectApiKeyId is null ? 0 : 1) + (appStoreConnectApiIssuerId is null ? 0 : 1);
+        if (appStoreConnectApiConfiguredCount != 0)
+        {
+            if (appStoreConnectApiConfiguredCount != 3)
+                throw new InvalidOperationException("AppleApps App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+            if (!options.AllowProvisioningUpdates)
+                throw new InvalidOperationException("AppleApps App Store Connect API-key authentication requires AllowProvisioningUpdates=true so xcodebuild can use the credentials.");
+            if (!File.Exists(appStoreConnectApiKeyPath))
+                throw new FileNotFoundException($"AppleApps App Store Connect API key file was not found: {appStoreConnectApiKeyPath}", appStoreConnectApiKeyPath);
+        }
 
         return new PowerForgeAppleReleasePlan
         {
@@ -741,9 +754,9 @@ internal sealed class PowerForgeReleaseService
             UploadSymbols = options.UploadSymbols,
             GenerateAppStoreInformation = options.GenerateAppStoreInformation,
             SigningStyle = string.IsNullOrWhiteSpace(options.SigningStyle) ? "automatic" : options.SigningStyle!.Trim(),
-            AppStoreConnectApiKeyPath = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyPath) ? null : ResolveOutputPath(projectRoot, options.AppStoreConnectApiKeyPath!),
-            AppStoreConnectApiKeyId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyId) ? null : options.AppStoreConnectApiKeyId!.Trim(),
-            AppStoreConnectApiIssuerId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiIssuerId) ? null : options.AppStoreConnectApiIssuerId!.Trim(),
+            AppStoreConnectApiKeyPath = appStoreConnectApiKeyPath,
+            AppStoreConnectApiKeyId = appStoreConnectApiKeyId,
+            AppStoreConnectApiIssuerId = appStoreConnectApiIssuerId,
             Apps = apps
         };
     }

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -253,6 +253,9 @@
         "UploadSymbols": { "type": "boolean" },
         "GenerateAppStoreInformation": { "type": "boolean" },
         "SigningStyle": { "type": [ "string", "null" ] },
+        "AppStoreConnectApiKeyPath": { "type": [ "string", "null" ] },
+        "AppStoreConnectApiKeyId": { "type": [ "string", "null" ] },
+        "AppStoreConnectApiIssuerId": { "type": [ "string", "null" ] },
         "ScreenshotConfigPath": { "type": [ "string", "null" ] },
         "ScreenshotConfigPaths": {
           "type": "array",


### PR DESCRIPTION
## Summary
- add App Store Connect API-key fields to Apple archive and upload requests
- propagate API-key auth through unified Apple release config, schema, and plans
- show Apple-only release plan output in the PowerForge CLI

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "AppleAppArchiveServiceTests|PowerForgeReleaseServiceTests"
- dotnet build PowerForge.Cli/PowerForge.Cli.csproj
- dotnet run --framework net10.0 --project PowerForge.Cli/PowerForge.Cli.csproj -- release --config ../EmailIMO-appstore-support/powerforge.release.appstore.json --plan