### PR TITLE
Harden release staging and ALC remoting imports

### DIFF
--- a/PSPublishModule/OnImportAndRemove.Core.cs
+++ b/PSPublishModule/OnImportAndRemove.Core.cs
@@ -29,7 +29,7 @@ public partial class OnModuleImportAndRemove {
                 return;
             }
 
-            _coreResolver = new AssemblyDependencyResolver(assemblyPath);
+            _coreResolver = TryCreateCoreResolver(assemblyPath);
             AssemblyLoadContext.Default.Resolving += ResolveCoreAssembly;
             _coreResolverRegistered = true;
         }
@@ -66,6 +66,14 @@ public partial class OnModuleImportAndRemove {
         }
 
         return null;
+    }
+
+    private static AssemblyDependencyResolver? TryCreateCoreResolver(string assemblyPath) {
+        try {
+            return new AssemblyDependencyResolver(assemblyPath);
+        } catch (InvalidOperationException) {
+            return null;
+        }
     }
 
     private static bool ShouldSkipCoreResolution(AssemblyName assemblyName) {

--- a/PowerForge.PowerShell/Services/ModuleIsolation/ModuleIsolationScriptPatcher.cs
+++ b/PowerForge.PowerShell/Services/ModuleIsolation/ModuleIsolationScriptPatcher.cs
@@ -131,7 +131,23 @@ namespace PowerForge.ModuleIsolation
                 assemblyDirectories.Add(directory);
             }
 
-            resolvers.Add(new AssemblyDependencyResolver(assemblyPath));
+            var resolver = TryCreateResolver(assemblyPath);
+            if (resolver != null)
+            {
+                resolvers.Add(resolver);
+            }
+        }
+
+        private static AssemblyDependencyResolver TryCreateResolver(string assemblyPath)
+        {
+            try
+            {
+                return new AssemblyDependencyResolver(assemblyPath);
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
         }
 
         protected override Assembly Load(AssemblyName assemblyName)

--- a/PowerForge.PowerShell/Services/ModuleIsolation/ModuleIsolationScriptPatcher.cs
+++ b/PowerForge.PowerShell/Services/ModuleIsolation/ModuleIsolationScriptPatcher.cs
@@ -341,6 +341,7 @@ namespace PowerForge.ModuleIsolation
                 }
 
                 yield return "osx";
+                yield return "unix";
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
@@ -361,6 +362,7 @@ namespace PowerForge.ModuleIsolation
                 }
 
                 yield return "linux";
+                yield return "unix";
             }
         }
 

--- a/PowerForge.PowerShell/Services/ModuleIsolation/ModuleIsolationScriptPatcher.cs
+++ b/PowerForge.PowerShell/Services/ModuleIsolation/ModuleIsolationScriptPatcher.cs
@@ -60,6 +60,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 
 namespace PowerForge.ModuleIsolation
@@ -179,6 +180,12 @@ namespace PowerForge.ModuleIsolation
 
             foreach (var directory in assemblyDirectories)
             {
+                var runtimeCandidatePath = ResolvePackagedRuntimeAssembly(directory, assemblyName.Name);
+                if (!string.IsNullOrWhiteSpace(runtimeCandidatePath) && File.Exists(runtimeCandidatePath))
+                {
+                    return LoadAssemblyFromPath(runtimeCandidatePath);
+                }
+
                 var candidatePath = Path.Combine(directory, assemblyName.Name + ".dll");
                 if (File.Exists(candidatePath))
                 {
@@ -201,7 +208,191 @@ namespace PowerForge.ModuleIsolation
                 }
             }
 
+            foreach (var directory in assemblyDirectories)
+            {
+                var packagedLibrary = LoadPackagedNativeLibrary(directory, unmanagedDllName);
+                if (packagedLibrary != IntPtr.Zero)
+                {
+                    return packagedLibrary;
+                }
+            }
+
             return IntPtr.Zero;
