### PR TITLE
Keep module and package release versions separate

### DIFF
--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -420,7 +420,7 @@ public sealed partial class ModulePipelineRunner
         if (useAsReleaseVersionSource && !runsBeforeModule)
         {
             throw new InvalidOperationException(
-                $"{laneType} lane '{laneLabel}' uses UseAsReleaseVersionSource and must run before the module build so the module manifest, stage-root tokens, and GitHub tag can use the resolved package version.");
+                $"{laneType} lane '{laneLabel}' uses UseAsReleaseVersionSource and must run before the module build so release coordination can use the resolved package version.");
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -382,7 +382,6 @@ public sealed partial class ModulePipelineRunner
                 cfg.Name ?? cfg.ConfigPath ?? "ProjectBuild",
                 "ProjectBuild",
                 cfg.BuildBeforeModule,
-                cfg.UseAsReleaseVersionSource,
                 cfg.ProvideLocalNuGetFeed);
         }
 
@@ -397,7 +396,6 @@ public sealed partial class ModulePipelineRunner
                 cfg.Name ?? cfg.RootPath ?? "PackageBuild",
                 "PackageBuild",
                 cfg.BuildBeforeModule,
-                cfg.UseAsReleaseVersionSource,
                 cfg.ProvideLocalNuGetFeed);
         }
     }
@@ -407,7 +405,6 @@ public sealed partial class ModulePipelineRunner
         string laneLabel,
         string laneType,
         bool buildBeforeModule,
