### PR TITLE
Add refresh delivery mode with path scoping

### DIFF
--- a/Docs/PSPublishModule.ModuleDocumentation.md
+++ b/Docs/PSPublishModule.ModuleDocumentation.md
@@ -96,11 +96,36 @@ This means each module version lands in its own folder such as `C:\Docs\MyModule
 | OnExists | Behavior |
 | --- | --- |
 | `Merge` | Add missing files and folders. Existing files are preserved unless `-Force` is used. Local files that are not part of the package remain in place. |
+| `Refresh` | Add missing files and overwrite files that are part of the package. Local files that are not part of the package remain in place. |
 | `Overwrite` | Delete the destination folder first, then copy a fresh documentation set. Use `-Force` when read-only files may need their attributes cleared before delete. |
 | `Skip` | Leave the destination unchanged and return the resolved destination path. |
 | `Stop` | Throw when the destination already exists. |
 
-`-Force` does not change the selected layout. With `-OnExists Merge`, it allows colliding files from the package to replace existing destination files while still leaving unrelated local files in place. With `-OnExists Overwrite`, it helps clear read-only attributes before the destination folder is deleted.
+`-Force` does not change the selected layout. With `-OnExists Merge`, it allows colliding files from the package to replace existing destination files while still leaving unrelated local files in place. With `-OnExists Refresh`, package-owned file collisions are replaced without needing `-Force`, and local files not present in the package are kept. With `-OnExists Overwrite`, `-Force` helps clear read-only attributes before the destination folder is deleted.
+
+Generated delivery helpers from `New-ConfigurationDelivery -GenerateInstallCommand -GenerateUpdateCommand` use the same conflict vocabulary:
+
+- generated `Install-<ModuleName>` helpers default to `Merge`
+- generated `Update-<ModuleName>` helpers default to `Refresh`
+- `IncludePaths` scopes which package files are managed by generated helpers
+- `ExcludePaths` removes package files from the managed set, and exclusions win over includes
+- `PreservePaths` can keep selected package paths during `Refresh`
+- `OverwritePaths` can opt selected package paths into replacement during `Merge`
+- `Overwrite` remains the destructive full-folder replacement mode for disposable destinations
+
+Use include/exclude patterns when the package contains support files that should not be installed or refreshed by default. Patterns are relative to the delivery `InternalsPath`:
+
+```powershell
+New-ConfigurationDelivery `
+  -Enable `
+  -GenerateInstallCommand `
+  -GenerateUpdateCommand `
+  -IncludePaths 'Config/*.sample.json', 'Scripts/*.ps1' `
+  -ExcludePaths 'Config/local/**' `
+  -PreservePaths 'Config/config.json'
+```
+
+In this shape, generated update helpers refresh shipped sample configuration and scripts, skip `Config/local/**`, preserve the active `Config/config.json`, and leave destination-only files in place.
 
 For validation, PowerForge can now enforce the old package's most-used missing-doc checks through `New-ConfigurationValidation`:
 

--- a/Module/Docs/Install-ModuleDependency.md
+++ b/Module/Docs/Install-ModuleDependency.md
@@ -127,7 +127,7 @@ Conflict handling when a dependency version folder already exists.
 Type: OnExistsOption
 Parameter Sets: ByName, ByModule
 Aliases: None
-Possible values: Merge, Overwrite, Skip, Stop
+Possible values: Merge, Refresh, Overwrite, Skip, Stop
 
 Required: False
 Position: named

--- a/Module/Docs/Install-ModuleDocumentation.md
+++ b/Module/Docs/Install-ModuleDocumentation.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 ## SYNOPSIS
 Copies a module's bundled documentation (Internals, README/CHANGELOG/LICENSE) to a chosen location.
 
-Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. When successful, returns the destination path.
+Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, refresh, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. The Refresh mode overwrites package files while keeping local files that are not part of the package. When successful, returns the destination path.
 
 ## SYNTAX
 ### ByName (Default)
@@ -24,7 +24,7 @@ Install-ModuleDocumentation -Path <string> [-Module <psmoduleinfo>] [-RequiredVe
 ## DESCRIPTION
 Copies a module's bundled documentation (Internals, README/CHANGELOG/LICENSE) to a chosen location.
 
-Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. When successful, returns the destination path.
+Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, refresh, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. The Refresh mode overwrites package files while keeping local files that are not part of the package. When successful, returns the destination path.
 
 ## EXAMPLES
 
@@ -192,13 +192,13 @@ Accept wildcard characters: True
 ```
 
 ### -OnExists
-Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used.
+Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used. Refresh overwrites package files without deleting unrelated local files.
 
 ```yaml
 Type: OnExistsOption
 Parameter Sets: ByName, ByModule
 Aliases: None
-Possible values: Merge, Overwrite, Skip, Stop
+Possible values: Merge, Refresh, Overwrite, Skip, Stop
 
 Required: False
 Position: named

--- a/Module/Docs/Install-ModuleScript.md
+++ b/Module/Docs/Install-ModuleScript.md
@@ -152,7 +152,7 @@ Conflict handling when a destination file already exists. Defaults to Merge (kee
 Type: OnExistsOption
 Parameter Sets: ByName, ByModule
 Aliases: None
-Possible values: Merge, Overwrite, Skip, Stop
+Possible values: Merge, Refresh, Overwrite, Skip, Stop
 
 Required: False
 Position: named

--- a/Module/Docs/New-ConfigurationDelivery.md
+++ b/Module/Docs/New-ConfigurationDelivery.md
@@ -11,7 +11,7 @@ Configures delivery metadata for bundling and installing internal docs/examples.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-ConfigurationDelivery [-Enable] [-InternalsPath <string>] [-Sign] [-IncludeRootReadme] [-IncludeRootChangelog] [-IncludeRootLicense] [-ReadmeDestination <DeliveryBundleDestination>] [-ChangelogDestination <DeliveryBundleDestination>] [-LicenseDestination <DeliveryBundleDestination>] [-ImportantLinks <DeliveryImportantLink[]>] [-IntroText <string[]>] [-UpgradeText <string[]>] [-IntroFile <string>] [-UpgradeFile <string>] [-RepositoryPaths <string[]>] [-RepositoryBranch <string>] [-DocumentationOrder <string[]>] [-PreservePaths <string[]>] [-OverwritePaths <string[]>] [-GenerateInstallCommand] [-GenerateUpdateCommand] [-InstallCommandName <string>] [-UpdateCommandName <string>] [<CommonParameters>]
+New-ConfigurationDelivery [-Enable] [-InternalsPath <string>] [-Sign] [-IncludeRootReadme] [-IncludeRootChangelog] [-IncludeRootLicense] [-ReadmeDestination <DeliveryBundleDestination>] [-ChangelogDestination <DeliveryBundleDestination>] [-LicenseDestination <DeliveryBundleDestination>] [-ImportantLinks <DeliveryImportantLink[]>] [-IntroText <string[]>] [-UpgradeText <string[]>] [-IntroFile <string>] [-UpgradeFile <string>] [-RepositoryPaths <string[]>] [-RepositoryBranch <string>] [-DocumentationOrder <string[]>] [-IncludePaths <string[]>] [-ExcludePaths <string[]>] [-PreservePaths <string[]>] [-OverwritePaths <string[]>] [-GenerateInstallCommand] [-GenerateUpdateCommand] [-InstallCommandName <string>] [-UpdateCommandName <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -20,8 +20,10 @@ generate public helper commands (Install-<ModuleName> / Update-<ModuleName>) tha
 
 This is intended for “script packages” where the module contains additional artifacts that should be deployed alongside it.
 
-Merge behavior for generated delivery commands can be fine-tuned with PreservePaths and
-OverwritePaths so selected relative paths keep local changes or are refreshed during updates.
+Generated install helpers default to merge behavior. Generated update helpers default to refresh behavior, which
+overwrites package files while keeping local files that are not part of the package. Use IncludePaths
+and ExcludePaths to scope which package files are managed, then use PreservePaths
+and OverwritePaths to fine-tune collision behavior for managed relative paths.
 
 ## EXAMPLES
 
@@ -41,10 +43,10 @@ Helps modules expose docs from a repository path in a consistent order.
 
 ### EXAMPLE 3
 ```powershell
-PS> New-ConfigurationDelivery -Enable -GenerateInstallCommand -GenerateUpdateCommand -InstallCommandName 'Install-ContosoToolkit' -UpdateCommandName 'Update-ContosoToolkit' -PreservePaths 'Config/**','Data/LocalSettings.json' -OverwritePaths 'Bin/**','Templates/**'
+PS> New-ConfigurationDelivery -Enable -GenerateInstallCommand -GenerateUpdateCommand -InstallCommandName 'Install-ContosoToolkit' -UpdateCommandName 'Update-ContosoToolkit' -IncludePaths 'Config/**','Scripts/*.ps1' -ExcludePaths 'Config/local/**' -PreservePaths 'Config/config.json' -OverwritePaths 'Bin/**','Templates/**'
 ```
 
-Generates custom delivery helpers and preserves selected local files while refreshing binaries and templates during merge installs.
+Generates custom delivery helpers, manages only selected package files, excludes local-only configuration paths, preserves the active configuration during refresh updates, and can refresh selected paths during merge installs.
 
 ## PARAMETERS
 
@@ -96,6 +98,23 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -ExcludePaths
+Optional wildcard patterns (relative to InternalsPath) that generated Install-/Update- helpers should not copy, refresh, or consider package-owned.
+Exclusions win over IncludePaths. Use this for local-only or user-owned package-adjacent paths such as Config/local/** or Config/config.json.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -GenerateInstallCommand
 When set, generates a public Install-<ModuleName> helper function during build that copies Internals to a destination folder.
 
@@ -113,7 +132,7 @@ Accept wildcard characters: True
 ```
 
 ### -GenerateUpdateCommand
-When set, generates a public Update-<ModuleName> helper function during build that delegates to the install command.
+When set, generates a public Update-<ModuleName> helper function during build that delegates to the install command in refresh mode by default.
 
 ```yaml
 Type: SwitchParameter
@@ -133,6 +152,24 @@ Important links (Title/Url). Accepts legacy hashtable array (@{ Title='..'; Url=
 
 ```yaml
 Type: DeliveryImportantLink[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -IncludePaths
+Optional wildcard patterns (relative to InternalsPath) that define which package files generated Install-/Update- helpers manage.
+Use this when a module ships mixed content but only selected folders should be copied or refreshed, for example Config/*.sample.json and Scripts/*.ps1.
+When omitted, all files under InternalsPath are managed.
+
+```yaml
+Type: String[]
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -290,7 +327,7 @@ Accept wildcard characters: True
 ```
 
 ### -PreservePaths
-Optional wildcard patterns (relative to Internals) that should be preserved during merge installs by generated Install-/Update- helpers.
+Optional wildcard patterns (relative to Internals) that should be preserved during merge or refresh installs by generated Install-/Update- helpers.
 Example: Config/**.
 
 ```yaml

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -99,7 +99,7 @@ Installs a module and its embedded dependencies to an explicit private runtime f
 ### [Install-ModuleDocumentation](Install-ModuleDocumentation.md)
 Copies a module's bundled documentation (Internals, README/CHANGELOG/LICENSE) to a chosen location.
 
-Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. When successful, returns the destination path.
+Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, refresh, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. The Refresh mode overwrites package files while keeping local files that are not part of the package. When successful, returns the destination path.
 
 ### [Install-ModuleScript](Install-ModuleScript.md)
 Copies only PowerShell scripts from a module's Internals\Scripts folder to a destination path.

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -8448,6 +8448,7 @@ into PSModulePath unless the chosen path is already part of PSModulePath.</maml:
           <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
           <command:parameterValueGroup>
             <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -8541,6 +8542,7 @@ into PSModulePath unless the chosen path is already part of PSModulePath.</maml:
           <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
           <command:parameterValueGroup>
             <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -8646,6 +8648,7 @@ into PSModulePath unless the chosen path is already part of PSModulePath.</maml:
         <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
         <command:parameterValueGroup>
           <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -8726,12 +8729,12 @@ System.Management.Automation.PSObject</maml:name>
       <command:noun>ModuleDocumentation</command:noun>
       <maml:description>
         <maml:para>Copies a module's bundled documentation (Internals, README/CHANGELOG/LICENSE) to a chosen location.</maml:para>
-        <maml:para>Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. When successful, returns the destination path.</maml:para>
+        <maml:para>Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, refresh, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. The Refresh mode overwrites package files while keeping local files that are not part of the package. When successful, returns the destination path.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
       <maml:para>Copies a module's bundled documentation (Internals, README/CHANGELOG/LICENSE) to a chosen location.</maml:para>
-      <maml:para>Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. When successful, returns the destination path.</maml:para>
+      <maml:para>Resolves the module and copies its documentation payload into a destination folder arranged by DocumentationLayout. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, refresh, overwrite, skip or stop based on OnExistsOption. The default Merge mode adds missing files and keeps existing files unless -Force is used. The Refresh mode overwrites package files while keeping local files that are not part of the package. When successful, returns the destination path.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="ByName">
@@ -8816,11 +8819,12 @@ System.Management.Automation.PSObject</maml:name>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OnExists</maml:name>
           <maml:description>
-            <maml:para>Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used.</maml:para>
+            <maml:para>Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used. Refresh overwrites package files without deleting unrelated local files.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
           <command:parameterValueGroup>
             <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -8950,11 +8954,12 @@ System.Management.Automation.PSObject</maml:name>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>OnExists</maml:name>
           <maml:description>
-            <maml:para>Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used.</maml:para>
+            <maml:para>Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used. Refresh overwrites package files without deleting unrelated local files.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
           <command:parameterValueGroup>
             <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -9096,11 +9101,12 @@ System.Management.Automation.PSObject</maml:name>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>OnExists</maml:name>
         <maml:description>
-          <maml:para>Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used.</maml:para>
+          <maml:para>Behavior when the destination folder already exists. The default, Merge, adds missing files and preserves existing files unless -Force is used. Refresh overwrites package files without deleting unrelated local files.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
         <command:parameterValueGroup>
           <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -9327,6 +9333,7 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
           <command:parameterValueGroup>
             <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -9456,6 +9463,7 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
           <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
           <command:parameterValueGroup>
             <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
             <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -9597,6 +9605,7 @@ The destination is flattened (no Module/Version subfolders).</maml:para>
         <command:parameterValue required="false" variableLength="false">OnExistsOption</command:parameterValue>
         <command:parameterValueGroup>
           <command:parameterValue required="false" variableLength="false">Merge</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Refresh</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Overwrite</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Skip</command:parameterValue>
           <command:parameterValue required="false" variableLength="false">Stop</command:parameterValue>
@@ -23417,8 +23426,10 @@ with Windows PowerShell 5.1 and/or PowerShell 7+.</maml:para>
       <maml:para>Delivery configuration is used to bundle “internals” (docs, examples, tools, configuration files) into a module and optionally&#xD;
 generate public helper commands (Install-&lt;ModuleName&gt; / Update-&lt;ModuleName&gt;) that can copy these files to a target folder.</maml:para>
       <maml:para>This is intended for “script packages” where the module contains additional artifacts that should be deployed alongside it.</maml:para>
-      <maml:para>Merge behavior for generated delivery commands can be fine-tuned with PreservePaths and&#xD;
-OverwritePaths so selected relative paths keep local changes or are refreshed during updates.</maml:para>
+      <maml:para>Generated install helpers default to merge behavior. Generated update helpers default to refresh behavior, which&#xD;
+overwrites package files while keeping local files that are not part of the package. Use IncludePaths&#xD;
+and ExcludePaths to scope which package files are managed, then use PreservePaths&#xD;
+and OverwritePaths to fine-tune collision behavior for managed relative paths.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
@@ -23465,6 +23476,19 @@ OverwritePaths so selected relative paths keep local changes or are refreshed du
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludePaths</maml:name>
+          <maml:description>
+            <maml:para>Optional wildcard patterns (relative to InternalsPath) that generated Install-/Update- helpers should not copy, refresh, or consider package-owned.&#xD;
+Exclusions win over IncludePaths. Use this for local-only or user-owned package-adjacent paths such as Config/local/** or Config/config.json.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>GenerateInstallCommand</maml:name>
           <maml:description>
@@ -23480,7 +23504,7 @@ OverwritePaths so selected relative paths keep local changes or are refreshed du
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>GenerateUpdateCommand</maml:name>
           <maml:description>
-            <maml:para>When set, generates a public Update-&lt;ModuleName&gt; helper function during build that delegates to the install command.</maml:para>
+            <maml:para>When set, generates a public Update-&lt;ModuleName&gt; helper function during build that delegates to the install command in refresh mode by default.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -23497,6 +23521,20 @@ OverwritePaths so selected relative paths keep local changes or are refreshed du
           <command:parameterValue required="false" variableLength="false">DeliveryImportantLink[]</command:parameterValue>
           <dev:type>
             <maml:name>DeliveryImportantLink[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludePaths</maml:name>
+          <maml:description>
+            <maml:para>Optional wildcard patterns (relative to InternalsPath) that define which package files generated Install-/Update- helpers manage.&#xD;
+Use this when a module ships mixed content but only selected folders should be copied or refreshed, for example Config/*.sample.json and Scripts/*.ps1.&#xD;
+When omitted, all files under InternalsPath are managed.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -23619,7 +23657,7 @@ Example: Artefacts/**.</maml:para>
         <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>PreservePaths</maml:name>
           <maml:description>
-            <maml:para>Optional wildcard patterns (relative to Internals) that should be preserved during merge installs by generated Install-/Update- helpers.&#xD;
+            <maml:para>Optional wildcard patterns (relative to Internals) that should be preserved during merge or refresh installs by generated Install-/Update- helpers.&#xD;
 Example: Config/**.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
@@ -23764,6 +23802,19 @@ Example: Config/**.</maml:para>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludePaths</maml:name>
+        <maml:description>
+          <maml:para>Optional wildcard patterns (relative to InternalsPath) that generated Install-/Update- helpers should not copy, refresh, or consider package-owned.&#xD;
+Exclusions win over IncludePaths. Use this for local-only or user-owned package-adjacent paths such as Config/local/** or Config/config.json.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>GenerateInstallCommand</maml:name>
         <maml:description>
@@ -23779,7 +23830,7 @@ Example: Config/**.</maml:para>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>GenerateUpdateCommand</maml:name>
         <maml:description>
-          <maml:para>When set, generates a public Update-&lt;ModuleName&gt; helper function during build that delegates to the install command.</maml:para>
+          <maml:para>When set, generates a public Update-&lt;ModuleName&gt; helper function during build that delegates to the install command in refresh mode by default.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -23796,6 +23847,20 @@ Example: Config/**.</maml:para>
         <command:parameterValue required="false" variableLength="false">DeliveryImportantLink[]</command:parameterValue>
         <dev:type>
           <maml:name>DeliveryImportantLink[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludePaths</maml:name>
+        <maml:description>
+          <maml:para>Optional wildcard patterns (relative to InternalsPath) that define which package files generated Install-/Update- helpers manage.&#xD;
+Use this when a module ships mixed content but only selected folders should be copied or refreshed, for example Config/*.sample.json and Scripts/*.ps1.&#xD;
+When omitted, all files under InternalsPath are managed.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -23918,7 +23983,7 @@ Example: Artefacts/**.</maml:para>
       <command:parameter required="false" variableLength="true" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>PreservePaths</maml:name>
         <maml:description>
-          <maml:para>Optional wildcard patterns (relative to Internals) that should be preserved during merge installs by generated Install-/Update- helpers.&#xD;
+          <maml:para>Optional wildcard patterns (relative to Internals) that should be preserved during merge or refresh installs by generated Install-/Update- helpers.&#xD;
 Example: Config/**.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
@@ -24064,9 +24129,9 @@ Example: Config/**.</maml:para>
         <maml:introduction>
           <maml:para>PS&gt; </maml:para>
         </maml:introduction>
-        <dev:code>New-ConfigurationDelivery -Enable -GenerateInstallCommand -GenerateUpdateCommand -InstallCommandName 'Install-ContosoToolkit' -UpdateCommandName 'Update-ContosoToolkit' -PreservePaths 'Config/**','Data/LocalSettings.json' -OverwritePaths 'Bin/**','Templates/**'</dev:code>
+        <dev:code>New-ConfigurationDelivery -Enable -GenerateInstallCommand -GenerateUpdateCommand -InstallCommandName 'Install-ContosoToolkit' -UpdateCommandName 'Update-ContosoToolkit' -IncludePaths 'Config/**','Scripts/*.ps1' -ExcludePaths 'Config/local/**' -PreservePaths 'Config/config.json' -OverwritePaths 'Bin/**','Templates/**'</dev:code>
         <dev:remarks>
-          <maml:para>Generates custom delivery helpers and preserves selected local files while refreshing binaries and templates during merge installs.</maml:para>
+          <maml:para>Generates custom delivery helpers, manages only selected package files, excludes local-only configuration paths, preserves the active configuration during refresh updates, and can refresh selected paths during merge installs.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/PSPublishModule/Cmdlets/InstallModuleDocumentationCommand.Parameters.cs
+++ b/PSPublishModule/Cmdlets/InstallModuleDocumentationCommand.Parameters.cs
@@ -29,7 +29,7 @@ public sealed partial class InstallModuleDocumentationCommand
     [Parameter]
     public DocumentationLayout Layout { get; set; } = DocumentationLayout.ModuleAndVersion;
 
-    /// <summary>Behavior when the destination folder already exists. The default, <see cref="OnExistsOption.Merge"/>, adds missing files and preserves existing files unless <c>-Force</c> is used.</summary>
+    /// <summary>Behavior when the destination folder already exists. The default, <see cref="OnExistsOption.Merge"/>, adds missing files and preserves existing files unless <c>-Force</c> is used. <see cref="OnExistsOption.Refresh"/> overwrites package files without deleting unrelated local files.</summary>
     [Parameter]
     public OnExistsOption OnExists { get; set; } = OnExistsOption.Merge;
 

--- a/PSPublishModule/Cmdlets/InstallModuleDocumentationCommand.cs
+++ b/PSPublishModule/Cmdlets/InstallModuleDocumentationCommand.cs
@@ -11,7 +11,7 @@ namespace PSPublishModule;
 
 /// <summary>
 /// <para type="synopsis">Copies a module's bundled documentation (Internals, README/CHANGELOG/LICENSE) to a chosen location.</para>
-/// <para type="description">Resolves the module and copies its documentation payload into a destination folder arranged by <see cref="DocumentationLayout"/>. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, overwrite, skip or stop based on <see cref="OnExistsOption"/>. The default <see cref="OnExistsOption.Merge"/> mode adds missing files and keeps existing files unless <c>-Force</c> is used. When successful, returns the destination path.</para>
+/// <para type="description">Resolves the module and copies its documentation payload into a destination folder arranged by <see cref="DocumentationLayout"/>. The payload is the module's delivery Internals folder (or the default Internals folder) plus selected root documentation files such as README, CHANGELOG and LICENSE. Repeat runs can merge, refresh, overwrite, skip or stop based on <see cref="OnExistsOption"/>. The default <see cref="OnExistsOption.Merge"/> mode adds missing files and keeps existing files unless <c>-Force</c> is used. The <see cref="OnExistsOption.Refresh"/> mode overwrites package files while keeping local files that are not part of the package. When successful, returns the destination path.</para>
 /// </summary>
 /// <example>
 ///   <summary>Install into Module\Version folder</summary>

--- a/PSPublishModule/Cmdlets/InstallModuleScriptCommand.cs
+++ b/PSPublishModule/Cmdlets/InstallModuleScriptCommand.cs
@@ -180,10 +180,9 @@ public sealed class InstallModuleScriptCommand : PSCmdlet
 
             if (ShouldProcess(target, exists ? "Overwrite script" : "Copy script"))
             {
-                if (exists && Force)
-                {
-                    try { File.SetAttributes(target, FileAttributes.Normal); } catch { /* ignore */ }
-                }
+                if (ShouldClearReadOnlyTarget(exists, OnExists, Force.IsPresent))
+                    TryClearReadOnlyAttribute(target);
+
                 File.Copy(file, target, overwrite: true);
                 if (Force)
                 {
@@ -277,6 +276,26 @@ public sealed class InstallModuleScriptCommand : PSCmdlet
 
     internal static string ResolveExistingScriptActionForTesting(bool exists, OnExistsOption onExists, bool force)
         => ResolveExistingScriptAction(exists, onExists, force);
+
+    internal static bool ShouldClearReadOnlyTargetForTesting(bool exists, OnExistsOption onExists, bool force)
+        => ShouldClearReadOnlyTarget(exists, onExists, force);
+
+    private static bool ShouldClearReadOnlyTarget(bool exists, OnExistsOption onExists, bool force)
+        => exists && (force || onExists is OnExistsOption.Refresh or OnExistsOption.Overwrite);
+
+    private static void TryClearReadOnlyAttribute(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                File.SetAttributes(path, attributes & ~FileAttributes.ReadOnly);
+        }
+        catch
+        {
+            /* best effort */
+        }
+    }
 
     private static string ResolveExistingScriptAction(bool exists, OnExistsOption onExists, bool force)
     {

--- a/PSPublishModule/Cmdlets/InstallModuleScriptCommand.cs
+++ b/PSPublishModule/Cmdlets/InstallModuleScriptCommand.cs
@@ -172,6 +172,7 @@ public sealed class InstallModuleScriptCommand : PSCmdlet
                         }
                         WriteVerbose($"Refreshing existing (merge/force): {target}");
                         break;
