### PR TITLE
Guard unified release artefact path conflicts

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -8,6 +8,108 @@ namespace PowerForge;
 
 public sealed partial class ModulePipelineRunner
 {
+    private static void ValidateReleaseArtefactOutputPathConflicts(
+        ModulePipelinePlan plan,
+        ModulePipelineRunState state)
+    {
+        if (plan.Artefacts is not { Length: > 0 })
+            return;
+
+        var protectedPaths = CollectReleaseProtectedPaths(plan, state);
+        if (protectedPaths.Count == 0)
+            return;
+
+        var conflicts = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var artefact in plan.Artefacts.Where(static item => item is not null))
+        {
+            var cfg = artefact.Configuration ?? new ArtefactConfiguration();
+            if (cfg.Enabled != true)
+                continue;
+
+            var outputRoot = ArtefactLayoutPathResolver.ResolveOutputRoot(
+                cfg.Path,
+                plan.ProjectRoot,
+                plan.ModuleName,
+                plan.ResolvedVersion,
+                plan.PreRelease,
+                artefact.ArtefactType);
+
+            foreach (var protectedPath in protectedPaths)
+            {
+                if (!IsSameOrChildPath(outputRoot, protectedPath.Path))
+                    continue;
+
+                var key = $"{artefact.ArtefactType}|{outputRoot}|{protectedPath.Path}";
+                if (!seen.Add(key))
+                    continue;
+
+                conflicts.Add(
+                    $"Artefact '{artefact.ArtefactType}' output root '{Path.GetFullPath(outputRoot)}' contains {protectedPath.Label} '{Path.GetFullPath(protectedPath.Path)}'. " +
+                    $"Use a dedicated artefact path such as '{GetDedicatedArtefactPathHint(artefact.ArtefactType)}' and keep release staging/project build outputs in separate subdirectories.");
+            }
+        }
+
+        if (conflicts.Count == 0)
+            return;
+
+        throw new InvalidOperationException(
+            "Release artefact configuration is unsafe:" + Environment.NewLine +
+            string.Join(Environment.NewLine, conflicts.Select(static message => "- " + message)));
+    }
+
+    private static List<ReleaseProtectedPath> CollectReleaseProtectedPaths(
+        ModulePipelinePlan plan,
+        ModulePipelineRunState state)
+    {
+        var paths = new List<ReleaseProtectedPath>();
+        var releaseStageRoot = plan.Release?.Configuration is null
+            ? null
+            : ResolveReleaseStageRoot(plan, plan.Release.Configuration);
+        AddReleaseProtectedPath(paths, releaseStageRoot, "release stage root");
+
+        foreach (var result in state.ProjectBuildResults)
+        {
+            AddReleaseProtectedPath(paths, result.StagingPath, "project build staging path");
+            AddReleaseProtectedPath(paths, result.OutputPath, "project build output path");
+            AddReleaseProtectedPath(paths, result.ReleaseZipOutputPath, "project build release zip output path");
+
+            foreach (var package in result.Result?.Release?.Projects.SelectMany(static project => project.Packages) ?? Array.Empty<string>())
+            {
+                AddReleaseProtectedPath(paths, package, "project build package asset");
+
+                var packageDirectory = string.IsNullOrWhiteSpace(package)
+                    ? null
+                    : Path.GetDirectoryName(Path.GetFullPath(package.Trim().Trim('"')));
+                AddReleaseProtectedPath(paths, packageDirectory, "project build package directory");
+            }
+        }
+
+        return paths;
+    }
+
+    private static void AddReleaseProtectedPath(
+        List<ReleaseProtectedPath> paths,
+        string? path,
+        string label)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        paths.Add(new ReleaseProtectedPath(
+            Path.GetFullPath(path!.Trim().Trim('"')),
+            label));
+    }
+
+    private static string GetDedicatedArtefactPathHint(ArtefactType type)
+        => type switch
+        {
+            ArtefactType.Unpacked => @"Artefacts\Unpacked",
+            ArtefactType.Packed => @"Artefacts\Packed",
+            _ => $@"Artefacts\{type}"
+        };
+
     private ModuleReleaseCoordinationResult? PrepareUnifiedReleaseAssets(
         ModulePipelinePlan plan,
         ModulePipelineRunState state,
@@ -307,4 +409,16 @@ public sealed partial class ModulePipelineRunner
         => path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
             ? path
             : path + Path.DirectorySeparatorChar;
+
+    private readonly struct ReleaseProtectedPath
+    {
+        public ReleaseProtectedPath(string path, string label)
+        {
+            Path = path;
+            Label = label;
+        }
+
+        public string Path { get; }
+        public string Label { get; }
+    }
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -114,12 +114,29 @@ public sealed partial class ModulePipelineRunner
 
         if (artefact.ArtefactType == ArtefactType.Packed)
         {
+            var packedRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "artefacts", "validation", plan.ModuleName);
+            var requiredModulesRoot = ArtefactLayoutPathResolver.ResolveRequiredModulesRootForPacked(
+                cfg,
+                outputRoot,
+                packedRoot,
+                plan.ModuleName,
+                plan.ResolvedVersion,
+                plan.PreRelease);
+            var modulesRoot = ArtefactLayoutPathResolver.ResolveModulesRootForPacked(
+                cfg,
+                outputRoot,
+                packedRoot,
+                requiredModulesRoot,
+                plan.ModuleName,
+                plan.ResolvedVersion,
+                plan.PreRelease);
+
             if (cfg.DoNotClear != true)
             {
                 paths.Add(new ArtefactDestructivePath(
                     outputRoot,
                     "direct output files",
-                    ArtefactDestructivePathKind.DirectChildFiles));
+                    ArtefactDestructivePathKind.DirectChildNonZipFiles));
             }
 
             paths.Add(new ArtefactDestructivePath(
@@ -127,11 +144,27 @@ public sealed partial class ModulePipelineRunner
                 "zip output file",
                 ArtefactDestructivePathKind.ExactFile));
 