-        bool useAsReleaseVersionSource,
         bool provideLocalNuGetFeed)
     {
         var runsBeforeModule = ShouldRunPackageBuildBeforeModule(plan, buildBeforeModule);
@@ -415,12 +412,6 @@ public sealed partial class ModulePipelineRunner
         {
             throw new InvalidOperationException(
                 $"{laneType} lane '{laneLabel}' uses ProvideLocalNuGetFeed and must run before the module build. Set BuildBeforeModule to true or configure Release BuildOrder so PackageBuild runs before Module.");
-        }
-
-        if (useAsReleaseVersionSource && !runsBeforeModule)
-        {
-            throw new InvalidOperationException(
-                $"{laneType} lane '{laneLabel}' uses UseAsReleaseVersionSource and must run before the module build so release coordination can use the resolved package version.");
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -358,6 +358,8 @@ public sealed partial class ModulePipelineRunner
         var moduleAssets = CollectModuleReleaseAssets(state.ArtefactResults, publishId);
         var packageAssets = CollectPackageReleaseAssets(state.ProjectBuildResults);
         var allAssets = moduleAssets.Concat(packageAssets).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        var moduleVersion = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
+        var releaseVersion = ResolveRequestedPackageReleaseVersion(plan, state) ?? moduleVersion;
 
         var stageRoot = ResolveReleaseStageRoot(plan, plan.Release.Configuration);
         string[] finalAssets;
@@ -367,12 +369,14 @@ public sealed partial class ModulePipelineRunner
         }
         else
         {
-            finalAssets = StageUnifiedReleaseAssets(plan, stageRoot!, moduleAssets, packageAssets);
+            finalAssets = StageUnifiedReleaseAssets(plan, stageRoot!, moduleAssets, packageAssets, releaseVersion);
         }
 
         return new ModuleReleaseCoordinationResult
         {
             StageRoot = stageRoot ?? string.Empty,
+            ModuleVersion = moduleVersion,
+            ReleaseVersion = releaseVersion,
             ModuleAssetPaths = string.IsNullOrWhiteSpace(stageRoot)
                 ? moduleAssets
                 : finalAssets.Where(path => IsPathBelow(path, Path.Combine(stageRoot!, "modules"))).ToArray(),
@@ -533,7 +537,8 @@ public sealed partial class ModulePipelineRunner
         ModulePipelinePlan plan,
         string stageRoot,
         IReadOnlyList<string> moduleAssets,
-        IReadOnlyList<string> packageAssets)
+        IReadOnlyList<string> packageAssets,
+        string releaseVersion)
     {
         var staged = new List<string>();
         var stagedSourcesByPath = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -542,7 +547,7 @@ public sealed partial class ModulePipelineRunner
         foreach (var asset in packageAssets)
             staged.Add(StageReleaseAsset(stageRoot, "nuget", asset, stagedSourcesByPath));
 
-        staged.AddRange(WriteReleaseMetadata(plan, stageRoot, staged));
+        staged.AddRange(WriteReleaseMetadata(plan, stageRoot, staged, releaseVersion));
         return staged.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
@@ -584,7 +589,7 @@ public sealed partial class ModulePipelineRunner
         return fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string[] WriteReleaseMetadata(ModulePipelinePlan plan, string stageRoot, IReadOnlyList<string> stagedAssets)
+    private static string[] WriteReleaseMetadata(ModulePipelinePlan plan, string stageRoot, IReadOnlyList<string> stagedAssets, string releaseVersion)
     {
         var metadataRoot = Path.Combine(stageRoot, "metadata");
         Directory.CreateDirectory(metadataRoot);
@@ -602,10 +607,13 @@ public sealed partial class ModulePipelineRunner
             .ToArray();
 
         var manifestPath = Path.Combine(metadataRoot, "release-manifest.json");
+        var moduleVersion = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
         var manifest = new
         {
             moduleName = plan.ModuleName,
-            version = ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease),
+            version = moduleVersion,
+            moduleVersion,
+            releaseVersion,
             generatedAtUtc = DateTimeOffset.UtcNow,
             assets = assetEntries
         };

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.ReleaseVersion.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.ReleaseVersion.cs
@@ -28,7 +28,12 @@ public sealed partial class ModulePipelineRunner
         {
             return release.VersionSource switch
             {
-                ReleaseVersionSource.Module => ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease),
+                ReleaseVersionSource.Module => ResolveCandidateVersion(
+                    state.ReleaseVersionCandidates,
+                    source: null,
+                    primaryProject: release.PrimaryProject,
+                    explicitOnly: true,
+                    required: false) ?? ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease),
                 ReleaseVersionSource.Manual => ResolveManualReleaseVersion(release),
                 ReleaseVersionSource.ProjectBuild => ResolveCandidateVersion(
                     state.ReleaseVersionCandidates,
@@ -52,6 +57,16 @@ public sealed partial class ModulePipelineRunner
             primaryProject: null,
             explicitOnly: true,
             required: false);
+    }
+
+    private static void ValidateRequestedReleaseVersion(
+        ModulePipelinePlan plan,
+        ModulePipelineRunState state)
+    {
+        if (plan.Release?.Configuration is null)
+            return;
+
+        _ = ResolveRequestedPackageReleaseVersion(plan, state);
     }
 
     private static string ResolveManualReleaseVersion(ReleaseConfiguration release)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.ReleaseVersion.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.ReleaseVersion.cs
@@ -19,27 +19,6 @@ public sealed partial class ModulePipelineRunner
             result));
     }
 