+        }
+
+        private static string ResolvePackagedRuntimeAssembly(string assemblyDirectory, string assemblyName)
+        {
+            if (string.IsNullOrWhiteSpace(assemblyDirectory) || string.IsNullOrWhiteSpace(assemblyName))
+            {
+                return null;
+            }
+
+            var fileName = assemblyName + ".dll";
+            foreach (var rid in GetRuntimeIdentifiers())
+            {
+                var runtimeLibRoot = Path.Combine(assemblyDirectory, "runtimes", rid, "lib");
+                if (!Directory.Exists(runtimeLibRoot))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    foreach (var path in Directory.EnumerateFiles(runtimeLibRoot, fileName, SearchOption.AllDirectories))
+                    {
+                        if (File.Exists(path))
+                        {
+                            return path;
+                        }
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
+                {
+                    continue;
+                }
+            }
+
+            return null;
+        }
+
+        private IntPtr LoadPackagedNativeLibrary(string assemblyDirectory, string unmanagedDllName)
+        {
+            if (string.IsNullOrWhiteSpace(assemblyDirectory) || string.IsNullOrWhiteSpace(unmanagedDllName))
+            {
+                return IntPtr.Zero;
+            }
+
+            foreach (var rid in GetRuntimeIdentifiers())
+            {
+                foreach (var fileName in GetNativeLibraryFileNames(unmanagedDllName))
+                {
+                    var path = Path.Combine(assemblyDirectory, "runtimes", rid, "native", fileName);
+                    if (File.Exists(path))
+                    {
+                        var loaded = TryLoadPackagedNativeLibrary(path);
+                        if (loaded != IntPtr.Zero)
+                        {
+                            return loaded;
+                        }
+                    }
+                }
+            }
+
+            foreach (var fileName in GetNativeLibraryFileNames(unmanagedDllName))
+            {
+                var path = Path.Combine(assemblyDirectory, fileName);
+                if (File.Exists(path))
+                {
+                    var loaded = TryLoadPackagedNativeLibrary(path);
+                    if (loaded != IntPtr.Zero)
+                    {
+                        return loaded;
+                    }
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+
+        private IntPtr TryLoadPackagedNativeLibrary(string path)
+        {
+            try
+            {
+                return LoadUnmanagedDllFromPath(path);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException || ex is DllNotFoundException || ex is FileLoadException)
+            {
+                return IntPtr.Zero;
+            }
+        }
+
+        private static IEnumerable<string> GetRuntimeIdentifiers()
+        {
+            var runtimeIdentifier = RuntimeInformation.RuntimeIdentifier ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(runtimeIdentifier))
+            {
+                yield return runtimeIdentifier;
+            }
+
+            var arch = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X64 => "x64",
+                Architecture.X86 => "x86",
+                Architecture.Arm64 => "arm64",
+                Architecture.Arm => "arm",
+                _ => null
+            };
+            var isMusl = runtimeIdentifier.Contains("musl", StringComparison.OrdinalIgnoreCase);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (arch is not null)
+                {
+                    yield return "win-" + arch;
+                }
+
+                yield return "win";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                if (arch is not null)
+                {
+                    yield return "osx-" + arch;
+                }
+
+                yield return "osx";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (arch is not null)
+                {
+                    if (isMusl)
+                    {
+                        yield return "linux-musl-" + arch;
+                        yield return "linux-musl";
+                        yield return "linux-" + arch;
+                    }
+                    else
+                    {
+                        yield return "linux-" + arch;
+                        yield return "linux-musl-" + arch;
+                        yield return "linux-musl";
+                    }
+                }
+
+                yield return "linux";
+            }
+        }
+
+        private static IEnumerable<string> GetNativeLibraryFileNames(string unmanagedDllName)
+        {
+            yield return unmanagedDllName;
+
+            if (Path.HasExtension(unmanagedDllName))
+            {
+                yield break;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                yield return unmanagedDllName + ".dll";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                yield return unmanagedDllName + ".dylib";
+                if (!unmanagedDllName.StartsWith("lib", StringComparison.Ordinal))
+                {
+                    yield return "lib" + unmanagedDllName + ".dylib";
+                }
+            }
+            else
+            {
+                yield return unmanagedDllName + ".so";
+                if (!unmanagedDllName.StartsWith("lib", StringComparison.Ordinal))
+                {
+                    yield return "lib" + unmanagedDllName + ".so";
+                }
+            }
         }
     }
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -213,13 +213,8 @@ public sealed partial class ModulePipelineRunner
         Directory.CreateDirectory(targetRoot);
 
         var targetPath = Path.Combine(targetRoot, Path.GetFileName(sourcePath));
-        if (File.Exists(targetPath))
-        {
-            if (PathsEqual(targetPath, sourcePath))
-                return Path.GetFullPath(targetPath);
-
-            throw new IOException($"Release staging asset collision detected: {targetPath}");
-        }
+        if (File.Exists(targetPath) && PathsEqual(targetPath, sourcePath))
+            return Path.GetFullPath(targetPath);
 
         File.Copy(sourcePath, targetPath, overwrite: true);
         return Path.GetFullPath(targetPath);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -198,26 +198,42 @@ public sealed partial class ModulePipelineRunner
         IReadOnlyList<string> packageAssets)
     {
         var staged = new List<string>();
+        var stagedSourcesByPath = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var asset in moduleAssets)
-            staged.Add(StageReleaseAsset(stageRoot, "modules", asset));
+            staged.Add(StageReleaseAsset(stageRoot, "modules", asset, stagedSourcesByPath));
         foreach (var asset in packageAssets)
-            staged.Add(StageReleaseAsset(stageRoot, "nuget", asset));
+            staged.Add(StageReleaseAsset(stageRoot, "nuget", asset, stagedSourcesByPath));
 
         staged.AddRange(WriteReleaseMetadata(plan, stageRoot, staged));
         return staged.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
-    private static string StageReleaseAsset(string stageRoot, string category, string sourcePath)
+    private static string StageReleaseAsset(
+        string stageRoot,
+        string category,
+        string sourcePath,
+        Dictionary<string, string> stagedSourcesByPath)
     {
         var targetRoot = Path.Combine(stageRoot, category);
         Directory.CreateDirectory(targetRoot);
 
-        var targetPath = Path.Combine(targetRoot, Path.GetFileName(sourcePath));
+        var sourceFullPath = Path.GetFullPath(sourcePath);
+        var targetPath = Path.GetFullPath(Path.Combine(targetRoot, Path.GetFileName(sourcePath)));
+        if (stagedSourcesByPath.TryGetValue(targetPath, out var existingSource))
+        {
+            if (!PathsEqual(existingSource, sourceFullPath))
+                throw new InvalidOperationException(
+                    $"Release staging collision: '{existingSource}' and '{sourceFullPath}' both stage to '{targetPath}'. Rename one asset or configure unique output file names.");
+
+            return targetPath;
+        }
+
+        stagedSourcesByPath[targetPath] = sourceFullPath;
         if (File.Exists(targetPath) && PathsEqual(targetPath, sourcePath))
-            return Path.GetFullPath(targetPath);
+            return targetPath;
 
         File.Copy(sourcePath, targetPath, overwrite: true);
-        return Path.GetFullPath(targetPath);
+        return targetPath;
     }
 
     private static bool PathsEqual(string left, string right)

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -218,6 +218,25 @@ public class ModuleBootstrapperGeneratorTests
     }
 
     [Fact]