+            paths.Add(new ArtefactDestructivePath(
+                Path.Combine(modulesRoot, plan.ModuleName),
+                "main packed module copy root",
+                ArtefactDestructivePathKind.DirectoryTree));
+
+            if (cfg.RequiredModules.Enabled == true)
+            {
+                foreach (var requiredModule in FilterRequiredModulesForArtefactValidation(plan.RequiredModulesForPackaging, cfg.RequiredModules.ExcludeModuleName))
+                {
+                    paths.Add(new ArtefactDestructivePath(
+                        Path.Combine(requiredModulesRoot, requiredModule.ModuleName!),
+                        "required packed module copy root",
+                        ArtefactDestructivePathKind.DirectoryTree));
+                }
+            }
+
             AddArtefactCopyMappingDestructivePaths(
                 paths,
                 cfg,
                 plan,
-                Path.Combine(Path.GetTempPath(), "PowerForge", "artefacts", "validation", plan.ModuleName),
+                packedRoot,
                 enforceRelativeDestination: true);
         }
 
@@ -189,8 +222,12 @@ public sealed partial class ModulePipelineRunner
         ReleaseProtectedPath protectedPath)
         => destructivePath.Kind switch
         {
-            ArtefactDestructivePathKind.DirectoryTree => IsSameOrChildPath(destructivePath.Path, protectedPath.Path),
-            ArtefactDestructivePathKind.DirectChildFiles => protectedPath.IsFile && IsDirectChildPath(destructivePath.Path, protectedPath.Path),
+            ArtefactDestructivePathKind.DirectoryTree => protectedPath.IsFile
+                ? IsSameOrChildPath(destructivePath.Path, protectedPath.Path)
+                : DoPathsOverlap(destructivePath.Path, protectedPath.Path),
+            ArtefactDestructivePathKind.DirectChildNonZipFiles => protectedPath.IsFile
+                && !IsZipFilePath(protectedPath.Path)
+                && IsDirectChildPath(destructivePath.Path, protectedPath.Path),
             ArtefactDestructivePathKind.ExactFile => PathsEqual(destructivePath.Path, protectedPath.Path),
             _ => false
         };
@@ -248,6 +285,9 @@ public sealed partial class ModulePipelineRunner
 
         return string.Equals(parent, candidateParent, StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsZipFilePath(string path)
+        => string.Equals(Path.GetExtension(path), ".zip", StringComparison.OrdinalIgnoreCase);
 
     private static List<ReleaseProtectedPath> CollectReleaseProtectedPaths(
         ModulePipelinePlan plan,
@@ -624,7 +664,7 @@ public sealed partial class ModulePipelineRunner
     private enum ArtefactDestructivePathKind
     {
         DirectoryTree,
-        DirectChildFiles,
+        DirectChildNonZipFiles,
         ExactFile
     }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -76,6 +76,7 @@ public sealed partial class ModulePipelineRunner
                     outputRoot,
                     "output root",
                     ArtefactDestructivePathKind.DirectoryTree));
+                AddArtefactCopyMappingDestructivePaths(paths, cfg, plan, outputRoot, enforceRelativeDestination: false);
                 return paths;
             }
 
@@ -258,6 +259,11 @@ public sealed partial class ModulePipelineRunner
                     ? null
                     : Path.GetDirectoryName(Path.GetFullPath(package.Trim().Trim('"')));
                 AddReleaseProtectedPath(paths, packageDirectory, "project build package directory");
+            }
+
+            foreach (var releaseZipPath in result.Result?.Release?.Projects.Select(static project => project.ReleaseZipPath) ?? Array.Empty<string?>())
+            {
+                AddReleaseProtectedPath(paths, releaseZipPath, "project build release zip asset", isFile: true);
             }
         }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -28,26 +28,21 @@ public sealed partial class ModulePipelineRunner
             if (cfg.Enabled != true)
                 continue;
 
