### PR TITLE
Allow website workflows to restore GitHub Packages

### DIFF
--- a/.github/workflows/powerforge-website-ci.yml
+++ b/.github/workflows/powerforge-website-ci.yml
@@ -77,6 +77,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -94,6 +94,7 @@ on:
 permissions:
   actions: write
   contents: read
+  packages: read
   pages: write
   id-token: write
 

--- a/.github/workflows/powerforge-website-maintenance.yml
+++ b/.github/workflows/powerforge-website-maintenance.yml
@@ -67,6 +67,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   # Required for maintenance tasks such as GitHub artifact pruning.
   actions: write
 

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -2,6 +2,35 @@ namespace PowerForge.Tests;
 
 public sealed class GitHubWebsiteRunWorkflowTests
 {
+    [Theory]
+    [InlineData("powerforge-website-ci.yml")]
+    [InlineData("powerforge-website-deploy.yml")]
+    [InlineData("powerforge-website-maintenance.yml")]
+    public void WebsiteWorkflows_ShouldAllowGitHubPackagesRestore(string workflowFileName)
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", workflowFileName);
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("packages: read", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WebsiteRunWorkflow_ShouldInheritCallerPermissions()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.DoesNotContain("permissions:", workflowYaml, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void WebsiteRunWorkflow_ShouldKeepTransientToolCachesInsideWorkspace()
     {

--- a/PowerForge.Tests/WebSiteScaffolderTests.cs
+++ b/PowerForge.Tests/WebSiteScaffolderTests.cs
@@ -79,6 +79,7 @@ public class WebSiteScaffolderTests
 
             var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "website-ci.yml"));
             Assert.Contains("POWERFORGE_LOCK_PATH: ./.powerforge/engine-lock.json", workflow, StringComparison.Ordinal);
+            Assert.Contains("packages: read", workflow, StringComparison.Ordinal);
             Assert.Contains("uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@main", workflow, StringComparison.Ordinal);
             Assert.Contains("website_root: .", workflow, StringComparison.Ordinal);
             Assert.Contains("pipeline_config: pipeline.json", workflow, StringComparison.Ordinal);
@@ -91,6 +92,7 @@ public class WebSiteScaffolderTests
             var maintenanceWorkflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "website-maintenance.yml"));
             Assert.Contains("name: Website Maintenance", maintenanceWorkflow, StringComparison.Ordinal);
             Assert.Contains("schedule:", maintenanceWorkflow, StringComparison.Ordinal);
+            Assert.Contains("packages: read", maintenanceWorkflow, StringComparison.Ordinal);
             Assert.Contains("actions: write", maintenanceWorkflow, StringComparison.Ordinal);
             Assert.Contains("uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@main", maintenanceWorkflow, StringComparison.Ordinal);
             Assert.Contains("pipeline_config: pipeline.maintenance.json", maintenanceWorkflow, StringComparison.Ordinal);

--- a/PowerForge.Web/Services/WebSiteScaffolder.cs
+++ b/PowerForge.Web/Services/WebSiteScaffolder.cs
@@ -1068,6 +1068,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: website-ci-${{ github.ref }}
@@ -1099,6 +1100,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   actions: write
 
 concurrency:


### PR DESCRIPTION
## Summary
- allow PowerForge website reusable workflows to request `packages: read`
- cover CI, deploy, maintenance, and direct website-run calls
- add a workflow contract test so GitHub Packages restore support does not regress

## Evidence
- TestimoX Website Build (PR) run 27790972761 failed in `powerforge-website-run.yml` during `dotnet-build` restore because `Licensing.Verification` from GitHub Packages returned 401 Unauthorized.
- TestimoX .NET workflows already request `packages: read`; the website workflow path did not.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Debug --filter FullyQualifiedName~GitHubWebsiteRunWorkflowTests /m:1 /nr:false`
- `git diff --check`