### PR TITLE
Add Apple release state summary

### DIFF
--- a/PSPublishModule/Cmdlets/GetAppStoreConnectReleaseStateCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectReleaseStateCommand.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Management.Automation;
+using PowerForge;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Reads a compact App Store Connect release state summary for App Store and TestFlight release work.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "AppStoreConnectReleaseState")]
+[OutputType(typeof(AppStoreConnectReleaseStateResult))]
+public sealed class GetAppStoreConnectReleaseStateCommand : PSCmdlet
+{
+    /// <summary>Issuer ID from App Store Connect API keys.</summary>
+    [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
+
+    /// <summary>Key ID associated with the private key.</summary>
+    [Parameter(Mandatory = true)] public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Private key text in PEM format.</summary>
+    [Parameter] public string? PrivateKey { get; set; }
+
+    /// <summary>Path to a private key file in PEM format.</summary>
+    [Parameter] public string? PrivateKeyPath { get; set; }
+
+    /// <summary>Token lifetime in minutes, up to 20.</summary>
+    [Parameter] public int TokenLifetimeMinutes { get; set; } = 15;
+
+    /// <summary>App Store Connect app id.</summary>
+    [Parameter(Mandatory = true)] public string AppId { get; set; } = string.Empty;
+
+    /// <summary>App Store marketing version to summarize.</summary>
+    [Parameter] public string? VersionString { get; set; }
+
+    /// <summary>Uploaded build number to summarize.</summary>
+    [Parameter] public string? BuildNumber { get; set; }
+
+    /// <summary>Apple platforms to summarize.</summary>
+    [Parameter] public ApplePlatform[] Platform { get; set; } = new[] { ApplePlatform.iOS };
+
+    /// <summary>Beta group ids to include in public-link/tester summary.</summary>
+    [Parameter] public string[] BetaGroupId { get; set; } = Array.Empty<string>();
+
+    /// <summary>Beta group names to include in public-link/tester summary.</summary>
+    [Parameter] public string[] BetaGroupName { get; set; } = Array.Empty<string>();
+
+    /// <summary>Include every beta group when no beta group filter is supplied.</summary>
+    [Parameter] public SwitchParameter IncludeAllBetaGroups { get; set; }
+
+    /// <summary>Reads App Store Connect release state.</summary>
+    protected override void ProcessRecord()
+    {
+        var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
+        var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
+        using var client = new AppStoreConnectClient(credential);
+        var service = new AppStoreConnectReleaseStateService(client);
+        var result = service.GetAsync(new AppStoreConnectReleaseStateRequest
+        {
+            Credential = credential,
+            AppId = AppId,
+            VersionString = VersionString,
+            BuildNumber = BuildNumber,
+            Platforms = Platform,
+            BetaGroupIds = BetaGroupId,
+            BetaGroupNames = BetaGroupName,
+            IncludeAllBetaGroups = IncludeAllBetaGroups.IsPresent
+        }).GetAwaiter().GetResult();
+
+        WriteObject(result);
+    }
+}

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -1069,6 +1069,141 @@ public sealed class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task ReleaseStateService_SummarizesAppStoreTestFlightAndBetaGroups()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "version-1",
+                      "type": "appStoreVersions",
+                      "attributes": { "versionString": "1.0.2", "platform": "IOS", "appStoreState": "WAITING_FOR_REVIEW", "appVersionState": "WAITING_FOR_REVIEW" }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-6",
+                      "type": "builds",
+                      "attributes": { "version": "6", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.2", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": { "type": "builds", "id": "build-6" } }"""),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": {
+                    "id": "build-6",
+                    "type": "builds",
+                    "attributes": { "version": "6", "processingState": "VALID", "expired": false },
+                    "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                  },
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.2", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "review-1",
+                      "type": "reviewSubmissions",
+                      "attributes": { "platform": "IOS", "state": "WAITING_FOR_REVIEW", "submitted": true }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": {
+                    "id": "detail-1",
+                    "type": "buildBetaDetails",
+                    "attributes": { "internalBuildState": "IN_BETA_TESTING", "externalBuildState": "WAITING_FOR_BETA_REVIEW", "autoNotifyEnabled": true }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": {
+                    "id": "beta-review-1",
+                    "type": "betaAppReviewSubmissions",
+                    "attributes": { "betaReviewState": "WAITING_FOR_REVIEW" },
+                    "relationships": { "build": { "data": { "type": "builds", "id": "build-6" } } }
+                  }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-1",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Discord Testers", "publicLinkEnabled": true, "publicLinkLimit": 10, "publicLink": "https://testflight.apple.com/join/example", "isInternalGroup": false }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "tester-1",
+                      "type": "betaTesters",
+                      "attributes": { "email": "tester@example.test" }
+                    }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectReleaseStateService(client);
+
+        var result = await service.GetAsync(new AppStoreConnectReleaseStateRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.2",
+            BuildNumber = "6",
+            Platforms = new[] { ApplePlatform.iOS },
+            BetaGroupNames = new[] { "Discord Testers" }
+        });
+
+        var platform = Assert.Single(result.Platforms);
+        Assert.Equal("version-1", platform.Version?.Id);
+        Assert.Equal("build-6", platform.MatchedBuild?.Id);
+        Assert.Equal("build-6", platform.SelectedBuild?.Id);
+        Assert.True(platform.MatchedBuildSelected);
+        Assert.Equal("WAITING_FOR_REVIEW", Assert.Single(platform.ReviewSubmissions).State);
+        Assert.Equal("WAITING_FOR_BETA_REVIEW", platform.BetaDetail?.ExternalBuildState);
+        Assert.Equal("WAITING_FOR_REVIEW", platform.BetaReviewSubmission?.BetaReviewState);
+        Assert.Contains("iOS: Wait for App Review.", result.NextActions);
+        Assert.Contains("iOS: Wait for Beta App Review.", result.NextActions);
+
+        var group = Assert.Single(result.BetaGroups);
+        Assert.Equal("Discord Testers", group.Name);
+        Assert.True(group.PublicLinkEnabled);
+        Assert.Equal(1, group.TesterCount);
+        Assert.False(group.IsFull);
+    }
+
+    [Fact]
     public async Task ReviewSubmissionClient_CreatesItemAndSubmits()
     {
         var handler = new SequenceHandler(

--- a/PowerForge/Models/AppStoreConnectReleaseStateModels.cs
+++ b/PowerForge/Models/AppStoreConnectReleaseStateModels.cs
@@ -1,0 +1,133 @@
+namespace PowerForge;
+
+/// <summary>
+/// Request to summarize App Store Connect release state for one app/version/build.
+/// </summary>
+public sealed class AppStoreConnectReleaseStateRequest
+{
+    /// <summary>App Store Connect API credential. Required when executed by the default cmdlet runner.</summary>
+    public AppStoreConnectApiCredential? Credential { get; set; }
+
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>Optional App Store marketing version to summarize.</summary>
+    public string? VersionString { get; set; }
+
+    /// <summary>Optional uploaded build number expected for the version.</summary>
+    public string? BuildNumber { get; set; }
+
+    /// <summary>Platforms to summarize.</summary>
+    public ApplePlatform[] Platforms { get; set; } = new[] { ApplePlatform.iOS };
+
+    /// <summary>Beta group ids to include in the summary.</summary>
+    public string[] BetaGroupIds { get; set; } = Array.Empty<string>();
+
+    /// <summary>Beta group names to resolve and include in the summary.</summary>
+    public string[] BetaGroupNames { get; set; } = Array.Empty<string>();
+
+    /// <summary>Include all beta groups when no group filters are supplied.</summary>
+    public bool IncludeAllBetaGroups { get; set; }
+}
+
+/// <summary>
+/// App Store Connect release state summary for an app.
+/// </summary>
+public sealed class AppStoreConnectReleaseStateResult
+{
+    /// <summary>App Store Connect app id.</summary>
+    public string AppId { get; set; } = string.Empty;
+
+    /// <summary>Version string used for the summary.</summary>
+    public string? VersionString { get; set; }
+
+    /// <summary>Build number used for the summary.</summary>
+    public string? BuildNumber { get; set; }
+
+    /// <summary>UTC time when the summary was gathered.</summary>
+    public DateTimeOffset CheckedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Per-platform App Store and TestFlight state.</summary>
+    public AppStoreConnectPlatformReleaseState[] Platforms { get; set; } = Array.Empty<AppStoreConnectPlatformReleaseState>();
+
+    /// <summary>Included beta group state.</summary>
+    public AppStoreConnectBetaGroupReleaseState[] BetaGroups { get; set; } = Array.Empty<AppStoreConnectBetaGroupReleaseState>();
+
+    /// <summary>Flattened next actions across platforms and beta groups.</summary>
+    public string[] NextActions { get; set; } = Array.Empty<string>();
+
+    /// <summary>Messages useful for release logs.</summary>
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Per-platform App Store Connect release state.
+/// </summary>
+public sealed class AppStoreConnectPlatformReleaseState
+{
+    /// <summary>Apple platform.</summary>
+    public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
+
+    /// <summary>Matched App Store version, when present.</summary>
+    public AppStoreConnectVersionInfo? Version { get; set; }
+
+    /// <summary>Build selected on the App Store version, when present.</summary>
+    public AppStoreConnectBuildInfo? SelectedBuild { get; set; }
+
+    /// <summary>Build matching the requested build number/version/platform, when present.</summary>
+    public AppStoreConnectBuildInfo? MatchedBuild { get; set; }
+
+    /// <summary>Build used for TestFlight state checks.</summary>
+    public AppStoreConnectBuildInfo? TestFlightBuild { get; set; }
+
+    /// <summary>Whether the matched build is selected on the App Store version.</summary>
+    public bool? MatchedBuildSelected { get; set; }
+
+    /// <summary>Recent/current production App Review submissions for this app/platform.</summary>
+    public AppStoreConnectReviewSubmissionInfo[] ReviewSubmissions { get; set; } = Array.Empty<AppStoreConnectReviewSubmissionInfo>();
+
+    /// <summary>TestFlight beta build detail for the matched or selected build.</summary>
+    public AppStoreConnectBuildBetaDetailInfo? BetaDetail { get; set; }
+
+    /// <summary>Beta App Review submission for the matched or selected build.</summary>
+    public AppStoreConnectBetaAppReviewSubmissionInfo? BetaReviewSubmission { get; set; }
+
+    /// <summary>Next actions inferred from this platform state.</summary>
+    public string[] NextActions { get; set; } = Array.Empty<string>();
+
+    /// <summary>Messages useful for release logs.</summary>
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Beta group release state useful for public TestFlight links.
+/// </summary>
+public sealed class AppStoreConnectBetaGroupReleaseState
+{
+    /// <summary>Beta group id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Beta group name.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Whether public links are enabled for the group.</summary>
+    public bool? PublicLinkEnabled { get; set; }
+
+    /// <summary>Public invitation link when available.</summary>
+    public string? PublicLink { get; set; }
+
+    /// <summary>Configured public link tester limit.</summary>
+    public int? PublicLinkLimit { get; set; }
+
+    /// <summary>Current tester count read from the group.</summary>
+    public int? TesterCount { get; set; }
+
+    /// <summary>Whether the group is full according to the public-link limit and tester count.</summary>
+    public bool? IsFull { get; set; }
+
+    /// <summary>Whether this is an internal beta group when reported by App Store Connect.</summary>
+    public bool? IsInternalGroup { get; set; }
+
+    /// <summary>Next actions inferred from this beta group state.</summary>
+    public string[] NextActions { get; set; } = Array.Empty<string>();
+}

--- a/PowerForge/Models/AppStoreConnectTestFlightModels.cs
+++ b/PowerForge/Models/AppStoreConnectTestFlightModels.cs
@@ -49,6 +49,24 @@ public sealed class AppStoreConnectBetaTesterInfo
 }
 
 /// <summary>
+/// App Store Connect TestFlight build beta detail summary.
+/// </summary>
+public sealed class AppStoreConnectBuildBetaDetailInfo
+{
+    /// <summary>Build beta detail id.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Internal TestFlight build state.</summary>
+    public string? InternalBuildState { get; set; }
+
+    /// <summary>External TestFlight build state.</summary>
+    public string? ExternalBuildState { get; set; }
+
+    /// <summary>Whether App Store Connect automatically notifies testers when available.</summary>
+    public bool? AutoNotifyEnabled { get; set; }
+}
+
+/// <summary>
 /// Tester specification for TestFlight distribution.
 /// </summary>
 public sealed class AppStoreConnectBetaTesterSpec

--- a/PowerForge/Services/AppStoreConnectClient.Builds.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Builds.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectClient
+{
+    /// <summary>
+    /// Reads a build by App Store Connect build id.
+    /// </summary>
+    public async Task<AppStoreConnectBuildInfo?> GetBuildAsync(
+        string buildId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(buildId))
+            throw new ArgumentException("Build id is required.", nameof(buildId));
+
+        using var doc = await GetJsonAsync(
+            $"builds/{Uri.EscapeDataString(buildId.Trim())}?include=preReleaseVersion",
+            cancellationToken,
+            returnNullOnNotFound: true).ConfigureAwait(false);
+        if (doc is null ||
+            !doc.RootElement.TryGetProperty("data", out var data) ||
+            data.ValueKind == JsonValueKind.Null)
+            return null;
+
+        return ParseBuild(data, ReadIncludedPreReleaseVersions(doc.RootElement));
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
+++ b/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
@@ -48,6 +48,28 @@ public sealed partial class AppStoreConnectClient
     }
 
     /// <summary>
+    /// Lists beta testers in a beta group.
+    /// </summary>
+    public Task<AppStoreConnectBetaTesterInfo[]> GetBetaTestersForGroupAsync(
+        string betaGroupId,
+        int limit = 200,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(betaGroupId))
+            throw new ArgumentException("Beta group id is required.", nameof(betaGroupId));
+
+        var query = new Dictionary<string, string?>
+        {
+            ["limit"] = ClampLimit(limit).ToString(CultureInfo.InvariantCulture)
+        };
+
+        return GetArrayAsync(
+            $"betaGroups/{Uri.EscapeDataString(betaGroupId.Trim())}/betaTesters" + BuildQuery(query),
+            ParseBetaTester,
+            cancellationToken);
+    }
+
+    /// <summary>
     /// Creates a beta tester and optionally adds the tester to beta groups.
     /// </summary>
     public Task<AppStoreConnectBetaTesterInfo> CreateBetaTesterAsync(
@@ -152,6 +174,22 @@ public sealed partial class AppStoreConnectClient
     }
 
     /// <summary>
+    /// Reads TestFlight beta detail for a build.
+    /// </summary>
+    public Task<AppStoreConnectBuildBetaDetailInfo?> GetBuildBetaDetailAsync(
+        string buildId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(buildId))
+            throw new ArgumentException("Build id is required.", nameof(buildId));
+
+        return GetSingleAsync(
+            $"builds/{Uri.EscapeDataString(buildId.Trim())}/buildBetaDetail",
+            ParseBuildBetaDetail,
+            cancellationToken);
+    }
+
+    /// <summary>
     /// Submits a build to Beta App Review for external TestFlight testing.
     /// </summary>
     public Task<AppStoreConnectBetaAppReviewSubmissionInfo> CreateBetaAppReviewSubmissionAsync(
@@ -225,6 +263,18 @@ public sealed partial class AppStoreConnectClient
             FirstName = GetString(attrs, "firstName"),
             LastName = GetString(attrs, "lastName"),
             InviteType = GetString(attrs, "inviteType")
+        };
+    }
+
+    private static AppStoreConnectBuildBetaDetailInfo ParseBuildBetaDetail(JsonElement item)
+    {
+        var attrs = GetAttributes(item);
+        return new AppStoreConnectBuildBetaDetailInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            InternalBuildState = GetString(attrs, "internalBuildState"),
+            ExternalBuildState = GetString(attrs, "externalBuildState"),
+            AutoNotifyEnabled = GetBool(attrs, "autoNotifyEnabled")
         };
     }
 

--- a/PowerForge/Services/AppStoreConnectReleaseStateService.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseStateService.cs
@@ -1,0 +1,267 @@
+namespace PowerForge;
+
+/// <summary>
+/// Builds compact App Store Connect release-state summaries.
+/// </summary>
+public sealed class AppStoreConnectReleaseStateService
+{
+    private readonly AppStoreConnectClient _client;
+
+    /// <summary>
+    /// Initializes a release state service.
+    /// </summary>
+    public AppStoreConnectReleaseStateService(AppStoreConnectClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <summary>
+    /// Reads App Store, TestFlight, review, and beta-group state for one app.
+    /// </summary>
+    public async Task<AppStoreConnectReleaseStateResult> GetAsync(
+        AppStoreConnectReleaseStateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrWhiteSpace(request.AppId))
+            throw new ArgumentException("AppId is required.", nameof(request));
+
+        var appId = request.AppId.Trim();
+        var platforms = NormalizePlatforms(request.Platforms);
+        var platformStates = new List<AppStoreConnectPlatformReleaseState>();
+        var messages = new List<string>();
+
+        foreach (var platform in platforms)
+            platformStates.Add(await GetPlatformStateAsync(appId, request, platform, cancellationToken).ConfigureAwait(false));
+
+        var betaGroups = await GetBetaGroupStatesAsync(appId, request, cancellationToken).ConfigureAwait(false);
+        if (betaGroups.Length == 0)
+            messages.Add("No beta groups were included in the summary.");
+
+        var nextActions = platformStates
+            .SelectMany(static state => state.NextActions.Select(action => $"{state.Platform}: {action}"))
+            .Concat(betaGroups.SelectMany(static group => group.NextActions.Select(action => $"BetaGroup {group.Name ?? group.Id}: {action}")))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new AppStoreConnectReleaseStateResult
+        {
+            AppId = appId,
+            VersionString = NormalizeOptional(request.VersionString),
+            BuildNumber = NormalizeOptional(request.BuildNumber),
+            CheckedAt = DateTimeOffset.UtcNow,
+            Platforms = platformStates.ToArray(),
+            BetaGroups = betaGroups,
+            NextActions = nextActions,
+            Messages = messages.ToArray()
+        };
+    }
+
+    private async Task<AppStoreConnectPlatformReleaseState> GetPlatformStateAsync(
+        string appId,
+        AppStoreConnectReleaseStateRequest request,
+        ApplePlatform platform,
+        CancellationToken cancellationToken)
+    {
+        var versionString = NormalizeOptional(request.VersionString);
+        var buildNumber = NormalizeOptional(request.BuildNumber);
+        var messages = new List<string>();
+        var nextActions = new List<string>();
+
+        var version = (await _client.GetVersionsAsync(
+            appId,
+            versionString,
+            platform,
+            limit: 10,
+            cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+        if (version is null)
+        {
+            messages.Add(versionString is null
+                ? "No App Store version matched the query."
+                : $"App Store version '{versionString}' was not found.");
+            nextActions.Add("Create App Store distribution version.");
+        }
+
+        AppStoreConnectBuildInfo? matchedBuild = null;
+        if (buildNumber is not null)
+        {
+            matchedBuild = (await _client.GetBuildsAsync(
+                appId,
+                buildNumber,
+                limit: 20,
+                marketingVersion: versionString,
+                platform: platform,
+                cancellationToken: cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+            if (matchedBuild is null)
+            {
+                messages.Add($"Build '{buildNumber}' was not found for platform '{platform}'.");
+                nextActions.Add("Upload or wait for the requested build to process.");
+            }
+        }
+
+        AppStoreConnectBuildInfo? selectedBuild = null;
+        var selectedBuildId = version is null
+            ? null
+            : await _client.GetVersionBuildIdAsync(version.Id, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(selectedBuildId))
+            selectedBuild = await _client.GetBuildAsync(selectedBuildId!, cancellationToken).ConfigureAwait(false);
+
+        bool? matchedBuildSelected = null;
+        if (matchedBuild is not null && version is not null)
+        {
+            matchedBuildSelected = string.Equals(selectedBuildId, matchedBuild.Id, StringComparison.OrdinalIgnoreCase);
+            if (matchedBuildSelected == false)
+                nextActions.Add("Select the requested build on the App Store version.");
+        }
+        else if (version is not null && selectedBuild is null)
+        {
+            nextActions.Add("Select a build on the App Store version.");
+        }
+
+        var reviewSubmissions = await _client.GetReviewSubmissionsAsync(
+            appId,
+            platform,
+            limit: 50,
+            cancellationToken).ConfigureAwait(false);
+
+        var testFlightBuild = matchedBuild ?? selectedBuild;
+        AppStoreConnectBuildBetaDetailInfo? betaDetail = null;
+        AppStoreConnectBetaAppReviewSubmissionInfo? betaSubmission = null;
+        if (testFlightBuild is not null)
+        {
+            betaDetail = await _client.GetBuildBetaDetailAsync(testFlightBuild.Id, cancellationToken).ConfigureAwait(false);
+            betaSubmission = await _client.GetBetaAppReviewSubmissionForBuildAsync(testFlightBuild.Id, cancellationToken).ConfigureAwait(false);
+        }
+
+        AddAppStoreNextActions(version, nextActions);
+        AddTestFlightNextActions(testFlightBuild, betaDetail, betaSubmission, nextActions);
+
+        return new AppStoreConnectPlatformReleaseState
+        {
+            Platform = platform,
+            Version = version,
+            SelectedBuild = selectedBuild,
+            MatchedBuild = matchedBuild,
+            TestFlightBuild = testFlightBuild,
+            MatchedBuildSelected = matchedBuildSelected,
+            ReviewSubmissions = reviewSubmissions,
+            BetaDetail = betaDetail,
+            BetaReviewSubmission = betaSubmission,
+            NextActions = nextActions.Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+            Messages = messages.ToArray()
+        };
+    }
+
+    private async Task<AppStoreConnectBetaGroupReleaseState[]> GetBetaGroupStatesAsync(
+        string appId,
+        AppStoreConnectReleaseStateRequest request,
+        CancellationToken cancellationToken)
+    {
+        var includeAll = request.IncludeAllBetaGroups;
+        var groupIds = NormalizeStrings(request.BetaGroupIds);
+        var groupNames = NormalizeStrings(request.BetaGroupNames);
+        if (!includeAll && groupIds.Length == 0 && groupNames.Length == 0)
+            return Array.Empty<AppStoreConnectBetaGroupReleaseState>();
+
+        var allGroups = await _client.GetBetaGroupsAsync(appId, limit: 200, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var groups = allGroups
+            .Where(group =>
+                includeAll ||
+                groupIds.Contains(group.Id, StringComparer.OrdinalIgnoreCase) ||
+                (!string.IsNullOrWhiteSpace(group.Name) && groupNames.Contains(group.Name!, StringComparer.OrdinalIgnoreCase)))
+            .GroupBy(static group => group.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToArray();
+
+        var result = new List<AppStoreConnectBetaGroupReleaseState>();
+        foreach (var group in groups)
+        {
+            var testers = await _client.GetBetaTestersForGroupAsync(group.Id, limit: 200, cancellationToken).ConfigureAwait(false);
+            var isFull = group.PublicLinkLimit.HasValue
+                ? testers.Length >= group.PublicLinkLimit.Value
+                : (bool?)null;
+            var nextActions = new List<string>();
+            if (group.PublicLinkEnabled == false)
+                nextActions.Add("Enable the public TestFlight link if external self-service testers are expected.");
+            if (isFull == true)
+                nextActions.Add("Raise the public-link tester limit or remove inactive testers.");
+
+            result.Add(new AppStoreConnectBetaGroupReleaseState
+            {
+                Id = group.Id,
+                Name = group.Name,
+                PublicLinkEnabled = group.PublicLinkEnabled,
+                PublicLink = group.PublicLink,
+                PublicLinkLimit = group.PublicLinkLimit,
+                TesterCount = testers.Length,
+                IsFull = isFull,
+                IsInternalGroup = group.IsInternalGroup,
+                NextActions = nextActions.ToArray()
+            });
+        }
+
+        return result.ToArray();
+    }
+
+    private static void AddAppStoreNextActions(AppStoreConnectVersionInfo? version, List<string> nextActions)
+    {
+        var state = version?.AppStoreState ?? version?.AppVersionState;
+        if (string.IsNullOrWhiteSpace(state))
+            return;
+
+        if (state.Equals("PREPARE_FOR_SUBMISSION", StringComparison.OrdinalIgnoreCase) ||
+            state.Equals("READY_FOR_REVIEW", StringComparison.OrdinalIgnoreCase))
+            nextActions.Add("Submit the App Store version for review when readiness passes.");
+        else if (state.Equals("WAITING_FOR_REVIEW", StringComparison.OrdinalIgnoreCase) ||
+                 state.Equals("IN_REVIEW", StringComparison.OrdinalIgnoreCase))
+            nextActions.Add("Wait for App Review.");
+        else if (state.Equals("PENDING_DEVELOPER_RELEASE", StringComparison.OrdinalIgnoreCase))
+            nextActions.Add("Release the approved App Store version when ready.");
+    }
+
+    private static void AddTestFlightNextActions(
+        AppStoreConnectBuildInfo? build,
+        AppStoreConnectBuildBetaDetailInfo? betaDetail,
+        AppStoreConnectBetaAppReviewSubmissionInfo? betaSubmission,
+        List<string> nextActions)
+    {
+        if (build is null)
+            return;
+        if (!string.Equals(build.ProcessingState, "VALID", StringComparison.OrdinalIgnoreCase))
+        {
+            nextActions.Add("Wait for the TestFlight build to finish processing.");
+            return;
+        }
+
+        var externalState = betaDetail?.ExternalBuildState;
+        if (string.IsNullOrWhiteSpace(externalState))
+            return;
+
+        if (externalState.Equals("READY_FOR_BETA_SUBMISSION", StringComparison.OrdinalIgnoreCase))
+            nextActions.Add("Submit the TestFlight build to Beta App Review.");
+        else if (externalState.Equals("WAITING_FOR_BETA_REVIEW", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(betaSubmission?.BetaReviewState, "WAITING_FOR_REVIEW", StringComparison.OrdinalIgnoreCase))
+            nextActions.Add("Wait for Beta App Review.");
+        else if (externalState.Equals("BETA_APPROVED", StringComparison.OrdinalIgnoreCase))
+            nextActions.Add("External TestFlight is approved; verify public link availability.");
+    }
+
+    private static ApplePlatform[] NormalizePlatforms(ApplePlatform[]? platforms)
+    {
+        var normalized = (platforms ?? Array.Empty<ApplePlatform>())
+            .Distinct()
+            .ToArray();
+        return normalized.Length == 0 ? new[] { ApplePlatform.iOS } : normalized;
+    }
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string[] NormalizeStrings(string[]? values)
+        => (values ?? Array.Empty<string>())
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+}

--- a/PowerForge/Services/AppStoreConnectReleaseStateService.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseStateService.cs
@@ -206,17 +206,17 @@ public sealed class AppStoreConnectReleaseStateService
 
     private static void AddAppStoreNextActions(AppStoreConnectVersionInfo? version, List<string> nextActions)
     {
-        var state = version?.AppStoreState ?? version?.AppVersionState;
-        if (string.IsNullOrWhiteSpace(state))
+        var state = NormalizeOptional(version?.AppStoreState ?? version?.AppVersionState);
+        if (state is null)
             return;
 
-        if (state.Equals("PREPARE_FOR_SUBMISSION", StringComparison.OrdinalIgnoreCase) ||
-            state.Equals("READY_FOR_REVIEW", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(state, "PREPARE_FOR_SUBMISSION", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(state, "READY_FOR_REVIEW", StringComparison.OrdinalIgnoreCase))
             nextActions.Add("Submit the App Store version for review when readiness passes.");
-        else if (state.Equals("WAITING_FOR_REVIEW", StringComparison.OrdinalIgnoreCase) ||
-                 state.Equals("IN_REVIEW", StringComparison.OrdinalIgnoreCase))
+        else if (string.Equals(state, "WAITING_FOR_REVIEW", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(state, "IN_REVIEW", StringComparison.OrdinalIgnoreCase))
             nextActions.Add("Wait for App Review.");
-        else if (state.Equals("PENDING_DEVELOPER_RELEASE", StringComparison.OrdinalIgnoreCase))
+        else if (string.Equals(state, "PENDING_DEVELOPER_RELEASE", StringComparison.OrdinalIgnoreCase))
             nextActions.Add("Release the approved App Store version when ready.");
     }
 
@@ -234,16 +234,16 @@ public sealed class AppStoreConnectReleaseStateService
             return;
         }
 
-        var externalState = betaDetail?.ExternalBuildState;
-        if (string.IsNullOrWhiteSpace(externalState))
+        var externalState = NormalizeOptional(betaDetail?.ExternalBuildState);
+        if (externalState is null)
             return;
 
-        if (externalState.Equals("READY_FOR_BETA_SUBMISSION", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(externalState, "READY_FOR_BETA_SUBMISSION", StringComparison.OrdinalIgnoreCase))
             nextActions.Add("Submit the TestFlight build to Beta App Review.");
-        else if (externalState.Equals("WAITING_FOR_BETA_REVIEW", StringComparison.OrdinalIgnoreCase) ||
+        else if (string.Equals(externalState, "WAITING_FOR_BETA_REVIEW", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(betaSubmission?.BetaReviewState, "WAITING_FOR_REVIEW", StringComparison.OrdinalIgnoreCase))
             nextActions.Add("Wait for Beta App Review.");
-        else if (externalState.Equals("BETA_APPROVED", StringComparison.OrdinalIgnoreCase))
+        else if (string.Equals(externalState, "BETA_APPROVED", StringComparison.OrdinalIgnoreCase))
             nextActions.Add("External TestFlight is approved; verify public link availability.");
     }
 
@@ -256,7 +256,7 @@ public sealed class AppStoreConnectReleaseStateService
     }
 
     private static string? NormalizeOptional(string? value)
-        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+        => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
 
     private static string[] NormalizeStrings(string[]? values)
         => (values ?? Array.Empty<string>())


### PR DESCRIPTION
## Summary
- add a read-only `Get-AppStoreConnectReleaseState` cmdlet that summarizes App Store version, selected build, TestFlight beta review, and beta-group public-link state
- add reusable PowerForge release-state models/service plus client helpers for build lookup, beta build detail, and beta-group testers
- cover the state summary with a focused App Store Connect client/service test

## Why
Tactra 1.0.2 exposed that Apple releases need a compact state-machine snapshot before deciding whether to wait, submit App Review, submit Beta App Review, fix screenshots, or inspect TestFlight links. This cmdlet lets future releases answer "where are we and what is next?" without reconstructing that state manually each time.

## Validation
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~AppStoreConnectClientTests"`
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~AppStoreConnectClientTests.ReleaseStateService_SummarizesAppStoreTestFlightAndBetaGroups"`
- `dotnet build PSPublishModule/PSPublishModule.csproj -c Release -f net8.0`
- live smoke against Tactra 1.0.2 build 6 returned next actions: iOS wait for App Review, iOS wait for Beta App Review, macOS wait for App Review, macOS wait for Beta App Review; Discord Testers public link enabled, 1/10 testers, not full
