### PR TITLE
Harden framework assembly resolver

### DIFF
--- a/PSPublishModule/OnImportAndRemove.cs
+++ b/PSPublishModule/OnImportAndRemove.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 /// </summary>
 public partial class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemblyCleanup {
     private static readonly object FrameworkResolverLock = new();
-    private static bool _frameworkResolverRegistered;
+    private static int _frameworkResolverRegistrationCount;
 
     /// <summary>
     /// Handles module import event.
@@ -40,23 +40,23 @@ public partial class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModu
 
     private static void RegisterFrameworkResolver() {
         lock (FrameworkResolverLock) {
-            if (_frameworkResolverRegistered) {
-                return;
+            _frameworkResolverRegistrationCount++;
+            if (_frameworkResolverRegistrationCount == 1) {
+                AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
             }
-
-            AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
-            _frameworkResolverRegistered = true;
         }
     }
 
     private static void UnregisterFrameworkResolver() {
         lock (FrameworkResolverLock) {
-            if (!_frameworkResolverRegistered) {
+            if (_frameworkResolverRegistrationCount <= 0) {
                 return;
             }
 
-            AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
-            _frameworkResolverRegistered = false;
+            _frameworkResolverRegistrationCount--;
+            if (_frameworkResolverRegistrationCount == 0) {
+                AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
+            }
         }
     }
 

--- a/PSPublishModule/OnImportAndRemove.cs
+++ b/PSPublishModule/OnImportAndRemove.cs
@@ -8,12 +8,15 @@ using System.Reflection;
 /// Namespace for module import and removal handling.
 /// </summary>
 public partial class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemblyCleanup {
+    private static readonly object FrameworkResolverLock = new();
+    private static bool _frameworkResolverRegistered;
+
     /// <summary>
     /// Handles module import event.
     /// </summary>
     public void OnImport() {
         if (IsNetFramework()) {
-            AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
+            RegisterFrameworkResolver();
         } else {
             RegisterCoreResolver();
         }
@@ -25,7 +28,7 @@ public partial class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModu
     /// <param name="module"></param>
     public void OnRemove(PSModuleInfo module) {
         if (IsNetFramework()) {
-            AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
+            UnregisterFrameworkResolver();
         } else {
             UnregisterCoreResolver();
         }
@@ -34,6 +37,28 @@ public partial class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModu
     partial void RegisterCoreResolver();
 
     partial void UnregisterCoreResolver();
+
+    private static void RegisterFrameworkResolver() {
+        lock (FrameworkResolverLock) {
+            if (_frameworkResolverRegistered) {
+                return;
+            }
+
+            AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
+            _frameworkResolverRegistered = true;
+        }
+    }
+
+    private static void UnregisterFrameworkResolver() {
+        lock (FrameworkResolverLock) {
+            if (!_frameworkResolverRegistered) {
+                return;
+            }
+
+            AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
+            _frameworkResolverRegistered = false;
+        }
+    }
 
     /// <summary>
     /// Custom assembly resolver to load assemblies from the module directory.
@@ -51,7 +76,7 @@ public partial class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModu
                 var candidate = Path.Combine(directoryPath, requestedName + ".dll");
                 if (File.Exists(candidate)) {
                     //Console.WriteLine($"Loading {args.Name} assembly {Path.GetFileName(candidate)}");
-                    return Assembly.LoadFile(candidate);
+                    return Assembly.LoadFrom(candidate);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- register the .NET Framework AssemblyResolve handler idempotently for PSPublishModule imports
- unregister it only when registered
- load same-folder framework dependencies with Assembly.LoadFrom instead of Assembly.LoadFile

## Validation
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release --no-restore -m:1
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~ModuleDocumentationReviewRegressionTests.CoreResolver_Allows_Module_Local_Microsoft_And_System_Package_Names"

Note: a normal targeted test build was blocked locally by an unrelated PowerForge.Web.Cli.exe lock on PowerForge.Web.dll, so the targeted test was rerun with --no-build after the PSPublishModule project build succeeded.