+    public void BuildAssemblyLoadContextSource_FallsBackToDirectoryProbingWhenResolverIsUnavailable()
+    {
+        var identity = new ModuleBootstrapperGenerator.AssemblyLoadContextLoaderIdentity(
+            "DemoModule.ModuleLoadContext",
+            "DemoModule.ModuleLoadContext",
+            "DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext");
+        var source = ModuleBootstrapperGenerator.BuildAssemblyLoadContextSource(identity);
+
+        Assert.Contains("private readonly AssemblyDependencyResolver? _resolver;", source);
+        Assert.Contains("_resolver = TryCreateResolver(_moduleAssemblyPath);", source);
+        Assert.Contains("catch (InvalidOperationException)", source);
+        Assert.Contains("return null;", source);
+        Assert.Contains("_resolver?.ResolveAssemblyToPath(assemblyName)", source);
+        Assert.Contains("_resolver?.ResolveUnmanagedDllToPath(unmanagedDllName)", source);
+        Assert.Contains("Path.Combine(_assemblyDirectory, assemblyName.Name + \".dll\")", source);
+        Assert.Contains("LoadPackagedNativeLibrary(unmanagedDllName)", source);
+    }
+
+    [Fact]
     [Trait("Category", "Integration")]
     public void Generate_WithAssemblyLoadContextAndDefaultOnlyLib_WritesLoaderBesideDefaultAssembly()
     {

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -213,6 +213,7 @@ public class ModuleBootstrapperGeneratorTests
         Assert.Contains("yield return \"linux-musl-\" + arch", source);
         Assert.Contains("yield return \"linux-musl\"", source);
         Assert.Contains("yield return \"osx\"", source);
+        Assert.Contains("yield return \"unix\"", source);
         Assert.Contains("yield return unmanagedDllName + \".so\";", source);
         Assert.Contains("yield return \"lib\" + unmanagedDllName + \".so\";", source);
     }

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -236,6 +236,8 @@ public class ModuleBootstrapperGeneratorTests
         Assert.Contains("_resolver?.ResolveUnmanagedDllToPath(unmanagedDllName)", source);
         Assert.Contains("_manifestResolver?.ResolveAssemblyToPath(assemblyName)", source);
         Assert.Contains("_manifestResolver?.ResolveUnmanagedDllToPath(unmanagedDllName)", source);
+        Assert.Contains("ResolvePackagedRuntimeAssembly(assemblyName.Name)", source);
+        Assert.Contains("Path.Combine(_assemblyDirectory, \"runtimes\", rid, \"lib\")", source);
         Assert.Contains("Path.ChangeExtension(assemblyPath, \".deps.json\")", source);
         Assert.Contains("Path.Combine(_assemblyDirectory, assemblyName.Name + \".dll\")", source);
         Assert.Contains("LoadPackagedNativeLibrary(unmanagedDllName)", source);
