### PR TITLE
Add TestFlight beta review submission flow

### DIFF
--- a/PSPublishModule/Cmdlets/SubmitAppStoreConnectTestFlightBuildForReviewCommand.cs
+++ b/PSPublishModule/Cmdlets/SubmitAppStoreConnectTestFlightBuildForReviewCommand.cs
@@ -1,0 +1,65 @@
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Submits a TestFlight build to Beta App Review for external testing.
+/// </summary>
+[Cmdlet(VerbsLifecycle.Submit, "AppStoreConnectTestFlightBuildForReview", SupportsShouldProcess = true)]
+[OutputType(typeof(AppStoreConnectBetaAppReviewSubmissionResult))]
+public sealed class SubmitAppStoreConnectTestFlightBuildForReviewCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    [Parameter(Mandatory = true)] public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number.</summary>
+    [Parameter(Mandatory = true)] public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the build.</summary>
+    [Parameter(Mandatory = true)] public ApplePlatform Platform { get; set; }
+
+    /// <summary>Allow submission when the build processing state is not VALID.</summary>
+    [Parameter] public SwitchParameter AllowUnprocessedBuild { get; set; }
+
+    /// <summary>Submits a TestFlight build to Beta App Review for external testing.</summary>
+    protected override void ProcessRecord()
+    {
+        var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
+        if (!ShouldProcess(target, "Submit App Store Connect TestFlight build to Beta App Review"))
+            return;
+
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectBetaAppReviewSubmissionService(client);
+        var result = service.SubmitAsync(new AppStoreConnectBetaAppReviewSubmissionRequest
+        {
+            AppId = AppId,
+            VersionString = VersionString,
+            BuildNumber = BuildNumber,
+            Platform = Platform,
+            RequireValidBuild = !AllowUnprocessedBuild.IsPresent
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -962,6 +962,113 @@ public sealed class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task BetaAppReviewSubmissionService_SubmitsBuildForExternalTesting()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-6",
+                      "type": "builds",
+                      "attributes": { "version": "6", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.2", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": null }"""),
+            new SequenceResponse(HttpStatusCode.Created,
+                """
+                {
+                  "data": {
+                    "id": "submission-6",
+                    "type": "betaAppReviewSubmissions",
+                    "attributes": { "betaReviewState": "WAITING_FOR_REVIEW" },
+                    "relationships": {
+                      "build": { "data": { "type": "builds", "id": "build-6" } }
+                    }
+                  }
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectBetaAppReviewSubmissionService(client);
+
+        var result = await service.SubmitAsync(new AppStoreConnectBetaAppReviewSubmissionRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.2",
+            BuildNumber = "6",
+            Platform = ApplePlatform.iOS
+        });
+
+        Assert.Equal("build-6", result.Build.Id);
+        Assert.Equal("submission-6", result.Submission.Id);
+        Assert.Equal("WAITING_FOR_REVIEW", result.Submission.BetaReviewState);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/builds/build-6/betaAppReviewSubmission", handler.RequestUris[1].ToString());
+        Assert.Equal(HttpMethod.Post, handler.Methods[2]);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaAppReviewSubmissions", handler.RequestUris[2].ToString());
+        Assert.Contains("\"type\":\"betaAppReviewSubmissions\"", handler.RequestBodies[2], StringComparison.Ordinal);
+        Assert.Contains("\"type\":\"builds\",\"id\":\"build-6\"", handler.RequestBodies[2], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BetaAppReviewSubmissionService_ReusesExistingSubmission()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-6",
+                      "type": "builds",
+                      "attributes": { "version": "6", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.2", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": {
+                    "id": "submission-6",
+                    "type": "betaAppReviewSubmissions",
+                    "attributes": { "betaReviewState": "APPROVED" },
+                    "relationships": {
+                      "build": { "data": { "type": "builds", "id": "build-6" } }
+                    }
+                  }
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectBetaAppReviewSubmissionService(client);
+
+        var result = await service.SubmitAsync(new AppStoreConnectBetaAppReviewSubmissionRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.2",
+            BuildNumber = "6",
+            Platform = ApplePlatform.iOS
+        });
+
+        Assert.Equal("submission-6", result.Submission.Id);
+        Assert.Equal("APPROVED", result.Submission.BetaReviewState);
+        Assert.Equal(2, handler.RequestUris.Count);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+    }
+
+    [Fact]
     public async Task ReviewSubmissionClient_CreatesItemAndSubmits()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -860,6 +860,145 @@ public sealed class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_AcceptsTestFlightBetaReviewSubmissionInUnifiedPlan()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+
+            var service = new PowerForgeReleaseService(new NullLogger());
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        SubmitTestFlightBetaReview = true,
+                        AllowUnprocessedTestFlightBuild = true,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.AppleAppPlan);
+            Assert.True(result.AppleAppPlan!.SubmitTestFlightBetaReview);
+            Assert.True(result.AppleAppPlan.AllowUnprocessedTestFlightBuild);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleApps_SubmitsTestFlightBetaReviewThroughSharedService()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj", "1.0.2", "6");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var betaReviewRequests = new List<AppStoreConnectBetaAppReviewSubmissionRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Archive should not run."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."),
+                submitTestFlightBetaReview: request =>
+                {
+                    betaReviewRequests.Add(request);
+                    return new AppStoreConnectBetaAppReviewSubmissionResult
+                    {
+                        AppId = request.AppId,
+                        VersionString = request.VersionString,
+                        BuildNumber = request.BuildNumber,
+                        Platform = request.Platform,
+                        Build = new AppStoreConnectBuildInfo { Id = "build-6", Version = request.BuildNumber },
+                        Submission = new AppStoreConnectBetaAppReviewSubmissionInfo
+                        {
+                            Id = "submission-6",
+                            BetaReviewState = "WAITING_FOR_REVIEW",
+                            BuildId = "build-6"
+                        }
+                    };
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        SubmitTestFlightBetaReview = true,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.True(result.Success);
+            var appResult = Assert.Single(result.AppleApps);
+            Assert.NotNull(appResult.TestFlightBetaReviewSubmission);
+            var request = Assert.Single(betaReviewRequests);
+            Assert.Equal("app-1", request.AppId);
+            Assert.Equal("1.0.2", request.VersionString);
+            Assert.Equal("6", request.BuildNumber);
+            Assert.Equal(ApplePlatform.iOS, request.Platform);
+            Assert.True(request.RequireValidBuild);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_AcceptsReviewSubmissionInUnifiedPlan()
     {
         var root = CreateSandbox();

--- a/PowerForge/Models/AppStoreConnectTestFlightModels.cs
+++ b/PowerForge/Models/AppStoreConnectTestFlightModels.cs
@@ -116,3 +116,72 @@ public sealed class AppStoreConnectTestFlightDistributionResult
     /// <summary>Distribution messages useful for release logs.</summary>
     public string[] Messages { get; set; } = Array.Empty<string>();
 }
+
+/// <summary>
+/// App Store Connect Beta App Review submission summary.
+/// </summary>
+public sealed class AppStoreConnectBetaAppReviewSubmissionInfo
+{
+    /// <summary>Beta App Review submission id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Current beta review state reported by App Store Connect.</summary>
+    public string? BetaReviewState { get; set; }
+
+    /// <summary>Date the beta submission was submitted, when reported by App Store Connect.</summary>
+    public DateTimeOffset? SubmittedDate { get; set; }
+
+    /// <summary>Build id associated with the beta submission when included.</summary>
+    public string? BuildId { get; set; }
+}
+
+/// <summary>
+/// Request to submit a TestFlight build to Beta App Review for external testing.
+/// </summary>
+public sealed class AppStoreConnectBetaAppReviewSubmissionRequest
+{
+    /// <summary>App Store Connect API credential. Required when the request is executed by the default release runner.</summary>
+    public AppStoreConnectApiCredential? Credential { get; set; }
+
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number.</summary>
+    public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the build.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Require the build to be valid and not expired before Beta App Review submission.</summary>
+    public bool RequireValidBuild { get; set; } = true;
+}
+
+/// <summary>
+/// Result of submitting a TestFlight build to Beta App Review.
+/// </summary>
+public sealed class AppStoreConnectBetaAppReviewSubmissionResult
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version.</summary>
+    public string VersionString { get; set; } = string.Empty;
+
+    /// <summary>Uploaded build number.</summary>
+    public string BuildNumber { get; set; } = string.Empty;
+
+    /// <summary>Apple platform for the submission.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Matched build.</summary>
+    public AppStoreConnectBuildInfo Build { get; set; } = new();
+
+    /// <summary>Beta App Review submission created or reused by the operation.</summary>
+    public AppStoreConnectBetaAppReviewSubmissionInfo Submission { get; set; } = new();
+
+    /// <summary>Submission messages useful for release logs.</summary>
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -342,6 +342,8 @@ internal sealed class PowerForgeAppleReleaseOptions
 
     public bool AllowUnprocessedTestFlightBuild { get; set; }
 
+    public bool SubmitTestFlightBetaReview { get; set; }
+
     public bool SubmitForReview { get; set; }
 
     public bool AllowUnselectedReviewBuild { get; set; }
@@ -402,6 +404,8 @@ internal sealed class PowerForgeAppleReleasePlan
     public bool CreateMissingTestFlightTesters { get; set; } = true;
 
     public bool AllowUnprocessedTestFlightBuild { get; set; }
+
+    public bool SubmitTestFlightBetaReview { get; set; }
 
     public bool SubmitForReview { get; set; }
 
@@ -488,6 +492,8 @@ internal sealed class PowerForgeAppleAppReleaseResult
     public AppStoreConnectReleasePreparationResult? Distribution { get; set; }
 
     public AppStoreConnectTestFlightDistributionResult? TestFlight { get; set; }
+
+    public AppStoreConnectBetaAppReviewSubmissionResult? TestFlightBetaReviewSubmission { get; set; }
 
     public AppStoreConnectReviewSubmissionResult? ReviewSubmission { get; set; }
 

--- a/PowerForge/Services/AppStoreConnectBetaAppReviewSubmissionService.cs
+++ b/PowerForge/Services/AppStoreConnectBetaAppReviewSubmissionService.cs
@@ -1,0 +1,81 @@
+namespace PowerForge;
+
+/// <summary>
+/// Submits TestFlight builds to Beta App Review for external testing.
+/// </summary>
+public sealed class AppStoreConnectBetaAppReviewSubmissionService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Initializes a Beta App Review submission service.
+    /// </summary>
+    public AppStoreConnectBetaAppReviewSubmissionService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Submits a processed build to Beta App Review, reusing an existing submission when App Store Connect already has one.
+    /// </summary>
+    public async Task<AppStoreConnectBetaAppReviewSubmissionResult> SubmitAsync(
+        AppStoreConnectBetaAppReviewSubmissionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrWhiteSpace(request.AppId))
+            throw new ArgumentException("AppId is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.VersionString))
+            throw new ArgumentException("VersionString is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.BuildNumber))
+            throw new ArgumentException("BuildNumber is required.", nameof(request));
+
+        var appId = request.AppId.Trim();
+        var versionString = request.VersionString.Trim();
+        var buildNumber = request.BuildNumber.Trim();
+        var messages = new List<string>();
+
+        var build = (await _client.GetBuildsAsync(
+            appId,
+            buildNumber,
+            limit: 20,
+            marketingVersion: versionString,
+            platform: request.Platform,
+            cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault()
+            ?? throw new InvalidOperationException($"Build '{buildNumber}' was not found for app '{appId}', version '{versionString}', and platform '{request.Platform}'.");
+
+        if (request.RequireValidBuild)
+            ValidateBuildIsSubmittable(build, buildNumber);
+
+        var submission = await _client.GetBetaAppReviewSubmissionForBuildAsync(build.Id, cancellationToken).ConfigureAwait(false);
+        if (submission is null)
+        {
+            submission = await _client.CreateBetaAppReviewSubmissionAsync(build.Id, cancellationToken).ConfigureAwait(false);
+            messages.Add($"Submitted build '{buildNumber}' to Beta App Review.");
+        }
+        else
+        {
+            messages.Add($"Reused existing Beta App Review submission '{submission.Id}' for build '{buildNumber}' with state '{submission.BetaReviewState ?? "unknown"}'.");
+        }
+
+        return new AppStoreConnectBetaAppReviewSubmissionResult
+        {
+            AppId = appId,
+            VersionString = versionString,
+            BuildNumber = buildNumber,
+            Platform = request.Platform,
+            Build = build,
+            Submission = submission,
+            Messages = messages.ToArray()
+        };
+    }
+
+    private static void ValidateBuildIsSubmittable(AppStoreConnectBuildInfo build, string buildNumber)
+    {
+        if (!string.Equals(build.ProcessingState, "VALID", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be submitted to Beta App Review because processing state is '{build.ProcessingState ?? "unknown"}'.");
+        if (build.Expired == true)
+            throw new InvalidOperationException($"Build '{buildNumber}' cannot be submitted to Beta App Review because it is expired.");
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
+++ b/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
@@ -135,6 +135,50 @@ public sealed partial class AppStoreConnectClient
             cancellationToken);
     }
 
+    /// <summary>
+    /// Reads the Beta App Review submission associated with a build, when one exists.
+    /// </summary>
+    public Task<AppStoreConnectBetaAppReviewSubmissionInfo?> GetBetaAppReviewSubmissionForBuildAsync(
+        string buildId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(buildId))
+            throw new ArgumentException("Build id is required.", nameof(buildId));
+
+        return GetSingleAsync(
+            $"builds/{Uri.EscapeDataString(buildId.Trim())}/betaAppReviewSubmission",
+            ParseBetaAppReviewSubmission,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Submits a build to Beta App Review for external TestFlight testing.
+    /// </summary>
+    public Task<AppStoreConnectBetaAppReviewSubmissionInfo> CreateBetaAppReviewSubmissionAsync(
+        string buildId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(buildId))
+            throw new ArgumentException("Build id is required.", nameof(buildId));
+
+        var body = new
+        {
+            data = new
+            {
+                type = "betaAppReviewSubmissions",
+                relationships = new
+                {
+                    build = new
+                    {
+                        data = new { type = "builds", id = buildId.Trim() }
+                    }
+                }
+            }
+        };
+
+        return PostSingleAsync("betaAppReviewSubmissions", body, ParseBetaAppReviewSubmission, cancellationToken);
+    }
+
     private async Task SendJsonNoContentAsync(
         HttpMethod method,
         string relativeUrl,
@@ -181,6 +225,18 @@ public sealed partial class AppStoreConnectClient
             FirstName = GetString(attrs, "firstName"),
             LastName = GetString(attrs, "lastName"),
             InviteType = GetString(attrs, "inviteType")
+        };
+    }
+
+    private static AppStoreConnectBetaAppReviewSubmissionInfo ParseBetaAppReviewSubmission(JsonElement item)
+    {
+        var attrs = GetAttributes(item);
+        return new AppStoreConnectBetaAppReviewSubmissionInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            BetaReviewState = GetString(attrs, "betaReviewState"),
+            SubmittedDate = GetDateTimeOffset(attrs, "submittedDate"),
+            BuildId = GetRelationshipDataId(item, "build")
         };
     }
 

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -59,6 +59,7 @@ internal sealed class PowerForgeReleaseService
     private readonly Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult> _uploadAppleApp;
     private readonly Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult> _prepareAppleDistribution;
     private readonly Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult> _distributeTestFlight;
+    private readonly Func<AppStoreConnectBetaAppReviewSubmissionRequest, AppStoreConnectBetaAppReviewSubmissionResult> _submitTestFlightBetaReview;
     private readonly Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult> _submitAppleReview;
     private readonly Func<AppStoreConnectVersionReleaseRequest, AppStoreConnectVersionReleaseResult> _releaseAppleVersion;
 
@@ -118,6 +119,7 @@ internal sealed class PowerForgeReleaseService
         Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null,
         Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null,
         Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult>? distributeTestFlight = null,
+        Func<AppStoreConnectBetaAppReviewSubmissionRequest, AppStoreConnectBetaAppReviewSubmissionResult>? submitTestFlightBetaReview = null,
         Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult>? submitAppleReview = null,
         Func<AppStoreConnectVersionReleaseRequest, AppStoreConnectVersionReleaseResult>? releaseAppleVersion = null)
     {
@@ -134,6 +136,7 @@ internal sealed class PowerForgeReleaseService
         _uploadAppleApp = uploadAppleApp ?? (request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult());
         _prepareAppleDistribution = prepareAppleDistribution ?? PrepareAppleDistribution;
         _distributeTestFlight = distributeTestFlight ?? DistributeTestFlight;
+        _submitTestFlightBetaReview = submitTestFlightBetaReview ?? SubmitTestFlightBetaReview;
         _submitAppleReview = submitAppleReview ?? SubmitAppleReview;
         _releaseAppleVersion = releaseAppleVersion ?? ReleaseAppleVersion;
     }
@@ -740,9 +743,9 @@ internal sealed class PowerForgeReleaseService
 
         if (apps.Length == 0)
             throw new InvalidOperationException("AppleApps.Apps must contain at least one enabled app entry.");
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview || options.ReleaseApprovedVersion) &&
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitTestFlightBetaReview || options.SubmitForReview || options.ReleaseApprovedVersion) &&
             apps.Any(app => string.IsNullOrWhiteSpace(app.AppStoreConnectAppId)))
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, SubmitForReview, or ReleaseApprovedVersion requires AppStoreConnectAppId for every selected app.");
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, SubmitTestFlightBetaReview, SubmitForReview, or ReleaseApprovedVersion requires AppStoreConnectAppId for every selected app.");
         if (options.DistributeTestFlight &&
             NormalizeStrings(options.TestFlightBetaGroupIds).Length == 0 &&
             NormalizeStrings(options.TestFlightBetaGroupNames).Length == 0)
@@ -781,8 +784,8 @@ internal sealed class PowerForgeReleaseService
                 Environment.GetEnvironmentVariable("ASC_ISSUER_ID"))
             : options.AppStoreConnectApiIssuerId?.Trim();
         var appStoreConnectApiConfiguredCount = (appStoreConnectApiKeyPath is null ? 0 : 1) + (appStoreConnectApiKeyId is null ? 0 : 1) + (appStoreConnectApiIssuerId is null ? 0 : 1);
