### PR TITLE
Carry screenshot readiness into App Review submission

### DIFF
--- a/PSPublishModule/Cmdlets/SubmitAppStoreConnectVersionForReviewCommand.cs
+++ b/PSPublishModule/Cmdlets/SubmitAppStoreConnectVersionForReviewCommand.cs
@@ -1,4 +1,7 @@
+using System;
+using System.IO;
 using System.Management.Automation;
+using System.Text.Json;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -37,6 +40,18 @@ public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
     /// <summary>Apple platform for the Distribution version.</summary>
     [Parameter(Mandatory = true)] public ApplePlatform Platform { get; set; }
 
+    /// <summary>Localization locale to check during readiness.</summary>
+    [Parameter] public string Locale { get; set; } = "en-US";
+
+    /// <summary>Screenshot display types that must have screenshots during readiness.</summary>
+    [Parameter] public string[] RequiredScreenshotDisplayTypes { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Optional screenshot sync config used to derive required screenshot display types during readiness.</summary>
+    [Parameter] public string? ScreenshotConfigPath { get; set; }
+
+    /// <summary>Minimum screenshot count for each required display type.</summary>
+    [Parameter] public int MinimumScreenshotsPerSet { get; set; } = 1;
+
     /// <summary>Allow submission without verifying that the requested build is selected on the Distribution version.</summary>
     [Parameter] public SwitchParameter AllowUnselectedBuild { get; set; }
 
@@ -58,6 +73,7 @@ public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
 
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        var screenshotSpec = ResolveScreenshotSpec();
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectReviewSubmissionService(client);
         var result = service.SubmitAsync(new AppStoreConnectReviewSubmissionRequest
@@ -69,9 +85,46 @@ public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
             RequireSelectedBuild = !AllowUnselectedBuild.IsPresent,
             RequireValidBuild = !AllowUnprocessedBuild.IsPresent,
             CheckReadiness = !SkipReadinessCheck.IsPresent,
-            RequireReady = !AllowNotReady.IsPresent
+            RequireReady = !AllowNotReady.IsPresent,
+            ReadinessRequest = new AppStoreConnectReleaseReadinessRequest
+            {
+                Locale = Locale,
+                RequiredScreenshotDisplayTypes = RequiredScreenshotDisplayTypes,
+                MinimumScreenshotsPerSet = MinimumScreenshotsPerSet,
+                ScreenshotSpec = screenshotSpec
+            }
         }).GetAwaiter().GetResult();
 
         WriteObject(result);