+                    case OnExistsOption.Refresh:
                     case OnExistsOption.Overwrite:
                         break;
                 }
@@ -284,6 +285,7 @@ public sealed class InstallModuleScriptCommand : PSCmdlet
 
         return onExists switch
         {
+            OnExistsOption.Refresh => "Overwrite",
             OnExistsOption.Overwrite => "Overwrite",
             OnExistsOption.Merge when force => "Overwrite",
             OnExistsOption.Skip => "Skip",

--- a/PSPublishModule/Cmdlets/NewConfigurationDeliveryCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationDeliveryCommand.cs
@@ -16,8 +16,10 @@ namespace PSPublishModule;
 /// This is intended for “script packages” where the module contains additional artifacts that should be deployed alongside it.
 /// </para>
 /// <para>
-/// Merge behavior for generated delivery commands can be fine-tuned with <see cref="PreservePaths"/> and
-/// <see cref="OverwritePaths"/> so selected relative paths keep local changes or are refreshed during updates.
+/// Generated install helpers default to merge behavior. Generated update helpers default to refresh behavior, which
+/// overwrites package files while keeping local files that are not part of the package. Use <see cref="IncludePaths"/>
+/// and <see cref="ExcludePaths"/> to scope which package files are managed, then use <see cref="PreservePaths"/>
+/// and <see cref="OverwritePaths"/> to fine-tune collision behavior for managed relative paths.
 /// </para>
 /// </remarks>
 /// <example>
@@ -35,8 +37,8 @@ namespace PSPublishModule;
 /// <example>
 /// <summary>Configure merge policies and custom helper names</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>New-ConfigurationDelivery -Enable -GenerateInstallCommand -GenerateUpdateCommand -InstallCommandName 'Install-ContosoToolkit' -UpdateCommandName 'Update-ContosoToolkit' -PreservePaths 'Config/**','Data/LocalSettings.json' -OverwritePaths 'Bin/**','Templates/**'</code>
-/// <para>Generates custom delivery helpers and preserves selected local files while refreshing binaries and templates during merge installs.</para>
+/// <code>New-ConfigurationDelivery -Enable -GenerateInstallCommand -GenerateUpdateCommand -InstallCommandName 'Install-ContosoToolkit' -UpdateCommandName 'Update-ContosoToolkit' -IncludePaths 'Config/**','Scripts/*.ps1' -ExcludePaths 'Config/local/**' -PreservePaths 'Config/config.json' -OverwritePaths 'Bin/**','Templates/**'</code>
+/// <para>Generates custom delivery helpers, manages only selected package files, excludes local-only configuration paths, preserves the active configuration during refresh updates, and can refresh selected paths during merge installs.</para>
 /// </example>
 [Cmdlet(VerbsCommon.New, "ConfigurationDelivery")]
 public sealed class NewConfigurationDeliveryCommand : PSCmdlet
@@ -97,7 +99,20 @@ public sealed class NewConfigurationDeliveryCommand : PSCmdlet
     [Parameter] public string[]? DocumentationOrder { get; set; }
 
     /// <summary>
-    /// Optional wildcard patterns (relative to Internals) that should be preserved during merge installs by generated Install-/Update- helpers.
+    /// Optional wildcard patterns (relative to <see cref="InternalsPath"/>) that define which package files generated Install-/Update- helpers manage.
+    /// Use this when a module ships mixed content but only selected folders should be copied or refreshed, for example <c>Config/*.sample.json</c> and <c>Scripts/*.ps1</c>.
+    /// When omitted, all files under <see cref="InternalsPath"/> are managed.
+    /// </summary>
+    [Parameter] public string[]? IncludePaths { get; set; }
+
+    /// <summary>
+    /// Optional wildcard patterns (relative to <see cref="InternalsPath"/>) that generated Install-/Update- helpers should not copy, refresh, or consider package-owned.
+    /// Exclusions win over <see cref="IncludePaths"/>. Use this for local-only or user-owned package-adjacent paths such as <c>Config/local/**</c> or <c>Config/config.json</c>.
+    /// </summary>
+    [Parameter] public string[]? ExcludePaths { get; set; }
+
+    /// <summary>
+    /// Optional wildcard patterns (relative to Internals) that should be preserved during merge or refresh installs by generated Install-/Update- helpers.
     /// Example: <c>Config/**</c>.
     /// </summary>
     [Parameter] public string[]? PreservePaths { get; set; }
@@ -114,7 +129,7 @@ public sealed class NewConfigurationDeliveryCommand : PSCmdlet
     [Parameter] public SwitchParameter GenerateInstallCommand { get; set; }
 
     /// <summary>
-    /// When set, generates a public Update-&lt;ModuleName&gt; helper function during build that delegates to the install command.
+    /// When set, generates a public Update-&lt;ModuleName&gt; helper function during build that delegates to the install command in refresh mode by default.
     /// </summary>
     [Parameter] public SwitchParameter GenerateUpdateCommand { get; set; }
 
@@ -150,6 +165,8 @@ public sealed class NewConfigurationDeliveryCommand : PSCmdlet
             RepositoryPaths = RepositoryPaths,
             RepositoryBranch = RepositoryBranch,
             DocumentationOrder = DocumentationOrder,
+            IncludePaths = IncludePaths,
+            ExcludePaths = ExcludePaths,
             PreservePaths = PreservePaths,
             OverwritePaths = OverwritePaths,
             GenerateInstallCommand = GenerateInstallCommand.IsPresent,

--- a/PowerForge.PowerShell/Models/DeliveryConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/DeliveryConfigurationRequest.cs
@@ -19,6 +19,8 @@ internal sealed class DeliveryConfigurationRequest
     public string[]? RepositoryPaths { get; set; }
     public string? RepositoryBranch { get; set; }
     public string[]? DocumentationOrder { get; set; }
+    public string[]? IncludePaths { get; set; }
+    public string[]? ExcludePaths { get; set; }
     public string[]? PreservePaths { get; set; }
     public string[]? OverwritePaths { get; set; }
     public bool GenerateInstallCommand { get; set; }

--- a/PowerForge.PowerShell/Services/DeliveryConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/DeliveryConfigurationFactory.cs
@@ -36,6 +36,8 @@ internal sealed class DeliveryConfigurationFactory
                     RepositoryPaths = request.RepositoryPaths,
                     RepositoryBranch = request.RepositoryBranch,
                     DocumentationOrder = request.DocumentationOrder,
+                    IncludePaths = NormalizeStringArray(request.IncludePaths),
+                    ExcludePaths = NormalizeStringArray(request.ExcludePaths),
                     PreservePaths = NormalizeStringArray(request.PreservePaths),
                     OverwritePaths = NormalizeStringArray(request.OverwritePaths),
                     GenerateInstallCommand = request.GenerateInstallCommand || !string.IsNullOrWhiteSpace(request.InstallCommandName),

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.FormattingSigningDelivery.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.FormattingSigningDelivery.cs
@@ -447,6 +447,26 @@ public sealed partial class ModulePipelineRunner
                         _manifestMutator.TrySetPsDataSubStringArray(manifestPath, parentKey, "RepositoryPaths", repoPaths);
                 }
 
