### PR TITLE
Expose GitHub Packages token to website runner

### DIFF
--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -183,6 +183,9 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}
+          LICENSING_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}
+          LICENSING_PACKAGES_USERNAME: ${{ github.repository_owner }}
           INDEXNOW_KEY: ${{ secrets.indexnow_key }}
           POWERFORGE_REPOSITORY_TOKEN: ${{ secrets.repository_read_token }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -32,6 +32,21 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
+    public void WebsiteRunWorkflow_ShouldExposeGitHubPackagesCredentialsToConsumerRestore()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("GITHUB_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("LICENSING_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("LICENSING_PACKAGES_USERNAME: ${{ github.repository_owner }}", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WebsiteRunWorkflow_ShouldKeepTransientToolCachesInsideWorkspace()
     {
         var repoRoot = FindRepoRoot();


### PR DESCRIPTION
## Summary
- expose GitHub Packages token env vars to the reusable PowerForge website runner process
- keep repository_read_token as the preferred override, falling back to the caller GITHUB_TOKEN
- add a workflow contract test so consumer restores keep receiving package credentials

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Debug --filter FullyQualifiedName~GitHubWebsiteRunWorkflowTests /m:1 /nr:false
- git diff --check