### PR TITLE
Add Apple distribution release automation

### DIFF
--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -99,6 +99,7 @@ Get-AppStoreConnectApp -IssuerId $issuerId -KeyId $keyId -PrivateKeyPath $keyPat
 Get-AppStoreConnectVersion -IssuerId $issuerId -KeyId $keyId -PrivateKeyPath $keyPath -AppId $appId
 Get-AppStoreConnectBuild -IssuerId $issuerId -KeyId $keyId -PrivateKeyPath $keyPath -AppId $appId
 Test-AppleAppReleaseDrift -IssuerId $issuerId -KeyId $keyId -PrivateKeyPath $keyPath -Path '.\Tactra.xcodeproj' -AppId $appId -Platform iOS
+Set-AppStoreConnectVersionBuild -IssuerId $issuerId -KeyId $keyId -PrivateKeyPath $keyPath -AppId $appId -VersionString '1.0.1' -BuildNumber '5' -Platform iOS
 ```
 
 ## Unified Release Flow
@@ -119,10 +120,21 @@ that need one release file to describe iPhone, iPad, macOS, and store-delivery l
     "ExportRoot": "Artifacts/Apple/Exports",
     "TeamId": "8ZPGZ79T7J",
     "Upload": false,
+    "PrepareDistribution": true,
+    "SelectBuildForDistribution": true,
+    "SyncScreenshots": true,
+    "ScreenshotConfigPaths": [
+      "build/appstore-screenshots/ios.json",
+      "build/appstore-screenshots/macos.json"
+    ],
+    "AppStoreConnectApiKeyPath": ".appstoreconnect/private_keys/AuthKey_ABC123DEFG.p8",
+    "AppStoreConnectApiKeyId": "ABC123DEFG",
+    "AppStoreConnectApiIssuerId": "00000000-0000-0000-0000-000000000000",
     "Apps": [
       {
         "Name": "Tactra iPhone",
         "BundleId": "com.evotecit.tactra",
+        "AppStoreConnectAppId": "1234567890",
         "Platform": "iOS",
         "ProjectPath": "Tactra.xcodeproj",
         "Scheme": "Tactra"
@@ -130,6 +142,7 @@ that need one release file to describe iPhone, iPad, macOS, and store-delivery l
       {
         "Name": "Tactra iPad",
         "BundleId": "com.evotecit.tactra",
+        "AppStoreConnectAppId": "1234567890",
         "Platform": "iPadOS",
         "ProjectPath": "Tactra.xcodeproj",
         "Scheme": "Tactra"
@@ -137,6 +150,7 @@ that need one release file to describe iPhone, iPad, macOS, and store-delivery l
       {
         "Name": "Tactra Mac",
         "BundleId": "com.evotecit.tactra.mac",
+        "AppStoreConnectAppId": "1234567890",
         "Platform": "macOS",
         "ProjectPath": "Tactra.xcodeproj",
         "Scheme": "TactraMac"
@@ -166,11 +180,16 @@ and `xcodebuild -exportArchive` helpers as `New-AppleAppArchive` and
 
 ## Current Boundary
 
-These helpers automate signed binary archive/upload and provide low-level screenshot
-upload primitives. App Store localized text metadata, build selection for review, and
-release submission still need dedicated App Store Connect write support before they
-should be automated here. Unified `AppleApps` screenshot sync is not wired yet; keep
-using `Sync-AppStoreConnectScreenshots` or project-specific screenshot scripts for now.
+These helpers automate signed binary archive/upload, App Store version preparation,
+processed build selection, and screenshot sync. `AppleApps.PrepareDistribution`
+creates the App Store version when needed, finds the matching uploaded build by
+marketing version/build number/platform, and attaches it once App Store Connect reports
+the build as `VALID`. `AppleApps.SyncScreenshots` runs the same screenshot sync engine
+from the unified release flow for matching screenshot config files.
+
+Localized text metadata, pricing, review submission, phased release controls, and final
+manual release/submission decisions still need dedicated App Store Connect automation
+before they should be driven by this lane.
 
 ## Screenshot Upload Flow
 

--- a/PSPublishModule/Cmdlets/SetAppStoreConnectVersionBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/SetAppStoreConnectVersionBuildCommand.cs
@@ -1,0 +1,73 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Creates or finds an App Store version and selects a processed build for Distribution.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "AppStoreConnectVersionBuild", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectReleasePreparationResult))]
+public sealed class SetAppStoreConnectVersionBuildCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version to create or update.</summary>
+    [Parameter(Mandatory = true)] public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number to select.</summary>
+    [Parameter(Mandatory = true)] public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the App Store version and build.</summary>
+    [Parameter(Mandatory = true)] public ApplePlatform Platform { get; set; }
+
+    /// <summary>Do not create the App Store version when it is missing.</summary>
+    [Parameter] public SwitchParameter NoCreateVersion { get; set; }
+
+    /// <summary>Do not attach the build to the App Store version.</summary>
+    [Parameter] public SwitchParameter NoSelectBuild { get; set; }
+
+    /// <summary>Allow selecting a build before App Store Connect reports VALID processing state.</summary>
+    [Parameter] public SwitchParameter AllowUnprocessedBuild { get; set; }
+
+    /// <summary>Creates or finds an App Store version and selects a processed build for Distribution.</summary>
+    protected override void ProcessRecord()
+    {
+        var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
+        if (!ShouldProcess(target, "Prepare App Store Connect version build"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectReleasePreparationService(client);
+        var result = service.PrepareAsync(new AppStoreConnectReleasePreparationRequest
+        {
+            AppId = AppId,
+            VersionString = VersionString,
+            BuildNumber = BuildNumber,
+            Platform = Platform,
+            CreateVersion = !NoCreateVersion.IsPresent,
+            SelectBuild = !NoSelectBuild.IsPresent,
+            RequireValidBuild = !AllowUnprocessedBuild.IsPresent
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -164,6 +164,121 @@ public sealed class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task CreateVersionAsync_PostsVersionPlatformAndAppRelationship()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "version-1",
+                    "type": "appStoreVersions",
+                    "attributes": {
+                      "versionString": "1.0.1",
+                      "platform": "IOS",
+                      "appStoreState": "PREPARE_FOR_SUBMISSION"
+                    }
+                  }
+                }
+                """));
+
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var version = await client.CreateVersionAsync("app-1", "1.0.1", ApplePlatform.iOS);
+
+        Assert.Equal("version-1", version.Id);
+        Assert.Equal("1.0.1", version.VersionString);
+        Assert.Equal(HttpMethod.Post, handler.Methods[0]);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/appStoreVersions", handler.RequestUris[0].ToString());
+        Assert.Contains("\"type\":\"appStoreVersions\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Contains("\"platform\":\"IOS\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Contains("\"versionString\":\"1.0.1\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Contains("\"type\":\"apps\",\"id\":\"app-1\"", handler.RequestBodies[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SetVersionBuildAsync_PatchesBuildRelationship()
+    {
+        var handler = new SequenceHandler(new SequenceResponse(HttpStatusCode.NoContent, string.Empty));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        await client.SetVersionBuildAsync("version-1", "build-5");
+
+        Assert.Equal(new HttpMethod("PATCH"), handler.Methods[0]);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/appStoreVersions/version-1/relationships/build", handler.RequestUris[0].ToString());
+        Assert.Contains("\"type\":\"builds\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Contains("\"id\":\"build-5\"", handler.RequestBodies[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReleasePreparationService_CreatesMissingVersionAndSelectsValidBuild()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "version-1",
+                    "type": "appStoreVersions",
+                    "attributes": { "versionString": "1.0.1", "platform": "IOS" }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-5",
+                      "type": "builds",
+                      "attributes": { "version": "5", "processingState": "VALID", "expired": false },
+                      "relationships": {
+                        "preReleaseVersion": {
+                          "data": { "id": "pre-1", "type": "preReleaseVersions" }
+                        }
+                      }
+                    }
+                  ],
+                  "included": [
+                    {
+                      "id": "pre-1",
+                      "type": "preReleaseVersions",
+                      "attributes": { "version": "1.0.1", "platform": "IOS" }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": null }"""),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty));
+
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectReleasePreparationService(client);
+
+        var result = await service.PrepareAsync(new AppStoreConnectReleasePreparationRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.1",
+            BuildNumber = "5",
+            Platform = ApplePlatform.iOS
+        });
+
+        Assert.True(result.CreatedVersion);
+        Assert.True(result.SelectedBuild);
+        Assert.Equal("version-1", result.Version.Id);
+        Assert.Equal("build-5", result.Build?.Id);
+        Assert.Equal(
+            new[] { HttpMethod.Get, HttpMethod.Post, HttpMethod.Get, HttpMethod.Get, new HttpMethod("PATCH") },
+            handler.Methods);
+        Assert.Contains("filter%5BversionString%5D=1.0.1", handler.RequestUris[0].Query, StringComparison.Ordinal);
+        Assert.Contains("filter%5Bversion%5D=5", handler.RequestUris[2].Query, StringComparison.Ordinal);
+        Assert.Contains("appStoreVersions/version-1/relationships/build", handler.RequestUris[4].ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task GetSubscriptionsForAppAsync_ListsGroupsAndSubscriptions()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -522,6 +522,93 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_PreparesDistributionVersionWithResolvedProjectVersion()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj", "1.0.1", "5");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var requests = new List<AppStoreConnectReleasePreparationRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Archive should not run."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."),
+                prepareAppleDistribution: request =>
+                {
+                    requests.Add(request);
+                    return new AppStoreConnectReleasePreparationResult
+                    {
+                        AppId = request.AppId,
+                        VersionString = request.VersionString,
+                        BuildNumber = request.BuildNumber,
+                        Platform = request.Platform,
+                        Version = new AppStoreConnectVersionInfo { Id = "version-1", VersionString = request.VersionString },
+                        Build = new AppStoreConnectBuildInfo { Id = "build-5", Version = request.BuildNumber },
+                        SelectedBuild = true
+                    };
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        PrepareDistribution = true,
+                        SelectBuildForDistribution = true,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.True(result.Success);
+            var request = Assert.Single(requests);
+            Assert.NotNull(request.Credential);
+            Assert.Equal("app-1", request.AppId);
+            Assert.Equal("1.0.1", request.VersionString);
+            Assert.Equal("5", request.BuildNumber);
+            Assert.True(request.CreateVersion);
+            Assert.True(request.SelectBuild);
+            Assert.True(request.RequireValidBuild);
+
+            var appResult = Assert.Single(result.AppleApps);
+            Assert.Equal("version-1", appResult.Distribution?.Version.Id);
+            Assert.Equal("build-5", appResult.Distribution?.Build?.Id);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_ToolsOnly_DoesNotRunAppleApps()
     {
         var root = CreateSandbox();
@@ -589,21 +676,30 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
-    public void Execute_AppleApps_RejectsScreenshotSyncUntilUnifiedSupportExists()
+    public void Execute_AppleApps_AcceptsScreenshotSyncInUnifiedPlan()
     {
         var root = CreateSandbox();
         try
         {
             CreateXcodeProject(root, "Tactra.xcodeproj");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var screenshotConfigPath = Path.Combine(root, "screenshots.json");
+            File.WriteAllText(screenshotConfigPath, """{ "appId": "app-1", "versionString": "1.0.0", "platform": "iOS", "screenshotSets": [] }""");
 
             var service = new PowerForgeReleaseService(new NullLogger());
-            var ex = Assert.Throws<NotSupportedException>(() => service.Execute(
+            var result = service.Execute(
                 new PowerForgeReleaseSpec
                 {
                     AppleApps = new PowerForgeAppleReleaseOptions
                     {
                         ProjectRoot = ".",
+                        Archive = false,
                         SyncScreenshots = true,
+                        ScreenshotConfigPath = "screenshots.json",
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
                         Apps = new[]
                         {
                             new AppleAppConfiguration
@@ -611,7 +707,8 @@ public sealed class PowerForgeReleaseServiceTests
                                 Name = "Tactra",
                                 ProjectPath = "Tactra.xcodeproj",
                                 Scheme = "Tactra",
-                                Platform = ApplePlatform.iOS
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
                             }
                         }
                     }
@@ -620,9 +717,12 @@ public sealed class PowerForgeReleaseServiceTests
                 {
                     ConfigPath = Path.Combine(root, "powerforge.release.json"),
                     PlanOnly = true
-                }));
+                });
 
-            Assert.Contains("SyncScreenshots is not supported", ex.Message, StringComparison.Ordinal);
+            Assert.True(result.Success);
+            Assert.NotNull(result.AppleAppPlan);
+            Assert.True(result.AppleAppPlan!.SyncScreenshots);
+            Assert.EndsWith("screenshots.json", result.AppleAppPlan.ScreenshotConfigPath, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge/Models/AppStoreConnectReleasePreparationModels.cs
+++ b/PowerForge/Models/AppStoreConnectReleasePreparationModels.cs
@@ -1,0 +1,79 @@
+namespace PowerForge;
+
+/// <summary>
+/// Request to prepare an App Store Connect distribution version for a processed build.
+/// </summary>
+public sealed class AppStoreConnectReleasePreparationRequest
+{
+    /// <summary>App Store Connect API credential. Required when the request is executed by the default release runner.</summary>
+    public AppStoreConnectApiCredential? Credential { get; set; }
+
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version, for example 1.0.1.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number to select for the version.</summary>
+    public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the App Store version and uploaded build.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Create the App Store version when it does not already exist.</summary>
+    public bool CreateVersion { get; set; } = true;
+
+    /// <summary>Select the matched build for the App Store version.</summary>
+    public bool SelectBuild { get; set; } = true;
+
+    /// <summary>Require the matched build to be valid and not expired before selecting it.</summary>
+    public bool RequireValidBuild { get; set; } = true;
+
+    /// <summary>Optional screenshot sync configuration to run after the version exists.</summary>
+    public AppStoreConnectScreenshotSyncSpec? ScreenshotSpec { get; set; }
+
+    /// <summary>Deletes existing screenshots before uploading screenshots from the local spec.</summary>
+    public bool ReplaceScreenshots { get; set; }
+
+    /// <summary>Base directory for resolving relative screenshot paths.</summary>
+    public string BaseDirectory { get; set; } = Directory.GetCurrentDirectory();
+}
+
+/// <summary>
+/// Result of preparing an App Store Connect distribution version.
+/// </summary>
+public sealed class AppStoreConnectReleasePreparationResult
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>Prepared marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Prepared build number.</summary>
+    public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Prepared Apple platform.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Matched or created App Store version.</summary>
+    public AppStoreConnectVersionInfo Version { get; set; } = new();
+
+    /// <summary>Matched App Store Connect build.</summary>
+    public AppStoreConnectBuildInfo? Build { get; set; }
+
+    /// <summary>Whether the App Store version was created by this run.</summary>
+    public bool CreatedVersion { get; set; }
+
+    /// <summary>Whether the requested build was selected by this run.</summary>
+    public bool SelectedBuild { get; set; }
+
+    /// <summary>Build id that was selected before this run, if any.</summary>
+    public string? PreviousBuildId { get; set; }
+
+    /// <summary>Screenshot sync result when screenshots were configured.</summary>
+    public AppStoreConnectScreenshotSyncResult? Screenshots { get; set; }
+
+    /// <summary>Preparation messages useful for release logs.</summary>
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -312,6 +312,12 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public string[] ScreenshotConfigPaths { get; set; } = Array.Empty<string>();
 
+    public bool PrepareDistribution { get; set; }
+
+    public bool SelectBuildForDistribution { get; set; } = true;
+
+    public bool AllowUnprocessedDistributionBuild { get; set; }
+
     public bool SyncScreenshots { get; set; }
 
     public bool ReplaceScreenshots { get; set; }
@@ -334,6 +340,12 @@ internal sealed class PowerForgeAppleReleasePlan
     public string? ScreenshotConfigPath { get; set; }
 
     public string[] ScreenshotConfigPaths { get; set; } = Array.Empty<string>();
+
+    public bool PrepareDistribution { get; set; }
+
+    public bool SelectBuildForDistribution { get; set; } = true;
+
+    public bool AllowUnprocessedDistributionBuild { get; set; }
 
     public bool ReplaceScreenshots { get; set; }
 
@@ -365,6 +377,8 @@ internal sealed class PowerForgeAppleAppReleaseTargetPlan
     public string? BundleId { get; set; }
 
     public ApplePlatform Platform { get; set; }
+
+    public string? AppStoreConnectAppId { get; set; }
 
     public string ProjectPath { get; set; } = string.Empty;
 
@@ -402,6 +416,8 @@ internal sealed class PowerForgeAppleAppReleaseResult
     public AppleAppArchiveUploadResult? Upload { get; set; }
 
     public XcodeProjectVersionUpdateResult? VersionUpdate { get; set; }
+
+    public AppStoreConnectReleasePreparationResult? Distribution { get; set; }
 
     public bool Success { get; set; }
 

--- a/PowerForge/Services/AppStoreConnectClient.cs
+++ b/PowerForge/Services/AppStoreConnectClient.cs
@@ -93,6 +93,90 @@ public sealed class AppStoreConnectClient : IDisposable
     }
 
     /// <summary>
+    /// Creates an App Store version for an app and platform.
+    /// </summary>
+    public Task<AppStoreConnectVersionInfo> CreateVersionAsync(
+        string appId,
+        string versionString,
+        ApplePlatform platform,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(appId))
+            throw new ArgumentException("App id is required.", nameof(appId));
+        if (string.IsNullOrWhiteSpace(versionString))
+            throw new ArgumentException("Version string is required.", nameof(versionString));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "appStoreVersions",
+                attributes = new
+                {
+                    platform = ToAppStoreConnectPlatform(platform),
+                    versionString = versionString.Trim()
+                },
+                relationships = new
+                {
+                    app = new
+                    {
+                        data = new { type = "apps", id = appId.Trim() }
+                    }
+                }
+            }
+        };
+
+        return PostSingleAsync("appStoreVersions", body, ParseVersion, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads the build relationship id currently selected for an App Store version.
+    /// </summary>
+    public async Task<string?> GetVersionBuildIdAsync(string versionId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(versionId))
+            throw new ArgumentException("Version id is required.", nameof(versionId));
+
+        using var doc = await GetJsonAsync(
+            $"appStoreVersions/{Uri.EscapeDataString(versionId.Trim())}/relationships/build",
+            cancellationToken,
+            returnNullOnNotFound: true).ConfigureAwait(false);
+        if (doc is null ||
+            !doc.RootElement.TryGetProperty("data", out var data) ||
+            data.ValueKind == JsonValueKind.Null)
+            return null;
+        if (data.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return GetString(data, "id");
+    }
+
+    /// <summary>
+    /// Selects a build for an App Store version.
+    /// </summary>
+    public async Task SetVersionBuildAsync(
+        string versionId,
+        string buildId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(versionId))
+            throw new ArgumentException("Version id is required.", nameof(versionId));
+        if (string.IsNullOrWhiteSpace(buildId))
+            throw new ArgumentException("Build id is required.", nameof(buildId));
+
+        var body = new
+        {
+            data = new { type = "builds", id = buildId.Trim() }
+        };
+
+        using var _ = await SendJsonAsync(
+            new HttpMethod("PATCH"),
+            $"appStoreVersions/{Uri.EscapeDataString(versionId.Trim())}/relationships/build",
+            body,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Lists builds for an app.
     /// </summary>
     public Task<AppStoreConnectBuildInfo[]> GetBuildsAsync(

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -1,0 +1,158 @@
+namespace PowerForge;
+
+/// <summary>
+/// Prepares App Store Connect Distribution metadata for an uploaded Apple app build.
+/// </summary>
+public sealed class AppStoreConnectReleasePreparationService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Creates a release preparation service.
+    /// </summary>
+    /// <param name="client">App Store Connect client.</param>
+    public AppStoreConnectReleasePreparationService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Ensures the App Store version exists, optionally selects a processed build, and optionally syncs screenshots.
+    /// </summary>
+    public async Task<AppStoreConnectReleasePreparationResult> PrepareAsync(
+        AppStoreConnectReleasePreparationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrWhiteSpace(request.AppId))
+            throw new ArgumentException("AppId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.VersionString))
+            throw new ArgumentException("VersionString is required.", nameof(request));
+        if (request.SelectBuild && string.IsNullOrWhiteSpace(request.BuildNumber))
+            throw new ArgumentException("BuildNumber is required when SelectBuild is enabled.", nameof(request));
+
+        var appId = request.AppId.Trim();
+        var versionString = request.VersionString.Trim();
+        var buildNumber = request.BuildNumber.Trim();
+        var messages = new List<string>();
+        var createdVersion = false;
+        var versions = await _client.GetVersionsAsync(
+            appId,
+            versionString,
+            request.Platform,
+            limit: 10,
+            cancellationToken).ConfigureAwait(false);
+        var version = versions.FirstOrDefault();
+        if (version is null)
+        {
+            if (!request.CreateVersion)
+                throw new InvalidOperationException($"App Store version '{versionString}' was not found for app '{appId}' and platform '{request.Platform}'.");
+
+            version = await _client.CreateVersionAsync(appId, versionString, request.Platform, cancellationToken).ConfigureAwait(false);
+            createdVersion = true;
+            messages.Add($"Created App Store version '{versionString}' for platform '{request.Platform}'.");
+        }
+        else
+        {
+            messages.Add($"Found App Store version '{versionString}' for platform '{request.Platform}'.");
+        }
+
+        AppStoreConnectBuildInfo? build = null;
+        string? previousBuildId = null;
+        var selectedBuild = false;
+        if (request.SelectBuild)
+        {
+            build = (await _client.GetBuildsAsync(
+                appId,
+                buildNumber,
+                limit: 20,
+                marketingVersion: versionString,
+                platform: request.Platform,
+                cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+            if (build is null)
+                throw new InvalidOperationException($"Build '{buildNumber}' was not found for app '{appId}', version '{versionString}', and platform '{request.Platform}'.");
+
+            if (request.RequireValidBuild)
+                ValidateBuildIsSelectable(build, buildNumber);
+
+            previousBuildId = await _client.GetVersionBuildIdAsync(version.Id, cancellationToken).ConfigureAwait(false);
+            if (string.Equals(previousBuildId, build.Id, StringComparison.OrdinalIgnoreCase))
+            {
+                messages.Add($"Build '{buildNumber}' is already selected for App Store version '{versionString}'.");
+            }
+            else
+            {
+                await _client.SetVersionBuildAsync(version.Id, build.Id, cancellationToken).ConfigureAwait(false);
+                selectedBuild = true;
+                messages.Add($"Selected build '{buildNumber}' for App Store version '{versionString}'.");
+            }
+        }
+
+        AppStoreConnectScreenshotSyncResult? screenshots = null;
+        if (request.ScreenshotSpec is not null)
+        {
+            var screenshotSpec = CreateScreenshotSpecForVersion(request.ScreenshotSpec, appId, versionString, request.Platform, version.Id);
+            screenshots = await new AppStoreConnectScreenshotSyncService(_client).SyncAsync(
+                new AppStoreConnectScreenshotSyncRequest
+                {
+                    Spec = screenshotSpec,
+                    ReplaceExisting = request.ReplaceScreenshots,
+                    BaseDirectory = request.BaseDirectory
+                },
+                cancellationToken).ConfigureAwait(false);
+            messages.Add("Synchronized App Store screenshots.");
+        }
+
+        return new AppStoreConnectReleasePreparationResult
+        {
+            AppId = appId,
+            VersionString = versionString,
+            BuildNumber = buildNumber,
+            Platform = request.Platform,
+            Version = version,
+            Build = build,
+            CreatedVersion = createdVersion,
+            SelectedBuild = selectedBuild,
+            PreviousBuildId = previousBuildId,
+            Screenshots = screenshots,
+            Messages = messages.ToArray()
+        };
+    }
+
+    private static void ValidateBuildIsSelectable(AppStoreConnectBuildInfo build, string buildNumber)
+    {
+        if (!string.Equals(build.ProcessingState, "VALID", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be selected because processing state is '{build.ProcessingState ?? "unknown"}'.");
+        if (build.Expired == true)
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be selected because it is expired.");
+    }
+
+    private static AppStoreConnectScreenshotSyncSpec CreateScreenshotSpecForVersion(
+        AppStoreConnectScreenshotSyncSpec source,
+        string appId,
+        string versionString,
+        ApplePlatform platform,
+        string versionId)
+    {
+        if (!string.IsNullOrWhiteSpace(source.AppId) &&
+            !string.Equals(source.AppId.Trim(), appId, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Screenshot config AppId '{source.AppId}' does not match release app id '{appId}'.");
+        var sourceVersionString = string.IsNullOrWhiteSpace(source.VersionString) ? null : source.VersionString!.Trim();
+        if (sourceVersionString is not null &&
+            !string.Equals(sourceVersionString, versionString, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Screenshot config VersionString '{source.VersionString}' does not match release version '{versionString}'.");
+        if (source.Platform != platform)
+            throw new InvalidOperationException($"Screenshot config Platform '{source.Platform}' does not match release platform '{platform}'.");
+
+        return new AppStoreConnectScreenshotSyncSpec
+        {
+            AppId = appId,
+            VersionString = versionString,
+            VersionId = versionId,
+            Platform = platform,
+            Locale = source.Locale,
+            ScreenshotSets = source.ScreenshotSets
+        };
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -57,6 +57,7 @@ internal sealed class PowerForgeReleaseService
     private readonly Func<PowerForgeWingetSubmissionPlan, PowerForgeWingetSubmissionResult> _submitWinget;
     private readonly Func<AppleAppArchiveRequest, AppleAppArchiveResult> _archiveAppleApp;
     private readonly Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult> _uploadAppleApp;
+    private readonly Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult> _prepareAppleDistribution;
 
     /// <summary>
     /// Creates a new unified release service.
@@ -73,7 +74,8 @@ internal sealed class PowerForgeReleaseService
             publishRequest => new GitHubReleasePublisher(logger).PublishRelease(publishRequest),
             plan => new WingetSubmissionService(logger).Run(plan),
             request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult(),
-            request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult())
+            request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult(),
+            null)
     {
     }
 
@@ -94,7 +96,8 @@ internal sealed class PowerForgeReleaseService
             publishGitHubRelease,
             plan => new WingetSubmissionService(logger).Run(plan),
             request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult(),
-            request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult())
+            request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult(),
+            null)
     {
     }
 
@@ -109,7 +112,8 @@ internal sealed class PowerForgeReleaseService
         Func<GitHubReleasePublishRequest, GitHubReleasePublishResult> publishGitHubRelease,
         Func<PowerForgeWingetSubmissionPlan, PowerForgeWingetSubmissionResult>? submitWinget = null,
         Func<AppleAppArchiveRequest, AppleAppArchiveResult>? archiveAppleApp = null,
-        Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null)
+        Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null,
+        Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -122,6 +126,7 @@ internal sealed class PowerForgeReleaseService
         _submitWinget = submitWinget ?? (plan => new WingetSubmissionService(logger).Run(plan));
         _archiveAppleApp = archiveAppleApp ?? (request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult());
         _uploadAppleApp = uploadAppleApp ?? (request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult());
+        _prepareAppleDistribution = prepareAppleDistribution ?? PrepareAppleDistribution;
     }
 
     /// <summary>
@@ -681,8 +686,6 @@ internal sealed class PowerForgeReleaseService
         bool allowUnresolvedResolvedVersion = false,
         bool validateReusableArchives = true)
     {
-        if (options.SyncScreenshots)
-            throw new NotSupportedException("AppleApps.SyncScreenshots is not supported by the unified release workflow yet. Use Sync-AppStoreConnectScreenshots or project-specific screenshot sync scripts for now.");
         if (skipBuild && options.Archive)
             throw new InvalidOperationException("PowerForge release SkipBuild is not supported when AppleApps.Archive is enabled. Set AppleApps.Archive=false to reuse an existing Apple archive explicitly.");
 
@@ -719,6 +722,11 @@ internal sealed class PowerForgeReleaseService
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
+        if ((options.PrepareDistribution || options.SyncScreenshots) &&
+            apps.Any(app => string.IsNullOrWhiteSpace(app.AppStoreConnectAppId)))
+            throw new InvalidOperationException("AppleApps PrepareDistribution or SyncScreenshots requires AppStoreConnectAppId for every selected app.");
+        if (options.SyncScreenshots && screenshotConfigPath is null && screenshotConfigPaths.Length == 0)
+            throw new InvalidOperationException("AppleApps SyncScreenshots requires ScreenshotConfigPath or ScreenshotConfigPaths.");
         if (!options.Archive && apps.Any(app => app.VersionUpdateRequested))
             throw new InvalidOperationException("Apple app version updates require AppleApps.Archive=true. Set Archive=true to build a fresh archive after updating versions, or remove version update fields when reusing an existing archive.");
         if (validateReusableArchives && !options.Archive && options.Upload)
@@ -727,10 +735,30 @@ internal sealed class PowerForgeReleaseService
             if (missingArchive is not null)
                 throw new FileNotFoundException($"Apple app archive was not found for upload-only release: {missingArchive.ArchivePath}", missingArchive.ArchivePath);
         }
-        var appStoreConnectApiKeyPath = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyPath) ? null : ResolveOutputPath(projectRoot, options.AppStoreConnectApiKeyPath!);
-        var appStoreConnectApiKeyId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyId) ? null : options.AppStoreConnectApiKeyId!.Trim();
-        var appStoreConnectApiIssuerId = string.IsNullOrWhiteSpace(options.AppStoreConnectApiIssuerId) ? null : options.AppStoreConnectApiIssuerId!.Trim();
+        var explicitAppStoreConnectApiConfiguredCount =
+            (string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyPath) ? 0 : 1) +
+            (string.IsNullOrWhiteSpace(options.AppStoreConnectApiKeyId) ? 0 : 1) +
+            (string.IsNullOrWhiteSpace(options.AppStoreConnectApiIssuerId) ? 0 : 1);
+        var allowAppStoreConnectEnvFallback = explicitAppStoreConnectApiConfiguredCount == 0;
+        var configuredAppStoreConnectApiKeyPath = allowAppStoreConnectEnvFallback
+            ? FirstNonEmpty(
+                Environment.GetEnvironmentVariable("APP_STORE_CONNECT_PRIVATE_KEY_PATH"),
+                Environment.GetEnvironmentVariable("ASC_PRIVATE_KEY_PATH"))
+            : options.AppStoreConnectApiKeyPath;
+        var appStoreConnectApiKeyPath = string.IsNullOrWhiteSpace(configuredAppStoreConnectApiKeyPath) ? null : ResolveOutputPath(projectRoot, configuredAppStoreConnectApiKeyPath!);
+        var appStoreConnectApiKeyId = allowAppStoreConnectEnvFallback
+            ? FirstNonEmpty(
+                Environment.GetEnvironmentVariable("APP_STORE_CONNECT_KEY_ID"),
+                Environment.GetEnvironmentVariable("ASC_KEY_ID"))
+            : options.AppStoreConnectApiKeyId?.Trim();
+        var appStoreConnectApiIssuerId = allowAppStoreConnectEnvFallback
+            ? FirstNonEmpty(
+                Environment.GetEnvironmentVariable("APP_STORE_CONNECT_ISSUER_ID"),
+                Environment.GetEnvironmentVariable("ASC_ISSUER_ID"))
+            : options.AppStoreConnectApiIssuerId?.Trim();
         var appStoreConnectApiConfiguredCount = (appStoreConnectApiKeyPath is null ? 0 : 1) + (appStoreConnectApiKeyId is null ? 0 : 1) + (appStoreConnectApiIssuerId is null ? 0 : 1);
+        if ((options.PrepareDistribution || options.SyncScreenshots) && appStoreConnectApiConfiguredCount != 3)
+            throw new InvalidOperationException("AppleApps PrepareDistribution or SyncScreenshots requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
         if (appStoreConnectApiConfiguredCount != 0)
         {
             if (appStoreConnectApiConfiguredCount != 3)
@@ -750,6 +778,9 @@ internal sealed class PowerForgeReleaseService
             SyncScreenshots = options.SyncScreenshots,
             ScreenshotConfigPath = screenshotConfigPath,
             ScreenshotConfigPaths = screenshotConfigPaths,
+            PrepareDistribution = options.PrepareDistribution,
+            SelectBuildForDistribution = options.SelectBuildForDistribution,
+            AllowUnprocessedDistributionBuild = options.AllowUnprocessedDistributionBuild,
             ReplaceScreenshots = options.ReplaceScreenshots,
             XcodeBuildExecutable = string.IsNullOrWhiteSpace(options.XcodeBuildExecutable) ? "xcodebuild" : options.XcodeBuildExecutable.Trim(),
             AllowProvisioningUpdates = options.AllowProvisioningUpdates,
@@ -814,6 +845,7 @@ internal sealed class PowerForgeReleaseService
             Name = name,
             BundleId = app.BundleId,
             Platform = platform,
+            AppStoreConnectAppId = string.IsNullOrWhiteSpace(app.AppStoreConnectAppId) ? null : app.AppStoreConnectAppId!.Trim(),
             ProjectPath = projectPath,
             IsWorkspace = isWorkspace,
             Scheme = app.Scheme!.Trim(),
@@ -833,6 +865,9 @@ internal sealed class PowerForgeReleaseService
     private PowerForgeAppleAppReleaseResult[] RunAppleRelease(PowerForgeAppleReleasePlan plan)
     {
         var results = new List<PowerForgeAppleAppReleaseResult>();
+        var screenshotSpecs = plan.SyncScreenshots
+            ? LoadAppleScreenshotSpecs(plan)
+            : Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
         foreach (var app in plan.Apps)
         {
             var result = new PowerForgeAppleAppReleaseResult
@@ -900,10 +935,132 @@ internal sealed class PowerForgeReleaseService
                 }
             }
 
+            if ((plan.PrepareDistribution || plan.SyncScreenshots) && result.Success)
+            {
+                var distributionValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
+                var matchingScreenshotSpec = plan.SyncScreenshots
+                    ? ResolveMatchingScreenshotSpec(screenshotSpecs, app, distributionValues.MarketingVersion)
+                    : null;
+
+                result.Distribution = _prepareAppleDistribution(new AppStoreConnectReleasePreparationRequest
+                {
+                    Credential = CreateAppStoreConnectCredential(plan),
+                    AppId = app.AppStoreConnectAppId!,
+                    VersionString = distributionValues.MarketingVersion,
+                    BuildNumber = distributionValues.BuildNumber,
+                    Platform = app.Platform,
+                    CreateVersion = plan.PrepareDistribution,
+                    SelectBuild = plan.PrepareDistribution && plan.SelectBuildForDistribution,
+                    RequireValidBuild = !plan.AllowUnprocessedDistributionBuild,
+                    ScreenshotSpec = matchingScreenshotSpec?.Spec,
+                    ReplaceScreenshots = plan.ReplaceScreenshots,
+                    BaseDirectory = matchingScreenshotSpec is null
+                        ? plan.ProjectRoot
+                        : Path.GetDirectoryName(matchingScreenshotSpec.Value.ConfigPath) ?? plan.ProjectRoot
+                });
+            }
+
             results.Add(result);
         }
 
         return results.ToArray();
+    }
+
+    private static AppStoreConnectReleasePreparationResult PrepareAppleDistribution(AppStoreConnectReleasePreparationRequest request)
+    {
+        if (request.Credential is null)
+            throw new ArgumentException("Credential is required.", nameof(request));
+
+        using var client = new AppStoreConnectClient(request.Credential);
+        return new AppStoreConnectReleasePreparationService(client).PrepareAsync(request).GetAwaiter().GetResult();
+    }
+
+    private static AppStoreConnectApiCredential CreateAppStoreConnectCredential(PowerForgeAppleReleasePlan plan)
+    {
+        if (string.IsNullOrWhiteSpace(plan.AppStoreConnectApiKeyPath) ||
+            string.IsNullOrWhiteSpace(plan.AppStoreConnectApiKeyId) ||
+            string.IsNullOrWhiteSpace(plan.AppStoreConnectApiIssuerId))
+            throw new InvalidOperationException("AppleApps App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+
+        return new AppStoreConnectApiCredential
+        {
+            IssuerId = plan.AppStoreConnectApiIssuerId!.Trim(),
+            KeyId = plan.AppStoreConnectApiKeyId!.Trim(),
+            PrivateKey = File.ReadAllText(plan.AppStoreConnectApiKeyPath!).Trim()
+        };
+    }
+
+    private static (string MarketingVersion, string BuildNumber) ResolveAppleDistributionValues(
+        PowerForgeAppleAppReleaseTargetPlan app,
+        XcodeProjectVersionUpdateResult? versionUpdate)
+    {
+        var marketingVersion = versionUpdate?.After.MarketingVersion ?? app.MarketingVersion;
+        var buildNumber = versionUpdate?.After.BuildNumber ?? app.BuildNumber;
+        if (string.IsNullOrWhiteSpace(marketingVersion) || string.IsNullOrWhiteSpace(buildNumber))
+        {
+            if (app.IsWorkspace)
+                throw new InvalidOperationException($"Apple app '{app.Name}' requires MarketingVersion and BuildNumber for Distribution preparation because workspace paths cannot be inspected for Xcode project versions.");
+
+            var local = new XcodeProjectVersionEditor().Read(app.ProjectPath);
+            if (string.IsNullOrWhiteSpace(marketingVersion))
+                marketingVersion = local.MarketingVersion;
+            if (string.IsNullOrWhiteSpace(buildNumber))
+                buildNumber = local.BuildNumber;
+        }
+
+        if (string.IsNullOrWhiteSpace(marketingVersion))
+            throw new InvalidOperationException($"Apple app '{app.Name}' requires a resolved marketing version before Distribution preparation.");
+        if (string.IsNullOrWhiteSpace(buildNumber))
+            throw new InvalidOperationException($"Apple app '{app.Name}' requires a resolved build number before Distribution preparation.");
+
+        return (marketingVersion!.Trim(), buildNumber!.Trim());
+    }
+
+    private static (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[] LoadAppleScreenshotSpecs(PowerForgeAppleReleasePlan plan)
+    {
+        var paths = new List<string>();
+        if (!string.IsNullOrWhiteSpace(plan.ScreenshotConfigPath))
+            paths.Add(plan.ScreenshotConfigPath!);
+        paths.AddRange(plan.ScreenshotConfigPaths.Where(static path => !string.IsNullOrWhiteSpace(path)));
+
+        return paths
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path =>
+            {
+                var json = File.ReadAllText(path);
+                var spec = JsonSerializer.Deserialize<AppStoreConnectScreenshotSyncSpec>(json, CreateJsonOptions())
+                    ?? throw new InvalidOperationException($"Unable to deserialize screenshot sync config: {path}");
+                return (spec, path);
+            })
+            .ToArray();
+    }
+
+    private static (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)? ResolveMatchingScreenshotSpec(
+        (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[] specs,
+        PowerForgeAppleAppReleaseTargetPlan app,
+        string marketingVersion)
+    {
+        var matches = specs
+            .Where(candidate =>
+                ScreenshotSpecMatches(candidate.Spec, app, marketingVersion))
+            .ToArray();
+        if (matches.Length > 1)
+            throw new InvalidOperationException($"Multiple screenshot sync configs match Apple app '{app.Name}' version '{marketingVersion}' platform '{app.Platform}'.");
+
+        return matches.Length == 0 ? null : matches[0];
+    }
+
+    private static bool ScreenshotSpecMatches(
+        AppStoreConnectScreenshotSyncSpec spec,
+        PowerForgeAppleAppReleaseTargetPlan app,
+        string marketingVersion)
+    {
+        var appIdMatches = string.IsNullOrWhiteSpace(spec.AppId) ||
+                           string.Equals(spec.AppId.Trim(), app.AppStoreConnectAppId, StringComparison.OrdinalIgnoreCase);
+        var specVersionString = string.IsNullOrWhiteSpace(spec.VersionString) ? null : spec.VersionString!.Trim();
+        var versionMatches = specVersionString is null ||
+                             string.Equals(specVersionString, marketingVersion, StringComparison.OrdinalIgnoreCase);
+        return appIdMatches && versionMatches && spec.Platform == app.Platform;
     }
 
     private static string NormalizeAppleArchiveProjectPath(string projectPath, string appName)
@@ -2868,6 +3025,9 @@ internal sealed class PowerForgeReleaseService
                 plan.Archive,
                 plan.Upload,
                 plan.SyncScreenshots,
+                plan.PrepareDistribution,
+                plan.SelectBuildForDistribution,
+                plan.AllowUnprocessedDistributionBuild,
                 plan.ScreenshotConfigPath,
                 plan.ScreenshotConfigPaths,
                 plan.ReplaceScreenshots,
@@ -2883,6 +3043,7 @@ internal sealed class PowerForgeReleaseService
                     app.Name,
                     app.BundleId,
                     Platform = app.Platform.ToString(),
+                    app.AppStoreConnectAppId,
                     app.ProjectPath,
                     app.IsWorkspace,
                     app.Scheme,
@@ -2933,6 +3094,20 @@ internal sealed class PowerForgeReleaseService
                     result.Upload.ExportOptionsPlistPath,
                     result.Upload.Succeeded,
                     ExitCode = result.Upload.ProcessResult.ExitCode
+                },
+                distribution = result.Distribution is null ? null : new
+                {
+                    result.Distribution.AppId,
+                    result.Distribution.VersionString,
+                    result.Distribution.BuildNumber,
+                    Platform = result.Distribution.Platform.ToString(),
+                    VersionId = result.Distribution.Version.Id,
+                    BuildId = result.Distribution.Build?.Id,
+                    result.Distribution.CreatedVersion,
+                    result.Distribution.SelectedBuild,
+                    result.Distribution.PreviousBuildId,
+                    ScreenshotSetCount = result.Distribution.Screenshots?.ScreenshotSets.Length ?? 0,
+                    result.Distribution.Messages
                 }
             }).ToArray()
         };

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -261,6 +261,9 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "PrepareDistribution": { "type": "boolean" },
+        "SelectBuildForDistribution": { "type": "boolean" },
+        "AllowUnprocessedDistributionBuild": { "type": "boolean" },
         "SyncScreenshots": { "type": "boolean" },
         "ReplaceScreenshots": { "type": "boolean" },
         "Apps": {


### PR DESCRIPTION
## Summary
- add App Store Connect API support for creating App Store versions and setting the version build relationship
- add reusable release preparation service plus Set-AppStoreConnectVersionBuild cmdlet
- wire PowerForge AppleApps to prepare Distribution versions, select processed builds, and run matching screenshot sync configs
- update release schema/docs and focused tests

Closes #462

## Validation
- PASS: dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "AppStoreConnectClientTests|PowerForgeReleaseServiceTests" -v minimal
- NOTE: full dotnet test PowerForge.Tests/PowerForge.Tests.csproj was attempted and interrupted after several minutes; it had already reported unrelated existing failures in WebAgentReadinessTests, DocumentationBinaryFixtureTests, WebSocialCardGeneratorTests, WebPipelineRunnerApiDocsPreflightTests, ScribanPfNavigationHelpersTests, MarkdownDocumentBuilderTests, ModuleBuildHostServiceTests, WebLinkServiceTests, RunProfileServiceTests, PSPublishModuleManifestContractTests, and other non-Apple/path/newline-sensitive areas.