### PR TITLE
Add reusable GitHub release asset replacement

### DIFF
--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -39,4 +39,16 @@ public sealed class GitHubReleasePublisherTests
 
         Assert.Throws<FileNotFoundException>(() => publisher.PublishRelease(request));
     }
+
+    [Fact]
+    public void TryReserveExistingAssetNameForReplacement_AllowsOnlyAssetsFromOriginalSnapshot()
+    {
+        var replaceableAssetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "PowerForge-win-x64.zip"
+        };
+
+        Assert.True(GitHubReleasePublisher.TryReserveExistingAssetNameForReplacement(replaceableAssetNames, "powerforge-win-x64.zip"));
+        Assert.False(GitHubReleasePublisher.TryReserveExistingAssetNameForReplacement(replaceableAssetNames, "PowerForge-win-x64.zip"));
+    }
 }

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -138,7 +138,8 @@ public sealed class PowerForgeReleaseServiceTests
                     {
                         Succeeded = true,
                         HtmlUrl = "https://example.test/release",
-                        ReusedExistingRelease = true
+                        ReusedExistingRelease = true,
+                        ReplacedExistingAssets = { "PowerForge-linux-x64.zip" }
                     };
                 });
 
@@ -154,7 +155,8 @@ public sealed class PowerForgeReleaseServiceTests
                             Repository = "PSPublishModule",
                             Token = "token",
                             TagTemplate = "{Target}-v{Version}",
-                            ReleaseNameTemplate = "{Target} {Version}"
+                            ReleaseNameTemplate = "{Target} {Version}",
+                            ReplaceExistingAssets = true
                         }
                     }
                 },
@@ -168,12 +170,14 @@ public sealed class PowerForgeReleaseServiceTests
             var publish = Assert.Single(publishCalls);
             Assert.Equal("PowerForge-v1.2.3", publish.TagName);
             Assert.Equal("PowerForge 1.2.3", publish.ReleaseName);
+            Assert.True(publish.ReplaceExistingAssets);
             Assert.Equal(2, publish.AssetFilePaths.Count);
 
             var release = Assert.Single(result.ToolGitHubReleases);
             Assert.True(release.Success);
             Assert.Equal(2, release.AssetPaths.Length);
             Assert.True(release.ReusedExistingRelease);
+            Assert.Equal(new[] { "PowerForge-linux-x64.zip" }, release.ReplacedExistingAssets);
         }
         finally
         {

--- a/PowerForge/Models/GitHubReleasePublishRequest.cs
+++ b/PowerForge/Models/GitHubReleasePublishRequest.cs
@@ -40,6 +40,9 @@ public sealed class GitHubReleasePublishRequest
     /// <summary>True to reuse an existing release when GitHub reports a tag conflict.</summary>
     public bool ReuseExistingReleaseOnConflict { get; set; } = true;
 
+    /// <summary>True to delete same-named assets from a reused release before uploading new files.</summary>
+    public bool ReplaceExistingAssets { get; set; }
+
     /// <summary>Asset file paths to upload.</summary>
     public IReadOnlyList<string> AssetFilePaths { get; set; } = System.Array.Empty<string>();
 }

--- a/PowerForge/Models/GitHubReleasePublishResult.cs
+++ b/PowerForge/Models/GitHubReleasePublishResult.cs
@@ -27,4 +27,7 @@ public sealed class GitHubReleasePublishResult
 
     /// <summary>Assets skipped because they already existed on the release.</summary>
     public List<string> SkippedExistingAssets { get; } = new();
+
+    /// <summary>Assets deleted from an existing release before uploading replacements.</summary>
+    public List<string> ReplacedExistingAssets { get; } = new();
 }

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -516,6 +516,8 @@ internal sealed class PowerForgeReleaseGitHubOptions
 
     public bool IsPreRelease { get; set; }
 
+    public bool ReplaceExistingAssets { get; set; }
+
     public string? TagTemplate { get; set; }
 
     public string? ReleaseNameTemplate { get; set; }
@@ -837,6 +839,8 @@ internal sealed class PowerForgeToolGitHubReleaseResult
     public string? ErrorMessage { get; set; }
 
     public string[] SkippedExistingAssets { get; set; } = Array.Empty<string>();