-        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitForReview || options.ReleaseApprovedVersion) && appStoreConnectApiConfiguredCount != 3)
-            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, SubmitForReview, or ReleaseApprovedVersion requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
+        if ((options.PrepareDistribution || options.SyncScreenshots || options.SyncMetadata || options.CheckReleaseReadiness || options.DistributeTestFlight || options.SubmitTestFlightBetaReview || options.SubmitForReview || options.ReleaseApprovedVersion) && appStoreConnectApiConfiguredCount != 3)
+            throw new InvalidOperationException("AppleApps PrepareDistribution, SyncMetadata, SyncScreenshots, CheckReleaseReadiness, DistributeTestFlight, SubmitTestFlightBetaReview, SubmitForReview, or ReleaseApprovedVersion requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.");
         if (appStoreConnectApiConfiguredCount != 0)
         {
             if (appStoreConnectApiConfiguredCount != 3)
@@ -816,6 +819,7 @@ internal sealed class PowerForgeReleaseService
             TestFlightTesterEmails = NormalizeStrings(options.TestFlightTesterEmails),
             CreateMissingTestFlightTesters = options.CreateMissingTestFlightTesters,
             AllowUnprocessedTestFlightBuild = options.AllowUnprocessedTestFlightBuild,
+            SubmitTestFlightBetaReview = options.SubmitTestFlightBetaReview,
             SubmitForReview = options.SubmitForReview,
             AllowUnselectedReviewBuild = options.AllowUnselectedReviewBuild,
             AllowUnprocessedReviewBuild = options.AllowUnprocessedReviewBuild,
@@ -1034,6 +1038,20 @@ internal sealed class PowerForgeReleaseService
                 });
             }
 
