### PR TITLE
Handle locked iPhone launch during device deploy

### DIFF
--- a/PSPublishModule/Cmdlets/PublishAppleAppToDeviceCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishAppleAppToDeviceCommand.cs
@@ -119,8 +119,10 @@ public sealed class PublishAppleAppToDeviceCommand : PSCmdlet
             ThrowTerminatingError(AppleDeviceCommandSupport.CreateProcessError(result.Build.ProcessResult, "AppleAppBuildFailed", "xcodebuild build failed."));
         if (result.Install is not null && !result.Install.Succeeded)
             ThrowTerminatingError(AppleDeviceCommandSupport.CreateProcessError(result.Install.ProcessResult, "AppleAppInstallFailed", "devicectl install failed."));
-        if (result.Launch is not null && !result.Launch.Succeeded)
+        if (result.Launch is not null && !result.Launch.Succeeded && !result.Launch.DeviceLocked)
             ThrowTerminatingError(AppleDeviceCommandSupport.CreateProcessError(result.Launch.ProcessResult, "AppleAppLaunchFailed", "devicectl launch failed."));
+        if (result.Launch is not null && result.Launch.DeviceLocked)
+            WriteWarning("The app was installed, but devicectl could not launch it because the device is locked. Unlock the device and launch the app manually or rerun Start-AppleApp.");
 
         WriteObject(result);
     }

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -21,6 +21,11 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
+  <!-- Keep runtime assets flowing to CLI/test consumers while avoiding a standalone deps file for this PowerShell-hosted library. -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0' ">
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
     <!-- Explicit NU1903 override for the vulnerable transitive 8.0.0 path. -->

--- a/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
+++ b/PowerForge.Tests/AppleDeviceDeploymentServiceTests.cs
@@ -304,6 +304,63 @@ App installed:
         }
     }
 
+    [Fact]
+    public async Task DeployAsync_treats_locked_device_launch_as_successful_deployment()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var project = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcodeproj"));
+            File.WriteAllText(Path.Combine(project.FullName, "project.pbxproj"), string.Empty);
+            var app = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.app"));
+            var runner = new CapturingProcessRunner(request =>
+            {
+                if (request.Arguments.Contains("install"))
+                    return Success("App installed:\n• bundleID: com.evotecit.tactra\n");
+
+                if (request.Arguments.Contains("launch"))
+                    return new ProcessRunResult(
+                        1,
+                        string.Empty,
+                        """
+                        ERROR: The application failed to launch. (com.apple.dt.CoreDeviceError error 10002 (0x2712))
+                               BundleIdentifier = com.evotecit.tactra
+                                   The request was denied by service delegate (SBMainWorkspace) for reason: Locked ("Unable to launch com.evotecit.tactra because the device was not, or could not be, unlocked").
+                                   BSErrorCodeDescription = Locked
+                        """,
+                        "xcrun-test",
+                        TimeSpan.FromMilliseconds(1),
+                        timedOut: false);
+
+                return Success("ok");
+            });
+            var service = new AppleDeviceDeploymentService(runner);
+
+            var result = await service.DeployAsync(new AppleAppDeviceDeploymentRequest
+            {
+                ProjectPath = project.FullName,
+                Scheme = "Tactra",
+                AppPath = app.FullName,
+                DeviceIdentifier = "device-1",
+                BundleIdentifier = "com.evotecit.tactra",
+                Launch = true,
+                XcodeBuildExecutable = "xcodebuild-test",
+                XcrunExecutable = "xcrun-test"
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.NotNull(result.Install);
+            Assert.True(result.Install.Succeeded);
+            Assert.NotNull(result.Launch);
+            Assert.False(result.Launch.Succeeded);
+            Assert.True(result.Launch.DeviceLocked);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static ProcessRunResult Success(string stdOut)
         => new(0, stdOut, string.Empty, "tool", TimeSpan.FromMilliseconds(1), false);
 

--- a/PowerForge/Models/AppleDeviceDeploymentModels.cs
+++ b/PowerForge/Models/AppleDeviceDeploymentModels.cs
@@ -216,6 +216,9 @@ public sealed class AppleAppLaunchResult
 
     /// <summary>True when devicectl completed successfully.</summary>
     public bool Succeeded => ProcessResult.Succeeded;
+
+    /// <summary>True when devicectl reported that launch was rejected because the device was locked.</summary>
+    public bool DeviceLocked => AppleDeviceLaunchFailureClassifier.IsDeviceLocked(ProcessResult);
 }
 
 /// <summary>
@@ -244,6 +247,6 @@ public sealed class AppleAppDeviceDeploymentResult
     /// <summary>Launch result, when Launch was requested and install succeeded.</summary>
     public AppleAppLaunchResult? Launch { get; set; }
 
-    /// <summary>True when all requested deployment stages completed successfully.</summary>
-    public bool Succeeded => Build.Succeeded && (Install?.Succeeded ?? false) && (Launch?.Succeeded ?? true);
+    /// <summary>True when build and install succeeded, and launch either succeeded or was blocked only because the device was locked.</summary>
+    public bool Succeeded => Build.Succeeded && (Install?.Succeeded ?? false) && (Launch is null || Launch.Succeeded || Launch.DeviceLocked);
 }

--- a/PowerForge/Models/AppleDeviceLaunchFailureClassifier.cs
+++ b/PowerForge/Models/AppleDeviceLaunchFailureClassifier.cs
@@ -1,0 +1,22 @@
+namespace PowerForge;
+
+/// <summary>
+/// Classifies expected devicectl launch failures that should not invalidate a completed device deployment.
+/// </summary>
+internal static class AppleDeviceLaunchFailureClassifier
+{
+    /// <summary>
+    /// Detects the CoreDevice/SpringBoard response emitted when an installed app cannot be launched because the device is locked.
+    /// </summary>
+    /// <param name="result">Launch process result returned by devicectl.</param>
+    /// <returns>True when the failure text identifies the device-locked launch rejection.</returns>
+    public static bool IsDeviceLocked(ProcessRunResult result)
+    {
+        if (result.Succeeded)
+            return false;
+
+        var text = string.Concat(result.StdErr, "\n", result.StdOut);
+        return text.IndexOf("BSErrorCodeDescription = Locked", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("because the device was not, or could not be, unlocked", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+}


### PR DESCRIPTION
## Summary
- Treat devicectl locked-device launch failures as non-fatal for Publish-AppleAppToDevice deployments after build/install succeed
- Keep AppleAppLaunchResult.Succeeded truthful while exposing DeviceLocked for diagnostics
- Warn from the cmdlet instead of failing the whole deployment when the phone auto-locks before launch
- Keep PowerForge.PowerShell and PSPublishModule multi-target builds working on non-Windows by skipping net8/net10 deps-file generation for PowerShell module assemblies that carry Windows-only PowerShell SDK runtime assets

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter AppleDeviceDeploymentServiceTests --no-restore --no-build
- dotnet build PowerForge/PowerForge.csproj --no-restore
- dotnet build PowerForge.PowerShell/PowerForge.PowerShell.csproj --no-restore
- dotnet build PSPublishModule/PSPublishModule.csproj --no-restore