### PR TITLE
Add Windows runner housekeeping coverage

### DIFF
--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -54,3 +54,35 @@ jobs:
       report_artifact_name: runner-housekeeping-${{ matrix.runner.name }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup-windows-runner:
+    # Windows runners currently share the default self-hosted labels. Run enough
+    # parallel slots to let GitHub spread housekeeping across the Windows pool.
+    if: ${{ github.repository == 'EvotecIT/PSPublishModule' || github.event.repository.private }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - name: windows-runner-01
+            labels: '["self-hosted","windows","X64"]'
+          - name: windows-runner-02
+            labels: '["self-hosted","windows","X64"]'
+          - name: windows-runner-03
+            labels: '["self-hosted","windows","X64"]'
+          - name: windows-runner-04
+            labels: '["self-hosted","windows","X64"]'
+          - name: windows-runner-05
+            labels: '["self-hosted","windows","X64"]'
+          - name: windows-runner-06
+            labels: '["self-hosted","windows","X64"]'
+    name: ${{ matrix.runner.name }}
+    uses: ./.github/workflows/powerforge-github-runner-housekeeping.yml
+    with:
+      config_path: ./.powerforge/runner-housekeeping.json
+      apply: ${{ github.event_name != 'workflow_dispatch' || inputs.apply == 'true' }}
+      powerforge_ref: ${{ github.sha }}
+      runner_labels_json: ${{ matrix.runner.labels }}
+      runner_min_free_gb: ${{ github.event_name == 'workflow_dispatch' && (inputs.min_free_gb != '' && inputs.min_free_gb || '15') || (vars.POWERFORGE_RUNNER_HOUSEKEEPING_MIN_FREE_GB != '' && vars.POWERFORGE_RUNNER_HOUSEKEEPING_MIN_FREE_GB || '') }}
+      report_artifact_name: runner-housekeeping-${{ matrix.runner.name }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/runner-housekeeping.yml
+++ b/.github/workflows/runner-housekeeping.yml
@@ -56,25 +56,23 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-windows-runner:
-    # Windows runners currently share the default self-hosted labels. Run enough
-    # parallel slots to let GitHub spread housekeeping across the Windows pool.
     if: ${{ github.repository == 'EvotecIT/PSPublishModule' || github.event.repository.private }}
     strategy:
       fail-fast: false
       matrix:
         runner:
-          - name: windows-runner-01
-            labels: '["self-hosted","windows","X64"]'
-          - name: windows-runner-02
-            labels: '["self-hosted","windows","X64"]'
-          - name: windows-runner-03
-            labels: '["self-hosted","windows","X64"]'
-          - name: windows-runner-04
-            labels: '["self-hosted","windows","X64"]'
-          - name: windows-runner-05
-            labels: '["self-hosted","windows","X64"]'
-          - name: windows-runner-06
-            labels: '["self-hosted","windows","X64"]'
+          - name: GITHUB-RUNNER-W
+            labels: '["self-hosted","windows","runner-github-runner-w"]'
+          - name: GITHUBRUNNERX1
+            labels: '["self-hosted","windows","runner-githubrunnerx1"]'
+          - name: GITHUBRUNNERX2
+            labels: '["self-hosted","windows","runner-githubrunnerx2"]'
+          - name: GITHUBRUNNERX3
+            labels: '["self-hosted","windows","runner-githubrunnerx3"]'
+          - name: GITHUBRUNNERX4
+            labels: '["self-hosted","windows","runner-githubrunnerx4"]'
+          - name: GITHUBRUNNERX5
+            labels: '["self-hosted","windows","runner-githubrunnerx5"]'
     name: ${{ matrix.runner.name }}
     uses: ./.github/workflows/powerforge-github-runner-housekeeping.yml
     with:

--- a/PowerForge.Tests/RunnerHousekeepingServiceTests.cs
+++ b/PowerForge.Tests/RunnerHousekeepingServiceTests.cs
@@ -461,6 +461,28 @@ public sealed class RunnerHousekeepingServiceTests
         Assert.Equal(expected, Assert.IsType<string>(value));
     }
 
+    [Fact]
+    public void IsRunnerStepFailureFatal_TreatsFilesystemCleanupFailuresAsWarningsOnlyAfterFreeSpaceTargetIsMet()
+    {
+        var lockedWorkspaceFailure = new RunnerHousekeepingStepResult
+        {
+            Id = "workspaces",
+            Success = false,
+            Message = "Deleted 0 item(s); failed 1 item(s)."
+        };
+        var commandFailure = new RunnerHousekeepingStepResult
+        {
+            Id = "dotnet-cache",
+            Success = false,
+            Command = "dotnet nuget locals all --clear",
+            ExitCode = 1
+        };
+
+        Assert.False(RunnerHousekeepingService.IsRunnerStepFailureFatal(lockedWorkspaceFailure, freeRequirementMet: true));
+        Assert.True(RunnerHousekeepingService.IsRunnerStepFailureFatal(lockedWorkspaceFailure, freeRequirementMet: false));
+        Assert.True(RunnerHousekeepingService.IsRunnerStepFailureFatal(commandFailure, freeRequirementMet: true));
+    }
+
     private static string CreateSandbox()
     {
         var path = Path.Combine(Path.GetTempPath(), "PowerForge.RunnerHousekeepingTests", Guid.NewGuid().ToString("N"));

--- a/PowerForge/Services/RunnerHousekeepingService.cs
+++ b/PowerForge/Services/RunnerHousekeepingService.cs
@@ -144,6 +144,14 @@ public sealed class RunnerHousekeepingService
         }
 
         var freeAfter = normalized.DryRun ? freeBefore : GetFreeBytes(normalized.FreeSpaceProbePath);
+        var failedSteps = steps
+            .Where(s => !s.Success && !s.Skipped)
+            .ToArray();
+        var freeRequirementMet = normalized.RequiredFreeBytes.HasValue && freeAfter >= normalized.RequiredFreeBytes.Value;
+        var fatalSteps = failedSteps
+            .Where(step => IsRunnerStepFailureFatal(step, freeRequirementMet))
+            .ToArray();
+
         var result = new RunnerHousekeepingResult
         {
             RunnerRootPath = normalized.RunnerRootPath,
@@ -158,7 +166,7 @@ public sealed class RunnerHousekeepingService
             AggressiveApplied = aggressiveApplied,
             DryRun = normalized.DryRun,
             Steps = steps.ToArray(),
-            Success = steps.All(s => s.Success || s.Skipped)
+            Success = fatalSteps.Length == 0
         };
 
         if (!normalized.DryRun)
@@ -169,8 +177,28 @@ public sealed class RunnerHousekeepingService
             result.Success = false;
             result.Message = $"Free disk after cleanup is {FormatGiB(freeAfter)} GiB (required: {FormatGiB(normalized.RequiredFreeBytes.Value)} GiB).";
         }
+        else if (failedSteps.Length > 0 && fatalSteps.Length == 0)
+        {
+            result.Message = $"Cleanup completed with {failedSteps.Length} non-fatal filesystem warning(s) because the free disk requirement was met.";
+        }
 
         return result;
+    }
+
+    /// <summary>
+    /// Determines whether a failed step should fail the runner cleanup after disk pressure is relieved.
+    /// Filesystem cleanup can leave locked Windows workspaces behind while still reclaiming enough space;
+    /// command failures remain fatal because they may indicate tooling or host-level problems.
+    /// </summary>
+    internal static bool IsRunnerStepFailureFatal(RunnerHousekeepingStepResult step, bool freeRequirementMet)
+    {
+        if (step.Success || step.Skipped)
+            return false;
+
+        if (!freeRequirementMet)
+            return true;
+
+        return step.Id is not ("diag" or "runner-temp" or "workspaces" or "actions-cache" or "tool-cache");
     }
 
     private sealed class NormalizedSpec


### PR DESCRIPTION
## Summary
- add Windows self-hosted runner slots to the central runner housekeeping workflow
- reuse the existing PowerForge runner housekeeping workflow and config instead of adding TestimoX-local cleanup

## Validation
- git diff --check