-            var outputRoot = ArtefactLayoutPathResolver.ResolveOutputRoot(
-                cfg.Path,
-                plan.ProjectRoot,
-                plan.ModuleName,
-                plan.ResolvedVersion,
-                plan.PreRelease,
-                artefact.ArtefactType);
-
-            foreach (var protectedPath in protectedPaths)
+            foreach (var destructivePath in CollectArtefactDestructivePaths(plan, artefact, cfg))
             {
-                if (!IsSameOrChildPath(outputRoot, protectedPath.Path))
-                    continue;
+                foreach (var protectedPath in protectedPaths)
+                {
+                    if (!DoesDestructivePathAffectProtectedPath(destructivePath, protectedPath))
+                        continue;
 
-                var key = $"{artefact.ArtefactType}|{outputRoot}|{protectedPath.Path}";
-                if (!seen.Add(key))
-                    continue;
+                    var key = $"{artefact.ArtefactType}|{destructivePath.Kind}|{destructivePath.Path}|{protectedPath.Path}";
+                    if (!seen.Add(key))
+                        continue;
 
-                conflicts.Add(
-                    $"Artefact '{artefact.ArtefactType}' output root '{Path.GetFullPath(outputRoot)}' contains {protectedPath.Label} '{Path.GetFullPath(protectedPath.Path)}'. " +
-                    $"Use a dedicated artefact path such as '{GetDedicatedArtefactPathHint(artefact.ArtefactType)}' and keep release staging/project build outputs in separate subdirectories.");
+                    conflicts.Add(
+                        $"Artefact '{artefact.ArtefactType}' {destructivePath.Label} '{Path.GetFullPath(destructivePath.Path)}' would affect {protectedPath.Label} '{Path.GetFullPath(protectedPath.Path)}'. " +
+                        $"Use a dedicated artefact path such as '{GetDedicatedArtefactPathHint(artefact.ArtefactType)}' and keep release staging/project build outputs in separate subdirectories.");
+                }
             }
         }
 
@@ -57,6 +52,186 @@ public sealed partial class ModulePipelineRunner
         throw new InvalidOperationException(
             "Release artefact configuration is unsafe:" + Environment.NewLine +
             string.Join(Environment.NewLine, conflicts.Select(static message => "- " + message)));