@@ -304,6 +306,77 @@ public class ModuleBootstrapperGeneratorTests
             var resolved = (string?)resolveAssembly.Invoke(resolver, new object[] { new System.Reflection.AssemblyName("NestedDependency") });
 
             Assert.Equal(nestedDependencyPath, resolved);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                try { Directory.Delete(root, true); } catch { /* generated loader assembly remains locked after reflection load */ }
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Generate_WithAssemblyLoadContext_ResolvesPackagedRuntimeAssemblyWithoutDepsJson()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-runtime-" + Guid.NewGuid().ToString("N"));
+        var libCore = Path.Combine(root, "Lib", "Core");
+        Directory.CreateDirectory(libCore);
+
+        try
+        {
+            var dependencyPath = BuildFixtureProject(
+                root,
+                "NestedDependency",
+                "NestedDependency",
+                """
+                namespace NestedDependency;
+
+                public static class Marker
+                {
+                    public static string Value => "runtime-probe";
+                }
+                """);
+
+            var modulePath = BuildFixtureProject(
+                root,
+                "DemoModule",
+                "DemoModule",
+                """
+                namespace DemoModule;
+
+                public static class Entry
+                {
+                    public static string Read() => NestedDependency.Marker.Value;
+                }
+                """,
+                new[] { dependencyPath });
+
+            File.Copy(modulePath, Path.Combine(libCore, "DemoModule.dll"), overwrite: true);
+            var nestedDependencyPath = Path.Combine(libCore, "runtimes", GetCurrentRuntimeAssetRid(), "lib", "net8.0", "NestedDependency.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(nestedDependencyPath)!);
+            File.Copy(dependencyPath, nestedDependencyPath, overwrite: true);
+
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true,
+                targetFrameworks: new[] { "net8.0" });
+
+            var loaderAssembly = System.Reflection.Assembly.LoadFile(Path.Combine(libCore, "DemoModule.ModuleLoadContext.dll"));
+            var contextType = loaderAssembly.GetType("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", throwOnError: true)!;
+            var loadModule = contextType.GetMethod("LoadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+            var moduleAssembly = (System.Reflection.Assembly)loadModule.Invoke(null, new object?[] { Path.Combine(libCore, "DemoModule.dll"), "DemoModule" })!;
+            var value = moduleAssembly.GetType("DemoModule.Entry", throwOnError: true)!
+                .GetMethod("Read", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!
+                .Invoke(null, null);
+
+            Assert.Equal("runtime-probe", value);
         }
         finally
         {
@@ -601,6 +674,16 @@ public class ModuleBootstrapperGeneratorTests
         var assemblyPath = Path.Combine(projectRoot.FullName, "bin", "Release", "net8.0", assemblyName + ".dll");
         Assert.True(File.Exists(assemblyPath), $"Built assembly not found: {assemblyPath}");
         return assemblyPath;
+    }
+
+    private static string GetCurrentRuntimeAssetRid()
+    {
+        if (OperatingSystem.IsWindows())
+            return "win";
+        if (OperatingSystem.IsMacOS())
+            return "osx";
+
+        return "linux";
     }
 
     private static void WriteDepsJson(string path)

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -227,13 +227,91 @@ public class ModuleBootstrapperGeneratorTests
         var source = ModuleBootstrapperGenerator.BuildAssemblyLoadContextSource(identity);
 
         Assert.Contains("private readonly AssemblyDependencyResolver? _resolver;", source);
+        Assert.Contains("private readonly DependencyManifestResolver? _manifestResolver;", source);
         Assert.Contains("_resolver = TryCreateResolver(_moduleAssemblyPath);", source);
+        Assert.Contains("_manifestResolver = DependencyManifestResolver.TryCreate(_moduleAssemblyPath);", source);
         Assert.Contains("catch (InvalidOperationException)", source);
         Assert.Contains("return null;", source);
         Assert.Contains("_resolver?.ResolveAssemblyToPath(assemblyName)", source);
         Assert.Contains("_resolver?.ResolveUnmanagedDllToPath(unmanagedDllName)", source);
+        Assert.Contains("_manifestResolver?.ResolveAssemblyToPath(assemblyName)", source);
+        Assert.Contains("_manifestResolver?.ResolveUnmanagedDllToPath(unmanagedDllName)", source);
+        Assert.Contains("Path.ChangeExtension(assemblyPath, \".deps.json\")", source);
         Assert.Contains("Path.Combine(_assemblyDirectory, assemblyName.Name + \".dll\")", source);
         Assert.Contains("LoadPackagedNativeLibrary(unmanagedDllName)", source);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Generate_WithAssemblyLoadContext_ResolvesNestedRuntimeAssetFromDepsJson()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-alc-deps-" + Guid.NewGuid().ToString("N"));
+        var libCore = Path.Combine(root, "Lib", "Core");
+        Directory.CreateDirectory(libCore);
+
+        try
+        {
+            var dependencyPath = BuildFixtureProject(
+                root,
+                "NestedDependency",
+                "NestedDependency",
+                """
+                namespace NestedDependency;
+
+                public static class Marker
+                {
+                    public static string Value => "deps";
+                }
+                """);
+
+            var modulePath = BuildFixtureProject(
+                root,
+                "DemoModule",
+                "DemoModule",
+                """
+                namespace DemoModule;
+
+                public static class Entry
+                {
+                    public static string Read() => NestedDependency.Marker.Value;
+                }
+                """,
+                new[] { dependencyPath });
+
+            File.Copy(modulePath, Path.Combine(libCore, "DemoModule.dll"), overwrite: true);
+            var nestedDependencyPath = Path.Combine(libCore, "lib", "net8.0", "NestedDependency.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(nestedDependencyPath)!);
+            File.Copy(dependencyPath, nestedDependencyPath, overwrite: true);
+            WriteDepsJson(Path.Combine(libCore, "DemoModule.deps.json"));
+
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true,
+                targetFrameworks: new[] { "net8.0" });
+
+            var loaderAssembly = System.Reflection.Assembly.LoadFile(Path.Combine(libCore, "DemoModule.ModuleLoadContext.dll"));
+            var resolverType = loaderAssembly.GetType("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext+DependencyManifestResolver", throwOnError: true)!;
+            var tryCreate = resolverType.GetMethod("TryCreate", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+            var resolver = tryCreate.Invoke(null, new object[] { Path.Combine(libCore, "DemoModule.dll") });
+            Assert.NotNull(resolver);
+
+            var resolveAssembly = resolverType.GetMethod("ResolveAssemblyToPath", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)!;
+            var resolved = (string?)resolveAssembly.Invoke(resolver, new object[] { new System.Reflection.AssemblyName("NestedDependency") });
+
+            Assert.Equal(nestedDependencyPath, resolved);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                try { Directory.Delete(root, true); } catch { /* generated loader assembly remains locked after reflection load */ }
+            }
+        }
     }
 
     [Fact]
@@ -463,5 +541,103 @@ public class ModuleBootstrapperGeneratorTests
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
         }
+    }
+
+    private static string BuildFixtureProject(
+        string root,
+        string projectName,
+        string assemblyName,
+        string source,
+        IReadOnlyList<string>? references = null)
+    {
+        var projectRoot = Directory.CreateDirectory(Path.Combine(root, projectName));
+        var projectPath = Path.Combine(projectRoot.FullName, projectName + ".csproj");
+        var sourcePath = Path.Combine(projectRoot.FullName, "Class1.cs");
+
+        var referenceItems = references is { Count: > 0 }
+            ? string.Join(
+                Environment.NewLine,
+                references.Select((reference, index) => $"""
+                  <Reference Include="Reference{index}">
+                    <HintPath>{reference}</HintPath>
+                  </Reference>
+                """))
+            : string.Empty;
+
+        File.WriteAllText(projectPath, $$"""
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>{{assemblyName}}</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+{{referenceItems}}
+  </ItemGroup>
+</Project>
+""");
+
+        File.WriteAllText(sourcePath, source);
+
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"build \"{projectPath}\" -c Release -nologo --verbosity quiet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = projectRoot.FullName
+        };
+
+        using var process = System.Diagnostics.Process.Start(psi)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, $"dotnet build failed for test fixture.{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
+
+        var assemblyPath = Path.Combine(projectRoot.FullName, "bin", "Release", "net8.0", assemblyName + ".dll");
+        Assert.True(File.Exists(assemblyPath), $"Built assembly not found: {assemblyPath}");
+        return assemblyPath;
+    }
+
+    private static void WriteDepsJson(string path)
+    {
+        File.WriteAllText(path, """
+{
+  "runtimeTarget": {
+    "name": ".NETCoreApp,Version=v8.0",
+    "signature": ""
+  },
+  "targets": {
+    ".NETCoreApp,Version=v8.0": {
+      "DemoModule/1.0.0": {
+        "runtime": {
+          "DemoModule.dll": {}
+        }
+      },
+      "NestedDependency/1.0.0": {
+        "runtime": {
+          "lib/net8.0/NestedDependency.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "DemoModule/1.0.0": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "NestedDependency/1.0.0": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    }
+  }
+}
+""");
     }
 }

