### PR TITLE
Improve PowerShell diagnostics and ALC conflict handling

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.BinaryConflicts.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.BinaryConflicts.cs
@@ -69,15 +69,17 @@ public sealed partial class ModulePipelineRunner
 
         var diagnostics = new List<BuildDiagnostic>();
         var editions = GetBinaryConflictEditions(plan.CompatiblePSEditions);
+        var strictAnalysis = cfg.AnalyzeBinaryConflicts == true;
         diagnostics.AddRange(CreateRequiredModuleOrderDiagnostics(
             requiredModules,
             installedModules,
             editions,
-            preferConflictOrder: cfg.PreferBinaryConflictOrder == true));
-        diagnostics.AddRange(CreateRequiredModuleBinaryConflictDiagnostics(installedModules, editions));
+            preferConflictOrder: cfg.PreferBinaryConflictOrder == true,
+            strictAnalysis: strictAnalysis));
+        diagnostics.AddRange(CreateRequiredModuleBinaryConflictDiagnostics(installedModules, editions, strictAnalysis));
 
         if (cfg.Self == true)
-            diagnostics.AddRange(CreateBuiltModuleBinaryConflictDiagnostics(plan, buildResult, installedModules, editions));
+            diagnostics.AddRange(CreateBuiltModuleBinaryConflictDiagnostics(plan, buildResult, installedModules, editions, strictAnalysis));
 
         return diagnostics.ToArray();
     }
@@ -122,10 +124,21 @@ public sealed partial class ModulePipelineRunner
         RequiredModuleReference[] requiredModules,
         InstalledModuleMetadata[] installedModules,
         string[] editions,
-        bool preferConflictOrder)
+        bool preferConflictOrder,
+        bool strictAnalysis)
     {
         if (installedModules.Length < 2)
             return Array.Empty<BuildDiagnostic>();
+
+        if (!strictAnalysis &&
+            editions.Length > 0 &&
+            editions.All(static edition => string.Equals(edition, "Core", StringComparison.OrdinalIgnoreCase)) &&
+            installedModules.All(module => BinaryConflictMitigationClassifier.ModuleHasAssemblyLoadContextIsolation(module.ModuleBasePath)))
+        {
+            if (_logger.IsVerbose)
+                _logger.Verbose("Suppressed RequiredModules import-order advisory; every required module appears to use AssemblyLoadContext isolation on PowerShell Core.");
+            return Array.Empty<BuildDiagnostic>();
+        }
 
         var declaredOrder = requiredModules
             .Where(static module => !string.IsNullOrWhiteSpace(module.ModuleName))
@@ -158,7 +171,8 @@ public sealed partial class ModulePipelineRunner
 
     private BuildDiagnostic[] CreateRequiredModuleBinaryConflictDiagnostics(
         InstalledModuleMetadata[] installedModules,
-        string[] editions)
+        string[] editions,
+        bool strictAnalysis)
     {
         if (installedModules.Length < 2)
             return Array.Empty<BuildDiagnostic>();
@@ -166,12 +180,16 @@ public sealed partial class ModulePipelineRunner
         var detector = new BinaryConflictDetectionService(_logger);
         var diagnostics = new List<BuildDiagnostic>();
         var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var isolationCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        var suppressed = 0;
 
         foreach (var module in installedModules)
         {
-            var otherModulePaths = installedModules
+            var otherModules = installedModules
                 .Where(other => !string.Equals(other.Name, module.Name, StringComparison.OrdinalIgnoreCase))
-                .Select(other => other.ModuleBasePath!)
+                .ToArray();
+            var otherModulePaths = otherModules
+                .Select(static other => other.ModuleBasePath!)
                 .ToArray();
             if (otherModulePaths.Length == 0)
                 continue;
@@ -186,6 +204,18 @@ public sealed partial class ModulePipelineRunner
 
                 foreach (var issue in result.Issues)
                 {
+                    var otherModule = FindInstalledModule(otherModules, issue);
+                    if (BinaryConflictMitigationClassifier.IsRequiredModuleConflictMitigatedByAlc(
+                            module,
+                            otherModule,
+                            issue.PowerShellEdition,
+                            strictAnalysis,
+                            isolationCache))
+                    {
+                        suppressed++;
+                        continue;
+                    }
+
                     var preferredFirst = issue.VersionComparison >= 0 ? module.Name : issue.InstalledModuleName;
                     var preferredSecond = issue.VersionComparison >= 0 ? issue.InstalledModuleName : module.Name;
                     var preferredVersion = issue.VersionComparison >= 0 ? issue.PayloadAssemblyVersion : issue.InstalledAssemblyVersion;
@@ -209,6 +239,9 @@ public sealed partial class ModulePipelineRunner
             }
         }
 
+        if (suppressed > 0 && _logger.IsVerbose)
+            _logger.Verbose($"Suppressed {suppressed} RequiredModules binary conflict advisory item(s); at least one side appears to use AssemblyLoadContext isolation on PowerShell Core.");
+
         return diagnostics.ToArray();
     }
 
@@ -216,11 +249,13 @@ public sealed partial class ModulePipelineRunner
         ModulePipelinePlan plan,
         ModuleBuildResult buildResult,
         InstalledModuleMetadata[] installedModules,
-        string[] editions)
+        string[] editions,
+        bool strictAnalysis)
     {
         var detector = new BinaryConflictDetectionService(_logger);
         var diagnostics = new List<BuildDiagnostic>();
         var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var suppressed = 0;
         var modulePaths = installedModules
             .Select(module => module.ModuleBasePath!)
             .ToArray();
@@ -235,6 +270,15 @@ public sealed partial class ModulePipelineRunner
 
             foreach (var issue in result.Issues)
             {
+                if (BinaryConflictMitigationClassifier.IsCurrentModuleConflictMitigatedByAlc(
+                        plan.BuildSpec.UseAssemblyLoadContext,
+                        issue.PowerShellEdition,
+                        strictAnalysis))
+                {
+                    suppressed++;
+                    continue;
+                }
+
                 var moduleLabel = string.IsNullOrWhiteSpace(issue.InstalledModuleVersion)
                     ? issue.InstalledModuleName
                     : issue.InstalledModuleName + " " + issue.InstalledModuleVersion;
@@ -256,7 +300,29 @@ public sealed partial class ModulePipelineRunner
             }
         }
 
+        if (suppressed > 0 && _logger.IsVerbose)
+            _logger.Verbose($"Suppressed {suppressed} built-module binary conflict advisory item(s); UseAssemblyLoadContext isolates the module payload on PowerShell Core.");
+
         return diagnostics.ToArray();