+    }
+
+    private static List<ArtefactDestructivePath> CollectArtefactDestructivePaths(
+        ModulePipelinePlan plan,
+        ConfigurationArtefactSegment artefact,
+        ArtefactConfiguration cfg)
+    {
+        var paths = new List<ArtefactDestructivePath>();
+        var outputRoot = ArtefactLayoutPathResolver.ResolveOutputRoot(
+            cfg.Path,
+            plan.ProjectRoot,
+            plan.ModuleName,
+            plan.ResolvedVersion,
+            plan.PreRelease,
+            artefact.ArtefactType);
+
+        if (artefact.ArtefactType == ArtefactType.Unpacked)
+        {
+            if (cfg.DoNotClear != true)
+            {
+                paths.Add(new ArtefactDestructivePath(
+                    outputRoot,
+                    "output root",
+                    ArtefactDestructivePathKind.DirectoryTree));
+                return paths;
+            }
+
+            var requiredModulesRoot = ArtefactLayoutPathResolver.ResolveRequiredModulesRootForUnpacked(
+                cfg,
+                outputRoot,
+                plan.ModuleName,
+                plan.ResolvedVersion,
+                plan.PreRelease);
+            var modulesRoot = ArtefactLayoutPathResolver.ResolveModulesRootForUnpacked(
+                cfg,
+                outputRoot,
+                requiredModulesRoot,
+                plan.ModuleName,
+                plan.ResolvedVersion,
+                plan.PreRelease);
+
+            paths.Add(new ArtefactDestructivePath(
+                Path.Combine(modulesRoot, plan.ModuleName),
+                "main module copy root",
+                ArtefactDestructivePathKind.DirectoryTree));
+
+            if (cfg.RequiredModules.Enabled == true)
+            {
+                foreach (var requiredModule in FilterRequiredModulesForArtefactValidation(plan.RequiredModulesForPackaging, cfg.RequiredModules.ExcludeModuleName))
+                {
+                    paths.Add(new ArtefactDestructivePath(
+                        Path.Combine(requiredModulesRoot, requiredModule.ModuleName!),
+                        "required module copy root",
+                        ArtefactDestructivePathKind.DirectoryTree));
+                }
+            }
+
+            AddArtefactCopyMappingDestructivePaths(paths, cfg, plan, outputRoot, enforceRelativeDestination: false);
+            return paths;
+        }
+
+        if (artefact.ArtefactType == ArtefactType.Packed)
+        {
+            if (cfg.DoNotClear != true)
+            {
+                paths.Add(new ArtefactDestructivePath(
+                    outputRoot,
+                    "direct output files",
+                    ArtefactDestructivePathKind.DirectChildFiles));
+            }
+
+            paths.Add(new ArtefactDestructivePath(
+                Path.Combine(outputRoot, ResolveArtefactFileNameForValidation(cfg, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease)),
+                "zip output file",
+                ArtefactDestructivePathKind.ExactFile));
+        }
+
+        return paths;
+    }
+
+    private static void AddArtefactCopyMappingDestructivePaths(
+        List<ArtefactDestructivePath> paths,
+        ArtefactConfiguration cfg,
+        ModulePipelinePlan plan,
+        string destinationRoot,
+        bool enforceRelativeDestination)
+    {
+        foreach (var mapping in cfg.DirectoryOutput ?? Array.Empty<ArtefactCopyMapping>())
+        {
+            if (mapping is null)
+                continue;
+
+            paths.Add(new ArtefactDestructivePath(
+                ResolveArtefactCopyOutputPath(mapping.Destination, destinationRoot, cfg.DestinationDirectoriesRelative == true, enforceRelativeDestination, plan),
+                "directory copy mapping output",
+                ArtefactDestructivePathKind.DirectoryTree));
+        }
+
+        foreach (var mapping in cfg.FilesOutput ?? Array.Empty<ArtefactCopyMapping>())
+        {
+            if (mapping is null)
+                continue;
+
+            paths.Add(new ArtefactDestructivePath(
+                ResolveArtefactCopyOutputPath(mapping.Destination, destinationRoot, cfg.DestinationFilesRelative == true, enforceRelativeDestination, plan),
+                "file copy mapping output",
+                ArtefactDestructivePathKind.ExactFile));
+        }
+    }
+
+    private static RequiredModuleReference[] FilterRequiredModulesForArtefactValidation(
+        IReadOnlyList<RequiredModuleReference>? requiredModules,
+        IReadOnlyList<string>? excludedModuleNames)
+    {
+        var excluded = new HashSet<string>(
+            (excludedModuleNames ?? Array.Empty<string>())
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+
+        return (requiredModules ?? Array.Empty<RequiredModuleReference>())
+            .Where(static module => module is not null && !string.IsNullOrWhiteSpace(module.ModuleName))
+            .Where(module => !excluded.Contains(module.ModuleName!))
+            .ToArray();
+    }
+
+    private static bool DoesDestructivePathAffectProtectedPath(
+        ArtefactDestructivePath destructivePath,
+        ReleaseProtectedPath protectedPath)
+        => destructivePath.Kind switch
+        {
+            ArtefactDestructivePathKind.DirectoryTree => IsSameOrChildPath(destructivePath.Path, protectedPath.Path),
+            ArtefactDestructivePathKind.DirectChildFiles => protectedPath.IsFile && IsDirectChildPath(destructivePath.Path, protectedPath.Path),
+            ArtefactDestructivePathKind.ExactFile => PathsEqual(destructivePath.Path, protectedPath.Path),
+            _ => false
+        };
+
+    private static string ResolveArtefactCopyOutputPath(
+        string? value,
+        string destinationRoot,
+        bool relativeToRoot,
+        bool enforceRelativeDestination,
+        ModulePipelinePlan plan)
+    {
+        var raw = ModulePathTokenFormatter.ReplacePathTokens(value ?? string.Empty, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease).Trim().Trim('"');
+        if (string.IsNullOrWhiteSpace(raw))
+            return Path.GetFullPath(destinationRoot);
+
+        if (enforceRelativeDestination && Path.IsPathRooted(raw))
+            throw new InvalidOperationException($"Packed artefact copy destinations must be relative, but got rooted path '{raw}'.");
+
+        if (relativeToRoot || !Path.IsPathRooted(raw))
+            return Path.GetFullPath(Path.Combine(destinationRoot, raw));
+
+        return Path.GetFullPath(raw);
+    }
+
+    private static string ResolveArtefactFileNameForValidation(
+        ArtefactConfiguration cfg,
+        string moduleName,
+        string moduleVersion,
+        string? preRelease)
+    {
+        if (!string.IsNullOrWhiteSpace(cfg.ArtefactName))
+            return ModulePathTokenFormatter.ReplacePathTokens(cfg.ArtefactName!.Trim(), moduleName, moduleVersion, preRelease);
+
+        var tagWithPre = ModulePathTokenFormatter.ReplacePathTokens("<TagModuleVersionWithPreRelease>", moduleName, moduleVersion, preRelease);
+        return cfg.IncludeTagName == true
+            ? $"{moduleName}.{tagWithPre}.zip"
+            : $"{moduleName}.zip";
+    }
+
+    private static bool IsDirectChildPath(string parentPath, string candidatePath)
+    {
+        var parent = Path.GetFullPath(parentPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidateParent = Path.GetDirectoryName(Path.GetFullPath(candidatePath))
+            ?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return string.Equals(parent, candidateParent, StringComparison.OrdinalIgnoreCase);
     }
 
     private static List<ReleaseProtectedPath> CollectReleaseProtectedPaths(
@@ -77,7 +252,7 @@ public sealed partial class ModulePipelineRunner
 
             foreach (var package in result.Result?.Release?.Projects.SelectMany(static project => project.Packages) ?? Array.Empty<string>())
             {
-                AddReleaseProtectedPath(paths, package, "project build package asset");
+                AddReleaseProtectedPath(paths, package, "project build package asset", isFile: true);
 
                 var packageDirectory = string.IsNullOrWhiteSpace(package)
                     ? null
@@ -92,14 +267,16 @@ public sealed partial class ModulePipelineRunner
     private static void AddReleaseProtectedPath(
         List<ReleaseProtectedPath> paths,
         string? path,
-        string label)
+        string label,
+        bool isFile = false)
     {
         if (string.IsNullOrWhiteSpace(path))
             return;
 
         paths.Add(new ReleaseProtectedPath(
             Path.GetFullPath(path!.Trim().Trim('"')),
-            label));
+            label,
+            isFile));
     }
 
     private static string GetDedicatedArtefactPathHint(ArtefactType type)
@@ -410,15 +587,38 @@ public sealed partial class ModulePipelineRunner
             ? path
             : path + Path.DirectorySeparatorChar;
 
-    private readonly struct ReleaseProtectedPath
+    private readonly struct ArtefactDestructivePath
     {
-        public ReleaseProtectedPath(string path, string label)
+        public ArtefactDestructivePath(string path, string label, ArtefactDestructivePathKind kind)
         {
-            Path = path;
+            Path = System.IO.Path.GetFullPath(path);
             Label = label;
+            Kind = kind;
         }
 
         public string Path { get; }
         public string Label { get; }
+        public ArtefactDestructivePathKind Kind { get; }
+    }
+
+    private enum ArtefactDestructivePathKind
+    {
+        DirectoryTree,
+        DirectChildFiles,
+        ExactFile
+    }
+
+    private readonly struct ReleaseProtectedPath
+    {
+        public ReleaseProtectedPath(string path, string label, bool isFile)
+        {
+            Path = path;
+            Label = label;
+            IsFile = isFile;
+        }
+
+        public string Path { get; }
+        public string Label { get; }
+        public bool IsFile { get; }
     }
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -70,16 +70,6 @@ public sealed partial class ModulePipelineRunner
 
         if (artefact.ArtefactType == ArtefactType.Unpacked)
         {
-            if (cfg.DoNotClear != true)
-            {
-                paths.Add(new ArtefactDestructivePath(
-                    outputRoot,
-                    "output root",
-                    ArtefactDestructivePathKind.DirectoryTree));
-                AddArtefactCopyMappingDestructivePaths(paths, cfg, plan, outputRoot, enforceRelativeDestination: false);
-                return paths;
-            }
-
             var requiredModulesRoot = ArtefactLayoutPathResolver.ResolveRequiredModulesRootForUnpacked(
                 cfg,
                 outputRoot,
@@ -93,6 +83,14 @@ public sealed partial class ModulePipelineRunner
                 plan.ModuleName,
                 plan.ResolvedVersion,
                 plan.PreRelease);
+
+            if (cfg.DoNotClear != true)
+            {
+                paths.Add(new ArtefactDestructivePath(
+                    outputRoot,
+                    "output root",
+                    ArtefactDestructivePathKind.DirectoryTree));
+            }
 
             paths.Add(new ArtefactDestructivePath(
                 Path.Combine(modulesRoot, plan.ModuleName),
@@ -128,6 +126,13 @@ public sealed partial class ModulePipelineRunner
                 Path.Combine(outputRoot, ResolveArtefactFileNameForValidation(cfg, plan.ModuleName, plan.ResolvedVersion, plan.PreRelease)),
                 "zip output file",
                 ArtefactDestructivePathKind.ExactFile));
+
+            AddArtefactCopyMappingDestructivePaths(
+                paths,
+                cfg,
+                plan,
+                Path.Combine(Path.GetTempPath(), "PowerForge", "artefacts", "validation", plan.ModuleName),
+                enforceRelativeDestination: true);
         }
 
         return paths;
@@ -205,7 +210,16 @@ public sealed partial class ModulePipelineRunner
             throw new InvalidOperationException($"Packed artefact copy destinations must be relative, but got rooted path '{raw}'.");
 
         if (relativeToRoot || !Path.IsPathRooted(raw))
-            return Path.GetFullPath(Path.Combine(destinationRoot, raw));
+        {
+            var resolved = Path.GetFullPath(Path.Combine(destinationRoot, raw));
+            if (enforceRelativeDestination && !IsSameOrChildPath(destinationRoot, resolved))
+            {
+                throw new InvalidOperationException(
+                    $"Packed artefact copy destination '{raw}' resolves outside the temporary packing root '{Path.GetFullPath(destinationRoot)}'. Use a destination path that stays within the packed artefact payload.");
+            }
+
+            return resolved;
+        }
 
         return Path.GetFullPath(raw);
     }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -648,6 +648,8 @@ public sealed partial class ModulePipelineRunner
     {
         var buildResult = state.RequireBuildResult();
 
+        ValidateReleaseArtefactOutputPathConflicts(plan, state);
+
         ExecuteActions(ModulePipelineActionStage.BeforeArtefacts, plan, session, state);
         if (plan.Artefacts is { Length: > 0 })
         {

--- a/PowerForge.Tests/ModulePipelineUnifiedReleasePathValidationTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleasePathValidationTests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class ModulePipelineUnifiedReleaseTests
+{
+    [Fact]
+    public void Run_RejectsPackedLayoutModuleRootThatEscapesTemporaryPayloadRoot()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var packageOutput = Path.Combine(artefactsRoot, "ProjectBuild");
+            var packagePath = Path.Combine(packageOutput, "Mailozaurr.1.0.0.nupkg");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, "package");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = Path.Combine(artefactsRoot, "Packed"),
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                ModulesPath = Path.Combine("..", "ProjectBuild")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("resolves outside the temporary packed artefact root", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("package", File.ReadAllText(packagePath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_RejectsUnpackedLayoutChildInsideProtectedProjectBuildStaging()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var protectedStagingPath = Path.Combine(artefactsRoot, "ProjectBuild");
+            var protectedChildPath = Path.Combine(protectedStagingPath, moduleName);
+            Directory.CreateDirectory(protectedChildPath);
+            File.WriteAllText(Path.Combine(protectedChildPath, "project-build.txt"), "project-build");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        StagingPath = protectedStagingPath,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = new DotNetRepositoryReleaseResult { Success = true }
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Unpacked,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = Path.Combine(artefactsRoot, "Unpacked"),
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                ModulesPath = protectedStagingPath
+                            }
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("main module copy root", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("project build staging path", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("project-build", File.ReadAllText(Path.Combine(protectedChildPath, "project-build.txt")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_AllowsPackedModuleZipBesideProjectReleaseZipWithDifferentName()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var releaseOutput = Path.Combine(root.FullName, "Artifacts", "Releases");
+            var releaseZipPath = Path.Combine(releaseOutput, "Mailozaurr.1.0.0.zip");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(releaseOutput);
+                    File.WriteAllText(releaseZipPath, "project-release-zip");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0",
+                        ReleaseZipPath = releaseZipPath
+                    };
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        ReleaseZipOutputPath = releaseOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = releaseOutput,
+                            ArtefactName = "TestModule.1.0.0.zip"
+                        }
+                    }
+                }
+            };
+
+            var result = runner.Run(spec);
+
+            Assert.Equal("project-release-zip", File.ReadAllText(releaseZipPath));
+            Assert.Contains(result.ArtefactResults, item => string.Equals(item.OutputPath, Path.Combine(releaseOutput, "TestModule.1.0.0.zip"), StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+}

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
@@ -335,10 +335,219 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
 
             Assert.Contains("Release artefact configuration is unsafe", ex.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("contains release stage root", ex.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("contains project build output path", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("would affect release stage root", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("would affect project build output path", ex.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(@"Artefacts\Unpacked", ex.Message, StringComparison.OrdinalIgnoreCase);
             Assert.True(File.Exists(packagePath), "The guard should stop before the unpacked artefact clears the package output tree.");
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_AllowsDoNotClearUnpackedArtefactRootWithSiblingReleaseAndProjectBuildOutputs()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var packageOutput = Path.Combine(artefactsRoot, "ProjectBuild", "packages");
+            var packagePath = Path.Combine(packageOutput, "Mailozaurr.1.0.0.nupkg");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, "package");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        StagingPath = Path.Combine(artefactsRoot, "ProjectBuild"),
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Unpacked,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            DoNotClear = true,
+                            Path = artefactsRoot
+                        }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(artefactsRoot, "UploadReady")
+                        }
+                    }
+                }
+            };
+
+            var result = runner.Run(spec);
+
+            Assert.True(File.Exists(packagePath), "DoNotClear unpacked artefacts should not clear sibling project-build package output.");
+            Assert.NotNull(result.ReleaseCoordinationResult);
+            Assert.Contains(result.ReleaseCoordinationResult!.PackageAssetPaths, path => string.Equals(path, Path.Combine(artefactsRoot, "UploadReady", "nuget", Path.GetFileName(packagePath)), StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_AllowsPackedArtefactRootWithSiblingReleaseAndProjectBuildDirectories()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var packageOutput = Path.Combine(artefactsRoot, "ProjectBuild", "packages");
+            var packagePath = Path.Combine(packageOutput, "Mailozaurr.1.0.0.nupkg");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, "package");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        StagingPath = Path.Combine(artefactsRoot, "ProjectBuild"),
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = artefactsRoot,
+                            ID = "module"
+                        }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(artefactsRoot, "UploadReady")
+                        }
+                    }
+                }
+            };
+
+            var result = runner.Run(spec);
+
+            Assert.True(File.Exists(packagePath), "Packed artefacts should not clear sibling project-build package directories.");
+            Assert.NotNull(result.ReleaseCoordinationResult);
+            Assert.Single(result.ReleaseCoordinationResult!.ModuleAssetPaths);
+            Assert.Contains(result.ReleaseCoordinationResult.PackageAssetPaths, path => string.Equals(path, Path.Combine(artefactsRoot, "UploadReady", "nuget", Path.GetFileName(packagePath)), StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
@@ -755,4 +755,196 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             try { root.Delete(recursive: true); } catch { }
         }
     }