--- a/PowerForge.Tests/ModuleIsolationScriptPatcherTests.cs
+++ b/PowerForge.Tests/ModuleIsolationScriptPatcherTests.cs
@@ -40,6 +40,7 @@ public sealed class ModuleIsolationScriptPatcherTests
         Assert.Contains("Path.Combine(assemblyDirectory, \"runtimes\", rid, \"lib\")", patched, StringComparison.Ordinal);
         Assert.Contains("Path.Combine(assemblyDirectory, \"runtimes\", rid, \"native\", fileName)", patched, StringComparison.Ordinal);
         Assert.Contains("RuntimeInformation.ProcessArchitecture", patched, StringComparison.Ordinal);
+        Assert.Contains("yield return \"unix\"", patched, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleIsolationScriptPatcherTests.cs
+++ b/PowerForge.Tests/ModuleIsolationScriptPatcherTests.cs
@@ -35,6 +35,11 @@ public sealed class ModuleIsolationScriptPatcherTests
         Assert.Contains("catch (InvalidOperationException)", patched, StringComparison.Ordinal);
         Assert.Contains("return null;", patched, StringComparison.Ordinal);
         Assert.Contains("Path.Combine(directory, assemblyName.Name + \".dll\")", patched, StringComparison.Ordinal);
+        Assert.Contains("ResolvePackagedRuntimeAssembly(directory, assemblyName.Name)", patched, StringComparison.Ordinal);
+        Assert.Contains("LoadPackagedNativeLibrary(directory, unmanagedDllName)", patched, StringComparison.Ordinal);
+        Assert.Contains("Path.Combine(assemblyDirectory, \"runtimes\", rid, \"lib\")", patched, StringComparison.Ordinal);
+        Assert.Contains("Path.Combine(assemblyDirectory, \"runtimes\", rid, \"native\", fileName)", patched, StringComparison.Ordinal);
+        Assert.Contains("RuntimeInformation.ProcessArchitecture", patched, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/ModuleIsolationScriptPatcherTests.cs
+++ b/PowerForge.Tests/ModuleIsolationScriptPatcherTests.cs
@@ -31,6 +31,10 @@ public sealed class ModuleIsolationScriptPatcherTests
         Assert.DoesNotContain("Import-Module $RestModulePath", patched, StringComparison.Ordinal);
         Assert.Contains("Contexts[contextName] = context", patched, StringComparison.Ordinal);
         Assert.Contains("LoadedModuleAssemblies", patched, StringComparison.Ordinal);
+        Assert.Contains("TryCreateResolver(assemblyPath)", patched, StringComparison.Ordinal);
+        Assert.Contains("catch (InvalidOperationException)", patched, StringComparison.Ordinal);
+        Assert.Contains("return null;", patched, StringComparison.Ordinal);
+        Assert.Contains("Path.Combine(directory, assemblyName.Name + \".dll\")", patched, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -473,6 +473,115 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
     }
 
     [Fact]
+    public void Run_OverwritesStagedReleaseAssetsOnRepeatedBuilds()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var packageOutput = Path.Combine(root.FullName, "Artifacts", "NuGet");
+            var packagePath = Path.Combine(packageOutput, "HtmlTinkerX.1.0.0.nupkg");
+            var packageBuildCalls = 0;
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    packageBuildCalls++;
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, $"package-{packageBuildCalls}");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "HtmlTinkerX",
+                        PackageId = "HtmlTinkerX",
+                        IsPackable = true,
+                        NewVersion = "1.0.0"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var stageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", "<ModuleName>", "<ModuleVersion>");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = Path.Combine(root.FullName, "Artifacts", "Module"),
+                            ID = "module"
+                        }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = stageRoot
+                        }
+                    }
+                }
+            };
+
+            runner.Run(spec);
+            var second = runner.Run(spec);
+
+            var resolvedStageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", moduleName, "1.0.0");
+            var stagedPackage = Path.Combine(resolvedStageRoot, "nuget", Path.GetFileName(packagePath));
+            Assert.True(File.Exists(stagedPackage), stagedPackage);
+            Assert.Equal("package-2", File.ReadAllText(stagedPackage));
+            Assert.Equal(2, packageBuildCalls);
+            Assert.NotNull(second.ReleaseCoordinationResult);
+            Assert.Contains(second.ReleaseCoordinationResult!.AssetPaths, path => string.Equals(path, stagedPackage, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Run_AppliesUnifiedReleasePublishOrderAcrossPackageAndModuleDestinations()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -574,6 +575,45 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.Equal(2, packageBuildCalls);
             Assert.NotNull(second.ReleaseCoordinationResult);
             Assert.Contains(second.ReleaseCoordinationResult!.AssetPaths, path => string.Equals(path, stagedPackage, StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void StageReleaseAsset_RejectsSameRunFilenameCollisionsButAllowsRepeatedBuildOverwrite()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var firstSource = Path.Combine(root.FullName, "first", "Package.1.0.0.nupkg");
+            var secondSource = Path.Combine(root.FullName, "second", "Package.1.0.0.nupkg");
+            Directory.CreateDirectory(Path.GetDirectoryName(firstSource)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(secondSource)!);
+            File.WriteAllText(firstSource, "first");
+            File.WriteAllText(secondSource, "second");
+
+            var method = typeof(ModulePipelineRunner).GetMethod("StageReleaseAsset", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var currentRunSources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var stageRoot = Path.Combine(root.FullName, "stage");
+
+            var stagedPath = Assert.IsType<string>(method.Invoke(null, new object[] { stageRoot, "nuget", firstSource, currentRunSources })!);
+            Assert.Equal("first", File.ReadAllText(stagedPath));
+
+            var collision = Assert.Throws<TargetInvocationException>(() =>
+                method.Invoke(null, new object[] { stageRoot, "nuget", secondSource, currentRunSources }));
+            var invalidOperation = Assert.IsType<InvalidOperationException>(collision.InnerException);
+            Assert.Contains("Release staging collision", invalidOperation.Message, StringComparison.Ordinal);
+            Assert.Equal("first", File.ReadAllText(stagedPath));
+
+            File.WriteAllText(firstSource, "first-updated");
+            var nextRunSources = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var restagedPath = Assert.IsType<string>(method.Invoke(null, new object[] { stageRoot, "nuget", firstSource, nextRunSources })!);
+
+            Assert.Equal(stagedPath, restagedPath);
+            Assert.Equal("first-updated", File.ReadAllText(restagedPath));
         }
         finally
         {

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -602,6 +602,10 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
             return LoadFromAssemblyPath(resolvedPath);
 
+        resolvedPath = ResolvePackagedRuntimeAssembly(assemblyName.Name);
+        if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
+            return LoadFromAssemblyPath(resolvedPath);
+
         var assemblyPath = Path.Combine(_assemblyDirectory, assemblyName.Name + "".dll"");
         return File.Exists(assemblyPath) ? LoadFromAssemblyPath(assemblyPath) : null;
     }}
@@ -861,6 +865,35 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
             values.Add(string.Empty);
             return values.ToArray();
         }}
+    }}
+
+    private string? ResolvePackagedRuntimeAssembly(string assemblyName)
+    {{
+        if (string.IsNullOrWhiteSpace(assemblyName))
+            return null;
+
+        var fileName = assemblyName + "".dll"";
+        foreach (var rid in GetRuntimeIdentifiers())
+        {{
+            var runtimeLibRoot = Path.Combine(_assemblyDirectory, ""runtimes"", rid, ""lib"");
+            if (!Directory.Exists(runtimeLibRoot))
+                continue;
+
+            try
+            {{
+                foreach (var path in Directory.EnumerateFiles(runtimeLibRoot, fileName, SearchOption.AllDirectories))
+                {{
+                    if (File.Exists(path))
+                        return path;
+                }}
+            }}
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is DirectoryNotFoundException)
+            {{
+                continue;
+            }}
+        }}
+
+        return null;
     }}
 
     private IntPtr LoadPackagedNativeLibrary(string unmanagedDllName)

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -968,6 +968,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
             if (arch is not null)
                 yield return ""osx-"" + arch;
             yield return ""osx"";