+    }
+
+    private static InstalledModuleMetadata? FindInstalledModule(
+        IEnumerable<InstalledModuleMetadata> modules,
+        BinaryConflictDetectionIssue issue)
+    {
+        foreach (var module in modules ?? Array.Empty<InstalledModuleMetadata>())
+        {
+            if (!string.Equals(module.Name, issue.InstalledModuleName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (string.IsNullOrWhiteSpace(issue.InstalledModuleVersion) ||
+                string.Equals(module.Version, issue.InstalledModuleVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                return module;
+            }
+        }
+
+        return null;
     }
 
     private string[] BuildPreferredRequiredModuleOrder(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.BinaryConflicts.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.BinaryConflicts.cs
@@ -256,6 +256,7 @@ public sealed partial class ModulePipelineRunner
         var diagnostics = new List<BuildDiagnostic>();
         var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var suppressed = 0;
+        var isolationCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         var modulePaths = installedModules
             .Select(module => module.ModuleBasePath!)
             .ToArray();
@@ -273,7 +274,9 @@ public sealed partial class ModulePipelineRunner
                 if (BinaryConflictMitigationClassifier.IsCurrentModuleConflictMitigatedByAlc(
                         plan.BuildSpec.UseAssemblyLoadContext,
                         issue.PowerShellEdition,
-                        strictAnalysis))
+                        strictAnalysis,
+                        buildResult.StagingPath,
+                        isolationCache))
                 {
                     suppressed++;
                     continue;

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.BinaryConflicts.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.BinaryConflicts.cs
@@ -257,6 +257,9 @@ public sealed partial class ModulePipelineRunner
         var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var suppressed = 0;
         var isolationCache = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        var hasGeneratedAssemblyLoadContext = BinaryConflictMitigationClassifier.ModuleHasAssemblyLoadContextIsolation(
+            buildResult.StagingPath,
+            isolationCache);
         var modulePaths = installedModules
             .Select(module => module.ModuleBasePath!)
             .ToArray();
@@ -272,7 +275,7 @@ public sealed partial class ModulePipelineRunner
             foreach (var issue in result.Issues)
             {
                 if (BinaryConflictMitigationClassifier.IsCurrentModuleConflictMitigatedByAlc(
-                        plan.BuildSpec.UseAssemblyLoadContext,
+                        plan.BuildSpec.UseAssemblyLoadContext || hasGeneratedAssemblyLoadContext,
                         issue.PowerShellEdition,
                         strictAnalysis,
                         buildResult.StagingPath,

--- a/PowerForge.PowerShell/Services/ModuleValidationService.Checks.cs
+++ b/PowerForge.PowerShell/Services/ModuleValidationService.Checks.cs
@@ -273,19 +273,30 @@ public sealed partial class ModuleValidationService
             if (parsed.Length == 0)
                 return BuildResult("PSScriptAnalyzer", settings.Severity, issues, $"Checked {CountLabel(scripts.Length, "script", "scripts")}, found 0 issues");
 
+            var structuredIssues = parsed
+                .Select(i => CreateScriptAnalyzerValidationIssue(moduleRoot, i))
+                .ToArray();
+
             foreach (var i in parsed.Take(25))
             {
-                var location = string.IsNullOrWhiteSpace(i.ScriptPath)
+                var scriptPathForDisplay = i.ScriptPath ?? string.Empty;
+                var relativePath = string.IsNullOrWhiteSpace(scriptPathForDisplay)
                     ? string.Empty
-                    : $"{Path.GetFileName(i.ScriptPath)}:{i.Line}:{i.Column}";
+                    : ProjectTextDetector.ComputeRelativePath(moduleRoot, scriptPathForDisplay);
+                var location = string.IsNullOrWhiteSpace(relativePath)
+                    ? string.Empty
+                    : $"{relativePath}:{i.Line}:{i.Column}";
                 var line = $"{i.RuleName} {i.Severity} {location}".Trim();
                 if (!string.IsNullOrWhiteSpace(i.Message))
                     line += $" - {i.Message}";
+                var recommendation = BuildScriptAnalyzerRecommendation(i.RuleName, i.Message, i.SuggestedCorrection);
+                if (!string.IsNullOrWhiteSpace(recommendation))
+                    line += $" Recommendation: {recommendation}";
                 issues.Add(line.Trim());
             }
 
             var summary = $"Checked {CountLabel(scripts.Length, "script", "scripts")}, found {CountLabel(parsed.Length, "issue", "issues")}";
-            return BuildResult("PSScriptAnalyzer", settings.Severity, issues, summary);
+            return BuildResult("PSScriptAnalyzer", settings.Severity, issues, summary, structuredIssues);
         }
         finally
         {
@@ -427,5 +438,57 @@ public sealed partial class ModuleValidationService
         ModuleValidationSpec spec,
         CsprojValidationSettings settings)
         => ModuleValidationCoreChecks.ValidateCsproj(spec, settings);
+
+    private static ModuleValidationIssue CreateScriptAnalyzerValidationIssue(string moduleRoot, ScriptAnalyzerIssue issue)
+    {
+        var path = issue.ScriptPath ?? string.Empty;
+        var relativePath = string.IsNullOrWhiteSpace(path)
+            ? string.Empty
+            : ProjectTextDetector.ComputeRelativePath(moduleRoot, path);
+        return new ModuleValidationIssue(
+            code: issue.RuleName ?? string.Empty,
+            severity: issue.Severity ?? string.Empty,
+            message: issue.Message ?? string.Empty,
+            filePath: path,
+            relativePath: relativePath,
+            line: issue.Line,
+            column: issue.Column,
+            endLine: issue.EndLine,
+            endColumn: issue.EndColumn,
+            recommendation: BuildScriptAnalyzerRecommendation(issue.RuleName, issue.Message, issue.SuggestedCorrection),
+            suggestedCorrection: issue.SuggestedCorrection ?? string.Empty,
+            source: "PSScriptAnalyzer");
+    }
+
+    private static string BuildScriptAnalyzerRecommendation(string? ruleName, string? message, string? suggestedCorrection)
+    {
+        if (!string.IsNullOrWhiteSpace(suggestedCorrection))
+            return $"Apply the suggested correction: {suggestedCorrection!.Trim()}";
+
+        var normalizedRule = (ruleName ?? string.Empty).Trim();
+        if (string.Equals(normalizedRule, "PSAvoidAssignmentToAutomaticVariable", StringComparison.OrdinalIgnoreCase))
+            return "Rename the variable so it does not overwrite a PowerShell automatic variable unless that assignment is intentional.";
+        if (string.Equals(normalizedRule, "PSAvoidUsingPlainTextForPassword", StringComparison.OrdinalIgnoreCase))
+            return "Use SecureString, PSCredential, SecretManagement, or another protected secret flow instead of plain text password values.";
+        if (string.Equals(normalizedRule, "PSUseApprovedVerbs", StringComparison.OrdinalIgnoreCase))
+            return "Rename the function to use an approved PowerShell verb returned by Get-Verb.";
+        if (string.Equals(normalizedRule, "PSAvoidUsingWriteHost", StringComparison.OrdinalIgnoreCase))
+            return "Use output, verbose, information, warning, or error streams instead of Write-Host unless host-only rendering is required.";
+        if (string.Equals(normalizedRule, "PSUseDeclaredVarsMoreThanAssignments", StringComparison.OrdinalIgnoreCase))
+            return "Remove the unused assignment or use the value where it is needed.";
+        if (string.Equals(normalizedRule, "PSAvoidUsingConvertToSecureStringWithPlainText", StringComparison.OrdinalIgnoreCase))
+            return "Avoid embedding plain text secrets; retrieve secrets from a secure provider or accept credentials from the caller.";
+        if (string.Equals(normalizedRule, "PSAvoidGlobalVars", StringComparison.OrdinalIgnoreCase))
+            return "Pass state through parameters, return values, or scoped script/module variables instead of global variables.";
+        if (string.Equals(normalizedRule, "PSAvoidUsingInvokeExpression", StringComparison.OrdinalIgnoreCase))
+            return "Replace Invoke-Expression with direct command invocation, splatting, or a validated parser-specific implementation.";
+        if (string.Equals(normalizedRule, "PSUseShouldProcessForStateChangingFunctions", StringComparison.OrdinalIgnoreCase))
+            return "Add SupportsShouldProcess and guard state-changing operations with ShouldProcess.";
+
+        if (!string.IsNullOrWhiteSpace(message))
+            return "Review the analyzer message and update the source so the rule no longer triggers.";
+
+        return "Review the PSScriptAnalyzer rule and update the source before rerunning validation.";
+    }
 
 }

--- a/PowerForge.PowerShell/Services/ModuleValidationService.Utils.cs
+++ b/PowerForge.PowerShell/Services/ModuleValidationService.Utils.cs
@@ -14,11 +14,15 @@ public sealed partial class ModuleValidationService
         string name,
         ValidationSeverity severity,
         List<string> issues,
-        string summary)
+        string summary,
+        IEnumerable<ModuleValidationIssue>? structuredIssues = null)
     {
         var issueArray = issues?.Where(i => !string.IsNullOrWhiteSpace(i)).ToArray() ?? Array.Empty<string>();
         var status = ResolveStatus(severity, issueArray.Length);
-        return new ModuleValidationCheckResult(name, severity, status, summary, issueArray);
+        var structuredIssueArray = structuredIssues?
+            .Where(static i => i is not null)
+            .ToArray() ?? Array.Empty<ModuleValidationIssue>();
+        return new ModuleValidationCheckResult(name, severity, status, summary, issueArray, structuredIssueArray);
     }
 
     private static CheckStatus ResolveStatus(ValidationSeverity severity, int issueCount)
@@ -204,5 +208,8 @@ public sealed partial class ModuleValidationService
         public string? ScriptPath { get; set; }
         public int Line { get; set; }
         public int Column { get; set; }
+        public int EndLine { get; set; }
+        public int EndColumn { get; set; }
+        public string? SuggestedCorrection { get; set; }
     }
 }

--- a/PowerForge.Tests/BinaryConflictMitigationClassifierTests.cs
+++ b/PowerForge.Tests/BinaryConflictMitigationClassifierTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+
+namespace PowerForge.Tests;
+
+public sealed class BinaryConflictMitigationClassifierTests
+{
+    [Fact]
+    public void SuppressCurrentModuleConflictsMitigatedByAlc_SuppressesCoreAutoMode()
+    {
+        var result = CreateResult("Core");
+
+        var filtered = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+            result,
+            useAssemblyLoadContext: true,
+            strictAnalysis: false);
+
+        Assert.False(filtered.HasConflicts);
+        Assert.Contains("mitigated", filtered.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SuppressCurrentModuleConflictsMitigatedByAlc_KeepsDesktopAndStrictFindings()
+    {
+        var desktop = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+            CreateResult("Desktop"),
+            useAssemblyLoadContext: true,
+            strictAnalysis: false);
+        var strict = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+            CreateResult("Core"),
+            useAssemblyLoadContext: true,
+            strictAnalysis: true);
+
+        Assert.True(desktop.HasConflicts);
+        Assert.True(strict.HasConflicts);
+    }
+
+    [Fact]
+    public void ModuleHasAssemblyLoadContextIsolation_DetectsPowerForgeGeneratedBootstrapper()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(root.FullName, "Demo.psm1"),
+                "$ModuleAssembly = [Demo.ModuleLoadContext.ModuleAssemblyLoadContext]::LoadModule($ModuleAssemblyPath, 'Demo')");
+
+            Assert.True(BinaryConflictMitigationClassifier.ModuleHasAssemblyLoadContextIsolation(root.FullName));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void IsRequiredModuleConflictMitigatedByAlc_UsesEitherSideInCoreAutoMode()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var isolatedRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "IsolatedModule"));
+            var regularRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "RegularModule"));
+            File.WriteAllText(
+                Path.Combine(isolatedRoot.FullName, "IsolatedModule.psm1"),
+                "Import-Module -Assembly $ModuleAssembly # AssemblyLoadContext");
+
+            var isolated = new InstalledModuleMetadata("IsolatedModule", "1.0.0", null, isolatedRoot.FullName);
+            var regular = new InstalledModuleMetadata("RegularModule", "1.0.0", null, regularRoot.FullName);
+
+            Assert.True(BinaryConflictMitigationClassifier.IsRequiredModuleConflictMitigatedByAlc(
+                isolated,
+                regular,
+                "Core",
+                strictAnalysis: false));
+            Assert.False(BinaryConflictMitigationClassifier.IsRequiredModuleConflictMitigatedByAlc(
+                isolated,
+                regular,
+                "Desktop",
+                strictAnalysis: false));
+            Assert.False(BinaryConflictMitigationClassifier.IsRequiredModuleConflictMitigatedByAlc(
+                isolated,
+                regular,
+                "Core",
+                strictAnalysis: true));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    private static BinaryConflictDetectionResult CreateResult(string edition)
+    {
+        return new BinaryConflictDetectionResult(
+            powerShellEdition: edition,
+            moduleRoot: @"C:\Repo\TestModule",
+            assemblyRootPath: @"C:\Repo\TestModule\Lib\Core",
+            assemblyRootRelativePath: @"Lib\Core",
+            issues: new[]
+            {
+                new BinaryConflictDetectionIssue(
+                    powerShellEdition: edition,
+                    assemblyName: "SharedAuth",
+                    payloadAssemblyFileName: "SharedAuth.dll",
+                    payloadAssemblyVersion: "2.0.0.0",
+                    installedModuleName: "OtherModule",
+                    installedModuleVersion: "1.0.0",
+                    installedAssemblyVersion: "1.0.0.0",
+                    installedAssemblyRelativePath: "OtherModule/1.0.0/bin/SharedAuth.dll",
+                    installedAssemblyPath: @"C:\Modules\OtherModule\1.0.0\bin\SharedAuth.dll",
+                    versionComparison: 1)
+            },
+            summary: "1 conflict across 1 module source");
+    }
+}