+
+    public string[] ReplacedExistingAssets { get; set; } = Array.Empty<string>();
 }
 
 internal sealed class PowerForgeUnifiedGitHubReleaseResult
@@ -862,4 +866,6 @@ internal sealed class PowerForgeUnifiedGitHubReleaseResult
     public string? ErrorMessage { get; set; }
 
     public string[] SkippedExistingAssets { get; set; } = Array.Empty<string>();
+
+    public string[] ReplacedExistingAssets { get; set; } = Array.Empty<string>();
 }

--- a/PowerForge/Models/PowerForgeToolRelease.cs
+++ b/PowerForge/Models/PowerForgeToolRelease.cs
@@ -99,6 +99,8 @@ internal sealed class PowerForgeToolReleaseGitHubOptions
 
     public bool IsPreRelease { get; set; }
 
+    public bool ReplaceExistingAssets { get; set; }
+
     public string? TagTemplate { get; set; }
 
     public string? ReleaseNameTemplate { get; set; }

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -230,13 +230,20 @@ public sealed class GitHubReleasePublisher
         List<string> replacedExistingAssets)
     {
         var skippedAssets = new List<string>();
+        var replaceableAssetNames = replaceExistingAssets
+            ? CreateReplaceableAssetNameSet(ListReleaseAssets(owner, repo, token, releaseId))
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var assetPath in assets)
         {
             var fileName = Path.GetFileName(assetPath) ?? assetPath;
 
-            if (replaceExistingAssets && DeleteExistingAssetByName(owner, repo, token, releaseId, fileName))
+            if (replaceExistingAssets &&
+                TryReserveExistingAssetNameForReplacement(replaceableAssetNames, fileName) &&
+                DeleteExistingAssetByName(owner, repo, token, releaseId, fileName))
+            {
                 replacedExistingAssets.Add(fileName);
+            }
 
             _logger.Info($"Uploading GitHub release asset: {fileName}");
 
@@ -245,6 +252,7 @@ public sealed class GitHubReleasePublisher
             if (!resp.IsSuccessStatusCode && replaceExistingAssets &&
                 (int)resp.StatusCode == 422 &&
                 IsAlreadyExistsValidationError(respText, fieldName: "name") &&
+                TryReserveExistingAssetNameForReplacement(replaceableAssetNames, fileName) &&
                 DeleteExistingAssetByName(owner, repo, token, releaseId, fileName))
             {
                 replacedExistingAssets.Add(fileName);
@@ -271,6 +279,26 @@ public sealed class GitHubReleasePublisher
         }
 
         return skippedAssets;
+    }
+
+    internal static bool TryReserveExistingAssetNameForReplacement(ISet<string> replaceableAssetNames, string fileName)
+    {
+        if (replaceableAssetNames is null) throw new ArgumentNullException(nameof(replaceableAssetNames));
+        if (string.IsNullOrWhiteSpace(fileName)) return false;
+
+        return replaceableAssetNames.Remove(fileName);
+    }
+
+    private static HashSet<string> CreateReplaceableAssetNameSet(IEnumerable<GitHubReleaseAssetResponse> existingAssets)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var asset in existingAssets)
+        {
+            if (!string.IsNullOrWhiteSpace(asset.Name))
+                names.Add(asset.Name!);
+        }
+
+        return names;
     }
 
     private static HttpResponseMessage UploadAsset(string uploadUrl, string assetPath, string fileName, string token)

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -42,6 +42,7 @@ public sealed class GitHubReleasePublisher
         var isDraft = request.IsDraft;
         var isPreRelease = request.IsPreRelease;
         var reuseExistingReleaseOnConflict = request.ReuseExistingReleaseOnConflict;
