### PR TITLE
Apply resolved MSI version to publish properties

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -100,6 +100,54 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
+    public void BuildPublishArguments_OmitsNoBuildWhenApplyToPublishRequiresPayloadStamping()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            spec.DotNet.NoBuildInPublish = true;
+            spec.Targets[0].Publish.Style = DotNetPublishStyle.PortableCompat;
+            spec.Installers = new[]
+            {
+                new DotNetPublishInstaller
+                {
+                    Id = "app.msi",
+                    PrepareFromTarget = "app",
+                    Authoring = CreateSimpleAuthoring("ProductFiles"),
+                    Versioning = new DotNetPublishMsiVersionOptions
+                    {
+                        Enabled = true,
+                        Major = 26,
+                        Minor = 6,
+                        FloorDateUtc = "2026-06-01",
+                        Monotonic = false,
+                        ApplyToPublish = true
+                    }
+                }
+            };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var target = Assert.Single(plan.Targets);
+            var args = DotNetPublishPipelineRunner.BuildPublishArguments(
+                plan,
+                target,
+                "net10.0",
+                "win-x64",
+                DotNetPublishStyle.PortableCompat,
+                Path.Combine(root, "publish"));
+
+            Assert.DoesNotContain("--no-build", args);
+            Assert.Contains(args, arg => arg.Contains("Version=26.6.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Plan_ApplyToPublishMsiVersions_AdvancesMonotonicStateAcrossCombinations()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -49,6 +49,57 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
+    public void BuildPublishMsBuildProperties_AppliesResolvedMsiVersion_WhenInstallerOptsIn()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            spec.Targets[0].Publish.Style = DotNetPublishStyle.PortableCompat;
+            spec.Installers = new[]
+            {
+                new DotNetPublishInstaller
+                {
+                    Id = "app.msi",
+                    PrepareFromTarget = "app",
+                    Authoring = CreateSimpleAuthoring("ProductFiles"),
+                    Versioning = new DotNetPublishMsiVersionOptions
+                    {
+                        Enabled = true,
+                        Major = 26,
+                        Minor = 6,
+                        FloorDateUtc = "2026-06-01",
+                        Monotonic = false,
+                        ApplyToPublish = true
+                    }
+                }
+            };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var target = Assert.Single(plan.Targets);
+            var expectedVersion = $"26.6.{DaysSince20000101(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc))}";
+
+            var properties = DotNetPublishPipelineRunner.BuildPublishMsBuildProperties(
+                plan,
+                target,
+                "net10.0",
+                "win-x64",
+                DotNetPublishStyle.PortableCompat);
+
+            Assert.Equal(expectedVersion, properties["Version"]);
+            Assert.Equal(expectedVersion, properties["PackageVersion"]);
+            Assert.Equal($"{expectedVersion}.0", properties["FileVersion"]);
+            Assert.Equal($"{expectedVersion}.0", properties["AssemblyVersion"]);
+            Assert.Equal(expectedVersion, properties["InformationalVersion"]);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void ResolveInstallerOutputDirectory_UsesConfiguredTemplate()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -100,6 +100,113 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
+    public void Plan_ApplyToPublishMsiVersions_AdvancesMonotonicStateAcrossCombinations()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            spec.Targets[0].Publish.Frameworks = new[] { "net10.0", "net8.0" };
+            spec.Targets[0].Publish.Style = DotNetPublishStyle.PortableCompat;
+            spec.Installers = new[]
+            {
+                new DotNetPublishInstaller
+                {
+                    Id = "app.msi",
+                    PrepareFromTarget = "app",
+                    Authoring = CreateSimpleAuthoring("ProductFiles"),
+                    Versioning = new DotNetPublishMsiVersionOptions
+                    {
+                        Enabled = true,
+                        Major = 26,
+                        Minor = 6,
+                        FloorDateUtc = "2026-06-01",
+                        Monotonic = true,
+                        StatePath = "Artifacts/version.state.json",
+                        ApplyToPublish = true
+                    }
+                }
+            };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var expectedPatch = DaysSince20000101(new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+            var versions = plan.MsiVersions.Values.OrderBy(value => value.Patch).ToArray();
+
+            Assert.Equal(2, versions.Length);
+            Assert.Equal(expectedPatch, versions[0].Patch);
+            Assert.Equal(expectedPatch + 1, versions[1].Patch);
+            Assert.Equal(versions[0].StatePath, versions[1].StatePath);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void BuildPublishMsBuildProperties_ThrowsWhenApplyToPublishInstallersResolveDifferentVersions()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            spec.Targets[0].Publish.Style = DotNetPublishStyle.PortableCompat;
+            spec.Installers = new[]
+            {
+                new DotNetPublishInstaller
+                {
+                    Id = "app-a.msi",
+                    PrepareFromTarget = "app",
+                    Authoring = CreateSimpleAuthoring("ProductFiles"),
+                    Versioning = new DotNetPublishMsiVersionOptions
+                    {
+                        Enabled = true,
+                        Major = 26,
+                        Minor = 6,
+                        FloorDateUtc = "2026-06-01",
+                        Monotonic = false,
+                        ApplyToPublish = true
+                    }
+                },
+                new DotNetPublishInstaller
+                {
+                    Id = "app-b.msi",
+                    PrepareFromTarget = "app",
+                    Authoring = CreateSimpleAuthoring("ProductFiles"),
+                    Versioning = new DotNetPublishMsiVersionOptions
+                    {
+                        Enabled = true,
+                        Major = 27,
+                        Minor = 6,
+                        FloorDateUtc = "2026-06-01",
+                        Monotonic = false,
+                        ApplyToPublish = true
+                    }
+                }
+            };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var target = Assert.Single(plan.Targets);
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                DotNetPublishPipelineRunner.BuildPublishMsBuildProperties(
+                    plan,
+                    target,
+                    "net10.0",
+                    "win-x64",
+                    DotNetPublishStyle.PortableCompat));
+
+            Assert.Contains("resolved publish property 'Version'", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void ResolveInstallerOutputDirectory_UsesConfiguredTemplate()
     {
         var root = CreateTempRoot();
@@ -1152,7 +1259,7 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
         var method = typeof(DotNetPublishPipelineRunner).GetMethod("ResolveMsiVersion", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
 
-        var raw = method!.Invoke(runner, new object?[] { plan, installer, step });
+        var raw = method!.Invoke(runner, new object?[] { plan, installer, step, null });
         Assert.NotNull(raw);
 
         var t = raw!.GetType();

--- a/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishPlan.cs
@@ -59,6 +59,9 @@ public sealed class DotNetPublishPlan
     /// <summary>Resolved installer definitions.</summary>
     public DotNetPublishInstallerPlan[] Installers { get; set; } = Array.Empty<DotNetPublishInstallerPlan>();
 
+    /// <summary>Resolved MSI versions keyed by installer, target, framework, runtime, and style.</summary>
+    public Dictionary<string, DotNetPublishMsiVersionPlan> MsiVersions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Resolved Microsoft Store / MSIX packaging definitions.</summary>
     public DotNetPublishStorePackagePlan[] StorePackages { get; set; } = Array.Empty<DotNetPublishStorePackagePlan>();
 
@@ -178,6 +181,27 @@ public sealed class DotNetPublishInstallerPlan
 
     /// <summary>Optional client-license injection options used by MSI build steps.</summary>
     public DotNetPublishMsiClientLicenseOptions? ClientLicense { get; set; }
+}
+
+/// <summary>
+/// Resolved MSI version for a concrete installer/target/framework/runtime/style combination.
+/// </summary>
+public sealed class DotNetPublishMsiVersionPlan
+{
+    /// <summary>MSI product version value, for example <c>26.6.9661</c>.</summary>
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>MSBuild property name used by the MSI project, usually <c>ProductVersion</c>.</summary>
+    public string? VersionPropertyName { get; set; }
+
+    /// <summary>Four-part assembly/file version derived from <see cref="Version"/>.</summary>
+    public string AssemblyVersion { get; set; } = string.Empty;
+
+    /// <summary>Resolved patch segment.</summary>
+    public int? Patch { get; set; }
+
+    /// <summary>Resolved monotonic state path when configured.</summary>
+    public string? StatePath { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
@@ -733,6 +733,17 @@ public sealed class DotNetPublishMsiVersionOptions
     public string? PropertyName { get; set; } = "ProductVersion";
 
     /// <summary>
+    /// When true, applies the resolved MSI version to the source publish MSBuild properties before packaging.
+    /// </summary>
+    public bool ApplyToPublish { get; set; }
+
+    /// <summary>
+    /// Optional publish MSBuild property names populated from the resolved MSI version.
+    /// Defaults to <c>Version</c>, <c>PackageVersion</c>, <c>FileVersion</c>, <c>AssemblyVersion</c>, and <c>InformationalVersion</c>.
+    /// </summary>
+    public string[] PublishProperties { get; set; } = Array.Empty<string>();
+
+    /// <summary>
     /// Maximum allowed patch segment. Default: 65535.
     /// </summary>
     public int PatchCap { get; set; } = 65535;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -535,7 +535,8 @@ public sealed partial class DotNetPublishPipelineRunner
     private MsiVersionResolution ResolveMsiVersion(
         DotNetPublishPlan plan,
         DotNetPublishInstallerPlan? installer,
-        DotNetPublishStep step)
+        DotNetPublishStep step,
+        IReadOnlyDictionary<string, MsiVersionState>? stateOverrides = null)
     {
         if (installer?.Versioning is null || !installer.Versioning.Enabled)
             return MsiVersionResolution.None();
@@ -570,7 +571,9 @@ public sealed partial class DotNetPublishPipelineRunner
             if (!plan.AllowOutputOutsideProjectRoot)
                 EnsurePathWithinRoot(plan.ProjectRoot, statePath, $"Installer '{installer.Id}' version state path");
 
-            var previous = ReadMsiVersionState(statePath);
+            var previous = stateOverrides is not null && stateOverrides.TryGetValue(statePath, out var plannedState)
+                ? plannedState
+                : ReadMsiVersionState(statePath);
             if (ShouldBumpMsiPatch(previous, major, minor, patch))
                 patch = Math.Min(patchCap, previous!.LastPatch + 1);
         }
@@ -635,7 +638,9 @@ public sealed partial class DotNetPublishPipelineRunner
     private static string BuildFourPartVersion(string version)
     {
         var parts = (version ?? string.Empty)
-            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static part => part.Trim())
+            .Where(static part => part.Length > 0)
             .Take(4)
             .ToList();
         while (parts.Count < 4)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -598,7 +598,10 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             var cached = FindResolvedMsiVersion(plan, installer.Id, step.TargetName, step.Framework, step.Runtime, step.Style);
             if (cached is not null)
+            {
+                ReserveMsiVersionState(cached, $"MSI build for installer '{installer.Id}'");
                 return new MsiVersionResolution(cached.Version, cached.VersionPropertyName, cached.Patch, cached.StatePath);
+            }
         }
 
         return ResolveMsiVersion(plan, installer, step);
@@ -647,6 +650,34 @@ public sealed partial class DotNetPublishPipelineRunner
             parts.Add("0");
 
         return string.Join(".", parts);
+    }
+
+    private static void ReserveMsiVersionState(DotNetPublishMsiVersionPlan version, string context)
+    {
+        if (version is null || string.IsNullOrWhiteSpace(version.StatePath) || !version.Patch.HasValue)
+            return;
+
+        if (!TryParseMsiVersion(version.Version, out var major, out var minor, out var patch))
+            return;
+
+        var previous = ReadMsiVersionState(version.StatePath!);
+        if (previous is not null
+            && previous.LastPatch == patch
+            && string.Equals(previous.Version, version.Version, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (ShouldBumpMsiPatch(previous, major, minor, patch))
+        {
+            var previousVersion = string.IsNullOrWhiteSpace(previous?.Version)
+                ? previous?.LastPatch.ToString(CultureInfo.InvariantCulture)
+                : previous!.Version;
+            throw new InvalidOperationException(
+                $"MSI version state '{version.StatePath}' advanced to '{previousVersion}' before {context} could reserve '{version.Version}'. Re-plan or rerun the publish to avoid duplicate MSI versions.");
+        }
+
+        WriteMsiVersionState(version.StatePath!, patch, version.Version);
     }
 
     private static int ResolveMsiVersionSegments(DotNetPublishMsiVersionOptions options, ref int major, ref int minor)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -48,7 +48,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
         var installerConfig = (plan.Installers ?? Array.Empty<DotNetPublishInstallerPlan>())
             .FirstOrDefault(i => string.Equals(i.Id, installerId, StringComparison.OrdinalIgnoreCase));
-        var versionResolution = ResolveMsiVersion(plan, installerConfig, step);
+        var versionResolution = ResolveMsiVersionForStep(plan, installerConfig, step);
         var licenseResolution = ResolveInstallerClientLicense(plan, installerConfig, step);
         var isGeneratedInstallerProject = IsGeneratedInstallerProject(step, installerConfig);
 
@@ -584,6 +584,64 @@ public sealed partial class DotNetPublishPipelineRunner
 
         var version = $"{major}.{minor}.{patch}";
         return new MsiVersionResolution(version, propertyName, patch, statePath);
+    }
+
+    private MsiVersionResolution ResolveMsiVersionForStep(
+        DotNetPublishPlan plan,
+        DotNetPublishInstallerPlan? installer,
+        DotNetPublishStep step)
+    {
+        if (installer is not null)
+        {
+            var cached = FindResolvedMsiVersion(plan, installer.Id, step.TargetName, step.Framework, step.Runtime, step.Style);
+            if (cached is not null)
+                return new MsiVersionResolution(cached.Version, cached.VersionPropertyName, cached.Patch, cached.StatePath);
+        }
+
+        return ResolveMsiVersion(plan, installer, step);
+    }
+
+    private static DotNetPublishMsiVersionPlan? FindResolvedMsiVersion(
+        DotNetPublishPlan plan,
+        string? installerId,
+        string? targetName,
+        string? framework,
+        string? runtime,
+        DotNetPublishStyle? style)
+    {
+        if (plan.MsiVersions is null || plan.MsiVersions.Count == 0 || !style.HasValue)
+            return null;
+
+        var key = BuildMsiVersionKey(installerId, targetName, framework, runtime, style.Value);
+        return plan.MsiVersions.TryGetValue(key, out var version) ? version : null;
+    }
+
+    private static string BuildMsiVersionKey(
+        string? installerId,
+        string? targetName,
+        string? framework,
+        string? runtime,
+        DotNetPublishStyle style)
+    {
+        return string.Join(
+            "|",
+            installerId?.Trim() ?? string.Empty,
+            targetName?.Trim() ?? string.Empty,
+            framework?.Trim() ?? string.Empty,
+            runtime?.Trim() ?? string.Empty,
+            style.ToString());
+    }
+
+    private static string BuildFourPartVersion(string version)
+    {
+        var parts = (version ?? string.Empty)
+            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Take(4)
+            .ToList();
+        while (parts.Count < 4)
+            parts.Add("0");
+
+        return string.Join(".", parts);
     }
 
     private static int ResolveMsiVersionSegments(DotNetPublishMsiVersionOptions options, ref int major, ref int minor)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -198,6 +198,12 @@ public sealed partial class DotNetPublishPipelineRunner
         var bundles = BuildBundlePlans(spec.Bundles, targets, projectRoot, spec.SigningProfiles);
         targets = OrderTargetsForBundleIncludes(targets, bundles);
         var installers = BuildInstallerPlans(spec.Installers, bundles, targets, projectCatalog, projectRoot, spec.SigningProfiles);
+        var msiVersions = ResolveMsiVersionPlans(
+            projectRoot,
+            spec.DotNet.AllowOutputOutsideProjectRoot,
+            cfg,
+            installers,
+            targets);
         var storePackages = BuildStorePackagePlans(spec.StorePackages, targets, projectCatalog, projectRoot);
 
         var outputs = new DotNetPublishOutputs
@@ -544,6 +550,7 @@ public sealed partial class DotNetPublishPipelineRunner
             Targets = targets.ToArray(),
             Bundles = bundles,
             Installers = installers,
+            MsiVersions = msiVersions,
             StorePackages = storePackages,
             BenchmarkGates = benchmarkGates,
             Outputs = outputs,
@@ -1333,6 +1340,8 @@ public sealed partial class DotNetPublishPipelineRunner
             Monotonic = versioning.Monotonic,
             StatePath = versioning.StatePath,
             PropertyName = versioning.PropertyName,
+            ApplyToPublish = versioning.ApplyToPublish,
+            PublishProperties = versioning.PublishProperties?.ToArray() ?? Array.Empty<string>(),
             PatchCap = versioning.PatchCap
         };
     }
@@ -1907,6 +1916,58 @@ public sealed partial class DotNetPublishPipelineRunner
         }
 
         return plans.ToArray();
+    }
+
+    private Dictionary<string, DotNetPublishMsiVersionPlan> ResolveMsiVersionPlans(
+        string projectRoot,
+        bool allowOutputOutsideProjectRoot,
+        string configuration,
+        DotNetPublishInstallerPlan[] installers,
+        IEnumerable<DotNetPublishTargetPlan> targets)
+    {
+        var versions = new Dictionary<string, DotNetPublishMsiVersionPlan>(StringComparer.OrdinalIgnoreCase);
+        var probePlan = new DotNetPublishPlan
+        {
+            ProjectRoot = projectRoot,
+            AllowOutputOutsideProjectRoot = allowOutputOutsideProjectRoot,
+            Configuration = configuration
+        };
+
+        foreach (var target in targets ?? Array.Empty<DotNetPublishTargetPlan>())
+        {
+            foreach (var combo in target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
+            {
+                foreach (var installer in installers.Where(i => string.Equals(i.PrepareFromTarget, target.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    if (!InstallerMatchesCombo(installer, combo))
+                        continue;
+
+                    var step = new DotNetPublishStep
+                    {
+                        InstallerId = installer.Id,
+                        TargetName = target.Name,
+                        Framework = combo.Framework,
+                        Runtime = combo.Runtime,
+                        Style = combo.Style
+                    };
+                    var resolved = ResolveMsiVersion(probePlan, installer, step);
+                    if (string.IsNullOrWhiteSpace(resolved.Version))
+                        continue;
+
+                    var key = BuildMsiVersionKey(installer.Id, target.Name, combo.Framework, combo.Runtime, combo.Style);
+                    versions[key] = new DotNetPublishMsiVersionPlan
+                    {
+                        Version = resolved.Version!,
+                        VersionPropertyName = resolved.PropertyName,
+                        AssemblyVersion = BuildFourPartVersion(resolved.Version!),
+                        Patch = resolved.Patch,
+                        StatePath = resolved.StatePath
+                    };
+                }
+            }
+        }
+
+        return versions;
     }
 
     private static DotNetPublishInstallerPlan[] BuildInstallerPlans(
@@ -2690,6 +2751,7 @@ public sealed partial class DotNetPublishPipelineRunner
             clone.PropertyName = "ProductVersion";
         else
             clone.PropertyName = clone.PropertyName!.Trim();
+        clone.PublishProperties = NormalizeStrings(clone.PublishProperties);
 
         return clone;
     }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
@@ -1932,6 +1933,7 @@ public sealed partial class DotNetPublishPipelineRunner
             AllowOutputOutsideProjectRoot = allowOutputOutsideProjectRoot,
             Configuration = configuration
         };
+        var plannedStates = new Dictionary<string, MsiVersionState>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var target in targets ?? Array.Empty<DotNetPublishTargetPlan>())
         {
@@ -1939,6 +1941,9 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 foreach (var installer in installers.Where(i => string.Equals(i.PrepareFromTarget, target.Name, StringComparison.OrdinalIgnoreCase)))
                 {
+                    if (installer.Versioning?.ApplyToPublish != true)
+                        continue;
+
                     if (!InstallerMatchesCombo(installer, combo))
                         continue;
 
@@ -1950,7 +1955,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         Runtime = combo.Runtime,
                         Style = combo.Style
                     };
-                    var resolved = ResolveMsiVersion(probePlan, installer, step);
+                    var resolved = ResolveMsiVersion(probePlan, installer, step, plannedStates);
                     if (string.IsNullOrWhiteSpace(resolved.Version))
                         continue;
 
@@ -1963,6 +1968,16 @@ public sealed partial class DotNetPublishPipelineRunner
                         Patch = resolved.Patch,
                         StatePath = resolved.StatePath
                     };
+
+                    if (!string.IsNullOrWhiteSpace(resolved.StatePath) && resolved.Patch.HasValue)
+                    {
+                        plannedStates[resolved.StatePath!] = new MsiVersionState
+                        {
+                            LastPatch = resolved.Patch.Value,
+                            Version = resolved.Version!,
+                            UpdatedUtc = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture)
+                        };
+                    }
                 }
             }
         }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -212,6 +212,32 @@ public sealed partial class DotNetPublishPipelineRunner
         var workDir = plan.ProjectRoot;
         var props = BuildMsBuildPropertyArgs(plan.MsBuildProperties);
 