+            if (plan.SubmitTestFlightBetaReview && result.Success)
+            {
+                var testFlightValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
+                result.TestFlightBetaReviewSubmission = _submitTestFlightBetaReview(new AppStoreConnectBetaAppReviewSubmissionRequest
+                {
+                    Credential = CreateAppStoreConnectCredential(plan),
+                    AppId = app.AppStoreConnectAppId!,
+                    VersionString = testFlightValues.MarketingVersion,
+                    BuildNumber = testFlightValues.BuildNumber,
+                    Platform = app.Platform,
+                    RequireValidBuild = !plan.AllowUnprocessedTestFlightBuild
+                });
+            }
+
             if (plan.SubmitForReview && result.Success)
             {
                 var reviewValues = ResolveAppleDistributionValues(app, result.VersionUpdate);
@@ -1097,6 +1115,17 @@ internal sealed class PowerForgeReleaseService
 
         using var client = new AppStoreConnectClient(request.Credential);
         return new AppStoreConnectTestFlightDistributionService(client).DistributeAsync(request).GetAwaiter().GetResult();
+    }
+
+    private static AppStoreConnectBetaAppReviewSubmissionResult SubmitTestFlightBetaReview(AppStoreConnectBetaAppReviewSubmissionRequest request)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (request.Credential is null)
+            throw new ArgumentException("Credential is required.", nameof(request));
+
+        using var client = new AppStoreConnectClient(request.Credential);
+        return new AppStoreConnectBetaAppReviewSubmissionService(client).SubmitAsync(request).GetAwaiter().GetResult();
     }
 
     private static AppStoreConnectReviewSubmissionResult SubmitAppleReview(AppStoreConnectReviewSubmissionRequest request)
