### PR TITLE
fix(PublishConfigurationFactory): 🛠️ enforce single-line secrets for …

### DIFF
--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -23,9 +23,9 @@ internal sealed class PublishConfigurationFactory
 
         var apiKeyToUse = request.ParameterSetName switch
         {
-            "ApiFromFile" => File.ReadAllText(request.FilePath).Trim(),
+            "ApiFromFile" => ReadSingleLineSecretFile(request.FilePath, nameof(request.FilePath)),
             "AzureArtifacts" => AzureArtifactsApiKeyPlaceholder,
-            "JFrog" when !string.IsNullOrWhiteSpace(request.FilePath) => File.ReadAllText(request.FilePath).Trim(),
+            "JFrog" when !string.IsNullOrWhiteSpace(request.FilePath) => ReadSingleLineSecretFile(request.FilePath, nameof(request.FilePath)),
             _ => request.ApiKey
         };
 
@@ -241,15 +241,39 @@ internal sealed class PublishConfigurationFactory
         string? secretEnvironmentVariable)
     {
         if (secretFileSpecified && !string.IsNullOrWhiteSpace(secretFilePath))
-            return File.ReadAllText(secretFilePath!.Trim()).Trim();
+            return ReadSingleLineSecretFile(secretFilePath!, nameof(PublishConfigurationRequest.RepositoryCredentialSecretFilePath));
 
         if (secretEnvironmentVariableSpecified && !string.IsNullOrWhiteSpace(secretEnvironmentVariable))
-            return Environment.GetEnvironmentVariable(secretEnvironmentVariable!.Trim())?.Trim() ?? string.Empty;
+            return ValidateSingleLineSecret(
+                Environment.GetEnvironmentVariable(secretEnvironmentVariable!.Trim())?.Trim() ?? string.Empty,
+                nameof(PublishConfigurationRequest.RepositoryCredentialSecretEnvironmentVariable));
 
         if (secretSpecified && !string.IsNullOrWhiteSpace(secret))
-            return secret!.Trim();
+            return ValidateSingleLineSecret(secret!.Trim(), nameof(PublishConfigurationRequest.RepositoryCredentialSecret));
 
         return string.Empty;
+    }
+
+    private static string ReadSingleLineSecretFile(string filePath, string parameterName)
+    {
+        var path = filePath.Trim();
+        var value = File.ReadAllText(path).Trim();
+        return ValidateSingleLineSecret(value, parameterName, path);
+    }
+
+    private static string ValidateSingleLineSecret(string value, string parameterName, string? path = null)
+    {
+        if (value.Contains('\r') || value.Contains('\n'))
+        {
+            var location = string.IsNullOrWhiteSpace(path)
+                ? parameterName
+                : $"{parameterName} '{path}'";
+            throw new ArgumentException(
+                $"{location} resolved to a multi-line secret. Publish API keys and repository credential secrets must be a single line; check that the path points to a secret file, not a script or configuration file.",
+                parameterName);
+        }
+
+        return value;
     }
 
     private static string? ResolveJfrogPlatformUri(string? explicitPlatformUri, string? jfrogBaseUri)

--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -26,7 +26,7 @@ internal sealed class PublishConfigurationFactory
             "ApiFromFile" => ReadSingleLineSecretFile(request.FilePath, nameof(request.FilePath)),
             "AzureArtifacts" => AzureArtifactsApiKeyPlaceholder,
             "JFrog" when !string.IsNullOrWhiteSpace(request.FilePath) => ReadSingleLineSecretFile(request.FilePath, nameof(request.FilePath)),
-            _ => request.ApiKey
+            _ => ValidateSingleLineSecret(request.ApiKey, nameof(PublishConfigurationRequest.ApiKey))
         };
 
         if (destination == PublishDestination.GitHub && string.IsNullOrWhiteSpace(request.UserName))

--- a/PowerForge.Tests/PublishConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/PublishConfigurationFactoryTests.cs
@@ -60,6 +60,25 @@ public sealed class PublishConfigurationFactoryTests
         }
     }
 
+    [Theory]
+    [InlineData("ApiKey")]
+    [InlineData("JFrog")]
+    public void Create_rejects_multiline_inline_publish_api_key(string parameterSetName)
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = parameterSetName,
+            Type = PublishDestination.PowerShellGallery,
+            ApiKey = "line-one" + Environment.NewLine + "line-two",
+            Enabled = true
+        }));
+
+        Assert.Contains("multi-line secret", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("single line", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void Create_rejects_multiline_repository_credential_secret_file()
     {

--- a/PowerForge.Tests/PublishConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/PublishConfigurationFactoryTests.cs
@@ -8,7 +8,7 @@ public sealed class PublishConfigurationFactoryTests
     public void Create_reads_publish_api_key_from_file()
     {
         var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
-        File.WriteAllText(path, " api-key ");
+        File.WriteAllText(path, " api-key " + Environment.NewLine);
         try
         {
             var factory = new PublishConfigurationFactory();
@@ -24,6 +24,67 @@ public sealed class PublishConfigurationFactoryTests
             Assert.Equal("api-key", segment.Configuration.ApiKey);
             Assert.Equal(PublishDestination.PowerShellGallery, segment.Configuration.Destination);
             Assert.True(segment.Configuration.Enabled);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Create_rejects_multiline_publish_api_key_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".ps1");
+        File.WriteAllText(path, "Write-Host 'not a key'" + Environment.NewLine + "Write-Host 'still not a key'");
+        try
+        {
+            var factory = new PublishConfigurationFactory();
+
+            var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+            {
+                ParameterSetName = "ApiFromFile",
+                Type = PublishDestination.PowerShellGallery,
+                FilePath = path,
+                Enabled = true
+            }));
+
+            Assert.Contains("multi-line secret", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("single line", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("not a script", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Create_rejects_multiline_repository_credential_secret_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "line-one" + Environment.NewLine + "line-two");
+        try
+        {
+            var factory = new PublishConfigurationFactory();
+
+            var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+            {
+                ParameterSetName = "JFrog",
+                Type = PublishDestination.PowerShellGallery,
+                RepositoryName = "JFrogPS",
+                Tool = PublishTool.PSResourceGet,
+                JFrogBaseUri = "https://company.jfrog.io/artifactory",
+                JFrogRepository = "powershell-virtual",
+                RepositoryCredentialUserName = "name@company.com",
+                RepositoryCredentialSecretFilePath = path,
+                RepositoryCredentialSecretFilePathSpecified = true,
+                Enabled = true
+            }));
+
+            Assert.Contains("multi-line secret", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("single line", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {


### PR DESCRIPTION
…API keys

* Updated methods to read secrets from files to ensure they are single-line.
* Added validation to reject multi-line secrets with descriptive error messages.
* Enhanced tests to cover scenarios for multi-line secret rejection.