### PR TITLE
Add shared GitHub Packages project build feed support

### DIFF
--- a/Docs/PSPublishModule.GitHubPackages.md
+++ b/Docs/PSPublishModule.GitHubPackages.md
@@ -45,6 +45,35 @@ Publish-NugetPackage -Path .\Artifacts\Packages -ProfileName LicensingGitHub -Sk
 `Publish-NugetPackage` uses the supplied `-ApiKey` when provided. For
 GitHub Packages profiles, it can also use `GITHUB_TOKEN` or `GH_TOKEN`.
 
+## Project Build Publish
+
+For repository project builds, prefer config over repo-local authentication
+helpers. `UseGitHubPackages` resolves both version lookup and package publish
+to the organization feed:
+
+```json
+{
+  "RootPath": "..",
+  "IncludeProjects": [ "ComputerX", "ADPlayground.Monitoring" ],
+  "UseGitHubPackages": true,
+  "GitHubPackagesOwner": "EvotecIT",
+  "GitHubAccessTokenEnvName": "GITHUB_TOKEN",
+  "Build": true,
+  "PublishNuget": true
+}
+```
+
+When `GitHubPackagesOwner` is omitted, PowerForge uses `GitHubUsername`. The
+resolved feed is `https://nuget.pkg.github.com/<owner>/index.json`. The GitHub
+token is reused as the `dotnet nuget push` API key unless a dedicated
+`PublishApiKey`, `PublishApiKeyFilePath`, or `PublishApiKeyEnvName` is supplied.
+
+This is the migration path for repositories such as TestimoX that currently
+carry repo-local GitHub Packages auth/test scripts. Keep the repo wrapper focused
+on invoking PowerForge, move feed ownership into `project.build.json`, and pass
+the token through the existing GitHub token or package-token environment
+variable.
+
 ## Consumer CI Restore
 
 Consumer repositories should add the GitHub Packages source before `dotnet

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -166,6 +166,12 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
     /// <summary>Whether release ZIPs should be created for package projects.</summary>
     [Parameter] public SwitchParameter CreateReleaseZip { get; set; }
 
+    /// <summary>Whether GitHub Packages should be used as the NuGet version lookup and publish feed.</summary>
+    [Parameter] public SwitchParameter UseGitHubPackages { get; set; }
+
+    /// <summary>GitHub user or organization that owns the GitHub Packages NuGet feed.</summary>
+    [Parameter] public string? GitHubPackagesOwner { get; set; }
+
     /// <summary>NuGet publish source.</summary>
     [Parameter] public string? PublishSource { get; set; }
 
@@ -286,6 +292,8 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
                 PublishNuget = BoundSwitch(nameof(PublishNuget), PublishNuget),
                 PublishGitHub = BoundSwitch(nameof(PublishGitHub), PublishGitHub),
                 CreateReleaseZip = BoundSwitch(nameof(CreateReleaseZip), CreateReleaseZip),
+                UseGitHubPackages = UseGitHubPackages.IsPresent,
+                GitHubPackagesOwner = Normalize(GitHubPackagesOwner),
                 PublishSource = Normalize(PublishSource),
                 PublishApiKey = PublishApiKey,
                 PublishApiKeyFilePath = Normalize(PublishApiKeyFilePath),

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -445,6 +445,8 @@ public sealed partial class ModulePipelineRunner
             PublishNuget = source.PublishNuget,
             PublishGitHub = source.PublishGitHub,
             CreateReleaseZip = source.CreateReleaseZip,
+            UseGitHubPackages = source.UseGitHubPackages,
+            GitHubPackagesOwner = source.GitHubPackagesOwner,
             PublishSource = source.PublishSource,
             PublishApiKey = source.PublishApiKey,
             PublishApiKeyFilePath = source.PublishApiKeyFilePath,

--- a/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
@@ -73,6 +73,8 @@ public sealed partial class ModulePipelinePackageBuildTests
                             Build = true,
                             PublishNuget = false,
                             PublishGitHub = false,
+                            UseGitHubPackages = true,
+                            GitHubPackagesOwner = "EvotecIT",
                             GitHubIncludeProjectNameInTag = false
                         }
                     }
@@ -97,6 +99,8 @@ public sealed partial class ModulePipelinePackageBuildTests
             Assert.True(calls[1].Request.Build);
             Assert.False(calls[1].Request.PublishNuget);
             Assert.False(calls[1].Request.PublishGitHub);
+            Assert.True(inlineConfiguration.UseGitHubPackages);
+            Assert.Equal("EvotecIT", inlineConfiguration.GitHubPackagesOwner);
             Assert.False(inlineConfiguration.GitHubIncludeProjectNameInTag);
 
             var projectPackageIndex = reporter.StartedKeys.IndexOf("package:project:01");

--- a/PowerForge.Tests/NuGetPackageVersionResolverTests.cs
+++ b/PowerForge.Tests/NuGetPackageVersionResolverTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed class NuGetPackageVersionResolverTests
+{
+    [Fact]
+    public void ResolveLatest_applies_source_scoped_credentials_only_to_matching_source()
+    {
+        var requests = new List<RecordedRequest>();
+        using var client = new HttpClient(new RecordingHandler(requests));
+        var resolver = new NuGetPackageVersionResolver(new NullLogger(), client);
+        var sources = new[]
+        {
+            "https://api.nuget.org/v3/index.json",
+            "https://nuget.pkg.github.com/EvotecIT/index.json"
+        };
+        var credentialsBySource = new Dictionary<string, RepositoryCredential>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["https://nuget.pkg.github.com/EvotecIT/index.json"] = new()
+            {
+                UserName = "EvotecIT",
+                Secret = "github-token"
+            }
+        };
+
+        var latest = resolver.ResolveLatest(
+            "Sample.Package",
+            sources,
+            credential: null,
+            credentialsBySource,
+            includePrerelease: false);
+
+        Assert.Equal(new Version(1, 0, 8), latest);
+        Assert.All(
+            requests.Where(request => string.Equals(request.Host, "api.nuget.org", StringComparison.OrdinalIgnoreCase)),
+            request => Assert.Null(request.Authorization));
+        var githubRequests = requests
+            .Where(request => string.Equals(request.Host, "nuget.pkg.github.com", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        Assert.NotEmpty(githubRequests);
+        Assert.All(githubRequests, request =>
+        {
+            Assert.NotNull(request.Authorization);
+            Assert.Equal("Basic", request.Authorization!.Scheme);
+            var decoded = Encoding.ASCII.GetString(Convert.FromBase64String(request.Authorization.Parameter!));
+            Assert.Equal("EvotecIT:github-token", decoded);
+        });
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly List<RecordedRequest> _requests;
+
+        public RecordingHandler(List<RecordedRequest> requests)
+        {
+            _requests = requests;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri ?? throw new InvalidOperationException("Request URI is required.");
+            _requests.Add(new RecordedRequest(uri.Host, uri.AbsoluteUri, request.Headers.Authorization));
+
+            var body = uri.AbsoluteUri switch
+            {
+                "https://api.nuget.org/v3/index.json" => CreateIndex("https://api.nuget.org/v3-flatcontainer/"),
+                "https://api.nuget.org/v3-flatcontainer/sample.package/index.json" => CreateVersions("1.0.2"),
+                "https://nuget.pkg.github.com/EvotecIT/index.json" => CreateIndex("https://nuget.pkg.github.com/EvotecIT/download/"),
+                "https://nuget.pkg.github.com/EvotecIT/download/sample.package/index.json" => CreateVersions("1.0.8"),
+                _ => null
+            };
+
+            if (body is null)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        }
+
+        private static string CreateIndex(string packageBaseAddress)
+            => "{\"resources\":[{\"@id\":\"" + packageBaseAddress + "\",\"@type\":\"PackageBaseAddress/3.0.0\"}]}";
+
+        private static string CreateVersions(string version)
+            => "{\"versions\":[\"" + version + "\"]}";
+    }
+
+    private sealed class RecordedRequest
+    {
+        public RecordedRequest(string host, string url, AuthenticationHeaderValue? authorization)
+        {
+            Host = host;
+            Url = url;
+            Authorization = authorization;
+        }
+
+        public string Host { get; }
+
+        public string Url { get; }
+
+        public AuthenticationHeaderValue? Authorization { get; }
+    }
+}

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -142,6 +142,8 @@ public sealed class PowerForgeProjectCmdletTests
             })
             .AddParameter("BuildBeforeModule")
             .AddParameter("PublishNuget", false)
+            .AddParameter("UseGitHubPackages")
+            .AddParameter("GitHubPackagesOwner", "EvotecIT")
             .AddParameter("GitHubIncludeProjectNameInTag", false);
 
         var results = ps.Invoke();
@@ -152,6 +154,8 @@ public sealed class PowerForgeProjectCmdletTests
         Assert.Equal("2.0.X", segment.Configuration.ExpectedVersionMap?["HtmlTinkerX"]);
         Assert.True(segment.Configuration.BuildBeforeModule);
         Assert.False(segment.Configuration.PublishNuget);
+        Assert.True(segment.Configuration.UseGitHubPackages);
+        Assert.Equal("EvotecIT", segment.Configuration.GitHubPackagesOwner);
         Assert.False(segment.Configuration.GitHubIncludeProjectNameInTag);
         Assert.NotNull(segment.Configuration.VersionTracks);
         var track = segment.Configuration.VersionTracks!["Core"];

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -118,6 +118,80 @@ public sealed class ProjectBuildPreparationServiceTests
         }
     }
 
+    [Fact]
+    public void Prepare_resolves_github_packages_feed_from_shared_settings()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-githubpackages-" + Guid.NewGuid().ToString("N")));
+        var gitHubEnv = "PF_TEST_GITHUB_PACKAGES_" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, "github-packages-token");
+
+            var service = new ProjectBuildPreparationService();
+            var config = new ProjectBuildConfiguration
+            {
+                UseGitHubPackages = true,
+                GitHubPackagesOwner = "EvotecIT",
+                GitHubAccessTokenEnvName = gitHubEnv,
+                PublishNuget = true
+            };
+
+            var context = service.Prepare(
+                config,
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions());
+
+            Assert.Equal("github-packages-token", context.PublishApiKey);
+            Assert.Equal("github-packages-token", context.GitHubToken);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", context.Spec.PublishSource);
+            Assert.Equal(new[] { "https://nuget.pkg.github.com/EvotecIT/index.json" }, context.Spec.VersionSources);
+            Assert.NotNull(context.Spec.VersionSourceCredential);
+            Assert.Equal("EvotecIT", context.Spec.VersionSourceCredential!.UserName);
+            Assert.Equal("github-packages-token", context.Spec.VersionSourceCredential.Secret);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, null);
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_uses_github_token_for_explicit_github_packages_publish_source()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-githubpackages-source-" + Guid.NewGuid().ToString("N")));
+        var gitHubEnv = "PF_TEST_GITHUB_PACKAGES_SOURCE_" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, "explicit-source-token");
+
+            var service = new ProjectBuildPreparationService();
+            var config = new ProjectBuildConfiguration
+            {
+                PublishSource = " https://nuget.pkg.github.com/EvotecIT/index.json ",
+                GitHubAccessTokenEnvName = gitHubEnv,
+                PublishNuget = true
+            };
+
+            var context = service.Prepare(
+                config,
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions());
+
+            Assert.Equal("explicit-source-token", context.PublishApiKey);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", context.Spec.PublishSource);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, null);
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
     [Theory]
     [InlineData(null, DotNetRepositoryPackStrategy.PerProject)]
     [InlineData("", DotNetRepositoryPackStrategy.PerProject)]

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -192,6 +192,94 @@ public sealed class ProjectBuildPreparationServiceTests
         }
     }
 
+    [Fact]
+    public void Prepare_derives_github_packages_owner_from_explicit_version_source()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-githubpackages-explicit-source-" + Guid.NewGuid().ToString("N")));
+        var gitHubEnv = "PF_TEST_GITHUB_PACKAGES_EXPLICIT_" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, "explicit-version-source-token");
+
+            var service = new ProjectBuildPreparationService();
+            var config = new ProjectBuildConfiguration
+            {
+                NugetSource = new[] { "https://nuget.pkg.github.com/EvotecIT/index.json" },
+                GitHubAccessTokenEnvName = gitHubEnv
+            };
+
+            var context = service.Prepare(
+                config,
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions());
+
+            Assert.NotNull(context.Spec.VersionSourceCredential);
+            Assert.Equal("EvotecIT", context.Spec.VersionSourceCredential!.UserName);
+            Assert.Equal("explicit-version-source-token", context.Spec.VersionSourceCredential.Secret);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, null);
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_does_not_apply_github_packages_token_to_mixed_version_sources()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-githubpackages-mixed-source-" + Guid.NewGuid().ToString("N")));
+        var gitHubEnv = "PF_TEST_GITHUB_PACKAGES_MIXED_" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, "mixed-version-source-token");
+
+            var service = new ProjectBuildPreparationService();
+            var config = new ProjectBuildConfiguration
+            {
+                NugetSource = new[]
+                {
+                    "https://nuget.pkg.github.com/EvotecIT/index.json",
+                    "https://api.nuget.org/v3/index.json"
+                },
+                GitHubAccessTokenEnvName = gitHubEnv
+            };
+
+            var context = service.Prepare(
+                config,
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions());
+
+            Assert.Null(context.Spec.VersionSourceCredential);
+            Assert.Equal(config.NugetSource, context.Spec.VersionSources);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, null);
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_rejects_github_packages_mode_without_owner()
+    {
+        var service = new ProjectBuildPreparationService();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Prepare(
+            new ProjectBuildConfiguration
+            {
+                UseGitHubPackages = true
+            },
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions()));
+
+        Assert.Contains("GitHubPackagesOwner", exception.Message, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(null, DotNetRepositoryPackStrategy.PerProject)]
     [InlineData("", DotNetRepositoryPackStrategy.PerProject)]
@@ -286,6 +374,43 @@ public sealed class ProjectBuildPreparationServiceTests
             Assert.Equal("1.0.5", context.Spec.ExpectedVersionsByProject!["PowerForge"]);
             Assert.Equal("1.0.5", context.Spec.ExpectedVersionsByProject["PowerForge.Cli"]);
             Assert.Equal("1.0.5", context.Spec.ExpectedVersionsByProject["PowerForge.Web.Cli"]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Version_tracks_use_resolved_default_sources()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-track-resolved-source-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var feed = root.CreateSubdirectory("feed");
+            File.WriteAllText(Path.Combine(feed.FullName, "PowerForge.1.0.4.nupkg"), string.Empty);
+
+            var config = new ProjectBuildConfiguration
+            {
+                ExpectedVersionMapAsInclude = true,
+                VersionTracks = new Dictionary<string, ProjectBuildVersionTrack>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["PowerForge"] = new()
+                    {
+                        ExpectedVersion = "1.0.X",
+                        AnchorProject = "PowerForge",
+                        Projects = new[] { "PowerForge.Cli" }
+                    }
+                }
+            };
+
+            var map = new ProjectBuildVersionTrackService(new NullLogger())
+                .ResolveExpectedVersionMap(config, new[] { feed.FullName }, credential: null);
+
+            Assert.NotNull(map);
+            Assert.Equal("1.0.5", map!["PowerForge"]);
+            Assert.Equal("1.0.5", map["PowerForge.Cli"]);
         }
         finally
         {

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -184,6 +184,10 @@ public sealed class ProjectBuildPreparationServiceTests
 
             Assert.Equal("explicit-source-token", context.PublishApiKey);
             Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", context.Spec.PublishSource);
+            var credential = Assert.Single(context.Spec.VersionSourceCredentials!);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", credential.Key);
+            Assert.Equal("EvotecIT", credential.Value.UserName);
+            Assert.Equal("explicit-source-token", credential.Value.Secret);
         }
         finally
         {
@@ -218,6 +222,10 @@ public sealed class ProjectBuildPreparationServiceTests
             Assert.NotNull(context.Spec.VersionSourceCredential);
             Assert.Equal("EvotecIT", context.Spec.VersionSourceCredential!.UserName);
             Assert.Equal("explicit-version-source-token", context.Spec.VersionSourceCredential.Secret);
+            var scopedCredential = Assert.Single(context.Spec.VersionSourceCredentials!);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", scopedCredential.Key);
+            Assert.Equal("EvotecIT", scopedCredential.Value.UserName);
+            Assert.Equal("explicit-version-source-token", scopedCredential.Value.Secret);
         }
         finally
         {
@@ -255,6 +263,53 @@ public sealed class ProjectBuildPreparationServiceTests
 
             Assert.Null(context.Spec.VersionSourceCredential);
             Assert.Equal(config.NugetSource, context.Spec.VersionSources);
+            var scopedCredential = Assert.Single(context.Spec.VersionSourceCredentials!);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", scopedCredential.Key);
+            Assert.Equal("EvotecIT", scopedCredential.Value.UserName);
+            Assert.Equal("mixed-version-source-token", scopedCredential.Value.Secret);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, null);
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_resolves_github_packages_credentials_from_version_track_sources()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-githubpackages-track-source-" + Guid.NewGuid().ToString("N")));
+        var gitHubEnv = "PF_TEST_GITHUB_PACKAGES_TRACK_" + Guid.NewGuid().ToString("N");
+
+        try
+        {
+            Environment.SetEnvironmentVariable(gitHubEnv, "track-source-token");
+
+            var service = new ProjectBuildPreparationService();
+            var config = new ProjectBuildConfiguration
+            {
+                GitHubAccessTokenEnvName = gitHubEnv,
+                VersionTracks = new Dictionary<string, ProjectBuildVersionTrack>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["PowerForge"] = new()
+                    {
+                        ExpectedVersion = "1.2.3",
+                        AnchorProject = "PowerForge",
+                        NugetSource = new[] { "https://nuget.pkg.github.com/EvotecIT/index.json" }
+                    }
+                }
+            };
+
+            var context = service.Prepare(
+                config,
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions());
+
+            var scopedCredential = Assert.Single(context.Spec.VersionSourceCredentials!);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", scopedCredential.Key);
+            Assert.Equal("EvotecIT", scopedCredential.Value.UserName);
+            Assert.Equal("track-source-token", scopedCredential.Value.Secret);
         }
         finally
         {

--- a/PowerForge.Tests/ProjectBuildPublishHostServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPublishHostServiceTests.cs
@@ -50,6 +50,41 @@ public sealed class ProjectBuildPublishHostServiceTests
     }
 
     [Fact]
+    public void LoadConfiguration_ResolvesGitHubPackagesPublishSourceAndToken()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var buildDirectory = Directory.CreateDirectory(Path.Combine(root, "Build")).FullName;
+        var configPath = Path.Combine(buildDirectory, "project.build.json");
+        File.WriteAllText(
+            configPath,
+            """
+            {
+              "PublishNuget": true,
+              "UseGitHubPackages": true,
+              "GitHubPackagesOwner": "EvotecIT",
+              "GitHubAccessTokenEnvName": "PFGH_PACKAGES_TOKEN"
+            }
+            """);
+
+        try
+        {
+            using var _ = new EnvironmentScope()
+                .Set("PFGH_PACKAGES_TOKEN", "github-packages-token");
+
+            var configuration = new ProjectBuildPublishHostService().LoadConfiguration(configPath);
+
+            Assert.True(configuration.PublishNuget);
+            Assert.Equal("https://nuget.pkg.github.com/EvotecIT/index.json", configuration.PublishSource);
+            Assert.Equal("github-packages-token", configuration.PublishApiKey);
+            Assert.Equal("github-packages-token", configuration.GitHubToken);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void PublishGitHub_MapsHostConfigurationIntoSharedRequest()
     {
         ProjectBuildGitHubPublishRequest? captured = null;

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -143,6 +143,12 @@ public sealed class PackageBuildConfiguration
     /// <summary>Whether release ZIPs should be created for package projects.</summary>
     public bool? CreateReleaseZip { get; set; }
 
+    /// <summary>Whether GitHub Packages should be used as the NuGet version lookup and publish feed.</summary>
+    public bool UseGitHubPackages { get; set; }
+
+    /// <summary>GitHub user or organization that owns the GitHub Packages NuGet feed.</summary>
+    public string? GitHubPackagesOwner { get; set; }
+
     /// <summary>NuGet publish source.</summary>
     public string? PublishSource { get; set; }
 

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -47,6 +47,9 @@ public sealed class DotNetRepositoryReleaseSpec
     /// <summary>Credential used for private version sources.</summary>
     public RepositoryCredential? VersionSourceCredential { get; set; }
 
+    /// <summary>Credentials scoped to individual private version sources.</summary>
+    public Dictionary<string, RepositoryCredential>? VersionSourceCredentials { get; set; }
+
     /// <summary>Whether to include prerelease versions during version resolution.</summary>
     public bool IncludePrerelease { get; set; }
 

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -31,6 +31,8 @@ internal sealed class ProjectBuildConfiguration
     public bool? PublishNuget { get; set; }
     public bool? PublishGitHub { get; set; }
     public bool? CreateReleaseZip { get; set; }
+    public bool UseGitHubPackages { get; set; }
+    public string? GitHubPackagesOwner { get; set; }
     public string? PublishSource { get; set; }
     public string? PublishApiKey { get; set; }
     public string? PublishApiKeyFilePath { get; set; }

--- a/PowerForge/Models/ProjectBuildPackageFeedSettings.cs
+++ b/PowerForge/Models/ProjectBuildPackageFeedSettings.cs
@@ -1,0 +1,25 @@
+namespace PowerForge;
+
+/// <summary>
+/// Resolved NuGet feed settings for project-build version lookup and package publishing.
+/// </summary>
+internal sealed class ProjectBuildPackageFeedSettings
+{
+    /// <summary>NuGet sources used for version lookup.</summary>
+    public string[]? VersionSources { get; set; }
+
+    /// <summary>Credential used for authenticated version lookup sources.</summary>
+    public RepositoryCredential? VersionSourceCredential { get; set; }
+
+    /// <summary>NuGet source used by <c>dotnet nuget push</c>.</summary>
+    public string? PublishSource { get; set; }
+
+    /// <summary>API key used by <c>dotnet nuget push</c>.</summary>
+    public string? PublishApiKey { get; set; }
+
+    /// <summary>GitHub token resolved from the project-build GitHub token settings.</summary>
+    public string? GitHubToken { get; set; }
+
+    /// <summary>GitHub Packages owner when the shared feed mode is active.</summary>
+    public string? GitHubPackagesOwner { get; set; }
+}

--- a/PowerForge/Models/ProjectBuildPackageFeedSettings.cs
+++ b/PowerForge/Models/ProjectBuildPackageFeedSettings.cs
@@ -11,6 +11,9 @@ internal sealed class ProjectBuildPackageFeedSettings
     /// <summary>Credential used for authenticated version lookup sources.</summary>
     public RepositoryCredential? VersionSourceCredential { get; set; }
 
+    /// <summary>Credentials scoped to individual version lookup sources.</summary>
+    public Dictionary<string, RepositoryCredential>? VersionSourceCredentials { get; set; }
+
     /// <summary>NuGet source used by <c>dotnet nuget push</c>.</summary>
     public string? PublishSource { get; set; }
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
@@ -69,6 +69,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 packageId: string.IsNullOrWhiteSpace(project.PackageId) ? project.ProjectName : project.PackageId,
                 sources: versionSources,
                 credential: spec.VersionSourceCredential,
+                credentialsBySource: spec.VersionSourceCredentials,
                 includePrerelease: spec.IncludePrerelease);
 
             if (latest is not null && Version.TryParse(project.NewVersion, out var target))

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -43,6 +43,7 @@ public sealed partial class DotNetRepositoryReleaseService
             packageId: string.IsNullOrWhiteSpace(project.PackageId) ? project.ProjectName : project.PackageId,
             sources: spec.VersionSources,
             credential: spec.VersionSourceCredential,
+            credentialsBySource: spec.VersionSourceCredentials,
             includePrerelease: spec.IncludePrerelease);
 
         if (current is null)

--- a/PowerForge/Services/NuGetPackageVersionResolver.cs
+++ b/PowerForge/Services/NuGetPackageVersionResolver.cs
@@ -35,6 +35,17 @@ public sealed class NuGetPackageVersionResolver
         IReadOnlyList<string>? sources,
         RepositoryCredential? credential,
         bool includePrerelease)
+        => ResolveLatest(packageId, sources, credential, credentialsBySource: null, includePrerelease);
+
+    /// <summary>
+    /// Resolves the latest version from the provided sources with optional source-scoped credentials.
+    /// </summary>
+    public Version? ResolveLatest(
+        string packageId,
+        IReadOnlyList<string>? sources,
+        RepositoryCredential? credential,
+        IReadOnlyDictionary<string, RepositoryCredential>? credentialsBySource,
+        bool includePrerelease)
     {
         if (string.IsNullOrWhiteSpace(packageId)) return null;
 
@@ -51,10 +62,11 @@ public sealed class NuGetPackageVersionResolver
         foreach (var source in normalizedSources)
         {
             Version? candidate = null;
+            var sourceCredential = ResolveCredentialForSource(source, credentialsBySource) ?? credential;
             if (IsLocalPath(source))
                 candidate = ResolveFromLocalPath(packageId, source, includePrerelease);
             else
-                candidate = ResolveFromV3Source(packageId, source, credential, includePrerelease);
+                candidate = ResolveFromV3Source(packageId, source, sourceCredential, includePrerelease);
 
             if (candidate is null) continue;
             if (latest is null || candidate > latest)
@@ -62,6 +74,31 @@ public sealed class NuGetPackageVersionResolver
         }
 
         return latest;
+    }
+
+    private static RepositoryCredential? ResolveCredentialForSource(
+        string source,
+        IReadOnlyDictionary<string, RepositoryCredential>? credentialsBySource)
+    {
+        if (credentialsBySource is null || credentialsBySource.Count == 0)
+            return null;
+
+        var normalized = source.Trim();
+        if (credentialsBySource.TryGetValue(normalized, out var credential))
+            return credential;
+
+        var trimmed = normalized.TrimEnd('/');
+        if (credentialsBySource.TryGetValue(trimmed, out credential))
+            return credential;
+
+        if (normalized.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
+        {
+            var withoutIndex = normalized.Substring(0, normalized.Length - "/index.json".Length).TrimEnd('/');
+            if (credentialsBySource.TryGetValue(withoutIndex, out credential))
+                return credential;
+        }
+
+        return null;
     }
 
     private static bool IsLocalPath(string source)

--- a/PowerForge/Services/ProjectBuildPackageFeedResolver.cs
+++ b/PowerForge/Services/ProjectBuildPackageFeedResolver.cs
@@ -77,7 +77,13 @@ internal static class ProjectBuildPackageFeedResolver
 
     private static string? ResolveGitHubPackagesOwner(ProjectBuildConfiguration config)
     {
-        var owner = TrimOrNull(config.GitHubPackagesOwner) ?? (config.UseGitHubPackages ? TrimOrNull(config.GitHubUsername) : null);
+        var owner = TrimOrNull(config.GitHubPackagesOwner) ??
+                    (config.UseGitHubPackages ? TrimOrNull(config.GitHubUsername) : null) ??
+                    ResolveGitHubPackagesOwnerFromSources(config.NugetSource) ??
+                    ResolveGitHubPackagesOwnerFromSource(config.PublishSource);
+        if (config.UseGitHubPackages && string.IsNullOrWhiteSpace(owner))
+            throw new InvalidOperationException("UseGitHubPackages is true but GitHubPackagesOwner/GitHubUsername is not set.");
+
         if (string.IsNullOrWhiteSpace(owner))
             return null;
 
@@ -139,6 +145,9 @@ internal static class ProjectBuildPackageFeedResolver
 
         if (ContainsGitHubPackagesSource(versionSources) && !string.IsNullOrWhiteSpace(githubToken))
         {
+            if (!ContainsOnlyGitHubPackagesSources(versionSources))
+                return null;
+
             return new RepositoryCredential
             {
                 UserName = githubPackagesOwner,
@@ -151,6 +160,38 @@ internal static class ProjectBuildPackageFeedResolver
 
     private static bool ContainsGitHubPackagesSource(string[]? sources)
         => sources is not null && sources.Any(IsGitHubPackagesSource);
+
+    private static bool ContainsOnlyGitHubPackagesSources(string[]? sources)
+    {
+        var normalized = (sources ?? Array.Empty<string>())
+            .Where(source => !string.IsNullOrWhiteSpace(source))
+            .ToArray();
+        return normalized.Length > 0 && normalized.All(IsGitHubPackagesSource);
+    }
+
+    private static string? ResolveGitHubPackagesOwnerFromSources(string[]? sources)
+    {
+        foreach (var source in sources ?? Array.Empty<string>())
+        {
+            var owner = ResolveGitHubPackagesOwnerFromSource(source);
+            if (!string.IsNullOrWhiteSpace(owner))
+                return owner;
+        }
+
+        return null;
+    }
+
+    private static string? ResolveGitHubPackagesOwnerFromSource(string? source)
+    {
+        if (!IsGitHubPackagesSource(source))
+            return null;
+
+        var uri = new Uri(source!.Trim(), UriKind.Absolute);
+        var owner = uri.AbsolutePath
+            .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault();
+        return TrimOrNull(owner);
+    }
 
     private static string? ResolveFirstEnvironmentSecret(params string[] names)
     {

--- a/PowerForge/Services/ProjectBuildPackageFeedResolver.cs
+++ b/PowerForge/Services/ProjectBuildPackageFeedResolver.cs
@@ -1,0 +1,176 @@
+namespace PowerForge;
+
+/// <summary>
+/// Resolves reusable NuGet feed settings for project-build package restore, version lookup, and publish.
+/// </summary>
+internal static class ProjectBuildPackageFeedResolver
+{
+    private const string DefaultNuGetPublishSource = "https://api.nuget.org/v3/index.json";
+    private const string GitHubPackagesHost = "nuget.pkg.github.com";
+
+    /// <summary>
+    /// Resolves NuGet feed settings from project-build configuration and existing secret conventions.
+    /// </summary>
+    public static ProjectBuildPackageFeedSettings Resolve(ProjectBuildConfiguration config, string configDir)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+        if (string.IsNullOrWhiteSpace(configDir))
+            throw new ArgumentException("Configuration directory is required.", nameof(configDir));
+
+        var githubToken = ResolveGitHubToken(config, configDir);
+        var githubPackagesOwner = ResolveGitHubPackagesOwner(config);
+        var githubPackagesSource = ResolveGitHubPackagesSource(config, githubPackagesOwner);
+        var versionSources = ResolveVersionSources(config, githubPackagesSource);
+        var publishSource = ResolvePublishSource(config, githubPackagesSource);
+        var publishApiKey = ProjectBuildSupportService.ResolveSecret(
+            config.PublishApiKey,
+            config.PublishApiKeyFilePath,
+            config.PublishApiKeyEnvName,
+            configDir);
+        if (string.IsNullOrWhiteSpace(publishApiKey) && IsGitHubPackagesSource(publishSource))
+            publishApiKey = githubToken;
+
+        return new ProjectBuildPackageFeedSettings
+        {
+            VersionSources = versionSources,
+            VersionSourceCredential = ResolveVersionSourceCredential(config, configDir, versionSources, githubPackagesOwner, githubToken),
+            PublishSource = publishSource,
+            PublishApiKey = publishApiKey,
+            GitHubToken = githubToken,
+            GitHubPackagesOwner = githubPackagesOwner
+        };
+    }
+
+    /// <summary>
+    /// Returns the default NuGet publish source used when no project-build source is configured.
+    /// </summary>
+    public static string GetDefaultPublishSource() => DefaultNuGetPublishSource;
+
+    /// <summary>
+    /// Returns true when a source points at GitHub Packages.
+    /// </summary>
+    public static bool IsGitHubPackagesSource(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return false;
+
+        return Uri.TryCreate(source!.Trim(), UriKind.Absolute, out var uri) &&
+               string.Equals(uri.Host, GitHubPackagesHost, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? ResolveGitHubToken(ProjectBuildConfiguration config, string configDir)
+    {
+        var token = ProjectBuildSupportService.ResolveSecret(
+            config.GitHubAccessToken,
+            config.GitHubAccessTokenFilePath,
+            config.GitHubAccessTokenEnvName,
+            configDir);
+        if (!string.IsNullOrWhiteSpace(token))
+            return token;
+
+        if (config.UseGitHubPackages || ContainsGitHubPackagesSource(config.NugetSource) || IsGitHubPackagesSource(config.PublishSource))
+            return ResolveFirstEnvironmentSecret("GITHUB_TOKEN", "GH_TOKEN");
+
+        return null;
+    }
+
+    private static string? ResolveGitHubPackagesOwner(ProjectBuildConfiguration config)
+    {
+        var owner = TrimOrNull(config.GitHubPackagesOwner) ?? (config.UseGitHubPackages ? TrimOrNull(config.GitHubUsername) : null);
+        if (string.IsNullOrWhiteSpace(owner))
+            return null;
+
+        return PrivateGalleryRepositoryEndpoints.Create(
+            PrivateGalleryProvider.GitHubPackages,
+            gitHubOwner: owner).GitHubOwner;
+    }
+
+    private static string? ResolveGitHubPackagesSource(ProjectBuildConfiguration config, string? owner)
+    {
+        if (!config.UseGitHubPackages)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(owner))
+            return null;
+
+        return PrivateGalleryRepositoryEndpoints.Create(
+            PrivateGalleryProvider.GitHubPackages,
+            gitHubOwner: owner).PSResourceGetUri;
+    }
+
+    private static string[]? ResolveVersionSources(ProjectBuildConfiguration config, string? githubPackagesSource)
+    {
+        if (config.NugetSource is { Length: > 0 })
+            return config.NugetSource;
+
+        return string.IsNullOrWhiteSpace(githubPackagesSource) ? null : new[] { githubPackagesSource! };
+    }
+
+    private static string? ResolvePublishSource(ProjectBuildConfiguration config, string? githubPackagesSource)
+    {
+        if (!string.IsNullOrWhiteSpace(config.PublishSource))
+            return config.PublishSource!.Trim();
+
+        return githubPackagesSource;
+    }
+
+    private static RepositoryCredential? ResolveVersionSourceCredential(
+        ProjectBuildConfiguration config,
+        string configDir,
+        string[]? versionSources,
+        string? githubPackagesOwner,
+        string? githubToken)
+    {
+        var nugetCredentialSecret = ProjectBuildSupportService.ResolveSecret(
+            config.NugetCredentialSecret,
+            config.NugetCredentialSecretFilePath,
+            config.NugetCredentialSecretEnvName,
+            configDir);
+        var nugetUser = TrimOrNull(config.NugetCredentialUserName);
+        if (!string.IsNullOrWhiteSpace(nugetUser) || !string.IsNullOrWhiteSpace(nugetCredentialSecret))
+        {
+            return new RepositoryCredential
+            {
+                UserName = nugetUser,
+                Secret = nugetCredentialSecret
+            };
+        }
+
+        if (ContainsGitHubPackagesSource(versionSources) && !string.IsNullOrWhiteSpace(githubToken))
+        {
+            return new RepositoryCredential
+            {
+                UserName = githubPackagesOwner,
+                Secret = githubToken
+            };
+        }
+
+        return null;
+    }
+
+    private static bool ContainsGitHubPackagesSource(string[]? sources)
+        => sources is not null && sources.Any(IsGitHubPackagesSource);
+
+    private static string? ResolveFirstEnvironmentSecret(params string[] names)
+    {
+        foreach (var name in names)
+        {
+            try
+            {
+                var value = Environment.GetEnvironmentVariable(name);
+                if (!string.IsNullOrWhiteSpace(value))
+                    return value!.Trim();
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TrimOrNull(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
+}

--- a/PowerForge/Services/ProjectBuildPackageFeedResolver.cs
+++ b/PowerForge/Services/ProjectBuildPackageFeedResolver.cs
@@ -35,6 +35,7 @@ internal static class ProjectBuildPackageFeedResolver
         {
             VersionSources = versionSources,
             VersionSourceCredential = ResolveVersionSourceCredential(config, configDir, versionSources, githubPackagesOwner, githubToken),
+            VersionSourceCredentials = ResolveVersionSourceCredentials(config, versionSources, publishSource, githubPackagesOwner, githubToken),
             PublishSource = publishSource,
             PublishApiKey = publishApiKey,
             GitHubToken = githubToken,
@@ -69,8 +70,13 @@ internal static class ProjectBuildPackageFeedResolver
         if (!string.IsNullOrWhiteSpace(token))
             return token;
 
-        if (config.UseGitHubPackages || ContainsGitHubPackagesSource(config.NugetSource) || IsGitHubPackagesSource(config.PublishSource))
+        if (config.UseGitHubPackages ||
+            ContainsGitHubPackagesSource(config.NugetSource) ||
+            IsGitHubPackagesSource(config.PublishSource) ||
+            ContainsGitHubPackagesSource(GetVersionTrackSources(config)))
+        {
             return ResolveFirstEnvironmentSecret("GITHUB_TOKEN", "GH_TOKEN");
+        }
 
         return null;
     }
@@ -80,7 +86,8 @@ internal static class ProjectBuildPackageFeedResolver
         var owner = TrimOrNull(config.GitHubPackagesOwner) ??
                     (config.UseGitHubPackages ? TrimOrNull(config.GitHubUsername) : null) ??
                     ResolveGitHubPackagesOwnerFromSources(config.NugetSource) ??
-                    ResolveGitHubPackagesOwnerFromSource(config.PublishSource);
+                    ResolveGitHubPackagesOwnerFromSource(config.PublishSource) ??
+                    ResolveGitHubPackagesOwnerFromSources(GetVersionTrackSources(config));
         if (config.UseGitHubPackages && string.IsNullOrWhiteSpace(owner))
             throw new InvalidOperationException("UseGitHubPackages is true but GitHubPackagesOwner/GitHubUsername is not set.");
 
@@ -158,6 +165,37 @@ internal static class ProjectBuildPackageFeedResolver
         return null;
     }
 
+    private static Dictionary<string, RepositoryCredential>? ResolveVersionSourceCredentials(
+        ProjectBuildConfiguration config,
+        string[]? versionSources,
+        string? publishSource,
+        string? githubPackagesOwner,
+        string? githubToken)
+    {
+        if (string.IsNullOrWhiteSpace(githubToken))
+            return null;
+
+        var credentials = new Dictionary<string, RepositoryCredential>(StringComparer.OrdinalIgnoreCase);
+        foreach (var source in GetCredentialCandidateSources(config, versionSources, publishSource))
+        {
+            if (!IsGitHubPackagesSource(source))
+                continue;
+
+            var normalizedSource = source.Trim();
+            var owner = ResolveGitHubPackagesOwnerFromSource(normalizedSource) ?? githubPackagesOwner;
+            if (string.IsNullOrWhiteSpace(owner))
+                continue;
+
+            credentials[normalizedSource] = new RepositoryCredential
+            {
+                UserName = owner,
+                Secret = githubToken
+            };
+        }
+
+        return credentials.Count == 0 ? null : credentials;
+    }
+
     private static bool ContainsGitHubPackagesSource(string[]? sources)
         => sources is not null && sources.Any(IsGitHubPackagesSource);
 
@@ -191,6 +229,38 @@ internal static class ProjectBuildPackageFeedResolver
             .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
             .FirstOrDefault();
         return TrimOrNull(owner);
+    }
+
+    private static string[]? GetVersionTrackSources(ProjectBuildConfiguration config)
+    {
+        if (config.VersionTracks is null || config.VersionTracks.Count == 0)
+            return null;
+
+        return config.VersionTracks.Values
+            .Where(track => track?.NugetSource is { Length: > 0 })
+            .SelectMany(track => track!.NugetSource!)
+            .Where(source => !string.IsNullOrWhiteSpace(source))
+            .Select(source => source.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IEnumerable<string> GetCredentialCandidateSources(
+        ProjectBuildConfiguration config,
+        string[]? versionSources,
+        string? publishSource)
+    {
+        foreach (var source in versionSources ?? Array.Empty<string>())
+        {
+            if (!string.IsNullOrWhiteSpace(source))
+                yield return source;
+        }
+
+        if (!string.IsNullOrWhiteSpace(publishSource))
+            yield return publishSource!;
+
+        foreach (var source in GetVersionTrackSources(config) ?? Array.Empty<string>())
+            yield return source;
     }
 
     private static string? ResolveFirstEnvironmentSecret(params string[] names)

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -73,7 +73,7 @@ internal sealed class ProjectBuildPreparationService
 
         var feed = ProjectBuildPackageFeedResolver.Resolve(config, configDir);
         var nugetCredential = feed.VersionSourceCredential;
-        var expectedVersionMap = new ProjectBuildVersionTrackService(_logger).ResolveExpectedVersionMap(config, nugetCredential);
+        var expectedVersionMap = new ProjectBuildVersionTrackService(_logger).ResolveExpectedVersionMap(config, feed.VersionSources, nugetCredential);
 
         context.PublishApiKey = feed.PublishApiKey;
         context.GitHubToken = feed.GitHubToken;

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -73,7 +73,11 @@ internal sealed class ProjectBuildPreparationService
 
         var feed = ProjectBuildPackageFeedResolver.Resolve(config, configDir);
         var nugetCredential = feed.VersionSourceCredential;
-        var expectedVersionMap = new ProjectBuildVersionTrackService(_logger).ResolveExpectedVersionMap(config, feed.VersionSources, nugetCredential);
+        var expectedVersionMap = new ProjectBuildVersionTrackService(_logger).ResolveExpectedVersionMap(
+            config,
+            feed.VersionSources,
+            nugetCredential,
+            feed.VersionSourceCredentials);
 
         context.PublishApiKey = feed.PublishApiKey;
         context.GitHubToken = feed.GitHubToken;
@@ -94,6 +98,7 @@ internal sealed class ProjectBuildPreparationService
             ExcludeDirectories = config.ExcludeDirectories,
             VersionSources = feed.VersionSources,
             VersionSourceCredential = nugetCredential,
+            VersionSourceCredentials = feed.VersionSourceCredentials,
             IncludePrerelease = config.IncludePrerelease,
             Configuration = string.IsNullOrWhiteSpace(config.Configuration) ? "Release" : config.Configuration!,
             OutputPath = context.OutputPath,

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -71,31 +71,12 @@ internal sealed class ProjectBuildPreparationService
         if (string.IsNullOrWhiteSpace(context.ReleaseZipOutputPath) && !string.IsNullOrWhiteSpace(context.StagingPath))
             context.ReleaseZipOutputPath = Path.Combine(context.StagingPath, "releases");
 
-        var nugetCredentialSecret = ProjectBuildSupportService.ResolveSecret(
-            config.NugetCredentialSecret,
-            config.NugetCredentialSecretFilePath,
-            config.NugetCredentialSecretEnvName,
-            configDir);
-        var nugetUser = string.IsNullOrWhiteSpace(config.NugetCredentialUserName) ? null : config.NugetCredentialUserName!.Trim();
-        var nugetCredential = (!string.IsNullOrWhiteSpace(nugetUser) || !string.IsNullOrWhiteSpace(nugetCredentialSecret))
-            ? new RepositoryCredential
-            {
-                UserName = nugetUser,
-                Secret = nugetCredentialSecret
-            }
-            : null;
+        var feed = ProjectBuildPackageFeedResolver.Resolve(config, configDir);
+        var nugetCredential = feed.VersionSourceCredential;
         var expectedVersionMap = new ProjectBuildVersionTrackService(_logger).ResolveExpectedVersionMap(config, nugetCredential);
 
-        context.PublishApiKey = ProjectBuildSupportService.ResolveSecret(
-            config.PublishApiKey,
-            config.PublishApiKeyFilePath,
-            config.PublishApiKeyEnvName,
-            configDir);
-        context.GitHubToken = ProjectBuildSupportService.ResolveSecret(
-            config.GitHubAccessToken,
-            config.GitHubAccessTokenFilePath,
-            config.GitHubAccessTokenEnvName,
-            configDir);
+        context.PublishApiKey = feed.PublishApiKey;
+        context.GitHubToken = feed.GitHubToken;
 
         var packStrategy = ProjectBuildSupportService.ParsePackStrategy(config.PackStrategy);
         if (!ProjectBuildSupportService.IsKnownPackStrategy(config.PackStrategy))
@@ -111,7 +92,7 @@ internal sealed class ProjectBuildPreparationService
             IncludeProjects = config.IncludeProjects,
             ExcludeProjects = config.ExcludeProjects,
             ExcludeDirectories = config.ExcludeDirectories,
-            VersionSources = config.NugetSource,
+            VersionSources = feed.VersionSources,
             VersionSourceCredential = nugetCredential,
             IncludePrerelease = config.IncludePrerelease,
             Configuration = string.IsNullOrWhiteSpace(config.Configuration) ? "Release" : config.Configuration!,
@@ -124,7 +105,7 @@ internal sealed class ProjectBuildPreparationService
             Pack = context.Build || context.PublishNuget || context.PublishGitHub,
             CreateReleaseZip = context.CreateReleaseZip,
             Publish = context.PublishNuget,
-            PublishSource = config.PublishSource,
+            PublishSource = feed.PublishSource,
             PublishApiKey = context.PublishApiKey,
             SkipDuplicate = config.SkipDuplicate ?? true,
             PublishFailFast = config.PublishFailFast ?? true,

--- a/PowerForge/Services/ProjectBuildPublishHostService.cs
+++ b/PowerForge/Services/ProjectBuildPublishHostService.cs
@@ -45,9 +45,10 @@ public sealed class ProjectBuildPublishHostService
             throw new InvalidOperationException($"Unable to resolve the configuration directory for '{resolvedConfigPath}'.");
 
         var config = new ProjectBuildSupportService(_logger).LoadConfig(resolvedConfigPath);
-        var publishSource = string.IsNullOrWhiteSpace(config.PublishSource)
-            ? "https://api.nuget.org/v3/index.json"
-            : config.PublishSource!.Trim();
+        var feed = ProjectBuildPackageFeedResolver.Resolve(config, configDirectory);
+        var publishSource = string.IsNullOrWhiteSpace(feed.PublishSource)
+            ? ProjectBuildPackageFeedResolver.GetDefaultPublishSource()
+            : feed.PublishSource!.Trim();
         var releaseMode = string.IsNullOrWhiteSpace(config.GitHubReleaseMode)
             ? "Single"
             : config.GitHubReleaseMode!.Trim();
@@ -56,16 +57,8 @@ public sealed class ProjectBuildPublishHostService
             PublishNuget = config.PublishNuget == true,
             PublishGitHub = config.PublishGitHub == true,
             PublishSource = publishSource,
-            PublishApiKey = ProjectBuildSupportService.ResolveSecret(
-                config.PublishApiKey,
-                config.PublishApiKeyFilePath,
-                config.PublishApiKeyEnvName,
-                configDirectory),
-            GitHubToken = ProjectBuildSupportService.ResolveSecret(
-                config.GitHubAccessToken,
-                config.GitHubAccessTokenFilePath,
-                config.GitHubAccessTokenEnvName,
-                configDirectory),
+            PublishApiKey = feed.PublishApiKey,
+            GitHubToken = feed.GitHubToken,
             GitHubUsername = TrimOrNull(config.GitHubUsername),
             GitHubRepositoryName = TrimOrNull(config.GitHubRepositoryName),
             GitHubIsPreRelease = config.GitHubIsPreRelease,

--- a/PowerForge/Services/ProjectBuildSupportService.cs
+++ b/PowerForge/Services/ProjectBuildSupportService.cs
@@ -229,7 +229,7 @@ internal sealed class ProjectBuildSupportService
         string? gitHubRepositoryName)
     {
         if (publishNuget && string.IsNullOrWhiteSpace(publishApiKey))
-            return "PublishNuget is enabled but no PublishApiKey was resolved (use PublishApiKey, PublishApiKeyFilePath, or PublishApiKeyEnvName).";
+            return "PublishNuget is enabled but no PublishApiKey was resolved (use PublishApiKey, PublishApiKeyFilePath, PublishApiKeyEnvName, or GitHubAccessToken for GitHub Packages).";
 
         if (publishGitHub && !createReleaseZip)
             return "PublishGitHub is enabled but CreateReleaseZip is false.";

--- a/PowerForge/Services/ProjectBuildVersionTrackService.cs
+++ b/PowerForge/Services/ProjectBuildVersionTrackService.cs
@@ -26,13 +26,20 @@ internal sealed class ProjectBuildVersionTrackService
         ProjectBuildConfiguration config,
         IReadOnlyList<string>? defaultSources,
         RepositoryCredential? credential)
+        => ResolveExpectedVersionMap(config, defaultSources, credential, credentialsBySource: null);
+
+    public Dictionary<string, string>? ResolveExpectedVersionMap(
+        ProjectBuildConfiguration config,
+        IReadOnlyList<string>? defaultSources,
+        RepositoryCredential? credential,
+        IReadOnlyDictionary<string, RepositoryCredential>? credentialsBySource)
     {
         if (config is null)
             throw new ArgumentNullException(nameof(config));
 
         var resolved = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var entry in ExpandTracks(config.VersionTracks, config.ExpectedVersion, defaultSources, credential, config.IncludePrerelease))
+        foreach (var entry in ExpandTracks(config.VersionTracks, config.ExpectedVersion, defaultSources, credential, credentialsBySource, config.IncludePrerelease))
             resolved[entry.Key] = entry.Value;
 
         var explicitMap = config.ExpectedVersionMap;
@@ -55,6 +62,7 @@ internal sealed class ProjectBuildVersionTrackService
         string? defaultExpectedVersion,
         IReadOnlyList<string>? defaultSources,
         RepositoryCredential? credential,
+        IReadOnlyDictionary<string, RepositoryCredential>? credentialsBySource,
         bool defaultIncludePrerelease)
     {
         if (tracks is null || tracks.Count == 0)
@@ -68,7 +76,7 @@ internal sealed class ProjectBuildVersionTrackService
             if (string.IsNullOrWhiteSpace(expectedVersion))
                 throw new ArgumentException($"VersionTracks['{trackName}'] must define ExpectedVersion or rely on a non-empty top-level ExpectedVersion.", nameof(tracks));
 
-            var resolvedVersion = ResolveTrackVersion(trackName, track, expectedVersion!, defaultSources, credential, defaultIncludePrerelease);
+            var resolvedVersion = ResolveTrackVersion(trackName, track, expectedVersion!, defaultSources, credential, credentialsBySource, defaultIncludePrerelease);
             foreach (var project in ResolveProjects(trackName, track))
                 yield return new KeyValuePair<string, string>(project, resolvedVersion);
         }
@@ -80,6 +88,7 @@ internal sealed class ProjectBuildVersionTrackService
         string expectedVersion,
         IReadOnlyList<string>? defaultSources,
         RepositoryCredential? credential,
+        IReadOnlyDictionary<string, RepositoryCredential>? credentialsBySource,
         bool defaultIncludePrerelease)
     {
         if (Version.TryParse(expectedVersion, out var exact))
@@ -96,7 +105,7 @@ internal sealed class ProjectBuildVersionTrackService
             .ToArray();
 
         var includePrerelease = track.IncludePrerelease ?? defaultIncludePrerelease;
-        var current = _resolver.ResolveLatest(anchorPackageId, sources, credential, includePrerelease);
+        var current = _resolver.ResolveLatest(anchorPackageId, sources, credential, credentialsBySource, includePrerelease);
         if (current is null)
             _logger.Info($"Version track '{trackName}' could not resolve an existing version for anchor '{anchorPackageId}'. Using the X-pattern baseline.");
 

--- a/PowerForge/Services/ProjectBuildVersionTrackService.cs
+++ b/PowerForge/Services/ProjectBuildVersionTrackService.cs
@@ -20,13 +20,19 @@ internal sealed class ProjectBuildVersionTrackService
     public Dictionary<string, string>? ResolveExpectedVersionMap(
         ProjectBuildConfiguration config,
         RepositoryCredential? credential)
+        => ResolveExpectedVersionMap(config, config.NugetSource, credential);
+
+    public Dictionary<string, string>? ResolveExpectedVersionMap(
+        ProjectBuildConfiguration config,
+        IReadOnlyList<string>? defaultSources,
+        RepositoryCredential? credential)
     {
         if (config is null)
             throw new ArgumentNullException(nameof(config));
 
         var resolved = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var entry in ExpandTracks(config.VersionTracks, config.ExpectedVersion, config.NugetSource, credential, config.IncludePrerelease))
+        foreach (var entry in ExpandTracks(config.VersionTracks, config.ExpectedVersion, defaultSources, credential, config.IncludePrerelease))
             resolved[entry.Key] = entry.Value;
 
         var explicitMap = config.ExpectedVersionMap;

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -128,6 +128,17 @@
     "CreateReleaseZip": {
       "type": "boolean"
     },
+    "UseGitHubPackages": {
+      "type": "boolean",
+      "description": "When true, resolves the NuGet version lookup and publish feed to GitHub Packages for GitHubPackagesOwner, or GitHubUsername when the owner is omitted."
+    },
+    "GitHubPackagesOwner": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "GitHub user or organization that owns the GitHub Packages NuGet feed. Defaults to GitHubUsername when UseGitHubPackages is true."
+    },
     "CertificateThumbprint": {
       "type": [
         "string",


### PR DESCRIPTION
## Summary
- add shared project-build GitHub Packages feed resolution with `UseGitHubPackages` and `GitHubPackagesOwner`
- reuse resolved GitHub tokens for GitHub Packages version lookup and `dotnet nuget push` when no dedicated publish key is configured
- document the TestimoX-style migration path from repo-local package auth/test scripts to thin PowerForge configuration

## Validation
- `dotnet test PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~ProjectBuildPreparationServiceTests|FullyQualifiedName~ProjectBuildPublishHostServiceTests|FullyQualifiedName~PowerForgeProjectCmdletTests"`
- `dotnet build PowerForge\PowerForge.csproj -c Release --no-restore`
- `dotnet build PSPublishModule\PSPublishModule.csproj -c Release --no-restore`
- `git diff --check`

Note: a full unfiltered `PowerForge.Tests` run was started but stayed silent for several minutes after entering the test runner, so I stopped that local process and left the exhaustive pass to CI.