+                if (delivery.IncludePaths is { Length: > 0 })
+                {
+                    var include = delivery.IncludePaths
+                        .Where(s => !string.IsNullOrWhiteSpace(s))
+                        .Select(s => s.Trim())
+                        .ToArray();
+                    if (include.Length > 0)
+                        _manifestMutator.TrySetPsDataSubStringArray(manifestPath, parentKey, "IncludePaths", include);
+                }
+
+                if (delivery.ExcludePaths is { Length: > 0 })
+                {
+                    var exclude = delivery.ExcludePaths
+                        .Where(s => !string.IsNullOrWhiteSpace(s))
+                        .Select(s => s.Trim())
+                        .ToArray();
+                    if (exclude.Length > 0)
+                        _manifestMutator.TrySetPsDataSubStringArray(manifestPath, parentKey, "ExcludePaths", exclude);
+                }
+
                 if (delivery.PreservePaths is { Length: > 0 })
                 {
                     var preserve = delivery.PreservePaths

--- a/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
+++ b/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
@@ -95,7 +95,7 @@ public sealed class DeliveryCommandGeneratorTests
             {
                 Enable = true,
                 InternalsPath = "Internals",
-                IncludePaths = new[] { "Config/**", "Scripts/*.ps1" },
+                IncludePaths = new[] { "Config/*.json", "Scripts/*.ps1" },
                 ExcludePaths = new[] { "Config/ignored.json", "Config/local/**" },
                 PreservePaths = new[] { "Config/preserved.json" },
                 GenerateInstallCommand = true,
@@ -107,12 +107,14 @@ public sealed class DeliveryCommandGeneratorTests
 
             var config = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Config"));
             var local = Directory.CreateDirectory(Path.Combine(config.FullName, "local"));
+            var nested = Directory.CreateDirectory(Path.Combine(config.FullName, "nested"));
             var scripts = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Scripts"));
             var docs = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Docs"));
             File.WriteAllText(Path.Combine(config.FullName, "config.sample.json"), "package-new");
             File.WriteAllText(Path.Combine(config.FullName, "ignored.json"), "package-ignored-new");
             File.WriteAllText(Path.Combine(config.FullName, "preserved.json"), "package-preserved-new");
             File.WriteAllText(Path.Combine(local.FullName, "default.json"), "package-local-new");
+            File.WriteAllText(Path.Combine(nested.FullName, "settings.json"), "package-nested-new");
             File.WriteAllText(Path.Combine(scripts.FullName, "tool.ps1"), "package-script-new");
             File.WriteAllText(Path.Combine(docs.FullName, "readme.md"), "package-doc-new");
             File.WriteAllText(Path.Combine(root.FullName, "TestDelivery.psm1"), """
@@ -145,6 +147,7 @@ public sealed class DeliveryCommandGeneratorTests
             Assert.Equal("local-preserved", File.ReadAllText(Path.Combine(destinationConfig.FullName, "preserved.json")));
             Assert.Equal("local-default", File.ReadAllText(Path.Combine(destinationLocal.FullName, "default.json")));
             Assert.Equal("package-script-new", File.ReadAllText(Path.Combine(destinationScripts.FullName, "tool.ps1")));
+            Assert.False(File.Exists(Path.Combine(destination.FullName, "Config", "nested", "settings.json")));
             Assert.False(File.Exists(Path.Combine(destination.FullName, "Docs", "readme.md")));
         }
         finally

--- a/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
+++ b/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
@@ -289,6 +289,37 @@ public sealed class DeliveryCommandGeneratorTests
         }
     }
 
+    [Fact]
+    public void Generate_SkipsUpdate_WhenExistingInstallCommandDoesNotSupportRefresh()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var publicFolder = Directory.CreateDirectory(Path.Combine(root.FullName, "Public"));
+            File.WriteAllText(
+                Path.Combine(publicFolder.FullName, "Install-EFAdminManager.ps1"),
+                "function Install-EFAdminManager { param([ValidateSet('Merge', 'Overwrite', 'Skip', 'Stop')] [string] $OnExists = 'Merge') }");
+
+            var delivery = new DeliveryOptionsConfiguration
+            {
+                Enable = true,
+                GenerateInstallCommand = true,
+                GenerateUpdateCommand = true
+            };
+
+            var generator = new DeliveryCommandGenerator(new NullLogger());
+            var generated = generator.Generate(root.FullName, "EFAdminManager", delivery);
+
+            Assert.DoesNotContain(generated, g => g.Name == "Install-EFAdminManager");
+            Assert.DoesNotContain(generated, g => g.Name == "Update-EFAdminManager");
+            Assert.False(File.Exists(Path.Combine(publicFolder.FullName, "Update-EFAdminManager.ps1")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static string? FindPowerShellExecutable()
     {
         var candidates = OperatingSystem.IsWindows()

--- a/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
+++ b/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
@@ -284,7 +284,7 @@ public sealed class DeliveryCommandGeneratorTests
             {
                 Enable = true,
                 InternalsPath = "Internals",
-                IncludePaths = new[] { "Config/[Pp]rod*.json" },
+                IncludePaths = new[] { "Config/[Pp]rod*.json", "Config/[Pp]rod.json" },
                 GenerateInstallCommand = true,
                 GenerateUpdateCommand = true
             };
@@ -293,6 +293,7 @@ public sealed class DeliveryCommandGeneratorTests
             generator.Generate(root.FullName, "TestDelivery", delivery);
 
             var config = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Config"));
+            File.WriteAllText(Path.Combine(config.FullName, "prod.json"), "prod-exact-new");
             File.WriteAllText(Path.Combine(config.FullName, "ProdSettings.json"), "prod-new");
             File.WriteAllText(Path.Combine(config.FullName, "devSettings.json"), "dev-new");
             File.WriteAllText(Path.Combine(root.FullName, "TestDelivery.psm1"), """
@@ -302,6 +303,7 @@ public sealed class DeliveryCommandGeneratorTests
 
             var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
             var destinationConfig = Directory.CreateDirectory(Path.Combine(destination.FullName, "Config"));
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "prod.json"), "prod-exact-old");
             File.WriteAllText(Path.Combine(destinationConfig.FullName, "ProdSettings.json"), "prod-old");
             File.WriteAllText(Path.Combine(destinationConfig.FullName, "devSettings.json"), "dev-old");
 
@@ -315,6 +317,7 @@ public sealed class DeliveryCommandGeneratorTests
             var result = RunPowerShell(powerShell, scriptPath);
 
             Assert.True(result.ExitCode == 0, $"PowerShell failed with exit code {result.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+            Assert.Equal("prod-exact-new", File.ReadAllText(Path.Combine(destinationConfig.FullName, "prod.json")));
             Assert.Equal("prod-new", File.ReadAllText(Path.Combine(destinationConfig.FullName, "ProdSettings.json")));
             Assert.Equal("dev-old", File.ReadAllText(Path.Combine(destinationConfig.FullName, "devSettings.json")));
         }

--- a/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
+++ b/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
@@ -271,6 +271,60 @@ public sealed class DeliveryCommandGeneratorTests
     }
 
     [Fact]