+
+    [Fact]
+    public void Run_RejectsUnpackedLayoutModuleRootThatWouldClearProjectBuildStaging()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var projectBuildRoot = Path.Combine(artefactsRoot, "ProjectBuild");
+            var protectedStagingPath = Path.Combine(projectBuildRoot, moduleName);
+            Directory.CreateDirectory(protectedStagingPath);
+            File.WriteAllText(Path.Combine(protectedStagingPath, "project-build.txt"), "project-build");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        StagingPath = protectedStagingPath,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = new DotNetRepositoryReleaseResult { Success = true }
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Unpacked,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = Path.Combine(artefactsRoot, "Unpacked"),
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                ModulesPath = projectBuildRoot
+                            }
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("main module copy root", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("project build staging path", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("project-build", File.ReadAllText(Path.Combine(protectedStagingPath, "project-build.txt")));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_RejectsPackedCopyMappingThatEscapesTemporaryPayloadRoot()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var mappingSource = Path.Combine(root.FullName, "MappingSource");
+            var packageOutput = Path.Combine(artefactsRoot, "ProjectBuild", "packages");
+            var packagePath = Path.Combine(packageOutput, "Mailozaurr.1.0.0.nupkg");
+            Directory.CreateDirectory(mappingSource);
+            File.WriteAllText(Path.Combine(mappingSource, "payload.txt"), "payload");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, "package");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = Path.Combine(artefactsRoot, "Packed"),
+                            DirectoryOutput = new[]
+                            {
+                                new ArtefactCopyMapping
+                                {
+                                    Source = mappingSource,
+                                    Destination = Path.Combine("..", "Escaped")
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("resolves outside the temporary packing root", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(packagePath), "The guard should stop before a packed copy mapping can escape the payload root.");
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
 }

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
@@ -554,4 +554,205 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             try { root.Delete(recursive: true); } catch { }
         }
     }