-    private void ApplyPackageReleaseVersionIfRequested(
-        ModulePipelinePlan plan,
-        ModulePipelineRunState state)
-    {
-        var resolved = ResolveRequestedPackageReleaseVersion(plan, state);
-        if (string.IsNullOrWhiteSpace(resolved))
-            return;
-
-        var version = SplitReleaseVersion(resolved!);
-        if (string.Equals(plan.ResolvedVersion, version.ModuleVersion, StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(plan.PreRelease, version.PreRelease, StringComparison.OrdinalIgnoreCase))
-        {
-            return;
-        }
-
-        plan.ResolvedVersion = version.ModuleVersion;
-        plan.PreRelease = version.PreRelease;
-        plan.BuildSpec.Version = version.ModuleVersion;
-        _logger.Info($"Release: using package/project build version '{resolved}' as the module release version.");
-    }
-
     private static string? ResolveRequestedPackageReleaseVersion(
         ModulePipelinePlan plan,
         ModulePipelineRunState state)
@@ -49,12 +28,7 @@ public sealed partial class ModulePipelineRunner
         {
             return release.VersionSource switch
             {
-                ReleaseVersionSource.Module => ResolveCandidateVersion(
-                    state.ReleaseVersionCandidates,
-                    source: null,
-                    primaryProject: release.PrimaryProject,
-                    explicitOnly: true,
-                    required: false),
+                ReleaseVersionSource.Module => ModulePathTokenFormatter.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease),
                 ReleaseVersionSource.Manual => ResolveManualReleaseVersion(release),
                 ReleaseVersionSource.ProjectBuild => ResolveCandidateVersion(
                     state.ReleaseVersionCandidates,
@@ -181,24 +155,6 @@ public sealed partial class ModulePipelineRunner
         return null;
     }
 
-    private static ModuleReleaseVersion SplitReleaseVersion(string version)
-    {
-        var normalized = version.Trim();
-        var metadataIndex = normalized.IndexOf('+');
-        if (metadataIndex >= 0)
-            normalized = normalized.Substring(0, metadataIndex);
-
-        var prereleaseIndex = normalized.IndexOf('-');
-        if (prereleaseIndex < 0)
-            return new ModuleReleaseVersion(normalized, preRelease: null);
-
-        var moduleVersion = normalized.Substring(0, prereleaseIndex).Trim();
-        var preRelease = normalized.Substring(prereleaseIndex + 1).Trim();
-        return new ModuleReleaseVersion(
-            moduleVersion,
-            string.IsNullOrWhiteSpace(preRelease) ? null : preRelease);
-    }
-
     private static string BuildMissingReleaseVersionMessage(
         ReleaseVersionSource? source,
         string? primaryProject,
@@ -213,15 +169,4 @@ public sealed partial class ModulePipelineRunner
         return $"Release version source '{sourceText}'{primaryText}{explicitText} did not produce a resolved version.";
     }
 
-    private readonly struct ModuleReleaseVersion
-    {
-        public ModuleReleaseVersion(string moduleVersion, string? preRelease)
-        {
-            ModuleVersion = moduleVersion;
-            PreRelease = preRelease;
-        }
-
-        public string ModuleVersion { get; }
-        public string? PreRelease { get; }
-    }
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -682,6 +682,7 @@ public sealed partial class ModulePipelineRunner
         ExecuteActions(ModulePipelineActionStage.AfterArtefacts, plan, session, state);
 
         ExecutePackageBuildsAfterModule(plan, session, state);
+        ValidateRequestedReleaseVersion(plan, state);
 
         ExecuteActions(ModulePipelineActionStage.BeforePublish, plan, session, state);
         ExecutePublishOperations(plan, session, buildResult, state);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.Phases.cs
@@ -18,7 +18,6 @@ public sealed partial class ModulePipelineRunner
         ExecuteActions(ModulePipelineActionStage.AfterDependencies, plan, session, state);
 
         ExecutePackageBuildsBeforeModule(plan, session, state);
-        ApplyPackageReleaseVersionIfRequested(plan, state);
 
         ExecuteActions(ModulePipelineActionStage.BeforeVersioning, plan, session, state);
         SyncSourceProjectVersionIfRequested(plan);

--- a/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
@@ -306,7 +306,7 @@ public sealed partial class ModulePipelinePackageBuildTests
     }
 
     [Fact]
-    public void Run_RejectsLatePackageReleaseVersionSourceLane()
+    public void Run_AllowsLatePackageReleaseVersionSourceLane()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -314,6 +314,7 @@ public sealed partial class ModulePipelinePackageBuildTests
             const string moduleName = "TestModule";
             WriteMinimalModule(root.FullName, moduleName, "1.0.0");
 
+            var packageBuildCalls = 0;
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
                 powerShellRunner: null,
@@ -322,7 +323,25 @@ public sealed partial class ModulePipelinePackageBuildTests
                 manifestMutator: null,
                 missingFunctionAnalysisService: null,
                 scriptFunctionExportDetector: null,
-                packageBuildExecutor: (request, configuration, configPath) => throw new InvalidOperationException("Package build should not run."));
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    packageBuildCalls++;
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = new DotNetRepositoryReleaseResult
+                            {
+                                Success = true,
+                                ResolvedVersion = "3.4.5"
+                            }
+                        }
+                    };
+                });
 
             var spec = new ModulePipelineSpec
             {
@@ -342,14 +361,24 @@ public sealed partial class ModulePipelinePackageBuildTests
                             RootPath = "Sources",
                             UseAsReleaseVersionSource = true
                         }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(root.FullName, "Artifacts", "Unified"),