+    public void GeneratedUpdate_CharacterClassIncludePath_MatchesPowerShellWildcardSemantics()
+    {
+        var powerShell = FindPowerShellExecutable();
+        if (powerShell is null)
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var delivery = new DeliveryOptionsConfiguration
+            {
+                Enable = true,
+                InternalsPath = "Internals",
+                IncludePaths = new[] { "Config/[Pp]rod*.json" },
+                GenerateInstallCommand = true,
+                GenerateUpdateCommand = true
+            };
+
+            var generator = new DeliveryCommandGenerator(new NullLogger());
+            generator.Generate(root.FullName, "TestDelivery", delivery);
+
+            var config = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Config"));
+            File.WriteAllText(Path.Combine(config.FullName, "ProdSettings.json"), "prod-new");
+            File.WriteAllText(Path.Combine(config.FullName, "devSettings.json"), "dev-new");
+            File.WriteAllText(Path.Combine(root.FullName, "TestDelivery.psm1"), """
+                . "$PSScriptRoot\Public\Install-TestDelivery.ps1"
+                . "$PSScriptRoot\Public\Update-TestDelivery.ps1"
+                """);
+
+            var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
+            var destinationConfig = Directory.CreateDirectory(Path.Combine(destination.FullName, "Config"));
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "ProdSettings.json"), "prod-old");
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "devSettings.json"), "dev-old");
+
+            var scriptPath = Path.Combine(root.FullName, "run-update-character-class.ps1");
+            File.WriteAllText(scriptPath, $$"""
+                $ErrorActionPreference = 'Stop'
+                Import-Module -Name '{{EscapePowerShellString(Path.Combine(root.FullName, "TestDelivery.psm1"))}}' -Force
+                Update-TestDelivery -Path '{{EscapePowerShellString(destination.FullName)}}' | Out-Null
+                """);
+
+            var result = RunPowerShell(powerShell, scriptPath);
+
+            Assert.True(result.ExitCode == 0, $"PowerShell failed with exit code {result.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+            Assert.Equal("prod-new", File.ReadAllText(Path.Combine(destinationConfig.FullName, "ProdSettings.json")));
+            Assert.Equal("dev-old", File.ReadAllText(Path.Combine(destinationConfig.FullName, "devSettings.json")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void GeneratedInstall_Overwrite_RemainsDestructive()
     {
         var powerShell = FindPowerShellExecutable();
@@ -353,22 +407,24 @@ public sealed class DeliveryCommandGeneratorTests
         {
             var publicFolder = Directory.CreateDirectory(Path.Combine(root.FullName, "Public"));
             File.WriteAllText(
-                Path.Combine(publicFolder.FullName, "Install-EFAdminManager.ps1"),
-                "function Install-EFAdminManager { param([ValidateSet('Merge', 'Overwrite', 'Skip', 'Stop')] [string] $OnExists = 'Merge') }");
+                Path.Combine(publicFolder.FullName, "Install-DataRefresh.ps1"),
+                "function Install-DataRefresh { param([ValidateSet('Merge', 'Overwrite', 'Skip', 'Stop')] [string] $OnExists = 'Merge') Write-Verbose 'Install-DataRefresh' }");
 
             var delivery = new DeliveryOptionsConfiguration
             {
                 Enable = true,
                 GenerateInstallCommand = true,
-                GenerateUpdateCommand = true
+                GenerateUpdateCommand = true,
+                InstallCommandName = "Install-DataRefresh",
+                UpdateCommandName = "Update-DataRefresh"
             };
 
             var generator = new DeliveryCommandGenerator(new NullLogger());
-            var generated = generator.Generate(root.FullName, "EFAdminManager", delivery);
+            var generated = generator.Generate(root.FullName, "DataRefresh", delivery);
 
-            Assert.DoesNotContain(generated, g => g.Name == "Install-EFAdminManager");
-            Assert.DoesNotContain(generated, g => g.Name == "Update-EFAdminManager");
-            Assert.False(File.Exists(Path.Combine(publicFolder.FullName, "Update-EFAdminManager.ps1")));
+            Assert.DoesNotContain(generated, g => g.Name == "Install-DataRefresh");
+            Assert.DoesNotContain(generated, g => g.Name == "Update-DataRefresh");
+            Assert.False(File.Exists(Path.Combine(publicFolder.FullName, "Update-DataRefresh.ps1")));
         }
         finally
         {

--- a/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
+++ b/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -16,6 +18,8 @@ public sealed class DeliveryCommandGeneratorTests
             {
                 Enable = true,
                 InternalsPath = "Internals",
+                IncludePaths = new[] { "Config/**", "Scripts/*.ps1" },
+                ExcludePaths = new[] { "Config/local/**" },
                 PreservePaths = new[] { "Config/**", "Docs" },
                 OverwritePaths = new[] { "Artefacts/**" },
                 GenerateInstallCommand = true,
@@ -38,6 +42,8 @@ public sealed class DeliveryCommandGeneratorTests
             Assert.Contains("function Install-EFAdminManager", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Write-Host \"[EFAdminManager] Installing bundled package content\"", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Write-DeliveryError", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string[]] $IncludePaths = @('Config/**', 'Scripts/*.ps1')", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string[]] $ExcludePaths = @('Config/local/**')", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[string[]] $PreservePaths = @('Config/**', 'Docs')", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[string[]] $OverwritePaths = @('Artefacts/**')", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[switch] $Bootstrap", installContent, StringComparison.OrdinalIgnoreCase);
@@ -45,7 +51,9 @@ public sealed class DeliveryCommandGeneratorTests
             Assert.Contains("[switch] $__DeliveryNoBootstrap", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("function Resolve-DeliverySecret", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("function Test-DeliveryPathMatch", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("function Test-DeliveryPathIncluded", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("function Get-DeliveryAction", installContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[ValidateSet('Merge', 'Refresh', 'Overwrite', 'Skip', 'Stop')]", installContent, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("{{", installContent, StringComparison.Ordinal);
 
             var updateContent = File.ReadAllText(updatePath);
@@ -53,14 +61,197 @@ public sealed class DeliveryCommandGeneratorTests
             Assert.Contains("Install-EFAdminManager", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Write-Host \"[EFAdminManager] Updating bundled package content via Install-EFAdminManager\"", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Delivery.InstallCommandMissing", updateContent, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("Install-EFAdminManager @PSBoundParameters", updateContent, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("& 'Install-EFAdminManager' @PSBoundParameters", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[ValidateSet('Merge', 'Refresh', 'Overwrite', 'Skip', 'Stop')]", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string] $OnExists = 'Refresh'", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("$forward['OnExists'] = $OnExists", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Install-EFAdminManager @forward", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Install-EFAdminManager @PSBoundParameters", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string[]] $IncludePaths", updateContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[string[]] $ExcludePaths", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[string[]] $PreservePaths", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[string[]] $OverwritePaths", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[switch] $Bootstrap", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[string] $RepositoryCredentialSecretFilePath", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("[switch] $__DeliveryNoBootstrap", updateContent, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("{{", updateContent, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void GeneratedUpdate_IncludeExcludePaths_ScopeManagedPackageFiles()
+    {
+        var powerShell = FindPowerShellExecutable();
+        if (powerShell is null)
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var delivery = new DeliveryOptionsConfiguration
+            {
+                Enable = true,
+                InternalsPath = "Internals",
+                IncludePaths = new[] { "Config/**", "Scripts/*.ps1" },
+                ExcludePaths = new[] { "Config/ignored.json", "Config/local/**" },
+                PreservePaths = new[] { "Config/preserved.json" },
+                GenerateInstallCommand = true,
+                GenerateUpdateCommand = true
+            };
+
+            var generator = new DeliveryCommandGenerator(new NullLogger());
+            generator.Generate(root.FullName, "TestDelivery", delivery);
+
+            var config = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Config"));
+            var local = Directory.CreateDirectory(Path.Combine(config.FullName, "local"));
+            var scripts = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Scripts"));
+            var docs = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Docs"));
+            File.WriteAllText(Path.Combine(config.FullName, "config.sample.json"), "package-new");
+            File.WriteAllText(Path.Combine(config.FullName, "ignored.json"), "package-ignored-new");
+            File.WriteAllText(Path.Combine(config.FullName, "preserved.json"), "package-preserved-new");
+            File.WriteAllText(Path.Combine(local.FullName, "default.json"), "package-local-new");
+            File.WriteAllText(Path.Combine(scripts.FullName, "tool.ps1"), "package-script-new");
+            File.WriteAllText(Path.Combine(docs.FullName, "readme.md"), "package-doc-new");
+            File.WriteAllText(Path.Combine(root.FullName, "TestDelivery.psm1"), """
+                . "$PSScriptRoot\Public\Install-TestDelivery.ps1"
+                . "$PSScriptRoot\Public\Update-TestDelivery.ps1"
+                """);
+
+            var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
+            var destinationConfig = Directory.CreateDirectory(Path.Combine(destination.FullName, "Config"));
+            var destinationLocal = Directory.CreateDirectory(Path.Combine(destinationConfig.FullName, "local"));
+            var destinationScripts = Directory.CreateDirectory(Path.Combine(destination.FullName, "Scripts"));
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "config.sample.json"), "package-old");
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "ignored.json"), "local-ignored");
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "preserved.json"), "local-preserved");
+            File.WriteAllText(Path.Combine(destinationLocal.FullName, "default.json"), "local-default");
+            File.WriteAllText(Path.Combine(destinationScripts.FullName, "tool.ps1"), "script-old");
+
+            var scriptPath = Path.Combine(root.FullName, "run-update-scoped.ps1");
+            File.WriteAllText(scriptPath, $$"""
+                $ErrorActionPreference = 'Stop'
+                Import-Module -Name '{{EscapePowerShellString(Path.Combine(root.FullName, "TestDelivery.psm1"))}}' -Force
+                Update-TestDelivery -Path '{{EscapePowerShellString(destination.FullName)}}' | Out-Null
+                """);
+
+            var result = RunPowerShell(powerShell, scriptPath);
+
+            Assert.True(result.ExitCode == 0, $"PowerShell failed with exit code {result.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+            Assert.Equal("package-new", File.ReadAllText(Path.Combine(destinationConfig.FullName, "config.sample.json")));
+            Assert.Equal("local-ignored", File.ReadAllText(Path.Combine(destinationConfig.FullName, "ignored.json")));
+            Assert.Equal("local-preserved", File.ReadAllText(Path.Combine(destinationConfig.FullName, "preserved.json")));
+            Assert.Equal("local-default", File.ReadAllText(Path.Combine(destinationLocal.FullName, "default.json")));
+            Assert.Equal("package-script-new", File.ReadAllText(Path.Combine(destinationScripts.FullName, "tool.ps1")));
+            Assert.False(File.Exists(Path.Combine(destination.FullName, "Docs", "readme.md")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void GeneratedUpdate_DefaultRefresh_OverwritesPackageFiles_AndPreservesLocalExtras()
+    {
+        var powerShell = FindPowerShellExecutable();
+        if (powerShell is null)
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var delivery = new DeliveryOptionsConfiguration
+            {
+                Enable = true,
+                InternalsPath = "Internals",
+                PreservePaths = new[] { "Config/preserved.json" },
+                GenerateInstallCommand = true,
+                GenerateUpdateCommand = true
+            };
+
+            var generator = new DeliveryCommandGenerator(new NullLogger());
+            generator.Generate(root.FullName, "TestDelivery", delivery);
+
+            var internals = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Config"));
+            File.WriteAllText(Path.Combine(internals.FullName, "config.sample.json"), "package-new");
+            File.WriteAllText(Path.Combine(internals.FullName, "preserved.json"), "package-new-preserved");
+            File.WriteAllText(Path.Combine(root.FullName, "TestDelivery.psm1"), """
+                . "$PSScriptRoot\Public\Install-TestDelivery.ps1"
+                . "$PSScriptRoot\Public\Update-TestDelivery.ps1"
+                """);
+
+            var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
+            var destinationConfig = Directory.CreateDirectory(Path.Combine(destination.FullName, "Config"));
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "config.sample.json"), "package-old");
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "preserved.json"), "local-preserved");
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "config.json"), "local-config");
+            File.WriteAllText(Path.Combine(destination.FullName, "local-only.txt"), "local-extra");
+
+            var scriptPath = Path.Combine(root.FullName, "run-update.ps1");
+            File.WriteAllText(scriptPath, $$"""
+                $ErrorActionPreference = 'Stop'
+                Import-Module -Name '{{EscapePowerShellString(Path.Combine(root.FullName, "TestDelivery.psm1"))}}' -Force
+                Update-TestDelivery -Path '{{EscapePowerShellString(destination.FullName)}}' | Out-Null
+                """);
+
+            var result = RunPowerShell(powerShell, scriptPath);
+
+            Assert.True(result.ExitCode == 0, $"PowerShell failed with exit code {result.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+            Assert.Equal("package-new", File.ReadAllText(Path.Combine(destinationConfig.FullName, "config.sample.json")));
+            Assert.Equal("local-preserved", File.ReadAllText(Path.Combine(destinationConfig.FullName, "preserved.json")));
+            Assert.Equal("local-config", File.ReadAllText(Path.Combine(destinationConfig.FullName, "config.json")));
+            Assert.Equal("local-extra", File.ReadAllText(Path.Combine(destination.FullName, "local-only.txt")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void GeneratedInstall_Overwrite_RemainsDestructive()
+    {
+        var powerShell = FindPowerShellExecutable();
+        if (powerShell is null)
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var delivery = new DeliveryOptionsConfiguration
+            {
+                Enable = true,
+                InternalsPath = "Internals",
+                GenerateInstallCommand = true
+            };
+
+            var generator = new DeliveryCommandGenerator(new NullLogger());
+            generator.Generate(root.FullName, "TestDelivery", delivery);
+
+            var internals = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals"));
+            File.WriteAllText(Path.Combine(internals.FullName, "package.txt"), "package-new");
+            File.WriteAllText(Path.Combine(root.FullName, "TestDelivery.psm1"), """
+                . "$PSScriptRoot\Public\Install-TestDelivery.ps1"
+                """);
+
+            var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
+            File.WriteAllText(Path.Combine(destination.FullName, "local-only.txt"), "local-extra");
+
+            var scriptPath = Path.Combine(root.FullName, "run-install.ps1");
+            File.WriteAllText(scriptPath, $$"""
+                $ErrorActionPreference = 'Stop'
+                Import-Module -Name '{{EscapePowerShellString(Path.Combine(root.FullName, "TestDelivery.psm1"))}}' -Force
+                Install-TestDelivery -Path '{{EscapePowerShellString(destination.FullName)}}' -OnExists Overwrite | Out-Null
+                """);
+
+            var result = RunPowerShell(powerShell, scriptPath);
+
+            Assert.True(result.ExitCode == 0, $"PowerShell failed with exit code {result.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+            Assert.Equal("package-new", File.ReadAllText(Path.Combine(destination.FullName, "package.txt")));
+            Assert.False(File.Exists(Path.Combine(destination.FullName, "local-only.txt")));
         }
         finally
         {
@@ -94,4 +285,64 @@ public sealed class DeliveryCommandGeneratorTests
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
     }
+
+    private static string? FindPowerShellExecutable()
+    {
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { "pwsh.exe", "pwsh", "powershell.exe" }
+            : new[] { "pwsh" };
+
+        return candidates.FirstOrDefault(CommandExists);
+    }
+
+    private static bool CommandExists(string command)
+    {
+        try
+        {
+            var probe = new ProcessStartInfo
+            {
+                FileName = command,
+                ArgumentList = { "-NoLogo", "-NoProfile", "-Command", "$PSVersionTable.PSVersion.ToString()" },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(probe);
+            if (process is null)
+                return false;
+
+            process.WaitForExit(10000);
+            return process.HasExited && process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static (int ExitCode, string StandardOutput, string StandardError) RunPowerShell(string executable, string scriptPath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            ArgumentList = { "-NoLogo", "-NoProfile", "-File", scriptPath },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start {executable}.");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit(30000);
+
+        return process.HasExited
+            ? (process.ExitCode, stdout, stderr)
+            : throw new TimeoutException($"{executable} did not finish. STDOUT: {stdout} STDERR: {stderr}");
+    }
+
+    private static string EscapePowerShellString(string value)
+        => value.Replace("'", "''", StringComparison.Ordinal);
 }

--- a/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
+++ b/PowerForge.Tests/DeliveryCommandGeneratorTests.cs
@@ -157,6 +157,62 @@ public sealed class DeliveryCommandGeneratorTests
     }
 
     [Fact]
+    public void GeneratedUpdate_RecursiveIncludePath_MatchesDirectAndNestedFiles()
+    {
+        var powerShell = FindPowerShellExecutable();
+        if (powerShell is null)
+            return;
+
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var delivery = new DeliveryOptionsConfiguration
+            {
+                Enable = true,
+                InternalsPath = "Internals",
+                IncludePaths = new[] { "Config/**/*.json" },
+                GenerateInstallCommand = true,
+                GenerateUpdateCommand = true
+            };
+
+            var generator = new DeliveryCommandGenerator(new NullLogger());
+            generator.Generate(root.FullName, "TestDelivery", delivery);
+
+            var config = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Config"));
+            var nested = Directory.CreateDirectory(Path.Combine(config.FullName, "nested"));
+            File.WriteAllText(Path.Combine(config.FullName, "app.json"), "direct-new");
+            File.WriteAllText(Path.Combine(nested.FullName, "app.json"), "nested-new");
+            File.WriteAllText(Path.Combine(root.FullName, "TestDelivery.psm1"), """
+                . "$PSScriptRoot\Public\Install-TestDelivery.ps1"
+                . "$PSScriptRoot\Public\Update-TestDelivery.ps1"
+                """);
+
+            var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
+            var destinationConfig = Directory.CreateDirectory(Path.Combine(destination.FullName, "Config"));
+            var destinationNested = Directory.CreateDirectory(Path.Combine(destinationConfig.FullName, "nested"));
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "app.json"), "direct-old");
+            File.WriteAllText(Path.Combine(destinationNested.FullName, "app.json"), "nested-old");
+
+            var scriptPath = Path.Combine(root.FullName, "run-update-recursive.ps1");
+            File.WriteAllText(scriptPath, $$"""
+                $ErrorActionPreference = 'Stop'
+                Import-Module -Name '{{EscapePowerShellString(Path.Combine(root.FullName, "TestDelivery.psm1"))}}' -Force
+                Update-TestDelivery -Path '{{EscapePowerShellString(destination.FullName)}}' | Out-Null
+                """);
+
+            var result = RunPowerShell(powerShell, scriptPath);
+
+            Assert.True(result.ExitCode == 0, $"PowerShell failed with exit code {result.ExitCode}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+            Assert.Equal("direct-new", File.ReadAllText(Path.Combine(destinationConfig.FullName, "app.json")));
+            Assert.Equal("nested-new", File.ReadAllText(Path.Combine(destinationNested.FullName, "app.json")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void GeneratedUpdate_DefaultRefresh_OverwritesPackageFiles_AndPreservesLocalExtras()
     {
         var powerShell = FindPowerShellExecutable();

--- a/PowerForge.Tests/DeliveryConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/DeliveryConfigurationFactoryTests.cs
@@ -1,4 +1,6 @@
 using PowerForge;
+using System;
+using System.IO;
 
 namespace PowerForge.Tests;
 
@@ -63,5 +65,15 @@ public sealed class DeliveryConfigurationFactoryTests
         var link = Assert.Single(links);
         Assert.Equal("Docs", link.Title);
         Assert.Equal("https://example.test/docs", link.Url);
+    }
+
+    [Fact]
+    public void Segments_schema_allows_delivery_include_and_exclude_paths()
+    {
+        var schemaPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Schemas", "powerforge.segments.schema.json"));
+        var schema = File.ReadAllText(schemaPath);
+
+        Assert.Contains("\"IncludePaths\"", schema, StringComparison.Ordinal);
+        Assert.Contains("\"ExcludePaths\"", schema, StringComparison.Ordinal);
     }
 }

--- a/PowerForge.Tests/DeliveryConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/DeliveryConfigurationFactoryTests.cs
@@ -33,6 +33,8 @@ public sealed class DeliveryConfigurationFactoryTests
                 new DeliveryImportantLink { Title = " Docs ", Url = " https://example.test/docs " },
                 new DeliveryImportantLink { Title = " ", Url = "https://ignored.test" }
             ],
+            IncludePaths = [" Config/*.sample.json ", "config/*.sample.json", "Scripts/*.ps1"],
+            ExcludePaths = [" Config/local/** ", "config/local/**", "  "],
             PreservePaths = [" Config/** ", "config/**", "  "],
             OverwritePaths = [" Bin/** ", "Templates/**", "bin/**"],
             InstallCommandName = " Install-ContosoToolkit ",
@@ -48,8 +50,12 @@ public sealed class DeliveryConfigurationFactoryTests
         Assert.True(delivery.GenerateUpdateCommand);
         Assert.Equal("Install-ContosoToolkit", delivery.InstallCommandName);
         Assert.Equal("Update-ContosoToolkit", delivery.UpdateCommandName);
+        var includePaths = Assert.IsType<string[]>(delivery.IncludePaths);
+        var excludePaths = Assert.IsType<string[]>(delivery.ExcludePaths);
         var preservePaths = Assert.IsType<string[]>(delivery.PreservePaths);
         var overwritePaths = Assert.IsType<string[]>(delivery.OverwritePaths);
+        Assert.Equal(["Config/*.sample.json", "Scripts/*.ps1"], includePaths);
+        Assert.Equal(["Config/local/**"], excludePaths);
         Assert.Equal(["Config/**"], preservePaths);
         Assert.Equal(["Bin/**", "Templates/**"], overwritePaths);
 

--- a/PowerForge.Tests/EmbeddedModuleDependencyServiceTests.cs
+++ b/PowerForge.Tests/EmbeddedModuleDependencyServiceTests.cs
@@ -279,7 +279,9 @@ public sealed class EmbeddedModuleDependencyServiceTests
             var destinationRoot = Path.Combine(root.FullName, "PrivateDeps");
             var destinationModule = Path.Combine(destinationRoot, "Microsoft.Graph.Authentication", "2.25.0");
             Directory.CreateDirectory(destinationModule);
-            File.WriteAllText(Path.Combine(destinationModule, "settings.json"), "package-old");
+            var targetSettings = Path.Combine(destinationModule, "settings.json");
+            File.WriteAllText(targetSettings, "package-old");
+            File.SetAttributes(targetSettings, File.GetAttributes(targetSettings) | FileAttributes.ReadOnly);
             File.WriteAllText(Path.Combine(destinationModule, "local-only.txt"), "local-extra");
 
             var results = service.Install(
@@ -289,11 +291,12 @@ public sealed class EmbeddedModuleDependencyServiceTests
 
             var result = Assert.Single(results);
             Assert.Equal("Refresh", result.Action);
-            Assert.Equal("package-new", File.ReadAllText(Path.Combine(destinationModule, "settings.json")));
+            Assert.Equal("package-new", File.ReadAllText(targetSettings));
             Assert.Equal("local-extra", File.ReadAllText(Path.Combine(destinationModule, "local-only.txt")));
         }
         finally
         {
+            ClearReadOnlyAttributes(root.FullName);
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
     }
@@ -678,6 +681,26 @@ public sealed class EmbeddedModuleDependencyServiceTests
 
     private static string CreateModule(string root, string name, string version)
         => CreateModuleAt(Path.Combine(root, "Dependencies", name, version), name, version);
+
+    private static void ClearReadOnlyAttributes(string root)
+    {
+        if (!Directory.Exists(root))
+            return;
+
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            try
+            {
+                var attributes = File.GetAttributes(file);
+                if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                    File.SetAttributes(file, attributes & ~FileAttributes.ReadOnly);
+            }
+            catch
+            {
+                /* best effort cleanup */
+            }
+        }
+    }
 
     private static string CreateModuleAt(string moduleRoot, string name, string version)
     {

--- a/PowerForge.Tests/EmbeddedModuleDependencyServiceTests.cs
+++ b/PowerForge.Tests/EmbeddedModuleDependencyServiceTests.cs
@@ -256,6 +256,49 @@ public sealed class EmbeddedModuleDependencyServiceTests
     }
 
     [Fact]
+    public void Install_RefreshOverwritesPayloadFilesAndPreservesLocalExtras()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "BuiltModule"));
+            var dependencyRoot = CreateModule(root.FullName, "Microsoft.Graph.Authentication", "2.25.0");
+            File.WriteAllText(Path.Combine(dependencyRoot, "settings.json"), "package-new");
+            var provider = new Provider(new InstalledModuleMetadata(
+                "Microsoft.Graph.Authentication",
+                "2.25.0",
+                guid: null,
+                moduleBasePath: dependencyRoot));
+
+            var service = new EmbeddedModuleDependencyService(new NullLogger());
+            service.Embed(
+                moduleRoot.FullName,
+                new[] { new RequiredModuleReference("Microsoft.Graph.Authentication", requiredVersion: "2.25.0") },
+                provider);
+
+            var destinationRoot = Path.Combine(root.FullName, "PrivateDeps");
+            var destinationModule = Path.Combine(destinationRoot, "Microsoft.Graph.Authentication", "2.25.0");
+            Directory.CreateDirectory(destinationModule);
+            File.WriteAllText(Path.Combine(destinationModule, "settings.json"), "package-old");
+            File.WriteAllText(Path.Combine(destinationModule, "local-only.txt"), "local-extra");
+
+            var results = service.Install(
+                Path.Combine(moduleRoot.FullName, "Internals", "Modules", "module-dependencies.json"),
+                destinationRoot,
+                onExists: OnExistsOption.Refresh);
+
+            var result = Assert.Single(results);
+            Assert.Equal("Refresh", result.Action);
+            Assert.Equal("package-new", File.ReadAllText(Path.Combine(destinationModule, "settings.json")));
+            Assert.Equal("local-extra", File.ReadAllText(Path.Combine(destinationModule, "local-only.txt")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Install_WithDependencyFilter_PreservesUnselectedExistingReceiptEntries()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModuleDocumentationReviewRegressionTests.cs
+++ b/PowerForge.Tests/ModuleDocumentationReviewRegressionTests.cs
@@ -57,6 +57,38 @@ public class ModuleDocumentationReviewRegressionTests
     {
         Assert.Equal("Keep", InstallModuleScriptCommand.ResolveExistingScriptActionForTesting(true, OnExistsOption.Merge, force: false));
         Assert.Equal("Overwrite", InstallModuleScriptCommand.ResolveExistingScriptActionForTesting(true, OnExistsOption.Merge, force: true));
+        Assert.Equal("Overwrite", InstallModuleScriptCommand.ResolveExistingScriptActionForTesting(true, OnExistsOption.Refresh, force: false));
+    }
+
+    [Fact]
+    public void DocumentationInstaller_Refresh_OverwritesPackageFiles_AndPreservesLocalExtras()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PFDocsRefresh", System.Guid.NewGuid().ToString("N")));
+        try
+        {
+            var internals = Directory.CreateDirectory(Path.Combine(root.FullName, "Internals", "Config"));
+            File.WriteAllText(Path.Combine(internals.FullName, "config.sample.json"), "package-new");
+            File.WriteAllText(Path.Combine(root.FullName, "README.md"), "readme-new");
+
+            var destination = Directory.CreateDirectory(Path.Combine(root.FullName, "Destination"));
+            var destinationConfig = Directory.CreateDirectory(Path.Combine(destination.FullName, "Config"));
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "config.sample.json"), "package-old");
+            File.WriteAllText(Path.Combine(destinationConfig.FullName, "config.json"), "local-config");
+            File.WriteAllText(Path.Combine(destination.FullName, "README.md"), "readme-old");
+            File.WriteAllText(Path.Combine(destination.FullName, "local-only.txt"), "local-extra");
+
+            var installer = new DocumentationInstaller();
+            installer.Install(root.FullName, "Demo", "1.0.0", destination.FullName, OnExistsOption.Refresh, force: false, open: false, noIntro: true);
+
+            Assert.Equal("package-new", File.ReadAllText(Path.Combine(destinationConfig.FullName, "config.sample.json")));
+            Assert.Equal("local-config", File.ReadAllText(Path.Combine(destinationConfig.FullName, "config.json")));
+            Assert.Equal("readme-new", File.ReadAllText(Path.Combine(destination.FullName, "README.md")));
+            Assert.Equal("local-extra", File.ReadAllText(Path.Combine(destination.FullName, "local-only.txt")));
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleDocumentationReviewRegressionTests.cs
+++ b/PowerForge.Tests/ModuleDocumentationReviewRegressionTests.cs
@@ -61,6 +61,25 @@ public class ModuleDocumentationReviewRegressionTests
     }
 
     [Fact]
+    public void InstallModuleScript_Refresh_Clears_ReadOnly_Targets()
+    {
+        Assert.False(InstallModuleScriptCommand.ShouldClearReadOnlyTargetForTesting(true, OnExistsOption.Merge, force: false));
+        Assert.True(InstallModuleScriptCommand.ShouldClearReadOnlyTargetForTesting(true, OnExistsOption.Merge, force: true));
+        Assert.True(InstallModuleScriptCommand.ShouldClearReadOnlyTargetForTesting(true, OnExistsOption.Refresh, force: false));
+        Assert.True(InstallModuleScriptCommand.ShouldClearReadOnlyTargetForTesting(true, OnExistsOption.Overwrite, force: false));
+    }
+
+    [Fact]
+    public void OnExistsOption_NumericValues_RemainBackwardCompatible()
+    {
+        Assert.Equal(0, (int)OnExistsOption.Merge);
+        Assert.Equal(1, (int)OnExistsOption.Overwrite);
+        Assert.Equal(2, (int)OnExistsOption.Skip);
+        Assert.Equal(3, (int)OnExistsOption.Stop);
+        Assert.Equal(4, (int)OnExistsOption.Refresh);
+    }
+
+    [Fact]
     public void DocumentationInstaller_Refresh_OverwritesPackageFiles_AndPreservesLocalExtras()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PFDocsRefresh", System.Guid.NewGuid().ToString("N")));

--- a/PowerForge/Enums/ModuleDocumentation/OnExistsOption.cs
+++ b/PowerForge/Enums/ModuleDocumentation/OnExistsOption.cs
@@ -9,23 +9,23 @@ public enum OnExistsOption
     /// Merge documentation into the existing folder. This is the default update mode: new files are added,
     /// unmentioned local files remain in place, and existing files are preserved unless <c>-Force</c> is used.
     /// </summary>
-    Merge,
+    Merge = 0,
     /// <summary>
     /// Refresh package-owned files without deleting local files that are not present in the package. Existing
     /// package files are overwritten, while unmentioned local files remain in place.
     /// </summary>
-    Refresh,
+    Refresh = 4,
     /// <summary>
     /// Delete the destination folder before copying a fresh documentation set. Use <c>-Force</c> when read-only
     /// files may need to be cleared before the delete.
     /// </summary>
-    Overwrite,
+    Overwrite = 1,
     /// <summary>
     /// Do nothing when the destination exists and return the resolved destination path.
     /// </summary>
-    Skip,
+    Skip = 2,
     /// <summary>
     /// Throw an error when the destination exists.
     /// </summary>
-    Stop
+    Stop = 3
 }

--- a/PowerForge/Enums/ModuleDocumentation/OnExistsOption.cs
+++ b/PowerForge/Enums/ModuleDocumentation/OnExistsOption.cs
@@ -11,6 +11,11 @@ public enum OnExistsOption
     /// </summary>
     Merge,
     /// <summary>
+    /// Refresh package-owned files without deleting local files that are not present in the package. Existing
+    /// package files are overwritten, while unmentioned local files remain in place.
+    /// </summary>
+    Refresh,
+    /// <summary>
     /// Delete the destination folder before copying a fresh documentation set. Use <c>-Force</c> when read-only
     /// files may need to be cleared before the delete.
     /// </summary>

--- a/PowerForge/Models/Configuration/ConfigurationOptionsSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationOptionsSegment.cs
@@ -125,7 +125,19 @@ public sealed class DeliveryOptionsConfiguration
     public string[]? DocumentationOrder { get; set; }
 
     /// <summary>
-    /// Optional wildcard patterns (relative to Internals) that should be preserved during merge installs.
+    /// Optional wildcard patterns (relative to <see cref="InternalsPath"/>) that define which package files generated delivery helpers manage.
+    /// Defaults to all package files when omitted.
+    /// </summary>
+    public string[]? IncludePaths { get; set; }
+
+    /// <summary>
+    /// Optional wildcard patterns (relative to <see cref="InternalsPath"/>) that generated delivery helpers should not copy or refresh.
+    /// Exclusions win over <see cref="IncludePaths"/>.
+    /// </summary>
+    public string[]? ExcludePaths { get; set; }
+
+    /// <summary>
+    /// Optional wildcard patterns (relative to Internals) that should be preserved during merge or refresh installs.
     /// Example: <c>Config/**</c>.
     /// </summary>
     public string[]? PreservePaths { get; set; }
@@ -143,7 +155,7 @@ public sealed class DeliveryOptionsConfiguration
     public bool GenerateInstallCommand { get; set; }
 
     /// <summary>
-    /// When true, generates a public <c>Update-&lt;ModuleName&gt;</c> helper function during build that delegates to the install command.
+    /// When true, generates a public <c>Update-&lt;ModuleName&gt;</c> helper function during build that delegates to the install command in refresh mode by default.
     /// </summary>
     public bool GenerateUpdateCommand { get; set; }
 

--- a/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
@@ -6,7 +6,8 @@
     .DESCRIPTION
     Copies files from the module's '{{InternalsPath}}' folder into a destination path.
     By default, existing files are preserved (OnExists=Merge) so local configuration is not overwritten.
-    You can define default merge behavior for relative paths using PreservePaths/OverwritePaths.
+    Use OnExists=Refresh to overwrite package files while keeping local files that are not part of the package.
+    Use IncludePaths/ExcludePaths to define which package files are managed, then define collision behavior using PreservePaths/OverwritePaths.
     Optional bootstrap parameters can install/import a selected module version before extraction.
 
     .PARAMETER Path
@@ -15,6 +16,7 @@
     .PARAMETER OnExists
     What to do when the destination folder already exists:
     - Merge (default): keep existing files; copy only missing files (use -Force to overwrite files)
+    - Refresh: overwrite package files, but keep destination files that are not part of the package
     - Overwrite: delete the destination folder and recreate it
     - Skip: do nothing
     - Stop: emit an error and stop processing
@@ -28,8 +30,15 @@
     .PARAMETER Unblock
     On Windows, removes Zone.Identifier (best effort) from copied files.
 
+    .PARAMETER IncludePaths
+    Optional wildcard patterns (relative to Internals) that define which package files are managed, for example: Config/*.sample.json, Scripts/*.ps1.
+    Defaults to all package files.
+
+    .PARAMETER ExcludePaths
+    Optional wildcard patterns (relative to Internals) to skip. Exclusions win over IncludePaths, for example: Config/local/**.
+
     .PARAMETER PreservePaths
-    Optional wildcard patterns (relative to Internals) to preserve during merge, for example: Config/**.
+    Optional wildcard patterns (relative to Internals) to preserve during merge or refresh, for example: Config/**.
 
     .PARAMETER OverwritePaths
     Optional wildcard patterns (relative to Internals) to overwrite during merge, for example: Artefacts/**.
@@ -64,13 +73,15 @@
         [ValidateNotNullOrEmpty()]
         [string] $Path,
 
-        [ValidateSet('Merge', 'Overwrite', 'Skip', 'Stop')]
+        [ValidateSet('Merge', 'Refresh', 'Overwrite', 'Skip', 'Stop')]
         [string] $OnExists = 'Merge',
 
         [switch] $Force,
         [switch] $ListOnly,
         [switch] $Unblock,
 
+        [string[]] $IncludePaths = {{IncludePathsArray}},
+        [string[]] $ExcludePaths = {{ExcludePathsArray}},
         [string[]] $PreservePaths = {{PreservePathsArray}},
         [string[]] $OverwritePaths = {{OverwritePathsArray}},
 
@@ -158,6 +169,26 @@
         return $false
     }
 
+    function Test-DeliveryPathIncluded {
+        [CmdletBinding()]
+        param(
+            [string] $RelativePath
+        )
+
+        if ([string]::IsNullOrWhiteSpace($RelativePath)) { return $false }
+
+        $hasInclude = $IncludePaths -and $IncludePaths.Count -gt 0
+        if ($hasInclude -and -not (Test-DeliveryPathMatch -RelativePath $RelativePath -Patterns $IncludePaths)) {
+            return $false
+        }
+
+        if (Test-DeliveryPathMatch -RelativePath $RelativePath -Patterns $ExcludePaths) {
+            return $false
+        }
+
+        return $true
+    }
+
     function Get-DeliveryAction {
         [CmdletBinding()]
         param(
@@ -166,6 +197,12 @@
         )
 
         if (-not $TargetExists) { return 'Copy' }
+
+        if ($OnExists -eq 'Refresh') {
+            if (Test-DeliveryPathMatch -RelativePath $RelativePath -Patterns $PreservePaths) { return 'Keep' }
+            return 'Overwrite'
+        }
+
         if ($Force) { return 'Overwrite' }
 
         if ($OnExists -eq 'Merge') {
@@ -345,7 +382,12 @@
 
     New-Item -ItemType Directory -Force -Path $dest | Out-Null
 
-    $files = [System.IO.Directory]::GetFiles($internalsRoot, '*', [System.IO.SearchOption]::AllDirectories)
+    $allFiles = [System.IO.Directory]::GetFiles($internalsRoot, '*', [System.IO.SearchOption]::AllDirectories)
+    $files = foreach ($file in $allFiles) {
+        $rel = $file.Substring($internalsRoot.Length).TrimStart('\','/')
+        if (Test-DeliveryPathIncluded -RelativePath $rel) { $file }
+    }
+
     if ($ListOnly) {
         foreach ($file in $files) {
             $rel = $file.Substring($internalsRoot.Length).TrimStart('\','/')
@@ -364,6 +406,12 @@
     Write-Host "  Destination : $dest" -ForegroundColor DarkGray
     Write-Host "  Mode        : $OnExists" -ForegroundColor DarkGray
     Write-Host "  File count  : $($files.Count)" -ForegroundColor DarkGray
+    if ($IncludePaths.Count -gt 0) {
+        Write-Host "  Include     : $($IncludePaths -join ', ')" -ForegroundColor DarkGray
+    }
+    if ($ExcludePaths.Count -gt 0) {
+        Write-Host "  Exclude     : $($ExcludePaths -join ', ')" -ForegroundColor DarkGray
+    }
     if ($PreservePaths.Count -gt 0) {
         Write-Host "  Preserve    : $($PreservePaths -join ', ')" -ForegroundColor DarkGray
     }
@@ -421,7 +469,7 @@
         try {
             Get-ChildItem -LiteralPath $moduleBase -Filter 'README*' -File -ErrorAction SilentlyContinue | ForEach-Object {
                 $target = [System.IO.Path]::Combine($dest, $_.Name)
-                if ((Test-Path -LiteralPath $target) -and (-not $Force)) {
+                if ((Test-Path -LiteralPath $target) -and (-not $Force) -and ($OnExists -ne 'Refresh')) {
                     $keptCount++
                     Write-Host "  [keep] $($_.Name) -> $target" -ForegroundColor DarkYellow
                     return
@@ -442,7 +490,7 @@
         try {
             Get-ChildItem -LiteralPath $moduleBase -Filter 'CHANGELOG*' -File -ErrorAction SilentlyContinue | ForEach-Object {
                 $target = [System.IO.Path]::Combine($dest, $_.Name)
-                if ((Test-Path -LiteralPath $target) -and (-not $Force)) {
+                if ((Test-Path -LiteralPath $target) -and (-not $Force) -and ($OnExists -ne 'Refresh')) {
                     $keptCount++
                     Write-Host "  [keep] $($_.Name) -> $target" -ForegroundColor DarkYellow
                     return
@@ -464,7 +512,7 @@
             $lic = Get-ChildItem -LiteralPath $moduleBase -Filter 'LICENSE*' -File -ErrorAction SilentlyContinue | Select-Object -First 1
             if ($lic) {
                 $target = [System.IO.Path]::Combine($dest, 'license.txt')
-                if (-not ((Test-Path -LiteralPath $target) -and (-not $Force))) {
+                if (-not ((Test-Path -LiteralPath $target) -and (-not $Force) -and ($OnExists -ne 'Refresh'))) {
                     $exists = Test-Path -LiteralPath $target
                     Copy-Item -LiteralPath $lic.FullName -Destination $target -Force
                     $extraCopiedCount++

--- a/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
@@ -157,7 +157,7 @@
             if ([string]::IsNullOrWhiteSpace($pattern)) { continue }
             if ($pattern.EndsWith('/')) { $pattern = "$pattern**" }
 
-            if ($pattern.IndexOf('*') -lt 0 -and $pattern.IndexOf('?') -lt 0) {
+            if ($pattern.IndexOf('*') -lt 0 -and $pattern.IndexOf('?') -lt 0 -and $pattern.IndexOf('[') -lt 0) {
                 if ($normalizedPath.StartsWith("$pattern/", [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
                 if ([string]::Equals($normalizedPath, $pattern, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
                 continue

--- a/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
@@ -201,6 +201,15 @@
                 continue
             }
 
+            if ($char -eq '[') {
+                $end = $Pattern.IndexOf(']', $i + 1)
+                if ($end -gt $i) {
+                    [void] $builder.Append($Pattern.Substring($i, $end - $i + 1))
+                    $i = $end
+                    continue
+                }
+            }
+
             [void] $builder.Append([System.Text.RegularExpressions.Regex]::Escape([string] $char))
         }
 

--- a/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
@@ -155,18 +155,52 @@
 
             $pattern = $raw.Trim().Replace('\', '/')
             if ([string]::IsNullOrWhiteSpace($pattern)) { continue }
-            if ($pattern.EndsWith('/')) { $pattern = "$pattern*" }
-            $pattern = $pattern.Replace('**', '*')
-
-            if ($normalizedPath -like $pattern) { return $true }
+            if ($pattern.EndsWith('/')) { $pattern = "$pattern**" }
 
             if ($pattern.IndexOf('*') -lt 0 -and $pattern.IndexOf('?') -lt 0) {
                 if ($normalizedPath.StartsWith("$pattern/", [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
                 if ([string]::Equals($normalizedPath, $pattern, [System.StringComparison]::OrdinalIgnoreCase)) { return $true }
+                continue
             }
+
+            $regex = Convert-DeliveryWildcardToRegex -Pattern $pattern
+            if ([System.Text.RegularExpressions.Regex]::IsMatch($normalizedPath, $regex, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)) { return $true }
         }
 
         return $false
+    }
+
+    function Convert-DeliveryWildcardToRegex {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory)]
+            [string] $Pattern
+        )
+
+        $builder = [System.Text.StringBuilder]::new()
+        [void] $builder.Append('^')
+        for ($i = 0; $i -lt $Pattern.Length; $i++) {
+            $char = $Pattern[$i]
+            if ($char -eq '*') {
+                if (($i + 1) -lt $Pattern.Length -and $Pattern[$i + 1] -eq '*') {
+                    [void] $builder.Append('.*')
+                    $i++
+                } else {
+                    [void] $builder.Append('[^/]*')
+                }
+                continue
+            }
+
+            if ($char -eq '?') {
+                [void] $builder.Append('[^/]')
+                continue
+            }
+
+            [void] $builder.Append([System.Text.RegularExpressions.Regex]::Escape([string] $char))
+        }
+
+        [void] $builder.Append('$')
+        return $builder.ToString()
     }
 
     function Test-DeliveryPathIncluded {

--- a/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Install-Delivery.Template.ps1
@@ -183,8 +183,13 @@
             $char = $Pattern[$i]
             if ($char -eq '*') {
                 if (($i + 1) -lt $Pattern.Length -and $Pattern[$i + 1] -eq '*') {
-                    [void] $builder.Append('.*')
-                    $i++
+                    if (($i + 2) -lt $Pattern.Length -and $Pattern[$i + 2] -eq '/') {
+                        [void] $builder.Append('(?:.*/)?')
+                        $i += 2
+                    } else {
+                        [void] $builder.Append('.*')
+                        $i++
+                    }
                 } else {
                     [void] $builder.Append('[^/]*')
                 }

--- a/PowerForge/Scripts/DeliveryCommands/Update-Delivery.Template.ps1
+++ b/PowerForge/Scripts/DeliveryCommands/Update-Delivery.Template.ps1
@@ -4,10 +4,25 @@
     Updates bundled module artefacts in a folder.
 
     .DESCRIPTION
-    Delegates to {{InstallCommandName}}. Re-running the install command is typically enough to update new files while keeping existing configuration.
+    Delegates to {{InstallCommandName}} in Refresh mode by default. Refresh overwrites package files while keeping destination files that are not part of the package.
+
+    .PARAMETER OnExists
+    What to do when the destination folder already exists:
+    - Merge: keep existing files; copy only missing files
+    - Refresh (default): overwrite package files, but keep destination files that are not part of the package
+    - Overwrite: delete the destination folder and recreate it
+    - Skip: do nothing
+    - Stop: emit an error and stop processing
 
     .PARAMETER PreservePaths
-    Optional wildcard patterns (relative to Internals) to preserve during merge, for example: Config/**.
+    Optional wildcard patterns (relative to Internals) to preserve during merge or refresh, for example: Config/**.
+
+    .PARAMETER IncludePaths
+    Optional wildcard patterns (relative to Internals) that define which package files are managed, for example: Config/*.sample.json, Scripts/*.ps1.
+    Defaults to the generated install helper configuration.
+
+    .PARAMETER ExcludePaths
+    Optional wildcard patterns (relative to Internals) to skip. Exclusions win over IncludePaths, for example: Config/local/**.
 
     .PARAMETER OverwritePaths
     Optional wildcard patterns (relative to Internals) to overwrite during merge, for example: Artefacts/**.
@@ -24,13 +39,15 @@
         [ValidateNotNullOrEmpty()]
         [string] $Path,
 
-        [ValidateSet('Merge', 'Overwrite', 'Skip', 'Stop')]
-        [string] $OnExists = 'Merge',
+        [ValidateSet('Merge', 'Refresh', 'Overwrite', 'Skip', 'Stop')]
+        [string] $OnExists = 'Refresh',
 
         [switch] $Force,
         [switch] $ListOnly,
         [switch] $Unblock,
 
+        [string[]] $IncludePaths,
+        [string[]] $ExcludePaths,
         [string[]] $PreservePaths,
         [string[]] $OverwritePaths,
 
@@ -57,5 +74,13 @@
     Write-Host "  Destination : $Path" -ForegroundColor DarkGray
     Write-Host "  Mode        : $OnExists" -ForegroundColor DarkGray
 
-    {{InstallCommandName}} @PSBoundParameters
+    $forward = @{}
+    foreach ($entry in $PSBoundParameters.GetEnumerator()) {
+        $forward[$entry.Key] = $entry.Value
+    }
+    if (-not $forward.ContainsKey('OnExists')) {
+        $forward['OnExists'] = $OnExists
+    }
+
+    {{InstallCommandName}} @forward
 }

--- a/PowerForge/Services/DeliveryCommandGenerator.cs
+++ b/PowerForge/Services/DeliveryCommandGenerator.cs
@@ -56,6 +56,10 @@ public sealed class DeliveryCommandGenerator
             {
                 _logger.Warn($"Delivery update command '{updateName}' matches install command; skipping update command generation.");
             }
+            else if (ExistingInstallCommandRejectsRefresh(publicFolder, installName))
+            {
+                _logger.Warn($"Delivery update command '{updateName}' was not generated because existing install command '{installName}' does not support OnExists=Refresh.");
+            }
             else
             {
                 output.AddRange(TryWriteUpdate(publicFolder, updateName, installName, moduleName));
@@ -112,6 +116,16 @@ public sealed class DeliveryCommandGenerator
 
     private static string EscapeSingleQuotes(string value)
         => (value ?? string.Empty).Replace("'", "''");
+
+    private static bool ExistingInstallCommandRejectsRefresh(string publicFolder, string installCommandName)
+    {
+        var scriptPath = Path.Combine(publicFolder, installCommandName + ".ps1");
+        if (!File.Exists(scriptPath))
+            return false;
+
+        var content = File.ReadAllText(scriptPath);
+        return content.IndexOf("Refresh", StringComparison.OrdinalIgnoreCase) < 0;
+    }
 
     private static string BuildInstallScript(
         string commandName,

--- a/PowerForge/Services/DeliveryCommandGenerator.cs
+++ b/PowerForge/Services/DeliveryCommandGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace PowerForge;
 
@@ -124,8 +125,25 @@ public sealed class DeliveryCommandGenerator
             return false;
 
         var content = File.ReadAllText(scriptPath);
-        return content.IndexOf("Refresh", StringComparison.OrdinalIgnoreCase) < 0;
+        var validateSets = Regex.Matches(content, @"\[ValidateSet\s*\((?<values>[^)]*)\)\]", RegexOptions.IgnoreCase);
+        foreach (Match validateSet in validateSets)
+        {
+            var values = validateSet.Groups["values"].Value;
+            var hasOnExistsValues =
+                ContainsQuotedToken(values, "Merge") &&
+                ContainsQuotedToken(values, "Overwrite") &&
+                ContainsQuotedToken(values, "Skip") &&
+                ContainsQuotedToken(values, "Stop");
+
+            if (hasOnExistsValues)
+                return !ContainsQuotedToken(values, "Refresh");
+        }
+
+        return false;
     }
+
+    private static bool ContainsQuotedToken(string value, string token)
+        => Regex.IsMatch(value, $@"(?<!\w)['""]{Regex.Escape(token)}['""](?!\w)", RegexOptions.IgnoreCase);
 
     private static string BuildInstallScript(
         string commandName,

--- a/PowerForge/Services/DeliveryCommandGenerator.cs
+++ b/PowerForge/Services/DeliveryCommandGenerator.cs
@@ -122,6 +122,8 @@ public sealed class DeliveryCommandGenerator
         var includeRootReadme = delivery.IncludeRootReadme ? "$true" : "$false";
         var includeRootChangelog = delivery.IncludeRootChangelog ? "$true" : "$false";
         var includeRootLicense = delivery.IncludeRootLicense ? "$true" : "$false";
+        var includePaths = BuildPowerShellStringArrayLiteral(delivery.IncludePaths);
+        var excludePaths = BuildPowerShellStringArrayLiteral(delivery.ExcludePaths);
         var preservePaths = BuildPowerShellStringArrayLiteral(delivery.PreservePaths);
         var overwritePaths = BuildPowerShellStringArrayLiteral(delivery.OverwritePaths);
 
@@ -137,6 +139,8 @@ public sealed class DeliveryCommandGenerator
             ["IncludeRootReadme"] = includeRootReadme,
             ["IncludeRootChangelog"] = includeRootChangelog,
             ["IncludeRootLicense"] = includeRootLicense,
+            ["IncludePathsArray"] = includePaths,
+            ["ExcludePathsArray"] = excludePaths,
             ["PreservePathsArray"] = preservePaths,
             ["OverwritePathsArray"] = overwritePaths
         };

--- a/PowerForge/Services/EmbeddedModuleDependencyService.cs
+++ b/PowerForge/Services/EmbeddedModuleDependencyService.cs
@@ -678,7 +678,27 @@ internal sealed class EmbeddedModuleDependencyService
             if (!overwriteFiles && File.Exists(target))
                 continue;
 
+            if (overwriteFiles)
+                TryClearReadOnlyAttribute(target);
+
             File.Copy(file, target, overwrite: overwriteFiles);
+        }
+    }
+
+    private static void TryClearReadOnlyAttribute(string path)
+    {
+        if (!File.Exists(path))
+            return;
+
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                File.SetAttributes(path, attributes & ~FileAttributes.ReadOnly);
+        }
+        catch
+        {
+            // Best effort. File.Copy will surface any remaining access error with the original path.
         }
     }
 

--- a/PowerForge/Services/EmbeddedModuleDependencyService.cs
+++ b/PowerForge/Services/EmbeddedModuleDependencyService.cs
@@ -156,6 +156,11 @@ internal sealed class EmbeddedModuleDependencyService
                         MergeDirectory(rootModuleBasePath!, destinationPath, overwriteFiles: force);
                         results.Add(CreateInstallResult(rootModule, rootModuleBasePath!, destinationPath, action, receiptPath, "RootModule"));
                     }
+                    else if (onExists == OnExistsOption.Refresh)
+                    {
+                        MergeDirectory(rootModuleBasePath!, destinationPath, overwriteFiles: true);
+                        results.Add(CreateInstallResult(rootModule, rootModuleBasePath!, destinationPath, action, receiptPath, "RootModule"));
+                    }
                     else
                     {
                         CopyDirectory(rootModuleBasePath!, destinationPath, overwrite: true);
@@ -195,6 +200,12 @@ internal sealed class EmbeddedModuleDependencyService
                     if (onExists == OnExistsOption.Merge)
                     {
                         MergeDirectory(sourcePath, destinationPath, overwriteFiles: force);
+                        results.Add(CreateInstallResult(entry, sourcePath, destinationPath, action, receiptPath, "Dependency"));
+                        continue;
+                    }
+                    if (onExists == OnExistsOption.Refresh)
+                    {
+                        MergeDirectory(sourcePath, destinationPath, overwriteFiles: true);
                         results.Add(CreateInstallResult(entry, sourcePath, destinationPath, action, receiptPath, "Dependency"));
                         continue;
                     }
@@ -610,6 +621,7 @@ internal sealed class EmbeddedModuleDependencyService
         if (!exists) return "Copy";
         return onExists switch
         {
+            OnExistsOption.Refresh => "Refresh",
             OnExistsOption.Overwrite => "Overwrite",
             OnExistsOption.Merge => force ? "MergeOverwrite" : "Merge",
             OnExistsOption.Skip => "Skip",

--- a/PowerForge/Services/ModuleDocumentation/DocumentationInstaller.cs
+++ b/PowerForge/Services/ModuleDocumentation/DocumentationInstaller.cs
@@ -68,6 +68,7 @@ internal sealed class DocumentationInstaller
                     PrepareDirectoryDeleteTarget(dest, force);
                     Directory.Delete(dest, true);
                     break;
+                case OnExistsOption.Refresh:
                 case OnExistsOption.Merge:
                     // keep existing, merge below
                     break;
@@ -77,7 +78,7 @@ internal sealed class DocumentationInstaller
         PathHelper.EnsureDirectory(dest);
         if (internals != null)
         {
-            CopyTree(internals, dest, overwrite: force);
+            CopyTree(internals, dest, overwrite: force || onExists == OnExistsOption.Refresh);
         }
         else
         {
@@ -85,16 +86,16 @@ internal sealed class DocumentationInstaller
         }
 
         // Copy selected root files
-        TryCopyIfMatch(root, "README*", dest, force);
-        TryCopyIfMatch(root, "CHANGELOG*", dest, force);
+        TryCopyIfMatch(root, "README*", dest, force, onExists == OnExistsOption.Refresh);
+        TryCopyIfMatch(root, "CHANGELOG*", dest, force, onExists == OnExistsOption.Refresh);
         // Normalize license name if present
         var lic = new DirectoryInfo(root).GetFiles("LICENSE*").FirstOrDefault();
         if (lic != null)
         {
             var licTarget = Path.Combine(dest, "license.txt");
-            if (!(File.Exists(licTarget) && !force))
+            if (!(File.Exists(licTarget) && !force && onExists != OnExistsOption.Refresh))
             {
-                PrepareOverwriteTarget(licTarget, force);
+                PrepareOverwriteTarget(licTarget, force || onExists == OnExistsOption.Refresh);
                 lic.CopyTo(licTarget, overwrite: true);
             }
         }
@@ -176,14 +177,14 @@ internal sealed class DocumentationInstaller
         }
     }
 
-    private static void TryCopyIfMatch(string root, string pattern, string dest, bool force)
+    private static void TryCopyIfMatch(string root, string pattern, string dest, bool force, bool refresh)
     {
         var di = new DirectoryInfo(root);
         foreach (var f in di.GetFiles(pattern))
         {
             var target = Path.Combine(dest, f.Name);
-            if (File.Exists(target) && !force) continue; // keep existing unless -Force
-            PrepareOverwriteTarget(target, force);
+            if (File.Exists(target) && !force && !refresh) continue; // keep existing unless -Force or refresh
+            PrepareOverwriteTarget(target, force || refresh);
             f.CopyTo(target, overwrite: true);
         }
     }

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -357,6 +357,8 @@
         "RepositoryPaths": { "type": ["array", "null"], "items": { "type": "string" } },
         "RepositoryBranch": { "type": ["string", "null"] },
         "DocumentationOrder": { "type": ["array", "null"], "items": { "type": "string" } },
+        "IncludePaths": { "type": ["array", "null"], "items": { "type": "string" } },
+        "ExcludePaths": { "type": ["array", "null"], "items": { "type": "string" } },
         "PreservePaths": { "type": ["array", "null"], "items": { "type": "string" } },
         "OverwritePaths": { "type": ["array", "null"], "items": { "type": "string" } },
         "GenerateInstallCommand": { "type": "boolean" },


### PR DESCRIPTION
## Summary
- Add `Refresh` delivery behavior so update helpers overwrite package-owned files while preserving destination-only local files.
- Add `IncludePaths` and `ExcludePaths` to scope which bundled Internals files generated delivery helpers manage.
- Update generated install/update helper templates, module documentation/help, and regression coverage for refresh/path-scoping behavior.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~EmbeddedModuleDependencyServiceTests|FullyQualifiedName~DeliveryCommandGeneratorTests|FullyQualifiedName~DeliveryConfigurationFactoryTests|FullyQualifiedName~ModuleDocumentationReviewRegressionTests" --logger "console;verbosity=minimal"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --logger "console;verbosity=minimal"`
- `dotnet build .\PowerForge.Cli\PowerForge.Cli.csproj -c Release -f net8.0 --nologo --verbosity minimal`
- `.\Build\Build-Module.ps1 -NoBuild -Configuration Release`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

## Notes
- Module build reports existing local binary-conflict advisories and the pre-existing mixed line-ending warning for `PSPublishModule.Tests.ps1`.