+        if (PlanUsesPublishMsiVersionProperties(plan))
+        {
+            foreach (var target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+            {
+                var combinations = (target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
+                    .Where(combination => string.IsNullOrWhiteSpace(runtime)
+                                          || string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
+                    .GroupBy(
+                        combination => string.Join("|", combination.Framework, combination.Runtime, combination.Style.ToString()),
+                        StringComparer.OrdinalIgnoreCase)
+                    .Select(group => group.First())
+                    .ToArray();
+
+                if (combinations.Length == 0)
+                {
+                    BuildTargetProject(plan, target, runtime, target.Publish.Framework, target.Publish.Style);
+                    continue;
+                }
+
+                foreach (var combination in combinations)
+                    BuildTargetProject(plan, target, combination.Runtime, combination.Framework, combination.Style);
+            }
+
+            return;
+        }
+
         if (!string.IsNullOrWhiteSpace(runtime))
         {
             foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
@@ -465,13 +491,55 @@ public sealed partial class DotNetPublishPipelineRunner
             foreach (var propertyName in ResolvePublishVersionProperties(versioning))
             {
                 var value = ResolvePublishVersionPropertyValue(propertyName, resolved);
-                if (string.IsNullOrWhiteSpace(value) || properties.ContainsKey(propertyName))
+                if (string.IsNullOrWhiteSpace(value))
                     continue;
+
+                if (properties.TryGetValue(propertyName, out var existing))
+                {
+                    if (!string.Equals(existing, value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            $"Installer '{installer.Id}' resolved publish property '{propertyName}' to '{value}', " +
+                            $"but the target already has '{existing}'. Align installer versioning or publish the target separately.");
+                    }
+
+                    continue;
+                }
 
                 properties[propertyName] = value!;
             }
         }
     }
+
+    private void BuildTargetProject(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        string? runtime,
+        string? framework,
+        DotNetPublishStyle style)
+    {
+        var args = new List<string> { "build", target.ProjectPath, "-c", plan.Configuration, "--nologo" };
+        if (!string.IsNullOrWhiteSpace(framework))
+            args.AddRange(new[] { "-f", framework! });
+        if (!string.IsNullOrWhiteSpace(runtime))
+            args.AddRange(new[] { "-r", runtime! });
+        if (plan.Restore) args.Add("--no-restore");
+
+        args.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildProperties(
+            plan,
+            target,
+            framework ?? target.Publish.Framework,
+            runtime ?? string.Empty,
+            style)));
+
+        var label = string.IsNullOrWhiteSpace(runtime) ? framework : $"{runtime}, {framework}";
+        _logger.Info($"Build ({label}) -> {target.ProjectPath}");
+        RunDotnet(plan.ProjectRoot, args, plan.EnvironmentVariables);
+    }
+
+    private static bool PlanUsesPublishMsiVersionProperties(DotNetPublishPlan plan)
+        => (plan.Installers ?? Array.Empty<DotNetPublishInstallerPlan>())
+            .Any(installer => installer.Versioning?.Enabled == true && installer.Versioning.ApplyToPublish);
 
     private static string[] ResolvePublishVersionProperties(DotNetPublishMsiVersionOptions versioning)
     {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -403,13 +403,21 @@ public sealed partial class DotNetPublishPipelineRunner
         if (plan.NoBuildInPublish) publishArgs.Add("--no-build");
 
         AppendPublishStyleArgs(publishArgs, target.Publish, style);
-        publishArgs.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildProperties(plan, target, style)));
+        publishArgs.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildProperties(plan, target, framework, runtime, style)));
         return publishArgs;
     }
 
     internal static Dictionary<string, string> BuildPublishMsBuildProperties(
         DotNetPublishPlan plan,
         DotNetPublishTargetPlan target,
+        DotNetPublishStyle style)
+        => BuildPublishMsBuildProperties(plan, target, target.Publish.Framework, string.Empty, style);
+
+    internal static Dictionary<string, string> BuildPublishMsBuildProperties(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        string framework,
+        string runtime,
         DotNetPublishStyle style)
     {
         if (plan is null) throw new ArgumentNullException(nameof(plan));
@@ -431,7 +439,70 @@ public sealed partial class DotNetPublishPipelineRunner
                 merged[kv.Key] = kv.Value;
         }
 