+                            VersionSource = ReleaseVersionSource.PackageBuild
+                        }
                     }
                 }
             };
 
-            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+            var result = runner.Run(spec);
 
-            Assert.Contains("UseAsReleaseVersionSource", ex.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("must run before the module build", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(1, packageBuildCalls);
+            Assert.NotNull(result.ReleaseCoordinationResult);
+            Assert.Equal("1.0.0", result.ReleaseCoordinationResult!.ModuleVersion);
+            Assert.Equal("3.4.5", result.ReleaseCoordinationResult.ReleaseVersion);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -244,7 +244,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
     }
 
     [Fact]
-    public void Run_UsesPackageLaneAsReleaseVersionSourceWithoutChangingModuleVersion()
+    public void Run_UsesExplicitPackageLaneAsDefaultReleaseVersionSourceWithoutChangingModuleVersion()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
@@ -303,8 +303,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                     {
                         Configuration = new ReleaseConfiguration
                         {
-                            StageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", "<ModuleName>", "<ModuleVersion>"),
-                            VersionSource = ReleaseVersionSource.PackageBuild
+                            StageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", "<ModuleName>", "<ModuleVersion>")
                         }
                     }
                 }
@@ -318,6 +317,71 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.NotNull(result.ReleaseCoordinationResult);
             Assert.Equal("1.0.0", result.ReleaseCoordinationResult!.ModuleVersion);
             Assert.Equal("3.4.5", result.ReleaseCoordinationResult.ReleaseVersion);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_ValidatesReleaseVersionSourceBeforeModulePublish()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var hostedOperations = new FakeHostedOperations(new List<string>());
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: hostedOperations,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null);
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0",
+                    StagingPath = stagingPath
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(root.FullName, "Artifacts", "Unified"),
+                            VersionSource = ReleaseVersionSource.PackageBuild
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Enabled = true,
+                            Destination = PublishDestination.PowerShellGallery,
+                            RepositoryName = "PSGallery",
+                            ApiKey = "gallery-token"
+                        }
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() => runner.Run(spec));
+
+            Assert.Contains("Release version source 'PackageBuild'", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Empty(hostedOperations.PublishedModuleVersions);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using Xunit;
 
 namespace PowerForge.Tests;
@@ -67,7 +68,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                         Succeeded = true,
                         ReleaseCreationSucceeded = true,
                         AllAssetUploadsSucceeded = true,
-                        HtmlUrl = "https://github.com/EvotecIT/TestModule/releases/tag/v2.0.1-beta1"
+                        HtmlUrl = "https://github.com/EvotecIT/TestModule/releases/tag/v1.2.3"
                     };
                 });
 
@@ -131,22 +132,23 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.NotNull(gitHubRequest);
             Assert.Equal("EvotecIT", gitHubRequest!.Owner);
             Assert.Equal("TestModule", gitHubRequest.Repository);
-            Assert.Equal("v2.0.1-beta1", gitHubRequest.TagName);
-            Assert.True(gitHubRequest.IsPreRelease);
+            Assert.Equal("v1.2.3", gitHubRequest.TagName);
+            Assert.False(gitHubRequest.IsPreRelease);
             Assert.True(gitHubRequest.GenerateReleaseNotes);
-            Assert.Equal("2.0.1", result.Plan.ResolvedVersion);
-            Assert.Equal("beta1", result.Plan.PreRelease);
-            Assert.Equal("2.0.1", result.Plan.BuildSpec.Version);
+            Assert.Equal("1.2.3", result.Plan.ResolvedVersion);
+            Assert.Null(result.Plan.PreRelease);
+            Assert.Equal("1.2.3", result.Plan.BuildSpec.Version);
             var projectManifestPath = Path.Combine(root.FullName, $"{moduleName}.psd1");
             var projectManifest = File.ReadAllText(projectManifestPath);