+        var replaceExistingAssets = request.ReplaceExistingAssets;
 
         if (string.IsNullOrWhiteSpace(owner)) throw new ArgumentException("Owner is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(repo)) throw new ArgumentException("Repository is required.", nameof(request));
@@ -88,7 +89,15 @@ public sealed class GitHubReleasePublisher
         if (assets.Length > 0)
         {
             var uploadUrl = RemoveUploadUrlTemplate(release.UploadUrl);
-            result.SkippedExistingAssets.AddRange(UploadAssets(uploadUrl, assets, token));
+            result.SkippedExistingAssets.AddRange(UploadAssets(
+                uploadUrl,
+                assets,
+                token,
+                owner,
+                repo,
+                release.Id,
+                replaceExistingAssets,
+                result.ReplacedExistingAssets));
         }
 
         return result;
@@ -187,7 +196,7 @@ public sealed class GitHubReleasePublisher
         if (string.IsNullOrWhiteSpace(upload))
             throw new InvalidOperationException("GitHub release creation succeeded but upload_url was empty.");
 
-        return new GitHubReleaseApiResponse(html, upload, reusedExistingRelease: false);
+        return new GitHubReleaseApiResponse(parsed.Id, html, upload, reusedExistingRelease: false);
     }
 
     private GitHubReleaseApiResponse GetReleaseByTag(string owner, string repo, string token, string tagName, bool reusedExistingRelease)
@@ -207,44 +216,127 @@ public sealed class GitHubReleasePublisher
         if (string.IsNullOrWhiteSpace(upload))
             throw new InvalidOperationException($"GitHub get-release-by-tag succeeded for '{tagName}' but upload_url was empty.");
 
-        return new GitHubReleaseApiResponse(html, upload, reusedExistingRelease);
+        return new GitHubReleaseApiResponse(parsed.Id, html, upload, reusedExistingRelease);
     }
 