+        ApplyPublishMsiVersionProperties(merged, plan, target.Name, framework, runtime, style);
         return merged;
+    }
+
+    private static void ApplyPublishMsiVersionProperties(
+        Dictionary<string, string> properties,
+        DotNetPublishPlan plan,
+        string targetName,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
+    {
+        foreach (var installer in plan.Installers.Where(i =>
+                     string.Equals(i.PrepareFromTarget, targetName, StringComparison.OrdinalIgnoreCase)))
+        {
+            var versioning = installer.Versioning;
+            if (versioning is null || !versioning.Enabled || !versioning.ApplyToPublish)
+                continue;
+
+            var resolved = FindResolvedMsiVersion(plan, installer.Id, targetName, framework, runtime, style);
+            if (resolved is null)
+                continue;
+
+            foreach (var propertyName in ResolvePublishVersionProperties(versioning))
+            {
+                var value = ResolvePublishVersionPropertyValue(propertyName, resolved);
+                if (string.IsNullOrWhiteSpace(value) || properties.ContainsKey(propertyName))
+                    continue;
+
+                properties[propertyName] = value!;
+            }
+        }
+    }
+
+    private static string[] ResolvePublishVersionProperties(DotNetPublishMsiVersionOptions versioning)
+    {
+        var configured = versioning.PublishProperties ?? Array.Empty<string>();
+        if (configured.Length > 0)
+        {
+            return configured
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Select(value => value.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        return new[]
+        {
+            "Version",
+            "PackageVersion",
+            "FileVersion",
+            "AssemblyVersion",
+            "InformationalVersion"
+        };
+    }
+
+    private static string? ResolvePublishVersionPropertyValue(
+        string propertyName,
+        DotNetPublishMsiVersionPlan resolved)
+    {
+        return propertyName.Equals("AssemblyVersion", StringComparison.OrdinalIgnoreCase)
+               || propertyName.Equals("FileVersion", StringComparison.OrdinalIgnoreCase)
+            ? resolved.AssemblyVersion
+            : resolved.Version;
     }
 
 }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -214,27 +214,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
         if (PlanUsesPublishMsiVersionProperties(plan))
         {
-            foreach (var target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
-            {
-                var combinations = (target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
-                    .Where(combination => string.IsNullOrWhiteSpace(runtime)
-                                          || string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
-                    .GroupBy(
-                        combination => string.Join("|", combination.Framework, combination.Runtime, combination.Style.ToString()),
-                        StringComparer.OrdinalIgnoreCase)
-                    .Select(group => group.First())
-                    .ToArray();
-
-                if (combinations.Length == 0)
-                {
-                    BuildTargetProject(plan, target, runtime, target.Publish.Framework, target.Publish.Style);
-                    continue;
-                }
-
-                foreach (var combination in combinations)
-                    BuildTargetProject(plan, target, combination.Runtime, combination.Framework, combination.Style);
-            }
-
+            _logger.Info("Build skipped because one or more installers apply resolved MSI versions to publish; publish steps will build isolated payloads.");
             return;
         }
 
@@ -426,10 +406,11 @@ public sealed partial class DotNetPublishPipelineRunner
         };
 
         if (plan.NoRestoreInPublish) publishArgs.Add("--no-restore");
-        if (plan.NoBuildInPublish) publishArgs.Add("--no-build");
+        if (plan.NoBuildInPublish && !TargetUsesPublishMsiVersionProperties(plan, target.Name, framework, runtime, style))
+            publishArgs.Add("--no-build");
 
         AppendPublishStyleArgs(publishArgs, target.Publish, style);
-        publishArgs.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildProperties(plan, target, framework, runtime, style)));
+        publishArgs.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildPropertiesForRun(plan, target, framework, runtime, style)));
         return publishArgs;
     }
 
