### PR TITLE
Update Scriban for PowerForge web audit

### DIFF
--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -505,8 +505,8 @@
       },
       "Scriban": {
         "type": "Transitive",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "resolved": "7.2.5",
+        "contentHash": "6HDyv0P6PVdx/prWM3Aw0QHAT/DCpkBxOovZ2iPIH4L4ZvJ13JNYJgyUI+xJ5K2agXreYTBe23AL5ZQNTqJQvA=="
       },
       "SixLabors.Fonts": {
         "type": "Transitive",
@@ -883,7 +883,7 @@
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.7, )",
           "PowerForge": "[1.0.0, )",
-          "Scriban": "[7.2.0, )",
+          "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }
       },

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -116,8 +116,8 @@
       },
       "Scriban": {
         "type": "Transitive",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "resolved": "7.2.5",
+        "contentHash": "6HDyv0P6PVdx/prWM3Aw0QHAT/DCpkBxOovZ2iPIH4L4ZvJ13JNYJgyUI+xJ5K2agXreYTBe23AL5ZQNTqJQvA=="
       },
       "SixLabors.Fonts": {
         "type": "Transitive",
@@ -178,7 +178,7 @@
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.7, )",
           "PowerForge": "[1.0.0, )",
-          "Scriban": "[7.2.0, )",
+          "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }
       }
@@ -297,8 +297,8 @@
       },
       "Scriban": {
         "type": "Transitive",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "resolved": "7.2.5",
+        "contentHash": "6HDyv0P6PVdx/prWM3Aw0QHAT/DCpkBxOovZ2iPIH4L4ZvJ13JNYJgyUI+xJ5K2agXreYTBe23AL5ZQNTqJQvA=="
       },
       "SixLabors.Fonts": {
         "type": "Transitive",
@@ -354,7 +354,7 @@
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.7, )",
           "PowerForge": "[1.0.0, )",
-          "Scriban": "[7.2.0, )",
+          "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }
       }

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="HtmlTinkerX" Version="2.0.6" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
     <PackageReference Include="OfficeIMO.Markdown" Version="0.6.7" />
-    <PackageReference Include="Scriban" Version="7.2.0" />
+    <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
 

--- a/PowerForge.Web/packages.lock.json
+++ b/PowerForge.Web/packages.lock.json
@@ -38,9 +38,9 @@
       },
       "Scriban": {
         "type": "Direct",
-        "requested": "[7.2.0, )",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "requested": "[7.2.5, )",
+        "resolved": "7.2.5",
+        "contentHash": "6HDyv0P6PVdx/prWM3Aw0QHAT/DCpkBxOovZ2iPIH4L4ZvJ13JNYJgyUI+xJ5K2agXreYTBe23AL5ZQNTqJQvA=="
       },
       "YamlDotNet": {
         "type": "Direct",
@@ -214,9 +214,9 @@
       },
       "Scriban": {
         "type": "Direct",
-        "requested": "[7.2.0, )",
-        "resolved": "7.2.0",
-        "contentHash": "GiAuu6bCPVWJeMMK8AkJMCNX+wyqt2qgiKjVAPLvRWxzBwpDJjLhJltVP034tsZUHOkBtdfA/Otrny+n3NelBw=="
+        "requested": "[7.2.5, )",
+        "resolved": "7.2.5",
+        "contentHash": "6HDyv0P6PVdx/prWM3Aw0QHAT/DCpkBxOovZ2iPIH4L4ZvJ13JNYJgyUI+xJ5K2agXreYTBe23AL5ZQNTqJQvA=="
       },
       "YamlDotNet": {
         "type": "Direct",


### PR DESCRIPTION
## Summary
- Update `Scriban` from 7.2.0 to 7.2.5 for PowerForge web rendering.
- Refresh package lock files for `PowerForge.Web`, `PowerForge.Web.Cli`, and `PowerForge.Tests`.

## Evidence
- Downstream IntelligenceX deploy proof on PSPublishModule `105a24cf399ce8c7a3a7a269427ef2bfbc3b5d64` failed with NU1902 advisories for `Scriban` 7.2.0: https://github.com/EvotecIT/IntelligenceX/actions/runs/28281127770
- `dotnet list .\PowerForge.Web.Cli\PowerForge.Web.Cli.csproj package --vulnerable --include-transitive` reports no vulnerable packages after the bump.

## Validation
- `dotnet list .\PowerForge.Web.Cli\PowerForge.Web.Cli.csproj package --vulnerable --include-transitive`
- `dotnet build .\PowerForge.Web.Cli\PowerForge.Web.Cli.csproj -c Debug -f net10.0 /m:1 /nr:false`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Debug --filter "FullyQualifiedName~ScribanPfNavigationHelpersTests|FullyQualifiedName~WebReleaseHubRenderingTests" /m:1 /nr:false`
- `git diff --check`