-            Assert.Contains("ModuleVersion = '2.0.1'", projectManifest, StringComparison.Ordinal);
+            Assert.Contains("ModuleVersion = '1.2.3'", projectManifest, StringComparison.Ordinal);
             Assert.False(ManifestEditor.TryGetTopLevelString(projectManifestPath, "Prerelease", out _));
-            Assert.True(ManifestEditor.TryGetPsDataStringArray(projectManifestPath, "Prerelease", out var prerelease));
-            Assert.Equal(new[] { "beta1" }, prerelease);
+            Assert.False(ManifestEditor.TryGetPsDataStringArray(projectManifestPath, "Prerelease", out _));
 
-            var resolvedStageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", moduleName, "2.0.1");
+            var resolvedStageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", moduleName, "1.2.3");
             Assert.NotNull(result.ReleaseCoordinationResult);
             Assert.Equal(Path.GetFullPath(resolvedStageRoot), result.ReleaseCoordinationResult!.StageRoot);
+            Assert.Equal("1.2.3", result.ReleaseCoordinationResult.ModuleVersion);
+            Assert.Equal("2.0.1-beta1+build.7", result.ReleaseCoordinationResult.ReleaseVersion);
             Assert.Equal(4, gitHubRequest.AssetFilePaths.Count);
             Assert.Contains(gitHubRequest.AssetFilePaths, path => path.StartsWith(Path.Combine(resolvedStageRoot, "modules"), StringComparison.OrdinalIgnoreCase));
             Assert.Contains(gitHubRequest.AssetFilePaths, path => string.Equals(path, Path.Combine(resolvedStageRoot, "nuget", Path.GetFileName(packagePath)), StringComparison.OrdinalIgnoreCase));
@@ -154,7 +156,10 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.Contains(gitHubRequest.AssetFilePaths, path => string.Equals(path, Path.Combine(resolvedStageRoot, "metadata", "SHA256SUMS.txt"), StringComparison.OrdinalIgnoreCase));
             Assert.All(gitHubRequest.AssetFilePaths, path => Assert.True(File.Exists(path), path));
             var manifestJson = File.ReadAllText(Path.Combine(resolvedStageRoot, "metadata", "release-manifest.json"));
-            Assert.Contains("\"version\": \"2.0.1-beta1\"", manifestJson, StringComparison.Ordinal);
+            using var releaseManifest = JsonDocument.Parse(manifestJson);
+            Assert.Equal("1.2.3", releaseManifest.RootElement.GetProperty("version").GetString());
+            Assert.Equal("1.2.3", releaseManifest.RootElement.GetProperty("moduleVersion").GetString());
+            Assert.Equal("2.0.1-beta1+build.7", releaseManifest.RootElement.GetProperty("releaseVersion").GetString());
             Assert.Contains("HtmlTinkerX.2.0.1-beta1.nupkg", manifestJson, StringComparison.Ordinal);
             Assert.Contains("nuget/HtmlTinkerX.2.0.1-beta1.nupkg", File.ReadAllText(Path.Combine(resolvedStageRoot, "metadata", "SHA256SUMS.txt")), StringComparison.Ordinal);
             Assert.Single(result.PublishResults);
@@ -167,7 +172,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
     }
 
     [Fact]
-    public void Run_UsesExplicitPackageLaneAsReleaseVersionSourceWithoutReleaseSegment()
+    public void Run_DoesNotUseExplicitPackageLaneAsModuleVersionSourceWithoutReleaseSegment()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
@@ -227,9 +232,9 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
 
             var result = runner.Run(spec);
 
