### PR TITLE
Add App Store metadata and readiness automation

### DIFF
--- a/PSPublishModule/Cmdlets/AddAppStoreConnectBetaTesterToGroupCommand.cs
+++ b/PSPublishModule/Cmdlets/AddAppStoreConnectBetaTesterToGroupCommand.cs
@@ -1,0 +1,44 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Adds App Store Connect beta testers to a TestFlight beta group.
+/// </summary>
+[Cmdlet(VerbsCommon.Add, "AppStoreConnectBetaTesterToGroup", SupportsShouldProcess = true)]
+public sealed class AddAppStoreConnectBetaTesterToGroupCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>Beta group id.</summary>
+    [Parameter(Mandatory = true)] public string BetaGroupId { get; set; } = string.Empty;
+
+    /// <summary>Beta tester id to add to the beta group.</summary>
+    [Parameter(Mandatory = true)] public string[] BetaTesterId { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Adds beta testers to a TestFlight beta group.</summary>
+    protected override void ProcessRecord()
+    {
+        if (!ShouldProcess(BetaGroupId, "Add App Store Connect beta tester(s) to beta group"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        client.AddBetaTestersToBetaGroupAsync(BetaGroupId, BetaTesterId).GetAwaiter().GetResult();
+    }
+}

--- a/PSPublishModule/Cmdlets/AddAppStoreConnectBuildToBetaGroupCommand.cs
+++ b/PSPublishModule/Cmdlets/AddAppStoreConnectBuildToBetaGroupCommand.cs
@@ -1,0 +1,44 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Adds App Store Connect builds to a TestFlight beta group.
+/// </summary>
+[Cmdlet(VerbsCommon.Add, "AppStoreConnectBuildToBetaGroup", SupportsShouldProcess = true)]
+public sealed class AddAppStoreConnectBuildToBetaGroupCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>Beta group id.</summary>
+    [Parameter(Mandatory = true)] public string BetaGroupId { get; set; } = string.Empty;
+
+    /// <summary>Build id to add to the beta group.</summary>
+    [Parameter(Mandatory = true)] public string[] BuildId { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Adds builds to a TestFlight beta group.</summary>
+    protected override void ProcessRecord()
+    {
+        if (!ShouldProcess(BetaGroupId, "Add App Store Connect build(s) to beta group"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        client.AddBuildsToBetaGroupAsync(BetaGroupId, BuildId).GetAwaiter().GetResult();
+    }
+}

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectBetaGroupCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectBetaGroupCommand.cs
@@ -1,0 +1,46 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Reads App Store Connect TestFlight beta groups for an app.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "AppStoreConnectBetaGroup")]
+[OutputType(typeof(AppStoreConnectBetaGroupInfo))]
+public sealed class GetAppStoreConnectBetaGroupCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>Optional beta group name filter.</summary>
+    [Parameter] public string? Name { get; set; }
+
+    /// <summary>Maximum result count.</summary>
+    [Parameter] public int Limit { get; set; } = 200;
+
+    /// <summary>Reads TestFlight beta groups.</summary>
+    protected override void ProcessRecord()
+    {
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var groups = client.GetBetaGroupsAsync(AppId, Name, Limit).GetAwaiter().GetResult();
+        WriteObject(groups, enumerateCollection: true);
+    }
+}

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectBetaTesterCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectBetaTesterCommand.cs
@@ -1,0 +1,43 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Reads App Store Connect TestFlight beta testers.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "AppStoreConnectBetaTester")]
+[OutputType(typeof(AppStoreConnectBetaTesterInfo))]
+public sealed class GetAppStoreConnectBetaTesterCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>Optional tester email filter.</summary>
+    [Parameter] public string? Email { get; set; }
+
+    /// <summary>Maximum result count.</summary>
+    [Parameter] public int Limit { get; set; } = 200;
+
+    /// <summary>Reads TestFlight beta testers.</summary>
+    protected override void ProcessRecord()
+    {
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var testers = client.GetBetaTestersAsync(Email, Limit).GetAwaiter().GetResult();
+        WriteObject(testers, enumerateCollection: true);
+    }
+}

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectScreenshotCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectScreenshotCommand.cs
@@ -1,0 +1,45 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Reads screenshots in an App Store Connect screenshot set.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "AppStoreConnectScreenshot")]
+[OutputType(typeof(AppStoreConnectScreenshotInfo))]
+public sealed class GetAppStoreConnectScreenshotCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>Screenshot set id.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string ScreenshotSetId { get; set; } = string.Empty;
+
+    /// <summary>Maximum result count.</summary>
+    [Parameter] public int Limit { get; set; } = 200;
+
+    /// <summary>Reads screenshots in an App Store Connect screenshot set.</summary>
+    protected override void ProcessRecord()
+    {
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var screenshots = client.GetScreenshotsAsync(ScreenshotSetId, Limit).GetAwaiter().GetResult();
+        WriteObject(screenshots, enumerateCollection: true);
+    }
+}