--- a/PowerForge.Tests/BinaryConflictMitigationClassifierTests.cs
+++ b/PowerForge.Tests/BinaryConflictMitigationClassifierTests.cs
@@ -8,43 +8,113 @@ public sealed class BinaryConflictMitigationClassifierTests
     [Fact]
     public void SuppressCurrentModuleConflictsMitigatedByAlc_SuppressesCoreAutoMode()
     {
-        var result = CreateResult("Core");
+        var root = CreateModuleRootWithAssemblyLoadContextMarker();
+        try
+        {
+            var result = CreateResult("Core", root.FullName);
 
-        var filtered = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
-            result,
-            useAssemblyLoadContext: true,
-            strictAnalysis: false);
+            var filtered = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+                result,
+                useAssemblyLoadContext: true,
+                strictAnalysis: false);
 
-        Assert.False(filtered.HasConflicts);
-        Assert.Contains("mitigated", filtered.Summary, StringComparison.OrdinalIgnoreCase);
+            Assert.False(filtered.HasConflicts);
+            Assert.Contains("mitigated", filtered.Summary, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
     }
 
     [Fact]
     public void SuppressCurrentModuleConflictsMitigatedByAlc_KeepsDesktopAndStrictFindings()
     {
-        var desktop = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
-            CreateResult("Desktop"),
-            useAssemblyLoadContext: true,
-            strictAnalysis: false);
-        var strict = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
-            CreateResult("Core"),
-            useAssemblyLoadContext: true,
-            strictAnalysis: true);
+        var root = CreateModuleRootWithAssemblyLoadContextMarker();
+        try
+        {
+            var desktop = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+                CreateResult("Desktop", root.FullName),
+                useAssemblyLoadContext: true,
+                strictAnalysis: false);
+            var strict = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+                CreateResult("Core", root.FullName),
+                useAssemblyLoadContext: true,
+                strictAnalysis: true);
 
-        Assert.True(desktop.HasConflicts);
-        Assert.True(strict.HasConflicts);
+            Assert.True(desktop.HasConflicts);
+            Assert.True(strict.HasConflicts);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void SuppressCurrentModuleConflictsMitigatedByAlc_KeepsCoreFindingsWithoutGeneratedLoader()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Demo.psm1"), "# regular bootstrapper");
+
+            var filtered = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+                CreateResult("Core", root.FullName),
+                useAssemblyLoadContext: true,
+                strictAnalysis: false);
+
+            Assert.True(filtered.HasConflicts);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void IsCurrentModuleConflictMitigatedByAlc_RequiresGeneratedLoaderMarker()
+    {
+        var root = CreateModuleRootWithAssemblyLoadContextMarker();
+        var plainRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(plainRoot.FullName, "Demo.psm1"), "# regular bootstrapper");
+
+            Assert.True(BinaryConflictMitigationClassifier.IsCurrentModuleConflictMitigatedByAlc(
+                useAssemblyLoadContext: true,
+                powerShellEdition: "Core",
+                strictAnalysis: false,
+                moduleRoot: root.FullName));
+            Assert.False(BinaryConflictMitigationClassifier.IsCurrentModuleConflictMitigatedByAlc(
+                useAssemblyLoadContext: true,
+                powerShellEdition: "Core",
+                strictAnalysis: false,
+                moduleRoot: plainRoot.FullName));
+            Assert.False(BinaryConflictMitigationClassifier.IsCurrentModuleConflictMitigatedByAlc(
+                useAssemblyLoadContext: true,
+                powerShellEdition: "Desktop",
+                strictAnalysis: false,
+                moduleRoot: root.FullName));
+            Assert.False(BinaryConflictMitigationClassifier.IsCurrentModuleConflictMitigatedByAlc(
+                useAssemblyLoadContext: true,
+                powerShellEdition: "Core",
+                strictAnalysis: true,
+                moduleRoot: root.FullName));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { plainRoot.Delete(recursive: true); } catch { }
+        }
     }
 
     [Fact]
     public void ModuleHasAssemblyLoadContextIsolation_DetectsPowerForgeGeneratedBootstrapper()
     {
-        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var root = CreateModuleRootWithAssemblyLoadContextMarker();
         try
         {
-            File.WriteAllText(
-                Path.Combine(root.FullName, "Demo.psm1"),
-                "$ModuleAssembly = [Demo.ModuleLoadContext.ModuleAssemblyLoadContext]::LoadModule($ModuleAssemblyPath, 'Demo')");
-
             Assert.True(BinaryConflictMitigationClassifier.ModuleHasAssemblyLoadContextIsolation(root.FullName));
         }
         finally
@@ -59,11 +129,8 @@ public sealed class BinaryConflictMitigationClassifierTests
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
         {
-            var isolatedRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "IsolatedModule"));
+            var isolatedRoot = CreateModuleRootWithAssemblyLoadContextMarker(root.FullName, "IsolatedModule");
             var regularRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "RegularModule"));
-            File.WriteAllText(
-                Path.Combine(isolatedRoot.FullName, "IsolatedModule.psm1"),
-                "Import-Module -Assembly $ModuleAssembly # AssemblyLoadContext");
 
             var isolated = new InstalledModuleMetadata("IsolatedModule", "1.0.0", null, isolatedRoot.FullName);
             var regular = new InstalledModuleMetadata("RegularModule", "1.0.0", null, regularRoot.FullName);
@@ -90,13 +157,25 @@ public sealed class BinaryConflictMitigationClassifierTests
         }
     }
 