-            Assert.Equal("3.4.5", result.Plan.ResolvedVersion);
-            Assert.Equal("3.4.5", result.Plan.BuildSpec.Version);
-            Assert.Contains("ModuleVersion = '3.4.5'", File.ReadAllText(result.BuildResult.ManifestPath), StringComparison.Ordinal);
+            Assert.Equal("1.0.0", result.Plan.ResolvedVersion);
+            Assert.Equal("1.0.0", result.Plan.BuildSpec.Version);
+            Assert.Contains("ModuleVersion = '1.0.0'", File.ReadAllText(result.BuildResult.ManifestPath), StringComparison.Ordinal);
         }
         finally
         {
@@ -239,7 +244,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
     }
 
     [Fact]
-    public void Run_UsesExplicitPackageLaneAsReleaseVersionSourceWithReleaseSegment()
+    public void Run_UsesPackageLaneAsReleaseVersionSourceWithoutChangingModuleVersion()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
@@ -298,7 +303,8 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                     {
                         Configuration = new ReleaseConfiguration
                         {
-                            StageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", "<ModuleName>", "<ModuleVersion>")
+                            StageRoot = Path.Combine(root.FullName, "Artifacts", "Unified", "<ModuleName>", "<ModuleVersion>"),
+                            VersionSource = ReleaseVersionSource.PackageBuild
                         }
                     }
                 }
@@ -306,9 +312,126 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
 
             var result = runner.Run(spec);
 
-            Assert.Equal("3.4.5", result.Plan.ResolvedVersion);
-            Assert.Equal("3.4.5", result.Plan.BuildSpec.Version);
-            Assert.Contains("ModuleVersion = '3.4.5'", File.ReadAllText(result.BuildResult.ManifestPath), StringComparison.Ordinal);
+            Assert.Equal("1.0.0", result.Plan.ResolvedVersion);
+            Assert.Equal("1.0.0", result.Plan.BuildSpec.Version);
+            Assert.Contains("ModuleVersion = '1.0.0'", File.ReadAllText(result.BuildResult.ManifestPath), StringComparison.Ordinal);
+            Assert.NotNull(result.ReleaseCoordinationResult);
+            Assert.Equal("1.0.0", result.ReleaseCoordinationResult!.ModuleVersion);
+            Assert.Equal("3.4.5", result.ReleaseCoordinationResult.ReleaseVersion);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Run_UsesProjectBuildReleaseVersionWithoutChangingModulePublishVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "Mailozaurr";
+            WriteMinimalModule(root.FullName, moduleName, "2.1.6");
+            WriteProjectBuildConfig(root.FullName, Path.Combine("Build", "project.build.json"));
+
+            var packageOutput = Path.Combine(root.FullName, "Artifacts", "NuGet");
+            var packagePath = Path.Combine(packageOutput, "Mailozaurr.2.0.11.nupkg");
+            var hostedOperations = new FakeHostedOperations(new List<string>());
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: hostedOperations,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    Directory.CreateDirectory(packageOutput);
+                    File.WriteAllText(packagePath, "package");
+
+                    var release = new DotNetRepositoryReleaseResult { Success = true, ResolvedVersion = "2.0.11" };
+                    release.ResolvedVersionsByProject[moduleName] = "2.0.11";
+                    var project = new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = moduleName,
+                        PackageId = moduleName,
+                        IsPackable = true,
+                        NewVersion = "2.0.11"
+                    };
+                    project.Packages.Add(packagePath);
+                    release.Projects.Add(project);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        OutputPath = packageOutput,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "2.1.6",
+                    StagingPath = stagingPath
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationProjectBuildSegment
+                    {
+                        Configuration = new ProjectBuildConfigurationReference
+                        {
+                            Name = moduleName,
+                            ConfigPath = Path.Combine("Build", "project.build.json"),
+                            BuildBeforeModule = true,
+                            UseAsReleaseVersionSource = true
+                        }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(root.FullName, "Artifacts", "Unified"),
+                            VersionSource = ReleaseVersionSource.ProjectBuild,
+                            PrimaryProject = moduleName
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Enabled = true,
+                            Destination = PublishDestination.PowerShellGallery,
+                            RepositoryName = "PSGallery",
+                            ApiKey = "gallery-token"
+                        }
+                    }
+                }
+            };
+
+            var result = runner.Run(spec);
+
+            Assert.Equal("2.1.6", result.Plan.ResolvedVersion);
+            Assert.Equal("2.1.6", result.Plan.BuildSpec.Version);
+            Assert.Contains("ModuleVersion = '2.1.6'", File.ReadAllText(result.BuildResult.ManifestPath), StringComparison.Ordinal);
+            Assert.NotNull(result.ReleaseCoordinationResult);
+            Assert.Equal("2.1.6", result.ReleaseCoordinationResult!.ModuleVersion);
+            Assert.Equal("2.0.11", result.ReleaseCoordinationResult.ReleaseVersion);
+            Assert.Equal(new[] { "2.1.6" }, hostedOperations.PublishedModuleVersions);
         }
         finally
         {
@@ -1015,6 +1138,23 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
         File.WriteAllText(Path.Combine(moduleRoot, $"{moduleName}.psd1"), psd1);
     }
 