+
+    [Fact]
+    public void Run_RejectsUnpackedCopyMappingThatWouldClearProjectBuildOutput()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var mappingSource = Path.Combine(root.FullName, "MappingSource");
+            var packageOutput = Path.Combine(artefactsRoot, "ProjectBuild", "packages");
+            var packagePath = Path.Combine(packageOutput, "Mailozaurr.1.0.0.nupkg");
+            Directory.CreateDirectory(mappingSource);
+            File.WriteAllText(Path.Combine(mappingSource, "payload.txt"), "payload");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, "package");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Unpacked,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = Path.Combine(artefactsRoot, "Unpacked"),
+                            DirectoryOutput = new[]
+                            {
+                                new ArtefactCopyMapping
+                                {
+                                    Source = mappingSource,
+                                    Destination = packageOutput
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("directory copy mapping output", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("project build output path", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(packagePath), "The guard should stop before an unpacked copy mapping clears package output.");
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_RejectsPackedArtefactZipThatWouldOverwriteProjectBuildReleaseZip()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var releaseOutput = Path.Combine(root.FullName, "Artifacts", "Releases");
+            var releaseZipPath = Path.Combine(releaseOutput, "Mailozaurr.1.0.0.zip");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(releaseOutput);
+                    File.WriteAllText(releaseZipPath, "project-release-zip");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0",
+                        ReleaseZipPath = releaseZipPath
+                    };
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        ReleaseZipOutputPath = releaseOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = releaseOutput,
+                            ArtefactName = Path.GetFileName(releaseZipPath)
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("zip output file", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("project build release zip asset", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("project-release-zip", File.ReadAllText(releaseZipPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
 }

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseReviewTests.cs
@@ -240,4 +240,109 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             try { root.Delete(recursive: true); } catch { }
         }
     }
+
+    [Fact]
+    public void Run_RejectsArtefactOutputRootThatContainsReleaseAndProjectBuildOutputs()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var artefactsRoot = Path.Combine(root.FullName, "Artifacts");
+            var packageOutput = Path.Combine(artefactsRoot, "ProjectBuild", "packages");
+            var packagePath = Path.Combine(packageOutput, "Mailozaurr.1.0.0.nupkg");
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, "package");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Mailozaurr",
+                        PackageId = "Mailozaurr",
+                        IsPackable = true,
+                        NewVersion = "1.0.0"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        StagingPath = Path.Combine(artefactsRoot, "ProjectBuild"),
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "Packages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Unpacked,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Enabled = true,
+                            Path = artefactsRoot
+                        }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(artefactsRoot, "UploadReady")
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("Release artefact configuration is unsafe", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("contains release stage root", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("contains project build output path", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(@"Artefacts\Unpacked", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(packagePath), "The guard should stop before the unpacked artefact clears the package output tree.");
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
 }

--- a/PowerForge/Services/ArtefactBuilder.Packaging.cs
+++ b/PowerForge/Services/ArtefactBuilder.Packaging.cs
@@ -274,16 +274,13 @@ public sealed partial class ArtefactBuilder
         string moduleName,
         string moduleVersion,
         string? preRelease)
-    {
-        return ResolvePackedLayoutRoot(
-            cfg.RequiredModules.Path,
+        => ArtefactLayoutPathResolver.ResolveRequiredModulesRootForPacked(
+            cfg,
             outputRoot,
-            packedRoot,
             packedRoot,
             moduleName,
             moduleVersion,
             preRelease);
-    }
 
     private static string ResolveModulesRootForPacked(
         ArtefactConfiguration cfg,
@@ -293,61 +290,13 @@ public sealed partial class ArtefactBuilder
         string moduleName,
         string moduleVersion,
         string? preRelease)
-    {
-        return ResolvePackedLayoutRoot(
-            cfg.RequiredModules.ModulesPath,
+        => ArtefactLayoutPathResolver.ResolveModulesRootForPacked(
+            cfg,
             outputRoot,
             packedRoot,
             requiredModulesRoot,
             moduleName,
             moduleVersion,
             preRelease);
-    }
-
-    private static string ResolvePackedLayoutRoot(
-        string? configuredPath,
-        string outputRoot,
-        string packedRoot,
-        string defaultRoot,
-        string moduleName,
-        string moduleVersion,
-        string? preRelease)
-    {
-        var raw = ModulePathTokenFormatter.ReplacePathTokens(configuredPath ?? string.Empty, moduleName, moduleVersion, preRelease).Trim().Trim('"');
-        if (string.IsNullOrWhiteSpace(raw))
-            return defaultRoot;
-
-        if (!Path.IsPathRooted(raw))
-            return Path.GetFullPath(Path.Combine(packedRoot, raw));
-
-        var resolved = Path.GetFullPath(raw);
-        var resolvedOutputRoot = Path.GetFullPath(outputRoot);
-        if (!IsSameOrChildPath(resolvedOutputRoot, resolved))
-        {
-            throw new InvalidOperationException(
-                $"Packed artefact module paths must resolve under artefact output '{resolvedOutputRoot}', but got '{resolved}'.");
-        }
-
-        var relative = ComputeRelativePath(resolvedOutputRoot, resolved);
-        if (string.IsNullOrWhiteSpace(relative) || relative == ".")
-            return packedRoot;
-
-        return Path.GetFullPath(Path.Combine(packedRoot, relative));
-    }
-
-    private static bool IsSameOrChildPath(string rootPath, string candidatePath)
-    {
-        var root = Path.GetFullPath(rootPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var candidate = Path.GetFullPath(candidatePath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (string.Equals(root, candidate, StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        var rootWithSeparator = root + Path.DirectorySeparatorChar;
-        var candidateWithSeparator = candidate + Path.DirectorySeparatorChar;
-        return candidateWithSeparator.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase);
-    }
 
 }

--- a/PowerForge/Services/ArtefactLayoutPathResolver.cs
+++ b/PowerForge/Services/ArtefactLayoutPathResolver.cs
@@ -62,9 +62,105 @@ internal static class ArtefactLayoutPathResolver
         return PathValueResolver.Resolve(outputRoot, replaced);
     }
 
+    internal static string ResolveRequiredModulesRootForPacked(
+        ArtefactConfiguration cfg,
+        string outputRoot,
+        string packedRoot,
+        string moduleName,
+        string moduleVersion,
+        string? preRelease)
+        => ResolvePackedLayoutRoot(
+            cfg.RequiredModules.Path,
+            outputRoot,
+            packedRoot,
+            packedRoot,
+            moduleName,
+            moduleVersion,
+            preRelease);
+
+    internal static string ResolveModulesRootForPacked(
+        ArtefactConfiguration cfg,
+        string outputRoot,
+        string packedRoot,
+        string requiredModulesRoot,
+        string moduleName,
+        string moduleVersion,
+        string? preRelease)
+        => ResolvePackedLayoutRoot(
+            cfg.RequiredModules.ModulesPath,
+            outputRoot,
+            packedRoot,
+            requiredModulesRoot,
+            moduleName,
+            moduleVersion,
+            preRelease);
+
+    private static string ResolvePackedLayoutRoot(
+        string? configuredPath,
+        string outputRoot,
+        string packedRoot,
+        string defaultRoot,
+        string moduleName,
+        string moduleVersion,
+        string? preRelease)
+    {
+        var raw = ModulePathTokenFormatter.ReplacePathTokens(configuredPath ?? string.Empty, moduleName, moduleVersion, preRelease);
+        raw = PathValueResolver.Clean(raw);
+        if (string.IsNullOrWhiteSpace(raw))
+            return defaultRoot;
+
+        if (!Path.IsPathRooted(raw))
+        {
+            var resolved = Path.GetFullPath(Path.Combine(packedRoot, raw));
+            if (!IsSameOrChildPath(packedRoot, resolved))
+            {
+                throw new InvalidOperationException(
+                    $"Packed artefact module path '{raw}' resolves outside the temporary packed artefact root '{Path.GetFullPath(packedRoot)}'. Use a path that stays within the packed artefact payload.");
+            }
+
+            return resolved;
+        }
+
+        var rooted = Path.GetFullPath(raw);
+        var resolvedOutputRoot = Path.GetFullPath(outputRoot);
+        if (!IsSameOrChildPath(resolvedOutputRoot, rooted))
+        {
+            throw new InvalidOperationException(
+                $"Packed artefact module paths must resolve under artefact output '{resolvedOutputRoot}', but got '{rooted}'.");
+        }
+
+        var relative = Path.GetRelativePath(resolvedOutputRoot, rooted);
+        if (string.IsNullOrWhiteSpace(relative) || relative == ".")
+            return packedRoot;
+
+        var mapped = Path.GetFullPath(Path.Combine(packedRoot, relative));
+        if (!IsSameOrChildPath(packedRoot, mapped))
+        {
+            throw new InvalidOperationException(
+                $"Packed artefact module path '{raw}' resolves outside the temporary packed artefact root '{Path.GetFullPath(packedRoot)}'. Use a path that stays within the packed artefact payload.");
+        }
+
+        return mapped;
+    }
+
     internal static string NormalizeDeliveryInternalsPath(string? configuredPath)
     {
         var normalized = PathValueResolver.Clean(configuredPath ?? string.Empty);
         return string.IsNullOrWhiteSpace(normalized) ? "Internals" : normalized;
+    }
+
+    private static bool IsSameOrChildPath(string rootPath, string candidatePath)
+    {
+        var root = Path.GetFullPath(rootPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidate = Path.GetFullPath(candidatePath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (string.Equals(root, candidate, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var rootWithSeparator = root + Path.DirectorySeparatorChar;
+        var candidateWithSeparator = candidate + Path.DirectorySeparatorChar;
+        return candidateWithSeparator.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge/Services/ArtefactLayoutPathResolver.cs
+++ b/PowerForge/Services/ArtefactLayoutPathResolver.cs
@@ -129,7 +129,7 @@ internal static class ArtefactLayoutPathResolver
                 $"Packed artefact module paths must resolve under artefact output '{resolvedOutputRoot}', but got '{rooted}'.");
         }
 
-        var relative = Path.GetRelativePath(resolvedOutputRoot, rooted);
+        var relative = FrameworkCompatibility.GetRelativePath(resolvedOutputRoot, rooted);
         if (string.IsNullOrWhiteSpace(relative) || relative == ".")
             return packedRoot;
 


### PR DESCRIPTION
## Summary
- add unified release validation that rejects module artefact output roots containing release staging or project-build output/package paths
- keep intentional staged-module reuse working by allowing artefacts under release category folders, while blocking destructive parent/equal roots
- add a regression test for a Mailozaurr-shaped Artefacts parent collision and prove the package output survives the guard

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --framework net10.0 --filter "FullyQualifiedName~ModulePipelineUnifiedRelease"
- git diff --check
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --framework net10.0 (first run had an isolated CLI JSON parse failure; exact test passed on rerun; full suite rerun passed 2470 tests)