### PR TITLE
Include restored Linux runners in housekeeping

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -35,8 +35,12 @@ jobs:
             labels: '["self-hosted","linux","runner-github-runner-linux"]'
           - name: github-runner-linux-01
             labels: '["self-hosted","linux","runner-github-runner-linux-01"]'
+          - name: github-runner-linux-02
+            labels: '["self-hosted","linux","runner-github-runner-linux-02"]'
           - name: github-runner-linux-03
             labels: '["self-hosted","linux","runner-github-runner-linux-03"]'
+          - name: github-runner-linux-04
+            labels: '["self-hosted","linux","runner-github-runner-linux-04"]'
           - name: github-runner-linux-05
             labels: '["self-hosted","linux","runner-github-runner-linux-05"]'
     name: ${{ matrix.runner.name }}

--- a/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubRunnerHousekeepingWorkflowTests.cs
@@ -43,11 +43,15 @@ public sealed class GitHubRunnerHousekeepingWorkflowTests
         Assert.Contains("fail-fast: false", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("name: github-runner-linux", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("name: github-runner-linux-01", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("name: github-runner-linux-02", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("name: github-runner-linux-03", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("name: github-runner-linux-04", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("name: github-runner-linux-05", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("\"runner-github-runner-linux\"", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("\"runner-github-runner-linux-01\"", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("\"runner-github-runner-linux-02\"", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("\"runner-github-runner-linux-03\"", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("\"runner-github-runner-linux-04\"", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("\"runner-github-runner-linux-05\"", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner_labels_json: ${{ matrix.runner.labels }}", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("runner-housekeeping-${{ matrix.runner.name }}", workflowYaml, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- include the restored `github-runner-linux-02` and `github-runner-linux-04` hosts in the central Runner Housekeeping matrix
- keep each runner routed through its unique runner label
- update the workflow contract test to cover all six Linux runners

## Validation
- Re-registered `github-runner-linux-02` and `github-runner-linux-04` as EvotecIT org runners after their stale registrations had been deleted by GitHub
- Confirmed all six Linux org runners are online and have unique `runner-github-runner-*` labels
- Parsed `.github/workflows/runner-housekeeping.yml` with PyYAML
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter GitHubRunnerHousekeepingWorkflowTests --no-restore`