### PR TITLE
Run central runner housekeeping from PSPublishModule

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -24,8 +24,9 @@ concurrency:
 
 jobs:
   cleanup-linux-runner:
-    # Self-hosted runner cleanup is only relevant for private repos in our current setup.
-    if: ${{ github.event.repository.private }}
+    # PSPublishModule owns the central EvotecIT runner cleanup even though this
+    # repository is public. Consumer public repos should still skip it.
+    if: ${{ github.repository == 'EvotecIT/PSPublishModule' || github.event.repository.private }}
     strategy:
       fail-fast: false
       # Nightly best-effort spread across idle Linux runners; workspace buildup is the main disk driver.
@@ -35,7 +36,7 @@ jobs:
     uses: ./.github/workflows/powerforge-github-runner-housekeeping.yml
     with:
       config_path: ./.powerforge/runner-housekeeping.json
-      apply: ${{ inputs.apply == 'true' }}
+      apply: ${{ github.event_name != 'workflow_dispatch' || inputs.apply == 'true' }}
       powerforge_ref: ${{ github.sha }}
       runner_labels_json: '["self-hosted","linux"]'
       runner_min_free_gb: ${{ github.event_name == 'workflow_dispatch' && (inputs.min_free_gb != '' && inputs.min_free_gb || '15') || (vars.POWERFORGE_RUNNER_HOUSEKEEPING_MIN_FREE_GB != '' && vars.POWERFORGE_RUNNER_HOUSEKEEPING_MIN_FREE_GB || '') }}

--- a/.powerforge/runner-housekeeping.json
+++ b/.powerforge/runner-housekeeping.json
@@ -10,10 +10,10 @@
   },
   "Runner": {
     "Enabled": true,
-    "MinFreeGb": 15,
+    "MinFreeGb": 20,
     "DiagnosticsRetentionDays": 14,
     "ActionsRetentionDays": 7,
-    "WorkspacesRetentionDays": 3,
+    "WorkspacesRetentionDays": 0,
     "CleanWorkspaces": true,
     "ToolCacheRetentionDays": 30
   }

--- a/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
@@ -38,10 +38,29 @@ public sealed class GitHubRunnerHousekeepingWorkflowTests
         var workflowYaml = File.ReadAllText(workflowPath);
 
         Assert.Contains("cron: \"17 2 * * *\"", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("github.repository == 'EvotecIT/PSPublishModule' || github.event.repository.private", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("apply: ${{ github.event_name != 'workflow_dispatch' || inputs.apply == 'true' }}", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("fail-fast: false", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("slot: [1, 2, 3, 4]", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner_labels_json: '[\"self-hosted\",\"linux\"]'", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner-housekeeping-reports-${{ matrix.slot }}", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CallerConfig_ShouldAggressivelyCleanCentralRunnerWorkspaces()
+    {
+        var repoRoot = FindRepoRoot();
+        var configPath = Path.Combine(repoRoot, ".powerforge", "runner-housekeeping.json");
+
+        Assert.True(File.Exists(configPath), $"Runner housekeeping config not found: {configPath}");
+
+        using var document = System.Text.Json.JsonDocument.Parse(File.ReadAllText(configPath));
+        var runner = document.RootElement.GetProperty("Runner");
+
+        Assert.True(runner.GetProperty("Enabled").GetBoolean());
+        Assert.Equal(20, runner.GetProperty("MinFreeGb").GetInt32());
+        Assert.True(runner.GetProperty("CleanWorkspaces").GetBoolean());
+        Assert.Equal(0, runner.GetProperty("WorkspacesRetentionDays").GetInt32());
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
## Summary
- allow the central PSPublishModule runner-housekeeping schedule to run from this public repo
- keep public consumer repos protected by the existing private-repo guard
- cover the caller workflow condition with the existing runner-housekeeping workflow contract test

## Evidence
- OfficeIMO GitHub Housekeeping run 27587936990 ran on hosted Ubuntu, used `apply: false`, and only planned OfficeIMO artifact/cache cleanup; it did not touch self-hosted runner disks.
- PSPublishModule Runner Housekeeping scheduled runs, including 27592047345, were skipped because the caller workflow required `github.event.repository.private` even though PSPublishModule owns the central cleanup.
- HtmlForgeX Deploy Website run 27569780960 failed on self-hosted `github-runner-linux` with `No space left on device` while writing a Pages diagnostic log.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Debug --filter FullyQualifiedName~GitHubRunnerHousekeepingWorkflowTests /m:1 /nr:false`
- `git diff --check`