-    private IReadOnlyList<string> UploadAssets(string uploadUrl, string[] assets, string token)
+    private IReadOnlyList<string> UploadAssets(
+        string uploadUrl,
+        string[] assets,
+        string token,
+        string owner,
+        string repo,
+        long releaseId,
+        bool replaceExistingAssets,
+        List<string> replacedExistingAssets)
     {
         var skippedAssets = new List<string>();
 
         foreach (var assetPath in assets)
         {
             var fileName = Path.GetFileName(assetPath) ?? assetPath;
-            var target = new Uri(uploadUrl + "?name=" + Uri.EscapeDataString(fileName));
+
+            if (replaceExistingAssets && DeleteExistingAssetByName(owner, repo, token, releaseId, fileName))
+                replacedExistingAssets.Add(fileName);
 
             _logger.Info($"Uploading GitHub release asset: {fileName}");
 
-            using var fs = File.OpenRead(assetPath);
-            using var content = new StreamContent(fs);
-            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-
-            using var req = new HttpRequestMessage(HttpMethod.Post, target) { Content = content };
-            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-            var resp = SharedClient.SendAsync(req).ConfigureAwait(false).GetAwaiter().GetResult();
+            var resp = UploadAsset(uploadUrl, assetPath, fileName, token);
             var respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            if (!resp.IsSuccessStatusCode)
+            if (!resp.IsSuccessStatusCode && replaceExistingAssets &&
+                (int)resp.StatusCode == 422 &&
+                IsAlreadyExistsValidationError(respText, fieldName: "name") &&
+                DeleteExistingAssetByName(owner, repo, token, releaseId, fileName))
             {
-                // Idempotency: reruns can hit "asset already exists". Prefer to continue rather than failing the whole build.
-                if ((int)resp.StatusCode == 422 && IsAlreadyExistsValidationError(respText, fieldName: "name"))
-                {
-                    _logger.Info($"GitHub release asset '{fileName}' already exists; skipping upload.");
-                    skippedAssets.Add(fileName);
-                    continue;
-                }
+                replacedExistingAssets.Add(fileName);
+                resp.Dispose();
+                resp = UploadAsset(uploadUrl, assetPath, fileName, token);
+                respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            }
 
-                throw new InvalidOperationException($"GitHub asset upload failed for '{fileName}' ({(int)resp.StatusCode} {resp.ReasonPhrase}). {TrimForMessage(respText)}");
+            using (resp)
+            {
+                if (!resp.IsSuccessStatusCode)
+                {
+                    // Idempotency: reruns can hit "asset already exists". Prefer to continue rather than failing the whole build.
+                    if ((int)resp.StatusCode == 422 && IsAlreadyExistsValidationError(respText, fieldName: "name"))
+                    {
+                        _logger.Info($"GitHub release asset '{fileName}' already exists; skipping upload.");
+                        skippedAssets.Add(fileName);
+                        continue;
+                    }
+
+                    throw new InvalidOperationException($"GitHub asset upload failed for '{fileName}' ({(int)resp.StatusCode} {resp.ReasonPhrase}). {TrimForMessage(respText)}");
+                }
             }
         }
 
         return skippedAssets;
+    }
+
+    private static HttpResponseMessage UploadAsset(string uploadUrl, string assetPath, string fileName, string token)
+    {
+        var target = new Uri(uploadUrl + "?name=" + Uri.EscapeDataString(fileName));
+
+        using var fs = File.OpenRead(assetPath);
+        using var content = new StreamContent(fs);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, target) { Content = content };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        return SharedClient.SendAsync(req).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    private bool DeleteExistingAssetByName(string owner, string repo, string token, long releaseId, string fileName)
+    {
+        if (releaseId <= 0)
+            throw new InvalidOperationException("GitHub release asset replacement requires the release id returned by GitHub.");
+
+        var asset = ListReleaseAssets(owner, repo, token, releaseId)
+            .FirstOrDefault(existing => string.Equals(existing.Name, fileName, StringComparison.OrdinalIgnoreCase));
+        if (asset is null)
+            return false;
+
+        var uri = new Uri($"https://api.github.com/repos/{owner}/{repo}/releases/assets/{asset.Id}");
+        using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = SharedClient.SendAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
+        var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        using (response)
+        {
+            if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
+                throw new InvalidOperationException($"GitHub asset delete failed for '{fileName}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}");
+        }
+
+        _logger.Info($"Deleted existing GitHub release asset before replacement: {fileName}");
+        return true;
+    }
+
+    private static IReadOnlyList<GitHubReleaseAssetResponse> ListReleaseAssets(string owner, string repo, string token, long releaseId)
+    {
+        var assets = new List<GitHubReleaseAssetResponse>();
+        for (var page = 1; ; page++)
+        {
+            var uri = new Uri($"https://api.github.com/repos/{owner}/{repo}/releases/{releaseId}/assets?per_page=100&page={page}");
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var response = SharedClient.SendAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
+            var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            using (response)
+            {
+                if (!response.IsSuccessStatusCode)
+                    throw new InvalidOperationException($"GitHub list-release-assets failed for release '{releaseId}' ({(int)response.StatusCode} {response.ReasonPhrase}). {TrimForMessage(responseText)}");
+            }
+
+            var pageAssets = Deserialize<GitHubReleaseAssetResponse[]>(responseText) ?? Array.Empty<GitHubReleaseAssetResponse>();
+            assets.AddRange(pageAssets);
+            if (pageAssets.Length < 100)
+                break;
+        }
+
+        return assets;
     }
 
     private static HttpClient CreateSharedClient()
@@ -354,8 +446,21 @@ public sealed class GitHubReleasePublisher
         [DataMember(Name = "html_url")]
         public string? HtmlUrl { get; set; }
 
+        [DataMember(Name = "id")]
+        public long Id { get; set; }
+
         [DataMember(Name = "upload_url")]
         public string? UploadUrl { get; set; }
+    }
+
+    [DataContract]
+    private sealed class GitHubReleaseAssetResponse
+    {
+        [DataMember(Name = "id")]
+        public long Id { get; set; }
+
+        [DataMember(Name = "name")]
+        public string? Name { get; set; }
     }
 
     [DataContract]