@@ -3247,6 +3276,7 @@ internal sealed class PowerForgeReleaseService
                 TestFlightTesterCount = plan.TestFlightTesterEmails.Length,
                 plan.CreateMissingTestFlightTesters,
                 plan.AllowUnprocessedTestFlightBuild,
+                plan.SubmitTestFlightBetaReview,
                 plan.SubmitForReview,
                 plan.AllowUnselectedReviewBuild,
                 plan.AllowUnprocessedReviewBuild,
@@ -3352,6 +3382,18 @@ internal sealed class PowerForgeReleaseService
                     }).ToArray(),
                     TesterCount = result.TestFlight.Testers.Length,
                     result.TestFlight.Messages
+                },
+                testFlightBetaReviewSubmission = result.TestFlightBetaReviewSubmission is null ? null : new
+                {
+                    result.TestFlightBetaReviewSubmission.AppId,
+                    result.TestFlightBetaReviewSubmission.VersionString,
+                    result.TestFlightBetaReviewSubmission.BuildNumber,
+                    Platform = result.TestFlightBetaReviewSubmission.Platform.ToString(),
+                    BuildId = result.TestFlightBetaReviewSubmission.Build.Id,
+                    SubmissionId = result.TestFlightBetaReviewSubmission.Submission.Id,
+                    result.TestFlightBetaReviewSubmission.Submission.BetaReviewState,
+                    result.TestFlightBetaReviewSubmission.Submission.SubmittedDate,
+                    result.TestFlightBetaReviewSubmission.Messages
                 },
                 reviewSubmission = result.ReviewSubmission is null ? null : new
                 {

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -296,6 +296,7 @@
         },
         "CreateMissingTestFlightTesters": { "type": "boolean" },
         "AllowUnprocessedTestFlightBuild": { "type": "boolean" },