+    }
+
+    private AppStoreConnectScreenshotSyncSpec? ResolveScreenshotSpec()
+    {
+        if (string.IsNullOrWhiteSpace(ScreenshotConfigPath))
+            return null;
+
+        var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(ScreenshotConfigPath);
+        var json = File.ReadAllText(resolvedPath);
+        var spec = JsonSerializer.Deserialize<AppStoreConnectScreenshotSyncSpec>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        }) ?? throw new InvalidOperationException($"Unable to deserialize screenshot sync config: {resolvedPath}");
+
+        var specAppId = string.IsNullOrWhiteSpace(spec.AppId) ? null : spec.AppId!.Trim();
+        var specVersionString = string.IsNullOrWhiteSpace(spec.VersionString) ? null : spec.VersionString!.Trim();
+        var appId = AppId.Trim();
+        var versionString = VersionString.Trim();
+        if (specAppId is not null &&
+            !string.Equals(specAppId, appId, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Screenshot config '{resolvedPath}' targets app '{spec.AppId}', not '{AppId}'.");
+
+        if (specVersionString is not null &&
+            !string.Equals(specVersionString, versionString, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Screenshot config '{resolvedPath}' targets version '{spec.VersionString}', not '{VersionString}'.");
+
+        if (spec.Platform != Platform)
+            throw new InvalidOperationException($"Screenshot config '{resolvedPath}' targets platform '{spec.Platform}', not '{Platform}'.");
+
+        return spec;
     }
 }

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -915,6 +915,111 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_PassesScreenshotSpecToReviewReadiness()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj", "1.0.2", "6");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            var screenshotConfigPath = Path.Combine(root, "appstoreconnect-screenshots-ios.json");
+            File.WriteAllText(keyPath, "private-key");
+            File.WriteAllText(screenshotConfigPath, """
+{
+  "appId": "app-1",
+  "versionString": "1.0.2",
+  "platform": "iOS",
+  "locale": "en-US",
+  "screenshotSets": [
+    {
+      "screenshotDisplayType": "APP_IPHONE_67",
+      "path": "../build/appstore-screenshots/upload/iphone-6-9-1320x2868",
+      "filter": "*.png"
+    },
+    {
+      "screenshotDisplayType": "APP_IPAD_PRO_3GEN_129",
+      "path": "../build/appstore-screenshots/upload/ipad-13-2064x2752",
+      "filter": "*.png"
+    }
+  ]
+}
+""");
+            var reviewRequests = new List<AppStoreConnectReviewSubmissionRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Archive should not run."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."),
+                submitAppleReview: request =>
+                {
+                    reviewRequests.Add(request);
+                    return new AppStoreConnectReviewSubmissionResult
+                    {
+                        AppId = request.AppId,
+                        VersionString = request.VersionString,
+                        BuildNumber = request.BuildNumber,
+                        Platform = request.Platform,
+                        ReviewSubmission = new AppStoreConnectReviewSubmissionInfo
+                        {
+                            Id = "submission-1",
+                            Platform = "IOS",
+                            IsSubmitted = true,
+                            State = "WAITING_FOR_REVIEW"
+                        }
+                    };
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        SubmitForReview = true,
+                        ScreenshotConfigPaths = new[] { screenshotConfigPath },
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.True(result.Success);
+            var request = Assert.Single(reviewRequests);
+            Assert.True(request.CheckReadiness);
+            Assert.NotNull(request.ReadinessRequest?.ScreenshotSpec);
+            Assert.Equal(new[] { "APP_IPHONE_67", "APP_IPAD_PRO_3GEN_129" },
+                request.ReadinessRequest!.ScreenshotSpec!.ScreenshotSets.Select(set => set.ScreenshotDisplayType).ToArray());
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_AcceptsApprovedVersionReleaseInUnifiedPlan()
     {
         var root = CreateSandbox();

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -906,7 +906,10 @@ internal sealed class PowerForgeReleaseService
     private PowerForgeAppleAppReleaseResult[] RunAppleRelease(PowerForgeAppleReleasePlan plan)
     {
         var results = new List<PowerForgeAppleAppReleaseResult>();
-        var screenshotSpecs = plan.SyncScreenshots
+        var needsScreenshotSpecs = plan.SyncScreenshots ||
+                                   plan.CheckReleaseReadiness ||
+                                   (plan.SubmitForReview && !plan.SkipReviewReadinessCheck);
+        var screenshotSpecs = needsScreenshotSpecs
             ? LoadAppleScreenshotSpecs(plan)
             : Array.Empty<(AppStoreConnectScreenshotSyncSpec Spec, string ConfigPath)>();
         var metadataSpecs = plan.SyncMetadata
@@ -982,7 +985,7 @@ internal sealed class PowerForgeReleaseService
             if ((plan.PrepareDistribution || plan.SyncScreenshots || plan.SyncMetadata || plan.CheckReleaseReadiness) && result.Success)
             {
                 var distributionValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
-                var matchingScreenshotSpec = plan.SyncScreenshots
+                var matchingScreenshotSpec = plan.SyncScreenshots || plan.CheckReleaseReadiness
                     ? ResolveMatchingScreenshotSpec(screenshotSpecs, app, distributionValues.MarketingVersion)
                     : null;
                 var matchingMetadataSpec = plan.SyncMetadata
@@ -1034,6 +1037,9 @@ internal sealed class PowerForgeReleaseService
             if (plan.SubmitForReview && result.Success)
             {
                 var reviewValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
+                var matchingScreenshotSpec = !plan.SkipReviewReadinessCheck
+                    ? ResolveMatchingScreenshotSpec(screenshotSpecs, app, reviewValues.MarketingVersion)
+                    : null;
                 result.ReviewSubmission = _submitAppleReview(new AppStoreConnectReviewSubmissionRequest
                 {
                     Credential = CreateAppStoreConnectCredential(plan),
@@ -1044,7 +1050,13 @@ internal sealed class PowerForgeReleaseService
                     RequireSelectedBuild = !plan.AllowUnselectedReviewBuild,
                     RequireValidBuild = !plan.AllowUnprocessedReviewBuild,
                     CheckReadiness = !plan.SkipReviewReadinessCheck,
-                    RequireReady = !plan.AllowReviewSubmissionWhenNotReady
+                    RequireReady = !plan.AllowReviewSubmissionWhenNotReady,
+                    ReadinessRequest = matchingScreenshotSpec is null
+                        ? null
+                        : new AppStoreConnectReleaseReadinessRequest
+                        {
+                            ScreenshotSpec = matchingScreenshotSpec.Value.Spec
+                        }
                 });
             }
 


### PR DESCRIPTION
## Summary
- add screenshot readiness parameters to Submit-AppStoreConnectVersionForReview
- allow submit readiness to derive required screenshot display types from a screenshot sync config
- pass matching screenshot specs into unified Apple SubmitForReview release runs, including readiness-only runs without SyncScreenshots
- document today's Tactra/CasaRay release lesson in the local Apple release skill

## Validation
- dotnet build PowerForge.Tests/PowerForge.Tests.csproj --no-restore
- dotnet test PowerForge.Tests/PowerForge.Tests.csproj --no-build --filter "FullyQualifiedName~Execute_AppleApps_PassesScreenshotSpecToReviewReadiness|FullyQualifiedName~ReviewSubmission" --logger "console;verbosity=normal"
- dotnet build PSPublishModule/PSPublishModule.csproj -c Release --no-restore
- Submit-AppStoreConnectVersionForReview ... -ScreenshotConfigPath /Users/przemyslawklys/Documents/GitHub/CasaRay/scripts/appstoreconnect-screenshots-ios.json -WhatIf

## Release note
This avoids needing -SkipReadinessCheck after an explicit screenshot-aware readiness pass and keeps consumer repos thin.