@@ -386,13 +491,15 @@ public sealed class GitHubReleasePublisher
 
     private sealed class GitHubReleaseApiResponse
     {
-        public GitHubReleaseApiResponse(string htmlUrl, string uploadUrl, bool reusedExistingRelease)
+        public GitHubReleaseApiResponse(long id, string htmlUrl, string uploadUrl, bool reusedExistingRelease)
         {
+            Id = id;
             HtmlUrl = htmlUrl;
             UploadUrl = uploadUrl;
             ReusedExistingRelease = reusedExistingRelease;
         }
 
+        public long Id { get; }
         public string HtmlUrl { get; }
         public string UploadUrl { get; }
         public bool ReusedExistingRelease { get; }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -1808,6 +1808,7 @@ internal sealed class PowerForgeReleaseService
                 GenerateReleaseNotes = gitHub.GenerateReleaseNotes,
                 IsPreRelease = gitHub.IsPreRelease,
                 ReuseExistingReleaseOnConflict = true,
+                ReplaceExistingAssets = gitHub.ReplaceExistingAssets,
                 AssetFilePaths = assets
             });
 
@@ -1823,7 +1824,8 @@ internal sealed class PowerForgeReleaseService
                 ReleaseUrl = publishResult.HtmlUrl,
                 ReusedExistingRelease = publishResult.ReusedExistingRelease,
                 ErrorMessage = publishResult.Succeeded ? null : "Unified GitHub release publish failed.",
-                SkippedExistingAssets = publishResult.SkippedExistingAssets?.ToArray() ?? Array.Empty<string>()
+                SkippedExistingAssets = publishResult.SkippedExistingAssets?.ToArray() ?? Array.Empty<string>(),
+                ReplacedExistingAssets = publishResult.ReplacedExistingAssets?.ToArray() ?? Array.Empty<string>()
             };
         }
         catch (Exception ex)
@@ -2029,6 +2031,7 @@ internal sealed class PowerForgeReleaseService
                 GenerateReleaseNotes = gitHub.GenerateReleaseNotes,
                 IsPreRelease = gitHub.IsPreRelease,
                 ReuseExistingReleaseOnConflict = true,
+                ReplaceExistingAssets = gitHub.ReplaceExistingAssets,
                 AssetFilePaths = assets
             });
 
@@ -2045,7 +2048,8 @@ internal sealed class PowerForgeReleaseService
                 ReleaseUrl = publishResult.HtmlUrl,
                 ReusedExistingRelease = publishResult.ReusedExistingRelease,
                 ErrorMessage = publishResult.Succeeded ? null : "GitHub release publish failed.",
-                SkippedExistingAssets = publishResult.SkippedExistingAssets?.ToArray() ?? Array.Empty<string>()
+                SkippedExistingAssets = publishResult.SkippedExistingAssets?.ToArray() ?? Array.Empty<string>(),
+                ReplacedExistingAssets = publishResult.ReplacedExistingAssets?.ToArray() ?? Array.Empty<string>()
             };
         }
         catch (Exception ex)

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -53,6 +53,10 @@
         "TokenEnvName": { "type": [ "string", "null" ] },
         "GenerateReleaseNotes": { "type": "boolean" },
         "IsPreRelease": { "type": "boolean" },
+        "ReplaceExistingAssets": {
+          "type": "boolean",
+          "description": "When true and an existing release is reused, delete same-named assets before uploading replacements."
+        },
         "TagTemplate": { "type": [ "string", "null" ] },
         "ReleaseNameTemplate": { "type": [ "string", "null" ] }
       }
@@ -230,6 +234,10 @@
             "TokenEnvName": { "type": [ "string", "null" ] },
             "GenerateReleaseNotes": { "type": "boolean" },
             "IsPreRelease": { "type": "boolean" },
+            "ReplaceExistingAssets": {
+              "type": "boolean",
+              "description": "When true and an existing release is reused, delete same-named assets before uploading replacements."
+            },
             "TagTemplate": { "type": [ "string", "null" ] },
             "ReleaseNameTemplate": { "type": [ "string", "null" ] }
           }


### PR DESCRIPTION
## Summary
- add reusable GitHub release asset replacement support to PowerForge release publishing
- expose ReplaceExistingAssets on project/tool GitHub release config and schema
- keep duplicate detection available while allowing stable release tags to refresh same-named assets

## Validation
- dotnet test PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~PowerForgeReleaseServiceTests|FullyQualifiedName~GitHubReleasePublisherTests"
- git diff --check

## Consumer
- Needed by EvotecIT/IntelligenceX reviewer publishing to keep a stable reviewer release tag instead of creating timestamped releases.