+        "SubmitTestFlightBetaReview": { "type": "boolean" },
         "SubmitForReview": { "type": "boolean" },
         "AllowUnselectedReviewBuild": { "type": "boolean" },
         "AllowUnprocessedReviewBuild": { "type": "boolean" },


### PR DESCRIPTION
## Summary
- add App Store Connect client/service support for `betaAppReviewSubmissions`
- add `Submit-AppStoreConnectTestFlightBuildForReview` for TestFlight-only external beta review submission
- add `SubmitTestFlightBetaReview` to unified Apple release config/results so App Store and TestFlight review steps can be run together or independently

## Validation
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~AppStoreConnectClientTests|FullyQualifiedName~PowerForgeReleaseServiceTests"`
- `dotnet build PSPublishModule/PSPublishModule.csproj -c Release -f net8.0`
- live smoke: `Submit-AppStoreConnectTestFlightBuildForReview` reused existing Tactra iOS/macOS 1.0.2 build 6 beta review submissions in `WAITING_FOR_REVIEW`

## Notes
- A broad `dotnet test PowerForge.Tests/PowerForge.Tests.csproj` run in the original checkout was stopped after unrelated existing macOS/path/web-doc failures and CLI timeouts appeared. The focused Apple/App Store Connect surface is covered by the targeted test run above.