+            yield return ""unix"";
         }}
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {{
@@ -987,6 +988,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
                 }}
             }}
             yield return ""linux"";
+            yield return ""unix"";
         }}
     }}
 

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -534,9 +534,11 @@ internal static class ModuleBootstrapperGenerator
         => $@"using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Text.Json;
 
 namespace {identity.Namespace};
 
@@ -549,6 +551,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
     private readonly string _assemblyDirectory;
     private readonly string _moduleAssemblyPath;
     private readonly AssemblyDependencyResolver? _resolver;
+    private readonly DependencyManifestResolver? _manifestResolver;
     private Assembly? _moduleAssembly;
 
     private ModuleAssemblyLoadContext(string moduleAssemblyPath, string contextName)
@@ -557,6 +560,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         _moduleAssemblyPath = Path.GetFullPath(moduleAssemblyPath);
         _assemblyDirectory = Path.GetDirectoryName(_moduleAssemblyPath) ?? string.Empty;
         _resolver = TryCreateResolver(_moduleAssemblyPath);
+        _manifestResolver = DependencyManifestResolver.TryCreate(_moduleAssemblyPath);
     }}
 
     public static Assembly LoadModule(string moduleAssemblyPath, string? contextName)
@@ -594,6 +598,10 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
             return LoadFromAssemblyPath(resolvedPath);
 
+        resolvedPath = _manifestResolver?.ResolveAssemblyToPath(assemblyName);
+        if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
+            return LoadFromAssemblyPath(resolvedPath);
+
         var assemblyPath = Path.Combine(_assemblyDirectory, assemblyName.Name + "".dll"");
         return File.Exists(assemblyPath) ? LoadFromAssemblyPath(assemblyPath) : null;
     }}