--- a/PSPublishModule/Cmdlets/NewAppStoreConnectBetaTesterCommand.cs
+++ b/PSPublishModule/Cmdlets/NewAppStoreConnectBetaTesterCommand.cs
@@ -1,0 +1,52 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Creates an App Store Connect TestFlight beta tester.
+/// </summary>
+[Cmdlet(VerbsCommon.New, "AppStoreConnectBetaTester", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectBetaTesterInfo))]
+public sealed class NewAppStoreConnectBetaTesterCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>Tester email address.</summary>
+    [Parameter(Mandatory = true)] public string Email { get; set; } = string.Empty;
+
+    /// <summary>Optional first name.</summary>
+    [Parameter] public string? FirstName { get; set; }
+
+    /// <summary>Optional last name.</summary>
+    [Parameter] public string? LastName { get; set; }
+
+    /// <summary>Optional beta group ids to add the tester to during creation.</summary>
+    [Parameter] public string[] BetaGroupId { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Creates a TestFlight beta tester.</summary>
+    protected override void ProcessRecord()
+    {
+        if (!ShouldProcess(Email, "Create App Store Connect beta tester"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var tester = client.CreateBetaTesterAsync(Email, FirstName, LastName, BetaGroupId).GetAwaiter().GetResult();
+        WriteObject(tester);
+    }
+}

--- a/PSPublishModule/Cmdlets/PublishAppStoreConnectApprovedVersionCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishAppStoreConnectApprovedVersionCommand.cs
@@ -1,0 +1,61 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Requests release of an approved App Store Connect version in Pending Developer Release.
+/// </summary>
+[Cmdlet(VerbsData.Publish, "AppStoreConnectApprovedVersion", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectVersionReleaseResult))]
+public sealed class PublishAppStoreConnectApprovedVersionCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    [Parameter(Mandatory = true)] public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the App Store version.</summary>
+    [Parameter(Mandatory = true)] public ApplePlatform Platform { get; set; }
+
+    /// <summary>Allow requesting release when the version state is not Pending Developer Release.</summary>
+    [Parameter] public SwitchParameter AllowNonPendingDeveloperRelease { get; set; }
+
+    /// <summary>Requests release of an approved App Store version.</summary>
+    protected override void ProcessRecord()
+    {
+        var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()}";
+        if (!ShouldProcess(target, "Publish approved App Store Connect version"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectVersionReleaseService(client);
+        var result = service.ReleaseAsync(new AppStoreConnectVersionReleaseRequest
+        {
+            AppId = AppId,
+            VersionString = VersionString,
+            Platform = Platform,
+            RequirePendingDeveloperRelease = !AllowNonPendingDeveloperRelease.IsPresent
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PSPublishModule/Cmdlets/PublishAppStoreConnectTestFlightBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishAppStoreConnectTestFlightBuildCommand.cs
@@ -1,0 +1,85 @@
+using System.Management.Automation;
+using System.Linq;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Distributes a processed App Store Connect build to TestFlight beta groups and optional testers.
+/// </summary>
+[Cmdlet(VerbsData.Publish, "AppStoreConnectTestFlightBuild", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectTestFlightDistributionResult))]
+public sealed class PublishAppStoreConnectTestFlightBuildCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    [Parameter(Mandatory = true)] public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number.</summary>
+    [Parameter(Mandatory = true)] public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the build.</summary>
+    [Parameter(Mandatory = true)] public ApplePlatform Platform { get; set; }
+
+    /// <summary>Beta group ids to receive the build.</summary>
+    [Parameter] public string[] BetaGroupId { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Beta group names to resolve and receive the build.</summary>
+    [Parameter] public string[] BetaGroupName { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Tester email addresses to create or resolve and add to target groups.</summary>
+    [Parameter] public string[] TesterEmail { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Do not create testers that do not already exist.</summary>
+    [Parameter] public SwitchParameter NoCreateMissingTesters { get; set; }
+
+    /// <summary>Allow a build whose processing state is not VALID.</summary>
+    [Parameter] public SwitchParameter AllowUnprocessedBuild { get; set; }
+
+    /// <summary>Distributes a processed build to TestFlight beta groups and optional testers.</summary>
+    protected override void ProcessRecord()
+    {
+        var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
+        if (!ShouldProcess(target, "Publish App Store Connect TestFlight build to beta groups"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectTestFlightDistributionService(client);
+        var result = service.DistributeAsync(new AppStoreConnectTestFlightDistributionRequest
+        {
+            AppId = AppId,
+            VersionString = VersionString,
+            BuildNumber = BuildNumber,
+            Platform = Platform,
+            BetaGroupIds = BetaGroupId,
+            BetaGroupNames = BetaGroupName,
+            Testers = TesterEmail
+                .Where(static email => !string.IsNullOrWhiteSpace(email))
+                .Select(static email => new AppStoreConnectBetaTesterSpec { Email = email.Trim() })
+                .ToArray(),
+            CreateMissingTesters = !NoCreateMissingTesters.IsPresent,
+            RequireValidBuild = !AllowUnprocessedBuild.IsPresent
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PSPublishModule/Cmdlets/SetAppStoreConnectVersionLocalizationCommand.cs
+++ b/PSPublishModule/Cmdlets/SetAppStoreConnectVersionLocalizationCommand.cs
@@ -1,0 +1,72 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Updates localized metadata fields on an App Store version localization.
+/// </summary>
+[Cmdlet(VerbsCommon.Set, "AppStoreConnectVersionLocalization", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectVersionLocalizationInfo))]
+public sealed class SetAppStoreConnectVersionLocalizationCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store version localization id.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string VersionLocalizationId { get; set; } = string.Empty;
+
+    /// <summary>Localized App Store description. Empty string clears the field.</summary>
+    [Parameter] public string? Description { get; set; }
+
+    /// <summary>Localized App Store keywords. Empty string clears the field.</summary>
+    [Parameter] public string? Keywords { get; set; }
+
+    /// <summary>Localized marketing URL. Empty string clears the field.</summary>
+    [Parameter] public string? MarketingUrl { get; set; }
+
+    /// <summary>Localized promotional text. Empty string clears the field.</summary>
+    [Parameter] public string? PromotionalText { get; set; }
+
+    /// <summary>Localized support URL. Empty string clears the field.</summary>
+    [Parameter] public string? SupportUrl { get; set; }
+
+    /// <summary>Localized release notes / what's new text. Empty string clears the field.</summary>
+    [Parameter] public string? WhatsNew { get; set; }
+
+    /// <summary>Updates localized App Store metadata fields.</summary>
+    protected override void ProcessRecord()
+    {
+        if (!ShouldProcess(VersionLocalizationId, "Update App Store Connect version localization"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var result = client.UpdateVersionLocalizationAsync(VersionLocalizationId, new AppStoreConnectVersionLocalizationUpdate
+        {
+            Description = Description,
+            Keywords = Keywords,
+            MarketingUrl = MarketingUrl,
+            PromotionalText = PromotionalText,
+            SupportUrl = SupportUrl,
+            WhatsNew = WhatsNew
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PSPublishModule/Cmdlets/SubmitAppStoreConnectVersionForReviewCommand.cs
+++ b/PSPublishModule/Cmdlets/SubmitAppStoreConnectVersionForReviewCommand.cs
@@ -1,0 +1,77 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Submits a prepared App Store Connect Distribution version to App Review.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Submit, "AppStoreConnectVersionForReview", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectReviewSubmissionResult))]
+public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    [Parameter(Mandatory = true)] public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number expected on the Distribution version.</summary>
+    [Parameter(Mandatory = true)] public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the Distribution version.</summary>
+    [Parameter(Mandatory = true)] public ApplePlatform Platform { get; set; }
+
+    /// <summary>Allow submission without verifying that the requested build is selected on the Distribution version.</summary>
+    [Parameter] public SwitchParameter AllowUnselectedBuild { get; set; }
+
+    /// <summary>Allow submission when the build processing state is not VALID.</summary>
+    [Parameter] public SwitchParameter AllowUnprocessedBuild { get; set; }
+
+    /// <summary>Skip release readiness checks before submission.</summary>
+    [Parameter] public SwitchParameter SkipReadinessCheck { get; set; }
+
+    /// <summary>Do not fail when readiness checks fail.</summary>
+    [Parameter] public SwitchParameter AllowNotReady { get; set; }
+
+    /// <summary>Submits the Distribution version to App Review.</summary>
+    protected override void ProcessRecord()
+    {
+        var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
+        if (!ShouldProcess(target, "Submit App Store Connect version to App Review"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectReviewSubmissionService(client);
+        var result = service.SubmitAsync(new AppStoreConnectReviewSubmissionRequest
+        {
+            AppId = AppId,
+            VersionString = VersionString,
+            BuildNumber = BuildNumber,
+            Platform = Platform,
+            RequireSelectedBuild = !AllowUnselectedBuild.IsPresent,
+            RequireValidBuild = !AllowUnprocessedBuild.IsPresent,
+            CheckReadiness = !SkipReadinessCheck.IsPresent,
+            RequireReady = !AllowNotReady.IsPresent
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PSPublishModule/Cmdlets/SyncAppStoreConnectVersionMetadataCommand.cs
+++ b/PSPublishModule/Cmdlets/SyncAppStoreConnectVersionMetadataCommand.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Management.Automation;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Syncs localized App Store version metadata from a JSON configuration file.
+/// </summary>
+[Cmdlet(VerbsData.Sync, "AppStoreConnectVersionMetadata", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectVersionMetadataSyncResult))]
+public sealed class SyncAppStoreConnectVersionMetadataCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>Path to the App Store version metadata JSON configuration file.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    [ValidateNotNullOrEmpty]
+    public string ConfigPath { get; set; } = string.Empty;
+
+    /// <summary>Syncs localized App Store version metadata.</summary>
+    protected override void ProcessRecord()
+    {
+        var resolvedConfigPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(ConfigPath);
+        if (!ShouldProcess(resolvedConfigPath, "Sync App Store Connect version metadata"))
+            return;
+
+        var json = File.ReadAllText(resolvedConfigPath);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        options.Converters.Add(new JsonStringEnumConverter());
+
+        var spec = JsonSerializer.Deserialize<AppStoreConnectVersionMetadataSpec>(json, options)
+            ?? throw new InvalidOperationException($"Unable to deserialize App Store version metadata config: {resolvedConfigPath}");
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectVersionMetadataSyncService(client);
+        var result = service.SyncAsync(new AppStoreConnectVersionMetadataSyncRequest
+        {
+            Spec = spec
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PSPublishModule/Cmdlets/TestAppStoreConnectReleaseReadinessCommand.cs
+++ b/PSPublishModule/Cmdlets/TestAppStoreConnectReleaseReadinessCommand.cs
@@ -1,0 +1,109 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Checks whether an App Store Connect Distribution version is ready for submission.
+/// </summary>
+[Cmdlet(VerbsDiagnostic.Test, "AppStoreConnectReleaseReadiness")]
+[OutputType(typeof(AppStoreConnectReleaseReadinessResult))]
+public sealed class TestAppStoreConnectReleaseReadinessCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version to check.</summary>
+    [Parameter(Mandatory = true)] public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Expected selected build number.</summary>
+    [Parameter] public string? BuildNumber { get; set; }
+
+    /// <summary>Apple platform for the App Store version.</summary>
+    [Parameter(Mandatory = true)] public ApplePlatform Platform { get; set; }
+
+    /// <summary>Localization locale to check.</summary>
+    [Parameter] public string Locale { get; set; } = "en-US";
+
+    /// <summary>Screenshot display types that must have screenshots.</summary>
+    [Parameter] public string[] RequiredScreenshotDisplayTypes { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Minimum screenshot count for each required display type.</summary>
+    [Parameter] public int MinimumScreenshotsPerSet { get; set; } = 1;
+
+    /// <summary>Require a selected build relationship. Enabled by default.</summary>
+    [Parameter] public SwitchParameter NoRequireSelectedBuild { get; set; }
+
+    /// <summary>Do not require the matched build to be VALID and not expired.</summary>
+    [Parameter] public SwitchParameter NoRequireValidBuild { get; set; }
+
+    /// <summary>Do not require description.</summary>
+    [Parameter] public SwitchParameter NoRequireDescription { get; set; }
+
+    /// <summary>Do not require keywords.</summary>
+    [Parameter] public SwitchParameter NoRequireKeywords { get; set; }
+
+    /// <summary>Do not require support URL.</summary>
+    [Parameter] public SwitchParameter NoRequireSupportUrl { get; set; }
+
+    /// <summary>Require marketing URL.</summary>
+    [Parameter] public SwitchParameter RequireMarketingUrl { get; set; }
+
+    /// <summary>Require promotional text.</summary>
+    [Parameter] public SwitchParameter RequirePromotionalText { get; set; }
+
+    /// <summary>Require what's new / release notes text.</summary>
+    [Parameter] public SwitchParameter RequireWhatsNew { get; set; }
+
+    /// <summary>Do not require screenshots.</summary>
+    [Parameter] public SwitchParameter NoRequireScreenshots { get; set; }
+
+    /// <summary>Do not require checked screenshot assets to be COMPLETE.</summary>
+    [Parameter] public SwitchParameter NoRequireCompleteScreenshots { get; set; }
+
+    /// <summary>Checks App Store Connect release readiness.</summary>
+    protected override void ProcessRecord()
+    {
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectReleaseReadinessService(client);
+        var result = service.CheckAsync(new AppStoreConnectReleaseReadinessRequest
+        {
+            AppId = AppId,
+            VersionString = VersionString,
+            BuildNumber = BuildNumber,
+            Platform = Platform,
+            Locale = Locale,
+            RequiredScreenshotDisplayTypes = RequiredScreenshotDisplayTypes,
+            MinimumScreenshotsPerSet = MinimumScreenshotsPerSet,
+            RequireSelectedBuild = !NoRequireSelectedBuild.IsPresent,
+            RequireValidBuild = !NoRequireValidBuild.IsPresent,
+            RequireDescription = !NoRequireDescription.IsPresent,
+            RequireKeywords = !NoRequireKeywords.IsPresent,
+            RequireSupportUrl = !NoRequireSupportUrl.IsPresent,
+            RequireMarketingUrl = RequireMarketingUrl.IsPresent,
+            RequirePromotionalText = RequirePromotionalText.IsPresent,
+            RequireWhatsNew = RequireWhatsNew.IsPresent,
+            RequireScreenshots = !NoRequireScreenshots.IsPresent,
+            RequireCompleteScreenshots = !NoRequireCompleteScreenshots.IsPresent
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -961,6 +961,156 @@ public sealed class AppStoreConnectClientTests
         Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-1/relationships/betaTesters", handler.RequestUris[5].ToString());
     }
 
+    [Fact]
+    public async Task ReviewSubmissionClient_CreatesItemAndSubmits()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "submission-1",
+                    "type": "reviewSubmissions",
+                    "attributes": { "platform": "IOS", "isSubmitted": false, "state": "IN_PROGRESS" }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "item-1",
+                    "type": "reviewSubmissionItems",
+                    "relationships": {
+                      "reviewSubmission": { "data": { "type": "reviewSubmissions", "id": "submission-1" } },
+                      "appStoreVersion": { "data": { "type": "appStoreVersions", "id": "version-1" } }
+                    }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": {
+                    "id": "submission-1",
+                    "type": "reviewSubmissions",
+                    "attributes": { "platform": "IOS", "isSubmitted": true, "state": "WAITING_FOR_REVIEW" }
+                  }
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var submission = await client.CreateReviewSubmissionAsync("app-1", ApplePlatform.iOS);
+        var item = await client.CreateReviewSubmissionItemAsync(submission.Id, "version-1");
+        var submitted = await client.SubmitReviewSubmissionAsync(submission.Id);
+
+        Assert.Equal("submission-1", submission.Id);
+        Assert.False(submission.IsSubmitted);
+        Assert.Equal("item-1", item.Id);
+        Assert.Equal("version-1", item.AppStoreVersionId);
+        Assert.True(submitted.IsSubmitted);
+        Assert.Equal(HttpMethod.Post, handler.Methods[0]);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/reviewSubmissions", handler.RequestUris[0].ToString());
+        Assert.Contains("\"type\":\"reviewSubmissions\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Contains("\"platform\":\"IOS\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/reviewSubmissionItems", handler.RequestUris[1].ToString());
+        Assert.Contains("\"type\":\"appStoreVersions\"", handler.RequestBodies[1], StringComparison.Ordinal);
+        Assert.Equal(new HttpMethod("PATCH"), handler.Methods[2]);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/reviewSubmissions/submission-1", handler.RequestUris[2].ToString());
+        Assert.Contains("\"isSubmitted\":true", handler.RequestBodies[2], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReviewSubmissionService_SubmitsSelectedValidBuild()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "version-1",
+                      "type": "appStoreVersions",
+                      "attributes": { "versionString": "1.0.1", "platform": "IOS", "appStoreState": "PREPARE_FOR_SUBMISSION" }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-5",
+                      "type": "builds",
+                      "attributes": { "version": "5", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.1", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": { "type": "builds", "id": "build-5" } }"""),
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "submission-1",
+                    "type": "reviewSubmissions",
+                    "attributes": { "platform": "IOS", "isSubmitted": false }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "item-1",
+                    "type": "reviewSubmissionItems",
+                    "relationships": {
+                      "reviewSubmission": { "data": { "type": "reviewSubmissions", "id": "submission-1" } },
+                      "appStoreVersion": { "data": { "type": "appStoreVersions", "id": "version-1" } }
+                    }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": {
+                    "id": "submission-1",
+                    "type": "reviewSubmissions",
+                    "attributes": { "platform": "IOS", "isSubmitted": true, "state": "WAITING_FOR_REVIEW" }
+                  }
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectReviewSubmissionService(client);
+
+        var result = await service.SubmitAsync(new AppStoreConnectReviewSubmissionRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.1",
+            BuildNumber = "5",
+            Platform = ApplePlatform.iOS,
+            CheckReadiness = false
+        });
+
+        Assert.Equal("version-1", result.Version.Id);
+        Assert.Equal("build-5", result.Build?.Id);
+        Assert.Equal("submission-1", result.ReviewSubmission.Id);
+        Assert.True(result.ReviewSubmission.IsSubmitted);
+        Assert.Equal("item-1", result.ReviewSubmissionItem?.Id);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/appStoreVersions/version-1/relationships/build", handler.RequestUris[2].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/reviewSubmissions", handler.RequestUris[3].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/reviewSubmissionItems", handler.RequestUris[4].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/reviewSubmissions/submission-1", handler.RequestUris[5].ToString());
+    }
+
     private static AppStoreConnectApiCredential CreateCredential()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -1111,6 +1111,92 @@ public sealed class AppStoreConnectClientTests
         Assert.Equal("https://api.appstoreconnect.apple.com/v1/reviewSubmissions/submission-1", handler.RequestUris[5].ToString());
     }
 
+    [Fact]
+    public async Task VersionReleaseService_ReleasesPendingDeveloperVersion()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "version-1",
+                      "type": "appStoreVersions",
+                      "attributes": {
+                        "versionString": "1.0.1",
+                        "platform": "IOS",
+                        "appStoreState": "PENDING_DEVELOPER_RELEASE"
+                      }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "release-1",
+                    "type": "appStoreVersionReleaseRequests",
+                    "relationships": {
+                      "appStoreVersion": { "data": { "type": "appStoreVersions", "id": "version-1" } }
+                    }
+                  }
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectVersionReleaseService(client);
+
+        var result = await service.ReleaseAsync(new AppStoreConnectVersionReleaseRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.1",
+            Platform = ApplePlatform.iOS
+        });
+
+        Assert.Equal("version-1", result.Version.Id);
+        Assert.Equal("release-1", result.ReleaseRequest.Id);
+        Assert.Equal("version-1", result.ReleaseRequest.AppStoreVersionId);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/appStoreVersionReleaseRequests", handler.RequestUris[1].ToString());
+        Assert.Contains("\"type\":\"appStoreVersionReleaseRequests\"", handler.RequestBodies[1], StringComparison.Ordinal);
+        Assert.Contains("\"id\":\"version-1\"", handler.RequestBodies[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task VersionReleaseService_BlocksNonPendingDeveloperVersionByDefault()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "version-1",
+                      "type": "appStoreVersions",
+                      "attributes": {
+                        "versionString": "1.0.1",
+                        "platform": "IOS",
+                        "appStoreState": "READY_FOR_REVIEW"
+                      }
+                    }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectVersionReleaseService(client);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.ReleaseAsync(new AppStoreConnectVersionReleaseRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.1",
+            Platform = ApplePlatform.iOS
+        }));
+
+        Assert.Contains("PENDING_DEVELOPER_RELEASE", ex.Message, StringComparison.Ordinal);
+        Assert.Single(handler.RequestUris);
+    }
+
     private static AppStoreConnectApiCredential CreateCredential()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -213,6 +213,179 @@ public sealed class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task GetVersionLocalizationsAsync_ParsesSubmissionMetadataFields()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "loc-1",
+                      "type": "appStoreVersionLocalizations",
+                      "attributes": {
+                        "locale": "en-US",
+                        "description": "Premium remote.",
+                        "keywords": "media,remote",
+                        "marketingUrl": "https://example.test",
+                        "promotionalText": "Fresh release.",
+                        "supportUrl": "https://example.test/support",
+                        "whatsNew": "Improved releases."
+                      }
+                    }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var localizations = await client.GetVersionLocalizationsAsync("version-1", "en-US");
+
+        var localization = Assert.Single(localizations);
+        Assert.Equal("Premium remote.", localization.Description);
+        Assert.Equal("media,remote", localization.Keywords);
+        Assert.Equal("https://example.test", localization.MarketingUrl);
+        Assert.Equal("Fresh release.", localization.PromotionalText);
+        Assert.Equal("https://example.test/support", localization.SupportUrl);
+        Assert.Equal("Improved releases.", localization.WhatsNew);
+    }
+
+    [Fact]
+    public async Task UpdateVersionLocalizationAsync_PatchesOnlyProvidedMetadataFields()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": {
+                    "id": "loc-1",
+                    "type": "appStoreVersionLocalizations",
+                    "attributes": {
+                      "locale": "en-US",
+                      "description": "Updated.",
+                      "supportUrl": "https://example.test/support"
+                    }
+                  }
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var result = await client.UpdateVersionLocalizationAsync("loc-1", new AppStoreConnectVersionLocalizationUpdate
+        {
+            Description = "Updated.",
+            SupportUrl = "https://example.test/support"
+        });
+
+        Assert.Equal("Updated.", result.Description);
+        Assert.Equal(new HttpMethod("PATCH"), handler.Methods[0]);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/loc-1", handler.RequestUris[0].ToString());
+        Assert.Contains("\"description\":\"Updated.\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Contains("\"supportUrl\":\"https://example.test/support\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.DoesNotContain("promotionalText", handler.RequestBodies[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReleaseReadinessService_RequiresSelectedBuildMetadataAndCompleteScreenshots()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "version-1",
+                      "type": "appStoreVersions",
+                      "attributes": { "versionString": "1.0.1", "platform": "IOS" }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-5",
+                      "type": "builds",
+                      "attributes": { "version": "5", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.1", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                { "data": { "id": "build-5", "type": "builds" } }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "loc-1",
+                      "type": "appStoreVersionLocalizations",
+                      "attributes": {
+                        "locale": "en-US",
+                        "description": "Premium remote.",
+                        "keywords": "media,remote",
+                        "supportUrl": "https://example.test/support"
+                      }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "set-1",
+                      "type": "appScreenshotSets",
+                      "attributes": { "screenshotDisplayType": "APP_IPHONE_65" }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "shot-1",
+                      "type": "appScreenshots",
+                      "attributes": {
+                        "fileName": "01.png",
+                        "assetDeliveryState": { "state": "COMPLETE" }
+                      }
+                    }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectReleaseReadinessService(client);
+
+        var result = await service.CheckAsync(new AppStoreConnectReleaseReadinessRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.1",
+            BuildNumber = "5",
+            Platform = ApplePlatform.iOS,
+            RequiredScreenshotDisplayTypes = new[] { "APP_IPHONE_65" }
+        });
+
+        Assert.True(result.IsReady);
+        Assert.All(result.Checks, check => Assert.True(check.Passed, check.Message));
+        Assert.Equal("build-5", result.SelectedBuildId);
+        Assert.Equal("Premium remote.", result.Localization?.Description);
+        Assert.Equal("COMPLETE", Assert.Single(Assert.Single(result.ScreenshotSets).AssetDeliveryStates));
+    }
+
+    [Fact]
     public async Task ReleasePreparationService_CreatesMissingVersionAndSelectsValidBuild()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -868,6 +868,99 @@ public sealed class AppStoreConnectClientTests
         }
     }
 
+    [Fact]
+    public async Task AddBuildsToBetaGroupAsync_PostsBuildRelationship()
+    {
+        var handler = new SequenceHandler(new SequenceResponse(HttpStatusCode.NoContent, string.Empty));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        await client.AddBuildsToBetaGroupAsync("group-1", new[] { "build-5" });
+
+        Assert.Equal(HttpMethod.Post, handler.Methods[0]);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-1/relationships/builds", handler.RequestUris[0].ToString());
+        Assert.Contains("\"type\":\"builds\"", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.Contains("\"id\":\"build-5\"", handler.RequestBodies[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TestFlightDistributionService_AddsValidBuildAndTesterToGroups()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-5",
+                      "type": "builds",
+                      "attributes": { "version": "5", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.1", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-1",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Internal", "publicLinkEnabled": false }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "tester-1",
+                    "type": "betaTesters",
+                    "attributes": { "email": "tester@example.test", "firstName": "Test", "lastName": "User" }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectTestFlightDistributionService(client);
+
+        var result = await service.DistributeAsync(new AppStoreConnectTestFlightDistributionRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.1",
+            BuildNumber = "5",
+            Platform = ApplePlatform.iOS,
+            BetaGroupNames = new[] { "Internal" },
+            Testers = new[]
+            {
+                new AppStoreConnectBetaTesterSpec
+                {
+                    Email = "tester@example.test",
+                    FirstName = "Test",
+                    LastName = "User"
+                }
+            }
+        });
+
+        Assert.Equal("build-5", result.Build.Id);
+        Assert.Equal("Internal", Assert.Single(result.BetaGroups).Name);
+        Assert.Equal("tester@example.test", Assert.Single(result.Testers).Email);
+        Assert.Contains("filter%5Bapp%5D=app-1", handler.RequestUris[1].Query, StringComparison.Ordinal);
+        Assert.Contains("filter%5Bname%5D=Internal", handler.RequestUris[1].Query, StringComparison.Ordinal);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-1/relationships/builds", handler.RequestUris[2].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaTesters?limit=10&filter%5Bemail%5D=tester%40example.test", handler.RequestUris[3].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaTesters", handler.RequestUris[4].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-1/relationships/betaTesters", handler.RequestUris[5].ToString());
+    }
+
     private static AppStoreConnectApiCredential CreateCredential()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -911,6 +911,58 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_AcceptsApprovedVersionReleaseInUnifiedPlan()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        ReleaseApprovedVersion = true,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.AppleAppPlan);
+            Assert.True(result.AppleAppPlan!.ReleaseApprovedVersion);
+            Assert.False(result.AppleAppPlan.AllowNonPendingDeveloperRelease);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_ValidatesProjectPathBeforeReportingSuccess()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -731,6 +731,76 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_AcceptsMetadataAndReadinessInUnifiedPlan()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var metadataConfigPath = Path.Combine(root, "metadata.json");
+            File.WriteAllText(metadataConfigPath,
+                """
+                {
+                  "appId": "app-1",
+                  "versionString": "1.0.0",
+                  "platform": "iOS",
+                  "locale": "en-US",
+                  "metadata": {
+                    "description": "Premium remote.",
+                    "keywords": "media,remote",
+                    "supportUrl": "https://example.test/support"
+                  }
+                }
+                """);
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        SyncMetadata = true,
+                        CheckReleaseReadiness = true,
+                        MetadataConfigPath = "metadata.json",
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.AppleAppPlan);
+            Assert.True(result.AppleAppPlan!.SyncMetadata);
+            Assert.True(result.AppleAppPlan.CheckReleaseReadiness);
+            Assert.EndsWith("metadata.json", result.AppleAppPlan.MetadataConfigPath, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_ValidatesProjectPathBeforeReportingSuccess()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -856,6 +856,61 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_AcceptsReviewSubmissionInUnifiedPlan()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        SubmitForReview = true,
+                        AllowReviewSubmissionWhenNotReady = true,
+                        SkipReviewReadinessCheck = true,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.AppleAppPlan);
+            Assert.True(result.AppleAppPlan!.SubmitForReview);
+            Assert.True(result.AppleAppPlan.SkipReviewReadinessCheck);
+            Assert.True(result.AppleAppPlan.AllowReviewSubmissionWhenNotReady);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_ValidatesProjectPathBeforeReportingSuccess()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -801,6 +801,61 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_AcceptsTestFlightDistributionInUnifiedPlan()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        DistributeTestFlight = true,
+                        TestFlightBetaGroupNames = new[] { "Internal" },
+                        TestFlightTesterEmails = new[] { "tester@example.test" },
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.AppleAppPlan);
+            Assert.True(result.AppleAppPlan!.DistributeTestFlight);
+            Assert.Equal("Internal", Assert.Single(result.AppleAppPlan.TestFlightBetaGroupNames));
+            Assert.Equal("tester@example.test", Assert.Single(result.AppleAppPlan.TestFlightTesterEmails));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_ValidatesProjectPathBeforeReportingSuccess()
     {
         var root = CreateSandbox();

--- a/PowerForge/Models/AppStoreConnectAssetModels.cs
+++ b/PowerForge/Models/AppStoreConnectAssetModels.cs
@@ -13,6 +13,24 @@ public sealed class AppStoreConnectVersionLocalizationInfo
 
     /// <summary>Localized app name.</summary>
     public string? Name { get; set; }
+
+    /// <summary>Localized App Store description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Localized App Store keywords.</summary>
+    public string? Keywords { get; set; }
+
+    /// <summary>Localized marketing URL.</summary>
+    public string? MarketingUrl { get; set; }
+
+    /// <summary>Localized promotional text.</summary>
+    public string? PromotionalText { get; set; }
+
+    /// <summary>Localized support URL.</summary>
+    public string? SupportUrl { get; set; }
+
+    /// <summary>Localized release notes / what's new text.</summary>
+    public string? WhatsNew { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/AppStoreConnectReleasePreparationModels.cs
+++ b/PowerForge/Models/AppStoreConnectReleasePreparationModels.cs
@@ -32,8 +32,17 @@ public sealed class AppStoreConnectReleasePreparationRequest
     /// <summary>Optional screenshot sync configuration to run after the version exists.</summary>
     public AppStoreConnectScreenshotSyncSpec? ScreenshotSpec { get; set; }
 
+    /// <summary>Optional localized metadata sync configuration to run after the version exists.</summary>
+    public AppStoreConnectVersionMetadataSpec? MetadataSpec { get; set; }
+
     /// <summary>Deletes existing screenshots before uploading screenshots from the local spec.</summary>
     public bool ReplaceScreenshots { get; set; }
+
+    /// <summary>Run a release readiness check after distribution preparation.</summary>
+    public bool CheckReadiness { get; set; }
+
+    /// <summary>Readiness check options. App/version/build/platform are filled from this request.</summary>
+    public AppStoreConnectReleaseReadinessRequest? ReadinessRequest { get; set; }
 
     /// <summary>Base directory for resolving relative screenshot paths.</summary>
     public string BaseDirectory { get; set; } = Directory.GetCurrentDirectory();
@@ -73,6 +82,12 @@ public sealed class AppStoreConnectReleasePreparationResult
 
     /// <summary>Screenshot sync result when screenshots were configured.</summary>
     public AppStoreConnectScreenshotSyncResult? Screenshots { get; set; }
+
+    /// <summary>Metadata sync result when metadata was configured.</summary>
+    public AppStoreConnectVersionMetadataSyncResult? Metadata { get; set; }
+
+    /// <summary>Release readiness result when requested.</summary>
+    public AppStoreConnectReleaseReadinessResult? Readiness { get; set; }
 
     /// <summary>Preparation messages useful for release logs.</summary>
     public string[] Messages { get; set; } = Array.Empty<string>();

--- a/PowerForge/Models/AppStoreConnectReviewSubmissionModels.cs
+++ b/PowerForge/Models/AppStoreConnectReviewSubmissionModels.cs
@@ -1,0 +1,106 @@
+namespace PowerForge;
+
+/// <summary>
+/// App Store Connect review submission summary.
+/// </summary>
+public sealed class AppStoreConnectReviewSubmissionInfo
+{
+    /// <summary>Review submission id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Submission platform.</summary>
+    public string? Platform { get; set; }
+
+    /// <summary>Whether the submission has been sent to App Review.</summary>
+    public bool? IsSubmitted { get; set; }
+
+    /// <summary>Submission state when reported by App Store Connect.</summary>
+    public string? State { get; set; }
+}
+
+/// <summary>
+/// App Store Connect review submission item summary.
+/// </summary>
+public sealed class AppStoreConnectReviewSubmissionItemInfo
+{
+    /// <summary>Review submission item id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Review submission id associated with the item.</summary>
+    public string? ReviewSubmissionId { get; set; }
+
+    /// <summary>App Store version id associated with the item.</summary>
+    public string? AppStoreVersionId { get; set; }
+}
+
+/// <summary>
+/// Request to submit an App Store version to App Review.
+/// </summary>
+public sealed class AppStoreConnectReviewSubmissionRequest
+{
+    /// <summary>App Store Connect API credential. Required when the request is executed by the default release runner.</summary>
+    public AppStoreConnectApiCredential? Credential { get; set; }
+
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number expected on the Distribution version.</summary>
+    public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the Distribution version.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Require the Distribution version to already have the requested build selected.</summary>
+    public bool RequireSelectedBuild { get; set; } = true;
+
+    /// <summary>Require the selected build to be valid and not expired before submission.</summary>
+    public bool RequireValidBuild { get; set; } = true;
+
+    /// <summary>Run release readiness checks before creating the review submission.</summary>
+    public bool CheckReadiness { get; set; } = true;
+
+    /// <summary>Fail when readiness checks do not pass.</summary>
+    public bool RequireReady { get; set; } = true;
+
+    /// <summary>Optional readiness request overrides.</summary>
+    public AppStoreConnectReleaseReadinessRequest? ReadinessRequest { get; set; }
+}
+
+/// <summary>
+/// Result of submitting an App Store version to App Review.
+/// </summary>
+public sealed class AppStoreConnectReviewSubmissionResult
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number.</summary>
+    public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the submission.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Matched App Store version.</summary>
+    public AppStoreConnectVersionInfo Version { get; set; } = new();
+
+    /// <summary>Matched selected build.</summary>
+    public AppStoreConnectBuildInfo? Build { get; set; }
+
+    /// <summary>Review submission created or reused by the operation.</summary>
+    public AppStoreConnectReviewSubmissionInfo ReviewSubmission { get; set; } = new();
+
+    /// <summary>Review submission item created for the App Store version.</summary>
+    public AppStoreConnectReviewSubmissionItemInfo? ReviewSubmissionItem { get; set; }
+
+    /// <summary>Release readiness result when requested.</summary>
+    public AppStoreConnectReleaseReadinessResult? Readiness { get; set; }
+
+    /// <summary>Submission messages useful for release logs.</summary>
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/AppStoreConnectTestFlightModels.cs
+++ b/PowerForge/Models/AppStoreConnectTestFlightModels.cs
@@ -1,0 +1,118 @@
+namespace PowerForge;
+
+/// <summary>
+/// App Store Connect TestFlight beta group summary.
+/// </summary>
+public sealed class AppStoreConnectBetaGroupInfo
+{
+    /// <summary>Beta group id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Beta group name.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Whether public links are enabled for the group.</summary>
+    public bool? PublicLinkEnabled { get; set; }
+
+    /// <summary>Public link limit when configured.</summary>
+    public int? PublicLinkLimit { get; set; }
+
+    /// <summary>Public invitation link when available.</summary>
+    public string? PublicLink { get; set; }
+
+    /// <summary>Whether crash feedback is enabled.</summary>
+    public bool? FeedbackEnabled { get; set; }
+
+    /// <summary>Whether this is an internal beta group when reported by App Store Connect.</summary>
+    public bool? IsInternalGroup { get; set; }
+}
+
+/// <summary>
+/// App Store Connect TestFlight beta tester summary.
+/// </summary>
+public sealed class AppStoreConnectBetaTesterInfo
+{
+    /// <summary>Beta tester id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Tester email address.</summary>
+    public string? Email { get; set; }
+
+    /// <summary>Tester first name.</summary>
+    public string? FirstName { get; set; }
+
+    /// <summary>Tester last name.</summary>
+    public string? LastName { get; set; }
+
+    /// <summary>Tester invitation type or state when available.</summary>
+    public string? InviteType { get; set; }
+}
+
+/// <summary>
+/// Tester specification for TestFlight distribution.
+/// </summary>
+public sealed class AppStoreConnectBetaTesterSpec
+{
+    /// <summary>Tester email address.</summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>Optional tester first name.</summary>
+    public string? FirstName { get; set; }
+
+    /// <summary>Optional tester last name.</summary>
+    public string? LastName { get; set; }
+}
+
+/// <summary>
+/// Request to distribute a TestFlight build to beta groups and testers.
+/// </summary>
+public sealed class AppStoreConnectTestFlightDistributionRequest
+{
+    /// <summary>App Store Connect API credential. Required when the request is executed by the default release runner.</summary>
+    public AppStoreConnectApiCredential? Credential { get; set; }
+
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number.</summary>
+    public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the build.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Beta group ids to receive the build.</summary>
+    public string[] BetaGroupIds { get; set; } = Array.Empty<string>();
+
+    /// <summary>Beta group names to resolve and receive the build.</summary>
+    public string[] BetaGroupNames { get; set; } = Array.Empty<string>();
+
+    /// <summary>Optional testers to create or resolve and add to the target groups.</summary>
+    public AppStoreConnectBetaTesterSpec[] Testers { get; set; } = Array.Empty<AppStoreConnectBetaTesterSpec>();
+
+    /// <summary>Create testers that do not already exist.</summary>
+    public bool CreateMissingTesters { get; set; } = true;
+
+    /// <summary>Require the build to be valid and not expired before assigning it to beta groups.</summary>
+    public bool RequireValidBuild { get; set; } = true;
+}
+
+/// <summary>
+/// Result of distributing a TestFlight build to beta groups and testers.
+/// </summary>
+public sealed class AppStoreConnectTestFlightDistributionResult
+{
+    /// <summary>Matched build.</summary>
+    public AppStoreConnectBuildInfo Build { get; set; } = new();
+
+    /// <summary>Target beta groups.</summary>
+    public AppStoreConnectBetaGroupInfo[] BetaGroups { get; set; } = Array.Empty<AppStoreConnectBetaGroupInfo>();
+
+    /// <summary>Created or resolved beta testers.</summary>
+    public AppStoreConnectBetaTesterInfo[] Testers { get; set; } = Array.Empty<AppStoreConnectBetaTesterInfo>();
+
+    /// <summary>Distribution messages useful for release logs.</summary>
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
+++ b/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
@@ -1,0 +1,212 @@
+namespace PowerForge;
+
+/// <summary>
+/// Optional App Store Connect localized metadata values for an App Store version localization.
+/// Null values are left unchanged; empty strings intentionally clear the corresponding field.
+/// </summary>
+public sealed class AppStoreConnectVersionLocalizationUpdate
+{
+    /// <summary>Localized App Store description.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Localized App Store keywords.</summary>
+    public string? Keywords { get; set; }
+
+    /// <summary>Localized marketing URL.</summary>
+    public string? MarketingUrl { get; set; }
+
+    /// <summary>Localized promotional text.</summary>
+    public string? PromotionalText { get; set; }
+
+    /// <summary>Localized support URL.</summary>
+    public string? SupportUrl { get; set; }
+
+    /// <summary>Localized release notes / what's new text.</summary>
+    public string? WhatsNew { get; set; }
+}
+
+/// <summary>
+/// JSON-friendly specification for syncing localized App Store version metadata.
+/// </summary>
+public sealed class AppStoreConnectVersionMetadataSpec
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store version string.</summary>
+    public string? VersionString { get; set; }
+
+    /// <summary>Optional App Store version id. When provided, version lookup by string is skipped.</summary>
+    public string? VersionId { get; set; }
+
+    /// <summary>Apple platform for the App Store version.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Localization locale, for example en-US.</summary>
+    public string Locale { get; set; } = "en-US";
+
+    /// <summary>Localized metadata to apply.</summary>
+    public AppStoreConnectVersionLocalizationUpdate Metadata { get; set; } = new();
+}
+
+/// <summary>
+/// Request to sync localized App Store version metadata.
+/// </summary>
+public sealed class AppStoreConnectVersionMetadataSyncRequest
+{
+    /// <summary>Metadata sync specification.</summary>
+    public AppStoreConnectVersionMetadataSpec Spec { get; set; } = new();
+}
+
+/// <summary>
+/// Result of syncing localized App Store version metadata.
+/// </summary>
+public sealed class AppStoreConnectVersionMetadataSyncResult
+{
+    /// <summary>Matched App Store version.</summary>
+    public AppStoreConnectVersionInfo Version { get; set; } = new();
+
+    /// <summary>Localization before the metadata update.</summary>
+    public AppStoreConnectVersionLocalizationInfo Before { get; set; } = new();
+
+    /// <summary>Localization after the metadata update.</summary>
+    public AppStoreConnectVersionLocalizationInfo After { get; set; } = new();
+
+    /// <summary>Updated field names.</summary>
+    public string[] UpdatedFields { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Request to check whether an App Store Connect version is ready for submission.
+/// </summary>
+public sealed class AppStoreConnectReleaseReadinessRequest
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Build number expected to be selected for Distribution.</summary>
+    public string? BuildNumber { get; set; }
+
+    /// <summary>Apple platform for the App Store version and build.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Localization locale to check.</summary>
+    public string Locale { get; set; } = "en-US";
+
+    /// <summary>Require the Distribution version to have the expected selected build.</summary>
+    public bool RequireSelectedBuild { get; set; } = true;
+
+    /// <summary>Require the matched build to be valid and not expired.</summary>
+    public bool RequireValidBuild { get; set; } = true;
+
+    /// <summary>Require localized App Store description.</summary>
+    public bool RequireDescription { get; set; } = true;
+
+    /// <summary>Require localized App Store keywords.</summary>
+    public bool RequireKeywords { get; set; } = true;
+
+    /// <summary>Require localized support URL.</summary>
+    public bool RequireSupportUrl { get; set; } = true;
+
+    /// <summary>Require localized marketing URL.</summary>
+    public bool RequireMarketingUrl { get; set; }
+
+    /// <summary>Require localized promotional text.</summary>
+    public bool RequirePromotionalText { get; set; }
+
+    /// <summary>Require localized what's new / release notes text.</summary>
+    public bool RequireWhatsNew { get; set; }
+
+    /// <summary>Require screenshots in the configured screenshot display types.</summary>
+    public bool RequireScreenshots { get; set; } = true;
+
+    /// <summary>Require every checked screenshot asset to have COMPLETE delivery state.</summary>
+    public bool RequireCompleteScreenshots { get; set; } = true;
+
+    /// <summary>Minimum screenshot count for each required display type.</summary>
+    public int MinimumScreenshotsPerSet { get; set; } = 1;
+
+    /// <summary>Screenshot display types that must be present for this platform version.</summary>
+    public string[] RequiredScreenshotDisplayTypes { get; set; } = Array.Empty<string>();
+
+    /// <summary>Optional screenshot spec used to derive required display types.</summary>
+    public AppStoreConnectScreenshotSyncSpec? ScreenshotSpec { get; set; }
+}
+
+/// <summary>
+/// Result of checking App Store Connect release readiness.
+/// </summary>
+public sealed class AppStoreConnectReleaseReadinessResult
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>Checked marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Checked build number.</summary>
+    public string? BuildNumber { get; set; }
+
+    /// <summary>Checked platform.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Whether every required readiness check passed.</summary>
+    public bool IsReady { get; set; }
+
+    /// <summary>Matched App Store version when found.</summary>
+    public AppStoreConnectVersionInfo? Version { get; set; }
+
+    /// <summary>Matched build when requested and found.</summary>
+    public AppStoreConnectBuildInfo? Build { get; set; }
+
+    /// <summary>Selected build relationship id when available.</summary>
+    public string? SelectedBuildId { get; set; }
+
+    /// <summary>Matched localization when found.</summary>
+    public AppStoreConnectVersionLocalizationInfo? Localization { get; set; }
+
+    /// <summary>Screenshot set readiness details.</summary>
+    public AppStoreConnectReleaseScreenshotSetReadiness[] ScreenshotSets { get; set; } = Array.Empty<AppStoreConnectReleaseScreenshotSetReadiness>();
+
+    /// <summary>Individual checks that compose readiness.</summary>
+    public AppStoreConnectReleaseReadinessCheck[] Checks { get; set; } = Array.Empty<AppStoreConnectReleaseReadinessCheck>();
+}
+
+/// <summary>
+/// One release readiness check.
+/// </summary>
+public sealed class AppStoreConnectReleaseReadinessCheck
+{
+    /// <summary>Machine-readable check name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>True when the check passed.</summary>
+    public bool Passed { get; set; }
+
+    /// <summary>Human-readable check message.</summary>
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Screenshot set details included in release readiness results.
+/// </summary>
+public sealed class AppStoreConnectReleaseScreenshotSetReadiness
+{
+    /// <summary>Screenshot display type.</summary>
+    public string ScreenshotDisplayType { get; set; } = string.Empty;
+
+    /// <summary>Screenshot set id when found.</summary>
+    public string? ScreenshotSetId { get; set; }
+
+    /// <summary>Number of screenshots currently in the set.</summary>
+    public int Count { get; set; }
+
+    /// <summary>Distinct asset delivery states reported for screenshots.</summary>
+    public string[] AssetDeliveryStates { get; set; } = Array.Empty<string>();
+
+    /// <summary>Screenshot file names currently in the set.</summary>
+    public string[] FileNames { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/AppStoreConnectVersionReleaseModels.cs
+++ b/PowerForge/Models/AppStoreConnectVersionReleaseModels.cs
@@ -1,0 +1,58 @@
+namespace PowerForge;
+
+/// <summary>
+/// App Store Connect manual version release request summary.
+/// </summary>
+public sealed class AppStoreConnectVersionReleaseRequestInfo
+{
+    /// <summary>Release request id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>App Store version id associated with the release request.</summary>
+    public string? AppStoreVersionId { get; set; }
+}
+
+/// <summary>
+/// Request to manually release an approved App Store version.
+/// </summary>
+public sealed class AppStoreConnectVersionReleaseRequest
+{
+    /// <summary>App Store Connect API credential. Required when the request is executed by the default release runner.</summary>
+    public AppStoreConnectApiCredential? Credential { get; set; }
+
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the App Store version.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Require the version to be in Pending Developer Release before requesting release.</summary>
+    public bool RequirePendingDeveloperRelease { get; set; } = true;
+}
+
+/// <summary>
+/// Result of manually releasing an approved App Store version.
+/// </summary>
+public sealed class AppStoreConnectVersionReleaseResult
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the App Store version.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Matched App Store version.</summary>
+    public AppStoreConnectVersionInfo Version { get; set; } = new();
+
+    /// <summary>Created release request.</summary>
+    public AppStoreConnectVersionReleaseRequestInfo ReleaseRequest { get; set; } = new();
+
+    /// <summary>Release messages useful for release logs.</summary>
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -302,15 +302,19 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public string? SigningStyle { get; set; }
 
-    public string? AppStoreConnectApiKeyPath { get; set; }
+    internal string? AppStoreConnectApiKeyPath { get; set; }
 
-    public string? AppStoreConnectApiKeyId { get; set; }
+    internal string? AppStoreConnectApiKeyId { get; set; }
 
-    public string? AppStoreConnectApiIssuerId { get; set; }
+    internal string? AppStoreConnectApiIssuerId { get; set; }
 
     public string? ScreenshotConfigPath { get; set; }
 
     public string[] ScreenshotConfigPaths { get; set; } = Array.Empty<string>();
+
+    public string? MetadataConfigPath { get; set; }
+
+    public string[] MetadataConfigPaths { get; set; } = Array.Empty<string>();
 
     public bool PrepareDistribution { get; set; }
 
@@ -318,9 +322,13 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public bool AllowUnprocessedDistributionBuild { get; set; }
 
+    public bool SyncMetadata { get; set; }
+
     public bool SyncScreenshots { get; set; }
 
     public bool ReplaceScreenshots { get; set; }
+
+    public bool CheckReleaseReadiness { get; set; }
 
     public AppleAppConfiguration[] Apps { get; set; } = Array.Empty<AppleAppConfiguration>();
 }
@@ -341,13 +349,21 @@ internal sealed class PowerForgeAppleReleasePlan
 
     public string[] ScreenshotConfigPaths { get; set; } = Array.Empty<string>();
 
+    public string? MetadataConfigPath { get; set; }
+
+    public string[] MetadataConfigPaths { get; set; } = Array.Empty<string>();
+
     public bool PrepareDistribution { get; set; }
 
     public bool SelectBuildForDistribution { get; set; } = true;
 
     public bool AllowUnprocessedDistributionBuild { get; set; }
 
+    public bool SyncMetadata { get; set; }
+
     public bool ReplaceScreenshots { get; set; }
+
+    public bool CheckReleaseReadiness { get; set; }
 
     public string XcodeBuildExecutable { get; set; } = "xcodebuild";
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -352,6 +352,10 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public bool AllowReviewSubmissionWhenNotReady { get; set; }
 
+    public bool ReleaseApprovedVersion { get; set; }
+
+    public bool AllowNonPendingDeveloperRelease { get; set; }
+
     public AppleAppConfiguration[] Apps { get; set; } = Array.Empty<AppleAppConfiguration>();
 }
 
@@ -408,6 +412,10 @@ internal sealed class PowerForgeAppleReleasePlan
     public bool SkipReviewReadinessCheck { get; set; }
 
     public bool AllowReviewSubmissionWhenNotReady { get; set; }
+
+    public bool ReleaseApprovedVersion { get; set; }
+
+    public bool AllowNonPendingDeveloperRelease { get; set; }
 
     public string XcodeBuildExecutable { get; set; } = "xcodebuild";
 
@@ -482,6 +490,8 @@ internal sealed class PowerForgeAppleAppReleaseResult
     public AppStoreConnectTestFlightDistributionResult? TestFlight { get; set; }
 
     public AppStoreConnectReviewSubmissionResult? ReviewSubmission { get; set; }
+
+    public AppStoreConnectVersionReleaseResult? VersionRelease { get; set; }
 
     public bool Success { get; set; }
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -330,6 +330,18 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public bool CheckReleaseReadiness { get; set; }
 
+    public bool DistributeTestFlight { get; set; }
+
+    public string[] TestFlightBetaGroupIds { get; set; } = Array.Empty<string>();
+
+    public string[] TestFlightBetaGroupNames { get; set; } = Array.Empty<string>();
+
+    public string[] TestFlightTesterEmails { get; set; } = Array.Empty<string>();
+
+    public bool CreateMissingTestFlightTesters { get; set; } = true;
+
+    public bool AllowUnprocessedTestFlightBuild { get; set; }
+
     public AppleAppConfiguration[] Apps { get; set; } = Array.Empty<AppleAppConfiguration>();
 }
 
@@ -364,6 +376,18 @@ internal sealed class PowerForgeAppleReleasePlan
     public bool ReplaceScreenshots { get; set; }
 
     public bool CheckReleaseReadiness { get; set; }
+
+    public bool DistributeTestFlight { get; set; }
+
+    public string[] TestFlightBetaGroupIds { get; set; } = Array.Empty<string>();
+
+    public string[] TestFlightBetaGroupNames { get; set; } = Array.Empty<string>();
+
+    public string[] TestFlightTesterEmails { get; set; } = Array.Empty<string>();
+
+    public bool CreateMissingTestFlightTesters { get; set; } = true;
+
+    public bool AllowUnprocessedTestFlightBuild { get; set; }
 
     public string XcodeBuildExecutable { get; set; } = "xcodebuild";
 
@@ -434,6 +458,8 @@ internal sealed class PowerForgeAppleAppReleaseResult
     public XcodeProjectVersionUpdateResult? VersionUpdate { get; set; }
 
     public AppStoreConnectReleasePreparationResult? Distribution { get; set; }
+
+    public AppStoreConnectTestFlightDistributionResult? TestFlight { get; set; }
 
     public bool Success { get; set; }
 

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -342,6 +342,16 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public bool AllowUnprocessedTestFlightBuild { get; set; }
 
+    public bool SubmitForReview { get; set; }
+
+    public bool AllowUnselectedReviewBuild { get; set; }
+
+    public bool AllowUnprocessedReviewBuild { get; set; }
+
+    public bool SkipReviewReadinessCheck { get; set; }
+
+    public bool AllowReviewSubmissionWhenNotReady { get; set; }
+
     public AppleAppConfiguration[] Apps { get; set; } = Array.Empty<AppleAppConfiguration>();
 }
 
@@ -388,6 +398,16 @@ internal sealed class PowerForgeAppleReleasePlan
     public bool CreateMissingTestFlightTesters { get; set; } = true;
 
     public bool AllowUnprocessedTestFlightBuild { get; set; }
+
+    public bool SubmitForReview { get; set; }
+
+    public bool AllowUnselectedReviewBuild { get; set; }
+
+    public bool AllowUnprocessedReviewBuild { get; set; }
+
+    public bool SkipReviewReadinessCheck { get; set; }
+
+    public bool AllowReviewSubmissionWhenNotReady { get; set; }
 
     public string XcodeBuildExecutable { get; set; } = "xcodebuild";
 
@@ -460,6 +480,8 @@ internal sealed class PowerForgeAppleAppReleaseResult
     public AppStoreConnectReleasePreparationResult? Distribution { get; set; }
 
     public AppStoreConnectTestFlightDistributionResult? TestFlight { get; set; }
+
+    public AppStoreConnectReviewSubmissionResult? ReviewSubmission { get; set; }
 
     public bool Success { get; set; }
 

--- a/PowerForge/Services/AppStoreConnectClient.ReviewSubmission.cs
+++ b/PowerForge/Services/AppStoreConnectClient.ReviewSubmission.cs
@@ -1,0 +1,153 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectClient
+{
+    /// <summary>
+    /// Lists recent and current review submissions for an app.
+    /// </summary>
+    public Task<AppStoreConnectReviewSubmissionInfo[]> GetReviewSubmissionsAsync(
+        string appId,
+        ApplePlatform? platform = null,
+        int limit = 20,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(appId))
+            throw new ArgumentException("App id is required.", nameof(appId));
+
+        var query = new Dictionary<string, string?>
+        {
+            ["filter[app]"] = appId.Trim(),
+            ["limit"] = ClampLimit(limit).ToString(CultureInfo.InvariantCulture)
+        };
+        if (platform.HasValue)
+            query["filter[platform]"] = ToAppStoreConnectPlatform(platform.Value);
+
+        return GetArrayAsync("reviewSubmissions" + BuildQuery(query), ParseReviewSubmission, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a review submission for an app and platform.
+    /// </summary>
+    public Task<AppStoreConnectReviewSubmissionInfo> CreateReviewSubmissionAsync(
+        string appId,
+        ApplePlatform platform,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(appId))
+            throw new ArgumentException("App id is required.", nameof(appId));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "reviewSubmissions",
+                attributes = new { platform = ToAppStoreConnectPlatform(platform) },
+                relationships = new
+                {
+                    app = new
+                    {
+                        data = new { type = "apps", id = appId.Trim() }
+                    }
+                }
+            }
+        };
+
+        return PostSingleAsync("reviewSubmissions", body, ParseReviewSubmission, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a review submission item for an App Store version.
+    /// </summary>
+    public Task<AppStoreConnectReviewSubmissionItemInfo> CreateReviewSubmissionItemAsync(
+        string reviewSubmissionId,
+        string appStoreVersionId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(reviewSubmissionId))
+            throw new ArgumentException("Review submission id is required.", nameof(reviewSubmissionId));
+        if (string.IsNullOrWhiteSpace(appStoreVersionId))
+            throw new ArgumentException("App Store version id is required.", nameof(appStoreVersionId));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "reviewSubmissionItems",
+                relationships = new
+                {
+                    reviewSubmission = new
+                    {
+                        data = new { type = "reviewSubmissions", id = reviewSubmissionId.Trim() }
+                    },
+                    appStoreVersion = new
+                    {
+                        data = new { type = "appStoreVersions", id = appStoreVersionId.Trim() }
+                    }
+                }
+            }
+        };
+
+        return PostSingleAsync("reviewSubmissionItems", body, ParseReviewSubmissionItem, cancellationToken);
+    }
+
+    /// <summary>
+    /// Marks a review submission as submitted to App Review.
+    /// </summary>
+    public Task<AppStoreConnectReviewSubmissionInfo> SubmitReviewSubmissionAsync(
+        string reviewSubmissionId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(reviewSubmissionId))
+            throw new ArgumentException("Review submission id is required.", nameof(reviewSubmissionId));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "reviewSubmissions",
+                id = reviewSubmissionId.Trim(),
+                attributes = new { isSubmitted = true }
+            }
+        };
+
+        return PatchSingleAsync(
+            $"reviewSubmissions/{Uri.EscapeDataString(reviewSubmissionId.Trim())}",
+            body,
+            ParseReviewSubmission,
+            cancellationToken);
+    }
+
+    private async Task<T> PatchSingleAsync<T>(string relativeUrl, object body, Func<JsonElement, T> parse, CancellationToken cancellationToken)
+    {
+        using var doc = await SendJsonAsync(new HttpMethod("PATCH"), relativeUrl, body, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("App Store Connect API request returned no response body.");
+        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind == JsonValueKind.Null)
+            throw new InvalidOperationException("App Store Connect API request returned no data.");
+        return parse(data);
+    }
+
+    private static AppStoreConnectReviewSubmissionInfo ParseReviewSubmission(JsonElement item)
+    {
+        var attrs = GetAttributes(item);
+        return new AppStoreConnectReviewSubmissionInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            Platform = GetString(attrs, "platform"),
+            IsSubmitted = GetBool(attrs, "isSubmitted"),
+            State = GetString(attrs, "state")
+        };
+    }
+
+    private static AppStoreConnectReviewSubmissionItemInfo ParseReviewSubmissionItem(JsonElement item)
+    {
+        return new AppStoreConnectReviewSubmissionItemInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            ReviewSubmissionId = GetRelationshipDataId(item, "reviewSubmission"),
+            AppStoreVersionId = GetRelationshipDataId(item, "appStoreVersion")
+        };
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.ReviewSubmission.cs
+++ b/PowerForge/Services/AppStoreConnectClient.ReviewSubmission.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net.Http;
 using System.Text.Json;
 
 namespace PowerForge;

--- a/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
+++ b/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
@@ -1,0 +1,196 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectClient
+{
+    /// <summary>
+    /// Lists TestFlight beta groups for an app.
+    /// </summary>
+    public Task<AppStoreConnectBetaGroupInfo[]> GetBetaGroupsAsync(
+        string appId,
+        string? name = null,
+        int limit = 200,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(appId))
+            throw new ArgumentException("App id is required.", nameof(appId));
+
+        var query = new Dictionary<string, string?>
+        {
+            ["filter[app]"] = appId.Trim(),
+            ["limit"] = ClampLimit(limit).ToString(CultureInfo.InvariantCulture)
+        };
+        if (!string.IsNullOrWhiteSpace(name))
+            query["filter[name]"] = name!.Trim();
+
+        return GetArrayAsync("betaGroups" + BuildQuery(query), ParseBetaGroup, cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists beta testers, optionally filtering by email.
+    /// </summary>
+    public Task<AppStoreConnectBetaTesterInfo[]> GetBetaTestersAsync(
+        string? email = null,
+        int limit = 200,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new Dictionary<string, string?>
+        {
+            ["limit"] = ClampLimit(limit).ToString(CultureInfo.InvariantCulture)
+        };
+        if (!string.IsNullOrWhiteSpace(email))
+            query["filter[email]"] = email!.Trim();
+
+        return GetArrayAsync("betaTesters" + BuildQuery(query), ParseBetaTester, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a beta tester and optionally adds the tester to beta groups.
+    /// </summary>
+    public Task<AppStoreConnectBetaTesterInfo> CreateBetaTesterAsync(
+        string email,
+        string? firstName = null,
+        string? lastName = null,
+        string[]? betaGroupIds = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Email is required.", nameof(email));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "betaTesters",
+                attributes = new
+                {
+                    email = email.Trim(),
+                    firstName = string.IsNullOrWhiteSpace(firstName) ? null : firstName!.Trim(),
+                    lastName = string.IsNullOrWhiteSpace(lastName) ? null : lastName!.Trim()
+                },
+                relationships = betaGroupIds is null || betaGroupIds.Length == 0
+                    ? null
+                    : new
+                    {
+                        betaGroups = new
+                        {
+                            data = betaGroupIds
+                                .Where(static id => !string.IsNullOrWhiteSpace(id))
+                                .Select(static id => new { type = "betaGroups", id = id.Trim() })
+                                .ToArray()
+                        }
+                    }
+            }
+        };
+
+        return PostSingleAsync("betaTesters", body, ParseBetaTester, cancellationToken);
+    }
+
+    /// <summary>
+    /// Adds one or more builds to a beta group.
+    /// </summary>
+    public Task AddBuildsToBetaGroupAsync(
+        string betaGroupId,
+        string[] buildIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(betaGroupId))
+            throw new ArgumentException("Beta group id is required.", nameof(betaGroupId));
+        var ids = NormalizeIds(buildIds, nameof(buildIds));
+        var body = new
+        {
+            data = ids.Select(static id => new { type = "builds", id }).ToArray()
+        };
+
+        return SendJsonNoContentAsync(
+            HttpMethod.Post,
+            $"betaGroups/{Uri.EscapeDataString(betaGroupId.Trim())}/relationships/builds",
+            body,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Adds one or more beta testers to a beta group.
+    /// </summary>
+    public Task AddBetaTestersToBetaGroupAsync(
+        string betaGroupId,
+        string[] betaTesterIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(betaGroupId))
+            throw new ArgumentException("Beta group id is required.", nameof(betaGroupId));
+        var ids = NormalizeIds(betaTesterIds, nameof(betaTesterIds));
+        var body = new
+        {
+            data = ids.Select(static id => new { type = "betaTesters", id }).ToArray()
+        };
+
+        return SendJsonNoContentAsync(
+            HttpMethod.Post,
+            $"betaGroups/{Uri.EscapeDataString(betaGroupId.Trim())}/relationships/betaTesters",
+            body,
+            cancellationToken);
+    }
+
+    private async Task SendJsonNoContentAsync(
+        HttpMethod method,
+        string relativeUrl,
+        object body,
+        CancellationToken cancellationToken)
+    {
+        using var _ = await SendJsonAsync(method, relativeUrl, body, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string[] NormalizeIds(string[]? ids, string parameterName)
+    {
+        var normalized = (ids ?? Array.Empty<string>())
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Select(static id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (normalized.Length == 0)
+            throw new ArgumentException("At least one id is required.", parameterName);
+        return normalized;
+    }
+
+    private static AppStoreConnectBetaGroupInfo ParseBetaGroup(JsonElement item)
+    {
+        var attrs = GetAttributes(item);
+        return new AppStoreConnectBetaGroupInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            Name = GetString(attrs, "name"),
+            PublicLinkEnabled = GetBool(attrs, "publicLinkEnabled"),
+            PublicLinkLimit = GetInt32(attrs, "publicLinkLimit"),
+            PublicLink = GetString(attrs, "publicLink"),
+            FeedbackEnabled = GetBool(attrs, "feedbackEnabled"),
+            IsInternalGroup = GetBool(attrs, "isInternalGroup")
+        };
+    }
+
+    private static AppStoreConnectBetaTesterInfo ParseBetaTester(JsonElement item)
+    {
+        var attrs = GetAttributes(item);
+        return new AppStoreConnectBetaTesterInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            Email = GetString(attrs, "email"),
+            FirstName = GetString(attrs, "firstName"),
+            LastName = GetString(attrs, "lastName"),
+            InviteType = GetString(attrs, "inviteType")
+        };
+    }
+
+    private static int? GetInt32(JsonElement element, string propertyName)
+    {
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty(propertyName, out var prop))
+            return null;
+        if (prop.ValueKind == JsonValueKind.Number && prop.TryGetInt32(out var value))
+            return value;
+        return int.TryParse(prop.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
+++ b/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net.Http;
 using System.Text.Json;
 
 namespace PowerForge;

--- a/PowerForge/Services/AppStoreConnectClient.VersionMetadata.cs
+++ b/PowerForge/Services/AppStoreConnectClient.VersionMetadata.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectClient
+{
+    /// <summary>
+    /// Updates localized App Store version metadata.
+    /// Null values are ignored; empty strings are sent to App Store Connect.
+    /// </summary>
+    public async Task<AppStoreConnectVersionLocalizationInfo> UpdateVersionLocalizationAsync(
+        string versionLocalizationId,
+        AppStoreConnectVersionLocalizationUpdate update,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(versionLocalizationId))
+            throw new ArgumentException("Version localization id is required.", nameof(versionLocalizationId));
+        if (update is null)
+            throw new ArgumentNullException(nameof(update));
+
+        var attributes = BuildLocalizationAttributes(update);
+        if (attributes.Count == 0)
+            throw new ArgumentException("At least one metadata field must be supplied.", nameof(update));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "appStoreVersionLocalizations",
+                id = versionLocalizationId.Trim(),
+                attributes
+            }
+        };
+
+        using var doc = await SendJsonAsync(
+            new HttpMethod("PATCH"),
+            $"appStoreVersionLocalizations/{Uri.EscapeDataString(versionLocalizationId.Trim())}",
+            body,
+            cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("App Store Connect API request returned no response body.");
+        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind == JsonValueKind.Null)
+            throw new InvalidOperationException("App Store Connect API request returned no data.");
+
+        return ParseVersionLocalization(data);
+    }
+
+    internal static string[] GetSuppliedLocalizationFields(AppStoreConnectVersionLocalizationUpdate update)
+        => BuildLocalizationAttributes(update).Keys.ToArray();
+
+    private static Dictionary<string, object?> BuildLocalizationAttributes(AppStoreConnectVersionLocalizationUpdate update)
+    {
+        var attributes = new Dictionary<string, object?>(StringComparer.Ordinal);
+        AddIfNotNull(attributes, "description", update.Description);
+        AddIfNotNull(attributes, "keywords", update.Keywords);
+        AddIfNotNull(attributes, "marketingUrl", update.MarketingUrl);
+        AddIfNotNull(attributes, "promotionalText", update.PromotionalText);
+        AddIfNotNull(attributes, "supportUrl", update.SupportUrl);
+        AddIfNotNull(attributes, "whatsNew", update.WhatsNew);
+        return attributes;
+    }
+
+    private static void AddIfNotNull(Dictionary<string, object?> attributes, string name, string? value)
+    {
+        if (value is not null)
+            attributes[name] = value;
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.VersionMetadata.cs
+++ b/PowerForge/Services/AppStoreConnectClient.VersionMetadata.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Text.Json;
 
 namespace PowerForge;

--- a/PowerForge/Services/AppStoreConnectClient.VersionRelease.cs
+++ b/PowerForge/Services/AppStoreConnectClient.VersionRelease.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectClient
+{
+    /// <summary>
+    /// Requests manual release of an approved App Store version.
+    /// </summary>
+    public Task<AppStoreConnectVersionReleaseRequestInfo> CreateVersionReleaseRequestAsync(
+        string appStoreVersionId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(appStoreVersionId))
+            throw new ArgumentException("App Store version id is required.", nameof(appStoreVersionId));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "appStoreVersionReleaseRequests",
+                relationships = new
+                {
+                    appStoreVersion = new
+                    {
+                        data = new { type = "appStoreVersions", id = appStoreVersionId.Trim() }
+                    }
+                }
+            }
+        };
+
+        return PostSingleAsync("appStoreVersionReleaseRequests", body, ParseVersionReleaseRequest, cancellationToken);
+    }
+
+    private static AppStoreConnectVersionReleaseRequestInfo ParseVersionReleaseRequest(JsonElement item)
+    {
+        return new AppStoreConnectVersionReleaseRequestInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            AppStoreVersionId = GetRelationshipDataId(item, "appStoreVersion")
+        };
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.cs
+++ b/PowerForge/Services/AppStoreConnectClient.cs
@@ -11,7 +11,7 @@ namespace PowerForge;
 /// <summary>
 /// App Store Connect API client.
 /// </summary>
-public sealed class AppStoreConnectClient : IDisposable
+public sealed partial class AppStoreConnectClient : IDisposable
 {
     private static readonly Uri DefaultBaseUri = new("https://api.appstoreconnect.apple.com/v1/");
 
@@ -759,7 +759,13 @@ public sealed class AppStoreConnectClient : IDisposable
         {
             Id = GetString(item, "id") ?? string.Empty,
             Locale = GetString(attrs, "locale"),
-            Name = GetString(attrs, "name")
+            Name = GetString(attrs, "name"),
+            Description = GetString(attrs, "description"),
+            Keywords = GetString(attrs, "keywords"),
+            MarketingUrl = GetString(attrs, "marketingUrl"),
+            PromotionalText = GetString(attrs, "promotionalText"),
+            SupportUrl = GetString(attrs, "supportUrl"),
+            WhatsNew = GetString(attrs, "whatsNew")
         };
     }
 

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -89,6 +89,16 @@ public sealed class AppStoreConnectReleasePreparationService
             }
         }
 
+        AppStoreConnectVersionMetadataSyncResult? metadata = null;
+        if (request.MetadataSpec is not null)
+        {
+            var metadataSpec = CreateMetadataSpecForVersion(request.MetadataSpec, appId, versionString, request.Platform, version.Id);
+            metadata = await new AppStoreConnectVersionMetadataSyncService(_client).SyncAsync(
+                new AppStoreConnectVersionMetadataSyncRequest { Spec = metadataSpec },
+                cancellationToken).ConfigureAwait(false);
+            messages.Add("Synchronized App Store version metadata.");
+        }
+
         AppStoreConnectScreenshotSyncResult? screenshots = null;
         if (request.ScreenshotSpec is not null)
         {
@@ -104,6 +114,24 @@ public sealed class AppStoreConnectReleasePreparationService
             messages.Add("Synchronized App Store screenshots.");
         }
 
+        AppStoreConnectReleaseReadinessResult? readiness = null;
+        if (request.CheckReadiness)
+        {
+            var readinessRequest = CreateReadinessRequestForVersion(
+                request.ReadinessRequest,
+                appId,
+                versionString,
+                buildNumber,
+                request.Platform,
+                request.ScreenshotSpec);
+            readiness = await new AppStoreConnectReleaseReadinessService(_client)
+                .CheckAsync(readinessRequest, cancellationToken)
+                .ConfigureAwait(false);
+            messages.Add(readiness.IsReady
+                ? "App Store version readiness check passed."
+                : "App Store version readiness check failed.");
+        }
+
         return new AppStoreConnectReleasePreparationResult
         {
             AppId = appId,
@@ -116,6 +144,8 @@ public sealed class AppStoreConnectReleasePreparationService
             SelectedBuild = selectedBuild,
             PreviousBuildId = previousBuildId,
             Screenshots = screenshots,
+            Metadata = metadata,
+            Readiness = readiness,
             Messages = messages.ToArray()
         };
     }
@@ -153,6 +183,66 @@ public sealed class AppStoreConnectReleasePreparationService
             Platform = platform,
             Locale = source.Locale,
             ScreenshotSets = source.ScreenshotSets
+        };
+    }
+
+    private static AppStoreConnectVersionMetadataSpec CreateMetadataSpecForVersion(
+        AppStoreConnectVersionMetadataSpec source,
+        string appId,
+        string versionString,
+        ApplePlatform platform,
+        string versionId)
+    {
+        if (!string.IsNullOrWhiteSpace(source.AppId) &&
+            !string.Equals(source.AppId.Trim(), appId, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Metadata config AppId '{source.AppId}' does not match release app id '{appId}'.");
+        var sourceVersionString = string.IsNullOrWhiteSpace(source.VersionString) ? null : source.VersionString!.Trim();
+        if (sourceVersionString is not null &&
+            !string.Equals(sourceVersionString, versionString, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Metadata config VersionString '{source.VersionString}' does not match release version '{versionString}'.");
+        if (source.Platform != platform)
+            throw new InvalidOperationException($"Metadata config Platform '{source.Platform}' does not match release platform '{platform}'.");
+
+        return new AppStoreConnectVersionMetadataSpec
+        {
+            AppId = appId,
+            VersionString = versionString,
+            VersionId = versionId,
+            Platform = platform,
+            Locale = source.Locale,
+            Metadata = source.Metadata
+        };
+    }
+
+    private static AppStoreConnectReleaseReadinessRequest CreateReadinessRequestForVersion(
+        AppStoreConnectReleaseReadinessRequest? source,
+        string appId,
+        string versionString,
+        string buildNumber,
+        ApplePlatform platform,
+        AppStoreConnectScreenshotSyncSpec? screenshotSpec)
+    {
+        source ??= new AppStoreConnectReleaseReadinessRequest();
+        return new AppStoreConnectReleaseReadinessRequest
+        {
+            AppId = appId,
+            VersionString = versionString,
+            BuildNumber = buildNumber,
+            Platform = platform,
+            Locale = string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim(),
+            RequireSelectedBuild = source.RequireSelectedBuild,
+            RequireValidBuild = source.RequireValidBuild,
+            RequireDescription = source.RequireDescription,
+            RequireKeywords = source.RequireKeywords,
+            RequireSupportUrl = source.RequireSupportUrl,
+            RequireMarketingUrl = source.RequireMarketingUrl,
+            RequirePromotionalText = source.RequirePromotionalText,
+            RequireWhatsNew = source.RequireWhatsNew,
+            RequireScreenshots = source.RequireScreenshots,
+            RequireCompleteScreenshots = source.RequireCompleteScreenshots,
+            MinimumScreenshotsPerSet = source.MinimumScreenshotsPerSet,
+            RequiredScreenshotDisplayTypes = source.RequiredScreenshotDisplayTypes,
+            ScreenshotSpec = screenshotSpec
         };
     }
 }

--- a/PowerForge/Services/AppStoreConnectReleaseReadinessService.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseReadinessService.cs
@@ -1,0 +1,239 @@
+namespace PowerForge;
+
+/// <summary>
+/// Checks App Store Connect Distribution readiness for one platform version.
+/// </summary>
+public sealed class AppStoreConnectReleaseReadinessService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Initializes a release readiness service.
+    /// </summary>
+    public AppStoreConnectReleaseReadinessService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Checks whether version, build, metadata, and screenshots satisfy the requested readiness contract.
+    /// </summary>
+    public async Task<AppStoreConnectReleaseReadinessResult> CheckAsync(
+        AppStoreConnectReleaseReadinessRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrWhiteSpace(request.AppId))
+            throw new ArgumentException("AppId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.VersionString))
+            throw new ArgumentException("VersionString is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.Locale))
+            throw new ArgumentException("Locale is required.", nameof(request));
+
+        var checks = new List<AppStoreConnectReleaseReadinessCheck>();
+        var version = (await _client.GetVersionsAsync(
+            request.AppId,
+            request.VersionString,
+            request.Platform,
+            limit: 10,
+            cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+        AddCheck(checks, "version", version is not null, version is null
+            ? $"App Store version '{request.VersionString}' was not found for platform '{request.Platform}'."
+            : $"App Store version '{request.VersionString}' exists for platform '{request.Platform}'.");
+
+        AppStoreConnectBuildInfo? build = null;
+        string? selectedBuildId = null;
+        AppStoreConnectVersionLocalizationInfo? localization = null;
+        var screenshotReadiness = Array.Empty<AppStoreConnectReleaseScreenshotSetReadiness>();
+
+        if (version is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(request.BuildNumber))
+            {
+                build = (await _client.GetBuildsAsync(
+                    request.AppId,
+                    request.BuildNumber,
+                    limit: 20,
+                    marketingVersion: request.VersionString,
+                    platform: request.Platform,
+                    cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+                AddCheck(checks, "build", build is not null, build is null
+                    ? $"Build '{request.BuildNumber}' was not found for version '{request.VersionString}' and platform '{request.Platform}'."
+                    : $"Build '{request.BuildNumber}' exists for version '{request.VersionString}' and platform '{request.Platform}'.");
+
+                if (build is not null && request.RequireValidBuild)
+                {
+                    var valid = string.Equals(build.ProcessingState, "VALID", StringComparison.OrdinalIgnoreCase) && build.Expired != true;
+                    AddCheck(checks, "build.valid", valid, valid
+                        ? $"Build '{request.BuildNumber}' is VALID and not expired."
+                        : $"Build '{request.BuildNumber}' is not selectable: processing state '{build.ProcessingState ?? "unknown"}', expired '{build.Expired?.ToString() ?? "unknown"}'.");
+                }
+
+                if (request.RequireSelectedBuild)
+                {
+                    selectedBuildId = await _client.GetVersionBuildIdAsync(version.Id, cancellationToken).ConfigureAwait(false);
+                    var selected = build is not null && string.Equals(selectedBuildId, build.Id, StringComparison.OrdinalIgnoreCase);
+                    AddCheck(checks, "build.selected", selected, selected
+                        ? $"Build '{request.BuildNumber}' is selected for Distribution."
+                        : $"Build '{request.BuildNumber}' is not selected for Distribution.");
+                }
+            }
+
+            localization = (await _client.GetVersionLocalizationsAsync(
+                version.Id,
+                request.Locale,
+                limit: 10,
+                cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+            AddCheck(checks, "localization", localization is not null, localization is null
+                ? $"Localization '{request.Locale}' was not found for App Store version '{version.Id}'."
+                : $"Localization '{request.Locale}' exists.");
+
+            if (localization is not null)
+            {
+                CheckLocalizedMetadata(checks, localization, request);
+                if (request.RequireScreenshots)
+                    screenshotReadiness = await CheckScreenshotsAsync(checks, localization.Id, request, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return new AppStoreConnectReleaseReadinessResult
+        {
+            AppId = request.AppId.Trim(),
+            VersionString = request.VersionString.Trim(),
+            BuildNumber = string.IsNullOrWhiteSpace(request.BuildNumber) ? null : request.BuildNumber!.Trim(),
+            Platform = request.Platform,
+            IsReady = checks.Count > 0 && checks.All(static check => check.Passed),
+            Version = version,
+            Build = build,
+            SelectedBuildId = selectedBuildId,
+            Localization = localization,
+            ScreenshotSets = screenshotReadiness,
+            Checks = checks.ToArray()
+        };
+    }
+
+    private static void CheckLocalizedMetadata(
+        List<AppStoreConnectReleaseReadinessCheck> checks,
+        AppStoreConnectVersionLocalizationInfo localization,
+        AppStoreConnectReleaseReadinessRequest request)
+    {
+        CheckField(checks, "metadata.description", request.RequireDescription, localization.Description, "description");
+        CheckField(checks, "metadata.keywords", request.RequireKeywords, localization.Keywords, "keywords");
+        CheckField(checks, "metadata.supportUrl", request.RequireSupportUrl, localization.SupportUrl, "support URL");
+        CheckField(checks, "metadata.marketingUrl", request.RequireMarketingUrl, localization.MarketingUrl, "marketing URL");
+        CheckField(checks, "metadata.promotionalText", request.RequirePromotionalText, localization.PromotionalText, "promotional text");
+        CheckField(checks, "metadata.whatsNew", request.RequireWhatsNew, localization.WhatsNew, "what's new text");
+    }
+
+    private async Task<AppStoreConnectReleaseScreenshotSetReadiness[]> CheckScreenshotsAsync(
+        List<AppStoreConnectReleaseReadinessCheck> checks,
+        string localizationId,
+        AppStoreConnectReleaseReadinessRequest request,
+        CancellationToken cancellationToken)
+    {
+        var requiredTypes = ResolveRequiredScreenshotTypes(request);
+        if (requiredTypes.Length == 0)
+        {
+            AddCheck(checks, "screenshots.configured", false, "No required screenshot display types were configured.");
+            return Array.Empty<AppStoreConnectReleaseScreenshotSetReadiness>();
+        }
+
+        var sets = await _client.GetScreenshotSetsAsync(localizationId, limit: 200, cancellationToken).ConfigureAwait(false);
+        var result = new List<AppStoreConnectReleaseScreenshotSetReadiness>();
+        foreach (var displayType in requiredTypes)
+        {
+            var set = sets.FirstOrDefault(candidate =>
+                string.Equals(candidate.ScreenshotDisplayType, displayType, StringComparison.OrdinalIgnoreCase));
+            if (set is null)
+            {
+                AddCheck(checks, $"screenshots.{displayType}", false, $"Screenshot set '{displayType}' was not found.");
+                result.Add(new AppStoreConnectReleaseScreenshotSetReadiness { ScreenshotDisplayType = displayType });
+                continue;
+            }
+
+            var screenshots = await _client.GetScreenshotsAsync(set.Id, limit: 200, cancellationToken).ConfigureAwait(false);
+            var deliveryStates = screenshots
+                .Select(static screenshot => screenshot.AssetDeliveryState)
+                .Where(static state => !string.IsNullOrWhiteSpace(state))
+                .Select(static state => state!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(static state => state, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var fileNames = screenshots
+                .Select(static screenshot => screenshot.FileName)
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name!)
+                .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            result.Add(new AppStoreConnectReleaseScreenshotSetReadiness
+            {
+                ScreenshotDisplayType = displayType,
+                ScreenshotSetId = set.Id,
+                Count = screenshots.Length,
+                AssetDeliveryStates = deliveryStates,
+                FileNames = fileNames
+            });
+
+            var enough = screenshots.Length >= Math.Max(1, request.MinimumScreenshotsPerSet);
+            AddCheck(checks, $"screenshots.{displayType}.count", enough, enough
+                ? $"Screenshot set '{displayType}' has {screenshots.Length} screenshot(s)."
+                : $"Screenshot set '{displayType}' has {screenshots.Length} screenshot(s), below required minimum {Math.Max(1, request.MinimumScreenshotsPerSet)}.");
+
+            if (request.RequireCompleteScreenshots)
+            {
+                var complete = screenshots.Length > 0 &&
+                               screenshots.All(static screenshot => string.Equals(screenshot.AssetDeliveryState, "COMPLETE", StringComparison.OrdinalIgnoreCase));
+                AddCheck(checks, $"screenshots.{displayType}.complete", complete, complete
+                    ? $"Screenshot set '{displayType}' assets are COMPLETE."
+                    : $"Screenshot set '{displayType}' assets are not all COMPLETE.");
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    private static string[] ResolveRequiredScreenshotTypes(AppStoreConnectReleaseReadinessRequest request)
+    {
+        var configured = request.RequiredScreenshotDisplayTypes ?? Array.Empty<string>();
+        if (configured.Length == 0 && request.ScreenshotSpec is not null)
+            configured = request.ScreenshotSpec.ScreenshotSets.Select(static set => set.ScreenshotDisplayType).ToArray();
+
+        return configured
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static void CheckField(
+        List<AppStoreConnectReleaseReadinessCheck> checks,
+        string name,
+        bool required,
+        string? value,
+        string label)
+    {
+        if (!required)
+            return;
+
+        var present = !string.IsNullOrWhiteSpace(value);
+        AddCheck(checks, name, present, present
+            ? $"Localized {label} is present."
+            : $"Localized {label} is missing.");
+    }
+
+    private static void AddCheck(
+        List<AppStoreConnectReleaseReadinessCheck> checks,
+        string name,
+        bool passed,
+        string message)
+    {
+        checks.Add(new AppStoreConnectReleaseReadinessCheck
+        {
+            Name = name,
+            Passed = passed,
+            Message = message
+        });
+    }
+}

--- a/PowerForge/Services/AppStoreConnectReviewSubmissionService.cs
+++ b/PowerForge/Services/AppStoreConnectReviewSubmissionService.cs
@@ -1,0 +1,154 @@
+namespace PowerForge;
+
+/// <summary>
+/// Submits prepared App Store Connect Distribution versions to App Review.
+/// </summary>
+public sealed class AppStoreConnectReviewSubmissionService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Initializes an App Review submission service.
+    /// </summary>
+    public AppStoreConnectReviewSubmissionService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Creates a review submission, adds the App Store version, and submits it.
+    /// </summary>
+    public async Task<AppStoreConnectReviewSubmissionResult> SubmitAsync(
+        AppStoreConnectReviewSubmissionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrWhiteSpace(request.AppId))
+            throw new ArgumentException("AppId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.VersionString))
+            throw new ArgumentException("VersionString is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.BuildNumber))
+            throw new ArgumentException("BuildNumber is required.", nameof(request));
+
+        var appId = request.AppId.Trim();
+        var versionString = request.VersionString.Trim();
+        var buildNumber = request.BuildNumber.Trim();
+        var messages = new List<string>();
+
+        var version = (await _client.GetVersionsAsync(
+            appId,
+            versionString,
+            request.Platform,
+            limit: 10,
+            cancellationToken).ConfigureAwait(false)).FirstOrDefault()
+            ?? throw new InvalidOperationException($"App Store version '{versionString}' was not found for app '{appId}' and platform '{request.Platform}'.");
+        messages.Add($"Found App Store version '{versionString}' for platform '{request.Platform}'.");
+
+        var build = await ResolveSelectedBuildAsync(version.Id, appId, versionString, buildNumber, request, cancellationToken).ConfigureAwait(false);
+        AppStoreConnectReleaseReadinessResult? readiness = null;
+        if (request.CheckReadiness)
+        {
+            readiness = await new AppStoreConnectReleaseReadinessService(_client)
+                .CheckAsync(CreateReadinessRequest(request, appId, versionString, buildNumber), cancellationToken)
+                .ConfigureAwait(false);
+            messages.Add(readiness.IsReady
+                ? "App Store version readiness check passed."
+                : "App Store version readiness check failed.");
+            if (request.RequireReady && !readiness.IsReady)
+                throw new InvalidOperationException("App Store version is not ready for review submission: " +
+                    string.Join("; ", readiness.Checks.Where(static check => !check.Passed).Select(static check => check.Message)));
+        }
+
+        var reviewSubmission = await _client.CreateReviewSubmissionAsync(appId, request.Platform, cancellationToken).ConfigureAwait(false);
+        messages.Add($"Created review submission '{reviewSubmission.Id}' for platform '{request.Platform}'.");
+
+        var reviewSubmissionItem = await _client.CreateReviewSubmissionItemAsync(reviewSubmission.Id, version.Id, cancellationToken).ConfigureAwait(false);
+        messages.Add($"Added App Store version '{versionString}' to review submission '{reviewSubmission.Id}'.");
+
+        reviewSubmission = await _client.SubmitReviewSubmissionAsync(reviewSubmission.Id, cancellationToken).ConfigureAwait(false);
+        messages.Add($"Submitted App Store version '{versionString}' to App Review.");
+
+        return new AppStoreConnectReviewSubmissionResult
+        {
+            AppId = appId,
+            VersionString = versionString,
+            BuildNumber = buildNumber,
+            Platform = request.Platform,
+            Version = version,
+            Build = build,
+            ReviewSubmission = reviewSubmission,
+            ReviewSubmissionItem = reviewSubmissionItem,
+            Readiness = readiness,
+            Messages = messages.ToArray()
+        };
+    }
+
+    private async Task<AppStoreConnectBuildInfo?> ResolveSelectedBuildAsync(
+        string versionId,
+        string appId,
+        string versionString,
+        string buildNumber,
+        AppStoreConnectReviewSubmissionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var expectedBuild = (await _client.GetBuildsAsync(
+            appId,
+            buildNumber,
+            limit: 20,
+            marketingVersion: versionString,
+            platform: request.Platform,
+            cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault()
+            ?? throw new InvalidOperationException($"Build '{buildNumber}' was not found for app '{appId}', version '{versionString}', and platform '{request.Platform}'.");
+
+        if (request.RequireValidBuild)
+            ValidateBuildIsSubmittable(expectedBuild, buildNumber);
+
+        if (!request.RequireSelectedBuild)
+            return expectedBuild;
+
+        var selectedBuildId = await _client.GetVersionBuildIdAsync(versionId, cancellationToken).ConfigureAwait(false);
+        if (!string.Equals(selectedBuildId, expectedBuild.Id, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"App Store version '{versionString}' does not have build '{buildNumber}' selected for platform '{request.Platform}'. Run PrepareDistribution first.");
+
+        return expectedBuild;
+    }
+
+    private static AppStoreConnectReleaseReadinessRequest CreateReadinessRequest(
+        AppStoreConnectReviewSubmissionRequest request,
+        string appId,
+        string versionString,
+        string buildNumber)
+    {
+        var source = request.ReadinessRequest ?? new AppStoreConnectReleaseReadinessRequest();
+        return new AppStoreConnectReleaseReadinessRequest
+        {
+            AppId = appId,
+            VersionString = versionString,
+            BuildNumber = buildNumber,
+            Platform = request.Platform,
+            Locale = string.IsNullOrWhiteSpace(source.Locale) ? "en-US" : source.Locale.Trim(),
+            RequireSelectedBuild = source.RequireSelectedBuild,
+            RequireValidBuild = source.RequireValidBuild,
+            RequireDescription = source.RequireDescription,
+            RequireKeywords = source.RequireKeywords,
+            RequireSupportUrl = source.RequireSupportUrl,
+            RequireMarketingUrl = source.RequireMarketingUrl,
+            RequirePromotionalText = source.RequirePromotionalText,
+            RequireWhatsNew = source.RequireWhatsNew,
+            RequireScreenshots = source.RequireScreenshots,
+            RequireCompleteScreenshots = source.RequireCompleteScreenshots,
+            MinimumScreenshotsPerSet = source.MinimumScreenshotsPerSet,
+            RequiredScreenshotDisplayTypes = source.RequiredScreenshotDisplayTypes,
+            ScreenshotSpec = source.ScreenshotSpec
+        };
+    }
+
+    private static void ValidateBuildIsSubmittable(AppStoreConnectBuildInfo build, string buildNumber)
+    {
+        if (!string.Equals(build.ProcessingState, "VALID", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be submitted because processing state is '{build.ProcessingState ?? "unknown"}'.");
+        if (build.Expired == true)
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be submitted because it is expired.");
+    }
+}

--- a/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
+++ b/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
@@ -1,0 +1,142 @@
+namespace PowerForge;
+
+/// <summary>
+/// Distributes processed App Store Connect builds through TestFlight beta groups.
+/// </summary>
+public sealed class AppStoreConnectTestFlightDistributionService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Initializes a TestFlight distribution service.
+    /// </summary>
+    public AppStoreConnectTestFlightDistributionService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Adds a build to beta groups and optionally ensures testers are present in those groups.
+    /// </summary>
+    public async Task<AppStoreConnectTestFlightDistributionResult> DistributeAsync(
+        AppStoreConnectTestFlightDistributionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrWhiteSpace(request.AppId))
+            throw new ArgumentException("AppId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.VersionString))
+            throw new ArgumentException("VersionString is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.BuildNumber))
+            throw new ArgumentException("BuildNumber is required.", nameof(request));
+
+        var build = (await _client.GetBuildsAsync(
+            request.AppId,
+            request.BuildNumber,
+            limit: 20,
+            marketingVersion: request.VersionString,
+            platform: request.Platform,
+            cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault()
+            ?? throw new InvalidOperationException($"Build '{request.BuildNumber}' was not found for app '{request.AppId}', version '{request.VersionString}', and platform '{request.Platform}'.");
+
+        if (request.RequireValidBuild)
+            ValidateBuildIsDistributable(build, request.BuildNumber);
+
+        var groups = await ResolveGroupsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (groups.Length == 0)
+            throw new InvalidOperationException("At least one beta group id or beta group name is required.");
+
+        var messages = new List<string>();
+        foreach (var group in groups)
+        {
+            await _client.AddBuildsToBetaGroupAsync(group.Id, new[] { build.Id }, cancellationToken).ConfigureAwait(false);
+            messages.Add($"Added build '{request.BuildNumber}' to beta group '{group.Name ?? group.Id}'.");
+        }
+
+        var testers = new List<AppStoreConnectBetaTesterInfo>();
+        foreach (var testerSpec in request.Testers ?? Array.Empty<AppStoreConnectBetaTesterSpec>())
+        {
+            var tester = await ResolveTesterAsync(testerSpec, request.CreateMissingTesters, groups, cancellationToken).ConfigureAwait(false);
+            testers.Add(tester);
+            foreach (var group in groups)
+                await _client.AddBetaTestersToBetaGroupAsync(group.Id, new[] { tester.Id }, cancellationToken).ConfigureAwait(false);
+            messages.Add($"Added beta tester '{tester.Email ?? tester.Id}' to {groups.Length} beta group(s).");
+        }
+
+        return new AppStoreConnectTestFlightDistributionResult
+        {
+            Build = build,
+            BetaGroups = groups,
+            Testers = testers.ToArray(),
+            Messages = messages.ToArray()
+        };
+    }
+
+    private async Task<AppStoreConnectBetaGroupInfo[]> ResolveGroupsAsync(
+        AppStoreConnectTestFlightDistributionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var groups = new List<AppStoreConnectBetaGroupInfo>();
+        foreach (var id in request.BetaGroupIds ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            var match = (await _client.GetBetaGroupsAsync(request.AppId, limit: 200, cancellationToken: cancellationToken).ConfigureAwait(false))
+                .FirstOrDefault(group => string.Equals(group.Id, id.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (match is null)
+                throw new InvalidOperationException($"Beta group id '{id}' was not found for app '{request.AppId}'.");
+            groups.Add(match);
+        }
+
+        foreach (var name in request.BetaGroupNames ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var matches = await _client.GetBetaGroupsAsync(request.AppId, name.Trim(), limit: 20, cancellationToken).ConfigureAwait(false);
+            if (matches.Length == 0)
+                throw new InvalidOperationException($"Beta group '{name}' was not found for app '{request.AppId}'.");
+            if (matches.Length > 1)
+                throw new InvalidOperationException($"Multiple beta groups matched '{name}' for app '{request.AppId}'; use BetaGroupIds.");
+            groups.Add(matches[0]);
+        }
+
+        return groups
+            .GroupBy(static group => group.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToArray();
+    }
+
+    private async Task<AppStoreConnectBetaTesterInfo> ResolveTesterAsync(
+        AppStoreConnectBetaTesterSpec testerSpec,
+        bool createMissing,
+        AppStoreConnectBetaGroupInfo[] groups,
+        CancellationToken cancellationToken)
+    {
+        if (testerSpec is null || string.IsNullOrWhiteSpace(testerSpec.Email))
+            throw new ArgumentException("Every tester requires Email.", nameof(testerSpec));
+
+        var existing = (await _client.GetBetaTestersAsync(testerSpec.Email.Trim(), limit: 10, cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+        if (existing is not null)
+            return existing;
+        if (!createMissing)
+            throw new InvalidOperationException($"Beta tester '{testerSpec.Email}' was not found and CreateMissingTesters is false.");
+
+        return await _client.CreateBetaTesterAsync(
+            testerSpec.Email,
+            testerSpec.FirstName,
+            testerSpec.LastName,
+            groups.Select(static group => group.Id).ToArray(),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void ValidateBuildIsDistributable(AppStoreConnectBuildInfo build, string buildNumber)
+    {
+        if (!string.Equals(build.ProcessingState, "VALID", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be distributed because processing state is '{build.ProcessingState ?? "unknown"}'.");
+        if (build.Expired == true)
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be distributed because it is expired.");
+    }
+}

--- a/PowerForge/Services/AppStoreConnectVersionMetadataSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectVersionMetadataSyncService.cs
@@ -1,0 +1,79 @@
+namespace PowerForge;
+
+/// <summary>
+/// Syncs localized App Store version metadata.
+/// </summary>
+public sealed class AppStoreConnectVersionMetadataSyncService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Initializes a metadata sync service.
+    /// </summary>
+    public AppStoreConnectVersionMetadataSyncService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Applies localized metadata to the matching App Store version localization.
+    /// </summary>
+    public async Task<AppStoreConnectVersionMetadataSyncResult> SyncAsync(
+        AppStoreConnectVersionMetadataSyncRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        var spec = request.Spec ?? throw new ArgumentException("Spec is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(spec.AppId))
+            throw new ArgumentException("Spec.AppId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(spec.VersionString) && string.IsNullOrWhiteSpace(spec.VersionId))
+            throw new ArgumentException("Spec.VersionString or Spec.VersionId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(spec.Locale))
+            throw new ArgumentException("Spec.Locale is required.", nameof(request));
+
+        var version = await ResolveVersionAsync(spec, cancellationToken).ConfigureAwait(false);
+        var localization = (await _client.GetVersionLocalizationsAsync(
+            version.Id,
+            spec.Locale,
+            limit: 10,
+            cancellationToken).ConfigureAwait(false)).FirstOrDefault()
+            ?? throw new InvalidOperationException($"Localization '{spec.Locale}' was not found for App Store version '{version.Id}'.");
+
+        var updated = await _client.UpdateVersionLocalizationAsync(
+            localization.Id,
+            spec.Metadata,
+            cancellationToken).ConfigureAwait(false);
+
+        return new AppStoreConnectVersionMetadataSyncResult
+        {
+            Version = version,
+            Before = localization,
+            After = updated,
+            UpdatedFields = AppStoreConnectClient.GetSuppliedLocalizationFields(spec.Metadata)
+        };
+    }
+
+    private async Task<AppStoreConnectVersionInfo> ResolveVersionAsync(
+        AppStoreConnectVersionMetadataSpec spec,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(spec.VersionId))
+        {
+            return new AppStoreConnectVersionInfo
+            {
+                Id = spec.VersionId!.Trim(),
+                VersionString = spec.VersionString,
+                Platform = spec.Platform.ToString()
+            };
+        }
+
+        return (await _client.GetVersionsAsync(
+            spec.AppId,
+            spec.VersionString,
+            spec.Platform,
+            limit: 10,
+            cancellationToken).ConfigureAwait(false)).FirstOrDefault()
+            ?? throw new InvalidOperationException($"App Store version '{spec.VersionString}' was not found for app '{spec.AppId}' and platform '{spec.Platform}'.");
+    }
+}

--- a/PowerForge/Services/AppStoreConnectVersionReleaseService.cs
+++ b/PowerForge/Services/AppStoreConnectVersionReleaseService.cs
@@ -1,0 +1,78 @@
+namespace PowerForge;
+
+/// <summary>
+/// Releases approved App Store Connect Distribution versions to the App Store.
+/// </summary>
+public sealed class AppStoreConnectVersionReleaseService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Initializes an App Store version release service.
+    /// </summary>
+    public AppStoreConnectVersionReleaseService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Requests manual release of an approved App Store version.
+    /// </summary>
+    public async Task<AppStoreConnectVersionReleaseResult> ReleaseAsync(
+        AppStoreConnectVersionReleaseRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrWhiteSpace(request.AppId))
+            throw new ArgumentException("AppId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.VersionString))
+            throw new ArgumentException("VersionString is required.", nameof(request));
+
+        var appId = request.AppId.Trim();
+        var versionString = request.VersionString.Trim();
+        var version = (await _client.GetVersionsAsync(
+            appId,
+            versionString,
+            request.Platform,
+            limit: 10,
+            cancellationToken).ConfigureAwait(false)).FirstOrDefault()
+            ?? throw new InvalidOperationException($"App Store version '{versionString}' was not found for app '{appId}' and platform '{request.Platform}'.");
+
+        if (request.RequirePendingDeveloperRelease)
+            ValidateVersionCanBeReleased(version, versionString, request.Platform);
+
+        var releaseRequest = await _client.CreateVersionReleaseRequestAsync(version.Id, cancellationToken).ConfigureAwait(false);
+        return new AppStoreConnectVersionReleaseResult
+        {
+            AppId = appId,
+            VersionString = versionString,
+            Platform = request.Platform,
+            Version = version,
+            ReleaseRequest = releaseRequest,
+            Messages = new[]
+            {
+                $"Requested App Store release for version '{versionString}' on platform '{request.Platform}'."
+            }
+        };
+    }
+
+    private static void ValidateVersionCanBeReleased(
+        AppStoreConnectVersionInfo version,
+        string versionString,
+        ApplePlatform platform)
+    {
+        if (IsPendingDeveloperRelease(version.AppStoreState) || IsPendingDeveloperRelease(version.AppVersionState))
+            return;
+
+        var state = FirstNonEmpty(version.AppStoreState, version.AppVersionState, "unknown");
+        throw new InvalidOperationException($"App Store version '{versionString}' for platform '{platform}' cannot be released because state is '{state}', not PENDING_DEVELOPER_RELEASE.");
+    }
+
+    private static bool IsPendingDeveloperRelease(string? state)
+        => string.Equals(state, "PENDING_DEVELOPER_RELEASE", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(state, "Pending Developer Release", StringComparison.OrdinalIgnoreCase);
+
+    private static string FirstNonEmpty(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
+}

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -58,6 +58,7 @@ internal sealed class PowerForgeReleaseService
     private readonly Func<AppleAppArchiveRequest, AppleAppArchiveResult> _archiveAppleApp;
     private readonly Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult> _uploadAppleApp;
     private readonly Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult> _prepareAppleDistribution;
+    private readonly Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult> _distributeTestFlight;
 
     /// <summary>
     /// Creates a new unified release service.
@@ -113,7 +114,8 @@ internal sealed class PowerForgeReleaseService
         Func<PowerForgeWingetSubmissionPlan, PowerForgeWingetSubmissionResult>? submitWinget = null,
         Func<AppleAppArchiveRequest, AppleAppArchiveResult>? archiveAppleApp = null,
         Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null,
-        Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null)
+        Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null,
+        Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult>? distributeTestFlight = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -127,6 +129,7 @@ internal sealed class PowerForgeReleaseService
         _archiveAppleApp = archiveAppleApp ?? (request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult());
         _uploadAppleApp = uploadAppleApp ?? (request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult());
         _prepareAppleDistribution = prepareAppleDistribution ?? PrepareAppleDistribution;
+        _distributeTestFlight = distributeTestFlight ?? DistributeTestFlight;
     }
 
     /// <summary>
@@ -731,9 +734,13 @@ internal sealed class PowerForgeReleaseService
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness) &&
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight) &&
             apps.Any(app => string.IsNullOrWhiteSpace(app.AppStoreConnectAppId)))
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, or CheckReleaseReadiness requires AppStoreConnectAppId for every selected app.");
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, or DistributeTestFlight requires AppStoreConnectAppId for every selected app.");
+        if (options.DistributeTestFlight &&
+            NormalizeStrings(options.TestFlightBetaGroupIds).Length == 0 &&
+            NormalizeStrings(options.TestFlightBetaGroupNames).Length == 0)
+            throw new InvalidOperationException("AppleApps DistributeTestFlight requires TestFlightBetaGroupIds or TestFlightBetaGroupNames.");
         if (options.SyncScreenshots && screenshotConfigPath is null && screenshotConfigPaths.Length == 0)
             throw new InvalidOperationException("AppleApps SyncScreenshots requires ScreenshotConfigPath or ScreenshotConfigPaths.");
         if (options.SyncMetadata && metadataConfigPath is null && metadataConfigPaths.Length == 0)
@@ -768,8 +775,8 @@ internal sealed class PowerForgeReleaseService
                 Environment.GetEnvironmentVariable("ASC_ISSUER_ID"))
             : options.AppStoreConnectApiIssuerId?.Trim();
         var appStoreConnectApiConfiguredCount = (appStoreConnectApiKeyPath is null ? 0 : 1) + (appStoreConnectApiKeyId is null ? 0 : 1) + (appStoreConnectApiIssuerId is null ? 0 : 1);
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness) && appStoreConnectApiConfiguredCount != 3)
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, or CheckReleaseReadiness requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight) && appStoreConnectApiConfiguredCount != 3)
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, or DistributeTestFlight requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
         if (appStoreConnectApiConfiguredCount != 0)
         {
             if (appStoreConnectApiConfiguredCount != 3)
@@ -797,6 +804,12 @@ internal sealed class PowerForgeReleaseService
             SyncMetadata = options.SyncMetadata,
             ReplaceScreenshots = options.ReplaceScreenshots,
             CheckReleaseReadiness = options.CheckReleaseReadiness,
+            DistributeTestFlight = options.DistributeTestFlight,
+            TestFlightBetaGroupIds = NormalizeStrings(options.TestFlightBetaGroupIds),
+            TestFlightBetaGroupNames = NormalizeStrings(options.TestFlightBetaGroupNames),
+            TestFlightTesterEmails = NormalizeStrings(options.TestFlightTesterEmails),
+            CreateMissingTestFlightTesters = options.CreateMissingTestFlightTesters,
+            AllowUnprocessedTestFlightBuild = options.AllowUnprocessedTestFlightBuild,
             XcodeBuildExecutable = string.IsNullOrWhiteSpace(options.XcodeBuildExecutable) ? "xcodebuild" : options.XcodeBuildExecutable.Trim(),
             AllowProvisioningUpdates = options.AllowProvisioningUpdates,
             ManageAppVersionAndBuildNumber = options.ManageAppVersionAndBuildNumber,
@@ -985,6 +998,26 @@ internal sealed class PowerForgeReleaseService
                 });
             }
 
+            if (plan.DistributeTestFlight && result.Success)
+            {
+                var testFlightValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
+                result.TestFlight = _distributeTestFlight(new AppStoreConnectTestFlightDistributionRequest
+                {
+                    Credential = CreateAppStoreConnectCredential(plan),
+                    AppId = app.AppStoreConnectAppId!,
+                    VersionString = testFlightValues.MarketingVersion,
+                    BuildNumber = testFlightValues.BuildNumber,
+                    Platform = app.Platform,
+                    BetaGroupIds = plan.TestFlightBetaGroupIds,
+                    BetaGroupNames = plan.TestFlightBetaGroupNames,
+                    Testers = plan.TestFlightTesterEmails
+                        .Select(static email => new AppStoreConnectBetaTesterSpec { Email = email })
+                        .ToArray(),
+                    CreateMissingTesters = plan.CreateMissingTestFlightTesters,
+                    RequireValidBuild = !plan.AllowUnprocessedTestFlightBuild
+                });
+            }
+
             results.Add(result);
         }
 
@@ -998,6 +1031,17 @@ internal sealed class PowerForgeReleaseService
 
         using var client = new AppStoreConnectClient(request.Credential);
         return new AppStoreConnectReleasePreparationService(client).PrepareAsync(request).GetAwaiter().GetResult();
+    }
+
+    private static AppStoreConnectTestFlightDistributionResult DistributeTestFlight(AppStoreConnectTestFlightDistributionRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (request.Credential is null)
+            throw new ArgumentException("Credential is required.", nameof(request));
+
+        using var client = new AppStoreConnectClient(request.Credential);
+        return new AppStoreConnectTestFlightDistributionService(client).DistributeAsync(request).GetAwaiter().GetResult();
     }
 
     private static AppStoreConnectApiCredential CreateAppStoreConnectCredential(PowerForgeAppleReleasePlan plan)
@@ -3116,6 +3160,12 @@ internal sealed class PowerForgeReleaseService
                 plan.MetadataConfigPaths,
                 plan.ReplaceScreenshots,
                 plan.CheckReleaseReadiness,
+                plan.DistributeTestFlight,
+                plan.TestFlightBetaGroupIds,
+                plan.TestFlightBetaGroupNames,
+                TestFlightTesterCount = plan.TestFlightTesterEmails.Length,
+                plan.CreateMissingTestFlightTesters,
+                plan.AllowUnprocessedTestFlightBuild,
                 plan.XcodeBuildExecutable,
                 plan.AllowProvisioningUpdates,
                 plan.ManageAppVersionAndBuildNumber,
@@ -3201,6 +3251,19 @@ internal sealed class PowerForgeReleaseService
                         check.Message
                     }).ToArray(),
                     result.Distribution.Messages
+                },
+                testFlight = result.TestFlight is null ? null : new
+                {
+                    BuildId = result.TestFlight.Build.Id,
+                    BuildNumber = result.TestFlight.Build.Version,
+                    BetaGroups = result.TestFlight.BetaGroups.Select(group => new
+                    {
+                        group.Id,
+                        group.Name,
+                        group.PublicLinkEnabled
+                    }).ToArray(),
+                    TesterCount = result.TestFlight.Testers.Length,
+                    result.TestFlight.Messages
                 }
             }).ToArray()
         };

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -60,6 +60,7 @@ internal sealed class PowerForgeReleaseService
     private readonly Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult> _prepareAppleDistribution;
     private readonly Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult> _distributeTestFlight;
     private readonly Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult> _submitAppleReview;
+    private readonly Func<AppStoreConnectVersionReleaseRequest, AppStoreConnectVersionReleaseResult> _releaseAppleVersion;
 
     /// <summary>
     /// Creates a new unified release service.
@@ -117,7 +118,8 @@ internal sealed class PowerForgeReleaseService
         Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null,
         Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null,
         Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult>? distributeTestFlight = null,
-        Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult>? submitAppleReview = null)
+        Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult>? submitAppleReview = null,
+        Func<AppStoreConnectVersionReleaseRequest, AppStoreConnectVersionReleaseResult>? releaseAppleVersion = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -133,6 +135,7 @@ internal sealed class PowerForgeReleaseService
         _prepareAppleDistribution = prepareAppleDistribution ?? PrepareAppleDistribution;
         _distributeTestFlight = distributeTestFlight ?? DistributeTestFlight;
         _submitAppleReview = submitAppleReview ?? SubmitAppleReview;
+        _releaseAppleVersion = releaseAppleVersion ?? ReleaseAppleVersion;
     }
 
     /// <summary>
@@ -737,9 +740,9 @@ internal sealed class PowerForgeReleaseService
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview) &&
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview || options.ReleaseApprovedVersion) &&
             apps.Any(app => string.IsNullOrWhiteSpace(app.AppStoreConnectAppId)))
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, or SubmitForReview requires AppStoreConnectAppId for every selected app.");
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, SubmitForReview, or ReleaseApprovedVersion requires AppStoreConnectAppId for every selected app.");
         if (options.DistributeTestFlight &&
             NormalizeStrings(options.TestFlightBetaGroupIds).Length == 0 &&
             NormalizeStrings(options.TestFlightBetaGroupNames).Length == 0)
@@ -778,8 +781,8 @@ internal sealed class PowerForgeReleaseService
                 Environment.GetEnvironmentVariable("ASC_ISSUER_ID"))
             : options.AppStoreConnectApiIssuerId?.Trim();
         var appStoreConnectApiConfiguredCount = (appStoreConnectApiKeyPath is null ? 0 : 1) + (appStoreConnectApiKeyId is null ? 0 : 1) + (appStoreConnectApiIssuerId is null ? 0 : 1);
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview) && appStoreConnectApiConfiguredCount != 3)
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, or SubmitForReview requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview || options.ReleaseApprovedVersion) && appStoreConnectApiConfiguredCount != 3)
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, SubmitForReview, or ReleaseApprovedVersion requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
         if (appStoreConnectApiConfiguredCount != 0)
         {
             if (appStoreConnectApiConfiguredCount != 3)
@@ -818,6 +821,8 @@ internal sealed class PowerForgeReleaseService
             AllowUnprocessedReviewBuild = options.AllowUnprocessedReviewBuild,
             SkipReviewReadinessCheck = options.SkipReviewReadinessCheck,
             AllowReviewSubmissionWhenNotReady = options.AllowReviewSubmissionWhenNotReady,
+            ReleaseApprovedVersion = options.ReleaseApprovedVersion,
+            AllowNonPendingDeveloperRelease = options.AllowNonPendingDeveloperRelease,
             XcodeBuildExecutable = string.IsNullOrWhiteSpace(options.XcodeBuildExecutable) ? "xcodebuild" : options.XcodeBuildExecutable.Trim(),
             AllowProvisioningUpdates = options.AllowProvisioningUpdates,
             ManageAppVersionAndBuildNumber = options.ManageAppVersionAndBuildNumber,
@@ -1043,6 +1048,19 @@ internal sealed class PowerForgeReleaseService
                 });
             }
 
+            if (plan.ReleaseApprovedVersion && result.Success)
+            {
+                var releaseValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
+                result.VersionRelease = _releaseAppleVersion(new AppStoreConnectVersionReleaseRequest
+                {
+                    Credential = CreateAppStoreConnectCredential(plan),
+                    AppId = app.AppStoreConnectAppId!,
+                    VersionString = releaseValues.MarketingVersion,
+                    Platform = app.Platform,
+                    RequirePendingDeveloperRelease = !plan.AllowNonPendingDeveloperRelease
+                });
+            }
+
             results.Add(result);
         }
 
@@ -1078,6 +1096,17 @@ internal sealed class PowerForgeReleaseService
 
         using var client = new AppStoreConnectClient(request.Credential);
         return new AppStoreConnectReviewSubmissionService(client).SubmitAsync(request).GetAwaiter().GetResult();
+    }
+
+    private static AppStoreConnectVersionReleaseResult ReleaseAppleVersion(AppStoreConnectVersionReleaseRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (request.Credential is null)
+            throw new ArgumentException("Credential is required.", nameof(request));
+
+        using var client = new AppStoreConnectClient(request.Credential);
+        return new AppStoreConnectVersionReleaseService(client).ReleaseAsync(request).GetAwaiter().GetResult();
     }
 
     private static AppStoreConnectApiCredential CreateAppStoreConnectCredential(PowerForgeAppleReleasePlan plan)
@@ -3207,6 +3236,8 @@ internal sealed class PowerForgeReleaseService
                 plan.AllowUnprocessedReviewBuild,
                 plan.SkipReviewReadinessCheck,
                 plan.AllowReviewSubmissionWhenNotReady,
+                plan.ReleaseApprovedVersion,
+                plan.AllowNonPendingDeveloperRelease,
                 plan.XcodeBuildExecutable,
                 plan.AllowProvisioningUpdates,
                 plan.ManageAppVersionAndBuildNumber,
@@ -3320,6 +3351,17 @@ internal sealed class PowerForgeReleaseService
                     ReviewSubmissionItemId = result.ReviewSubmission.ReviewSubmissionItem?.Id,
                     ReadinessReady = result.ReviewSubmission.Readiness?.IsReady,
                     result.ReviewSubmission.Messages
+                },
+                versionRelease = result.VersionRelease is null ? null : new
+                {
+                    result.VersionRelease.AppId,
+                    result.VersionRelease.VersionString,
+                    Platform = result.VersionRelease.Platform.ToString(),
+                    VersionId = result.VersionRelease.Version.Id,
+                    result.VersionRelease.Version.AppStoreState,
+                    result.VersionRelease.Version.AppVersionState,
+                    ReleaseRequestId = result.VersionRelease.ReleaseRequest.Id,
+                    result.VersionRelease.Messages
                 }
             }).ToArray()
         };

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -320,6 +320,8 @@ internal sealed class PowerForgeReleaseService
                 selectedAppleTargets,
                 validateReusableArchives: !request.PlanOnly && !request.ValidateOnly);
             result.AppleAppPlan = applePlan;
+            if (request.PlanOnly || request.ValidateOnly)
+                ScrubApplePlanCredentials(result.AppleAppPlan);
         }
 
         if (runTools)
@@ -701,6 +703,13 @@ internal sealed class PowerForgeReleaseService
             .Where(static path => !string.IsNullOrWhiteSpace(path))
             .Select(path => ResolveOutputPath(projectRoot, path))
             .ToArray();
+        var metadataConfigPath = string.IsNullOrWhiteSpace(options.MetadataConfigPath)
+            ? null
+            : ResolveOutputPath(projectRoot, options.MetadataConfigPath!);
+        var metadataConfigPaths = (options.MetadataConfigPaths ?? Array.Empty<string>())
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => ResolveOutputPath(projectRoot, path))
+            .ToArray();
 
         var selectedTargets = NormalizeStrings(selectedTargetNames);
         var configuredApps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
@@ -722,11 +731,13 @@ internal sealed class PowerForgeReleaseService
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
-        if ((options.PrepareDistribution || options.SyncScreenshots) &&
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness) &&
             apps.Any(app => string.IsNullOrWhiteSpace(app.AppStoreConnectAppId)))
-            throw new InvalidOperationException("AppleApps PrepareDistribution or SyncScreenshots requires AppStoreConnectAppId for every selected app.");
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, or CheckReleaseReadiness requires AppStoreConnectAppId for every selected app.");
         if (options.SyncScreenshots && screenshotConfigPath is null && screenshotConfigPaths.Length == 0)
             throw new InvalidOperationException("AppleApps SyncScreenshots requires ScreenshotConfigPath or ScreenshotConfigPaths.");
+        if (options.SyncMetadata && metadataConfigPath is null && metadataConfigPaths.Length == 0)
+            throw new InvalidOperationException("AppleApps SyncMetadata requires MetadataConfigPath or MetadataConfigPaths.");
         if (!options.Archive && apps.Any(app => app.VersionUpdateRequested))
             throw new InvalidOperationException("Apple app version updates require AppleApps.Archive=true. Set Archive=true to build a fresh archive after updating versions, or remove version update fields when reusing an existing archive.");
         if (validateReusableArchives && !options.Archive && options.Upload)
@@ -757,8 +768,8 @@ internal sealed class PowerForgeReleaseService
                 Environment.GetEnvironmentVariable("ASC_ISSUER_ID"))
             : options.AppStoreConnectApiIssuerId?.Trim();
         var appStoreConnectApiConfiguredCount = (appStoreConnectApiKeyPath is null ? 0 : 1) + (appStoreConnectApiKeyId is null ? 0 : 1) + (appStoreConnectApiIssuerId is null ? 0 : 1);
-        if ((options.PrepareDistribution || options.SyncScreenshots) && appStoreConnectApiConfiguredCount != 3)
-            throw new InvalidOperationException("AppleApps PrepareDistribution or SyncScreenshots requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness) && appStoreConnectApiConfiguredCount != 3)
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, or CheckReleaseReadiness requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
         if (appStoreConnectApiConfiguredCount != 0)
         {
             if (appStoreConnectApiConfiguredCount != 3)
@@ -778,10 +789,14 @@ internal sealed class PowerForgeReleaseService
             SyncScreenshots = options.SyncScreenshots,
             ScreenshotConfigPath = screenshotConfigPath,
             ScreenshotConfigPaths = screenshotConfigPaths,
+            MetadataConfigPath = metadataConfigPath,
+            MetadataConfigPaths = metadataConfigPaths,
             PrepareDistribution = options.PrepareDistribution,
             SelectBuildForDistribution = options.SelectBuildForDistribution,
             AllowUnprocessedDistributionBuild = options.AllowUnprocessedDistributionBuild,
+            SyncMetadata = options.SyncMetadata,
             ReplaceScreenshots = options.ReplaceScreenshots,
+            CheckReleaseReadiness = options.CheckReleaseReadiness,
             XcodeBuildExecutable = string.IsNullOrWhiteSpace(options.XcodeBuildExecutable) ? "xcodebuild" : options.XcodeBuildExecutable.Trim(),
             AllowProvisioningUpdates = options.AllowProvisioningUpdates,
             ManageAppVersionAndBuildNumber = options.ManageAppVersionAndBuildNumber,
@@ -868,6 +883,9 @@ internal sealed class PowerForgeReleaseService
         var screenshotSpecs = plan.SyncScreenshots
             ? LoadAppleScreenshotSpecs(plan)
             : Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
+        var metadataSpecs = plan.SyncMetadata
+            ? LoadAppleMetadataSpecs(plan)
+            : Array.Empty<(AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)>();
         foreach (var app in plan.Apps)
         {
             var result = new PowerForgeAppleAppReleaseResult
@@ -935,11 +953,14 @@ internal sealed class PowerForgeReleaseService
                 }
             }
 
-            if ((plan.PrepareDistribution || plan.SyncScreenshots) && result.Success)
+            if ((plan.PrepareDistribution || plan.SyncScreenshots || plan.SyncMetadata || plan.CheckReleaseReadiness) && result.Success)
             {
                 var distributionValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
                 var matchingScreenshotSpec = plan.SyncScreenshots
                     ? ResolveMatchingScreenshotSpec(screenshotSpecs, app, distributionValues.MarketingVersion)
+                    : null;
+                var matchingMetadataSpec = plan.SyncMetadata
+                    ? ResolveMatchingMetadataSpec(metadataSpecs, app, distributionValues.MarketingVersion)
                     : null;
 
                 result.Distribution = _prepareAppleDistribution(new AppStoreConnectReleasePreparationRequest
@@ -953,9 +974,13 @@ internal sealed class PowerForgeReleaseService
                     SelectBuild = plan.PrepareDistribution && plan.SelectBuildForDistribution,
                     RequireValidBuild = !plan.AllowUnprocessedDistributionBuild,
                     ScreenshotSpec = matchingScreenshotSpec?.Spec,
+                    MetadataSpec = matchingMetadataSpec?.Spec,
                     ReplaceScreenshots = plan.ReplaceScreenshots,
+                    CheckReadiness = plan.CheckReleaseReadiness,
                     BaseDirectory = matchingScreenshotSpec is null
-                        ? plan.ProjectRoot
+                        ? matchingMetadataSpec is null
+                            ? plan.ProjectRoot
+                            : Path.GetDirectoryName(matchingMetadataSpec.Value.ConfigPath) ?? plan.ProjectRoot
                         : Path.GetDirectoryName(matchingScreenshotSpec.Value.ConfigPath) ?? plan.ProjectRoot
                 });
             }
@@ -988,6 +1013,16 @@ internal sealed class PowerForgeReleaseService
             KeyId = plan.AppStoreConnectApiKeyId!.Trim(),
             PrivateKey = File.ReadAllText(plan.AppStoreConnectApiKeyPath!).Trim()
         };
+    }
+
+    private static void ScrubApplePlanCredentials(PowerForgeAppleReleasePlan? plan)
+    {
+        if (plan is null)
+            return;
+
+        plan.AppStoreConnectApiKeyPath = null;
+        plan.AppStoreConnectApiKeyId = null;
+        plan.AppStoreConnectApiIssuerId = null;
     }
 
     private static (string MarketingVersion, string BuildNumber) ResolveAppleDistributionValues(
@@ -1035,6 +1070,25 @@ internal sealed class PowerForgeReleaseService
             .ToArray();
     }
 
+    private static (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] LoadAppleMetadataSpecs(PowerForgeAppleReleasePlan plan)
+    {
+        var paths = new List<string>();
+        if (!string.IsNullOrWhiteSpace(plan.MetadataConfigPath))
+            paths.Add(plan.MetadataConfigPath!);
+        paths.AddRange(plan.MetadataConfigPaths.Where(static path => !string.IsNullOrWhiteSpace(path)));
+
+        return paths
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path =>
+            {
+                var json = File.ReadAllText(path);
+                var spec = JsonSerializer.Deserialize<AppStoreConnectVersionMetadataSpec>(json, CreateJsonOptions())
+                    ?? throw new InvalidOperationException($"Unable to deserialize App Store version metadata config: {path}");
+                return (spec, path);
+            })
+            .ToArray();
+    }
+
     private static (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)? ResolveMatchingScreenshotSpec(
         (AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)[] specs,
         PowerForgeAppleAppReleaseTargetPlan app,
@@ -1052,6 +1106,33 @@ internal sealed class PowerForgeReleaseService
 
     private static bool ScreenshotSpecMatches(
         AppStoreConnectScreenshotSyncSpec spec,
+        PowerForgeAppleAppReleaseTargetPlan app,
+        string marketingVersion)
+    {
+        var appIdMatches = string.IsNullOrWhiteSpace(spec.AppId) ||
+                           string.Equals(spec.AppId.Trim(), app.AppStoreConnectAppId, StringComparison.OrdinalIgnoreCase);
+        var specVersionString = string.IsNullOrWhiteSpace(spec.VersionString) ? null : spec.VersionString!.Trim();
+        var versionMatches = specVersionString is null ||
+                             string.Equals(specVersionString, marketingVersion, StringComparison.OrdinalIgnoreCase);
+        return appIdMatches && versionMatches && spec.Platform == app.Platform;
+    }
+
+    private static (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)? ResolveMatchingMetadataSpec(
+        (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] specs,
+        PowerForgeAppleAppReleaseTargetPlan app,
+        string marketingVersion)
+    {
+        var matches = specs
+            .Where(candidate => MetadataSpecMatches(candidate.Spec, app, marketingVersion))
+            .ToArray();
+        if (matches.Length > 1)
+            throw new InvalidOperationException($"Multiple App Store metadata configs match Apple app '{app.Name}' version '{marketingVersion}' platform '{app.Platform}'.");
+
+        return matches.Length == 0 ? null : matches[0];
+    }
+
+    private static bool MetadataSpecMatches(
+        AppStoreConnectVersionMetadataSpec spec,
         PowerForgeAppleAppReleaseTargetPlan app,
         string marketingVersion)
     {
@@ -3025,12 +3106,16 @@ internal sealed class PowerForgeReleaseService
                 plan.Archive,
                 plan.Upload,
                 plan.SyncScreenshots,
+                plan.SyncMetadata,
                 plan.PrepareDistribution,
                 plan.SelectBuildForDistribution,
                 plan.AllowUnprocessedDistributionBuild,
                 plan.ScreenshotConfigPath,
                 plan.ScreenshotConfigPaths,
+                plan.MetadataConfigPath,
+                plan.MetadataConfigPaths,
                 plan.ReplaceScreenshots,
+                plan.CheckReleaseReadiness,
                 plan.XcodeBuildExecutable,
                 plan.AllowProvisioningUpdates,
                 plan.ManageAppVersionAndBuildNumber,
@@ -3107,6 +3192,14 @@ internal sealed class PowerForgeReleaseService
                     result.Distribution.SelectedBuild,
                     result.Distribution.PreviousBuildId,
                     ScreenshotSetCount = result.Distribution.Screenshots?.ScreenshotSets.Length ?? 0,
+                    MetadataUpdatedFields = result.Distribution.Metadata?.UpdatedFields ?? Array.Empty<string>(),
+                    ReadinessReady = result.Distribution.Readiness?.IsReady,
+                    ReadinessChecks = result.Distribution.Readiness?.Checks.Select(check => new
+                    {
+                        check.Name,
+                        check.Passed,
+                        check.Message
+                    }).ToArray(),
                     result.Distribution.Messages
                 }
             }).ToArray()

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -59,6 +59,7 @@ internal sealed class PowerForgeReleaseService
     private readonly Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult> _uploadAppleApp;
     private readonly Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult> _prepareAppleDistribution;
     private readonly Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult> _distributeTestFlight;
+    private readonly Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult> _submitAppleReview;
 
     /// <summary>
     /// Creates a new unified release service.
@@ -115,7 +116,8 @@ internal sealed class PowerForgeReleaseService
         Func<AppleAppArchiveRequest, AppleAppArchiveResult>? archiveAppleApp = null,
         Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null,
         Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null,
-        Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult>? distributeTestFlight = null)
+        Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult>? distributeTestFlight = null,
+        Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult>? submitAppleReview = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -130,6 +132,7 @@ internal sealed class PowerForgeReleaseService
         _uploadAppleApp = uploadAppleApp ?? (request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult());
         _prepareAppleDistribution = prepareAppleDistribution ?? PrepareAppleDistribution;
         _distributeTestFlight = distributeTestFlight ?? DistributeTestFlight;
+        _submitAppleReview = submitAppleReview ?? SubmitAppleReview;
     }
 
     /// <summary>
@@ -734,9 +737,9 @@ internal sealed class PowerForgeReleaseService
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight) &&
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview) &&
             apps.Any(app => string.IsNullOrWhiteSpace(app.AppStoreConnectAppId)))
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, or DistributeTestFlight requires AppStoreConnectAppId for every selected app.");
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, or SubmitForReview requires AppStoreConnectAppId for every selected app.");
         if (options.DistributeTestFlight &&
             NormalizeStrings(options.TestFlightBetaGroupIds).Length == 0 &&
             NormalizeStrings(options.TestFlightBetaGroupNames).Length == 0)
@@ -775,8 +778,8 @@ internal sealed class PowerForgeReleaseService
                 Environment.GetEnvironmentVariable("ASC_ISSUER_ID"))
             : options.AppStoreConnectApiIssuerId?.Trim();
         var appStoreConnectApiConfiguredCount = (appStoreConnectApiKeyPath is null ? 0 : 1) + (appStoreConnectApiKeyId is null ? 0 : 1) + (appStoreConnectApiIssuerId is null ? 0 : 1);
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight) && appStoreConnectApiConfiguredCount != 3)
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, or DistributeTestFlight requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview) && appStoreConnectApiConfiguredCount != 3)
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, or SubmitForReview requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
         if (appStoreConnectApiConfiguredCount != 0)
         {
             if (appStoreConnectApiConfiguredCount != 3)
@@ -810,6 +813,11 @@ internal sealed class PowerForgeReleaseService
             TestFlightTesterEmails = NormalizeStrings(options.TestFlightTesterEmails),
             CreateMissingTestFlightTesters = options.CreateMissingTestFlightTesters,
             AllowUnprocessedTestFlightBuild = options.AllowUnprocessedTestFlightBuild,
+            SubmitForReview = options.SubmitForReview,
+            AllowUnselectedReviewBuild = options.AllowUnselectedReviewBuild,
+            AllowUnprocessedReviewBuild = options.AllowUnprocessedReviewBuild,
+            SkipReviewReadinessCheck = options.SkipReviewReadinessCheck,
+            AllowReviewSubmissionWhenNotReady = options.AllowReviewSubmissionWhenNotReady,
             XcodeBuildExecutable = string.IsNullOrWhiteSpace(options.XcodeBuildExecutable) ? "xcodebuild" : options.XcodeBuildExecutable.Trim(),
             AllowProvisioningUpdates = options.AllowProvisioningUpdates,
             ManageAppVersionAndBuildNumber = options.ManageAppVersionAndBuildNumber,
@@ -1018,6 +1026,23 @@ internal sealed class PowerForgeReleaseService
                 });
             }
 
+            if (plan.SubmitForReview && result.Success)
+            {
+                var reviewValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
+                result.ReviewSubmission = _submitAppleReview(new AppStoreConnectReviewSubmissionRequest
+                {
+                    Credential = CreateAppStoreConnectCredential(plan),
+                    AppId = app.AppStoreConnectAppId!,
+                    VersionString = reviewValues.MarketingVersion,
+                    BuildNumber = reviewValues.BuildNumber,
+                    Platform = app.Platform,
+                    RequireSelectedBuild = !plan.AllowUnselectedReviewBuild,
+                    RequireValidBuild = !plan.AllowUnprocessedReviewBuild,
+                    CheckReadiness = !plan.SkipReviewReadinessCheck,
+                    RequireReady = !plan.AllowReviewSubmissionWhenNotReady
+                });
+            }
+
             results.Add(result);
         }
 
@@ -1042,6 +1067,17 @@ internal sealed class PowerForgeReleaseService
 
         using var client = new AppStoreConnectClient(request.Credential);
         return new AppStoreConnectTestFlightDistributionService(client).DistributeAsync(request).GetAwaiter().GetResult();
+    }
+
+    private static AppStoreConnectReviewSubmissionResult SubmitAppleReview(AppStoreConnectReviewSubmissionRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (request.Credential is null)
+            throw new ArgumentException("Credential is required.", nameof(request));
+
+        using var client = new AppStoreConnectClient(request.Credential);
+        return new AppStoreConnectReviewSubmissionService(client).SubmitAsync(request).GetAwaiter().GetResult();
     }
 
     private static AppStoreConnectApiCredential CreateAppStoreConnectCredential(PowerForgeAppleReleasePlan plan)
@@ -3166,6 +3202,11 @@ internal sealed class PowerForgeReleaseService
                 TestFlightTesterCount = plan.TestFlightTesterEmails.Length,
                 plan.CreateMissingTestFlightTesters,
                 plan.AllowUnprocessedTestFlightBuild,
+                plan.SubmitForReview,
+                plan.AllowUnselectedReviewBuild,
+                plan.AllowUnprocessedReviewBuild,
+                plan.SkipReviewReadinessCheck,
+                plan.AllowReviewSubmissionWhenNotReady,
                 plan.XcodeBuildExecutable,
                 plan.AllowProvisioningUpdates,
                 plan.ManageAppVersionAndBuildNumber,
@@ -3264,6 +3305,21 @@ internal sealed class PowerForgeReleaseService
                     }).ToArray(),
                     TesterCount = result.TestFlight.Testers.Length,
                     result.TestFlight.Messages
+                },
+                reviewSubmission = result.ReviewSubmission is null ? null : new
+                {
+                    result.ReviewSubmission.AppId,
+                    result.ReviewSubmission.VersionString,
+                    result.ReviewSubmission.BuildNumber,
+                    Platform = result.ReviewSubmission.Platform.ToString(),
+                    VersionId = result.ReviewSubmission.Version.Id,
+                    BuildId = result.ReviewSubmission.Build?.Id,
+                    ReviewSubmissionId = result.ReviewSubmission.ReviewSubmission.Id,
+                    result.ReviewSubmission.ReviewSubmission.IsSubmitted,
+                    result.ReviewSubmission.ReviewSubmission.State,
+                    ReviewSubmissionItemId = result.ReviewSubmission.ReviewSubmissionItem?.Id,
+                    ReadinessReady = result.ReviewSubmission.Readiness?.IsReady,
+                    result.ReviewSubmission.Messages
                 }
             }).ToArray()
         };

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -273,6 +273,21 @@
         "SyncScreenshots": { "type": "boolean" },
         "ReplaceScreenshots": { "type": "boolean" },
         "CheckReleaseReadiness": { "type": "boolean" },
+        "DistributeTestFlight": { "type": "boolean" },
+        "TestFlightBetaGroupIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "TestFlightBetaGroupNames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "TestFlightTesterEmails": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "CreateMissingTestFlightTesters": { "type": "boolean" },
+        "AllowUnprocessedTestFlightBuild": { "type": "boolean" },
         "Apps": {
           "type": "array",
           "items": { "$ref": "powerforge.segments.schema.json#/$defs/AppleAppConfiguration" }

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -288,6 +288,11 @@
         },
         "CreateMissingTestFlightTesters": { "type": "boolean" },
         "AllowUnprocessedTestFlightBuild": { "type": "boolean" },
+        "SubmitForReview": { "type": "boolean" },
+        "AllowUnselectedReviewBuild": { "type": "boolean" },
+        "AllowUnprocessedReviewBuild": { "type": "boolean" },
+        "SkipReviewReadinessCheck": { "type": "boolean" },
+        "AllowReviewSubmissionWhenNotReady": { "type": "boolean" },
         "Apps": {
           "type": "array",
           "items": { "$ref": "powerforge.segments.schema.json#/$defs/AppleAppConfiguration" }

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -293,6 +293,8 @@
         "AllowUnprocessedReviewBuild": { "type": "boolean" },
         "SkipReviewReadinessCheck": { "type": "boolean" },
         "AllowReviewSubmissionWhenNotReady": { "type": "boolean" },
+        "ReleaseApprovedVersion": { "type": "boolean" },
+        "AllowNonPendingDeveloperRelease": { "type": "boolean" },
         "Apps": {
           "type": "array",
           "items": { "$ref": "powerforge.segments.schema.json#/$defs/AppleAppConfiguration" }

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -261,11 +261,18 @@
           "type": "array",
           "items": { "type": "string" }
         },
+        "MetadataConfigPath": { "type": [ "string", "null" ] },
+        "MetadataConfigPaths": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
         "PrepareDistribution": { "type": "boolean" },
         "SelectBuildForDistribution": { "type": "boolean" },
         "AllowUnprocessedDistributionBuild": { "type": "boolean" },
+        "SyncMetadata": { "type": "boolean" },
         "SyncScreenshots": { "type": "boolean" },
         "ReplaceScreenshots": { "type": "boolean" },
+        "CheckReleaseReadiness": { "type": "boolean" },
         "Apps": {
           "type": "array",
           "items": { "$ref": "powerforge.segments.schema.json#/$defs/AppleAppConfiguration" }


### PR DESCRIPTION
## Summary
- add reusable App Store Connect localized metadata sync models, service, and cmdlets
- add release readiness checks for selected builds, required metadata, and complete screenshots
- wire metadata sync and readiness into the unified PowerForge AppleApps release lane
- scrub App Store Connect credential fields from plan-only release output

## Validation
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~AppStoreConnectClientTests|FullyQualifiedName~PowerForgeReleaseServiceTests"
- dotnet build PSPublishModule/PSPublishModule.csproj -c Release -f net8.0