@@ -469,13 +450,29 @@ public sealed partial class DotNetPublishPipelineRunner
         return merged;
     }
 
+    private static Dictionary<string, string> BuildPublishMsBuildPropertiesForRun(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+        if (target is null) throw new ArgumentNullException(nameof(target));
+
+        var merged = BuildPublishMsBuildProperties(plan, target, framework, runtime, style);
+        ApplyPublishMsiVersionProperties(merged, plan, target.Name, framework, runtime, style, reserveMonotonicVersions: true);
+        return merged;
+    }
+
     private static void ApplyPublishMsiVersionProperties(
         Dictionary<string, string> properties,
         DotNetPublishPlan plan,
         string targetName,
         string framework,
         string runtime,
-        DotNetPublishStyle style)
+        DotNetPublishStyle style,
+        bool reserveMonotonicVersions = false)
     {
         foreach (var installer in plan.Installers.Where(i =>
                      string.Equals(i.PrepareFromTarget, targetName, StringComparison.OrdinalIgnoreCase)))
@@ -487,6 +484,9 @@ public sealed partial class DotNetPublishPipelineRunner
             var resolved = FindResolvedMsiVersion(plan, installer.Id, targetName, framework, runtime, style);
             if (resolved is null)
                 continue;
+
+            if (reserveMonotonicVersions)
+                ReserveMsiVersionState(resolved, $"publish for installer '{installer.Id}'");
 
             foreach (var propertyName in ResolvePublishVersionProperties(versioning))
             {
@@ -511,35 +511,24 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
-    private void BuildTargetProject(
-        DotNetPublishPlan plan,
-        DotNetPublishTargetPlan target,
-        string? runtime,
-        string? framework,
-        DotNetPublishStyle style)
-    {
-        var args = new List<string> { "build", target.ProjectPath, "-c", plan.Configuration, "--nologo" };
-        if (!string.IsNullOrWhiteSpace(framework))
-            args.AddRange(new[] { "-f", framework! });
-        if (!string.IsNullOrWhiteSpace(runtime))
-            args.AddRange(new[] { "-r", runtime! });
-        if (plan.Restore) args.Add("--no-restore");
-
-        args.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildProperties(
-            plan,
-            target,
-            framework ?? target.Publish.Framework,
-            runtime ?? string.Empty,
-            style)));
-
-        var label = string.IsNullOrWhiteSpace(runtime) ? framework : $"{runtime}, {framework}";
-        _logger.Info($"Build ({label}) -> {target.ProjectPath}");
-        RunDotnet(plan.ProjectRoot, args, plan.EnvironmentVariables);
-    }
-
     private static bool PlanUsesPublishMsiVersionProperties(DotNetPublishPlan plan)
         => (plan.Installers ?? Array.Empty<DotNetPublishInstallerPlan>())
             .Any(installer => installer.Versioning?.Enabled == true && installer.Versioning.ApplyToPublish);