+    private static void WriteProjectBuildConfig(string rootPath, string relativePath)
+    {
+        var path = Path.Combine(rootPath, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(
+            path,
+            string.Join(Environment.NewLine, new[]
+            {
+                "{",
+                "  \"RootPath\": \"Sources\",",
+                "  \"Build\": true,",
+                "  \"PublishNuget\": false,",
+                "  \"PublishGitHub\": false",
+                "}"
+            }));
+    }
+
     private sealed class FakeHostedOperations : IModulePipelineHostedOperations
     {
         private readonly List<string> _events;
@@ -1023,6 +1163,8 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
         {
             _events = events;
         }
+
+        public List<string> PublishedModuleVersions { get; } = new();
 
         public IReadOnlyList<ModuleDependencyInstallResult> EnsureDependenciesInstalled(
             ModuleDependency[] dependencies,
@@ -1062,6 +1204,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             bool includeScriptFolders)
         {
             _events.Add($"module:{publish.Destination}");
+            PublishedModuleVersions.Add(plan.ResolvedVersion);
             return new ModulePublishResult(
                 publish.Destination,
                 publish.RepositoryName,

--- a/PowerForge/Models/ModuleReleaseCoordinationResult.cs
+++ b/PowerForge/Models/ModuleReleaseCoordinationResult.cs
@@ -8,6 +8,12 @@ public sealed class ModuleReleaseCoordinationResult
     /// <summary>Configured or resolved release stage root. Empty when assets were not staged.</summary>
     public string StageRoot { get; set; } = string.Empty;
 
+    /// <summary>PowerShell module version used for module artefacts and module publishes.</summary>
+    public string ModuleVersion { get; set; } = string.Empty;
+
+    /// <summary>Coordinated release version selected from module, project-build, package-build, or manual release configuration.</summary>
+    public string ReleaseVersion { get; set; } = string.Empty;
+
     /// <summary>Module artifact paths included in the unified release payload.</summary>
     public string[] ModuleAssetPaths { get; set; } = Array.Empty<string>();
 


### PR DESCRIPTION
## Summary
- stop package/project release version sources from mutating the PowerShell module version, prerelease, PSD1, PSGallery publish version, or module GitHub tag
- keep unified release metadata explicit with moduleVersion and releaseVersion values
- add regressions for package-build and Mailozaurr-shaped project-build lanes where package version differs from module version

## Validation
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --framework net10.0 --filter "FullyQualifiedName~ModulePipelineUnifiedRelease"
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --framework net10.0 --filter "FullyQualifiedName=PowerForge.Tests.ModulePipelinePackageBuildTests.Run_RejectsLatePackageReleaseVersionSourceLane"
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --framework net10.0 (first run had the known WebStaticServer timeout; isolated rerun passed; full retry passed 2480/2480)
- dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --framework net10.0 --filter "FullyQualifiedName=PowerForge.Tests.WebStaticServerTests.ServeWithPortFallback_UsesNextAvailablePort_AndServesContent"
- dotnet build .\PowerForge\PowerForge.csproj -c Release -f net472 --nologo
- dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release -f net472 --nologo
- dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472 --nologo
- git diff --check