@@ -601,6 +609,10 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
     {{
         var resolvedPath = _resolver?.ResolveUnmanagedDllToPath(unmanagedDllName);
+        if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
+            return LoadUnmanagedDllFromPath(resolvedPath);
+
+        resolvedPath = _manifestResolver?.ResolveUnmanagedDllToPath(unmanagedDllName);
         if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
             return LoadUnmanagedDllFromPath(resolvedPath);
 
@@ -626,6 +638,228 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         catch (InvalidOperationException)
         {{
             return null;
+        }}
+    }}
+
+    private sealed class DependencyManifestResolver
+    {{
+        private readonly string _assemblyDirectory;
+        private readonly JsonElement _target;
+        private readonly string[] _runtimeIdentifiers;
+
+        private DependencyManifestResolver(string assemblyPath, JsonElement target)
+        {{
+            _assemblyDirectory = Path.GetDirectoryName(assemblyPath) ?? string.Empty;
+            _target = target;
+            _runtimeIdentifiers = BuildRuntimeIdentifiers();
+        }}
+
+        public static DependencyManifestResolver? TryCreate(string assemblyPath)
+        {{
+            var depsPath = Path.ChangeExtension(assemblyPath, "".deps.json"");
+            if (string.IsNullOrWhiteSpace(depsPath) || !File.Exists(depsPath))
+                return null;
+
+            try
+            {{
+                var document = JsonDocument.Parse(File.ReadAllText(depsPath));
+                if (!document.RootElement.TryGetProperty(""targets"", out var targets) || targets.ValueKind != JsonValueKind.Object)
+                {{
+                    document.Dispose();
+                    return null;
+                }}
+
+                JsonElement target;
+                if (document.RootElement.TryGetProperty(""runtimeTarget"", out var runtimeTarget) &&
+                    runtimeTarget.TryGetProperty(""name"", out var targetName) &&
+                    targetName.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrWhiteSpace(targetName.GetString()) &&
+                    targets.TryGetProperty(targetName.GetString()!, out target))
+                {{
+                    var clonedTarget = target.Clone();
+                    document.Dispose();
+                    return new DependencyManifestResolver(assemblyPath, clonedTarget);
+                }}
+
+                foreach (var candidate in targets.EnumerateObject())
+                {{
+                    var clonedTarget = candidate.Value.Clone();
+                    document.Dispose();
+                    return new DependencyManifestResolver(assemblyPath, clonedTarget);
+                }}
+
+                document.Dispose();
+                return null;
+            }}
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is JsonException || ex is InvalidOperationException)
+            {{
+                return null;
+            }}
+        }}
+
+        public string? ResolveAssemblyToPath(AssemblyName assemblyName)
+        {{
+            if (assemblyName is null || string.IsNullOrWhiteSpace(assemblyName.Name))
+                return null;
+
+            var resolved = SearchRuntimeTargets(assemblyName.Name, ""runtime"");
+            if (!string.IsNullOrWhiteSpace(resolved))
+                return resolved;
+
+            return SearchAssetGroup(assemblyName.Name, ""runtime"");
+        }}
+
+        public string? ResolveUnmanagedDllToPath(string unmanagedDllName)
+        {{
+            if (string.IsNullOrWhiteSpace(unmanagedDllName))
+                return null;
+
+            var names = new HashSet<string>(GetNativeLibraryFileNames(unmanagedDllName), StringComparer.OrdinalIgnoreCase);
+            var resolved = SearchRuntimeTargets(names, ""native"");
+            if (!string.IsNullOrWhiteSpace(resolved))
+                return resolved;
+
+            return SearchAssetGroup(names, ""native"");
+        }}
+
+        private string? SearchRuntimeTargets(string assemblyName, string assetType)
+        {{
+            foreach (var library in _target.EnumerateObject())
+            {{
+                if (!library.Value.TryGetProperty(""runtimeTargets"", out var runtimeTargets) ||
+                    runtimeTargets.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                foreach (var rid in _runtimeIdentifiers)
+                {{
+                    foreach (var asset in runtimeTargets.EnumerateObject())
+                    {{
+                        if (!asset.Value.TryGetProperty(""assetType"", out var declaredAssetType) ||
+                            !string.Equals(declaredAssetType.GetString(), assetType, StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        if (!asset.Value.TryGetProperty(""rid"", out var declaredRid) ||
+                            !string.Equals(declaredRid.GetString(), rid, StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        if (string.Equals(Path.GetFileNameWithoutExtension(asset.Name), assemblyName, StringComparison.OrdinalIgnoreCase))
+                        {{
+                            var resolved = ResolveAssetPath(asset.Name);
+                            if (!string.IsNullOrWhiteSpace(resolved))
+                                return resolved;
+                        }}
+                    }}
+                }}
+            }}
+
+            return null;
+        }}
+
+        private string? SearchRuntimeTargets(HashSet<string> fileNames, string assetType)
+        {{
+            foreach (var library in _target.EnumerateObject())
+            {{
+                if (!library.Value.TryGetProperty(""runtimeTargets"", out var runtimeTargets) ||
+                    runtimeTargets.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                foreach (var rid in _runtimeIdentifiers)
+                {{
+                    foreach (var asset in runtimeTargets.EnumerateObject())
+                    {{
+                        if (!asset.Value.TryGetProperty(""assetType"", out var declaredAssetType) ||
+                            !string.Equals(declaredAssetType.GetString(), assetType, StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        if (!asset.Value.TryGetProperty(""rid"", out var declaredRid) ||
+                            !string.Equals(declaredRid.GetString(), rid, StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        if (fileNames.Contains(Path.GetFileName(asset.Name)))
+                        {{
+                            var resolved = ResolveAssetPath(asset.Name);
+                            if (!string.IsNullOrWhiteSpace(resolved))
+                                return resolved;
+                        }}
+                    }}
+                }}
+            }}
+
+            return null;
+        }}
+
+        private string? SearchAssetGroup(string assemblyName, string groupName)
+        {{
+            foreach (var library in _target.EnumerateObject())
+            {{
+                if (!library.Value.TryGetProperty(groupName, out var assets) || assets.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                foreach (var asset in assets.EnumerateObject())
+                {{
+                    if (string.Equals(Path.GetFileNameWithoutExtension(asset.Name), assemblyName, StringComparison.OrdinalIgnoreCase))
+                    {{
+                        var resolved = ResolveAssetPath(asset.Name);
+                        if (!string.IsNullOrWhiteSpace(resolved))
+                            return resolved;
+                    }}
+                }}
+            }}
+
+            return null;
+        }}
+
+        private string? SearchAssetGroup(HashSet<string> fileNames, string groupName)
+        {{
+            foreach (var library in _target.EnumerateObject())
+            {{
+                if (!library.Value.TryGetProperty(groupName, out var assets) || assets.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                foreach (var asset in assets.EnumerateObject())
+                {{
+                    if (fileNames.Contains(Path.GetFileName(asset.Name)))
+                    {{
+                        var resolved = ResolveAssetPath(asset.Name);
+                        if (!string.IsNullOrWhiteSpace(resolved))
+                            return resolved;
+                    }}
+                }}
+            }}
+
+            return null;
+        }}
+
+        private string? ResolveAssetPath(string assetPath)
+        {{
+            if (string.IsNullOrWhiteSpace(assetPath))
+                return null;
+
+            var normalized = assetPath.Replace('/', Path.DirectorySeparatorChar);
+            foreach (var candidate in new[]
+            {{
+                Path.Combine(_assemblyDirectory, normalized),
+                Path.Combine(_assemblyDirectory, Path.GetFileName(normalized))
+            }})
+            {{
+                if (File.Exists(candidate))
+                    return candidate;
+            }}
+
+            return null;
+        }}
+
+        private static string[] BuildRuntimeIdentifiers()
+        {{
+            var values = new List<string>();
+            foreach (var rid in GetRuntimeIdentifiers())
+            {{
+                if (!string.IsNullOrWhiteSpace(rid) && !values.Contains(rid, StringComparer.OrdinalIgnoreCase))
+                    values.Add(rid);
+            }}
+
+            values.Add(string.Empty);
+            return values.ToArray();
         }}
     }}
 

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -548,7 +548,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 
     private readonly string _assemblyDirectory;
     private readonly string _moduleAssemblyPath;
-    private readonly AssemblyDependencyResolver _resolver;
+    private readonly AssemblyDependencyResolver? _resolver;
     private Assembly? _moduleAssembly;
 
     private ModuleAssemblyLoadContext(string moduleAssemblyPath, string contextName)
@@ -556,7 +556,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
     {{
         _moduleAssemblyPath = Path.GetFullPath(moduleAssemblyPath);
         _assemblyDirectory = Path.GetDirectoryName(_moduleAssemblyPath) ?? string.Empty;
-        _resolver = new AssemblyDependencyResolver(_moduleAssemblyPath);
+        _resolver = TryCreateResolver(_moduleAssemblyPath);
     }}
 
     public static Assembly LoadModule(string moduleAssemblyPath, string? contextName)
@@ -590,7 +590,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         if (AssemblyName.ReferenceMatchesDefinition(loaderAssembly, assemblyName))
             return typeof(ModuleAssemblyLoadContext).Assembly;
 
-        var resolvedPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        var resolvedPath = _resolver?.ResolveAssemblyToPath(assemblyName);
         if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
             return LoadFromAssemblyPath(resolvedPath);
 
@@ -600,7 +600,7 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
     {{
-        var resolvedPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        var resolvedPath = _resolver?.ResolveUnmanagedDllToPath(unmanagedDllName);
         if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
             return LoadUnmanagedDllFromPath(resolvedPath);
 
@@ -615,6 +615,18 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         // Called only while LoadModule holds Sync; keep the one-time main assembly load under that lock.
         _moduleAssembly ??= LoadFromAssemblyPath(_moduleAssemblyPath);
         return _moduleAssembly;
+    }}
+
+    private static AssemblyDependencyResolver? TryCreateResolver(string assemblyPath)
+    {{
+        try
+        {{
+            return new AssemblyDependencyResolver(assemblyPath);
+        }}
+        catch (InvalidOperationException)
+        {{
+            return null;
+        }}
     }}
 
     private IntPtr LoadPackagedNativeLibrary(string unmanagedDllName)


### PR DESCRIPTION
## Summary

Fixes shared packaging/runtime issues found while wiring PSParseHTML and investigating HtmlTinkerX issue #400:

- allow unified release staging to overwrite an existing staged asset from a repeated build, while rejecting same-run filename collisions that would silently drop assets
- make generated AssemblyLoadContext loaders resilient when `AssemblyDependencyResolver` cannot initialize inside WSMan-hosted PowerShell, such as `Enter-PSSession` / `wsmprovhost`
- add a `.deps.json`-aware fallback resolver for generated ALC loaders so modules with nested runtime asset layouts are covered
- directly probe packaged `runtimes/<rid>/lib/**` managed assemblies and `runtimes/<rid>/native` native assets when resolver metadata is unavailable, including broad Unix RID fallback paths
- apply safe resolver construction and runtime/native fallback probing to `Import-IsolatedModule` generated wrappers and PSPublishModule's own Core dependency resolver

## Root Cause

The generated ALC loader treated `AssemblyDependencyResolver` construction as mandatory. In WSMan-hosted CoreCLR processes, hostpolicy may not be initialized through the normal `dotnet` host path, so resolver construction can throw before the packaged module has a chance to load.

The loader now keeps ALC isolation, but resolves in layers:

1. `AssemblyDependencyResolver` when the host supports it
2. `.deps.json` runtime/native asset resolution when available
3. packaged module folder, `runtimes/<rid>/lib/**`, `runtimes/<rid>/native`, and broad `unix` RID probing as final fallbacks

## Validation

- `dotnet build .\PowerForge\PowerForge.csproj --no-restore`
- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj --no-restore`
- `dotnet build .\PowerForge.Tests\PowerForge.Tests.csproj --no-restore`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --no-build --filter "FullyQualifiedName~ModuleBootstrapperGeneratorTests|FullyQualifiedName~ModuleIsolationScriptPatcherTests|FullyQualifiedName~ModulePipelineUnifiedReleaseTests.Run_OverwritesStagedReleaseAssetsOnRepeatedBuilds|FullyQualifiedName~ModulePipelineUnifiedReleaseTests.StageReleaseAsset_RejectsSameRunFilenameCollisionsButAllowsRepeatedBuildOverwrite"`

Focused test result: 25 passed.

Additional local proof:

- extracted the `Import-IsolatedModule` generated `Add-Type` block from `ModuleIsolationScriptPatcher` output and compiled it successfully in PowerShell

Live proofs:

- generated a tiny PSPublishModule ALC-packaged binary module, copied it into `New-PSSession -ComputerName ad0.ad.evotec.xyz -ConfigurationName PowerShell.7`, imported it inside `wsmprovhost` on PowerShell 7.6.3, and called the binary code successfully: `Value = ok`, `LoaderContexts = 1`
- generated a second ALC-packaged module whose dependency lives at `lib/net8.0/NestedDependency.dll` and is resolved through `DemoModule.deps.json`; copied it into the same `ad0` WSMan endpoint and invoked it successfully: `Value = deps`, `LoaderContexts = 1`

## Follow-up

Modules that use PSPublishModule-generated ALC loaders need to be rebuilt and released after this PSPublishModule change so their published packages contain the updated loader.