+
+    private static bool TargetUsesPublishMsiVersionProperties(
+        DotNetPublishPlan plan,
+        string targetName,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
+    {
+        return (plan.Installers ?? Array.Empty<DotNetPublishInstallerPlan>())
+            .Where(installer => string.Equals(installer.PrepareFromTarget, targetName, StringComparison.OrdinalIgnoreCase))
+            .Any(installer =>
+                installer.Versioning?.Enabled == true
+                && installer.Versioning.ApplyToPublish
+                && FindResolvedMsiVersion(plan, installer.Id, targetName, framework, runtime, style) is not null);
+    }
 
     private static string[] ResolvePublishVersionProperties(DotNetPublishMsiVersionOptions versioning)
     {

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -128,6 +128,11 @@
         "Monotonic": { "type": "boolean" },
         "StatePath": { "type": ["string", "null"] },
         "PropertyName": { "type": ["string", "null"] },
+        "ApplyToPublish": { "type": "boolean" },
+        "PublishProperties": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
         "PatchCap": { "type": "integer", "minimum": 1, "maximum": 65535 }
       }
     },


### PR DESCRIPTION
## Summary
- add shared DotNet publish support for reusing the resolved MSI version during publish
- expose `Versioning.ApplyToPublish` and optional `PublishProperties` in the typed model and schema
- cache MSI version planning so publish and MSI build use the same resolved value

## Validation
- `dotnet build PowerForge.Tests/PowerForge.Tests.csproj -c Release --no-restore -v minimal /clp:ErrorsOnly`
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~DotNetPublishPipelineRunnerMsiBuildTests|FullyQualifiedName~DotNetPublishPipelineRunnerPublishPropertyTests" -v minimal /clp:ErrorsOnly`
- Full `PowerForge.Tests` run: 2288 passed, 1 local timeout in `WebStaticServerTests.ServeWithPortFallback_UsesNextAvailablePort_AndServesContent`; targeted rerun of that test passed.