-    private static BinaryConflictDetectionResult CreateResult(string edition)
+    private static DirectoryInfo CreateModuleRootWithAssemblyLoadContextMarker(string? parent = null, string moduleName = "Demo")
+    {
+        var rootPath = parent is null
+            ? Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"))
+            : Path.Combine(parent, moduleName);
+        var root = Directory.CreateDirectory(rootPath);
+        File.WriteAllText(
+            Path.Combine(root.FullName, moduleName + ".psm1"),
+            "$ModuleAssembly = [Demo.ModuleLoadContext.ModuleAssemblyLoadContext]::LoadModule($ModuleAssemblyPath, 'Demo')");
+        return root;
+    }
+
+    private static BinaryConflictDetectionResult CreateResult(string edition, string moduleRoot)
     {
         return new BinaryConflictDetectionResult(
             powerShellEdition: edition,
-            moduleRoot: @"C:\Repo\TestModule",
-            assemblyRootPath: @"C:\Repo\TestModule\Lib\Core",
-            assemblyRootRelativePath: @"Lib\Core",
+            moduleRoot: moduleRoot,
+            assemblyRootPath: Path.Combine(moduleRoot, "Lib", edition),
+            assemblyRootRelativePath: "Lib/" + edition,
             issues: new[]
             {
                 new BinaryConflictDetectionIssue(

--- a/PowerForge.Tests/BuildDiagnosticsFactoryTests.cs
+++ b/PowerForge.Tests/BuildDiagnosticsFactoryTests.cs
@@ -152,6 +152,46 @@ public sealed class BuildDiagnosticsFactoryTests
     }
 
     [Fact]
+    public void CreateValidationDiagnostics_ProducesPerFindingPssaRecommendations()
+    {
+        var report = new ModuleValidationReport(new[]
+        {
+            new ModuleValidationCheckResult(
+                name: "PSScriptAnalyzer",
+                severity: ValidationSeverity.Warning,
+                status: CheckStatus.Warning,
+                summary: "Checked 1 script, found 1 issue",
+                issues: new[] { "PSAvoidAssignmentToAutomaticVariable Warning TestScript.ps1:1:1 - automatic variable" },
+                structuredIssues: new[]
+                {
+                    new ModuleValidationIssue(
+                        code: "PSAvoidAssignmentToAutomaticVariable",
+                        severity: "Warning",
+                        message: "The Variable 'profile' is an automatic variable that is built into PowerShell.",
+                        filePath: @"C:\Repo\TestScript.ps1",
+                        relativePath: "TestScript.ps1",
+                        line: 1,
+                        column: 1,
+                        endLine: 1,
+                        endColumn: 9,
+                        recommendation: "Rename the variable so it does not overwrite a PowerShell automatic variable unless that assignment is intentional.",
+                        source: "PSScriptAnalyzer")
+                })
+        });
+
+        var diagnostics = BuildDiagnosticsFactory.CreateValidationDiagnostics(report);
+
+        var pssa = Assert.Single(diagnostics);
+        Assert.Equal("VALIDATION-PSSA-PSAVOIDASSIGNMENTTOAUTOMATICVARIABLE", pssa.RuleId);
+        Assert.Equal(BuildDiagnosticOwner.ModuleAuthor, pssa.Owner);
+        Assert.Equal(BuildDiagnosticScope.Project, pssa.Scope);
+        Assert.Equal("TestScript.ps1:1:1", pssa.SourcePath);
+        Assert.Contains("TestScript.ps1:1:1", pssa.Details);
+        Assert.Contains("automatic variable", pssa.RecommendedAction, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("PSScriptAnalyzer", pssa.GeneratedBy);
+    }
+
+    [Fact]
     public void CreatePipelineDiagnostics_AggregatesConfiguredAreas()
     {
         var settings = new FileConsistencySettings

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -711,6 +712,55 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void BuildToStaging_WithAssemblyLoadContext_DefersBinaryConflictNotesUntilBootstrapperExists()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "DemoModule";
+            var source = Path.Combine(tempRoot.FullName, "src");
+            var staging = Path.Combine(tempRoot.FullName, "staging");
+            var stagedAssembly = BuildLibrary(tempRoot.FullName, "SharedAuth", "2.0.0");
+            var installedAssembly = BuildLibrary(tempRoot.FullName, "SharedAuth", "1.0.0", projectFolderName: "SharedAuth_Other");
+
+            WriteMinimalBinaryModule(source, moduleName);
+            File.Copy(stagedAssembly, Path.Combine(source, "Lib", "Core", "SharedAuth.dll"), overwrite: true);
+
+            var moduleSearchRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "PSModules"));
+            var installedModuleDir = Directory.CreateDirectory(Path.Combine(moduleSearchRoot.FullName, "OtherModule", "1.0.0", "bin"));
+            File.Copy(installedAssembly, Path.Combine(installedModuleDir.FullName, "SharedAuth.dll"), overwrite: true);
+
+            var pipeline = ModuleBuildPipelineFactory.Create(new NullLogger());
+            var result = pipeline.BuildToStaging(new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = source,
+                StagingPath = staging,
+                Version = "1.0.0",
+                Frameworks = new[] { "net8.0" },
+                ExportAssemblies = new[] { "SharedAuth.dll" },
+                DisableBinaryCmdletScan = true,
+                UseAssemblyLoadContext = true,
+                BinaryConflictSearchRoots = new[] { moduleSearchRoot.FullName }
+            });
+
+            var bootstrapper = File.ReadAllText(Path.Combine(result.StagingPath, moduleName + ".psm1"));
+            Assert.Contains("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", bootstrapper);
+            Assert.Contains(
+                result.BuildNotes,
+                note => note.Summary.Contains("Core: no conflicts", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(
+                result.BuildNotes,
+                note => note.Severity == ModuleOwnerNoteSeverity.Warning &&
+                        note.Title.Contains("Binary Conflicts (Core)", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void BuildToStaging_DirectBuildSpecExplicitNone_DoesNotEmitTypeAcceleratorBootstrapper()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -855,5 +905,56 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
         }) + Environment.NewLine;
 
         File.WriteAllText(Path.Combine(moduleRoot, moduleName + ".psd1"), psd1);
+    }
+
+    private static string BuildLibrary(string rootPath, string assemblyName, string version, string? projectFolderName = null)
+    {
+        var projectRoot = Directory.CreateDirectory(Path.Combine(rootPath, projectFolderName ?? (assemblyName + "_" + version.Replace('.', '_'))));
+        var projectPath = Path.Combine(projectRoot.FullName, assemblyName + ".csproj");
+        var sourcePath = Path.Combine(projectRoot.FullName, "Class1.cs");
+
+        File.WriteAllText(projectPath, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>{{assemblyName}}</AssemblyName>
+    <Version>{{version}}</Version>
+    <AssemblyVersion>{{version}}.0</AssemblyVersion>
+    <FileVersion>{{version}}.0</FileVersion>
+  </PropertyGroup>
+</Project>
+""");
+
+        File.WriteAllText(sourcePath, $$"""
+namespace {{assemblyName}}Lib;
+
+public sealed class Marker
+{
+}
+""");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"build \"{projectPath}\" -c Release -nologo --verbosity quiet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = projectRoot.FullName
+        };
+
+        using var process = Process.Start(psi)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, $"dotnet build failed for test fixture.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+
+        var assemblyPath = Path.Combine(projectRoot.FullName, "bin", "Release", "net8.0", assemblyName + ".dll");
+        Assert.True(File.Exists(assemblyPath), $"Built assembly not found: {assemblyPath}");
+        return assemblyPath;
     }
 }

--- a/PowerForge.Tests/ModuleValidationServiceTests.cs
+++ b/PowerForge.Tests/ModuleValidationServiceTests.cs
@@ -380,6 +380,22 @@ public sealed class ModuleValidationServiceTests
     }
 
     [Fact]
+    public void ScriptAnalyzerRunner_PrefersExtentFileBeforeLeafScriptName()
+    {
+        var script = EmbeddedScripts.Load("Scripts/Validation/Invoke-ScriptAnalyzer.ps1");
+
+        var extentFileIndex = script.IndexOf("$extent.File", StringComparison.Ordinal);
+        var scriptPathIndex = script.IndexOf("$Issue.ScriptPath", StringComparison.Ordinal);
+        var scriptNameIndex = script.IndexOf("$Issue.ScriptName", StringComparison.Ordinal);
+
+        Assert.True(extentFileIndex >= 0, "Expected the runner to inspect Extent.File.");
+        Assert.True(scriptPathIndex >= 0, "Expected the runner to inspect ScriptPath.");
+        Assert.True(scriptNameIndex >= 0, "Expected the runner to inspect ScriptName.");
+        Assert.True(extentFileIndex < scriptPathIndex, "Extent.File should be preferred over ScriptPath when available.");
+        Assert.True(extentFileIndex < scriptNameIndex, "Extent.File should be preferred over ScriptName when available.");
+    }
+
+    [Fact]
     public void Run_ScriptAnalyzerInstallIfUnavailable_UsesRuntimeDependencyInstaller()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModuleValidationServiceTests.cs
+++ b/PowerForge.Tests/ModuleValidationServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;
+using System.Text.Json;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -300,6 +301,85 @@ public sealed class ModuleValidationServiceTests
     }
 
     [Fact]
+    public void Run_ScriptAnalyzerFindings_CapturesStructuredRecommendations()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var scriptPath = Path.Combine(root.FullName, "TestScript.ps1");
+            File.WriteAllText(scriptPath, "$profile = 'custom'");
+
+            var settings = new ModuleValidationSettings
+            {
+                Enable = true,
+                Structure = new ModuleStructureValidationSettings { Severity = ValidationSeverity.Off },
+                Documentation = new DocumentationValidationSettings { Severity = ValidationSeverity.Off },
+                ScriptAnalyzer = new ScriptAnalyzerValidationSettings
+                {
+                    Enable = true,
+                    Severity = ValidationSeverity.Warning,
+                    ExcludeDirectories = Array.Empty<string>(),
+                    ExcludeRules = Array.Empty<string>(),
+                    SkipIfUnavailable = false,
+                    TimeoutSeconds = 5
+                },
+                FileIntegrity = new FileIntegrityValidationSettings { Severity = ValidationSeverity.Off },
+                Tests = new TestSuiteValidationSettings { Severity = ValidationSeverity.Off },
+                Binary = new BinaryModuleValidationSettings { Severity = ValidationSeverity.Off },
+                Csproj = new CsprojValidationSettings { Severity = ValidationSeverity.Off }
+            };
+
+            var analyzerJson = JsonSerializer.Serialize(new[]
+            {
+                new
+                {
+                    RuleName = "PSAvoidAssignmentToAutomaticVariable",
+                    Severity = "Warning",
+                    Message = "The Variable 'profile' is an automatic variable that is built into PowerShell.",
+                    ScriptPath = scriptPath,
+                    Line = 1,
+                    Column = 1,
+                    EndLine = 1,
+                    EndColumn = 9,
+                    SuggestedCorrection = ""
+                }
+            });
+
+            var service = new ModuleValidationService(
+                new NullLogger(),
+                new JsonWritingPowerShellRunner(analyzerJson));
+
+            var report = service.Run(new ModuleValidationSpec
+            {
+                ProjectRoot = root.FullName,
+                StagingPath = root.FullName,
+                ModuleName = "TestModule",
+                ManifestPath = string.Empty,
+                Settings = settings
+            });
+
+            var check = Assert.Single(report.Checks);
+            Assert.Equal("PSScriptAnalyzer", check.Name);
+            Assert.Equal(CheckStatus.Warning, check.Status);
+            Assert.Contains(check.Issues, issue => issue.Contains("PSAvoidAssignmentToAutomaticVariable", StringComparison.Ordinal));
+            Assert.Contains(check.Issues, issue => issue.Contains("Recommendation:", StringComparison.Ordinal));
+
+            var structuredIssue = Assert.Single(check.StructuredIssues);
+            Assert.Equal("PSAvoidAssignmentToAutomaticVariable", structuredIssue.Code);
+            Assert.Equal("Warning", structuredIssue.Severity);
+            Assert.Equal("TestScript.ps1", structuredIssue.RelativePath);
+            Assert.Equal(1, structuredIssue.Line);
+            Assert.Equal(1, structuredIssue.Column);
+            Assert.Contains("automatic variable", structuredIssue.Recommendation, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("PSScriptAnalyzer", structuredIssue.Source);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Run_ScriptAnalyzerInstallIfUnavailable_UsesRuntimeDependencyInstaller()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -571,6 +651,28 @@ public sealed class ModuleValidationServiceTests
         public PowerShellRunResult Run(PowerShellRunRequest request)
         {
             return _result;
+        }
+    }
+
+    private sealed class JsonWritingPowerShellRunner : IPowerShellRunner
+    {
+        private readonly string _json;
+
+        public JsonWritingPowerShellRunner(string json)
+        {
+            _json = json;
+        }
+
+        public PowerShellRunResult Run(PowerShellRunRequest request)
+        {
+            var outputPath = request.Arguments[2];
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            File.WriteAllText(outputPath, _json);
+            return new PowerShellRunResult(
+                0,
+                string.Empty,
+                string.Empty,
+                TestPowerShellExecutable);
         }
     }
 

--- a/PowerForge.Tests/SpectrePipelineSummaryWriterTests.cs
+++ b/PowerForge.Tests/SpectrePipelineSummaryWriterTests.cs
@@ -7,6 +7,34 @@ namespace PowerForge.Tests;
 public sealed class SpectrePipelineSummaryWriterTests
 {
     [Fact]
+    public void BuildRecommendationRows_PreservesDiagnosticLocation()
+    {
+        var diagnostics = new[]
+        {
+            new BuildDiagnostic(
+                ruleId: "VALIDATION-PSSA-PSAVOIDASSIGNMENTTOAUTOMATICVARIABLE",
+                area: BuildDiagnosticArea.Validation,
+                severity: BuildDiagnosticSeverity.Warning,
+                scope: BuildDiagnosticScope.Project,
+                owner: BuildDiagnosticOwner.ModuleAuthor,
+                remediationKind: BuildDiagnosticRemediationKind.ManualFix,
+                canAutoFix: false,
+                summary: "Fix PSAvoidAssignmentToAutomaticVariable",
+                details: "Tests\\Test.ps1:75:1 - The variable profile is automatic.",
+                recommendedAction: "Rename the variable so it does not overwrite a PowerShell automatic variable.",
+                sourcePath: "Tests\\Test.ps1:75:1",
+                generatedBy: "PSScriptAnalyzer")
+        };
+
+        var rows = SpectrePipelineSummaryWriter.BuildRecommendationRows(diagnostics, BuildDiagnosticArea.Validation);
+
+        var row = Assert.Single(rows);
+        Assert.Equal("Fix PSAvoidAssignmentToAutomaticVariable", row.When);
+        Assert.Equal("Tests\\Test.ps1:75:1", row.Where);
+        Assert.Contains("Rename the variable", row.Action);
+    }
+
+    [Fact]
     public void NormalizeFailureMessage_PreservesStructuredImportDiagnosticsWithoutTruncation()
     {
         var detail = new string('x', 400);

--- a/PowerForge/Models/Validation/ModuleValidationIssue.cs
+++ b/PowerForge/Models/Validation/ModuleValidationIssue.cs
@@ -1,0 +1,74 @@
+namespace PowerForge;
+
+/// <summary>
+/// Structured issue produced by a module validation check.
+/// </summary>
+public sealed class ModuleValidationIssue
+{
+    /// <summary>Validation rule or issue code.</summary>
+    public string Code { get; }
+
+    /// <summary>Tool-specific severity, when available.</summary>
+    public string Severity { get; }
+
+    /// <summary>Human-readable issue message.</summary>
+    public string Message { get; }
+
+    /// <summary>Full file path associated with the issue.</summary>
+    public string FilePath { get; }
+
+    /// <summary>Path relative to the validated module root, when available.</summary>
+    public string RelativePath { get; }
+
+    /// <summary>One-based start line.</summary>
+    public int Line { get; }
+
+    /// <summary>One-based start column.</summary>
+    public int Column { get; }
+
+    /// <summary>One-based end line.</summary>
+    public int EndLine { get; }
+
+    /// <summary>One-based end column.</summary>
+    public int EndColumn { get; }
+
+    /// <summary>Recommended action for the module author.</summary>
+    public string Recommendation { get; }
+
+    /// <summary>Tool-supplied suggested correction, when available.</summary>
+    public string SuggestedCorrection { get; }
+
+    /// <summary>Tool or validation component that produced the issue.</summary>
+    public string Source { get; }
+
+    /// <summary>
+    /// Creates a structured validation issue.
+    /// </summary>
+    public ModuleValidationIssue(
+        string code,
+        string severity,
+        string message,
+        string filePath = "",
+        string relativePath = "",
+        int line = 0,
+        int column = 0,
+        int endLine = 0,
+        int endColumn = 0,
+        string recommendation = "",
+        string suggestedCorrection = "",
+        string source = "")
+    {
+        Code = code ?? string.Empty;
+        Severity = severity ?? string.Empty;
+        Message = message ?? string.Empty;
+        FilePath = filePath ?? string.Empty;
+        RelativePath = relativePath ?? string.Empty;
+        Line = line;
+        Column = column;
+        EndLine = endLine;
+        EndColumn = endColumn;
+        Recommendation = recommendation ?? string.Empty;
+        SuggestedCorrection = suggestedCorrection ?? string.Empty;
+        Source = source ?? string.Empty;
+    }
+}

--- a/PowerForge/Models/Validation/ModuleValidationReport.cs
+++ b/PowerForge/Models/Validation/ModuleValidationReport.cs
@@ -76,23 +76,29 @@ public sealed class ModuleValidationCheckResult
     /// <summary>Issues found by the check.</summary>
     public string[] Issues { get; }
 
+    /// <summary>Structured issues found by the check.</summary>
+    public ModuleValidationIssue[] StructuredIssues { get; }
+
     /// <summary>Creates a single validation check result.</summary>
     /// <param name="name">Check name.</param>
     /// <param name="severity">Configured severity.</param>
     /// <param name="status">Computed status.</param>
     /// <param name="summary">Short summary.</param>
     /// <param name="issues">Issues discovered by the check.</param>
+    /// <param name="structuredIssues">Structured issues discovered by the check.</param>
     public ModuleValidationCheckResult(
         string name,
         ValidationSeverity severity,
         CheckStatus status,
         string summary,
-        string[] issues)
+        string[] issues,
+        ModuleValidationIssue[]? structuredIssues = null)
     {
         Name = name ?? string.Empty;
         Severity = severity;
         Status = status;
         Summary = summary ?? string.Empty;
         Issues = issues ?? System.Array.Empty<string>();
+        StructuredIssues = structuredIssues ?? System.Array.Empty<ModuleValidationIssue>();
     }
 }

--- a/PowerForge/Models/Validation/ModuleValidationReport.cs
+++ b/PowerForge/Models/Validation/ModuleValidationReport.cs
@@ -85,6 +85,22 @@ public sealed class ModuleValidationCheckResult
     /// <param name="status">Computed status.</param>
     /// <param name="summary">Short summary.</param>
     /// <param name="issues">Issues discovered by the check.</param>
+    public ModuleValidationCheckResult(
+        string name,
+        ValidationSeverity severity,
+        CheckStatus status,
+        string summary,
+        string[] issues)
+        : this(name, severity, status, summary, issues, System.Array.Empty<ModuleValidationIssue>())
+    {
+    }
+
+    /// <summary>Creates a single validation check result.</summary>
+    /// <param name="name">Check name.</param>
+    /// <param name="severity">Configured severity.</param>
+    /// <param name="status">Computed status.</param>
+    /// <param name="summary">Short summary.</param>
+    /// <param name="issues">Issues discovered by the check.</param>
     /// <param name="structuredIssues">Structured issues discovered by the check.</param>
     public ModuleValidationCheckResult(
         string name,
@@ -92,7 +108,7 @@ public sealed class ModuleValidationCheckResult
         CheckStatus status,
         string summary,
         string[] issues,
-        ModuleValidationIssue[]? structuredIssues = null)
+        ModuleValidationIssue[]? structuredIssues)
     {
         Name = name ?? string.Empty;
         Severity = severity;

--- a/PowerForge/Scripts/Validation/Invoke-ScriptAnalyzer.ps1
+++ b/PowerForge/Scripts/Validation/Invoke-ScriptAnalyzer.ps1
@@ -102,7 +102,7 @@ try {
     $issues = Invoke-ScriptAnalyzer -Path $paths -ExcludeRule $exclude -ErrorAction Continue
     if ($null -eq $issues) { $issues = @() }
     $records = @($issues | ConvertTo-PssaIssueRecord)
-    $json = if ($records.Count -eq 0) { '[]' } else { $records | ConvertTo-Json -Depth 5 }
+    $json = if ($records.Count -eq 0) { '[]' } else { ConvertTo-Json -InputObject ([object[]]$records) -Depth 5 }
     Set-Content -Path $OutJson -Value $json -Encoding UTF8 -ErrorAction Stop
 } catch {
     $message = if ($_.Exception) { $_.Exception.Message } else { "$_" }

--- a/PowerForge/Scripts/Validation/Invoke-ScriptAnalyzer.ps1
+++ b/PowerForge/Scripts/Validation/Invoke-ScriptAnalyzer.ps1
@@ -25,6 +25,50 @@ function Test-PssaAssemblyConflict([string]$message) {
         $message.IndexOf('already loaded', [System.StringComparison]::OrdinalIgnoreCase) -ge 0
 }
 
+function ConvertTo-PssaIssueRecord {
+    param(
+        [Parameter(ValueFromPipeline)]
+        $Issue
+    )
+
+    process {
+        if ($null -eq $Issue) { return }
+
+        $extent = $Issue.Extent
+        $path = if (-not [string]::IsNullOrWhiteSpace($Issue.ScriptPath)) {
+            $Issue.ScriptPath
+        } elseif (-not [string]::IsNullOrWhiteSpace($Issue.ScriptName)) {
+            $Issue.ScriptName
+        } elseif ($null -ne $extent -and -not [string]::IsNullOrWhiteSpace($extent.File)) {
+            $extent.File
+        } else {
+            ''
+        }
+
+        $correction = ''
+        $suggestedCorrections = @($Issue.SuggestedCorrections)
+        if ($suggestedCorrections.Count -gt 0 -and $null -ne $suggestedCorrections[0]) {
+            if (-not [string]::IsNullOrWhiteSpace($suggestedCorrections[0].Description)) {
+                $correction = $suggestedCorrections[0].Description
+            } elseif (-not [string]::IsNullOrWhiteSpace($suggestedCorrections[0].Text)) {
+                $correction = $suggestedCorrections[0].Text
+            }
+        }
+
+        [pscustomobject]@{
+            RuleName = [string]$Issue.RuleName
+            Severity = [string]$Issue.Severity
+            Message = [string]$Issue.Message
+            ScriptPath = [string]$path
+            Line = if ($null -ne $extent) { [int]$extent.StartLineNumber } else { 0 }
+            Column = if ($null -ne $extent) { [int]$extent.StartColumnNumber } else { 0 }
+            EndLine = if ($null -ne $extent) { [int]$extent.EndLineNumber } else { 0 }
+            EndColumn = if ($null -ne $extent) { [int]$extent.EndColumnNumber } else { 0 }
+            SuggestedCorrection = [string]$correction
+        }
+    }
+}
+
 try {
     $paths = DecodeLines $PathsB64
     $exclude = DecodeLines $ExcludeB64
@@ -57,7 +101,8 @@ try {
 
     $issues = Invoke-ScriptAnalyzer -Path $paths -ExcludeRule $exclude -ErrorAction Continue
     if ($null -eq $issues) { $issues = @() }
-    $json = if (@($issues).Count -eq 0) { '[]' } else { @($issues) | ConvertTo-Json -Depth 6 }
+    $records = @($issues | ConvertTo-PssaIssueRecord)
+    $json = if ($records.Count -eq 0) { '[]' } else { $records | ConvertTo-Json -Depth 5 }
     Set-Content -Path $OutJson -Value $json -Encoding UTF8 -ErrorAction Stop
 } catch {
     $message = if ($_.Exception) { $_.Exception.Message } else { "$_" }

--- a/PowerForge/Scripts/Validation/Invoke-ScriptAnalyzer.ps1
+++ b/PowerForge/Scripts/Validation/Invoke-ScriptAnalyzer.ps1
@@ -35,12 +35,12 @@ function ConvertTo-PssaIssueRecord {
         if ($null -eq $Issue) { return }
 
         $extent = $Issue.Extent
-        $path = if (-not [string]::IsNullOrWhiteSpace($Issue.ScriptPath)) {
+        $path = if ($null -ne $extent -and -not [string]::IsNullOrWhiteSpace($extent.File)) {
+            $extent.File
+        } elseif (-not [string]::IsNullOrWhiteSpace($Issue.ScriptPath)) {
             $Issue.ScriptPath
         } elseif (-not [string]::IsNullOrWhiteSpace($Issue.ScriptName)) {
             $Issue.ScriptName
-        } elseif ($null -ne $extent -and -not [string]::IsNullOrWhiteSpace($extent.File)) {
-            $extent.File
         } else {
             ''
         }

--- a/PowerForge/Services/BinaryConflictMitigationClassifier.cs
+++ b/PowerForge/Services/BinaryConflictMitigationClassifier.cs
@@ -13,6 +13,7 @@ internal static class BinaryConflictMitigationClassifier
         BinaryConflictDetectionResult result,
         bool useAssemblyLoadContext,
         bool strictAnalysis,
+        IDictionary<string, bool>? moduleIsolationCache = null,
         ILogger? logger = null)
     {
         if (result is null)
@@ -20,7 +21,12 @@ internal static class BinaryConflictMitigationClassifier
         if (result.Issues.Length == 0)
             return result;
 
-        if (!IsCurrentModuleConflictMitigatedByAlc(useAssemblyLoadContext, result.PowerShellEdition, strictAnalysis))
+        if (!IsCurrentModuleConflictMitigatedByAlc(
+                useAssemblyLoadContext,
+                result.PowerShellEdition,
+                strictAnalysis,
+                result.ModuleRoot,
+                moduleIsolationCache))
             return result;
 
         var suppressed = result.Issues.Length;
@@ -39,11 +45,14 @@ internal static class BinaryConflictMitigationClassifier
     internal static bool IsCurrentModuleConflictMitigatedByAlc(
         bool useAssemblyLoadContext,
         string? powerShellEdition,
-        bool strictAnalysis)
+        bool strictAnalysis,
+        string? moduleRoot,
+        IDictionary<string, bool>? moduleIsolationCache = null)
     {
         return !strictAnalysis &&
                useAssemblyLoadContext &&
-               IsCoreEdition(powerShellEdition);
+               IsCoreEdition(powerShellEdition) &&
+               ModuleHasAssemblyLoadContextIsolation(moduleRoot, moduleIsolationCache);
     }
 
     internal static bool IsRequiredModuleConflictMitigatedByAlc(

--- a/PowerForge/Services/BinaryConflictMitigationClassifier.cs
+++ b/PowerForge/Services/BinaryConflictMitigationClassifier.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+internal static class BinaryConflictMitigationClassifier
+{
+    private const long MaxMarkerScanBytes = 1024 * 1024;
+
+    internal static BinaryConflictDetectionResult SuppressCurrentModuleConflictsMitigatedByAlc(
+        BinaryConflictDetectionResult result,
+        bool useAssemblyLoadContext,
+        bool strictAnalysis,
+        ILogger? logger = null)
+    {
+        if (result is null)
+            throw new ArgumentNullException(nameof(result));
+        if (result.Issues.Length == 0)
+            return result;
+
+        if (!IsCurrentModuleConflictMitigatedByAlc(useAssemblyLoadContext, result.PowerShellEdition, strictAnalysis))
+            return result;
+
+        var suppressed = result.Issues.Length;
+        if (logger?.IsVerbose == true)
+            logger.Verbose($"Suppressed {suppressed} binary conflict advisory item(s) for {result.PowerShellEdition}; UseAssemblyLoadContext isolates the module payload on PowerShell Core.");
+
+        return new BinaryConflictDetectionResult(
+            result.PowerShellEdition,
+            result.ModuleRoot,
+            result.AssemblyRootPath,
+            result.AssemblyRootRelativePath,
+            Array.Empty<BinaryConflictDetectionIssue>(),
+            $"0 conflicts ({suppressed} mitigated by AssemblyLoadContext)");
+    }
+
+    internal static bool IsCurrentModuleConflictMitigatedByAlc(
+        bool useAssemblyLoadContext,
+        string? powerShellEdition,
+        bool strictAnalysis)
+    {
+        return !strictAnalysis &&
+               useAssemblyLoadContext &&
+               IsCoreEdition(powerShellEdition);
+    }
+
+    internal static bool IsRequiredModuleConflictMitigatedByAlc(
+        InstalledModuleMetadata? currentModule,
+        InstalledModuleMetadata? otherModule,
+        string? powerShellEdition,
+        bool strictAnalysis,
+        IDictionary<string, bool>? moduleIsolationCache = null)
+    {
+        if (strictAnalysis || !IsCoreEdition(powerShellEdition))
+            return false;
+
+        return ModuleHasAssemblyLoadContextIsolation(currentModule?.ModuleBasePath, moduleIsolationCache) ||
+               ModuleHasAssemblyLoadContextIsolation(otherModule?.ModuleBasePath, moduleIsolationCache);
+    }
+
+    internal static bool ModuleHasAssemblyLoadContextIsolation(
+        string? moduleRoot,
+        IDictionary<string, bool>? cache = null)
+    {
+        if (string.IsNullOrWhiteSpace(moduleRoot) || !Directory.Exists(moduleRoot))
+            return false;
+
+        var key = Path.GetFullPath(moduleRoot);
+        if (cache is not null && cache.TryGetValue(key, out var cached))
+            return cached;
+
+        var result = ModuleHasAssemblyLoadContextIsolationCore(key);
+        if (cache is not null)
+            cache[key] = result;
+        return result;
+    }
+
+    private static bool ModuleHasAssemblyLoadContextIsolationCore(string moduleRoot)
+    {
+        foreach (var file in EnumerateCandidateFiles(moduleRoot))
+        {
+            string text;
+            try
+            {
+                var info = new FileInfo(file);
+                if (!info.Exists || info.Length > MaxMarkerScanBytes)
+                    continue;
+                text = File.ReadAllText(file);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (ContainsIsolationMarker(text))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> EnumerateCandidateFiles(string moduleRoot)
+    {
+        foreach (var pattern in new[] { "*.psm1", "*.ps1" })
+        {
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(moduleRoot, pattern, SearchOption.TopDirectoryOnly).ToArray();
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var file in files)
+                yield return file;
+        }
+    }
+
+    private static bool ContainsIsolationMarker(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        return text.IndexOf("ModuleAssemblyLoadContext", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("PowerForge.ModuleIsolation.ModuleLoadContext", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("ModuleLoadContext]::LoadModule", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               (text.IndexOf("AssemblyLoadContext", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                text.IndexOf("Import-Module -Assembly", StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    private static bool IsCoreEdition(string? powerShellEdition)
+        => string.Equals(powerShellEdition, "Core", StringComparison.OrdinalIgnoreCase);
+}

--- a/PowerForge/Services/BuildDiagnosticsFactory.cs
+++ b/PowerForge/Services/BuildDiagnosticsFactory.cs
@@ -480,6 +480,7 @@ public static class BuildDiagnosticsFactory
         var diagnostics = new List<BuildDiagnostic>();
         var detail = BuildCheckDetail(check);
         var issues = check.Issues ?? System.Array.Empty<string>();
+        var structuredIssues = check.StructuredIssues ?? System.Array.Empty<ModuleValidationIssue>();
         var missingTool = issues.Any(static issue =>
             issue.Contains("PSScriptAnalyzer not found", System.StringComparison.OrdinalIgnoreCase));
         var skippedTool = check.Summary?.IndexOf("skipped", System.StringComparison.OrdinalIgnoreCase) >= 0;
@@ -487,7 +488,57 @@ public static class BuildDiagnosticsFactory
             issue.Contains("runner completed without writing the results file", System.StringComparison.OrdinalIgnoreCase) ||
             issue.Contains("PSScriptAnalyzer failed", System.StringComparison.OrdinalIgnoreCase));
 
-        if (missingTool || skippedTool)
+        if (structuredIssues.Length > 0)
+        {
+            foreach (var issue in structuredIssues.Take(25))
+            {
+                var ruleName = string.IsNullOrWhiteSpace(issue.Code) ? "PSScriptAnalyzer" : issue.Code;
+                var sourcePath = !string.IsNullOrWhiteSpace(issue.RelativePath) ? issue.RelativePath : issue.FilePath;
+                var location = FormatValidationLocation(sourcePath, issue.Line, issue.Column);
+                var details = string.IsNullOrWhiteSpace(location)
+                    ? issue.Message
+                    : $"{location} - {issue.Message}";
+                var diagnosticSourcePath = string.IsNullOrWhiteSpace(location) ? sourcePath : location;
+                var recommendedAction = !string.IsNullOrWhiteSpace(issue.Recommendation)
+                    ? issue.Recommendation
+                    : "Review the analyzer message and update the PowerShell source so the rule no longer triggers.";
+                if (!string.IsNullOrWhiteSpace(issue.SuggestedCorrection) &&
+                    recommendedAction.IndexOf(issue.SuggestedCorrection, System.StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    recommendedAction += $" Suggested correction: {issue.SuggestedCorrection}";
+                }
+
+                diagnostics.Add(new BuildDiagnostic(
+                    ruleId: "VALIDATION-PSSA-" + NormalizeRuleId(ruleName),
+                    area: BuildDiagnosticArea.Validation,
+                    severity: severity,
+                    scope: BuildDiagnosticScope.Project,
+                    owner: BuildDiagnosticOwner.ModuleAuthor,
+                    remediationKind: BuildDiagnosticRemediationKind.ManualFix,
+                    canAutoFix: false,
+                    summary: $"Fix {ruleName}",
+                    details: details,
+                    recommendedAction: recommendedAction,
+                    sourcePath: diagnosticSourcePath,
+                    generatedBy: issue.Source));
+            }
+
+            if (structuredIssues.Length > 25)
+            {
+                diagnostics.Add(new BuildDiagnostic(
+                    ruleId: "VALIDATION-PSSA-MORE-FINDINGS",
+                    area: BuildDiagnosticArea.Validation,
+                    severity: severity,
+                    scope: BuildDiagnosticScope.Project,
+                    owner: BuildDiagnosticOwner.ModuleAuthor,
+                    remediationKind: BuildDiagnosticRemediationKind.ManualFix,
+                    canAutoFix: false,
+                    summary: "Review additional PSScriptAnalyzer findings",
+                    details: $"{structuredIssues.Length - 25} additional finding(s) were omitted from structured diagnostics.",
+                    recommendedAction: "Review the full module validation output or rerun PSScriptAnalyzer locally for the complete finding list."));
+            }
+        }
+        else if (missingTool || skippedTool)
         {
             diagnostics.Add(new BuildDiagnostic(
                 ruleId: "VALIDATION-PSSA-TOOLING",
@@ -532,6 +583,35 @@ public static class BuildDiagnosticsFactory
         }
 
         return diagnostics;
+    }
+
+    private static string FormatValidationLocation(string path, int line, int column)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        if (line <= 0)
+            return path;
+
+        if (column <= 0)
+            return $"{path}:{line}";
+
+        return $"{path}:{line}:{column}";
+    }
+
+    private static string NormalizeRuleId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return "FINDING";
+
+        var chars = value
+            .Trim()
+            .Select(static c => char.IsLetterOrDigit(c) ? char.ToUpperInvariant(c) : '-')
+            .ToArray();
+        var normalized = new string(chars).Trim('-');
+        while (normalized.Contains("--"))
+            normalized = normalized.Replace("--", "-");
+        return string.IsNullOrWhiteSpace(normalized) ? "FINDING" : normalized;
     }
 
     private static BuildDiagnosticSeverity ToBuildSeverity(CheckStatus status)

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -130,7 +130,7 @@ public sealed class ModuleBuildPipeline
             _logger,
             _manifestMutator,
             _scriptFunctionExportDetector);
-        var buildNotes = builder.BuildInPlace(new ModuleBuilder.Options
+        var buildOptions = new ModuleBuilder.Options
         {
             ProjectRoot = staging,
             ModuleName = spec.Name,
@@ -153,7 +153,9 @@ public sealed class ModuleBuildPipeline
             ExcludeLibraryFilter = spec.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = spec.DoNotCopyLibrariesRecursively,
             CsprojRequiredReasons = spec.RefreshManifestOnly ? Array.Empty<string>() : spec.CsprojRequiredReasons ?? Array.Empty<string>(),
-        });
+            EmitBinaryConflictOwnerNotes = false,
+        };
+        _ = builder.BuildInPlace(buildOptions);
 
         var psd1 = Path.Combine(staging, $"{spec.Name}.psd1");
         if (!File.Exists(psd1))
@@ -184,6 +186,7 @@ public sealed class ModuleBuildPipeline
             _logger.Info("RefreshPSD1Only enabled: skipping bootstrapper/libraries regeneration.");
         }
 
+        var buildNotes = builder.AnalyzeInstalledBinaryConflicts(buildOptions);
         return new ModuleBuildResult(staging, psd1, exports, buildNotes);
     }
 

--- a/PowerForge/Services/ModuleBuildPipeline.cs
+++ b/PowerForge/Services/ModuleBuildPipeline.cs
@@ -116,11 +116,20 @@ public sealed class ModuleBuildPipeline
         var staging = Path.GetFullPath(stagingPath);
         if (!Directory.Exists(staging)) throw new DirectoryNotFoundException($"Staging directory not found: {staging}");
 
+        var tfms = spec.Frameworks is { Length: > 0 } ? spec.Frameworks : new[] { "net472", "net8.0" };
+        var assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorOptions.ResolveMode(
+            spec.AssemblyTypeAcceleratorMode,
+            spec.AssemblyTypeAccelerators,
+            spec.AssemblyTypeAcceleratorAssemblies);
+        var useAssemblyLoadContext = spec.UseAssemblyLoadContext
+            || assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None;
+        if (useAssemblyLoadContext && !spec.UseAssemblyLoadContext)
+            _logger.Info("Assembly type accelerators requested; UseAssemblyLoadContext automatically enabled.");
+
         var builder = new ModuleBuilder(
             _logger,
             _manifestMutator,
             _scriptFunctionExportDetector);
-        var tfms = spec.Frameworks is { Length: > 0 } ? spec.Frameworks : new[] { "net472", "net8.0" };
         var buildNotes = builder.BuildInPlace(new ModuleBuilder.Options
         {
             ProjectRoot = staging,
@@ -140,6 +149,7 @@ public sealed class ModuleBuildPipeline
             BinaryConflictSearchRoots = spec.BinaryConflictSearchRoots ?? Array.Empty<string>(),
             BinaryConflictPriorityModuleNames = spec.BinaryConflictPriorityModuleNames ?? Array.Empty<string>(),
             BinaryConflictReportRoot = spec.BinaryConflictReportRoot,
+            UseAssemblyLoadContext = useAssemblyLoadContext,
             ExcludeLibraryFilter = spec.ExcludeLibraryFilter ?? Array.Empty<string>(),
             DoNotCopyLibrariesRecursively = spec.DoNotCopyLibrariesRecursively,
             CsprojRequiredReasons = spec.RefreshManifestOnly ? Array.Empty<string>() : spec.CsprojRequiredReasons ?? Array.Empty<string>(),
@@ -155,15 +165,6 @@ public sealed class ModuleBuildPipeline
         // This keeps artefacts and installs aligned with historical PSPublishModule behavior for binary/mixed modules.
         if (!spec.RefreshManifestOnly)
         {
-            var assemblyTypeAcceleratorMode = AssemblyTypeAcceleratorOptions.ResolveMode(
-                spec.AssemblyTypeAcceleratorMode,
-                spec.AssemblyTypeAccelerators,
-                spec.AssemblyTypeAcceleratorAssemblies);
-            var useAssemblyLoadContext = spec.UseAssemblyLoadContext
-                || assemblyTypeAcceleratorMode != AssemblyTypeAcceleratorExportMode.None;
-            if (useAssemblyLoadContext && !spec.UseAssemblyLoadContext)
-                _logger.Info("Assembly type accelerators requested; UseAssemblyLoadContext automatically enabled.");
-
             ModuleBootstrapperGenerator.Generate(
                 staging,
                 spec.Name,

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -614,7 +614,7 @@ public sealed class ModuleBuilder
                 result,
                 opts.UseAssemblyLoadContext,
                 strictAnalysis: false,
-                _logger);
+                logger: _logger);
             if (!result.HasConflicts)
             {
                 editionStatuses.Add((result.PowerShellEdition, false));

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -119,6 +119,12 @@ public sealed class ModuleBuilder
         /// When populated and <see cref="CsprojPath"/> is empty, the builder fails instead of reusing an existing Lib payload.
         /// </summary>
         public IReadOnlyList<string> CsprojRequiredReasons { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// When true, returns binary conflict owner notes from <see cref="BuildInPlace"/>.
+        /// Pipelines that generate a bootstrapper after the in-place build can defer this check until the final staged module exists.
+        /// </summary>
+        public bool EmitBinaryConflictOwnerNotes { get; set; } = true;
     }
 
     /// <summary>
@@ -230,8 +236,6 @@ public sealed class ModuleBuilder
             }
         }
 
-        var buildNotes = WarnOnInstalledBinaryConflicts(opts);
-
         // 2) Manifest generation
         var psd1 = Path.Combine(opts.ProjectRoot, $"{opts.ModuleName}.psd1");
         // Prefer a script RootModule for compatibility; load binary via NestedModules
@@ -312,7 +316,21 @@ public sealed class ModuleBuilder
         }
 
         SetManifestExports(psd1, functions: functionsToSet, cmdlets: cmdletsToSet, aliases: aliasesToSet);
-        return buildNotes;
+        return opts.EmitBinaryConflictOwnerNotes
+            ? WarnOnInstalledBinaryConflicts(opts)
+            : Array.Empty<ModuleOwnerNote>();
+    }
+
+    internal ModuleOwnerNote[] AnalyzeInstalledBinaryConflicts(Options opts)
+    {
+        if (opts is null)
+            throw new ArgumentNullException(nameof(opts));
+        if (string.IsNullOrWhiteSpace(opts.ProjectRoot) || !Directory.Exists(opts.ProjectRoot))
+            throw new DirectoryNotFoundException($"Project root not found: {opts.ProjectRoot}");
+        if (string.IsNullOrWhiteSpace(opts.ModuleName))
+            throw new ArgumentException("ModuleName is required", nameof(opts.ModuleName));
+
+        return WarnOnInstalledBinaryConflicts(opts);
     }
 
     /// <summary>

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -99,6 +99,12 @@ public sealed class ModuleBuilder
         public string? BinaryConflictReportRoot { get; set; }
 
         /// <summary>
+        /// When true, suppresses PowerShell Core binary conflict advisories that are mitigated by the generated
+        /// module-scoped AssemblyLoadContext loader.
+        /// </summary>
+        public bool UseAssemblyLoadContext { get; set; }
+
+        /// <summary>
         /// Optional filters used to exclude copied binary libraries by package id, target key, relative path, or file name.
         /// </summary>
         public IReadOnlyList<string> ExcludeLibraryFilter { get; set; } = Array.Empty<string>();
@@ -604,6 +610,11 @@ public sealed class ModuleBuilder
                 edition,
                 currentModuleName: opts.ModuleName,
                 searchRoots: opts.BinaryConflictSearchRoots);
+            result = BinaryConflictMitigationClassifier.SuppressCurrentModuleConflictsMitigatedByAlc(
+                result,
+                opts.UseAssemblyLoadContext,
+                strictAnalysis: false,
+                _logger);
             if (!result.HasConflicts)
             {
                 editionStatuses.Add((result.PowerShellEdition, false));

--- a/Shared/SpectrePipelineSummaryWriter.cs
+++ b/Shared/SpectrePipelineSummaryWriter.cs
@@ -674,19 +674,49 @@ internal static class SpectrePipelineSummaryWriter
         AnsiConsole.Write(table);
     }
 
-    private static List<(string When, string Action)> BuildRecommendations(
+    internal sealed class RecommendationRow
+    {
+        public string When { get; }
+        public string Where { get; }
+        public string Action { get; }
+
+        public RecommendationRow(string when, string where, string action)
+        {
+            When = when ?? string.Empty;
+            Where = where ?? string.Empty;
+            Action = action ?? string.Empty;
+        }
+    }
+
+    internal static IReadOnlyList<RecommendationRow> BuildRecommendations(
         ModulePipelineResult result,
         BuildDiagnosticArea area,
         BuildDiagnosticScope? scope = null)
     {
         if (result?.Diagnostics is null || result.Diagnostics.Length == 0)
-            return new List<(string When, string Action)>();
+            return new List<RecommendationRow>();
 
-        return result.Diagnostics
+        return BuildRecommendationRows(result.Diagnostics, area, scope);
+    }
+
+    internal static IReadOnlyList<RecommendationRow> BuildRecommendationRows(
+        IEnumerable<BuildDiagnostic> diagnostics,
+        BuildDiagnosticArea area,
+        BuildDiagnosticScope? scope = null)
+    {
+        if (diagnostics is null)
+            return new List<RecommendationRow>();
+
+        return diagnostics
+            .Where(static diagnostic => diagnostic is not null)
             .Where(diagnostic => diagnostic.Area == area && (!scope.HasValue || diagnostic.Scope == scope.Value))
-            .Select(static diagnostic => (When: diagnostic.Summary, Action: BuildRecommendationAction(diagnostic)))
+            .Select(static diagnostic => new RecommendationRow(
+                diagnostic.Summary,
+                BuildRecommendationLocation(diagnostic),
+                BuildRecommendationAction(diagnostic)))
             .Where(static item => !string.IsNullOrWhiteSpace(item.When) && !string.IsNullOrWhiteSpace(item.Action))
-            .Distinct()
+            .GroupBy(static item => string.Join("|", item.When, item.Where, item.Action), StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
             .ToList();
     }
 
@@ -707,7 +737,7 @@ internal static class SpectrePipelineSummaryWriter
 
     private static void WriteRecommendationTable(
         string title,
-        IReadOnlyList<(string When, string Action)> recommendations,
+        IReadOnlyList<RecommendationRow> recommendations,
         TableBorder border)
     {
         if (recommendations is null || recommendations.Count == 0)
@@ -715,17 +745,29 @@ internal static class SpectrePipelineSummaryWriter
 
         static string Esc(string? s) => Markup.Escape(s ?? string.Empty);
 
-        var table = new Table()
-            .Border(border)
-            .AddColumn(new TableColumn(title).NoWrap())
-            .AddColumn(new TableColumn("Do this"));
+        var hasLocation = recommendations.Any(static recommendation => !string.IsNullOrWhiteSpace(recommendation.Where));
+        var table = new Table().Border(border);
+        table.AddColumn(new TableColumn(title).NoWrap());
+        if (hasLocation)
+            table.AddColumn(new TableColumn("Where").NoWrap());
+        table.AddColumn(new TableColumn("Do this"));
 
         foreach (var recommendation in recommendations)
         {
             if (string.IsNullOrWhiteSpace(recommendation.When) || string.IsNullOrWhiteSpace(recommendation.Action))
                 continue;
 
-            table.AddRow(Esc(recommendation.When), Esc(recommendation.Action));
+            if (hasLocation)
+            {
+                table.AddRow(
+                    Esc(recommendation.When),
+                    Esc(recommendation.Where),
+                    Esc(recommendation.Action));
+            }
+            else
+            {
+                table.AddRow(Esc(recommendation.When), Esc(recommendation.Action));
+            }
         }
 
         if (table.Rows.Count > 0)
@@ -908,6 +950,14 @@ internal static class SpectrePipelineSummaryWriter
             return $"{diagnostic.RecommendedAction} Suggested command: {diagnostic.SuggestedCommand}";
 
         return diagnostic.RecommendedAction;
+    }
+
+    private static string BuildRecommendationLocation(BuildDiagnostic diagnostic)
+    {
+        if (diagnostic is null)
+            return string.Empty;
+
+        return diagnostic.SourcePath ?? string.Empty;
     }
 
     private static List<string> BuildFileConsistencyReasons(


### PR DESCRIPTION
## Summary
- Add structured PSScriptAnalyzer findings to module validation and build diagnostics, including file/line/column, rule id, message, suggested correction, and rule-aware recommendations.
- Render diagnostic recommendations with a location-aware Spectre table so PowerShell findings show the exact source location.
- Suppress binary conflict advisories that are already mitigated by PowerForge AssemblyLoadContext support in auto mode, while keeping strict diagnostics when AnalyzeBinaryConflicts is explicitly true.

## Validation
- dotnet build .\PSPublishModule.sln -c Release --no-restore -m:1
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "BinaryConflictMitigationClassifierTests|BuildDiagnosticsFactoryTests|SpectrePipelineSummaryWriterTests|ModuleValidationServiceTests"
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "ModuleBuilderBinaryConflictAdvisoryTests|BinaryConflictDetectionServiceTests|ModulePipelineStepTests|ModulePipelineDependencyMetadataProviderTests"
- dotnet test .\PowerForge.Net472SmokeTests\PowerForge.Net472SmokeTests.csproj -c Release --no-build