### PR TITLE
Fix module build workspace path resolution

### DIFF
--- a/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
@@ -187,9 +187,15 @@ public sealed class ArtefactConfigurationFactory
     {
         var cleaned = StripCurrentDirectoryPrefix(PathValueResolver.Clean(path));
         var normalizedSegment = segment.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return cleaned.Equals(normalizedSegment, StringComparison.OrdinalIgnoreCase) ||
-               cleaned.StartsWith(normalizedSegment + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
-               cleaned.StartsWith(normalizedSegment + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(cleaned) || string.IsNullOrWhiteSpace(normalizedSegment))
+            return false;
+
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        var firstSegment = cleaned
+            .Split(separators, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault() ?? string.Empty;
+
+        return ModuleBuildPathPolicy.SamePathSegment(firstSegment, normalizedSegment);
     }
 
     private static string StripCurrentDirectoryPrefix(string path)

--- a/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
@@ -185,11 +185,24 @@ public sealed class ArtefactConfigurationFactory
 
     private static bool StartsWithPathSegment(string path, string segment)
     {
-        var cleaned = PathValueResolver.Clean(path);
+        var cleaned = StripCurrentDirectoryPrefix(PathValueResolver.Clean(path));
         var normalizedSegment = segment.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         return cleaned.Equals(normalizedSegment, StringComparison.OrdinalIgnoreCase) ||
                cleaned.StartsWith(normalizedSegment + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
                cleaned.StartsWith(normalizedSegment + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string StripCurrentDirectoryPrefix(string path)
+    {
+        var cleaned = path;
+        while (cleaned.Length >= 2 &&
+               cleaned[0] == '.' &&
+               (cleaned[1] == Path.DirectorySeparatorChar || cleaned[1] == Path.AltDirectorySeparatorChar))
+        {
+            cleaned = cleaned.Substring(2);
+        }
+
+        return cleaned;
     }
 
     private static ArtefactCopyMapping[]? NormalizeMappings(ArtefactCopyMapping[]? input)

--- a/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/ArtefactConfigurationFactory.cs
@@ -142,12 +142,30 @@ public sealed class ArtefactConfigurationFactory
     {
         var scriptContent = !string.IsNullOrWhiteSpace(inlineScript)
             ? inlineScript
-            : (!string.IsNullOrWhiteSpace(scriptPath) ? File.ReadAllText(scriptPath) : null);
+            : (!string.IsNullOrWhiteSpace(scriptPath) ? File.ReadAllText(ResolveMergeScriptPath(scriptPath!)) : null);
 
         if (string.IsNullOrWhiteSpace(scriptContent))
             return null;
 
         return _formatter.Format(scriptContent!);
+    }
+
+    private static string ResolveMergeScriptPath(string scriptPath)
+    {
+        var cleaned = PathValueResolver.Clean(scriptPath);
+        if (Path.IsPathRooted(cleaned))
+            return cleaned;
+
+        var currentDirectory = new DirectoryInfo(Directory.GetCurrentDirectory());
+        if (currentDirectory.Parent is not null &&
+            StartsWithPathSegment(cleaned, currentDirectory.Name))
+        {
+            var workspaceCandidate = PathValueResolver.Resolve(currentDirectory.Parent.FullName, cleaned);
+            if (File.Exists(workspaceCandidate))
+                return workspaceCandidate;
+        }
+
+        return PathValueResolver.Resolve(currentDirectory.FullName, cleaned);
     }
 
     private static string ResolveSecret(string? secret, string? secretFilePath)
@@ -164,6 +182,15 @@ public sealed class ArtefactConfigurationFactory
 
     private static string NormalizePath(string value)
         => PathValueResolver.NormalizeSeparators(value);
+
+    private static bool StartsWithPathSegment(string path, string segment)
+    {
+        var cleaned = PathValueResolver.Clean(path);
+        var normalizedSegment = segment.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return cleaned.Equals(normalizedSegment, StringComparison.OrdinalIgnoreCase) ||
+               cleaned.StartsWith(normalizedSegment + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+               cleaned.StartsWith(normalizedSegment + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
 
     private static ArtefactCopyMapping[]? NormalizeMappings(ArtefactCopyMapping[]? input)
     {

--- a/PowerForge.PowerShell/Services/ModuleBuildPathPolicy.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPathPolicy.cs
@@ -184,6 +184,9 @@ internal static class ModuleBuildPathPolicy
         return candidateWithSeparator.StartsWith(rootWithSeparator, PathStringComparison);
     }
 
+    internal static bool SamePathSegment(string left, string right)
+        => string.Equals(left, right, PathStringComparison);
+
     private static StringComparison PathStringComparison
         => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? StringComparison.OrdinalIgnoreCase

--- a/PowerForge.PowerShell/Services/ModuleBuildPathPolicy.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPathPolicy.cs
@@ -1,0 +1,264 @@
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace PowerForge;
+
+internal static class ModuleBuildPathPolicy
+{
+    private static readonly string[] PathTokens =
+    {
+        "<TagName>",
+        "{TagName}",
+        "<ModuleVersion>",
+        "{ModuleVersion}",
+        "<ModuleVersionWithPreRelease>",
+        "{ModuleVersionWithPreRelease}",
+        "<TagModuleVersionWithPreRelease>",
+        "{TagModuleVersionWithPreRelease}",
+        "<ModuleName>",
+        "{ModuleName}"
+    };
+
+    internal static string? ResolveWorkspacePath(string workspaceRoot, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path))
+            return path;
+
+        if (ContainsToken(path!))
+            return Path.Combine(workspaceRoot, PathValueResolver.Clean(path!));
+
+        return PathValueResolver.Resolve(workspaceRoot, path!);
+    }
+
+    internal static string[] ResolveWorkspacePaths(string workspaceRoot, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path => ResolveWorkspacePath(workspaceRoot, path) ?? string.Empty)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+    }
+
+    internal static string ResolveConfigPath(string baseDir, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        return PathValueResolver.Resolve(baseDir, path!);
+    }
+
+    internal static string? ResolveConfigPathNullable(string baseDir, string? path)
+        => string.IsNullOrWhiteSpace(path)
+            ? null
+            : ResolveConfigPath(baseDir, path);
+
+    internal static string? ResolveTokenAwareConfigPathNullable(string baseDir, string? path)
+        => string.IsNullOrWhiteSpace(path)
+            ? null
+            : ContainsToken(path!)
+                ? NormalizeForJson(path!)
+                : ResolveConfigPath(baseDir, path);
+
+    internal static string[] ResolveConfigPaths(string rootPath, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path => ResolveConfigPathNullable(rootPath, path) ?? string.Empty)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+    }
+
+    internal static string[] ResolveRootedConfigPaths(string rootPath, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path =>
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    return string.Empty;
+
+                var cleaned = PathValueResolver.Clean(path);
+                return Path.IsPathRooted(cleaned)
+                    ? ResolveConfigPath(rootPath, path)
+                    : NormalizeForJson(path);
+            })
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+    }
+
+    internal static string? MakeRelativeForProjectRoot(string projectRoot, string? path)
+        => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: false, projectRoot);
+
+    internal static string? MakeRelativeForProjectRoot(string projectRoot, string? path, bool preserveExternalRooted)
+        => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted, projectRoot);
+
+    internal static string? MakeRelativeForProjectRoot(string projectRoot, string? path, bool preserveExternalRooted, string workspaceRoot)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        if (ContainsToken(path!))
+            return MakeTokenizedPathRelativeForProjectRoot(projectRoot, path!);
+
+        var resolved = ResolveConfigPath(projectRoot, path);
+        if (preserveExternalRooted &&
+            Path.IsPathRooted(PathValueResolver.Clean(path!)) &&
+            !IsSameOrChildPath(projectRoot, resolved) &&
+            !IsSameOrChildPath(workspaceRoot, resolved))
+        {
+            return NormalizeForJson(resolved);
+        }
+
+        return MakeRelativeForConfig(projectRoot, resolved);
+    }
+
+    internal static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted = false)
+        => MakePathsRelativeForProjectRoot(projectRoot, paths, preserveExternalRooted, projectRoot);
+
+    internal static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted, string workspaceRoot)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted, workspaceRoot) ?? string.Empty)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+    }
+
+    internal static string MakeRelativeForConfig(string baseDir, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return path;
+
+        try
+        {
+            var full = Path.GetFullPath(path);
+            var rel = GetRelativePath(baseDir, full);
+            return rel.Replace('\\', '/');
+        }
+        catch
+        {
+            return path.Replace('\\', '/');
+        }
+    }
+
+    internal static string? MakeRelativeForConfigNullable(string baseDir, string? path)
+        => string.IsNullOrWhiteSpace(path)
+            ? null
+            : MakeRelativeForConfig(baseDir, path!);
+
+    internal static string NormalizeForJson(string path)
+        => path.Replace('\\', '/');
+
+    internal static bool ContainsToken(string path)
+        => IndexOfToken(path) >= 0;
+
+    internal static bool SamePath(string left, string right)
+    {
+        var normalizedLeft = Path.GetFullPath(left)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedRight = Path.GetFullPath(right)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return string.Equals(normalizedLeft, normalizedRight, PathStringComparison);
+    }
+
+    internal static bool IsSameOrChildPath(string rootPath, string candidatePath)
+    {
+        var root = Path.GetFullPath(rootPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidate = Path.GetFullPath(candidatePath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (string.Equals(root, candidate, PathStringComparison))
+            return true;
+
+        var rootWithSeparator = root + Path.DirectorySeparatorChar;
+        var candidateWithSeparator = candidate + Path.DirectorySeparatorChar;
+        return candidateWithSeparator.StartsWith(rootWithSeparator, PathStringComparison);
+    }
+
+    private static StringComparison PathStringComparison
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    private static string MakeTokenizedPathRelativeForProjectRoot(string projectRoot, string path)
+    {
+        var cleaned = PathValueResolver.Clean(path);
+        if (!Path.IsPathRooted(cleaned))
+            return NormalizeForJson(cleaned);
+
+        var tokenIndex = IndexOfToken(cleaned);
+        if (tokenIndex < 0)
+            return NormalizeForJson(cleaned);
+
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        var prefix = cleaned.Substring(0, tokenIndex).TrimEnd(separators);
+        if (string.IsNullOrWhiteSpace(prefix))
+            return NormalizeForJson(cleaned);
+
+        var prefixFullPath = Path.GetFullPath(prefix);
+        if (!IsSameOrChildPath(projectRoot, prefixFullPath))
+            return NormalizeForJson(cleaned);
+
+        var relativePrefix = MakeRelativeForConfig(projectRoot, prefixFullPath);
+        var tokenStartsNewSegment = tokenIndex == 0 || separators.Contains(cleaned[tokenIndex - 1]);
+        var suffix = tokenStartsNewSegment
+            ? cleaned.Substring(tokenIndex).TrimStart(separators)
+            : cleaned.Substring(tokenIndex);
+        return string.Equals(relativePrefix, ".", StringComparison.Ordinal)
+            ? NormalizeForJson(suffix)
+            : NormalizeForJson(tokenStartsNewSegment
+                ? Path.Combine(relativePrefix, suffix)
+                : relativePrefix + suffix);
+    }
+
+    private static int IndexOfToken(string path)
+    {
+        var index = -1;
+        foreach (var token in PathTokens)
+        {
+            var tokenIndex = path.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+            if (tokenIndex >= 0 && (index < 0 || tokenIndex < index))
+                index = tokenIndex;
+        }
+
+        return index;
+    }
+
+    private static string GetRelativePath(string baseDir, string fullPath)
+    {
+#if NET472
+        var baseFull = EnsureTrailingSeparator(Path.GetFullPath(baseDir));
+        var baseUri = new Uri(baseFull);
+        var pathUri = new Uri(Path.GetFullPath(fullPath));
+
+        if (!string.Equals(baseUri.Scheme, pathUri.Scheme, StringComparison.OrdinalIgnoreCase))
+            return fullPath;
+
+        var relativeUri = baseUri.MakeRelativeUri(pathUri);
+        var relative = Uri.UnescapeDataString(relativeUri.ToString());
+        return relative.Replace('/', Path.DirectorySeparatorChar);
+#else
+        return Path.GetRelativePath(baseDir, fullPath);
+#endif
+
+#if NET472
+        static string EnsureTrailingSeparator(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input)) return input;
+            if (input.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+                input.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+                return input;
+            return input + Path.DirectorySeparatorChar;
+        }
+#endif
+    }
+}

--- a/PowerForge.PowerShell/Services/ModuleBuildPathPolicy.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPathPolicy.cs
@@ -104,7 +104,7 @@ internal static class ModuleBuildPathPolicy
             return null;
 
         if (ContainsToken(path!))
-            return MakeTokenizedPathRelativeForProjectRoot(projectRoot, path!);
+            return MakeTokenizedPathRelativeForProjectRoot(projectRoot, path!, workspaceRoot);
 
         var resolved = ResolveConfigPath(projectRoot, path);
         if (preserveExternalRooted &&
@@ -189,7 +189,7 @@ internal static class ModuleBuildPathPolicy
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 
-    private static string MakeTokenizedPathRelativeForProjectRoot(string projectRoot, string path)
+    private static string MakeTokenizedPathRelativeForProjectRoot(string projectRoot, string path, string workspaceRoot)
     {
         var cleaned = PathValueResolver.Clean(path);
         if (!Path.IsPathRooted(cleaned))
@@ -205,8 +205,11 @@ internal static class ModuleBuildPathPolicy
             return NormalizeForJson(cleaned);
 
         var prefixFullPath = Path.GetFullPath(prefix);
-        if (!IsSameOrChildPath(projectRoot, prefixFullPath))
+        if (!IsSameOrChildPath(projectRoot, prefixFullPath) &&
+            !IsSameOrChildPath(workspaceRoot, prefixFullPath))
+        {
             return NormalizeForJson(cleaned);
+        }
 
         var relativePrefix = MakeRelativeForConfig(projectRoot, prefixFullPath);
         var tokenStartsNewSegment = tokenIndex == 0 || separators.Contains(cleaned[tokenIndex - 1]);

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -438,6 +438,10 @@ internal sealed class ModuleBuildPreparationService
                     documentation.Configuration.PathReadme = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, documentation.Configuration.PathReadme) ?? string.Empty;
                     break;
                 case ConfigurationBuildDocumentationSegment buildDocumentation:
+                    buildDocumentation.Configuration.AboutTopicsSourcePath = ResolveWorkspaceQualifiedStagingRelativePaths(
+                        workspaceRoot,
+                        projectRoot,
+                        buildDocumentation.Configuration.AboutTopicsSourcePath);
                     break;
                 case ConfigurationTestSegment test:
                     test.Configuration.TestsPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, test.Configuration.TestsPath) ?? string.Empty;
@@ -502,26 +506,10 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static string? ResolveWorkspacePath(string workspaceRoot, string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path))
-            return path;
-
-        if (ContainsPathToken(path!))
-            return Path.Combine(workspaceRoot, PathValueResolver.Clean(path!));
-
-        return PathValueResolver.Resolve(workspaceRoot, path!);
-    }
+        => ModuleBuildPathPolicy.ResolveWorkspacePath(workspaceRoot, path);
 
     private static string[] ResolveWorkspacePaths(string workspaceRoot, string[]? paths)
-    {
-        if (paths is null || paths.Length == 0)
-            return Array.Empty<string>();
-
-        return paths
-            .Select(path => ResolveWorkspacePath(workspaceRoot, path) ?? string.Empty)
-            .Where(static path => !string.IsNullOrWhiteSpace(path))
-            .ToArray();
-    }
+        => ModuleBuildPathPolicy.ResolveWorkspacePaths(workspaceRoot, paths);
 
     private static string? ResolveWorkspaceQualifiedPath(string workspaceRoot, string projectRoot, string? path)
     {
@@ -535,30 +523,7 @@ internal sealed class ModuleBuildPreparationService
         return ResolveWorkspacePath(workspaceRoot, path);
     }
 
-    private static bool ContainsPathToken(string path)
-        => path.Contains("<TagName>", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("{TagName}", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("<ModuleVersion>", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("{ModuleVersion}", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("<ModuleVersionWithPreRelease>", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("{ModuleVersionWithPreRelease}", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("<TagModuleVersionWithPreRelease>", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("{TagModuleVersionWithPreRelease}", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("<ModuleName>", StringComparison.OrdinalIgnoreCase) ||
-           path.Contains("{ModuleName}", StringComparison.OrdinalIgnoreCase);
-
-    private static string[] ResolveConfigPaths(string rootPath, string[]? paths)
-    {
-        if (paths is null || paths.Length == 0)
-            return Array.Empty<string>();
-
-        return paths
-            .Select(path => ResolveConfigPathNullable(rootPath, path) ?? string.Empty)
-            .Where(static path => !string.IsNullOrWhiteSpace(path))
-            .ToArray();
-    }
-
-    private static string[] ResolveRootedConfigPaths(string rootPath, string[]? paths)
+    private static string[] ResolveWorkspaceQualifiedStagingRelativePaths(string workspaceRoot, string projectRoot, string[]? paths)
     {
         if (paths is null || paths.Length == 0)
             return Array.Empty<string>();
@@ -566,17 +531,26 @@ internal sealed class ModuleBuildPreparationService
         return paths
             .Select(path =>
             {
-                if (string.IsNullOrWhiteSpace(path))
+                var resolved = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, path);
+                if (string.IsNullOrWhiteSpace(resolved))
                     return string.Empty;
 
-                var cleaned = PathValueResolver.Clean(path);
-                return Path.IsPathRooted(cleaned)
-                    ? ResolveConfigPath(rootPath, path)
-                    : NormalizePathSeparators(path);
+                return Path.IsPathRooted(resolved!) && IsSameOrChildPath(projectRoot, resolved!)
+                    ? MakeRelativeForConfig(projectRoot, resolved!)
+                    : NormalizePathSeparators(resolved!);
             })
             .Where(static path => !string.IsNullOrWhiteSpace(path))
             .ToArray();
     }
+
+    private static bool ContainsPathToken(string path)
+        => ModuleBuildPathPolicy.ContainsToken(path);
+
+    private static string[] ResolveConfigPaths(string rootPath, string[]? paths)
+        => ModuleBuildPathPolicy.ResolveConfigPaths(rootPath, paths);
+
+    private static string[] ResolveRootedConfigPaths(string rootPath, string[]? paths)
+        => ModuleBuildPathPolicy.ResolveRootedConfigPaths(rootPath, paths);
 
     private static IConfigurationSegment[] CollectSettingsFromWorkspace(ScriptBlock? settings, string workspaceRoot)
     {
@@ -722,13 +696,7 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static bool SamePath(string left, string right)
-    {
-        var normalizedLeft = Path.GetFullPath(left)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var normalizedRight = Path.GetFullPath(right)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return string.Equals(normalizedLeft, normalizedRight, StringComparison.OrdinalIgnoreCase);
-    }
+        => ModuleBuildPathPolicy.SamePath(left, right);
 
     private static string[] BuildStageExcludeFiles(string[]? excludeFiles, string moduleName)
     {
@@ -779,24 +747,13 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static string ResolveConfigPath(string baseDir, string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return string.Empty;
-        return PathValueResolver.Resolve(baseDir, path!);
-    }
+        => ModuleBuildPathPolicy.ResolveConfigPath(baseDir, path);
 
     private static string? ResolveConfigPathNullable(string baseDir, string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return null;
-        return ResolveConfigPath(baseDir, path);
-    }
+        => ModuleBuildPathPolicy.ResolveConfigPathNullable(baseDir, path);
 
     private static string? ResolveTokenAwareConfigPathNullable(string baseDir, string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return null;
-        return ContainsPathToken(path!)
-            ? NormalizePathSeparators(path!)
-            : ResolveConfigPath(baseDir, path);
-    }
+        => ModuleBuildPathPolicy.ResolveTokenAwareConfigPathNullable(baseDir, path);
 
     private static void PrepareSpecForJsonExport(ModulePipelineSpec spec, string jsonFullPath)
     {
@@ -938,10 +895,15 @@ internal sealed class ModuleBuildPreparationService
     private static string ResolveJsonWorkspaceRoot(string projectRoot)
     {
         var projectDirectory = new DirectoryInfo(Path.GetFullPath(projectRoot));
-        return string.Equals(projectDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) && projectDirectory.Parent is not null
-            ? projectDirectory.Parent.FullName
+        return UsesRepositoryModuleLayout(projectDirectory)
+            ? projectDirectory.Parent!.FullName
             : projectRoot;
     }
+
+    private static bool UsesRepositoryModuleLayout(DirectoryInfo projectDirectory)
+        => string.Equals(projectDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) &&
+           projectDirectory.Parent is not null &&
+           File.Exists(Path.Combine(projectDirectory.FullName, "Build", "Build-Module.ps1"));
 
     private static string? MakeArtefactLayoutPathForJson(string projectRoot, string workspaceRoot, string? artefactPath, string? layoutPath)
     {
@@ -981,31 +943,13 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static string? MakeRelativeForProjectRoot(string projectRoot, string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return null;
-        return MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: false);
-    }
+        => ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, path);
 
     private static string? MakeRelativeForProjectRoot(string projectRoot, string? path, bool preserveExternalRooted)
-        => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted, projectRoot);
+        => ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted);
 
     private static string? MakeRelativeForProjectRoot(string projectRoot, string? path, bool preserveExternalRooted, string workspaceRoot)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return null;
-        if (ContainsPathToken(path!))
-            return MakeTokenizedPathRelativeForProjectRoot(projectRoot, path!);
-
-        var resolved = ResolveConfigPath(projectRoot, path);
-        if (preserveExternalRooted &&
-            Path.IsPathRooted(PathValueResolver.Clean(path!)) &&
-            !IsSameOrChildPath(projectRoot, resolved) &&
-            !IsSameOrChildPath(workspaceRoot, resolved))
-        {
-            return NormalizePathSeparators(resolved);
-        }
-
-        return MakeRelativeForConfig(projectRoot, resolved);
-    }
+        => ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted, workspaceRoot);
 
     private static void MakePackageBuildOptionPathsRelative(Dictionary<string, object?>? options, string projectRoot, string workspaceRoot)
     {
@@ -1026,76 +970,10 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted = false)
-        => MakePathsRelativeForProjectRoot(projectRoot, paths, preserveExternalRooted, projectRoot);
+        => ModuleBuildPathPolicy.MakePathsRelativeForProjectRoot(projectRoot, paths, preserveExternalRooted);
 
     private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted, string workspaceRoot)
-    {
-        if (paths is null || paths.Length == 0)
-            return Array.Empty<string>();
-
-        return paths
-            .Select(path => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted, workspaceRoot) ?? string.Empty)
-            .Where(static path => !string.IsNullOrWhiteSpace(path))
-            .ToArray();
-    }
-
-    private static string MakeTokenizedPathRelativeForProjectRoot(string projectRoot, string path)
-    {
-        var cleaned = PathValueResolver.Clean(path);
-        if (!Path.IsPathRooted(cleaned))
-            return NormalizePathSeparators(cleaned);
-
-        var tokenIndex = IndexOfPathToken(cleaned);
-        if (tokenIndex < 0)
-            return NormalizePathSeparators(cleaned);
-
-        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
-        var prefix = cleaned.Substring(0, tokenIndex).TrimEnd(separators);
-        if (string.IsNullOrWhiteSpace(prefix))
-            return NormalizePathSeparators(cleaned);
-
-        var prefixFullPath = Path.GetFullPath(prefix);
-        if (!IsSameOrChildPath(projectRoot, prefixFullPath))
-            return NormalizePathSeparators(cleaned);
-
-        var relativePrefix = MakeRelativeForConfig(projectRoot, prefixFullPath);
-        var tokenStartsNewSegment = tokenIndex == 0 || separators.Contains(cleaned[tokenIndex - 1]);
-        var suffix = tokenStartsNewSegment
-            ? cleaned.Substring(tokenIndex).TrimStart(separators)
-            : cleaned.Substring(tokenIndex);
-        return string.Equals(relativePrefix, ".", StringComparison.Ordinal)
-            ? NormalizePathSeparators(suffix)
-            : NormalizePathSeparators(tokenStartsNewSegment
-                ? Path.Combine(relativePrefix, suffix)
-                : relativePrefix + suffix);
-    }
-
-    private static int IndexOfPathToken(string path)
-    {
-        var tokens = new[]
-        {
-            "<TagName>",
-            "{TagName}",
-            "<ModuleVersion>",
-            "{ModuleVersion}",
-            "<ModuleVersionWithPreRelease>",
-            "{ModuleVersionWithPreRelease}",
-            "<TagModuleVersionWithPreRelease>",
-            "{TagModuleVersionWithPreRelease}",
-            "<ModuleName>",
-            "{ModuleName}"
-        };
-
-        var index = -1;
-        foreach (var token in tokens)
-        {
-            var tokenIndex = path.IndexOf(token, StringComparison.OrdinalIgnoreCase);
-            if (tokenIndex >= 0 && (index < 0 || tokenIndex < index))
-                index = tokenIndex;
-        }
-
-        return index;
-    }
+        => ModuleBuildPathPolicy.MakePathsRelativeForProjectRoot(projectRoot, paths, preserveExternalRooted, workspaceRoot);
 
     private static string? GetStringOptionValue(object? value)
     {
@@ -1108,71 +986,14 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static string MakeRelativeForConfig(string baseDir, string path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return path;
-
-        try
-        {
-            var full = Path.GetFullPath(path);
-            var rel = GetRelativePath(baseDir, full);
-            return rel.Replace('\\', '/');
-        }
-        catch
-        {
-            return path.Replace('\\', '/');
-        }
-    }
+        => ModuleBuildPathPolicy.MakeRelativeForConfig(baseDir, path);
 
     private static string? MakeRelativeForConfigNullable(string baseDir, string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path)) return null;
-        return MakeRelativeForConfig(baseDir, path!);
-    }
+        => ModuleBuildPathPolicy.MakeRelativeForConfigNullable(baseDir, path);
 
     private static string NormalizePathSeparators(string path)
-        => path.Replace('\\', '/');
+        => ModuleBuildPathPolicy.NormalizeForJson(path);
 
     private static bool IsSameOrChildPath(string rootPath, string candidatePath)
-    {
-        var root = Path.GetFullPath(rootPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var candidate = Path.GetFullPath(candidatePath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (string.Equals(root, candidate, StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        var rootWithSeparator = root + Path.DirectorySeparatorChar;
-        var candidateWithSeparator = candidate + Path.DirectorySeparatorChar;
-        return candidateWithSeparator.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string GetRelativePath(string baseDir, string fullPath)
-    {
-#if NET472
-        var baseFull = EnsureTrailingSeparator(Path.GetFullPath(baseDir));
-        var baseUri = new Uri(baseFull);
-        var pathUri = new Uri(Path.GetFullPath(fullPath));
-
-        if (!string.Equals(baseUri.Scheme, pathUri.Scheme, StringComparison.OrdinalIgnoreCase))
-            return fullPath;
-
-        var relativeUri = baseUri.MakeRelativeUri(pathUri);
-        var relative = Uri.UnescapeDataString(relativeUri.ToString());
-        return relative.Replace('/', Path.DirectorySeparatorChar);
-#else
-        return Path.GetRelativePath(baseDir, fullPath);
-#endif
-
-#if NET472
-        static string EnsureTrailingSeparator(string input)
-        {
-            if (string.IsNullOrWhiteSpace(input)) return input;
-            if (input.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
-                input.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
-                return input;
-            return input + Path.DirectorySeparatorChar;
-        }
-#endif
-    }
+        => ModuleBuildPathPolicy.IsSameOrChildPath(rootPath, candidatePath);
 }

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -262,7 +262,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.AboutTopicsSourcePath = ResolveConfigPaths(projectRoot, cfg.AboutTopicsSourcePath);
+            cfg.AboutTopicsSourcePath = ResolveRootedConfigPaths(projectRoot, cfg.AboutTopicsSourcePath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
@@ -558,6 +558,26 @@ internal sealed class ModuleBuildPreparationService
             .ToArray();
     }
 
+    private static string[] ResolveRootedConfigPaths(string rootPath, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path =>
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                    return string.Empty;
+
+                var cleaned = PathValueResolver.Clean(path);
+                return Path.IsPathRooted(cleaned)
+                    ? ResolveConfigPath(rootPath, path)
+                    : NormalizePathSeparators(path);
+            })
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+    }
+
     private static IConfigurationSegment[] CollectSettingsFromWorkspace(ScriptBlock? settings, string workspaceRoot)
     {
         if (settings is null)
@@ -643,7 +663,14 @@ internal sealed class ModuleBuildPreparationService
 
     private static string? ResolveArtefactLayoutPath(string rootPath, string? artefactPath, string? layoutPath)
     {
-        if (string.IsNullOrWhiteSpace(layoutPath) || Path.IsPathRooted(layoutPath))
+        if (string.IsNullOrWhiteSpace(layoutPath))
+            return layoutPath;
+        if (!string.IsNullOrWhiteSpace(artefactPath) &&
+            (ContainsPathToken(layoutPath!) || ContainsPathToken(artefactPath!)))
+        {
+            return layoutPath;
+        }
+        if (Path.IsPathRooted(layoutPath))
             return layoutPath;
         if (string.IsNullOrWhiteSpace(artefactPath))
             return layoutPath;
@@ -868,7 +895,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null || string.IsNullOrWhiteSpace(cfg.StageRoot)) continue;
-            cfg.StageRoot = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.StageRoot));
+            cfg.StageRoot = MakeReleaseStageRootPathForJson(projectRoot, cfg.StageRoot!);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationPublishSegment>() ?? Enumerable.Empty<ConfigurationPublishSegment>())
@@ -923,6 +950,11 @@ internal sealed class ModuleBuildPreparationService
             ? MakeRelativeForProjectRoot(projectRoot, candidate)
             : NormalizePathSeparators(layoutPath!);
     }
+
+    private static string MakeReleaseStageRootPathForJson(string projectRoot, string stageRoot)
+        => ContainsPathToken(stageRoot)
+            ? MakeRelativeForProjectRoot(projectRoot, stageRoot) ?? NormalizePathSeparators(stageRoot)
+            : MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, stageRoot));
 
     private static void MakeCopyMappingSourcesRelative(ArtefactCopyMapping[]? mappings, string projectRoot, string workspaceRoot)
     {
@@ -1022,10 +1054,15 @@ internal sealed class ModuleBuildPreparationService
             return NormalizePathSeparators(cleaned);
 
         var relativePrefix = MakeRelativeForConfig(projectRoot, prefixFullPath);
-        var suffix = cleaned.Substring(tokenIndex).TrimStart(separators);
+        var tokenStartsNewSegment = tokenIndex == 0 || separators.Contains(cleaned[tokenIndex - 1]);
+        var suffix = tokenStartsNewSegment
+            ? cleaned.Substring(tokenIndex).TrimStart(separators)
+            : cleaned.Substring(tokenIndex);
         return string.Equals(relativePrefix, ".", StringComparison.Ordinal)
             ? NormalizePathSeparators(suffix)
-            : NormalizePathSeparators(Path.Combine(relativePrefix, suffix));
+            : NormalizePathSeparators(tokenStartsNewSegment
+                ? Path.Combine(relativePrefix, suffix)
+                : relativePrefix + suffix);
     }
 
     private static int IndexOfPathToken(string path)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -459,10 +459,10 @@ internal sealed class ModuleBuildPreparationService
                     action.Configuration.WorkingDirectory = ResolveWorkspacePath(workspaceRoot, action.Configuration.WorkingDirectory);
                     break;
                 case ConfigurationAppleAppSegment appleApp:
-                    appleApp.Configuration.ProjectPath = ResolveWorkspacePath(workspaceRoot, appleApp.Configuration.ProjectPath) ?? string.Empty;
+                    appleApp.Configuration.ProjectPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, appleApp.Configuration.ProjectPath) ?? string.Empty;
                     break;
                 case ConfigurationXcodeProjectVersionSegment xcodeProject:
-                    xcodeProject.Configuration.Path = ResolveWorkspacePath(workspaceRoot, xcodeProject.Configuration.Path) ?? string.Empty;
+                    xcodeProject.Configuration.Path = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, xcodeProject.Configuration.Path) ?? string.Empty;
                     break;
                 case ConfigurationArtefactSegment artefact:
                     ResolveWorkspaceRelativeArtefactPaths(artefact.Configuration, workspaceRoot, projectRoot);
@@ -473,9 +473,12 @@ internal sealed class ModuleBuildPreparationService
 
     private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot, string projectRoot)
     {
-        configuration.Path = ResolveWorkspacePath(workspaceRoot, configuration.Path);
-        configuration.RequiredModules.Path = ResolveArtefactLayoutPath(workspaceRoot, configuration.Path, configuration.RequiredModules.Path);
-        configuration.RequiredModules.ModulesPath = ResolveArtefactLayoutPath(workspaceRoot, configuration.Path, configuration.RequiredModules.ModulesPath);
+        configuration.Path = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, configuration.Path);
+        var layoutRoot = Path.IsPathRooted(configuration.Path ?? string.Empty)
+            ? workspaceRoot
+            : projectRoot;
+        configuration.RequiredModules.Path = ResolveArtefactLayoutPath(layoutRoot, configuration.Path, configuration.RequiredModules.Path);
+        configuration.RequiredModules.ModulesPath = ResolveArtefactLayoutPath(layoutRoot, configuration.Path, configuration.RequiredModules.ModulesPath);
         ResolveCopyMappingSources(configuration.DirectoryOutput, workspaceRoot, projectRoot);
         ResolveCopyMappingSources(configuration.FilesOutput, workspaceRoot, projectRoot);
     }
@@ -653,8 +656,9 @@ internal sealed class ModuleBuildPreparationService
     {
         var cleaned = PathValueResolver.Clean(path);
         var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
-        var firstSeparator = cleaned.IndexOfAny(separators);
-        return firstSeparator < 0 ? cleaned : cleaned.Substring(0, firstSeparator);
+        return cleaned
+            .Split(separators, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(static segment => !string.Equals(segment, ".", StringComparison.Ordinal)) ?? string.Empty;
     }
 
     private static bool SamePath(string left, string right)
@@ -738,13 +742,13 @@ internal sealed class ModuleBuildPreparationService
         spec.Build.StagingPath = MakeRelativeForConfigNullable(baseDir, spec.Build.StagingPath);
         spec.Build.CsprojPath = MakeRelativeForConfigNullable(baseDir, spec.Build.CsprojPath);
         spec.Build.DevelopmentBinariesPath = MakeRelativeForConfigNullable(baseDir, spec.Build.DevelopmentBinariesPath);
-        spec.Build.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Build.BinaryConflictSearchRoots);
+        spec.Build.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Build.BinaryConflictSearchRoots, preserveExternalRooted: true);
         if (spec.Install?.Roots is not null)
             spec.Install.Roots = MakePathsRelativeForProjectRoot(projectRoot, spec.Install.Roots, preserveExternalRooted: true);
         if (spec.Diagnostics is not null && !string.IsNullOrWhiteSpace(spec.Diagnostics.BaselinePath))
             spec.Diagnostics.BaselinePath = MakeRelativeForConfig(baseDir, spec.Diagnostics.BaselinePath!);
         if (spec.Diagnostics is not null)
-            spec.Diagnostics.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Diagnostics.BinaryConflictSearchRoots);
+            spec.Diagnostics.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Diagnostics.BinaryConflictSearchRoots, preserveExternalRooted: true);
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationAppleAppSegment>() ?? Enumerable.Empty<ConfigurationAppleAppSegment>())
         {
@@ -838,7 +842,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.ApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.ApiKeyFilePath);
+            cfg.ApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.ApiKeyFilePath, preserveExternalRooted: true);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationActionSegment>() ?? Enumerable.Empty<ConfigurationActionSegment>())
@@ -889,7 +893,7 @@ internal sealed class ModuleBuildPreparationService
             if (mapping is null || string.IsNullOrWhiteSpace(mapping.Source))
                 continue;
 
-            mapping.Source = MakeRelativeForProjectRoot(projectRoot, mapping.Source) ?? string.Empty;
+            mapping.Source = MakeRelativeForProjectRoot(projectRoot, mapping.Source, preserveExternalRooted: true) ?? string.Empty;
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -66,7 +66,9 @@ internal sealed class ModuleBuildPreparationService
                 Name = moduleName!,
                 SourcePath = projectRoot,
                 StagingPath = ResolveWorkspacePath(workspaceRoot, request.StagingPath),
-                CsprojPath = ResolveWorkspacePath(workspaceRoot, request.CsprojPath),
+                CsprojPath = UsesModuleFolderLayout(workspaceRoot, projectRoot)
+                    ? ResolveProjectPreferredPath(workspaceRoot, projectRoot, request.CsprojPath)
+                    : ResolveWorkspacePath(workspaceRoot, request.CsprojPath),
                 Version = "1.0.0",
                 Configuration = request.DotNetConfiguration,
                 Frameworks = frameworks,
@@ -222,9 +224,13 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
+            var optionsRoot = projectRoot;
             if (!string.IsNullOrWhiteSpace(cfg.ConfigPath))
+            {
                 cfg.ConfigPath = ResolveConfigPath(projectRoot, cfg.ConfigPath);
-            ResolvePackageBuildOptionPaths(cfg.Options, projectRoot);
+                optionsRoot = Path.GetDirectoryName(cfg.ConfigPath) ?? projectRoot;
+            }
+            ResolvePackageBuildOptionPaths(cfg.Options, optionsRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
@@ -523,6 +529,27 @@ internal sealed class ModuleBuildPreparationService
         return ResolveWorkspacePath(workspaceRoot, path);
     }
 
+    private static string? ResolveProjectPreferredPath(string workspaceRoot, string projectRoot, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return path;
+        if (Path.IsPathRooted(path) || SamePath(workspaceRoot, projectRoot))
+            return ResolveWorkspacePath(projectRoot, path);
+
+        var moduleDirectoryName = Path.GetFileName(projectRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)) ?? string.Empty;
+        if (StartsWithPathSegment(path!, moduleDirectoryName))
+            return ResolveWorkspacePath(workspaceRoot, path);
+
+        var projectCandidate = PathValueResolver.Resolve(projectRoot, path!);
+        if (File.Exists(projectCandidate) || Directory.Exists(projectCandidate))
+            return projectCandidate;
+
+        var workspaceCandidate = PathValueResolver.Resolve(workspaceRoot, path!);
+        return File.Exists(workspaceCandidate) || Directory.Exists(workspaceCandidate)
+            ? workspaceCandidate
+            : projectCandidate;
+    }
+
     private static string[] ResolveWorkspaceQualifiedStagingRelativePaths(string workspaceRoot, string projectRoot, string[]? paths)
     {
         if (paths is null || paths.Length == 0)
@@ -794,9 +821,14 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
+            var optionsRoot = projectRoot;
             if (!string.IsNullOrWhiteSpace(cfg.ConfigPath))
-                cfg.ConfigPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.ConfigPath));
-            MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot, workspaceRoot);
+            {
+                var configPath = ResolveConfigPath(projectRoot, cfg.ConfigPath);
+                optionsRoot = Path.GetDirectoryName(configPath) ?? projectRoot;
+                cfg.ConfigPath = MakeRelativeForConfig(projectRoot, configPath);
+            }
+            MakePackageBuildOptionPathsRelative(cfg.Options, optionsRoot, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -405,36 +405,32 @@ internal sealed class ModuleBuildPreparationService
         if (segments.Count == 0 || SamePath(workspaceRoot, projectRoot))
             return;
 
-        var preserveModuleLocalBuildPaths = UsesModuleFolderLayout(workspaceRoot, projectRoot);
+        var preserveProjectRelativeSegmentPaths = UsesModuleFolderLayout(workspaceRoot, projectRoot);
         foreach (var segment in segments)
         {
             switch (segment)
             {
                 case ConfigurationBuildLibrariesSegment buildLibraries:
                     var libraries = buildLibraries.BuildLibraries;
-                    if (!preserveModuleLocalBuildPaths)
-                    {
-                        libraries.NETProjectPath = ResolveWorkspacePath(workspaceRoot, libraries.NETProjectPath);
-                        libraries.DevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.DevelopmentBinariesPath);
-                        libraries.NETDevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.NETDevelopmentBinariesPath);
-                    }
+                    libraries.NETProjectPath = ResolveSegmentPath(workspaceRoot, projectRoot, libraries.NETProjectPath, preserveProjectRelativeSegmentPaths);
+                    libraries.DevelopmentBinariesPath = ResolveSegmentPath(workspaceRoot, projectRoot, libraries.DevelopmentBinariesPath, preserveProjectRelativeSegmentPaths);
+                    libraries.NETDevelopmentBinariesPath = ResolveSegmentPath(workspaceRoot, projectRoot, libraries.NETDevelopmentBinariesPath, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationProjectBuildSegment projectBuild:
-                    if (!preserveModuleLocalBuildPaths)
-                        projectBuild.Configuration.ConfigPath = ResolveWorkspacePath(workspaceRoot, projectBuild.Configuration.ConfigPath) ?? string.Empty;
-                    ResolvePackageBuildOptionPaths(projectBuild.Configuration.Options, workspaceRoot);
+                    projectBuild.Configuration.ConfigPath = ResolveSegmentPath(workspaceRoot, projectRoot, projectBuild.Configuration.ConfigPath, preserveProjectRelativeSegmentPaths) ?? string.Empty;
+                    ResolvePackageBuildOptionPaths(projectBuild.Configuration.Options, workspaceRoot, projectRoot, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationPackageBuildSegment packageBuild:
                     var package = packageBuild.Configuration;
-                    package.RootPath = ResolveWorkspacePath(workspaceRoot, package.RootPath);
-                    package.OutputPath = ResolveWorkspacePath(workspaceRoot, package.OutputPath);
-                    package.ReleaseZipOutputPath = ResolveWorkspacePath(workspaceRoot, package.ReleaseZipOutputPath);
-                    package.StagingPath = ResolveWorkspacePath(workspaceRoot, package.StagingPath);
-                    package.PlanOutputPath = ResolveWorkspacePath(workspaceRoot, package.PlanOutputPath);
-                    package.PublishApiKeyFilePath = ResolveWorkspacePath(workspaceRoot, package.PublishApiKeyFilePath);
-                    package.NugetCredentialSecretFilePath = ResolveWorkspacePath(workspaceRoot, package.NugetCredentialSecretFilePath);
-                    package.GitHubAccessTokenFilePath = ResolveWorkspacePath(workspaceRoot, package.GitHubAccessTokenFilePath);
-                    ResolvePackageBuildOptionPaths(package.Options, workspaceRoot);
+                    package.RootPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.RootPath, preserveProjectRelativeSegmentPaths);
+                    package.OutputPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.OutputPath, preserveProjectRelativeSegmentPaths);
+                    package.ReleaseZipOutputPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.ReleaseZipOutputPath, preserveProjectRelativeSegmentPaths);
+                    package.StagingPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.StagingPath, preserveProjectRelativeSegmentPaths);
+                    package.PlanOutputPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.PlanOutputPath, preserveProjectRelativeSegmentPaths);
+                    package.PublishApiKeyFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, package.PublishApiKeyFilePath, preserveProjectRelativeSegmentPaths);
+                    package.NugetCredentialSecretFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, package.NugetCredentialSecretFilePath, preserveProjectRelativeSegmentPaths);
+                    package.GitHubAccessTokenFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, package.GitHubAccessTokenFilePath, preserveProjectRelativeSegmentPaths);
+                    ResolvePackageBuildOptionPaths(package.Options, workspaceRoot, projectRoot, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationDocumentationSegment documentation:
                     documentation.Configuration.Path = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, documentation.Configuration.Path) ?? string.Empty;
@@ -451,17 +447,17 @@ internal sealed class ModuleBuildPreparationService
                 case ConfigurationOptionsSegment options:
                     var signing = options.Options?.Signing;
                     if (signing is not null)
-                        signing.CertificatePFXPath = ResolveWorkspacePath(workspaceRoot, signing.CertificatePFXPath);
+                        signing.CertificatePFXPath = ResolveSegmentPath(workspaceRoot, projectRoot, signing.CertificatePFXPath, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationReleaseSegment release:
-                    release.Configuration.StageRoot = ResolveWorkspacePath(workspaceRoot, release.Configuration.StageRoot);
+                    release.Configuration.StageRoot = ResolveSegmentPath(workspaceRoot, projectRoot, release.Configuration.StageRoot, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationPublishSegment publish:
-                    publish.Configuration.ApiKeyFilePath = ResolveWorkspacePath(workspaceRoot, publish.Configuration.ApiKeyFilePath);
+                    publish.Configuration.ApiKeyFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, publish.Configuration.ApiKeyFilePath, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationActionSegment action:
-                    action.Configuration.FilePath = ResolveWorkspacePath(workspaceRoot, action.Configuration.FilePath);
-                    action.Configuration.WorkingDirectory = ResolveWorkspacePath(workspaceRoot, action.Configuration.WorkingDirectory);
+                    action.Configuration.FilePath = ResolveSegmentPath(workspaceRoot, projectRoot, action.Configuration.FilePath, preserveProjectRelativeSegmentPaths);
+                    action.Configuration.WorkingDirectory = ResolveSegmentPath(workspaceRoot, projectRoot, action.Configuration.WorkingDirectory, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationAppleAppSegment appleApp:
                     appleApp.Configuration.ProjectPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, appleApp.Configuration.ProjectPath) ?? string.Empty;
@@ -475,6 +471,11 @@ internal sealed class ModuleBuildPreparationService
             }
         }
     }
+
+    private static string? ResolveSegmentPath(string workspaceRoot, string projectRoot, string? path, bool preserveProjectRelativePath)
+        => preserveProjectRelativePath
+            ? ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, path)
+            : ResolveWorkspacePath(workspaceRoot, path);
 
     private static bool UsesModuleFolderLayout(string workspaceRoot, string projectRoot)
     {
@@ -614,6 +615,28 @@ internal sealed class ModuleBuildPreparationService
                 continue;
 
             options[optionName] = ResolveWorkspacePath(rootPath, path);
+        }
+    }
+
+    private static void ResolvePackageBuildOptionPaths(
+        Dictionary<string, object?>? options,
+        string workspaceRoot,
+        string projectRoot,
+        bool preserveProjectRelativePath)
+    {
+        if (options is null || options.Count == 0)
+            return;
+
+        foreach (var optionName in PackageBuildOptionPathNames)
+        {
+            if (!options.TryGetValue(optionName, out var value))
+                continue;
+
+            var path = GetStringOptionValue(value);
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+
+            options[optionName] = ResolveSegmentPath(workspaceRoot, projectRoot, path, preserveProjectRelativePath);
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -232,13 +232,30 @@ internal sealed class ModuleBuildPreparationService
             cfg.StageRoot = ResolveConfigPath(projectRoot, cfg.StageRoot);
         }
 
+        foreach (var segment in spec.Segments?.OfType<ConfigurationPublishSegment>() ?? Enumerable.Empty<ConfigurationPublishSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.ApiKeyFilePath = ResolveConfigPathNullable(projectRoot, cfg.ApiKeyFilePath);
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationActionSegment>() ?? Enumerable.Empty<ConfigurationActionSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.FilePath = ResolveConfigPathNullable(projectRoot, cfg.FilePath);
+            cfg.WorkingDirectory = ResolveConfigPathNullable(projectRoot, cfg.WorkingDirectory);
+        }
+
         foreach (var segment in spec.Segments?.OfType<ConfigurationArtefactSegment>() ?? Enumerable.Empty<ConfigurationArtefactSegment>())
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
             cfg.Path = ResolveConfigPathNullable(projectRoot, cfg.Path);
-            cfg.RequiredModules.Path = ResolveConfigPathNullable(projectRoot, cfg.RequiredModules.Path);
-            cfg.RequiredModules.ModulesPath = ResolveConfigPathNullable(projectRoot, cfg.RequiredModules.ModulesPath);
+            cfg.RequiredModules.Path = ResolveArtefactLayoutPath(projectRoot, cfg.Path, cfg.RequiredModules.Path);
+            cfg.RequiredModules.ModulesPath = ResolveArtefactLayoutPath(projectRoot, cfg.Path, cfg.RequiredModules.ModulesPath);
+            ResolveCopyMappingSources(cfg.DirectoryOutput, projectRoot);
+            ResolveCopyMappingSources(cfg.FilesOutput, projectRoot);
         }
     }
 
@@ -355,6 +372,13 @@ internal sealed class ModuleBuildPreparationService
                 case ConfigurationReleaseSegment release:
                     release.Configuration.StageRoot = ResolveWorkspacePath(workspaceRoot, release.Configuration.StageRoot);
                     break;
+                case ConfigurationPublishSegment publish:
+                    publish.Configuration.ApiKeyFilePath = ResolveWorkspacePath(workspaceRoot, publish.Configuration.ApiKeyFilePath);
+                    break;
+                case ConfigurationActionSegment action:
+                    action.Configuration.FilePath = ResolveWorkspacePath(workspaceRoot, action.Configuration.FilePath);
+                    action.Configuration.WorkingDirectory = ResolveWorkspacePath(workspaceRoot, action.Configuration.WorkingDirectory);
+                    break;
                 case ConfigurationAppleAppSegment appleApp:
                     appleApp.Configuration.ProjectPath = ResolveWorkspacePath(workspaceRoot, appleApp.Configuration.ProjectPath) ?? string.Empty;
                     break;
@@ -371,8 +395,10 @@ internal sealed class ModuleBuildPreparationService
     private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot)
     {
         configuration.Path = ResolveWorkspacePath(workspaceRoot, configuration.Path);
-        configuration.RequiredModules.Path = ResolveWorkspacePath(workspaceRoot, configuration.RequiredModules.Path);
-        configuration.RequiredModules.ModulesPath = ResolveWorkspacePath(workspaceRoot, configuration.RequiredModules.ModulesPath);
+        configuration.RequiredModules.Path = ResolveArtefactLayoutPath(workspaceRoot, configuration.Path, configuration.RequiredModules.Path);
+        configuration.RequiredModules.ModulesPath = ResolveArtefactLayoutPath(workspaceRoot, configuration.Path, configuration.RequiredModules.ModulesPath);
+        ResolveCopyMappingSources(configuration.DirectoryOutput, workspaceRoot);
+        ResolveCopyMappingSources(configuration.FilesOutput, workspaceRoot);
     }
 
     private static string? ResolveWorkspacePath(string workspaceRoot, string? path)
@@ -381,6 +407,32 @@ internal sealed class ModuleBuildPreparationService
             return path;
 
         return PathValueResolver.Resolve(workspaceRoot, path!);
+    }
+
+    private static string? ResolveArtefactLayoutPath(string rootPath, string? artefactPath, string? layoutPath)
+    {
+        if (string.IsNullOrWhiteSpace(layoutPath) || Path.IsPathRooted(layoutPath))
+            return layoutPath;
+        if (string.IsNullOrWhiteSpace(artefactPath))
+            return layoutPath;
+
+        var artefactRoot = PathValueResolver.Resolve(rootPath, artefactPath!);
+        var candidate = PathValueResolver.Resolve(rootPath, layoutPath!);
+        return IsSameOrChildPath(artefactRoot, candidate) ? candidate : layoutPath;
+    }
+
+    private static void ResolveCopyMappingSources(ArtefactCopyMapping[]? mappings, string rootPath)
+    {
+        if (mappings is null)
+            return;
+
+        foreach (var mapping in mappings)
+        {
+            if (mapping is null || string.IsNullOrWhiteSpace(mapping.Source) || Path.IsPathRooted(mapping.Source))
+                continue;
+
+            mapping.Source = PathValueResolver.Resolve(rootPath, mapping.Source);
+        }
     }
 
     private static bool SamePath(string left, string right)
@@ -501,13 +553,60 @@ internal sealed class ModuleBuildPreparationService
             cfg.StageRoot = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.StageRoot));
         }
 
+        foreach (var segment in spec.Segments?.OfType<ConfigurationPublishSegment>() ?? Enumerable.Empty<ConfigurationPublishSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.ApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.ApiKeyFilePath);
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationActionSegment>() ?? Enumerable.Empty<ConfigurationActionSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.FilePath = MakeRelativeForProjectRoot(projectRoot, cfg.FilePath);
+            cfg.WorkingDirectory = MakeRelativeForProjectRoot(projectRoot, cfg.WorkingDirectory);
+        }
+
         foreach (var segment in spec.Segments?.OfType<ConfigurationArtefactSegment>() ?? Enumerable.Empty<ConfigurationArtefactSegment>())
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
             cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path);
-            cfg.RequiredModules.Path = MakeRelativeForProjectRoot(projectRoot, cfg.RequiredModules.Path);
-            cfg.RequiredModules.ModulesPath = MakeRelativeForProjectRoot(projectRoot, cfg.RequiredModules.ModulesPath);
+            cfg.RequiredModules.Path = MakeArtefactLayoutPathForJson(projectRoot, cfg.Path, cfg.RequiredModules.Path);
+            cfg.RequiredModules.ModulesPath = MakeArtefactLayoutPathForJson(projectRoot, cfg.Path, cfg.RequiredModules.ModulesPath);
+            MakeCopyMappingSourcesRelative(cfg.DirectoryOutput, projectRoot);
+            MakeCopyMappingSourcesRelative(cfg.FilesOutput, projectRoot);
+        }
+    }
+
+    private static string? MakeArtefactLayoutPathForJson(string projectRoot, string? artefactPath, string? layoutPath)
+    {
+        if (string.IsNullOrWhiteSpace(layoutPath))
+            return null;
+        if (Path.IsPathRooted(layoutPath))
+            return MakeRelativeForProjectRoot(projectRoot, layoutPath);
+        if (string.IsNullOrWhiteSpace(artefactPath))
+            return NormalizePathSeparators(layoutPath!);
+
+        var artefactRoot = ResolveConfigPath(projectRoot, artefactPath);
+        var candidate = ResolveConfigPath(projectRoot, layoutPath);
+        return IsSameOrChildPath(artefactRoot, candidate)
+            ? MakeRelativeForProjectRoot(projectRoot, candidate)
+            : NormalizePathSeparators(layoutPath!);
+    }
+
+    private static void MakeCopyMappingSourcesRelative(ArtefactCopyMapping[]? mappings, string projectRoot)
+    {
+        if (mappings is null)
+            return;
+
+        foreach (var mapping in mappings)
+        {
+            if (mapping is null || string.IsNullOrWhiteSpace(mapping.Source))
+                continue;
+
+            mapping.Source = MakeRelativeForProjectRoot(projectRoot, mapping.Source) ?? string.Empty;
         }
     }
 
@@ -537,6 +636,24 @@ internal sealed class ModuleBuildPreparationService
     {
         if (string.IsNullOrWhiteSpace(path)) return null;
         return MakeRelativeForConfig(baseDir, path!);
+    }
+
+    private static string NormalizePathSeparators(string path)
+        => path.Replace('\\', '/');
+
+    private static bool IsSameOrChildPath(string rootPath, string candidatePath)
+    {
+        var root = Path.GetFullPath(rootPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var candidate = Path.GetFullPath(candidatePath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (string.Equals(root, candidate, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var rootWithSeparator = root + Path.DirectorySeparatorChar;
+        var candidateWithSeparator = candidate + Path.DirectorySeparatorChar;
+        return candidateWithSeparator.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string GetRelativePath(string baseDir, string fullPath)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -835,20 +835,20 @@ internal sealed class ModuleBuildPreparationService
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
         {
             var cfg = segment.BuildLibraries;
-            cfg.NETProjectPath = MakeRelativeForProjectRoot(projectRoot, cfg.NETProjectPath);
-            cfg.DevelopmentBinariesPath = MakeRelativeForProjectRoot(projectRoot, cfg.DevelopmentBinariesPath);
-            cfg.NETDevelopmentBinariesPath = MakeRelativeForProjectRoot(projectRoot, cfg.NETDevelopmentBinariesPath);
+            cfg.NETProjectPath = MakeRelativeForProjectRoot(projectRoot, cfg.NETProjectPath, preserveExternalRooted: true, workspaceRoot);
+            cfg.DevelopmentBinariesPath = MakeRelativeForProjectRoot(projectRoot, cfg.DevelopmentBinariesPath, preserveExternalRooted: true, workspaceRoot);
+            cfg.NETDevelopmentBinariesPath = MakeRelativeForProjectRoot(projectRoot, cfg.NETDevelopmentBinariesPath, preserveExternalRooted: true, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationPackageBuildSegment>() ?? Enumerable.Empty<ConfigurationPackageBuildSegment>())
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.RootPath = MakeRelativeForProjectRoot(projectRoot, cfg.RootPath);
-            cfg.OutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.OutputPath);
-            cfg.ReleaseZipOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.ReleaseZipOutputPath);
-            cfg.StagingPath = MakeRelativeForProjectRoot(projectRoot, cfg.StagingPath);
-            cfg.PlanOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.PlanOutputPath);
+            cfg.RootPath = MakeRelativeForProjectRoot(projectRoot, cfg.RootPath, preserveExternalRooted: true, workspaceRoot);
+            cfg.OutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.OutputPath, preserveExternalRooted: true, workspaceRoot);
+            cfg.ReleaseZipOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.ReleaseZipOutputPath, preserveExternalRooted: true, workspaceRoot);
+            cfg.StagingPath = MakeRelativeForProjectRoot(projectRoot, cfg.StagingPath, preserveExternalRooted: true, workspaceRoot);
+            cfg.PlanOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.PlanOutputPath, preserveExternalRooted: true, workspaceRoot);
             cfg.PublishApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.PublishApiKeyFilePath, preserveExternalRooted: true, workspaceRoot);
             cfg.NugetCredentialSecretFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.NugetCredentialSecretFilePath, preserveExternalRooted: true, workspaceRoot);
             cfg.GitHubAccessTokenFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.GitHubAccessTokenFilePath, preserveExternalRooted: true, workspaceRoot);
@@ -874,14 +874,14 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null || string.IsNullOrWhiteSpace(cfg.TestsPath)) continue;
-            cfg.TestsPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.TestsPath));
+            cfg.TestsPath = MakeRelativeForProjectRoot(projectRoot, cfg.TestsPath, preserveExternalRooted: true, workspaceRoot) ?? string.Empty;
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationValidationSegment>() ?? Enumerable.Empty<ConfigurationValidationSegment>())
         {
             var settings = segment.Settings;
             if (settings is null) continue;
-            settings.Tests.TestPath = MakeRelativeForProjectRoot(projectRoot, settings.Tests.TestPath);
+            settings.Tests.TestPath = MakeRelativeForProjectRoot(projectRoot, settings.Tests.TestPath, preserveExternalRooted: true, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationOptionsSegment>() ?? Enumerable.Empty<ConfigurationOptionsSegment>())
@@ -917,9 +917,9 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path);
-            cfg.RequiredModules.Path = MakeArtefactLayoutPathForJson(projectRoot, cfg.Path, cfg.RequiredModules.Path);
-            cfg.RequiredModules.ModulesPath = MakeArtefactLayoutPathForJson(projectRoot, cfg.Path, cfg.RequiredModules.ModulesPath);
+            cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path, preserveExternalRooted: true, workspaceRoot);
+            cfg.RequiredModules.Path = MakeArtefactLayoutPathForJson(projectRoot, workspaceRoot, cfg.Path, cfg.RequiredModules.Path);
+            cfg.RequiredModules.ModulesPath = MakeArtefactLayoutPathForJson(projectRoot, workspaceRoot, cfg.Path, cfg.RequiredModules.ModulesPath);
             MakeCopyMappingSourcesRelative(cfg.DirectoryOutput, projectRoot, workspaceRoot);
             MakeCopyMappingSourcesRelative(cfg.FilesOutput, projectRoot, workspaceRoot);
         }
@@ -933,12 +933,12 @@ internal sealed class ModuleBuildPreparationService
             : projectRoot;
     }
 
-    private static string? MakeArtefactLayoutPathForJson(string projectRoot, string? artefactPath, string? layoutPath)
+    private static string? MakeArtefactLayoutPathForJson(string projectRoot, string workspaceRoot, string? artefactPath, string? layoutPath)
     {
         if (string.IsNullOrWhiteSpace(layoutPath))
             return null;
         if (Path.IsPathRooted(layoutPath))
-            return MakeRelativeForProjectRoot(projectRoot, layoutPath);
+            return MakeRelativeForProjectRoot(projectRoot, layoutPath, preserveExternalRooted: true, workspaceRoot);
         if (string.IsNullOrWhiteSpace(artefactPath))
             return NormalizePathSeparators(layoutPath!);
         if (ContainsPathToken(layoutPath!) || ContainsPathToken(artefactPath!))
@@ -947,7 +947,7 @@ internal sealed class ModuleBuildPreparationService
         var artefactRoot = ResolveConfigPath(projectRoot, artefactPath);
         var candidate = ResolveConfigPath(projectRoot, layoutPath);
         return IsSameOrChildPath(artefactRoot, candidate)
-            ? MakeRelativeForProjectRoot(projectRoot, candidate)
+            ? MakeRelativeForProjectRoot(projectRoot, candidate, preserveExternalRooted: true, workspaceRoot)
             : NormalizePathSeparators(layoutPath!);
     }
 
@@ -1011,14 +1011,9 @@ internal sealed class ModuleBuildPreparationService
             if (string.IsNullOrWhiteSpace(path))
                 continue;
 
-            options[optionName] = MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: IsPackageCredentialPathName(optionName), workspaceRoot);
+            options[optionName] = MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: true, workspaceRoot);
         }
     }
-
-    private static bool IsPackageCredentialPathName(string optionName)
-        => string.Equals(optionName, nameof(PackageBuildConfiguration.PublishApiKeyFilePath), StringComparison.OrdinalIgnoreCase) ||
-           string.Equals(optionName, nameof(PackageBuildConfiguration.NugetCredentialSecretFilePath), StringComparison.OrdinalIgnoreCase) ||
-           string.Equals(optionName, nameof(PackageBuildConfiguration.GitHubAccessTokenFilePath), StringComparison.OrdinalIgnoreCase);
 
     private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted = false)
         => MakePathsRelativeForProjectRoot(projectRoot, paths, preserveExternalRooted, projectRoot);

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -796,7 +796,7 @@ internal sealed class ModuleBuildPreparationService
         if (spec.Install?.Roots is not null)
             spec.Install.Roots = MakePathsRelativeForProjectRoot(projectRoot, spec.Install.Roots, preserveExternalRooted: true, workspaceRoot);
         if (spec.Diagnostics is not null && !string.IsNullOrWhiteSpace(spec.Diagnostics.BaselinePath))
-            spec.Diagnostics.BaselinePath = MakeRelativeForConfig(baseDir, spec.Diagnostics.BaselinePath!);
+            spec.Diagnostics.BaselinePath = MakeDiagnosticsBaselinePathForJson(baseDir, projectRoot, workspaceRoot, spec.Diagnostics.BaselinePath!);
         if (spec.Diagnostics is not null)
             spec.Diagnostics.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Diagnostics.BinaryConflictSearchRoots, preserveExternalRooted: true, workspaceRoot);
 
@@ -913,9 +913,10 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
+            var artefactPath = cfg.Path;
             cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path, preserveExternalRooted: true, workspaceRoot);
-            cfg.RequiredModules.Path = MakeArtefactLayoutPathForJson(projectRoot, workspaceRoot, cfg.Path, cfg.RequiredModules.Path);
-            cfg.RequiredModules.ModulesPath = MakeArtefactLayoutPathForJson(projectRoot, workspaceRoot, cfg.Path, cfg.RequiredModules.ModulesPath);
+            cfg.RequiredModules.Path = MakeArtefactLayoutPathForJson(projectRoot, workspaceRoot, artefactPath, cfg.RequiredModules.Path);
+            cfg.RequiredModules.ModulesPath = MakeArtefactLayoutPathForJson(projectRoot, workspaceRoot, artefactPath, cfg.RequiredModules.ModulesPath);
             MakeCopyMappingSourcesRelative(cfg.DirectoryOutput, projectRoot, workspaceRoot);
             MakeCopyMappingSourcesRelative(cfg.FilesOutput, projectRoot, workspaceRoot);
         }
@@ -939,12 +940,29 @@ internal sealed class ModuleBuildPreparationService
         => File.Exists(Path.Combine(directory, ".git")) ||
            Directory.Exists(Path.Combine(directory, ".git"));
 
+    private static string MakeDiagnosticsBaselinePathForJson(string baseDir, string projectRoot, string workspaceRoot, string baselinePath)
+    {
+        var cleaned = PathValueResolver.Clean(baselinePath);
+        var resolved = ResolveConfigPath(projectRoot, baselinePath);
+        if (Path.IsPathRooted(cleaned) &&
+            !IsSameOrChildPath(projectRoot, resolved) &&
+            !IsSameOrChildPath(workspaceRoot, resolved))
+        {
+            return NormalizePathSeparators(resolved);
+        }
+
+        return MakeRelativeForConfig(baseDir, resolved);
+    }
+
     private static string? MakeArtefactLayoutPathForJson(string projectRoot, string workspaceRoot, string? artefactPath, string? layoutPath)
     {
         if (string.IsNullOrWhiteSpace(layoutPath))
             return null;
         if (Path.IsPathRooted(layoutPath))
-            return MakeRelativeForProjectRoot(projectRoot, layoutPath, preserveExternalRooted: true, workspaceRoot);
+        {
+            var outputRelativePath = MakeTokenizedArtefactLayoutPathOutputRelative(projectRoot, artefactPath, layoutPath!);
+            return outputRelativePath ?? MakeRelativeForProjectRoot(projectRoot, layoutPath, preserveExternalRooted: true, workspaceRoot);
+        }
         if (string.IsNullOrWhiteSpace(artefactPath))
             return NormalizePathSeparators(layoutPath!);
         if (ContainsPathToken(layoutPath!) || ContainsPathToken(artefactPath!))
@@ -955,6 +973,54 @@ internal sealed class ModuleBuildPreparationService
         return IsSameOrChildPath(artefactRoot, candidate)
             ? MakeRelativeForProjectRoot(projectRoot, candidate, preserveExternalRooted: true, workspaceRoot)
             : NormalizePathSeparators(layoutPath!);
+    }
+
+    private static string? MakeTokenizedArtefactLayoutPathOutputRelative(string projectRoot, string? artefactPath, string layoutPath)
+    {
+        if (string.IsNullOrWhiteSpace(artefactPath) ||
+            ContainsPathToken(artefactPath!) ||
+            !ContainsPathToken(layoutPath))
+        {
+            return null;
+        }
+
+        var cleanedLayoutPath = PathValueResolver.Clean(layoutPath);
+        var tokenIndex = IndexOfPathToken(cleanedLayoutPath);
+        if (tokenIndex < 0)
+            return null;
+
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        var prefix = cleanedLayoutPath.Substring(0, tokenIndex).TrimEnd(separators);
+        if (string.IsNullOrWhiteSpace(prefix))
+            return null;
+
+        var artefactRoot = ResolveConfigPath(projectRoot, artefactPath);
+        var prefixRoot = Path.GetFullPath(prefix);
+        if (!IsSameOrChildPath(artefactRoot, prefixRoot))
+            return null;
+
+        var relativePrefix = MakeRelativeForConfig(artefactRoot, prefixRoot);
+        var tokenStartsNewSegment = tokenIndex == 0 || separators.Contains(cleanedLayoutPath[tokenIndex - 1]);
+        var suffix = tokenStartsNewSegment
+            ? cleanedLayoutPath.Substring(tokenIndex).TrimStart(separators)
+            : cleanedLayoutPath.Substring(tokenIndex);
+
+        return string.Equals(relativePrefix, ".", StringComparison.Ordinal)
+            ? NormalizePathSeparators(suffix)
+            : NormalizePathSeparators(tokenStartsNewSegment
+                ? Path.Combine(relativePrefix, suffix)
+                : relativePrefix + suffix);
+    }
+
+    private static int IndexOfPathToken(string path)
+    {
+        var angleToken = path.IndexOf('<');
+        var braceToken = path.IndexOf('{');
+        if (angleToken < 0)
+            return braceToken;
+        if (braceToken < 0)
+            return angleToken;
+        return Math.Min(angleToken, braceToken);
     }
 
     private static string? MakeDocumentationPathForJson(string projectRoot, string workspaceRoot, string? path)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -47,7 +47,7 @@ internal sealed class ModuleBuildPreparationService
         var segments = useLegacy
             ? (string.Equals(request.ParameterSetName, "Configuration", StringComparison.Ordinal)
                 ? LegacySegmentAdapter.CollectFromLegacyConfiguration(request.Configuration)
-                : CollectSettingsFromWorkspace(request.Settings, workspaceRoot))
+                : CollectSettingsFromWorkspace(request.Settings, UsesModuleFolderLayout(workspaceRoot, projectRoot) ? projectRoot : workspaceRoot))
             : Array.Empty<IConfigurationSegment>();
         ResolveWorkspaceRelativeSegmentPaths(segments, workspaceRoot, projectRoot);
 
@@ -262,6 +262,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
+            cfg.AboutTopicsSourcePath = ResolveConfigPaths(projectRoot, cfg.AboutTopicsSourcePath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
@@ -831,14 +832,15 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path) ?? string.Empty;
-            cfg.PathReadme = MakeRelativeForProjectRoot(projectRoot, cfg.PathReadme) ?? string.Empty;
+            cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path, preserveExternalRooted: true, workspaceRoot) ?? string.Empty;
+            cfg.PathReadme = MakeRelativeForProjectRoot(projectRoot, cfg.PathReadme, preserveExternalRooted: true, workspaceRoot) ?? string.Empty;
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildDocumentationSegment>() ?? Enumerable.Empty<ConfigurationBuildDocumentationSegment>())
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
+            cfg.AboutTopicsSourcePath = MakePathsRelativeForProjectRoot(projectRoot, cfg.AboutTopicsSourcePath, preserveExternalRooted: true, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -27,7 +27,7 @@ internal sealed class ModuleBuildPreparationService
         if (string.IsNullOrWhiteSpace(moduleName))
             throw new PSArgumentException("ModuleName is required.");
 
-        var (projectRoot, basePathForScaffold) = ResolveProjectPaths(request, moduleName!);
+        var (projectRoot, basePathForScaffold, workspaceRoot) = ResolveProjectPaths(request, moduleName!);
         var useLegacy = request.Legacy ||
                         string.Equals(request.ParameterSetName, "Configuration", StringComparison.Ordinal) ||
                         request.Settings is not null;
@@ -36,6 +36,7 @@ internal sealed class ModuleBuildPreparationService
                 ? LegacySegmentAdapter.CollectFromLegacyConfiguration(request.Configuration)
                 : LegacySegmentAdapter.CollectFromSettings(request.Settings))
             : Array.Empty<IConfigurationSegment>();
+        ResolveWorkspaceRelativeSegmentPaths(segments, workspaceRoot, projectRoot);
 
         var frameworks = useLegacy && !request.DotNetFrameworkWasBound
             ? Array.Empty<string>()
@@ -266,20 +267,104 @@ internal sealed class ModuleBuildPreparationService
         return baseVersion;
     }
 
-    private static (string ProjectRoot, string? BasePathForScaffold) ResolveProjectPaths(ModuleBuildPreparationRequest request, string moduleName)
+    private static (string ProjectRoot, string? BasePathForScaffold, string WorkspaceRoot) ResolveProjectPaths(ModuleBuildPreparationRequest request, string moduleName)
     {
         if (string.Equals(request.ParameterSetName, "Modern", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(request.InputPath))
         {
             var basePath = request.ResolvePath!(request.InputPath!);
             var fullProjectPath = Path.Combine(basePath, moduleName);
-            return (fullProjectPath, basePath);
+            return (fullProjectPath, basePath, basePath);
         }
 
         var rootToUse = !string.IsNullOrWhiteSpace(request.ScriptRoot)
             ? Path.GetFullPath(Path.Combine(request.ScriptRoot!, ".."))
             : request.CurrentPath;
 
-        return (rootToUse, null);
+        return (rootToUse, null, ResolveWorkspaceRoot(rootToUse, request.ScriptRoot));
+    }
+
+    private static string ResolveWorkspaceRoot(string projectRoot, string? scriptRoot)
+    {
+        if (string.IsNullOrWhiteSpace(scriptRoot))
+            return projectRoot;
+
+        var scriptDirectory = new DirectoryInfo(Path.GetFullPath(scriptRoot!));
+        var moduleDirectory = new DirectoryInfo(Path.GetFullPath(projectRoot));
+        if (!string.Equals(scriptDirectory.Name, "Build", StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(moduleDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) ||
+            moduleDirectory.Parent is null)
+        {
+            return projectRoot;
+        }
+
+        return moduleDirectory.Parent.FullName;
+    }
+
+    private static void ResolveWorkspaceRelativeSegmentPaths(
+        IReadOnlyList<IConfigurationSegment> segments,
+        string workspaceRoot,
+        string projectRoot)
+    {
+        if (segments.Count == 0 || SamePath(workspaceRoot, projectRoot))
+            return;
+
+        foreach (var segment in segments)
+        {
+            switch (segment)
+            {
+                case ConfigurationBuildLibrariesSegment buildLibraries:
+                    var libraries = buildLibraries.BuildLibraries;
+                    libraries.NETProjectPath = ResolveWorkspacePath(workspaceRoot, libraries.NETProjectPath);
+                    libraries.DevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.DevelopmentBinariesPath);
+                    libraries.NETDevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.NETDevelopmentBinariesPath);
+                    break;
+                case ConfigurationProjectBuildSegment projectBuild:
+                    projectBuild.Configuration.ConfigPath = ResolveWorkspacePath(workspaceRoot, projectBuild.Configuration.ConfigPath) ?? string.Empty;
+                    break;
+                case ConfigurationPackageBuildSegment packageBuild:
+                    var package = packageBuild.Configuration;
+                    package.RootPath = ResolveWorkspacePath(workspaceRoot, package.RootPath);
+                    package.OutputPath = ResolveWorkspacePath(workspaceRoot, package.OutputPath);
+                    package.ReleaseZipOutputPath = ResolveWorkspacePath(workspaceRoot, package.ReleaseZipOutputPath);
+                    package.StagingPath = ResolveWorkspacePath(workspaceRoot, package.StagingPath);
+                    package.PlanOutputPath = ResolveWorkspacePath(workspaceRoot, package.PlanOutputPath);
+                    break;
+                case ConfigurationReleaseSegment release:
+                    release.Configuration.StageRoot = ResolveWorkspacePath(workspaceRoot, release.Configuration.StageRoot);
+                    break;
+                case ConfigurationAppleAppSegment appleApp:
+                    appleApp.Configuration.ProjectPath = ResolveWorkspacePath(workspaceRoot, appleApp.Configuration.ProjectPath) ?? string.Empty;
+                    break;
+                case ConfigurationXcodeProjectVersionSegment xcodeProject:
+                    xcodeProject.Configuration.Path = ResolveWorkspacePath(workspaceRoot, xcodeProject.Configuration.Path) ?? string.Empty;
+                    break;
+                case ConfigurationArtefactSegment artefact:
+                    ResolveWorkspaceRelativeArtefactPaths(artefact.Configuration, workspaceRoot);
+                    break;
+            }
+        }
+    }
+
+    private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot)
+    {
+        configuration.Path = ResolveWorkspacePath(workspaceRoot, configuration.Path);
+    }
+
+    private static string? ResolveWorkspacePath(string workspaceRoot, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path))
+            return path;
+
+        return PathValueResolver.Resolve(workspaceRoot, path!);
+    }
+
+    private static bool SamePath(string left, string right)
+    {
+        var normalizedLeft = Path.GetFullPath(left)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedRight = Path.GetFullPath(right)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return string.Equals(normalizedLeft, normalizedRight, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string[] BuildStageExcludeFiles(string[]? excludeFiles, string moduleName)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -139,7 +139,7 @@ internal sealed class ModuleBuildPreparationService
             BasePathForScaffold = null,
             UseLegacy = false,
             PipelineSpec = spec,
-            JsonOutputPath = request.JsonOnly ? ResolveJsonOutputPath(request, spec.Build.SourcePath, spec.Build.SourcePath) : null,
+            JsonOutputPath = request.JsonOnly ? ResolveJsonOutputPath(request, spec.Build.SourcePath, request.CurrentPath) : null,
             ConfigLabel = "json",
             ConfigFilePath = configFullPath
         };
@@ -626,7 +626,7 @@ internal sealed class ModuleBuildPreparationService
 
             if (!string.IsNullOrWhiteSpace(requiredFirstSegment) && !StartsWithPathSegment(mapping.Source, requiredFirstSegment!))
             {
-                if (string.IsNullOrWhiteSpace(projectRoot) || !ExistsUnderWorkspaceRoot(rootPath, projectRoot!, mapping.Source))
+                if (string.IsNullOrWhiteSpace(projectRoot) || IsModuleRelativeCopySource(mapping.Source))
                     continue;
             }
 
@@ -634,14 +634,10 @@ internal sealed class ModuleBuildPreparationService
         }
     }
 
-    private static bool ExistsUnderWorkspaceRoot(string rootPath, string projectRoot, string path)
+    private static bool IsModuleRelativeCopySource(string path)
     {
-        var workspacePath = PathValueResolver.Resolve(rootPath, path);
-        if (!File.Exists(workspacePath) && !Directory.Exists(workspacePath))
-            return false;
-
-        var projectPath = PathValueResolver.Resolve(projectRoot, path);
-        return !File.Exists(projectPath) && !Directory.Exists(projectPath);
+        var firstSegment = GetFirstPathSegment(path);
+        return string.Equals(firstSegment, "Examples", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool StartsWithPathSegment(string path, string segment)
@@ -649,11 +645,16 @@ internal sealed class ModuleBuildPreparationService
         if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(segment))
             return false;
 
+        var firstSegment = GetFirstPathSegment(path);
+        return string.Equals(firstSegment, segment, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetFirstPathSegment(string path)
+    {
         var cleaned = PathValueResolver.Clean(path);
         var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
         var firstSeparator = cleaned.IndexOfAny(separators);
-        var firstSegment = firstSeparator < 0 ? cleaned : cleaned.Substring(0, firstSeparator);
-        return string.Equals(firstSegment, segment, StringComparison.OrdinalIgnoreCase);
+        return firstSeparator < 0 ? cleaned : cleaned.Substring(0, firstSeparator);
     }
 
     private static bool SamePath(string left, string right)
@@ -739,7 +740,7 @@ internal sealed class ModuleBuildPreparationService
         spec.Build.DevelopmentBinariesPath = MakeRelativeForConfigNullable(baseDir, spec.Build.DevelopmentBinariesPath);
         spec.Build.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Build.BinaryConflictSearchRoots);
         if (spec.Install?.Roots is not null)
-            spec.Install.Roots = MakePathsRelativeForProjectRoot(projectRoot, spec.Install.Roots);
+            spec.Install.Roots = MakePathsRelativeForProjectRoot(projectRoot, spec.Install.Roots, preserveExternalRooted: true);
         if (spec.Diagnostics is not null && !string.IsNullOrWhiteSpace(spec.Diagnostics.BaselinePath))
             spec.Diagnostics.BaselinePath = MakeRelativeForConfig(baseDir, spec.Diagnostics.BaselinePath!);
         if (spec.Diagnostics is not null)
@@ -868,6 +869,8 @@ internal sealed class ModuleBuildPreparationService
             return MakeRelativeForProjectRoot(projectRoot, layoutPath);
         if (string.IsNullOrWhiteSpace(artefactPath))
             return NormalizePathSeparators(layoutPath!);
+        if (ContainsPathToken(layoutPath!) || ContainsPathToken(artefactPath!))
+            return NormalizePathSeparators(layoutPath!);
 
         var artefactRoot = ResolveConfigPath(projectRoot, artefactPath);
         var candidate = ResolveConfigPath(projectRoot, layoutPath);
@@ -893,7 +896,20 @@ internal sealed class ModuleBuildPreparationService
     private static string? MakeRelativeForProjectRoot(string projectRoot, string? path)
     {
         if (string.IsNullOrWhiteSpace(path)) return null;
-        return MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, path));
+        return MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: false);
+    }
+
+    private static string? MakeRelativeForProjectRoot(string projectRoot, string? path, bool preserveExternalRooted)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        if (ContainsPathToken(path!))
+            return MakeTokenizedPathRelativeForProjectRoot(projectRoot, path!);
+
+        var resolved = ResolveConfigPath(projectRoot, path);
+        if (preserveExternalRooted && Path.IsPathRooted(PathValueResolver.Clean(path!)) && !IsSameOrChildPath(projectRoot, resolved))
+            return NormalizePathSeparators(resolved);
+
+        return MakeRelativeForConfig(projectRoot, resolved);
     }
 
     private static void MakePackageBuildOptionPathsRelative(Dictionary<string, object?>? options, string projectRoot)
@@ -914,15 +930,68 @@ internal sealed class ModuleBuildPreparationService
         }
     }
 
-    private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths)
+    private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted = false)
     {
         if (paths is null || paths.Length == 0)
             return Array.Empty<string>();
 
         return paths
-            .Select(path => MakeRelativeForProjectRoot(projectRoot, path) ?? string.Empty)
+            .Select(path => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted) ?? string.Empty)
             .Where(static path => !string.IsNullOrWhiteSpace(path))
             .ToArray();
+    }
+
+    private static string MakeTokenizedPathRelativeForProjectRoot(string projectRoot, string path)
+    {
+        var cleaned = PathValueResolver.Clean(path);
+        if (!Path.IsPathRooted(cleaned))
+            return NormalizePathSeparators(cleaned);
+
+        var tokenIndex = IndexOfPathToken(cleaned);
+        if (tokenIndex < 0)
+            return NormalizePathSeparators(cleaned);
+
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        var prefix = cleaned.Substring(0, tokenIndex).TrimEnd(separators);
+        if (string.IsNullOrWhiteSpace(prefix))
+            return NormalizePathSeparators(cleaned);
+
+        var prefixFullPath = Path.GetFullPath(prefix);
+        if (!IsSameOrChildPath(projectRoot, prefixFullPath))
+            return NormalizePathSeparators(cleaned);
+
+        var relativePrefix = MakeRelativeForConfig(projectRoot, prefixFullPath);
+        var suffix = cleaned.Substring(tokenIndex).TrimStart(separators);
+        return string.Equals(relativePrefix, ".", StringComparison.Ordinal)
+            ? NormalizePathSeparators(suffix)
+            : NormalizePathSeparators(Path.Combine(relativePrefix, suffix));
+    }
+
+    private static int IndexOfPathToken(string path)
+    {
+        var tokens = new[]
+        {
+            "<TagName>",
+            "{TagName}",
+            "<ModuleVersion>",
+            "{ModuleVersion}",
+            "<ModuleVersionWithPreRelease>",
+            "{ModuleVersionWithPreRelease}",
+            "<TagModuleVersionWithPreRelease>",
+            "{TagModuleVersionWithPreRelease}",
+            "<ModuleName>",
+            "{ModuleName}"
+        };
+
+        var index = -1;
+        foreach (var token in tokens)
+        {
+            var tokenIndex = path.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+            if (tokenIndex >= 0 && (index < 0 || tokenIndex < index))
+                index = tokenIndex;
+        }
+
+        return index;
     }
 
     private static string? GetStringOptionValue(object? value)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -86,7 +86,7 @@ internal sealed class ModuleBuildPreparationService
             },
             Diagnostics = new ModulePipelineDiagnosticsOptions
             {
-                BaselinePath = ResolveWorkspacePath(workspaceRoot, request.DiagnosticsBaselinePath),
+                BaselinePath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, request.DiagnosticsBaselinePath),
                 GenerateBaseline = request.GenerateDiagnosticsBaseline,
                 UpdateBaseline = request.UpdateDiagnosticsBaseline,
                 FailOnNewDiagnostics = request.FailOnNewDiagnostics,
@@ -438,10 +438,10 @@ internal sealed class ModuleBuildPreparationService
                 case ConfigurationBuildDocumentationSegment buildDocumentation:
                     break;
                 case ConfigurationTestSegment test:
-                    test.Configuration.TestsPath = ResolveWorkspacePath(workspaceRoot, test.Configuration.TestsPath) ?? string.Empty;
+                    test.Configuration.TestsPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, test.Configuration.TestsPath) ?? string.Empty;
                     break;
                 case ConfigurationValidationSegment validation:
-                    validation.Settings.Tests.TestPath = ResolveWorkspacePath(workspaceRoot, validation.Settings.Tests.TestPath);
+                    validation.Settings.Tests.TestPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, validation.Settings.Tests.TestPath);
                     break;
                 case ConfigurationOptionsSegment options:
                     var signing = options.Options?.Signing;
@@ -485,6 +485,9 @@ internal sealed class ModuleBuildPreparationService
         if (string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path))
             return path;
 
+        if (ContainsPathToken(path!))
+            return Path.Combine(workspaceRoot, PathValueResolver.Clean(path!));
+
         return PathValueResolver.Resolve(workspaceRoot, path!);
     }
 
@@ -510,6 +513,18 @@ internal sealed class ModuleBuildPreparationService
 
         return ResolveWorkspacePath(workspaceRoot, path);
     }
+
+    private static bool ContainsPathToken(string path)
+        => path.Contains("<TagName>", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("{TagName}", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("<ModuleVersion>", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("{ModuleVersion}", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("<ModuleVersionWithPreRelease>", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("{ModuleVersionWithPreRelease}", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("<TagModuleVersionWithPreRelease>", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("{TagModuleVersionWithPreRelease}", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("<ModuleName>", StringComparison.OrdinalIgnoreCase) ||
+           path.Contains("{ModuleName}", StringComparison.OrdinalIgnoreCase);
 
     private static string[] ResolveConfigPaths(string rootPath, string[]? paths)
     {

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -610,10 +610,23 @@ internal sealed class ModuleBuildPreparationService
                 continue;
 
             if (!string.IsNullOrWhiteSpace(requiredFirstSegment) && !StartsWithPathSegment(mapping.Source, requiredFirstSegment!))
-                continue;
+            {
+                if (string.IsNullOrWhiteSpace(projectRoot) || !ExistsUnderWorkspaceRoot(rootPath, projectRoot!, mapping.Source))
+                    continue;
+            }
 
             mapping.Source = PathValueResolver.Resolve(rootPath, mapping.Source);
         }
+    }
+
+    private static bool ExistsUnderWorkspaceRoot(string rootPath, string projectRoot, string path)
+    {
+        var workspacePath = PathValueResolver.Resolve(rootPath, path);
+        if (!File.Exists(workspacePath) && !Directory.Exists(workspacePath))
+            return false;
+
+        var projectPath = PathValueResolver.Resolve(projectRoot, path);
+        return !File.Exists(projectPath) && !Directory.Exists(projectPath);
     }
 
     private static bool StartsWithPathSegment(string path, string segment)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -47,7 +47,7 @@ internal sealed class ModuleBuildPreparationService
         var segments = useLegacy
             ? (string.Equals(request.ParameterSetName, "Configuration", StringComparison.Ordinal)
                 ? LegacySegmentAdapter.CollectFromLegacyConfiguration(request.Configuration)
-                : CollectSettingsFromWorkspace(request.Settings, UsesModuleFolderLayout(workspaceRoot, projectRoot) ? projectRoot : workspaceRoot))
+                : CollectSettingsFromWorkspace(request.Settings, projectRoot))
             : Array.Empty<IConfigurationSegment>();
         ResolveWorkspaceRelativeSegmentPaths(segments, workspaceRoot, projectRoot);
 
@@ -224,13 +224,10 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            var optionsRoot = projectRoot;
             if (!string.IsNullOrWhiteSpace(cfg.ConfigPath))
             {
                 cfg.ConfigPath = ResolveConfigPath(projectRoot, cfg.ConfigPath);
-                optionsRoot = Path.GetDirectoryName(cfg.ConfigPath) ?? projectRoot;
             }
-            ResolvePackageBuildOptionPaths(cfg.Options, optionsRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
@@ -409,71 +406,71 @@ internal sealed class ModuleBuildPreparationService
             return;
 
         var preserveProjectRelativeSegmentPaths = UsesModuleFolderLayout(workspaceRoot, projectRoot);
+        var segmentRoot = preserveProjectRelativeSegmentPaths ? workspaceRoot : projectRoot;
         foreach (var segment in segments)
         {
             switch (segment)
             {
                 case ConfigurationBuildLibrariesSegment buildLibraries:
                     var libraries = buildLibraries.BuildLibraries;
-                    libraries.NETProjectPath = ResolveSegmentPath(workspaceRoot, projectRoot, libraries.NETProjectPath, preserveProjectRelativeSegmentPaths);
-                    libraries.DevelopmentBinariesPath = ResolveSegmentPath(workspaceRoot, projectRoot, libraries.DevelopmentBinariesPath, preserveProjectRelativeSegmentPaths);
-                    libraries.NETDevelopmentBinariesPath = ResolveSegmentPath(workspaceRoot, projectRoot, libraries.NETDevelopmentBinariesPath, preserveProjectRelativeSegmentPaths);
+                    libraries.NETProjectPath = ResolveSegmentPath(segmentRoot, projectRoot, libraries.NETProjectPath, preserveProjectRelativeSegmentPaths);
+                    libraries.DevelopmentBinariesPath = ResolveSegmentPath(segmentRoot, projectRoot, libraries.DevelopmentBinariesPath, preserveProjectRelativeSegmentPaths);
+                    libraries.NETDevelopmentBinariesPath = ResolveSegmentPath(segmentRoot, projectRoot, libraries.NETDevelopmentBinariesPath, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationProjectBuildSegment projectBuild:
-                    projectBuild.Configuration.ConfigPath = ResolveSegmentPath(workspaceRoot, projectRoot, projectBuild.Configuration.ConfigPath, preserveProjectRelativeSegmentPaths) ?? string.Empty;
-                    ResolvePackageBuildOptionPaths(projectBuild.Configuration.Options, workspaceRoot, projectRoot, preserveProjectRelativeSegmentPaths);
+                    projectBuild.Configuration.ConfigPath = ResolveSegmentPath(segmentRoot, projectRoot, projectBuild.Configuration.ConfigPath, preserveProjectRelativeSegmentPaths) ?? string.Empty;
                     break;
                 case ConfigurationPackageBuildSegment packageBuild:
                     var package = packageBuild.Configuration;
-                    package.RootPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.RootPath, preserveProjectRelativeSegmentPaths);
-                    package.OutputPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.OutputPath, preserveProjectRelativeSegmentPaths);
-                    package.ReleaseZipOutputPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.ReleaseZipOutputPath, preserveProjectRelativeSegmentPaths);
-                    package.StagingPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.StagingPath, preserveProjectRelativeSegmentPaths);
-                    package.PlanOutputPath = ResolveSegmentPath(workspaceRoot, projectRoot, package.PlanOutputPath, preserveProjectRelativeSegmentPaths);
-                    package.PublishApiKeyFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, package.PublishApiKeyFilePath, preserveProjectRelativeSegmentPaths);
-                    package.NugetCredentialSecretFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, package.NugetCredentialSecretFilePath, preserveProjectRelativeSegmentPaths);
-                    package.GitHubAccessTokenFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, package.GitHubAccessTokenFilePath, preserveProjectRelativeSegmentPaths);
-                    ResolvePackageBuildOptionPaths(package.Options, workspaceRoot, projectRoot, preserveProjectRelativeSegmentPaths);
+                    package.RootPath = ResolveSegmentPath(segmentRoot, projectRoot, package.RootPath, preserveProjectRelativeSegmentPaths);
+                    package.OutputPath = ResolveSegmentPath(segmentRoot, projectRoot, package.OutputPath, preserveProjectRelativeSegmentPaths);
+                    package.ReleaseZipOutputPath = ResolveSegmentPath(segmentRoot, projectRoot, package.ReleaseZipOutputPath, preserveProjectRelativeSegmentPaths);
+                    package.StagingPath = ResolveSegmentPath(segmentRoot, projectRoot, package.StagingPath, preserveProjectRelativeSegmentPaths);
+                    package.PlanOutputPath = ResolveSegmentPath(segmentRoot, projectRoot, package.PlanOutputPath, preserveProjectRelativeSegmentPaths);
+                    package.PublishApiKeyFilePath = ResolveSegmentPath(segmentRoot, projectRoot, package.PublishApiKeyFilePath, preserveProjectRelativeSegmentPaths);
+                    package.NugetCredentialSecretFilePath = ResolveSegmentPath(segmentRoot, projectRoot, package.NugetCredentialSecretFilePath, preserveProjectRelativeSegmentPaths);
+                    package.GitHubAccessTokenFilePath = ResolveSegmentPath(segmentRoot, projectRoot, package.GitHubAccessTokenFilePath, preserveProjectRelativeSegmentPaths);
+                    ResolvePackageBuildOptionPaths(package.Options, segmentRoot, projectRoot, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationDocumentationSegment documentation:
-                    documentation.Configuration.Path = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, documentation.Configuration.Path) ?? string.Empty;
-                    documentation.Configuration.PathReadme = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, documentation.Configuration.PathReadme) ?? string.Empty;
+                    documentation.Configuration.Path = ResolveWorkspaceQualifiedPath(segmentRoot, projectRoot, documentation.Configuration.Path) ?? string.Empty;
+                    documentation.Configuration.PathReadme = ResolveWorkspaceQualifiedPath(segmentRoot, projectRoot, documentation.Configuration.PathReadme) ?? string.Empty;
                     break;
                 case ConfigurationBuildDocumentationSegment buildDocumentation:
                     buildDocumentation.Configuration.AboutTopicsSourcePath = ResolveWorkspaceQualifiedStagingRelativePaths(
-                        workspaceRoot,
+                        segmentRoot,
                         projectRoot,
                         buildDocumentation.Configuration.AboutTopicsSourcePath);
                     break;
                 case ConfigurationTestSegment test:
-                    test.Configuration.TestsPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, test.Configuration.TestsPath) ?? string.Empty;
+                    test.Configuration.TestsPath = ResolveWorkspaceQualifiedPath(segmentRoot, projectRoot, test.Configuration.TestsPath) ?? string.Empty;
                     break;
                 case ConfigurationValidationSegment validation:
-                    validation.Settings.Tests.TestPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, validation.Settings.Tests.TestPath);
+                    validation.Settings.Tests.TestPath = ResolveWorkspaceQualifiedPath(segmentRoot, projectRoot, validation.Settings.Tests.TestPath);
                     break;
                 case ConfigurationOptionsSegment options:
                     var signing = options.Options?.Signing;
                     if (signing is not null)
-                        signing.CertificatePFXPath = ResolveSegmentPath(workspaceRoot, projectRoot, signing.CertificatePFXPath, preserveProjectRelativeSegmentPaths);
+                        signing.CertificatePFXPath = ResolveSegmentPath(segmentRoot, projectRoot, signing.CertificatePFXPath, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationReleaseSegment release:
-                    release.Configuration.StageRoot = ResolveSegmentPath(workspaceRoot, projectRoot, release.Configuration.StageRoot, preserveProjectRelativeSegmentPaths);
+                    release.Configuration.StageRoot = ResolveSegmentPath(segmentRoot, projectRoot, release.Configuration.StageRoot, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationPublishSegment publish:
-                    publish.Configuration.ApiKeyFilePath = ResolveSegmentPath(workspaceRoot, projectRoot, publish.Configuration.ApiKeyFilePath, preserveProjectRelativeSegmentPaths);
+                    publish.Configuration.ApiKeyFilePath = ResolveSegmentPath(segmentRoot, projectRoot, publish.Configuration.ApiKeyFilePath, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationActionSegment action:
-                    action.Configuration.FilePath = ResolveSegmentPath(workspaceRoot, projectRoot, action.Configuration.FilePath, preserveProjectRelativeSegmentPaths);
-                    action.Configuration.WorkingDirectory = ResolveSegmentPath(workspaceRoot, projectRoot, action.Configuration.WorkingDirectory, preserveProjectRelativeSegmentPaths);
+                    action.Configuration.FilePath = ResolveSegmentPath(segmentRoot, projectRoot, action.Configuration.FilePath, preserveProjectRelativeSegmentPaths);
+                    action.Configuration.WorkingDirectory = ResolveSegmentPath(segmentRoot, projectRoot, action.Configuration.WorkingDirectory, preserveProjectRelativeSegmentPaths);
                     break;
                 case ConfigurationAppleAppSegment appleApp:
-                    appleApp.Configuration.ProjectPath = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, appleApp.Configuration.ProjectPath) ?? string.Empty;
+                    appleApp.Configuration.ProjectPath = ResolveWorkspaceQualifiedPath(segmentRoot, projectRoot, appleApp.Configuration.ProjectPath) ?? string.Empty;
                     break;
                 case ConfigurationXcodeProjectVersionSegment xcodeProject:
-                    xcodeProject.Configuration.Path = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, xcodeProject.Configuration.Path) ?? string.Empty;
+                    xcodeProject.Configuration.Path = ResolveWorkspaceQualifiedPath(segmentRoot, projectRoot, xcodeProject.Configuration.Path) ?? string.Empty;
                     break;
                 case ConfigurationArtefactSegment artefact:
-                    ResolveWorkspaceRelativeArtefactPaths(artefact.Configuration, workspaceRoot, projectRoot);
+                    ResolveWorkspaceRelativeArtefactPaths(artefact.Configuration, segmentRoot, projectRoot);
                     break;
             }
         }

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -203,6 +203,14 @@ internal sealed class ModuleBuildPreparationService
             cfg.ConfigPath = ResolveConfigPath(projectRoot, cfg.ConfigPath);
         }
 
+        foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
+        {
+            var cfg = segment.BuildLibraries;
+            cfg.NETProjectPath = ResolveConfigPathNullable(projectRoot, cfg.NETProjectPath);
+            cfg.DevelopmentBinariesPath = ResolveConfigPathNullable(projectRoot, cfg.DevelopmentBinariesPath);
+            cfg.NETDevelopmentBinariesPath = ResolveConfigPathNullable(projectRoot, cfg.NETDevelopmentBinariesPath);
+        }
+
         foreach (var segment in spec.Segments?.OfType<ConfigurationPackageBuildSegment>() ?? Enumerable.Empty<ConfigurationPackageBuildSegment>())
         {
             var cfg = segment.Configuration;
@@ -212,6 +220,9 @@ internal sealed class ModuleBuildPreparationService
             cfg.ReleaseZipOutputPath = ResolveConfigPathNullable(projectRoot, cfg.ReleaseZipOutputPath);
             cfg.StagingPath = ResolveConfigPathNullable(projectRoot, cfg.StagingPath);
             cfg.PlanOutputPath = ResolveConfigPathNullable(projectRoot, cfg.PlanOutputPath);
+            cfg.PublishApiKeyFilePath = ResolveConfigPathNullable(projectRoot, cfg.PublishApiKeyFilePath);
+            cfg.NugetCredentialSecretFilePath = ResolveConfigPathNullable(projectRoot, cfg.NugetCredentialSecretFilePath);
+            cfg.GitHubAccessTokenFilePath = ResolveConfigPathNullable(projectRoot, cfg.GitHubAccessTokenFilePath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationReleaseSegment>() ?? Enumerable.Empty<ConfigurationReleaseSegment>())
@@ -219,6 +230,15 @@ internal sealed class ModuleBuildPreparationService
             var cfg = segment.Configuration;
             if (cfg is null || string.IsNullOrWhiteSpace(cfg.StageRoot)) continue;
             cfg.StageRoot = ResolveConfigPath(projectRoot, cfg.StageRoot);
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationArtefactSegment>() ?? Enumerable.Empty<ConfigurationArtefactSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.Path = ResolveConfigPathNullable(projectRoot, cfg.Path);
+            cfg.RequiredModules.Path = ResolveConfigPathNullable(projectRoot, cfg.RequiredModules.Path);
+            cfg.RequiredModules.ModulesPath = ResolveConfigPathNullable(projectRoot, cfg.RequiredModules.ModulesPath);
         }
     }
 
@@ -273,7 +293,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var basePath = request.ResolvePath!(request.InputPath!);
             var fullProjectPath = Path.Combine(basePath, moduleName);
-            return (fullProjectPath, basePath, basePath);
+            return (fullProjectPath, basePath, fullProjectPath);
         }
 
         var rootToUse = !string.IsNullOrWhiteSpace(request.ScriptRoot)
@@ -328,6 +348,9 @@ internal sealed class ModuleBuildPreparationService
                     package.ReleaseZipOutputPath = ResolveWorkspacePath(workspaceRoot, package.ReleaseZipOutputPath);
                     package.StagingPath = ResolveWorkspacePath(workspaceRoot, package.StagingPath);
                     package.PlanOutputPath = ResolveWorkspacePath(workspaceRoot, package.PlanOutputPath);
+                    package.PublishApiKeyFilePath = ResolveWorkspacePath(workspaceRoot, package.PublishApiKeyFilePath);
+                    package.NugetCredentialSecretFilePath = ResolveWorkspacePath(workspaceRoot, package.NugetCredentialSecretFilePath);
+                    package.GitHubAccessTokenFilePath = ResolveWorkspacePath(workspaceRoot, package.GitHubAccessTokenFilePath);
                     break;
                 case ConfigurationReleaseSegment release:
                     release.Configuration.StageRoot = ResolveWorkspacePath(workspaceRoot, release.Configuration.StageRoot);
@@ -348,6 +371,8 @@ internal sealed class ModuleBuildPreparationService
     private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot)
     {
         configuration.Path = ResolveWorkspacePath(workspaceRoot, configuration.Path);
+        configuration.RequiredModules.Path = ResolveWorkspacePath(workspaceRoot, configuration.RequiredModules.Path);
+        configuration.RequiredModules.ModulesPath = ResolveWorkspacePath(workspaceRoot, configuration.RequiredModules.ModulesPath);
     }
 
     private static string? ResolveWorkspacePath(string workspaceRoot, string? path)
@@ -447,6 +472,14 @@ internal sealed class ModuleBuildPreparationService
             cfg.ConfigPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.ConfigPath));
         }
 
+        foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
+        {
+            var cfg = segment.BuildLibraries;
+            cfg.NETProjectPath = MakeRelativeForProjectRoot(projectRoot, cfg.NETProjectPath);
+            cfg.DevelopmentBinariesPath = MakeRelativeForProjectRoot(projectRoot, cfg.DevelopmentBinariesPath);
+            cfg.NETDevelopmentBinariesPath = MakeRelativeForProjectRoot(projectRoot, cfg.NETDevelopmentBinariesPath);
+        }
+
         foreach (var segment in spec.Segments?.OfType<ConfigurationPackageBuildSegment>() ?? Enumerable.Empty<ConfigurationPackageBuildSegment>())
         {
             var cfg = segment.Configuration;
@@ -456,6 +489,9 @@ internal sealed class ModuleBuildPreparationService
             cfg.ReleaseZipOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.ReleaseZipOutputPath);
             cfg.StagingPath = MakeRelativeForProjectRoot(projectRoot, cfg.StagingPath);
             cfg.PlanOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.PlanOutputPath);
+            cfg.PublishApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.PublishApiKeyFilePath);
+            cfg.NugetCredentialSecretFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.NugetCredentialSecretFilePath);
+            cfg.GitHubAccessTokenFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.GitHubAccessTokenFilePath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationReleaseSegment>() ?? Enumerable.Empty<ConfigurationReleaseSegment>())
@@ -463,6 +499,15 @@ internal sealed class ModuleBuildPreparationService
             var cfg = segment.Configuration;
             if (cfg is null || string.IsNullOrWhiteSpace(cfg.StageRoot)) continue;
             cfg.StageRoot = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.StageRoot));
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationArtefactSegment>() ?? Enumerable.Empty<ConfigurationArtefactSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path);
+            cfg.RequiredModules.Path = MakeRelativeForProjectRoot(projectRoot, cfg.RequiredModules.Path);
+            cfg.RequiredModules.ModulesPath = MakeRelativeForProjectRoot(projectRoot, cfg.RequiredModules.ModulesPath);
         }
     }
 

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -54,6 +54,10 @@ internal sealed class ModuleBuildPreparationService
         var frameworks = useLegacy && !request.DotNetFrameworkWasBound
             ? Array.Empty<string>()
             : request.DotNetFramework;
+        var binaryConflictSearchRoots = ResolveWorkspacePaths(workspaceRoot, request.DiagnosticsBinaryConflictSearchRoot);
+        var installRoots = request.InstallRootsWasBound
+            ? ResolveWorkspacePaths(workspaceRoot, request.InstallRoots)
+            : null;
 
         var spec = new ModulePipelineSpec
         {
@@ -69,14 +73,14 @@ internal sealed class ModuleBuildPreparationService
                 KeepStaging = request.KeepStaging,
                 ExcludeDirectories = request.ExcludeDirectories ?? Array.Empty<string>(),
                 ExcludeFiles = BuildStageExcludeFiles(request.ExcludeFiles, moduleName!),
-                BinaryConflictSearchRoots = request.DiagnosticsBinaryConflictSearchRoot ?? Array.Empty<string>(),
+                BinaryConflictSearchRoots = binaryConflictSearchRoots,
             },
             Install = new ModulePipelineInstallOptions
             {
                 Enabled = !request.SkipInstall,
                 Strategy = request.InstallStrategyWasBound ? request.InstallStrategy : null,
                 KeepVersions = request.KeepVersionsWasBound ? request.KeepVersions : null,
-                Roots = request.InstallRootsWasBound ? (request.InstallRoots ?? Array.Empty<string>()) : null,
+                Roots = installRoots,
                 LegacyFlatHandling = request.LegacyFlatHandlingWasBound ? request.LegacyFlatHandling : null,
                 PreserveVersions = request.PreserveInstallVersionsWasBound ? request.PreserveInstallVersions : null,
             },
@@ -87,7 +91,7 @@ internal sealed class ModuleBuildPreparationService
                 UpdateBaseline = request.UpdateDiagnosticsBaseline,
                 FailOnNewDiagnostics = request.FailOnNewDiagnostics,
                 FailOnSeverity = request.FailOnDiagnosticsSeverity,
-                BinaryConflictSearchRoots = request.DiagnosticsBinaryConflictSearchRoot ?? Array.Empty<string>()
+                BinaryConflictSearchRoots = binaryConflictSearchRoots
             },
             Segments = segments
         };
@@ -101,7 +105,7 @@ internal sealed class ModuleBuildPreparationService
             BasePathForScaffold = basePathForScaffold,
             UseLegacy = useLegacy,
             PipelineSpec = spec,
-            JsonOutputPath = request.JsonOnly ? ResolveJsonOutputPath(request, projectRoot) : null,
+            JsonOutputPath = request.JsonOnly ? ResolveJsonOutputPath(request, projectRoot, workspaceRoot) : null,
             ConfigLabel = useLegacy ? "dsl" : "cmdlet"
         };
     }
@@ -135,7 +139,7 @@ internal sealed class ModuleBuildPreparationService
             BasePathForScaffold = null,
             UseLegacy = false,
             PipelineSpec = spec,
-            JsonOutputPath = request.JsonOnly ? ResolveJsonOutputPath(request, spec.Build.SourcePath) : null,
+            JsonOutputPath = request.JsonOnly ? ResolveJsonOutputPath(request, spec.Build.SourcePath, spec.Build.SourcePath) : null,
             ConfigLabel = "json",
             ConfigFilePath = configFullPath
         };
@@ -192,8 +196,13 @@ internal sealed class ModuleBuildPreparationService
         spec.Build.StagingPath = ResolveConfigPathNullable(baseDir, spec.Build.StagingPath);
         spec.Build.CsprojPath = ResolveConfigPathNullable(baseDir, spec.Build.CsprojPath);
         spec.Build.DevelopmentBinariesPath = ResolveConfigPathNullable(baseDir, spec.Build.DevelopmentBinariesPath);
+        spec.Build.BinaryConflictSearchRoots = ResolveConfigPaths(projectRoot, spec.Build.BinaryConflictSearchRoots);
+        if (spec.Install?.Roots is not null)
+            spec.Install.Roots = ResolveConfigPaths(projectRoot, spec.Install.Roots);
         if (spec.Diagnostics is not null && !string.IsNullOrWhiteSpace(spec.Diagnostics.BaselinePath))
             spec.Diagnostics.BaselinePath = ResolveConfigPath(baseDir, spec.Diagnostics.BaselinePath!);
+        if (spec.Diagnostics is not null)
+            spec.Diagnostics.BinaryConflictSearchRoots = ResolveConfigPaths(projectRoot, spec.Diagnostics.BinaryConflictSearchRoots);
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationAppleAppSegment>() ?? Enumerable.Empty<ConfigurationAppleAppSegment>())
         {
@@ -253,7 +262,6 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.AboutTopicsSourcePath = ResolveConfigPaths(projectRoot, cfg.AboutTopicsSourcePath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
@@ -428,7 +436,6 @@ internal sealed class ModuleBuildPreparationService
                     documentation.Configuration.PathReadme = ResolveWorkspacePath(workspaceRoot, documentation.Configuration.PathReadme) ?? string.Empty;
                     break;
                 case ConfigurationBuildDocumentationSegment buildDocumentation:
-                    buildDocumentation.Configuration.AboutTopicsSourcePath = ResolveWorkspacePaths(workspaceRoot, buildDocumentation.Configuration.AboutTopicsSourcePath);
                     break;
                 case ConfigurationTestSegment test:
                     test.Configuration.TestsPath = ResolveWorkspacePath(workspaceRoot, test.Configuration.TestsPath) ?? string.Empty;
@@ -611,10 +618,10 @@ internal sealed class ModuleBuildPreparationService
         return set.ToArray();
     }
 
-    private static string ResolveJsonOutputPath(ModuleBuildPreparationRequest request, string projectRoot)
+    private static string ResolveJsonOutputPath(ModuleBuildPreparationRequest request, string projectRoot, string jsonBasePath)
     {
         if (!string.IsNullOrWhiteSpace(request.JsonPath))
-            return request.ResolvePath!(request.JsonPath!);
+            return ResolveConfigPath(jsonBasePath, request.JsonPath);
 
         return Path.Combine(projectRoot, "powerforge.json");
     }
@@ -655,8 +662,13 @@ internal sealed class ModuleBuildPreparationService
         spec.Build.StagingPath = MakeRelativeForConfigNullable(baseDir, spec.Build.StagingPath);
         spec.Build.CsprojPath = MakeRelativeForConfigNullable(baseDir, spec.Build.CsprojPath);
         spec.Build.DevelopmentBinariesPath = MakeRelativeForConfigNullable(baseDir, spec.Build.DevelopmentBinariesPath);
+        spec.Build.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Build.BinaryConflictSearchRoots);
+        if (spec.Install?.Roots is not null)
+            spec.Install.Roots = MakePathsRelativeForProjectRoot(projectRoot, spec.Install.Roots);
         if (spec.Diagnostics is not null && !string.IsNullOrWhiteSpace(spec.Diagnostics.BaselinePath))
             spec.Diagnostics.BaselinePath = MakeRelativeForConfig(baseDir, spec.Diagnostics.BaselinePath!);
+        if (spec.Diagnostics is not null)
+            spec.Diagnostics.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Diagnostics.BinaryConflictSearchRoots);
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationAppleAppSegment>() ?? Enumerable.Empty<ConfigurationAppleAppSegment>())
         {
@@ -716,7 +728,6 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.AboutTopicsSourcePath = MakePathsRelativeForProjectRoot(projectRoot, cfg.AboutTopicsSourcePath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -405,18 +405,23 @@ internal sealed class ModuleBuildPreparationService
         if (segments.Count == 0 || SamePath(workspaceRoot, projectRoot))
             return;
 
+        var preserveModuleLocalBuildPaths = UsesModuleFolderLayout(workspaceRoot, projectRoot);
         foreach (var segment in segments)
         {
             switch (segment)
             {
                 case ConfigurationBuildLibrariesSegment buildLibraries:
                     var libraries = buildLibraries.BuildLibraries;
-                    libraries.NETProjectPath = ResolveWorkspacePath(workspaceRoot, libraries.NETProjectPath);
-                    libraries.DevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.DevelopmentBinariesPath);
-                    libraries.NETDevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.NETDevelopmentBinariesPath);
+                    if (!preserveModuleLocalBuildPaths)
+                    {
+                        libraries.NETProjectPath = ResolveWorkspacePath(workspaceRoot, libraries.NETProjectPath);
+                        libraries.DevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.DevelopmentBinariesPath);
+                        libraries.NETDevelopmentBinariesPath = ResolveWorkspacePath(workspaceRoot, libraries.NETDevelopmentBinariesPath);
+                    }
                     break;
                 case ConfigurationProjectBuildSegment projectBuild:
-                    projectBuild.Configuration.ConfigPath = ResolveWorkspacePath(workspaceRoot, projectBuild.Configuration.ConfigPath) ?? string.Empty;
+                    if (!preserveModuleLocalBuildPaths)
+                        projectBuild.Configuration.ConfigPath = ResolveWorkspacePath(workspaceRoot, projectBuild.Configuration.ConfigPath) ?? string.Empty;
                     ResolvePackageBuildOptionPaths(projectBuild.Configuration.Options, workspaceRoot);
                     break;
                 case ConfigurationPackageBuildSegment packageBuild:
@@ -469,6 +474,17 @@ internal sealed class ModuleBuildPreparationService
                     break;
             }
         }
+    }
+
+    private static bool UsesModuleFolderLayout(string workspaceRoot, string projectRoot)
+    {
+        if (SamePath(workspaceRoot, projectRoot))
+            return false;
+
+        var projectDirectory = new DirectoryInfo(Path.GetFullPath(projectRoot));
+        return string.Equals(projectDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) &&
+               projectDirectory.Parent is not null &&
+               SamePath(workspaceRoot, projectDirectory.Parent.FullName);
     }
 
     private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot, string projectRoot)
@@ -728,18 +744,19 @@ internal sealed class ModuleBuildPreparationService
         var baseDir = Path.GetDirectoryName(jsonFullPath);
         if (string.IsNullOrWhiteSpace(baseDir)) return;
         var projectRoot = ResolveConfigPath(baseDir, spec.Build.SourcePath);
+        var workspaceRoot = ResolveJsonWorkspaceRoot(projectRoot);
 
         spec.Build.SourcePath = MakeRelativeForConfig(baseDir, spec.Build.SourcePath);
         spec.Build.StagingPath = MakeRelativeForConfigNullable(baseDir, spec.Build.StagingPath);
         spec.Build.CsprojPath = MakeRelativeForConfigNullable(baseDir, spec.Build.CsprojPath);
         spec.Build.DevelopmentBinariesPath = MakeRelativeForConfigNullable(baseDir, spec.Build.DevelopmentBinariesPath);
-        spec.Build.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Build.BinaryConflictSearchRoots, preserveExternalRooted: true);
+        spec.Build.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Build.BinaryConflictSearchRoots, preserveExternalRooted: true, workspaceRoot);
         if (spec.Install?.Roots is not null)
-            spec.Install.Roots = MakePathsRelativeForProjectRoot(projectRoot, spec.Install.Roots, preserveExternalRooted: true);
+            spec.Install.Roots = MakePathsRelativeForProjectRoot(projectRoot, spec.Install.Roots, preserveExternalRooted: true, workspaceRoot);
         if (spec.Diagnostics is not null && !string.IsNullOrWhiteSpace(spec.Diagnostics.BaselinePath))
             spec.Diagnostics.BaselinePath = MakeRelativeForConfig(baseDir, spec.Diagnostics.BaselinePath!);
         if (spec.Diagnostics is not null)
-            spec.Diagnostics.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Diagnostics.BinaryConflictSearchRoots, preserveExternalRooted: true);
+            spec.Diagnostics.BinaryConflictSearchRoots = MakePathsRelativeForProjectRoot(projectRoot, spec.Diagnostics.BinaryConflictSearchRoots, preserveExternalRooted: true, workspaceRoot);
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationAppleAppSegment>() ?? Enumerable.Empty<ConfigurationAppleAppSegment>())
         {
@@ -761,7 +778,7 @@ internal sealed class ModuleBuildPreparationService
             if (cfg is null) continue;
             if (!string.IsNullOrWhiteSpace(cfg.ConfigPath))
                 cfg.ConfigPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.ConfigPath));
-            MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot);
+            MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
@@ -781,10 +798,10 @@ internal sealed class ModuleBuildPreparationService
             cfg.ReleaseZipOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.ReleaseZipOutputPath);
             cfg.StagingPath = MakeRelativeForProjectRoot(projectRoot, cfg.StagingPath);
             cfg.PlanOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.PlanOutputPath);
-            cfg.PublishApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.PublishApiKeyFilePath, preserveExternalRooted: true);
-            cfg.NugetCredentialSecretFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.NugetCredentialSecretFilePath, preserveExternalRooted: true);
-            cfg.GitHubAccessTokenFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.GitHubAccessTokenFilePath, preserveExternalRooted: true);
-            MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot);
+            cfg.PublishApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.PublishApiKeyFilePath, preserveExternalRooted: true, workspaceRoot);
+            cfg.NugetCredentialSecretFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.NugetCredentialSecretFilePath, preserveExternalRooted: true, workspaceRoot);
+            cfg.GitHubAccessTokenFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.GitHubAccessTokenFilePath, preserveExternalRooted: true, workspaceRoot);
+            MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationDocumentationSegment>() ?? Enumerable.Empty<ConfigurationDocumentationSegment>())
@@ -819,7 +836,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var signing = segment.Options?.Signing;
             if (signing is null) continue;
-            signing.CertificatePFXPath = MakeRelativeForProjectRoot(projectRoot, signing.CertificatePFXPath, preserveExternalRooted: true);
+            signing.CertificatePFXPath = MakeRelativeForProjectRoot(projectRoot, signing.CertificatePFXPath, preserveExternalRooted: true, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationReleaseSegment>() ?? Enumerable.Empty<ConfigurationReleaseSegment>())
@@ -833,15 +850,15 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.ApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.ApiKeyFilePath, preserveExternalRooted: true);
+            cfg.ApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.ApiKeyFilePath, preserveExternalRooted: true, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationActionSegment>() ?? Enumerable.Empty<ConfigurationActionSegment>())
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.FilePath = MakeRelativeForProjectRoot(projectRoot, cfg.FilePath, preserveExternalRooted: true);
-            cfg.WorkingDirectory = MakeRelativeForProjectRoot(projectRoot, cfg.WorkingDirectory, preserveExternalRooted: true);
+            cfg.FilePath = MakeRelativeForProjectRoot(projectRoot, cfg.FilePath, preserveExternalRooted: true, workspaceRoot);
+            cfg.WorkingDirectory = MakeRelativeForProjectRoot(projectRoot, cfg.WorkingDirectory, preserveExternalRooted: true, workspaceRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationArtefactSegment>() ?? Enumerable.Empty<ConfigurationArtefactSegment>())
@@ -851,9 +868,17 @@ internal sealed class ModuleBuildPreparationService
             cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path);
             cfg.RequiredModules.Path = MakeArtefactLayoutPathForJson(projectRoot, cfg.Path, cfg.RequiredModules.Path);
             cfg.RequiredModules.ModulesPath = MakeArtefactLayoutPathForJson(projectRoot, cfg.Path, cfg.RequiredModules.ModulesPath);
-            MakeCopyMappingSourcesRelative(cfg.DirectoryOutput, projectRoot);
-            MakeCopyMappingSourcesRelative(cfg.FilesOutput, projectRoot);
+            MakeCopyMappingSourcesRelative(cfg.DirectoryOutput, projectRoot, workspaceRoot);
+            MakeCopyMappingSourcesRelative(cfg.FilesOutput, projectRoot, workspaceRoot);
         }
+    }
+
+    private static string ResolveJsonWorkspaceRoot(string projectRoot)
+    {
+        var projectDirectory = new DirectoryInfo(Path.GetFullPath(projectRoot));
+        return string.Equals(projectDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) && projectDirectory.Parent is not null
+            ? projectDirectory.Parent.FullName
+            : projectRoot;
     }
 
     private static string? MakeArtefactLayoutPathForJson(string projectRoot, string? artefactPath, string? layoutPath)
@@ -874,7 +899,7 @@ internal sealed class ModuleBuildPreparationService
             : NormalizePathSeparators(layoutPath!);
     }
 
-    private static void MakeCopyMappingSourcesRelative(ArtefactCopyMapping[]? mappings, string projectRoot)
+    private static void MakeCopyMappingSourcesRelative(ArtefactCopyMapping[]? mappings, string projectRoot, string workspaceRoot)
     {
         if (mappings is null)
             return;
@@ -884,7 +909,7 @@ internal sealed class ModuleBuildPreparationService
             if (mapping is null || string.IsNullOrWhiteSpace(mapping.Source))
                 continue;
 
-            mapping.Source = MakeRelativeForProjectRoot(projectRoot, mapping.Source, preserveExternalRooted: true) ?? string.Empty;
+            mapping.Source = MakeRelativeForProjectRoot(projectRoot, mapping.Source, preserveExternalRooted: true, workspaceRoot) ?? string.Empty;
         }
     }
 
@@ -895,19 +920,27 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static string? MakeRelativeForProjectRoot(string projectRoot, string? path, bool preserveExternalRooted)
+        => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted, projectRoot);
+
+    private static string? MakeRelativeForProjectRoot(string projectRoot, string? path, bool preserveExternalRooted, string workspaceRoot)
     {
         if (string.IsNullOrWhiteSpace(path)) return null;
         if (ContainsPathToken(path!))
             return MakeTokenizedPathRelativeForProjectRoot(projectRoot, path!);
 
         var resolved = ResolveConfigPath(projectRoot, path);
-        if (preserveExternalRooted && Path.IsPathRooted(PathValueResolver.Clean(path!)) && !IsSameOrChildPath(projectRoot, resolved))
+        if (preserveExternalRooted &&
+            Path.IsPathRooted(PathValueResolver.Clean(path!)) &&
+            !IsSameOrChildPath(projectRoot, resolved) &&
+            !IsSameOrChildPath(workspaceRoot, resolved))
+        {
             return NormalizePathSeparators(resolved);
+        }
 
         return MakeRelativeForConfig(projectRoot, resolved);
     }
 
-    private static void MakePackageBuildOptionPathsRelative(Dictionary<string, object?>? options, string projectRoot)
+    private static void MakePackageBuildOptionPathsRelative(Dictionary<string, object?>? options, string projectRoot, string workspaceRoot)
     {
         if (options is null || options.Count == 0)
             return;
@@ -921,7 +954,7 @@ internal sealed class ModuleBuildPreparationService
             if (string.IsNullOrWhiteSpace(path))
                 continue;
 
-            options[optionName] = MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: IsPackageCredentialPathName(optionName));
+            options[optionName] = MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: IsPackageCredentialPathName(optionName), workspaceRoot);
         }
     }
 
@@ -931,12 +964,15 @@ internal sealed class ModuleBuildPreparationService
            string.Equals(optionName, nameof(PackageBuildConfiguration.GitHubAccessTokenFilePath), StringComparison.OrdinalIgnoreCase);
 
     private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted = false)
+        => MakePathsRelativeForProjectRoot(projectRoot, paths, preserveExternalRooted, projectRoot);
+
+    private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted, string workspaceRoot)
     {
         if (paths is null || paths.Length == 0)
             return Array.Empty<string>();
 
         return paths
-            .Select(path => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted) ?? string.Empty)
+            .Select(path => MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted, workspaceRoot) ?? string.Empty)
             .Where(static path => !string.IsNullOrWhiteSpace(path))
             .ToArray();
     }

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -370,7 +370,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var basePath = request.ResolvePath!(request.InputPath!);
             var fullProjectPath = Path.Combine(basePath, moduleName);
-            return (fullProjectPath, basePath, fullProjectPath);
+            return (fullProjectPath, basePath, basePath);
         }
 
         var rootToUse = !string.IsNullOrWhiteSpace(request.ScriptRoot)
@@ -628,19 +628,10 @@ internal sealed class ModuleBuildPreparationService
                 continue;
 
             if (!string.IsNullOrWhiteSpace(requiredFirstSegment) && !StartsWithPathSegment(mapping.Source, requiredFirstSegment!))
-            {
-                if (string.IsNullOrWhiteSpace(projectRoot) || IsModuleRelativeCopySource(mapping.Source))
-                    continue;
-            }
+                continue;
 
             mapping.Source = PathValueResolver.Resolve(rootPath, mapping.Source);
         }
-    }
-
-    private static bool IsModuleRelativeCopySource(string path)
-    {
-        var firstSegment = GetFirstPathSegment(path);
-        return string.Equals(firstSegment, "Examples", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool StartsWithPathSegment(string path, string segment)
@@ -790,9 +781,9 @@ internal sealed class ModuleBuildPreparationService
             cfg.ReleaseZipOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.ReleaseZipOutputPath);
             cfg.StagingPath = MakeRelativeForProjectRoot(projectRoot, cfg.StagingPath);
             cfg.PlanOutputPath = MakeRelativeForProjectRoot(projectRoot, cfg.PlanOutputPath);
-            cfg.PublishApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.PublishApiKeyFilePath);
-            cfg.NugetCredentialSecretFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.NugetCredentialSecretFilePath);
-            cfg.GitHubAccessTokenFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.GitHubAccessTokenFilePath);
+            cfg.PublishApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.PublishApiKeyFilePath, preserveExternalRooted: true);
+            cfg.NugetCredentialSecretFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.NugetCredentialSecretFilePath, preserveExternalRooted: true);
+            cfg.GitHubAccessTokenFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.GitHubAccessTokenFilePath, preserveExternalRooted: true);
             MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot);
         }
 
@@ -828,7 +819,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var signing = segment.Options?.Signing;
             if (signing is null) continue;
-            signing.CertificatePFXPath = MakeRelativeForProjectRoot(projectRoot, signing.CertificatePFXPath);
+            signing.CertificatePFXPath = MakeRelativeForProjectRoot(projectRoot, signing.CertificatePFXPath, preserveExternalRooted: true);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationReleaseSegment>() ?? Enumerable.Empty<ConfigurationReleaseSegment>())
@@ -849,8 +840,8 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.FilePath = MakeRelativeForProjectRoot(projectRoot, cfg.FilePath);
-            cfg.WorkingDirectory = MakeRelativeForProjectRoot(projectRoot, cfg.WorkingDirectory);
+            cfg.FilePath = MakeRelativeForProjectRoot(projectRoot, cfg.FilePath, preserveExternalRooted: true);
+            cfg.WorkingDirectory = MakeRelativeForProjectRoot(projectRoot, cfg.WorkingDirectory, preserveExternalRooted: true);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationArtefactSegment>() ?? Enumerable.Empty<ConfigurationArtefactSegment>())
@@ -930,9 +921,14 @@ internal sealed class ModuleBuildPreparationService
             if (string.IsNullOrWhiteSpace(path))
                 continue;
 
-            options[optionName] = MakeRelativeForProjectRoot(projectRoot, path);
+            options[optionName] = MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: IsPackageCredentialPathName(optionName));
         }
     }
+
+    private static bool IsPackageCredentialPathName(string optionName)
+        => string.Equals(optionName, nameof(PackageBuildConfiguration.PublishApiKeyFilePath), StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(optionName, nameof(PackageBuildConfiguration.NugetCredentialSecretFilePath), StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(optionName, nameof(PackageBuildConfiguration.GitHubAccessTokenFilePath), StringComparison.OrdinalIgnoreCase);
 
     private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted = false)
     {

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -432,8 +432,8 @@ internal sealed class ModuleBuildPreparationService
                     ResolvePackageBuildOptionPaths(package.Options, workspaceRoot);
                     break;
                 case ConfigurationDocumentationSegment documentation:
-                    documentation.Configuration.Path = ResolveWorkspacePath(workspaceRoot, documentation.Configuration.Path) ?? string.Empty;
-                    documentation.Configuration.PathReadme = ResolveWorkspacePath(workspaceRoot, documentation.Configuration.PathReadme) ?? string.Empty;
+                    documentation.Configuration.Path = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, documentation.Configuration.Path) ?? string.Empty;
+                    documentation.Configuration.PathReadme = ResolveWorkspaceQualifiedPath(workspaceRoot, projectRoot, documentation.Configuration.PathReadme) ?? string.Empty;
                     break;
                 case ConfigurationBuildDocumentationSegment buildDocumentation:
                     break;
@@ -465,19 +465,19 @@ internal sealed class ModuleBuildPreparationService
                     xcodeProject.Configuration.Path = ResolveWorkspacePath(workspaceRoot, xcodeProject.Configuration.Path) ?? string.Empty;
                     break;
                 case ConfigurationArtefactSegment artefact:
-                    ResolveWorkspaceRelativeArtefactPaths(artefact.Configuration, workspaceRoot);
+                    ResolveWorkspaceRelativeArtefactPaths(artefact.Configuration, workspaceRoot, projectRoot);
                     break;
             }
         }
     }
 
-    private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot)
+    private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot, string projectRoot)
     {
         configuration.Path = ResolveWorkspacePath(workspaceRoot, configuration.Path);
         configuration.RequiredModules.Path = ResolveArtefactLayoutPath(workspaceRoot, configuration.Path, configuration.RequiredModules.Path);
         configuration.RequiredModules.ModulesPath = ResolveArtefactLayoutPath(workspaceRoot, configuration.Path, configuration.RequiredModules.ModulesPath);
-        ResolveCopyMappingSources(configuration.DirectoryOutput, workspaceRoot);
-        ResolveCopyMappingSources(configuration.FilesOutput, workspaceRoot);
+        ResolveCopyMappingSources(configuration.DirectoryOutput, workspaceRoot, projectRoot);
+        ResolveCopyMappingSources(configuration.FilesOutput, workspaceRoot, projectRoot);
     }
 
     private static string? ResolveWorkspacePath(string workspaceRoot, string? path)
@@ -497,6 +497,18 @@ internal sealed class ModuleBuildPreparationService
             .Select(path => ResolveWorkspacePath(workspaceRoot, path) ?? string.Empty)
             .Where(static path => !string.IsNullOrWhiteSpace(path))
             .ToArray();
+    }
+
+    private static string? ResolveWorkspaceQualifiedPath(string workspaceRoot, string projectRoot, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || Path.IsPathRooted(path) || SamePath(workspaceRoot, projectRoot))
+            return path;
+
+        var moduleDirectoryName = Path.GetFileName(projectRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)) ?? string.Empty;
+        if (!StartsWithPathSegment(path!, moduleDirectoryName))
+            return path;
+
+        return ResolveWorkspacePath(workspaceRoot, path);
     }
 
     private static string[] ResolveConfigPaths(string rootPath, string[]? paths)
@@ -583,18 +595,37 @@ internal sealed class ModuleBuildPreparationService
         return IsSameOrChildPath(artefactRoot, candidate) ? candidate : layoutPath;
     }
 
-    private static void ResolveCopyMappingSources(ArtefactCopyMapping[]? mappings, string rootPath)
+    private static void ResolveCopyMappingSources(ArtefactCopyMapping[]? mappings, string rootPath, string? projectRoot = null)
     {
         if (mappings is null)
             return;
+
+        var requiredFirstSegment = string.IsNullOrWhiteSpace(projectRoot)
+            ? null
+            : Path.GetFileName(projectRoot!.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)) ?? string.Empty;
 
         foreach (var mapping in mappings)
         {
             if (mapping is null || string.IsNullOrWhiteSpace(mapping.Source) || Path.IsPathRooted(mapping.Source))
                 continue;
 
+            if (!string.IsNullOrWhiteSpace(requiredFirstSegment) && !StartsWithPathSegment(mapping.Source, requiredFirstSegment!))
+                continue;
+
             mapping.Source = PathValueResolver.Resolve(rootPath, mapping.Source);
         }
+    }
+
+    private static bool StartsWithPathSegment(string path, string segment)
+    {
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(segment))
+            return false;
+
+        var cleaned = PathValueResolver.Clean(path);
+        var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        var firstSeparator = cleaned.IndexOfAny(separators);
+        var firstSegment = firstSeparator < 0 ? cleaned : cleaned.Substring(0, firstSeparator);
+        return string.Equals(firstSegment, segment, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool SamePath(string left, string right)
@@ -621,9 +652,25 @@ internal sealed class ModuleBuildPreparationService
     private static string ResolveJsonOutputPath(ModuleBuildPreparationRequest request, string projectRoot, string jsonBasePath)
     {
         if (!string.IsNullOrWhiteSpace(request.JsonPath))
-            return ResolveConfigPath(jsonBasePath, request.JsonPath);
+        {
+            var jsonPath = request.JsonPath!;
+            if (RequiresPowerShellPathResolution(jsonPath))
+                return request.ResolvePath!(jsonPath);
+
+            return ResolveConfigPath(jsonBasePath, jsonPath);
+        }
 
         return Path.Combine(projectRoot, "powerforge.json");
+    }
+
+    private static bool RequiresPowerShellPathResolution(string path)
+    {
+        var cleaned = PathValueResolver.Clean(path);
+        if (cleaned.StartsWith("~", StringComparison.Ordinal))
+            return true;
+
+        var colonIndex = cleaned.IndexOf(':');
+        return colonIndex > 0 && cleaned.Substring(0, colonIndex).All(static c => char.IsLetterOrDigit(c) || c is '_' or '-' or '.');
     }
 
     private static JsonSerializerOptions CreateJsonOptions()

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -394,14 +394,10 @@ internal sealed class ModuleBuildPreparationService
 
         var scriptDirectory = new DirectoryInfo(Path.GetFullPath(scriptRoot!));
         var moduleDirectory = new DirectoryInfo(Path.GetFullPath(projectRoot));
-        if (!string.Equals(scriptDirectory.Name, "Build", StringComparison.OrdinalIgnoreCase) ||
-            !string.Equals(moduleDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) ||
-            moduleDirectory.Parent is null)
-        {
-            return projectRoot;
-        }
-
-        return moduleDirectory.Parent.FullName;
+        return string.Equals(scriptDirectory.Name, "Build", StringComparison.OrdinalIgnoreCase) &&
+               UsesRepositoryModuleLayout(moduleDirectory)
+            ? moduleDirectory.Parent!.FullName
+            : projectRoot;
     }
 
     private static void ResolveWorkspaceRelativeSegmentPaths(
@@ -494,9 +490,8 @@ internal sealed class ModuleBuildPreparationService
             return false;
 
         var projectDirectory = new DirectoryInfo(Path.GetFullPath(projectRoot));
-        return string.Equals(projectDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) &&
-               projectDirectory.Parent is not null &&
-               SamePath(workspaceRoot, projectDirectory.Parent.FullName);
+        return UsesRepositoryModuleLayout(projectDirectory) &&
+               SamePath(workspaceRoot, projectDirectory.Parent!.FullName);
     }
 
     private static void ResolveWorkspaceRelativeArtefactPaths(ArtefactConfiguration configuration, string workspaceRoot, string projectRoot)
@@ -627,7 +622,7 @@ internal sealed class ModuleBuildPreparationService
         if (options is null || options.Count == 0)
             return;
 
-        foreach (var optionName in PackageBuildOptionPathNames)
+        foreach (var optionName in GetPackageBuildOptionPathKeys(options))
         {
             if (!options.TryGetValue(optionName, out var value))
                 continue;
@@ -649,7 +644,7 @@ internal sealed class ModuleBuildPreparationService
         if (options is null || options.Count == 0)
             return;
 
-        foreach (var optionName in PackageBuildOptionPathNames)
+        foreach (var optionName in GetPackageBuildOptionPathKeys(options))
         {
             if (!options.TryGetValue(optionName, out var value))
                 continue;
@@ -710,7 +705,7 @@ internal sealed class ModuleBuildPreparationService
             return false;
 
         var firstSegment = GetFirstPathSegment(path);
-        return string.Equals(firstSegment, segment, StringComparison.OrdinalIgnoreCase);
+        return ModuleBuildPathPolicy.SamePathSegment(firstSegment, segment);
     }
 
     private static string GetFirstPathSegment(string path)
@@ -894,7 +889,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null || string.IsNullOrWhiteSpace(cfg.StageRoot)) continue;
-            cfg.StageRoot = MakeReleaseStageRootPathForJson(projectRoot, cfg.StageRoot!);
+            cfg.StageRoot = MakeReleaseStageRootPathForJson(projectRoot, workspaceRoot, cfg.StageRoot!);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationPublishSegment>() ?? Enumerable.Empty<ConfigurationPublishSegment>())
@@ -935,7 +930,12 @@ internal sealed class ModuleBuildPreparationService
     private static bool UsesRepositoryModuleLayout(DirectoryInfo projectDirectory)
         => string.Equals(projectDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) &&
            projectDirectory.Parent is not null &&
+           HasRepositoryRootMarker(projectDirectory.Parent.FullName) &&
            File.Exists(Path.Combine(projectDirectory.FullName, "Build", "Build-Module.ps1"));
+
+    private static bool HasRepositoryRootMarker(string directory)
+        => File.Exists(Path.Combine(directory, ".git")) ||
+           Directory.Exists(Path.Combine(directory, ".git"));
 
     private static string? MakeArtefactLayoutPathForJson(string projectRoot, string workspaceRoot, string? artefactPath, string? layoutPath)
     {
@@ -955,9 +955,9 @@ internal sealed class ModuleBuildPreparationService
             : NormalizePathSeparators(layoutPath!);
     }
 
-    private static string MakeReleaseStageRootPathForJson(string projectRoot, string stageRoot)
+    private static string MakeReleaseStageRootPathForJson(string projectRoot, string workspaceRoot, string stageRoot)
         => ContainsPathToken(stageRoot)
-            ? MakeRelativeForProjectRoot(projectRoot, stageRoot) ?? NormalizePathSeparators(stageRoot)
+            ? MakeRelativeForProjectRoot(projectRoot, stageRoot, preserveExternalRooted: true, workspaceRoot) ?? NormalizePathSeparators(stageRoot)
             : MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, stageRoot));
 
     private static void MakeCopyMappingSourcesRelative(ArtefactCopyMapping[]? mappings, string projectRoot, string workspaceRoot)
@@ -988,7 +988,7 @@ internal sealed class ModuleBuildPreparationService
         if (options is null || options.Count == 0)
             return;
 
-        foreach (var optionName in PackageBuildOptionPathNames)
+        foreach (var optionName in GetPackageBuildOptionPathKeys(options))
         {
             if (!options.TryGetValue(optionName, out var value))
                 continue;
@@ -1000,6 +1000,11 @@ internal sealed class ModuleBuildPreparationService
             options[optionName] = MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: true, workspaceRoot);
         }
     }
+
+    private static string[] GetPackageBuildOptionPathKeys(Dictionary<string, object?> options)
+        => options.Keys
+            .Where(key => PackageBuildOptionPathNames.Contains(key))
+            .ToArray();
 
     private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths, bool preserveExternalRooted = false)
         => ModuleBuildPathPolicy.MakePathsRelativeForProjectRoot(projectRoot, paths, preserveExternalRooted);

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -312,7 +312,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.Path = ResolveConfigPathNullable(projectRoot, cfg.Path);
+            cfg.Path = ResolveTokenAwareConfigPathNullable(projectRoot, cfg.Path);
             cfg.RequiredModules.Path = ResolveArtefactLayoutPath(projectRoot, cfg.Path, cfg.RequiredModules.Path);
             cfg.RequiredModules.ModulesPath = ResolveArtefactLayoutPath(projectRoot, cfg.Path, cfg.RequiredModules.ModulesPath);
             ResolveCopyMappingSources(cfg.DirectoryOutput, projectRoot);
@@ -693,6 +693,8 @@ internal sealed class ModuleBuildPreparationService
         {
             if (mapping is null || string.IsNullOrWhiteSpace(mapping.Source) || Path.IsPathRooted(mapping.Source))
                 continue;
+            if (ContainsPathToken(mapping.Source))
+                continue;
 
             if (!string.IsNullOrWhiteSpace(requiredFirstSegment) && !StartsWithPathSegment(mapping.Source, requiredFirstSegment!))
                 continue;
@@ -786,6 +788,14 @@ internal sealed class ModuleBuildPreparationService
     {
         if (string.IsNullOrWhiteSpace(path)) return null;
         return ResolveConfigPath(baseDir, path);
+    }
+
+    private static string? ResolveTokenAwareConfigPathNullable(string baseDir, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        return ContainsPathToken(path!)
+            ? NormalizePathSeparators(path!)
+            : ResolveConfigPath(baseDir, path);
     }
 
     private static void PrepareSpecForJsonExport(ModulePipelineSpec spec, string jsonFullPath)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.IO;
 using System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -46,7 +47,7 @@ internal sealed class ModuleBuildPreparationService
         var segments = useLegacy
             ? (string.Equals(request.ParameterSetName, "Configuration", StringComparison.Ordinal)
                 ? LegacySegmentAdapter.CollectFromLegacyConfiguration(request.Configuration)
-                : LegacySegmentAdapter.CollectFromSettings(request.Settings))
+                : CollectSettingsFromWorkspace(request.Settings, workspaceRoot))
             : Array.Empty<IConfigurationSegment>();
         ResolveWorkspaceRelativeSegmentPaths(segments, workspaceRoot, projectRoot);
 
@@ -60,8 +61,8 @@ internal sealed class ModuleBuildPreparationService
             {
                 Name = moduleName!,
                 SourcePath = projectRoot,
-                StagingPath = request.StagingPath,
-                CsprojPath = request.CsprojPath,
+                StagingPath = ResolveWorkspacePath(workspaceRoot, request.StagingPath),
+                CsprojPath = ResolveWorkspacePath(workspaceRoot, request.CsprojPath),
                 Version = "1.0.0",
                 Configuration = request.DotNetConfiguration,
                 Frameworks = frameworks,
@@ -81,7 +82,7 @@ internal sealed class ModuleBuildPreparationService
             },
             Diagnostics = new ModulePipelineDiagnosticsOptions
             {
-                BaselinePath = request.DiagnosticsBaselinePath,
+                BaselinePath = ResolveWorkspacePath(workspaceRoot, request.DiagnosticsBaselinePath),
                 GenerateBaseline = request.GenerateDiagnosticsBaseline,
                 UpdateBaseline = request.UpdateDiagnosticsBaseline,
                 FailOnNewDiagnostics = request.FailOnNewDiagnostics,
@@ -240,11 +241,33 @@ internal sealed class ModuleBuildPreparationService
             ResolvePackageBuildOptionPaths(cfg.Options, projectRoot);
         }
 
+        foreach (var segment in spec.Segments?.OfType<ConfigurationDocumentationSegment>() ?? Enumerable.Empty<ConfigurationDocumentationSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.Path = ResolveConfigPathNullable(projectRoot, cfg.Path) ?? string.Empty;
+            cfg.PathReadme = ResolveConfigPathNullable(projectRoot, cfg.PathReadme) ?? string.Empty;
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationBuildDocumentationSegment>() ?? Enumerable.Empty<ConfigurationBuildDocumentationSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.AboutTopicsSourcePath = ResolveConfigPaths(projectRoot, cfg.AboutTopicsSourcePath);
+        }
+
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
         {
             var cfg = segment.Configuration;
             if (cfg is null || string.IsNullOrWhiteSpace(cfg.TestsPath)) continue;
             cfg.TestsPath = ResolveConfigPath(projectRoot, cfg.TestsPath);
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationValidationSegment>() ?? Enumerable.Empty<ConfigurationValidationSegment>())
+        {
+            var settings = segment.Settings;
+            if (settings is null) continue;
+            settings.Tests.TestPath = ResolveConfigPathNullable(projectRoot, settings.Tests.TestPath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationOptionsSegment>() ?? Enumerable.Empty<ConfigurationOptionsSegment>())
@@ -400,8 +423,18 @@ internal sealed class ModuleBuildPreparationService
                     package.GitHubAccessTokenFilePath = ResolveWorkspacePath(workspaceRoot, package.GitHubAccessTokenFilePath);
                     ResolvePackageBuildOptionPaths(package.Options, workspaceRoot);
                     break;
+                case ConfigurationDocumentationSegment documentation:
+                    documentation.Configuration.Path = ResolveWorkspacePath(workspaceRoot, documentation.Configuration.Path) ?? string.Empty;
+                    documentation.Configuration.PathReadme = ResolveWorkspacePath(workspaceRoot, documentation.Configuration.PathReadme) ?? string.Empty;
+                    break;
+                case ConfigurationBuildDocumentationSegment buildDocumentation:
+                    buildDocumentation.Configuration.AboutTopicsSourcePath = ResolveWorkspacePaths(workspaceRoot, buildDocumentation.Configuration.AboutTopicsSourcePath);
+                    break;
                 case ConfigurationTestSegment test:
                     test.Configuration.TestsPath = ResolveWorkspacePath(workspaceRoot, test.Configuration.TestsPath) ?? string.Empty;
+                    break;
+                case ConfigurationValidationSegment validation:
+                    validation.Settings.Tests.TestPath = ResolveWorkspacePath(workspaceRoot, validation.Settings.Tests.TestPath);
                     break;
                 case ConfigurationOptionsSegment options:
                     var signing = options.Options?.Signing;
@@ -446,6 +479,71 @@ internal sealed class ModuleBuildPreparationService
             return path;
 
         return PathValueResolver.Resolve(workspaceRoot, path!);
+    }
+
+    private static string[] ResolveWorkspacePaths(string workspaceRoot, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path => ResolveWorkspacePath(workspaceRoot, path) ?? string.Empty)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+    }
+
+    private static string[] ResolveConfigPaths(string rootPath, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path => ResolveConfigPathNullable(rootPath, path) ?? string.Empty)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+    }
+
+    private static IConfigurationSegment[] CollectSettingsFromWorkspace(ScriptBlock? settings, string workspaceRoot)
+    {
+        if (settings is null)
+            return Array.Empty<IConfigurationSegment>();
+
+        if (string.IsNullOrWhiteSpace(workspaceRoot) || !Directory.Exists(workspaceRoot))
+            return LegacySegmentAdapter.CollectFromSettings(settings);
+
+        var previousDirectory = Directory.GetCurrentDirectory();
+        var runspace = Runspace.DefaultRunspace;
+        var runspaceLocationChanged = false;
+        string? previousRunspaceLocation = null;
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspaceRoot);
+            if (runspace is not null)
+            {
+                try
+                {
+                    previousRunspaceLocation = runspace.SessionStateProxy.Path.CurrentFileSystemLocation?.ProviderPath;
+                    runspace.SessionStateProxy.Path.SetLocation(workspaceRoot);
+                    runspaceLocationChanged = true;
+                }
+                catch
+                {
+                    runspaceLocationChanged = false;
+                }
+            }
+
+            return LegacySegmentAdapter.CollectFromSettings(settings);
+        }
+        finally
+        {
+            if (runspaceLocationChanged && !string.IsNullOrWhiteSpace(previousRunspaceLocation))
+            {
+                try { runspace!.SessionStateProxy.Path.SetLocation(previousRunspaceLocation!); } catch { }
+            }
+
+            try { Directory.SetCurrentDirectory(previousDirectory); } catch { }
+        }
     }
 
     private static void ResolvePackageBuildOptionPaths(Dictionary<string, object?>? options, string rootPath)
@@ -606,11 +704,33 @@ internal sealed class ModuleBuildPreparationService
             MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot);
         }
 
+        foreach (var segment in spec.Segments?.OfType<ConfigurationDocumentationSegment>() ?? Enumerable.Empty<ConfigurationDocumentationSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path) ?? string.Empty;
+            cfg.PathReadme = MakeRelativeForProjectRoot(projectRoot, cfg.PathReadme) ?? string.Empty;
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationBuildDocumentationSegment>() ?? Enumerable.Empty<ConfigurationBuildDocumentationSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null) continue;
+            cfg.AboutTopicsSourcePath = MakePathsRelativeForProjectRoot(projectRoot, cfg.AboutTopicsSourcePath);
+        }
+
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
         {
             var cfg = segment.Configuration;
             if (cfg is null || string.IsNullOrWhiteSpace(cfg.TestsPath)) continue;
             cfg.TestsPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.TestsPath));
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationValidationSegment>() ?? Enumerable.Empty<ConfigurationValidationSegment>())
+        {
+            var settings = segment.Settings;
+            if (settings is null) continue;
+            settings.Tests.TestPath = MakeRelativeForProjectRoot(projectRoot, settings.Tests.TestPath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationOptionsSegment>() ?? Enumerable.Empty<ConfigurationOptionsSegment>())
@@ -706,6 +826,17 @@ internal sealed class ModuleBuildPreparationService
 
             options[optionName] = MakeRelativeForProjectRoot(projectRoot, path);
         }
+    }
+
+    private static string[] MakePathsRelativeForProjectRoot(string projectRoot, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path => MakeRelativeForProjectRoot(projectRoot, path) ?? string.Empty)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
     }
 
     private static string? GetStringOptionValue(object? value)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -9,6 +9,18 @@ namespace PowerForge;
 
 internal sealed class ModuleBuildPreparationService
 {
+    private static readonly HashSet<string> PackageBuildOptionPathNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        nameof(PackageBuildConfiguration.RootPath),
+        nameof(PackageBuildConfiguration.OutputPath),
+        nameof(PackageBuildConfiguration.ReleaseZipOutputPath),
+        nameof(PackageBuildConfiguration.StagingPath),
+        nameof(PackageBuildConfiguration.PlanOutputPath),
+        nameof(PackageBuildConfiguration.PublishApiKeyFilePath),
+        nameof(PackageBuildConfiguration.NugetCredentialSecretFilePath),
+        nameof(PackageBuildConfiguration.GitHubAccessTokenFilePath)
+    };
+
     public ModuleBuildPreparedContext Prepare(ModuleBuildPreparationRequest request)
     {
         if (request is null)
@@ -199,8 +211,10 @@ internal sealed class ModuleBuildPreparationService
         foreach (var segment in spec.Segments?.OfType<ConfigurationProjectBuildSegment>() ?? Enumerable.Empty<ConfigurationProjectBuildSegment>())
         {
             var cfg = segment.Configuration;
-            if (cfg is null || string.IsNullOrWhiteSpace(cfg.ConfigPath)) continue;
-            cfg.ConfigPath = ResolveConfigPath(projectRoot, cfg.ConfigPath);
+            if (cfg is null) continue;
+            if (!string.IsNullOrWhiteSpace(cfg.ConfigPath))
+                cfg.ConfigPath = ResolveConfigPath(projectRoot, cfg.ConfigPath);
+            ResolvePackageBuildOptionPaths(cfg.Options, projectRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
@@ -223,6 +237,21 @@ internal sealed class ModuleBuildPreparationService
             cfg.PublishApiKeyFilePath = ResolveConfigPathNullable(projectRoot, cfg.PublishApiKeyFilePath);
             cfg.NugetCredentialSecretFilePath = ResolveConfigPathNullable(projectRoot, cfg.NugetCredentialSecretFilePath);
             cfg.GitHubAccessTokenFilePath = ResolveConfigPathNullable(projectRoot, cfg.GitHubAccessTokenFilePath);
+            ResolvePackageBuildOptionPaths(cfg.Options, projectRoot);
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null || string.IsNullOrWhiteSpace(cfg.TestsPath)) continue;
+            cfg.TestsPath = ResolveConfigPath(projectRoot, cfg.TestsPath);
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationOptionsSegment>() ?? Enumerable.Empty<ConfigurationOptionsSegment>())
+        {
+            var signing = segment.Options?.Signing;
+            if (signing is null) continue;
+            signing.CertificatePFXPath = ResolveConfigPathNullable(projectRoot, signing.CertificatePFXPath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationReleaseSegment>() ?? Enumerable.Empty<ConfigurationReleaseSegment>())
@@ -357,6 +386,7 @@ internal sealed class ModuleBuildPreparationService
                     break;
                 case ConfigurationProjectBuildSegment projectBuild:
                     projectBuild.Configuration.ConfigPath = ResolveWorkspacePath(workspaceRoot, projectBuild.Configuration.ConfigPath) ?? string.Empty;
+                    ResolvePackageBuildOptionPaths(projectBuild.Configuration.Options, workspaceRoot);
                     break;
                 case ConfigurationPackageBuildSegment packageBuild:
                     var package = packageBuild.Configuration;
@@ -368,6 +398,15 @@ internal sealed class ModuleBuildPreparationService
                     package.PublishApiKeyFilePath = ResolveWorkspacePath(workspaceRoot, package.PublishApiKeyFilePath);
                     package.NugetCredentialSecretFilePath = ResolveWorkspacePath(workspaceRoot, package.NugetCredentialSecretFilePath);
                     package.GitHubAccessTokenFilePath = ResolveWorkspacePath(workspaceRoot, package.GitHubAccessTokenFilePath);
+                    ResolvePackageBuildOptionPaths(package.Options, workspaceRoot);
+                    break;
+                case ConfigurationTestSegment test:
+                    test.Configuration.TestsPath = ResolveWorkspacePath(workspaceRoot, test.Configuration.TestsPath) ?? string.Empty;
+                    break;
+                case ConfigurationOptionsSegment options:
+                    var signing = options.Options?.Signing;
+                    if (signing is not null)
+                        signing.CertificatePFXPath = ResolveWorkspacePath(workspaceRoot, signing.CertificatePFXPath);
                     break;
                 case ConfigurationReleaseSegment release:
                     release.Configuration.StageRoot = ResolveWorkspacePath(workspaceRoot, release.Configuration.StageRoot);
@@ -407,6 +446,24 @@ internal sealed class ModuleBuildPreparationService
             return path;
 
         return PathValueResolver.Resolve(workspaceRoot, path!);
+    }
+
+    private static void ResolvePackageBuildOptionPaths(Dictionary<string, object?>? options, string rootPath)
+    {
+        if (options is null || options.Count == 0)
+            return;
+
+        foreach (var optionName in PackageBuildOptionPathNames)
+        {
+            if (!options.TryGetValue(optionName, out var value))
+                continue;
+
+            var path = GetStringOptionValue(value);
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+
+            options[optionName] = ResolveWorkspacePath(rootPath, path);
+        }
     }
 
     private static string? ResolveArtefactLayoutPath(string rootPath, string? artefactPath, string? layoutPath)
@@ -520,8 +577,10 @@ internal sealed class ModuleBuildPreparationService
         foreach (var segment in spec.Segments?.OfType<ConfigurationProjectBuildSegment>() ?? Enumerable.Empty<ConfigurationProjectBuildSegment>())
         {
             var cfg = segment.Configuration;
-            if (cfg is null || string.IsNullOrWhiteSpace(cfg.ConfigPath)) continue;
-            cfg.ConfigPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.ConfigPath));
+            if (cfg is null) continue;
+            if (!string.IsNullOrWhiteSpace(cfg.ConfigPath))
+                cfg.ConfigPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.ConfigPath));
+            MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationBuildLibrariesSegment>() ?? Enumerable.Empty<ConfigurationBuildLibrariesSegment>())
@@ -544,6 +603,21 @@ internal sealed class ModuleBuildPreparationService
             cfg.PublishApiKeyFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.PublishApiKeyFilePath);
             cfg.NugetCredentialSecretFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.NugetCredentialSecretFilePath);
             cfg.GitHubAccessTokenFilePath = MakeRelativeForProjectRoot(projectRoot, cfg.GitHubAccessTokenFilePath);
+            MakePackageBuildOptionPathsRelative(cfg.Options, projectRoot);
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
+        {
+            var cfg = segment.Configuration;
+            if (cfg is null || string.IsNullOrWhiteSpace(cfg.TestsPath)) continue;
+            cfg.TestsPath = MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, cfg.TestsPath));
+        }
+
+        foreach (var segment in spec.Segments?.OfType<ConfigurationOptionsSegment>() ?? Enumerable.Empty<ConfigurationOptionsSegment>())
+        {
+            var signing = segment.Options?.Signing;
+            if (signing is null) continue;
+            signing.CertificatePFXPath = MakeRelativeForProjectRoot(projectRoot, signing.CertificatePFXPath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationReleaseSegment>() ?? Enumerable.Empty<ConfigurationReleaseSegment>())
@@ -614,6 +688,34 @@ internal sealed class ModuleBuildPreparationService
     {
         if (string.IsNullOrWhiteSpace(path)) return null;
         return MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, path));
+    }
+
+    private static void MakePackageBuildOptionPathsRelative(Dictionary<string, object?>? options, string projectRoot)
+    {
+        if (options is null || options.Count == 0)
+            return;
+
+        foreach (var optionName in PackageBuildOptionPathNames)
+        {
+            if (!options.TryGetValue(optionName, out var value))
+                continue;
+
+            var path = GetStringOptionValue(value);
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+
+            options[optionName] = MakeRelativeForProjectRoot(projectRoot, path);
+        }
+    }
+
+    private static string? GetStringOptionValue(object? value)
+    {
+        return value switch
+        {
+            string text => text,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => null
+        };
     }
 
     private static string MakeRelativeForConfig(string baseDir, string path)

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -928,7 +928,7 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static bool UsesRepositoryModuleLayout(DirectoryInfo projectDirectory)
-        => string.Equals(projectDirectory.Name, "Module", StringComparison.OrdinalIgnoreCase) &&
+        => ModuleBuildPathPolicy.SamePathSegment(projectDirectory.Name, "Module") &&
            projectDirectory.Parent is not null &&
            HasRepositoryRootMarker(projectDirectory.Parent.FullName) &&
            File.Exists(Path.Combine(projectDirectory.FullName, "Build", "Build-Module.ps1"));
@@ -956,9 +956,7 @@ internal sealed class ModuleBuildPreparationService
     }
 
     private static string MakeReleaseStageRootPathForJson(string projectRoot, string workspaceRoot, string stageRoot)
-        => ContainsPathToken(stageRoot)
-            ? MakeRelativeForProjectRoot(projectRoot, stageRoot, preserveExternalRooted: true, workspaceRoot) ?? NormalizePathSeparators(stageRoot)
-            : MakeRelativeForConfig(projectRoot, ResolveConfigPath(projectRoot, stageRoot));
+        => MakeRelativeForProjectRoot(projectRoot, stageRoot, preserveExternalRooted: true, workspaceRoot) ?? NormalizePathSeparators(stageRoot);
 
     private static void MakeCopyMappingSourcesRelative(ArtefactCopyMapping[]? mappings, string projectRoot, string workspaceRoot)
     {

--- a/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildPreparationService.cs
@@ -591,7 +591,7 @@ internal sealed class ModuleBuildPreparationService
             {
                 try
                 {
-                    previousRunspaceLocation = runspace.SessionStateProxy.Path.CurrentFileSystemLocation?.ProviderPath;
+                    previousRunspaceLocation = runspace.SessionStateProxy.Path.CurrentLocation?.Path;
                     runspace.SessionStateProxy.Path.SetLocation(workspaceRoot);
                     runspaceLocationChanged = true;
                 }
@@ -689,10 +689,15 @@ internal sealed class ModuleBuildPreparationService
             if (ContainsPathToken(mapping.Source))
                 continue;
 
-            if (!string.IsNullOrWhiteSpace(requiredFirstSegment) && !StartsWithPathSegment(mapping.Source, requiredFirstSegment!))
+            if (string.IsNullOrWhiteSpace(requiredFirstSegment) || StartsWithPathSegment(mapping.Source, requiredFirstSegment!))
+            {
+                mapping.Source = PathValueResolver.Resolve(rootPath, mapping.Source);
                 continue;
+            }
 
-            mapping.Source = PathValueResolver.Resolve(rootPath, mapping.Source);
+            var workspaceCandidate = PathValueResolver.Resolve(rootPath, mapping.Source);
+            if (File.Exists(workspaceCandidate) || Directory.Exists(workspaceCandidate))
+                mapping.Source = workspaceCandidate;
         }
     }
 
@@ -850,7 +855,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.Path = MakeRelativeForProjectRoot(projectRoot, cfg.Path, preserveExternalRooted: true, workspaceRoot) ?? string.Empty;
+            cfg.Path = MakeDocumentationPathForJson(projectRoot, workspaceRoot, cfg.Path) ?? string.Empty;
             cfg.PathReadme = MakeRelativeForProjectRoot(projectRoot, cfg.PathReadme, preserveExternalRooted: true, workspaceRoot) ?? string.Empty;
         }
 
@@ -858,7 +863,7 @@ internal sealed class ModuleBuildPreparationService
         {
             var cfg = segment.Configuration;
             if (cfg is null) continue;
-            cfg.AboutTopicsSourcePath = MakePathsRelativeForProjectRoot(projectRoot, cfg.AboutTopicsSourcePath, preserveExternalRooted: true, workspaceRoot);
+            cfg.AboutTopicsSourcePath = MakeDocumentationPathsForJson(projectRoot, workspaceRoot, cfg.AboutTopicsSourcePath);
         }
 
         foreach (var segment in spec.Segments?.OfType<ConfigurationTestSegment>() ?? Enumerable.Empty<ConfigurationTestSegment>())
@@ -950,6 +955,34 @@ internal sealed class ModuleBuildPreparationService
         return IsSameOrChildPath(artefactRoot, candidate)
             ? MakeRelativeForProjectRoot(projectRoot, candidate, preserveExternalRooted: true, workspaceRoot)
             : NormalizePathSeparators(layoutPath!);
+    }
+
+    private static string? MakeDocumentationPathForJson(string projectRoot, string workspaceRoot, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var cleaned = PathValueResolver.Clean(path!);
+        if (Path.IsPathRooted(cleaned) &&
+            !SamePath(workspaceRoot, projectRoot) &&
+            IsSameOrChildPath(workspaceRoot, cleaned) &&
+            !IsSameOrChildPath(projectRoot, cleaned))
+        {
+            return NormalizePathSeparators(cleaned);
+        }
+
+        return MakeRelativeForProjectRoot(projectRoot, path, preserveExternalRooted: true, workspaceRoot);
+    }
+
+    private static string[] MakeDocumentationPathsForJson(string projectRoot, string workspaceRoot, string[]? paths)
+    {
+        if (paths is null || paths.Length == 0)
+            return Array.Empty<string>();
+
+        return paths
+            .Select(path => MakeDocumentationPathForJson(projectRoot, workspaceRoot, path) ?? string.Empty)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
     }
 
     private static string MakeReleaseStageRootPathForJson(string projectRoot, string workspaceRoot, string stageRoot)

--- a/PowerForge.Tests/ArtefactConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/ArtefactConfigurationFactoryTests.cs
@@ -100,6 +100,46 @@ public sealed class ArtefactConfigurationFactoryTests
         Assert.Equal(Normalize("Artefacts/Modules"), segment.Configuration.RequiredModules.Path);
     }
 
+    [Fact]
+    public void Create_resolves_merge_script_prefix_with_platform_path_casing()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-artefact-casing-" + Guid.NewGuid().ToString("N")));
+        var previousDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var moduleBuildRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            File.WriteAllText(Path.Combine(moduleBuildRoot.FullName, "header.ps1"), "Write-Output 'workspace'");
+
+            var localLowerBuildRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "module", "Build"));
+            File.WriteAllText(Path.Combine(localLowerBuildRoot.FullName, "header.ps1"), "Write-Output 'local'");
+
+            if (!OperatingSystem.IsWindows())
+            {
+                var workspaceLowerBuildRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "module", "Build"));
+                File.WriteAllText(Path.Combine(workspaceLowerBuildRoot.FullName, "header.ps1"), "Write-Output 'workspace-lower'");
+            }
+
+            Directory.SetCurrentDirectory(moduleRoot.FullName);
+            var factory = new ArtefactConfigurationFactory(new NullLogger());
+
+            var segment = factory.Create(new ArtefactConfigurationRequest
+            {
+                Type = ArtefactType.Packed,
+                PreScriptMergePath = "module/Build/header.ps1"
+            });
+
+            var expected = OperatingSystem.IsWindows() ? "workspace" : "local";
+            Assert.Contains(expected, segment.Configuration.PreScriptMerge, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.SetCurrentDirectory(previousDirectory); } catch { }
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
     private static string Normalize(string value)
     {
         return OperatingSystem.IsWindows()

--- a/PowerForge.Tests/ModuleBuildPathPolicyTests.cs
+++ b/PowerForge.Tests/ModuleBuildPathPolicyTests.cs
@@ -48,12 +48,15 @@ public sealed class ModuleBuildPathPolicyTests
         var workspaceRoot = Path.Combine(Path.GetTempPath(), "pf-path-policy-workspace-" + Guid.NewGuid().ToString("N"));
         var projectRoot = Path.Combine(workspaceRoot, "Module");
         var projectPath = Path.Combine(projectRoot, "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>");
+        var workspacePath = Path.Combine(workspaceRoot, "Artefacts", "Packed", "<ModuleVersion>");
         var externalPath = Path.Combine(Path.GetTempPath(), "pf-path-policy-external-" + Guid.NewGuid().ToString("N"), "Packed", "<ModuleVersion>");
 
         var projectRelative = ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, projectPath, preserveExternalRooted: true, workspaceRoot);
+        var workspaceRelative = ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, workspacePath, preserveExternalRooted: true, workspaceRoot);
         var externalPreserved = ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, externalPath, preserveExternalRooted: true, workspaceRoot);
 
         Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>", projectRelative);
+        Assert.Equal("../Artefacts/Packed/<ModuleVersion>", workspaceRelative);
         Assert.Equal(NormalizeForJson(externalPath), externalPreserved);
     }
 

--- a/PowerForge.Tests/ModuleBuildPathPolicyTests.cs
+++ b/PowerForge.Tests/ModuleBuildPathPolicyTests.cs
@@ -70,6 +70,16 @@ public sealed class ModuleBuildPathPolicyTests
         Assert.Equal(expected, matched);
     }
 
+    [Fact]
+    public void SamePathSegment_uses_platform_path_case_semantics()
+    {
+        var expected = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        var matched = ModuleBuildPathPolicy.SamePathSegment("Module", "module");
+
+        Assert.Equal(expected, matched);
+    }
+
     private static string NormalizeForJson(string path)
         => path.Replace('\\', '/');
 }

--- a/PowerForge.Tests/ModuleBuildPathPolicyTests.cs
+++ b/PowerForge.Tests/ModuleBuildPathPolicyTests.cs
@@ -1,0 +1,72 @@
+using PowerForge;
+using System.Runtime.InteropServices;
+
+namespace PowerForge.Tests;
+
+public sealed class ModuleBuildPathPolicyTests
+{
+    [Fact]
+    public void ResolveTokenAwareConfigPathNullable_preserves_tokenized_relative_paths()
+    {
+        var projectRoot = Path.Combine(Path.GetTempPath(), "pf-path-policy-" + Guid.NewGuid().ToString("N"));
+
+        var resolved = ModuleBuildPathPolicy.ResolveTokenAwareConfigPathNullable(projectRoot, @"Artefacts\Packed\<TagModuleVersionWithPreRelease>");
+
+        Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>", resolved);
+    }
+
+    [Fact]
+    public void ResolveRootedConfigPaths_only_resolves_rooted_paths()
+    {
+        var projectRoot = Path.Combine(Path.GetTempPath(), "pf-path-policy-" + Guid.NewGuid().ToString("N"));
+        var rootedPath = Path.Combine(projectRoot, "Help", "Rooted");
+
+        var resolved = ModuleBuildPathPolicy.ResolveRootedConfigPaths(projectRoot, new[] { "Help/About", rootedPath });
+
+        Assert.Equal(new[] { "Help/About", Path.GetFullPath(rootedPath) }, resolved);
+    }
+
+    [Fact]
+    public void MakeRelativeForProjectRoot_preserves_external_rooted_paths_when_requested()
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "pf-path-policy-workspace-" + Guid.NewGuid().ToString("N"));
+        var projectRoot = Path.Combine(workspaceRoot, "Module");
+        var externalRoot = Path.Combine(Path.GetTempPath(), "pf-path-policy-external-" + Guid.NewGuid().ToString("N"));
+        var externalPath = Path.Combine(externalRoot, "Packages");
+        var workspaceSiblingPath = Path.Combine(workspaceRoot, "Artefacts", "Packages");
+
+        var preservedExternal = ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, externalPath, preserveExternalRooted: true, workspaceRoot);
+        var workspaceRelative = ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, workspaceSiblingPath, preserveExternalRooted: true, workspaceRoot);
+
+        Assert.Equal(NormalizeForJson(Path.GetFullPath(externalPath)), preservedExternal);
+        Assert.Equal("../Artefacts/Packages", workspaceRelative);
+    }
+
+    [Fact]
+    public void MakeRelativeForProjectRoot_preserves_token_intent_without_resolving_tokens()
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "pf-path-policy-workspace-" + Guid.NewGuid().ToString("N"));
+        var projectRoot = Path.Combine(workspaceRoot, "Module");
+        var projectPath = Path.Combine(projectRoot, "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>");
+        var externalPath = Path.Combine(Path.GetTempPath(), "pf-path-policy-external-" + Guid.NewGuid().ToString("N"), "Packed", "<ModuleVersion>");
+
+        var projectRelative = ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, projectPath, preserveExternalRooted: true, workspaceRoot);
+        var externalPreserved = ModuleBuildPathPolicy.MakeRelativeForProjectRoot(projectRoot, externalPath, preserveExternalRooted: true, workspaceRoot);
+
+        Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>", projectRelative);
+        Assert.Equal(NormalizeForJson(externalPath), externalPreserved);
+    }
+
+    [Fact]
+    public void IsSameOrChildPath_uses_platform_path_case_semantics()
+    {
+        var expected = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        var matched = ModuleBuildPathPolicy.IsSameOrChildPath("/tmp/Repo", "/tmp/repo/secrets");
+
+        Assert.Equal(expected, matched);
+    }
+
+    private static string NormalizeForJson(string path)
+        => path.Replace('\\', '/');
+}

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -61,6 +61,8 @@ public sealed class ModuleBuildPreparationServiceTests
         {
             var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
             var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            MarkRepositoryRoot(root.FullName);
+            File.WriteAllText(Path.Combine(scriptRoot.FullName, "Build-Module.ps1"), string.Empty);
             Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
             Directory.CreateDirectory(Path.Combine(root.FullName, "Build", "Templates"));
             Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Examples"));
@@ -79,7 +81,7 @@ $projectOptions = [System.Collections.Generic.Dictionary[string,object]]::new()
 $projectOptions['OutputPath'] = 'Artefacts/ProjectBuild/options'
 $projectOptions['PlanOutputPath'] = 'Build/project-options-plan.json'
 $packageOptions = [System.Collections.Generic.Dictionary[string,object]]::new()
-$packageOptions['OutputPath'] = 'Artefacts/PackageBuild/options'
+$packageOptions['outputPath'] = 'Module/Artefacts/PackageBuild/options'
 $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationBuildLibrariesSegment]@{
     BuildLibraries = [PowerForge.BuildLibrariesConfiguration]@{
@@ -317,7 +319,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal("Build/nuget.key", packageBuild.Configuration.PublishApiKeyFilePath);
                 Assert.Equal("Build/nuget.secret", packageBuild.Configuration.NugetCredentialSecretFilePath);
                 Assert.Equal("Build/github.token", packageBuild.Configuration.GitHubAccessTokenFilePath);
-                Assert.Equal("Artefacts/PackageBuild/options", packageBuild.Configuration.Options!["OutputPath"]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "PackageBuild", "options"), packageBuild.Configuration.Options!["outputPath"]);
                 Assert.Equal("Build/package-options-plan.json", packageBuild.Configuration.Options["PlanOutputPath"]);
 
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules"), artefact.Configuration.RequiredModules.Path);
@@ -386,6 +388,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         {
             var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
             var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            MarkRepositoryRoot(root.FullName);
+            File.WriteAllText(Path.Combine(scriptRoot.FullName, "Build-Module.ps1"), string.Empty);
             var moduleProject = Path.Combine(moduleRoot.FullName, "Sources", "Foo", "Foo.csproj");
             Directory.CreateDirectory(Path.GetDirectoryName(moduleProject)!);
             File.WriteAllText(moduleProject, "<Project />");
@@ -421,6 +425,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         {
             var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
             var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            MarkRepositoryRoot(root.FullName);
+            File.WriteAllText(Path.Combine(scriptRoot.FullName, "Build-Module.ps1"), string.Empty);
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "SampleModule.psd1"), "@{ ModuleVersion = '1.0.0' }");
             var resolvedJsonPath = Path.Combine(root.FullName, "ResolvedFromPSDrive", "powerforge.json");
 
@@ -441,6 +447,45 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             });
 
             Assert.Equal(resolvedJsonPath, prepared.JsonOutputPath);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_from_standalone_module_folder_keeps_workspace_paths_under_module()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-standalone-module-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            File.WriteAllText(Path.Combine(scriptRoot.FullName, "Build-Module.ps1"), string.Empty);
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "SampleModule.psd1"), "@{ ModuleVersion = '1.0.0' }");
+
+            var prepared = new ModuleBuildPreparationService().Prepare(new ModuleBuildPreparationRequest
+            {
+                ParameterSetName = "Modern",
+                ModuleName = "SampleModule",
+                CurrentPath = moduleRoot.FullName,
+                ScriptRoot = scriptRoot.FullName,
+                ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(moduleRoot.FullName, path)),
+                StagingPath = "Artefacts/Staging",
+                DiagnosticsBinaryConflictSearchRoot = new[] { "Modules" },
+                InstallRootsWasBound = true,
+                InstallRoots = new[] { "Artefacts/Modules" },
+                DotNetFramework = Array.Empty<string>(),
+                ExcludeDirectories = Array.Empty<string>(),
+                ExcludeFiles = Array.Empty<string>()
+            });
+
+            Assert.Equal(moduleRoot.FullName, prepared.ProjectRoot);
+            Assert.Equal(Path.Combine(moduleRoot.FullName, "Artefacts", "Staging"), prepared.PipelineSpec.Build.StagingPath);
+            Assert.Equal(new[] { Path.Combine(moduleRoot.FullName, "Modules") }, prepared.PipelineSpec.Build.BinaryConflictSearchRoots);
+            Assert.Equal(new[] { Path.Combine(moduleRoot.FullName, "Artefacts", "Modules") }, prepared.PipelineSpec.Install.Roots);
         }
         finally
         {
@@ -642,6 +687,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         {
             var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
             var buildRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            MarkRepositoryRoot(root.FullName);
             File.WriteAllText(Path.Combine(buildRoot.FullName, "Build-Module.ps1"), string.Empty);
             var jsonPath = Path.Combine(root.FullName, "Build", "powerforge.json");
             var externalRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "External-" + Guid.NewGuid().ToString("N"));
@@ -693,6 +739,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             FilePath = Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1"),
                             WorkingDirectory = Path.Combine(root.FullName, "Build")
                         }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(root.FullName, "Artefacts", "UploadReady", "<ModuleVersion>")
+                        }
                     }
                 }
             };
@@ -709,6 +762,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains($"\"ApiKeyFilePath\": \"{externalPublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"FilePath\": \"../Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
             Assert.Contains("\"WorkingDirectory\": \"../Build\"", json, StringComparison.Ordinal);
+            var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
+            var release = Assert.IsType<ConfigurationReleaseSegment>(Assert.Single(jsonSpec!.Segments.OfType<ConfigurationReleaseSegment>()));
+            Assert.Equal("../Artefacts/UploadReady/<ModuleVersion>", release.Configuration.StageRoot);
         }
         finally
         {
@@ -1057,7 +1113,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             GitHubAccessTokenFilePath = packageGitHubToken,
                             Options = new Dictionary<string, object?>
                             {
-                                ["OutputPath"] = packageOptionsOutputPath,
+                                ["outputPath"] = packageOptionsOutputPath,
                                 ["PlanOutputPath"] = externalPackageOutputPath,
                                 ["PublishApiKeyFilePath"] = packageOptionsCredentialPath
                             }
@@ -1199,7 +1255,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"PlanOutputPath\": \"Artifacts/Packages/plan.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"OutputPath\": \"../Artifacts/ProjectBuild/options\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PlanOutputPath\": \"project-options-plan.json\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"OutputPath\": \"Artifacts/PackageBuild/options\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"outputPath\": \"Artifacts/PackageBuild/options\"", json, StringComparison.Ordinal);
             Assert.Contains($"\"PlanOutputPath\": \"{externalPackageOutputPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"PublishApiKeyFilePath\": \"{packagePublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"NugetCredentialSecretFilePath\": \"{packageCredentialSecret.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
@@ -1259,7 +1315,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(packagePublishKey, packageBuild.Configuration.PublishApiKeyFilePath);
             Assert.Equal(packageCredentialSecret, packageBuild.Configuration.NugetCredentialSecretFilePath);
             Assert.Equal(packageGitHubToken, packageBuild.Configuration.GitHubAccessTokenFilePath);
-            Assert.Equal(packageOptionsOutputPath, packageBuild.Configuration.Options!["OutputPath"]);
+            Assert.Equal(packageOptionsOutputPath, packageBuild.Configuration.Options!["outputPath"]);
             Assert.Equal(externalPackageOutputPath.Replace('\\', '/'), packageBuild.Configuration.Options["PlanOutputPath"]);
             Assert.Equal(packageOptionsCredentialPath.Replace('\\', '/'), packageBuild.Configuration.Options["PublishApiKeyFilePath"]);
             Assert.Equal(artefactRoot, artefact.Configuration.Path);
@@ -1706,6 +1762,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         options.Converters.Add(new ConfigurationSegmentJsonConverter());
         return options;
     }
+
+    private static void MarkRepositoryRoot(string rootPath)
+        => Directory.CreateDirectory(Path.Combine(rootPath, ".git"));
 
     private static void ResolvePipelineSpecPathsLikeCli(ModulePipelineSpec spec, string configFullPath)
     {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -58,7 +58,11 @@ public sealed class ModuleBuildPreparationServiceTests
             var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
             var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
             Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Build", "Templates"));
+            Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Examples"));
             File.WriteAllText(Path.Combine(root.FullName, "Build", "header.ps1"), "Write-Output 'header'");
+            File.WriteAllText(Path.Combine(root.FullName, "Build", "NOTICE.txt"), "notice");
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "Examples", "NOTICE.txt"), "module notice");
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "DbaClientX.psd1"), "@{ ModuleVersion = '1.0.0' }");
 
             var settings = ScriptBlock.Create("""
@@ -93,12 +97,20 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             [PowerForge.ArtefactCopyMapping]@{
                 Source = 'Module/Build/LICENSE'
                 Destination = 'LICENSE'
+            },
+            [PowerForge.ArtefactCopyMapping]@{
+                Source = 'Build/Templates'
+                Destination = 'Templates'
             }
         )
         FilesOutput = [PowerForge.ArtefactCopyMapping[]]@(
             [PowerForge.ArtefactCopyMapping]@{
                 Source = 'Examples/NOTICE.txt'
                 Destination = 'NOTICE.txt'
+            },
+            [PowerForge.ArtefactCopyMapping]@{
+                Source = 'Build/NOTICE.txt'
+                Destination = 'RepoNotice.txt'
             }
         )
     }
@@ -239,8 +251,12 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Build", "LICENSE"), artefact.Configuration.DirectoryOutput![0].Source);
                 Assert.Equal("LICENSE", artefact.Configuration.DirectoryOutput[0].Destination);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "Templates"), artefact.Configuration.DirectoryOutput[1].Source);
+                Assert.Equal("Templates", artefact.Configuration.DirectoryOutput[1].Destination);
                 Assert.Equal("Examples/NOTICE.txt", artefact.Configuration.FilesOutput![0].Source);
                 Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "NOTICE.txt"), artefact.Configuration.FilesOutput[1].Source);
+                Assert.Equal("RepoNotice.txt", artefact.Configuration.FilesOutput[1].Destination);
 
                 var artefactWithRelativeLayout = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[3]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Unpacked"), artefactWithRelativeLayout.Configuration.Path);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -1260,6 +1260,14 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             {
                                 Path = "Artefacts/Packed/<TagModuleVersionWithPreRelease>/RequiredModules",
                                 ModulesPath = "Artefacts/Packed/<TagModuleVersionWithPreRelease>/Modules"
+                            },
+                            FilesOutput = new[]
+                            {
+                                new ArtefactCopyMapping
+                                {
+                                    Source = "Payload/<ModuleVersion>/NOTICE.txt",
+                                    Destination = "NOTICE.txt"
+                                }
                             }
                         }
                     }
@@ -1279,9 +1287,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed", "Modules"), workspaceQualifiedLayout.Configuration.RequiredModules.ModulesPath);
 
             var tokenizedLayout = Assert.IsType<ConfigurationArtefactSegment>(spec.Segments[2]);
-            Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>"), tokenizedLayout.Configuration.Path);
+            Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>", tokenizedLayout.Configuration.Path);
             Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>/RequiredModules", tokenizedLayout.Configuration.RequiredModules.Path);
             Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>/Modules", tokenizedLayout.Configuration.RequiredModules.ModulesPath);
+            Assert.Equal("Payload/<ModuleVersion>/NOTICE.txt", tokenizedLayout.Configuration.FilesOutput![0].Source);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -161,7 +161,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 }
 [PowerForge.ConfigurationReleaseSegment]@{
     Configuration = [PowerForge.ReleaseConfiguration]@{
-        StageRoot = 'Module/Artefacts/UploadReady'
+        StageRoot = 'Artefacts/UploadReady/<ModuleVersion>'
         VersionSource = [PowerForge.ReleaseVersionSource]::ProjectBuild
     }
 }
@@ -190,7 +190,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     Type = [PowerForge.ArtefactType]::Packed
     EnableSpecified = $true
     Enable = $true
-    Path = 'Module/Artefacts/FileBacked'
+    Path = 'Module/Artefacts/FileBacked/<TagModuleVersionWithPreRelease>'
     PreScriptMergePath = 'Build/header.ps1'
 })
 """);
@@ -232,7 +232,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(moduleRoot.FullName, prepared.PipelineSpec.Build.SourcePath);
                 Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Staging"), prepared.PipelineSpec.Build.StagingPath);
                 Assert.Equal(Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj"), prepared.PipelineSpec.Build.CsprojPath);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "diagnostics.json"), prepared.PipelineSpec.Diagnostics.BaselinePath);
+                Assert.Equal("Build/diagnostics.json", prepared.PipelineSpec.Diagnostics.BaselinePath);
                 Assert.Equal(new[] { Path.Combine(root.FullName, "Modules") }, prepared.PipelineSpec.Build.BinaryConflictSearchRoots);
                 Assert.Equal(new[] { Path.Combine(root.FullName, "Modules") }, prepared.PipelineSpec.Diagnostics.BinaryConflictSearchRoots);
                 Assert.Equal(new[] { Path.Combine(root.FullName, "Artefacts", "Modules") }, prepared.PipelineSpec.Install.Roots);
@@ -276,7 +276,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules"), artefact.Configuration.RequiredModules.ModulesPath);
 
                 var test = Assert.IsType<ConfigurationTestSegment>(prepared.PipelineSpec.Segments[5]);
-                Assert.Equal(Path.Combine(root.FullName, "Tests"), test.Configuration.TestsPath);
+                Assert.Equal("Tests", test.Configuration.TestsPath);
 
                 var options = Assert.IsType<ConfigurationOptionsSegment>(prepared.PipelineSpec.Segments[6]);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "cert.pfx"), options.Options.Signing!.CertificatePFXPath);
@@ -289,10 +289,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Build"), action.Configuration.WorkingDirectory);
 
                 var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[9]);
-                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "UploadReady"), release.Configuration.StageRoot);
+                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "UploadReady", "<ModuleVersion>"), release.Configuration.StageRoot);
 
                 var validation = Assert.IsType<ConfigurationValidationSegment>(prepared.PipelineSpec.Segments[10]);
-                Assert.Equal(Path.Combine(root.FullName, "Tests"), validation.Settings.Tests.TestPath);
+                Assert.Equal("Tests", validation.Settings.Tests.TestPath);
 
                 var documentation = Assert.IsType<ConfigurationDocumentationSegment>(prepared.PipelineSpec.Segments[11]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Docs"), documentation.Configuration.Path);
@@ -302,7 +302,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(new[] { "Help/About" }, buildDocumentation.Configuration.AboutTopicsSourcePath);
 
                 var fileBackedArtefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[13]);
-                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "FileBacked"), fileBackedArtefact.Configuration.Path);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "FileBacked", "<TagModuleVersionWithPreRelease>"), fileBackedArtefact.Configuration.Path);
                 Assert.Contains("Write-Output", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
             }
             finally

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -23,6 +23,8 @@ public sealed class ModuleBuildPreparationServiceTests
                 InputPath = root.FullName,
                 CurrentPath = root.FullName,
                 ResolvePath = path => path,
+                StagingPath = "Artefacts/Staging",
+                CsprojPath = "Sources/SampleModule.PowerShell/SampleModule.PowerShell.csproj",
                 DotNetFramework = new[] { "net8.0" },
                 DotNetFrameworkWasBound = false,
                 Legacy = true,
@@ -37,6 +39,8 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Equal(Path.Combine(root.FullName, "SampleModule"), prepared.ProjectRoot);
             Assert.Equal(root.FullName, prepared.BasePathForScaffold);
             Assert.True(prepared.UseLegacy);
+            Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Staging"), prepared.PipelineSpec.Build.StagingPath);
+            Assert.Equal(Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "SampleModule.PowerShell.csproj"), prepared.PipelineSpec.Build.CsprojPath);
             Assert.Empty(prepared.PipelineSpec.Build.Frameworks);
             Assert.Contains(".gitignore", prepared.PipelineSpec.Build.ExcludeFiles);
             Assert.Contains("SampleModule.Tests.ps1", prepared.PipelineSpec.Build.ExcludeFiles);
@@ -101,6 +105,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             [PowerForge.ArtefactCopyMapping]@{
                 Source = 'Build/Templates'
                 Destination = 'Templates'
+            },
+            [PowerForge.ArtefactCopyMapping]@{
+                Source = 'Docs/Help'
+                Destination = 'Help'
             }
         )
         FilesOutput = [PowerForge.ArtefactCopyMapping[]]@(
@@ -115,6 +123,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             [PowerForge.ArtefactCopyMapping]@{
                 Source = 'Artefacts/ProjectBuild/packages/Foo.nupkg'
                 Destination = 'Packages/Foo.nupkg'
+            },
+            [PowerForge.ArtefactCopyMapping]@{
+                Source = 'Assets/logo.png'
+                Destination = 'Assets/logo.png'
             }
         )
     }
@@ -267,14 +279,18 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Build", "LICENSE"), artefact.Configuration.DirectoryOutput![0].Source);
                 Assert.Equal("LICENSE", artefact.Configuration.DirectoryOutput[0].Destination);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "Templates"), artefact.Configuration.DirectoryOutput[1].Source);
+                Assert.Equal("Build/Templates", artefact.Configuration.DirectoryOutput[1].Source);
                 Assert.Equal("Templates", artefact.Configuration.DirectoryOutput[1].Destination);
+                Assert.Equal("Docs/Help", artefact.Configuration.DirectoryOutput[2].Source);
+                Assert.Equal("Help", artefact.Configuration.DirectoryOutput[2].Destination);
                 Assert.Equal("Examples/NOTICE.txt", artefact.Configuration.FilesOutput![0].Source);
                 Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "NOTICE.txt"), artefact.Configuration.FilesOutput[1].Source);
+                Assert.Equal("Build/NOTICE.txt", artefact.Configuration.FilesOutput[1].Source);
                 Assert.Equal("RepoNotice.txt", artefact.Configuration.FilesOutput[1].Destination);
-                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "packages", "Foo.nupkg"), artefact.Configuration.FilesOutput[2].Source);
+                Assert.Equal("Artefacts/ProjectBuild/packages/Foo.nupkg", artefact.Configuration.FilesOutput[2].Source);
                 Assert.Equal("Packages/Foo.nupkg", artefact.Configuration.FilesOutput[2].Destination);
+                Assert.Equal("Assets/logo.png", artefact.Configuration.FilesOutput[3].Source);
+                Assert.Equal("Assets/logo.png", artefact.Configuration.FilesOutput[3].Destination);
 
                 var artefactWithRelativeLayout = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[3]);
                 Assert.Equal("Artefacts/Unpacked", artefactWithRelativeLayout.Configuration.Path);
@@ -379,7 +395,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     }
 
     [Fact]
-    public void Prepare_from_modern_path_keeps_segment_paths_relative_to_module_root()
+    public void Prepare_from_modern_path_uses_input_root_for_workspace_paths()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-path-root-" + Guid.NewGuid().ToString("N")));
 
@@ -422,7 +438,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 });
 
                 var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
-                Assert.Equal("Sources/Demo/Demo.csproj", buildLibraries.BuildLibraries.NETProjectPath);
+                Assert.Equal(Path.Combine(root.FullName, "Sources", "Demo", "Demo.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
 
                 var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[1]);
                 Assert.Equal("Artefacts/Packed", artefact.Configuration.Path);
@@ -688,15 +704,18 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var developmentBinaries = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "bin");
             var packageRoot = Path.Combine(root.FullName, "Sources");
             var stagingRoot = Path.Combine(root.FullName, "Artifacts", "Packages", "Staging");
+            var packagePublishKey = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "nuget.key");
+            var packageCredentialSecret = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "nuget.secret");
+            var packageGitHubToken = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "github.token");
             var releaseRoot = Path.Combine(root.FullName, "Artifacts", "Release");
             var artefactRoot = Path.Combine(root.FullName, "Module", "Artefacts", "Packed");
             var artefactRequiredModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules");
             var artefactModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules");
             var publishKey = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "psgallery.key");
-            var actionFile = Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1");
-            var actionWorkingDirectory = Path.Combine(root.FullName, "Build");
+            var actionFile = Path.Combine(Path.GetTempPath(), "PowerForge", "Actions-" + Guid.NewGuid().ToString("N"), "Test-ReleaseReady.ps1");
+            var actionWorkingDirectory = Path.Combine(Path.GetTempPath(), "PowerForge", "Actions-" + Guid.NewGuid().ToString("N"));
             var testsPath = Path.Combine(root.FullName, "Tests");
-            var signingPfxPath = Path.Combine(root.FullName, "Build", "cert.pfx");
+            var signingPfxPath = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "cert.pfx");
             var documentationPath = Path.Combine(root.FullName, "Module", "Docs");
             var documentationReadmePath = Path.Combine(root.FullName, "README.md");
             const string aboutTopicsPath = "Help/About";
@@ -707,6 +726,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var projectOptionsPlanPath = Path.Combine(root.FullName, "Build", "project-options-plan.json");
             var packageOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "PackageBuild", "options");
             var packageOptionsPlanPath = Path.Combine(root.FullName, "Build", "package-options-plan.json");
+            var packageOptionsCredentialPath = Path.Combine(Path.GetTempPath(), "PowerForge", "OptionSecrets-" + Guid.NewGuid().ToString("N"), "nuget-option.key");
             var spec = new ModulePipelineSpec
             {
                 Build = new ModuleBuildSpec
@@ -757,13 +777,14 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             StagingPath = stagingRoot,
                             OutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "NuGet"),
                             PlanOutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "plan.json"),
-                            PublishApiKeyFilePath = Path.Combine(root.FullName, "Build", "nuget.key"),
-                            NugetCredentialSecretFilePath = Path.Combine(root.FullName, "Build", "nuget.secret"),
-                            GitHubAccessTokenFilePath = Path.Combine(root.FullName, "Build", "github.token"),
+                            PublishApiKeyFilePath = packagePublishKey,
+                            NugetCredentialSecretFilePath = packageCredentialSecret,
+                            GitHubAccessTokenFilePath = packageGitHubToken,
                             Options = new Dictionary<string, object?>
                             {
                                 ["OutputPath"] = packageOptionsOutputPath,
-                                ["PlanOutputPath"] = packageOptionsPlanPath
+                                ["PlanOutputPath"] = packageOptionsPlanPath,
+                                ["PublishApiKeyFilePath"] = packageOptionsCredentialPath
                             }
                         }
                     },
@@ -895,24 +916,25 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"PlanOutputPath\": \"Build/project-options-plan.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"OutputPath\": \"Artifacts/PackageBuild/options\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PlanOutputPath\": \"Build/package-options-plan.json\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"PublishApiKeyFilePath\": \"Build/nuget.key\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"NugetCredentialSecretFilePath\": \"Build/nuget.secret\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"GitHubAccessTokenFilePath\": \"Build/github.token\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"PublishApiKeyFilePath\": \"{packagePublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"\"NugetCredentialSecretFilePath\": \"{packageCredentialSecret.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"\"GitHubAccessTokenFilePath\": \"{packageGitHubToken.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"\"PublishApiKeyFilePath\": \"{packageOptionsCredentialPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"Path\": \"Module/Artefacts/Packed/RequiredModules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ModulesPath\": \"Module/Artefacts/Packed/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/Templates\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/NOTICE.txt\"", json, StringComparison.Ordinal);
             Assert.Contains($"\"Source\": \"{externalCopyFileSource.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"TestsPath\": \"Tests\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"CertificatePFXPath\": \"Build/cert.pfx\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"CertificatePFXPath\": \"{signingPfxPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"Path\": \"Module/Docs\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PathReadme\": \"README.md\"", json, StringComparison.Ordinal);
             Assert.Contains("\"TestPath\": \"Tests\"", json, StringComparison.Ordinal);
             Assert.Contains("\"AboutTopicsSourcePath\": [", json, StringComparison.Ordinal);
             Assert.Contains("\"Help/About\"", json, StringComparison.Ordinal);
             Assert.Contains($"\"ApiKeyFilePath\": \"{publishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("\"FilePath\": \"Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"WorkingDirectory\": \"Build\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"FilePath\": \"{actionFile.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"\"WorkingDirectory\": \"{actionWorkingDirectory.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"StageRoot\": \"Artifacts/Release\"", json, StringComparison.Ordinal);
 
             var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
@@ -945,11 +967,12 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(developmentBinaries, buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
             Assert.Equal(packageRoot, packageBuild.Configuration.RootPath);
             Assert.Equal(stagingRoot, packageBuild.Configuration.StagingPath);
-            Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.key"), packageBuild.Configuration.PublishApiKeyFilePath);
-            Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.secret"), packageBuild.Configuration.NugetCredentialSecretFilePath);
-            Assert.Equal(Path.Combine(root.FullName, "Build", "github.token"), packageBuild.Configuration.GitHubAccessTokenFilePath);
+            Assert.Equal(packagePublishKey, packageBuild.Configuration.PublishApiKeyFilePath);
+            Assert.Equal(packageCredentialSecret, packageBuild.Configuration.NugetCredentialSecretFilePath);
+            Assert.Equal(packageGitHubToken, packageBuild.Configuration.GitHubAccessTokenFilePath);
             Assert.Equal(packageOptionsOutputPath, packageBuild.Configuration.Options!["OutputPath"]);
             Assert.Equal(packageOptionsPlanPath, packageBuild.Configuration.Options["PlanOutputPath"]);
+            Assert.Equal(packageOptionsCredentialPath.Replace('\\', '/'), packageBuild.Configuration.Options["PublishApiKeyFilePath"]);
             Assert.Equal(artefactRoot, artefact.Configuration.Path);
             Assert.Equal(artefactRequiredModules, artefact.Configuration.RequiredModules.Path);
             Assert.Equal(artefactModules, artefact.Configuration.RequiredModules.ModulesPath);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -76,6 +76,19 @@ public sealed class ModuleBuildPreparationServiceTests
     ArtefactType = [PowerForge.ArtefactType]::Packed
     Configuration = [PowerForge.ArtefactConfiguration]@{
         Path = 'Module/Artefacts/Packed'
+        RequiredModules = [PowerForge.ArtefactRequiredModulesConfiguration]@{
+            Path = 'Module/Artefacts/Packed/RequiredModules'
+            ModulesPath = 'Module/Artefacts/Packed/Modules'
+        }
+    }
+}
+[PowerForge.ConfigurationPackageBuildSegment]@{
+    Configuration = [PowerForge.PackageBuildConfiguration]@{
+        RootPath = 'Sources'
+        OutputPath = 'Artefacts/ProjectBuild/packages'
+        PublishApiKeyFilePath = 'Build/nuget.key'
+        NugetCredentialSecretFilePath = 'Build/nuget.secret'
+        GitHubAccessTokenFilePath = 'Build/github.token'
     }
 }
 [PowerForge.ConfigurationReleaseSegment]@{
@@ -119,8 +132,78 @@ public sealed class ModuleBuildPreparationServiceTests
                 var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[2]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
 
-                var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[3]);
+                var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(prepared.PipelineSpec.Segments[3]);
+                Assert.Equal(Path.Combine(root.FullName, "Sources"), packageBuild.Configuration.RootPath);
+                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "packages"), packageBuild.Configuration.OutputPath);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.key"), packageBuild.Configuration.PublishApiKeyFilePath);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.secret"), packageBuild.Configuration.NugetCredentialSecretFilePath);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "github.token"), packageBuild.Configuration.GitHubAccessTokenFilePath);
+
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules"), artefact.Configuration.RequiredModules.Path);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules"), artefact.Configuration.RequiredModules.ModulesPath);
+
+                var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[4]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "UploadReady"), release.Configuration.StageRoot);
+            }
+            finally
+            {
+                Runspace.DefaultRunspace = previousRunspace;
+            }
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_from_modern_path_keeps_segment_paths_relative_to_module_root()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-path-root-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "SampleModule"));
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "SampleModule.psd1"), "@{ ModuleVersion = '1.0.0' }");
+
+            var settings = ScriptBlock.Create("""
+[PowerForge.ConfigurationBuildLibrariesSegment]@{
+    BuildLibraries = [PowerForge.BuildLibrariesConfiguration]@{
+        NETProjectPath = 'Sources/Demo/Demo.csproj'
+    }
+}
+[PowerForge.ConfigurationArtefactSegment]@{
+    ArtefactType = [PowerForge.ArtefactType]::Packed
+    Configuration = [PowerForge.ArtefactConfiguration]@{
+        Path = 'Artefacts/Packed'
+    }
+}
+""");
+
+            using var runspace = RunspaceFactory.CreateRunspace();
+            runspace.Open();
+            var previousRunspace = Runspace.DefaultRunspace;
+            Runspace.DefaultRunspace = runspace;
+            try
+            {
+                var prepared = new ModuleBuildPreparationService().Prepare(new ModuleBuildPreparationRequest
+                {
+                    ParameterSetName = "Modern",
+                    ModuleName = "SampleModule",
+                    InputPath = root.FullName,
+                    Settings = settings,
+                    CurrentPath = root.FullName,
+                    ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                    DotNetFramework = Array.Empty<string>(),
+                    ExcludeDirectories = Array.Empty<string>(),
+                    ExcludeFiles = Array.Empty<string>()
+                });
+
+                var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
+                Assert.Equal("Sources/Demo/Demo.csproj", buildLibraries.BuildLibraries.NETProjectPath);
+
+                var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[1]);
+                Assert.Equal("Artefacts/Packed", artefact.Configuration.Path);
             }
             finally
             {
@@ -329,9 +412,14 @@ public sealed class ModuleBuildPreparationServiceTests
         {
             var jsonPath = Path.Combine(root.FullName, ".powerforge", "powerforge.json");
             var projectConfig = Path.Combine(root.FullName, "Build", "project.build.json");
+            var netProject = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "SampleModule.PowerShell.csproj");
+            var developmentBinaries = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "bin");
             var packageRoot = Path.Combine(root.FullName, "Sources");
             var stagingRoot = Path.Combine(root.FullName, "Artifacts", "Packages", "Staging");
             var releaseRoot = Path.Combine(root.FullName, "Artifacts", "Release");
+            var artefactRoot = Path.Combine(root.FullName, "Module", "Artefacts", "Packed");
+            var artefactRequiredModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules");
+            var artefactModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules");
             var spec = new ModulePipelineSpec
             {
                 Build = new ModuleBuildSpec
@@ -349,6 +437,14 @@ public sealed class ModuleBuildPreparationServiceTests
                             BuildBeforeModule = true
                         }
                     },
+                    new ConfigurationBuildLibrariesSegment
+                    {
+                        BuildLibraries = new BuildLibrariesConfiguration
+                        {
+                            NETProjectPath = netProject,
+                            NETDevelopmentBinariesPath = developmentBinaries
+                        }
+                    },
                     new ConfigurationPackageBuildSegment
                     {
                         Configuration = new PackageBuildConfiguration
@@ -356,7 +452,23 @@ public sealed class ModuleBuildPreparationServiceTests
                             RootPath = packageRoot,
                             StagingPath = stagingRoot,
                             OutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "NuGet"),
-                            PlanOutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "plan.json")
+                            PlanOutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "plan.json"),
+                            PublishApiKeyFilePath = Path.Combine(root.FullName, "Build", "nuget.key"),
+                            NugetCredentialSecretFilePath = Path.Combine(root.FullName, "Build", "nuget.secret"),
+                            GitHubAccessTokenFilePath = Path.Combine(root.FullName, "Build", "github.token")
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = artefactRoot,
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                Path = artefactRequiredModules,
+                                ModulesPath = artefactModules
+                            }
                         }
                     },
                     new ConfigurationReleaseSegment
@@ -375,9 +487,17 @@ public sealed class ModuleBuildPreparationServiceTests
 
             var json = File.ReadAllText(jsonPath);
             Assert.Contains("\"ConfigPath\": \"Build/project.build.json\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"NETProjectPath\": \"Sources/SampleModule.PowerShell/SampleModule.PowerShell.csproj\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"NETDevelopmentBinariesPath\": \"Sources/SampleModule.PowerShell/bin\"", json, StringComparison.Ordinal);
             Assert.Contains("\"RootPath\": \"Sources\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StagingPath\": \"Artifacts/Packages/Staging\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PlanOutputPath\": \"Artifacts/Packages/plan.json\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"PublishApiKeyFilePath\": \"Build/nuget.key\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"NugetCredentialSecretFilePath\": \"Build/nuget.secret\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"GitHubAccessTokenFilePath\": \"Build/github.token\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Path\": \"Module/Artefacts/Packed\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Path\": \"Module/Artefacts/Packed/RequiredModules\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"ModulesPath\": \"Module/Artefacts/Packed/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StageRoot\": \"Artifacts/Release\"", json, StringComparison.Ordinal);
 
             var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
@@ -385,11 +505,21 @@ public sealed class ModuleBuildPreparationServiceTests
 
             service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
             var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(jsonSpec!.Segments[0]);
-            var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[1]);
-            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[2]);
+            var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(jsonSpec.Segments[1]);
+            var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[2]);
+            var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[3]);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[4]);
             Assert.Equal(projectConfig, projectBuild.Configuration.ConfigPath);
+            Assert.Equal(netProject, buildLibraries.BuildLibraries.NETProjectPath);
+            Assert.Equal(developmentBinaries, buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
             Assert.Equal(packageRoot, packageBuild.Configuration.RootPath);
             Assert.Equal(stagingRoot, packageBuild.Configuration.StagingPath);
+            Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.key"), packageBuild.Configuration.PublishApiKeyFilePath);
+            Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.secret"), packageBuild.Configuration.NugetCredentialSecretFilePath);
+            Assert.Equal(Path.Combine(root.FullName, "Build", "github.token"), packageBuild.Configuration.GitHubAccessTokenFilePath);
+            Assert.Equal(artefactRoot, artefact.Configuration.Path);
+            Assert.Equal(artefactRequiredModules, artefact.Configuration.RequiredModules.Path);
+            Assert.Equal(artefactModules, artefact.Configuration.RequiredModules.ModulesPath);
             Assert.Equal(releaseRoot, release.Configuration.StageRoot);
         }
         finally

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -202,7 +202,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationBuildDocumentationSegment]@{
     Configuration = [PowerForge.BuildDocumentationConfiguration]@{
         Enable = $true
-        AboutTopicsSourcePath = @('Help/About')
+        AboutTopicsSourcePath = @('Help/About', 'Module/Help/Workspace')
     }
 }
 [PowerForge.ArtefactConfigurationFactory]::new([PowerForge.NullLogger]::new()).Create([PowerForge.ArtefactConfigurationRequest]@{
@@ -344,7 +344,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal("Docs/Readme.md", documentation.Configuration.PathReadme);
 
                 var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(prepared.PipelineSpec.Segments[12]);
-                Assert.Equal(new[] { "Help/About" }, buildDocumentation.Configuration.AboutTopicsSourcePath);
+                Assert.Equal(new[] { "Help/About", "Help/Workspace" }, buildDocumentation.Configuration.AboutTopicsSourcePath);
 
                 var fileBackedArtefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[13]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "FileBacked", "<TagModuleVersionWithPreRelease>"), fileBackedArtefact.Configuration.Path);
@@ -603,6 +603,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         try
         {
             var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var buildRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            File.WriteAllText(Path.Combine(buildRoot.FullName, "Build-Module.ps1"), string.Empty);
             var jsonPath = Path.Combine(root.FullName, "Build", "powerforge.json");
             var externalRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "External-" + Guid.NewGuid().ToString("N"));
             var externalPublishKey = Path.Combine(externalRoot, "psgallery.key");
@@ -669,6 +671,48 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains($"\"ApiKeyFilePath\": \"{externalPublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"FilePath\": \"../Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
             Assert.Contains("\"WorkingDirectory\": \"../Build\"", json, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void WritePipelineSpecJson_preserves_external_sibling_paths_for_standalone_module_folder()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-standalone-module-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var siblingSecretPath = Path.Combine(root.FullName, "Secrets", "psgallery.key");
+            var jsonPath = Path.Combine(moduleRoot.FullName, ".powerforge", "powerforge.json");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = moduleRoot.FullName
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Destination = PublishDestination.PowerShellGallery,
+                            ApiKeyFilePath = siblingSecretPath
+                        }
+                    }
+                }
+            };
+
+            new ModuleBuildPreparationService().WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            Assert.Contains($"\"ApiKeyFilePath\": \"{siblingSecretPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("\"ApiKeyFilePath\": \"../Secrets/psgallery.key\"", json, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -91,13 +91,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         }
         DirectoryOutput = [PowerForge.ArtefactCopyMapping[]]@(
             [PowerForge.ArtefactCopyMapping]@{
-                Source = 'Build/LICENSE'
+                Source = 'Module/Build/LICENSE'
                 Destination = 'LICENSE'
             }
         )
         FilesOutput = [PowerForge.ArtefactCopyMapping[]]@(
             [PowerForge.ArtefactCopyMapping]@{
-                Source = 'Build/NOTICE.txt'
+                Source = 'Examples/NOTICE.txt'
                 Destination = 'NOTICE.txt'
             }
         )
@@ -165,7 +165,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationDocumentationSegment]@{
     Configuration = [PowerForge.DocumentationConfiguration]@{
         Path = 'Module/Docs'
-        PathReadme = 'README.md'
+        PathReadme = 'Docs/Readme.md'
     }
 }
 [PowerForge.ConfigurationBuildDocumentationSegment]@{
@@ -237,9 +237,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 
                 var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[2]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "LICENSE"), artefact.Configuration.DirectoryOutput![0].Source);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Build", "LICENSE"), artefact.Configuration.DirectoryOutput![0].Source);
                 Assert.Equal("LICENSE", artefact.Configuration.DirectoryOutput[0].Destination);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "NOTICE.txt"), artefact.Configuration.FilesOutput![0].Source);
+                Assert.Equal("Examples/NOTICE.txt", artefact.Configuration.FilesOutput![0].Source);
                 Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
 
                 var artefactWithRelativeLayout = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[3]);
@@ -280,7 +280,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 
                 var documentation = Assert.IsType<ConfigurationDocumentationSegment>(prepared.PipelineSpec.Segments[11]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Docs"), documentation.Configuration.Path);
-                Assert.Equal(Path.Combine(root.FullName, "README.md"), documentation.Configuration.PathReadme);
+                Assert.Equal("Docs/Readme.md", documentation.Configuration.PathReadme);
 
                 var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(prepared.PipelineSpec.Segments[12]);
                 Assert.Equal(new[] { "Help/About" }, buildDocumentation.Configuration.AboutTopicsSourcePath);
@@ -295,6 +295,42 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Runspace.DefaultRunspace = previousRunspace;
                 try { outsideRoot.Delete(recursive: true); } catch { }
             }
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_from_module_build_script_uses_powershell_resolver_for_json_path_syntax()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-jsonpath-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "SampleModule.psd1"), "@{ ModuleVersion = '1.0.0' }");
+            var resolvedJsonPath = Path.Combine(root.FullName, "ResolvedFromPSDrive", "powerforge.json");
+
+            var prepared = new ModuleBuildPreparationService().Prepare(new ModuleBuildPreparationRequest
+            {
+                ParameterSetName = "Modern",
+                ModuleName = "SampleModule",
+                CurrentPath = root.FullName,
+                ScriptRoot = scriptRoot.FullName,
+                ResolvePath = path => string.Equals(path, "Temp:\\powerforge.json", StringComparison.OrdinalIgnoreCase)
+                    ? resolvedJsonPath
+                    : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                JsonOnly = true,
+                JsonPath = "Temp:\\powerforge.json",
+                DotNetFramework = Array.Empty<string>(),
+                ExcludeDirectories = Array.Empty<string>(),
+                ExcludeFiles = Array.Empty<string>()
+            });
+
+            Assert.Equal(resolvedJsonPath, prepared.JsonOutputPath);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -950,6 +950,52 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     }
 
     [Fact]
+    public void WritePipelineSpecJson_preserves_external_release_stage_root()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-release-external-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var jsonPath = Path.Combine(root.FullName, ".powerforge", "powerforge.json");
+            var externalReleaseRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "Release-" + Guid.NewGuid().ToString("N"));
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = root.FullName
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = externalReleaseRoot
+                        }
+                    }
+                }
+            };
+
+            var service = new ModuleBuildPreparationService();
+            service.WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            Assert.Contains($"\"StageRoot\": \"{externalReleaseRoot.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+
+            var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
+            Assert.NotNull(jsonSpec);
+            service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(Assert.Single(jsonSpec!.Segments.OfType<ConfigurationReleaseSegment>()));
+            Assert.Equal(Path.GetFullPath(externalReleaseRoot), release.Configuration.StageRoot);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void WritePipelineSpecJson_keeps_apple_and_xcode_paths_relative_to_project_root()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-apple-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -122,7 +122,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationArtefactSegment]@{
     ArtefactType = [PowerForge.ArtefactType]::Unpacked
     Configuration = [PowerForge.ArtefactConfiguration]@{
-        Path = 'Module/Artefacts/Unpacked'
+        Path = 'Artefacts/Unpacked'
         RequiredModules = [PowerForge.ArtefactRequiredModulesConfiguration]@{
             Path = 'Modules'
             ModulesPath = 'Payload/MainModules'
@@ -180,7 +180,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 }
 [PowerForge.ConfigurationDocumentationSegment]@{
     Configuration = [PowerForge.DocumentationConfiguration]@{
-        Path = 'Module/Docs'
+        Path = '.\Module\Docs'
         PathReadme = 'Docs/Readme.md'
     }
 }
@@ -197,6 +197,18 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     Path = 'Module/Artefacts/FileBacked/<TagModuleVersionWithPreRelease>'
     PreScriptMergePath = 'Build/header.ps1'
 })
+[PowerForge.ConfigurationAppleAppSegment]@{
+    Configuration = [PowerForge.AppleAppConfiguration]@{
+        ProjectPath = '.\Tactra.xcodeproj'
+        UseResolvedVersion = $true
+    }
+}
+[PowerForge.ConfigurationXcodeProjectVersionSegment]@{
+    Configuration = [PowerForge.XcodeProjectVersionConfiguration]@{
+        Path = 'Mac\TactraMac.xcodeproj'
+        UseResolvedVersion = $true
+    }
+}
 """);
 
             var outsideRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-outside-" + Guid.NewGuid().ToString("N")));
@@ -265,7 +277,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal("Packages/Foo.nupkg", artefact.Configuration.FilesOutput[2].Destination);
 
                 var artefactWithRelativeLayout = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[3]);
-                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Unpacked"), artefactWithRelativeLayout.Configuration.Path);
+                Assert.Equal("Artefacts/Unpacked", artefactWithRelativeLayout.Configuration.Path);
                 Assert.Equal("Modules", artefactWithRelativeLayout.Configuration.RequiredModules.Path);
                 Assert.Equal("Payload/MainModules", artefactWithRelativeLayout.Configuration.RequiredModules.ModulesPath);
 
@@ -310,6 +322,12 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 var fileBackedArtefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[13]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "FileBacked", "<TagModuleVersionWithPreRelease>"), fileBackedArtefact.Configuration.Path);
                 Assert.Contains("Write-Output", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
+
+                var appleApp = Assert.IsType<ConfigurationAppleAppSegment>(prepared.PipelineSpec.Segments[14]);
+                Assert.Equal(".\\Tactra.xcodeproj", appleApp.Configuration.ProjectPath);
+
+                var xcodeProject = Assert.IsType<ConfigurationXcodeProjectVersionSegment>(prepared.PipelineSpec.Segments[15]);
+                Assert.Equal("Mac\\TactraMac.xcodeproj", xcodeProject.Configuration.Path);
             }
             finally
             {
@@ -662,6 +680,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var buildStagingPath = Path.Combine(root.FullName, "Artifacts", "Module", "Staging");
             var buildCsprojPath = Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj");
             var binaryConflictSearchRoot = Path.Combine(root.FullName, "Modules");
+            var externalBinaryConflictSearchRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "BinaryScan-" + Guid.NewGuid().ToString("N"));
             var installRoot = Path.Combine(root.FullName, "Artifacts", "Modules");
             var externalInstallRoot = Path.Combine(Path.GetTempPath(), "PowerShell", "Modules");
             var diagnosticsBaselinePath = Path.Combine(root.FullName, "Build", "diagnostics.json");
@@ -673,7 +692,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var artefactRoot = Path.Combine(root.FullName, "Module", "Artefacts", "Packed");
             var artefactRequiredModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules");
             var artefactModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules");
-            var publishKey = Path.Combine(root.FullName, "Build", "psgallery.key");
+            var publishKey = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "psgallery.key");
             var actionFile = Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1");
             var actionWorkingDirectory = Path.Combine(root.FullName, "Build");
             var testsPath = Path.Combine(root.FullName, "Tests");
@@ -683,6 +702,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             const string aboutTopicsPath = "Help/About";
             var copyDirectorySource = Path.Combine(root.FullName, "Build", "Templates");
             var copyFileSource = Path.Combine(root.FullName, "Build", "NOTICE.txt");
+            var externalCopyFileSource = Path.Combine(Path.GetTempPath(), "PowerForge", "Shared-" + Guid.NewGuid().ToString("N"), "NOTICE.txt");
             var projectOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "ProjectBuild", "options");
             var projectOptionsPlanPath = Path.Combine(root.FullName, "Build", "project-options-plan.json");
             var packageOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "PackageBuild", "options");
@@ -695,7 +715,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                     SourcePath = root.FullName,
                     StagingPath = buildStagingPath,
                     CsprojPath = buildCsprojPath,
-                    BinaryConflictSearchRoots = new[] { binaryConflictSearchRoot }
+                    BinaryConflictSearchRoots = new[] { binaryConflictSearchRoot, externalBinaryConflictSearchRoot }
                 },
                 Install = new ModulePipelineInstallOptions
                 {
@@ -704,7 +724,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Diagnostics = new ModulePipelineDiagnosticsOptions
                 {
                     BaselinePath = diagnosticsBaselinePath,
-                    BinaryConflictSearchRoots = new[] { binaryConflictSearchRoot }
+                    BinaryConflictSearchRoots = new[] { binaryConflictSearchRoot, externalBinaryConflictSearchRoot }
                 },
                 Segments = new IConfigurationSegment[]
                 {
@@ -772,6 +792,11 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                                 {
                                     Source = copyFileSource,
                                     Destination = "NOTICE.txt"
+                                },
+                                new ArtefactCopyMapping
+                                {
+                                    Source = externalCopyFileSource,
+                                    Destination = "ExternalNotice.txt"
                                 }
                             }
                         }
@@ -856,6 +881,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"CsprojPath\": \"../Sources/TopLevel/TopLevel.csproj\"", json, StringComparison.Ordinal);
             Assert.Contains("\"BinaryConflictSearchRoots\": [", json, StringComparison.Ordinal);
             Assert.Contains("\"Modules\"", json, StringComparison.Ordinal);
+            Assert.Contains(externalBinaryConflictSearchRoot.Replace('\\', '/'), json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"Roots\": [", json, StringComparison.Ordinal);
             Assert.Contains("\"Artifacts/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"BaselinePath\": \"../Build/diagnostics.json\"", json, StringComparison.Ordinal);
@@ -876,6 +902,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"ModulesPath\": \"Module/Artefacts/Packed/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/Templates\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/NOTICE.txt\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"Source\": \"{externalCopyFileSource.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"TestsPath\": \"Tests\"", json, StringComparison.Ordinal);
             Assert.Contains("\"CertificatePFXPath\": \"Build/cert.pfx\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Path\": \"Module/Docs\"", json, StringComparison.Ordinal);
@@ -883,7 +910,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"TestPath\": \"Tests\"", json, StringComparison.Ordinal);
             Assert.Contains("\"AboutTopicsSourcePath\": [", json, StringComparison.Ordinal);
             Assert.Contains("\"Help/About\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"ApiKeyFilePath\": \"Build/psgallery.key\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"ApiKeyFilePath\": \"{publishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"FilePath\": \"Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
             Assert.Contains("\"WorkingDirectory\": \"Build\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StageRoot\": \"Artifacts/Release\"", json, StringComparison.Ordinal);
@@ -895,10 +922,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             service.ResolvePipelineSpecPaths(jsonSpec, jsonPath);
             Assert.Equal(buildStagingPath, jsonSpec!.Build.StagingPath);
             Assert.Equal(buildCsprojPath, jsonSpec.Build.CsprojPath);
-            Assert.Equal(new[] { binaryConflictSearchRoot }, jsonSpec.Build.BinaryConflictSearchRoots);
+            Assert.Equal(new[] { binaryConflictSearchRoot, externalBinaryConflictSearchRoot }, jsonSpec.Build.BinaryConflictSearchRoots);
             Assert.Equal(new[] { installRoot, externalInstallRoot }, jsonSpec.Install.Roots);
             Assert.Equal(diagnosticsBaselinePath, jsonSpec.Diagnostics!.BaselinePath);
-            Assert.Equal(new[] { binaryConflictSearchRoot }, jsonSpec.Diagnostics.BinaryConflictSearchRoots);
+            Assert.Equal(new[] { binaryConflictSearchRoot, externalBinaryConflictSearchRoot }, jsonSpec.Diagnostics.BinaryConflictSearchRoots);
             var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(jsonSpec!.Segments[0]);
             var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(jsonSpec.Segments[1]);
             var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[2]);
@@ -930,6 +957,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal("Templates", artefact.Configuration.DirectoryOutput[0].Destination);
             Assert.Equal(copyFileSource, artefact.Configuration.FilesOutput![0].Source);
             Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
+            Assert.Equal(externalCopyFileSource.Replace('\\', '/'), artefact.Configuration.FilesOutput[1].Source);
+            Assert.Equal("ExternalNotice.txt", artefact.Configuration.FilesOutput[1].Destination);
             Assert.Equal(testsPath, test.Configuration.TestsPath);
             Assert.Equal(signingPfxPath, options.Options.Signing!.CertificatePFXPath);
             Assert.Equal(documentationPath, documentation.Configuration.Path);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -515,6 +515,18 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         Path = 'Artefacts/Packed'
     }
 }
+[PowerForge.ConfigurationPackageBuildSegment]@{
+    Configuration = [PowerForge.PackageBuildConfiguration]@{
+        RootPath = '.\Sources'
+        OutputPath = '.\Artefacts\Packages'
+    }
+}
+[PowerForge.ConfigurationActionSegment]@{
+    Configuration = [PowerForge.ModulePipelineActionConfiguration]@{
+        FilePath = '.\Build\Test-DocsShape.ps1'
+        WorkingDirectory = '.\Build'
+    }
+}
 """);
 
             using var runspace = RunspaceFactory.CreateRunspace();
@@ -537,10 +549,18 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 });
 
                 var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
-                Assert.Equal(Path.Combine(root.FullName, "Sources", "Demo", "Demo.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
+                Assert.Equal(Path.Combine(moduleRoot.FullName, "Sources", "Demo", "Demo.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
 
                 var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[1]);
                 Assert.Equal("Artefacts/Packed", artefact.Configuration.Path);
+
+                var package = Assert.IsType<ConfigurationPackageBuildSegment>(prepared.PipelineSpec.Segments[2]);
+                Assert.Equal(Path.Combine(moduleRoot.FullName, "Sources"), package.Configuration.RootPath);
+                Assert.Equal(Path.Combine(moduleRoot.FullName, "Artefacts", "Packages"), package.Configuration.OutputPath);
+
+                var action = Assert.IsType<ConfigurationActionSegment>(prepared.PipelineSpec.Segments[3]);
+                Assert.Equal(Path.Combine(moduleRoot.FullName, "Build", "Test-DocsShape.ps1"), action.Configuration.FilePath);
+                Assert.Equal(Path.Combine(moduleRoot.FullName, "Build"), action.Configuration.WorkingDirectory);
             }
             finally
             {
@@ -1350,8 +1370,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[11]);
             var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[12]);
             Assert.Equal(projectConfig, projectBuild.Configuration.ConfigPath);
-            Assert.Equal(projectOptionsOutputPath, projectBuild.Configuration.Options!["OutputPath"]);
-            Assert.Equal(projectOptionsPlanPath, projectBuild.Configuration.Options["PlanOutputPath"]);
+            Assert.Equal("../Artifacts/ProjectBuild/options", projectBuild.Configuration.Options!["OutputPath"]?.ToString());
+            Assert.Equal("project-options-plan.json", projectBuild.Configuration.Options["PlanOutputPath"]?.ToString());
             Assert.Equal(externalNetProject, buildLibraries.BuildLibraries.NETProjectPath);
             Assert.Equal(externalDevelopmentBinaries, buildLibraries.BuildLibraries.DevelopmentBinariesPath);
             Assert.Equal(developmentBinaries, buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -57,6 +57,8 @@ public sealed class ModuleBuildPreparationServiceTests
         {
             var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
             var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
+            File.WriteAllText(Path.Combine(root.FullName, "Build", "header.ps1"), "Write-Output 'header'");
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "DbaClientX.psd1"), "@{ ModuleVersion = '1.0.0' }");
 
             var settings = ScriptBlock.Create("""
@@ -151,14 +153,47 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         VersionSource = [PowerForge.ReleaseVersionSource]::ProjectBuild
     }
 }
+[PowerForge.ConfigurationValidationSegment]@{
+    Settings = [PowerForge.ModuleValidationSettings]@{
+        Enable = $true
+        Tests = [PowerForge.TestSuiteValidationSettings]@{
+            Enable = $true
+            TestPath = 'Tests'
+        }
+    }
+}
+[PowerForge.ConfigurationDocumentationSegment]@{
+    Configuration = [PowerForge.DocumentationConfiguration]@{
+        Path = 'Module/Docs'
+        PathReadme = 'README.md'
+    }
+}
+[PowerForge.ConfigurationBuildDocumentationSegment]@{
+    Configuration = [PowerForge.BuildDocumentationConfiguration]@{
+        Enable = $true
+        AboutTopicsSourcePath = @('Module/Docs/About')
+    }
+}
+[PowerForge.ArtefactConfigurationFactory]::new([PowerForge.NullLogger]::new()).Create([PowerForge.ArtefactConfigurationRequest]@{
+    Type = [PowerForge.ArtefactType]::Packed
+    EnableSpecified = $true
+    Enable = $true
+    Path = 'Module/Artefacts/FileBacked'
+    PreScriptMergePath = 'Build/header.ps1'
+})
 """);
 
+            var outsideRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-outside-" + Guid.NewGuid().ToString("N")));
+            var previousCurrentDirectory = Directory.GetCurrentDirectory();
             using var runspace = RunspaceFactory.CreateRunspace();
             runspace.Open();
             var previousRunspace = Runspace.DefaultRunspace;
             Runspace.DefaultRunspace = runspace;
             try
             {
+                Directory.SetCurrentDirectory(outsideRoot.FullName);
+                runspace.SessionStateProxy.Path.SetLocation(outsideRoot.FullName);
+
                 var prepared = new ModuleBuildPreparationService().Prepare(new ModuleBuildPreparationRequest
                 {
                     ParameterSetName = "Modern",
@@ -167,6 +202,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                     CurrentPath = root.FullName,
                     ScriptRoot = scriptRoot.FullName,
                     ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                    StagingPath = "Artefacts/Staging",
+                    CsprojPath = "Sources/TopLevel/TopLevel.csproj",
+                    DiagnosticsBaselinePath = "Build/diagnostics.json",
                     DotNetFramework = Array.Empty<string>(),
                     ExcludeDirectories = Array.Empty<string>(),
                     ExcludeFiles = Array.Empty<string>()
@@ -175,6 +213,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(moduleRoot.FullName, prepared.ProjectRoot);
                 Assert.Null(prepared.BasePathForScaffold);
                 Assert.Equal(moduleRoot.FullName, prepared.PipelineSpec.Build.SourcePath);
+                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Staging"), prepared.PipelineSpec.Build.StagingPath);
+                Assert.Equal(Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj"), prepared.PipelineSpec.Build.CsprojPath);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "diagnostics.json"), prepared.PipelineSpec.Diagnostics.BaselinePath);
 
                 var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
                 Assert.Equal(Path.Combine(root.FullName, "DbaClientX.PowerShell", "DbaClientX.PowerShell.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
@@ -224,10 +265,26 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 
                 var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[9]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "UploadReady"), release.Configuration.StageRoot);
+
+                var validation = Assert.IsType<ConfigurationValidationSegment>(prepared.PipelineSpec.Segments[10]);
+                Assert.Equal(Path.Combine(root.FullName, "Tests"), validation.Settings.Tests.TestPath);
+
+                var documentation = Assert.IsType<ConfigurationDocumentationSegment>(prepared.PipelineSpec.Segments[11]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Docs"), documentation.Configuration.Path);
+                Assert.Equal(Path.Combine(root.FullName, "README.md"), documentation.Configuration.PathReadme);
+
+                var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(prepared.PipelineSpec.Segments[12]);
+                Assert.Equal(new[] { Path.Combine(root.FullName, "Module", "Docs", "About") }, buildDocumentation.Configuration.AboutTopicsSourcePath);
+
+                var fileBackedArtefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[13]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "FileBacked"), fileBackedArtefact.Configuration.Path);
+                Assert.Contains("Write-Output", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
             }
             finally
             {
+                try { Directory.SetCurrentDirectory(previousCurrentDirectory); } catch { }
                 Runspace.DefaultRunspace = previousRunspace;
+                try { outsideRoot.Delete(recursive: true); } catch { }
             }
         }
         finally
@@ -492,6 +549,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
         {
             var jsonPath = Path.Combine(root.FullName, ".powerforge", "powerforge.json");
             var projectConfig = Path.Combine(root.FullName, "Build", "project.build.json");
+            var buildStagingPath = Path.Combine(root.FullName, "Artifacts", "Module", "Staging");
+            var buildCsprojPath = Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj");
+            var diagnosticsBaselinePath = Path.Combine(root.FullName, "Build", "diagnostics.json");
             var netProject = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "SampleModule.PowerShell.csproj");
             var developmentBinaries = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "bin");
             var packageRoot = Path.Combine(root.FullName, "Sources");
@@ -505,6 +565,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var actionWorkingDirectory = Path.Combine(root.FullName, "Build");
             var testsPath = Path.Combine(root.FullName, "Tests");
             var signingPfxPath = Path.Combine(root.FullName, "Build", "cert.pfx");
+            var documentationPath = Path.Combine(root.FullName, "Module", "Docs");
+            var documentationReadmePath = Path.Combine(root.FullName, "README.md");
+            var aboutTopicsPath = Path.Combine(root.FullName, "Module", "Docs", "About");
             var copyDirectorySource = Path.Combine(root.FullName, "Build", "Templates");
             var copyFileSource = Path.Combine(root.FullName, "Build", "NOTICE.txt");
             var projectOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "ProjectBuild", "options");
@@ -516,7 +579,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Build = new ModuleBuildSpec
                 {
                     Name = "SampleModule",
-                    SourcePath = root.FullName
+                    SourcePath = root.FullName,
+                    StagingPath = buildStagingPath,
+                    CsprojPath = buildCsprojPath
+                },
+                Diagnostics = new ModulePipelineDiagnosticsOptions
+                {
+                    BaselinePath = diagnosticsBaselinePath
                 },
                 Segments = new IConfigurationSegment[]
                 {
@@ -605,6 +674,34 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             }
                         }
                     },
+                    new ConfigurationDocumentationSegment
+                    {
+                        Configuration = new DocumentationConfiguration
+                        {
+                            Path = documentationPath,
+                            PathReadme = documentationReadmePath
+                        }
+                    },
+                    new ConfigurationBuildDocumentationSegment
+                    {
+                        Configuration = new BuildDocumentationConfiguration
+                        {
+                            Enable = true,
+                            AboutTopicsSourcePath = new[] { aboutTopicsPath }
+                        }
+                    },
+                    new ConfigurationValidationSegment
+                    {
+                        Settings = new ModuleValidationSettings
+                        {
+                            Enable = true,
+                            Tests = new TestSuiteValidationSettings
+                            {
+                                Enable = true,
+                                TestPath = testsPath
+                            }
+                        }
+                    },
                     new ConfigurationPublishSegment
                     {
                         Configuration = new PublishConfiguration
@@ -636,6 +733,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             service.WritePipelineSpecJson(spec, jsonPath);
 
             var json = File.ReadAllText(jsonPath);
+            Assert.Contains("\"StagingPath\": \"../Artifacts/Module/Staging\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"CsprojPath\": \"../Sources/TopLevel/TopLevel.csproj\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"BaselinePath\": \"../Build/diagnostics.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ConfigPath\": \"Build/project.build.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"NETProjectPath\": \"Sources/SampleModule.PowerShell/SampleModule.PowerShell.csproj\"", json, StringComparison.Ordinal);
             Assert.Contains("\"NETDevelopmentBinariesPath\": \"Sources/SampleModule.PowerShell/bin\"", json, StringComparison.Ordinal);
@@ -656,6 +756,11 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"Source\": \"Build/NOTICE.txt\"", json, StringComparison.Ordinal);
             Assert.Contains("\"TestsPath\": \"Tests\"", json, StringComparison.Ordinal);
             Assert.Contains("\"CertificatePFXPath\": \"Build/cert.pfx\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Path\": \"Module/Docs\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"PathReadme\": \"README.md\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"TestPath\": \"Tests\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"AboutTopicsSourcePath\": [", json, StringComparison.Ordinal);
+            Assert.Contains("\"Module/Docs/About\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ApiKeyFilePath\": \"Build/psgallery.key\"", json, StringComparison.Ordinal);
             Assert.Contains("\"FilePath\": \"Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
             Assert.Contains("\"WorkingDirectory\": \"Build\"", json, StringComparison.Ordinal);
@@ -665,15 +770,21 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.NotNull(jsonSpec);
 
             service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
+            Assert.Equal(buildStagingPath, jsonSpec!.Build.StagingPath);
+            Assert.Equal(buildCsprojPath, jsonSpec.Build.CsprojPath);
+            Assert.Equal(diagnosticsBaselinePath, jsonSpec.Diagnostics!.BaselinePath);
             var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(jsonSpec!.Segments[0]);
             var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(jsonSpec.Segments[1]);
             var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[2]);
             var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[3]);
             var test = Assert.IsType<ConfigurationTestSegment>(jsonSpec.Segments[4]);
             var options = Assert.IsType<ConfigurationOptionsSegment>(jsonSpec.Segments[5]);
-            var publish = Assert.IsType<ConfigurationPublishSegment>(jsonSpec.Segments[6]);
-            var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[7]);
-            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[8]);
+            var documentation = Assert.IsType<ConfigurationDocumentationSegment>(jsonSpec.Segments[6]);
+            var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(jsonSpec.Segments[7]);
+            var validation = Assert.IsType<ConfigurationValidationSegment>(jsonSpec.Segments[8]);
+            var publish = Assert.IsType<ConfigurationPublishSegment>(jsonSpec.Segments[9]);
+            var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[10]);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[11]);
             Assert.Equal(projectConfig, projectBuild.Configuration.ConfigPath);
             Assert.Equal(projectOptionsOutputPath, projectBuild.Configuration.Options!["OutputPath"]);
             Assert.Equal(projectOptionsPlanPath, projectBuild.Configuration.Options["PlanOutputPath"]);
@@ -695,6 +806,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
             Assert.Equal(testsPath, test.Configuration.TestsPath);
             Assert.Equal(signingPfxPath, options.Options.Signing!.CertificatePFXPath);
+            Assert.Equal(documentationPath, documentation.Configuration.Path);
+            Assert.Equal(documentationReadmePath, documentation.Configuration.PathReadme);
+            Assert.Equal(new[] { aboutTopicsPath }, buildDocumentation.Configuration.AboutTopicsSourcePath);
+            Assert.Equal(testsPath, validation.Settings.Tests.TestPath);
             Assert.Equal(publishKey, publish.Configuration.ApiKeyFilePath);
             Assert.Equal(actionFile, action.Configuration.FilePath);
             Assert.Equal(actionWorkingDirectory, action.Configuration.WorkingDirectory);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -64,6 +64,9 @@ public sealed class ModuleBuildPreparationServiceTests
             Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
             Directory.CreateDirectory(Path.Combine(root.FullName, "Build", "Templates"));
             Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Examples"));
+            var topLevelProject = Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(topLevelProject)!);
+            File.WriteAllText(topLevelProject, "<Project />");
             File.WriteAllText(Path.Combine(root.FullName, "Build", "header.ps1"), "Write-Output 'repo header'");
             File.WriteAllText(Path.Combine(scriptRoot.FullName, "header.ps1"), "Write-Output 'module header'");
             File.WriteAllText(Path.Combine(scriptRoot.FullName, "workspace-header.ps1"), "Write-Output 'workspace-qualified module header'");
@@ -367,6 +370,41 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Runspace.DefaultRunspace = previousRunspace;
                 try { outsideRoot.Delete(recursive: true); } catch { }
             }
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_from_module_build_script_prefers_module_local_csproj_when_it_exists()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-module-csproj-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            var moduleProject = Path.Combine(moduleRoot.FullName, "Sources", "Foo", "Foo.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(moduleProject)!);
+            File.WriteAllText(moduleProject, "<Project />");
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "SampleModule.psd1"), "@{ ModuleVersion = '1.0.0' }");
+
+            var prepared = new ModuleBuildPreparationService().Prepare(new ModuleBuildPreparationRequest
+            {
+                ParameterSetName = "Modern",
+                ModuleName = "SampleModule",
+                CurrentPath = root.FullName,
+                ScriptRoot = scriptRoot.FullName,
+                ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                CsprojPath = "Sources/Foo/Foo.csproj",
+                DotNetFramework = Array.Empty<string>(),
+                ExcludeDirectories = Array.Empty<string>(),
+                ExcludeFiles = Array.Empty<string>()
+            });
+
+            Assert.Equal(moduleProject, prepared.PipelineSpec.Build.CsprojPath);
         }
         finally
         {
@@ -1159,8 +1197,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"StagingPath\": \"Artifacts/Packages/Staging\"", json, StringComparison.Ordinal);
             Assert.Contains($"\"OutputPath\": \"{externalPackageOutputPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"PlanOutputPath\": \"Artifacts/Packages/plan.json\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"OutputPath\": \"Artifacts/ProjectBuild/options\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"PlanOutputPath\": \"Build/project-options-plan.json\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"OutputPath\": \"../Artifacts/ProjectBuild/options\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"PlanOutputPath\": \"project-options-plan.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"OutputPath\": \"Artifacts/PackageBuild/options\"", json, StringComparison.Ordinal);
             Assert.Contains($"\"PlanOutputPath\": \"{externalPackageOutputPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"PublishApiKeyFilePath\": \"{packagePublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -64,7 +64,8 @@ public sealed class ModuleBuildPreparationServiceTests
             Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
             Directory.CreateDirectory(Path.Combine(root.FullName, "Build", "Templates"));
             Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Examples"));
-            File.WriteAllText(Path.Combine(root.FullName, "Build", "header.ps1"), "Write-Output 'header'");
+            File.WriteAllText(Path.Combine(root.FullName, "Build", "header.ps1"), "Write-Output 'repo header'");
+            File.WriteAllText(Path.Combine(scriptRoot.FullName, "header.ps1"), "Write-Output 'module header'");
             File.WriteAllText(Path.Combine(root.FullName, "Build", "NOTICE.txt"), "notice");
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "Examples", "NOTICE.txt"), "module notice");
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "DbaClientX.psd1"), "@{ ModuleVersion = '1.0.0' }");
@@ -339,7 +340,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 
                 var fileBackedArtefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[13]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "FileBacked", "<TagModuleVersionWithPreRelease>"), fileBackedArtefact.Configuration.Path);
-                Assert.Contains("Write-Output", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
+                Assert.Contains("module header", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
+                Assert.DoesNotContain("repo header", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
 
                 var appleApp = Assert.IsType<ConfigurationAppleAppSegment>(prepared.PipelineSpec.Segments[14]);
                 Assert.Equal(".\\Tactra.xcodeproj", appleApp.Configuration.ProjectPath);
@@ -655,6 +657,72 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains($"\"ApiKeyFilePath\": \"{externalPublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"FilePath\": \"../Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
             Assert.Contains("\"WorkingDirectory\": \"../Build\"", json, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void WritePipelineSpecJson_preserves_external_documentation_and_portable_about_paths()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-docs-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var jsonPath = Path.Combine(root.FullName, ".powerforge", "powerforge.json");
+            var externalDocs = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalDocs-" + Guid.NewGuid().ToString("N"));
+            var externalReadme = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalReadme-" + Guid.NewGuid().ToString("N"), "README.md");
+            var projectAboutTopics = Path.Combine(root.FullName, "Help", "About");
+            var externalAboutTopics = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalAbout-" + Guid.NewGuid().ToString("N"));
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = root.FullName
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationDocumentationSegment
+                    {
+                        Configuration = new DocumentationConfiguration
+                        {
+                            Path = externalDocs,
+                            PathReadme = externalReadme
+                        }
+                    },
+                    new ConfigurationBuildDocumentationSegment
+                    {
+                        Configuration = new BuildDocumentationConfiguration
+                        {
+                            Enable = true,
+                            AboutTopicsSourcePath = new[] { projectAboutTopics, externalAboutTopics }
+                        }
+                    }
+                }
+            };
+
+            var service = new ModuleBuildPreparationService();
+            service.WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            Assert.Contains($"\"Path\": \"{externalDocs.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"\"PathReadme\": \"{externalReadme.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"Help/About\"", json, StringComparison.Ordinal);
+            Assert.Contains(externalAboutTopics.Replace('\\', '/'), json, StringComparison.OrdinalIgnoreCase);
+
+            var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
+            Assert.NotNull(jsonSpec);
+
+            service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
+            var documentation = Assert.IsType<ConfigurationDocumentationSegment>(jsonSpec!.Segments[0]);
+            var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(jsonSpec.Segments[1]);
+            Assert.Equal(externalDocs, documentation.Configuration.Path);
+            Assert.Equal(externalReadme, documentation.Configuration.PathReadme);
+            Assert.Equal(projectAboutTopics, buildDocumentation.Configuration.AboutTopicsSourcePath[0]);
+            Assert.Equal(externalAboutTopics, buildDocumentation.Configuration.AboutTopicsSourcePath[1]);
         }
         finally
         {
@@ -1069,7 +1137,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(signingPfxPath, options.Options.Signing!.CertificatePFXPath);
             Assert.Equal(documentationPath, documentation.Configuration.Path);
             Assert.Equal(documentationReadmePath, documentation.Configuration.PathReadme);
-            Assert.Equal(new[] { aboutTopicsPath }, buildDocumentation.Configuration.AboutTopicsSourcePath);
+            Assert.Equal(Path.Combine(root.FullName, "Help", "About"), Path.GetFullPath(buildDocumentation.Configuration.AboutTopicsSourcePath[0]));
             Assert.Equal(testsPath, validation.Settings.Tests.TestPath);
             Assert.Equal(publishKey, publish.Configuration.ApiKeyFilePath);
             Assert.Equal(actionFile, action.Configuration.FilePath);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -111,6 +111,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             [PowerForge.ArtefactCopyMapping]@{
                 Source = 'Build/NOTICE.txt'
                 Destination = 'RepoNotice.txt'
+            },
+            [PowerForge.ArtefactCopyMapping]@{
+                Source = 'Artefacts/ProjectBuild/packages/Foo.nupkg'
+                Destination = 'Packages/Foo.nupkg'
             }
         )
     }
@@ -257,6 +261,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "NOTICE.txt"), artefact.Configuration.FilesOutput[1].Source);
                 Assert.Equal("RepoNotice.txt", artefact.Configuration.FilesOutput[1].Destination);
+                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "packages", "Foo.nupkg"), artefact.Configuration.FilesOutput[2].Source);
+                Assert.Equal("Packages/Foo.nupkg", artefact.Configuration.FilesOutput[2].Destination);
 
                 var artefactWithRelativeLayout = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[3]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Unpacked"), artefactWithRelativeLayout.Configuration.Path);
@@ -540,6 +546,49 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     }
 
     [Fact]
+    public void WritePipelineSpecJson_preserves_tokenized_artefact_paths()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-tokens-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var jsonPath = Path.Combine(root.FullName, ".powerforge", "powerforge.json");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = root.FullName
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>")
+                        }
+                    }
+                }
+            };
+
+            new ModuleBuildPreparationService().WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
+            Assert.NotNull(jsonSpec);
+
+            var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec!.Segments[0]);
+            Assert.Equal("Module/Artefacts/Packed/<TagModuleVersionWithPreRelease>", artefact.Configuration.Path);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void WritePipelineSpecJson_keeps_apple_and_xcode_paths_relative_to_project_root()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-apple-" + Guid.NewGuid().ToString("N")));
@@ -614,6 +663,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var buildCsprojPath = Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj");
             var binaryConflictSearchRoot = Path.Combine(root.FullName, "Modules");
             var installRoot = Path.Combine(root.FullName, "Artifacts", "Modules");
+            var externalInstallRoot = Path.Combine(Path.GetTempPath(), "PowerShell", "Modules");
             var diagnosticsBaselinePath = Path.Combine(root.FullName, "Build", "diagnostics.json");
             var netProject = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "SampleModule.PowerShell.csproj");
             var developmentBinaries = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "bin");
@@ -649,7 +699,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 },
                 Install = new ModulePipelineInstallOptions
                 {
-                    Roots = new[] { installRoot }
+                    Roots = new[] { installRoot, externalInstallRoot }
                 },
                 Diagnostics = new ModulePipelineDiagnosticsOptions
                 {
@@ -822,7 +872,6 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"PublishApiKeyFilePath\": \"Build/nuget.key\"", json, StringComparison.Ordinal);
             Assert.Contains("\"NugetCredentialSecretFilePath\": \"Build/nuget.secret\"", json, StringComparison.Ordinal);
             Assert.Contains("\"GitHubAccessTokenFilePath\": \"Build/github.token\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"Path\": \"Module/Artefacts/Packed\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Path\": \"Module/Artefacts/Packed/RequiredModules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ModulesPath\": \"Module/Artefacts/Packed/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/Templates\"", json, StringComparison.Ordinal);
@@ -841,12 +890,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 
             var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
             Assert.NotNull(jsonSpec);
+            Assert.Contains(jsonSpec!.Install.Roots!, root => string.Equals(root, externalInstallRoot.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase));
 
-            service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
+            service.ResolvePipelineSpecPaths(jsonSpec, jsonPath);
             Assert.Equal(buildStagingPath, jsonSpec!.Build.StagingPath);
             Assert.Equal(buildCsprojPath, jsonSpec.Build.CsprojPath);
             Assert.Equal(new[] { binaryConflictSearchRoot }, jsonSpec.Build.BinaryConflictSearchRoots);
-            Assert.Equal(new[] { installRoot }, jsonSpec.Install.Roots);
+            Assert.Equal(new[] { installRoot, externalInstallRoot }, jsonSpec.Install.Roots);
             Assert.Equal(diagnosticsBaselinePath, jsonSpec.Diagnostics!.BaselinePath);
             Assert.Equal(new[] { binaryConflictSearchRoot }, jsonSpec.Diagnostics.BinaryConflictSearchRoots);
             var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(jsonSpec!.Segments[0]);
@@ -1253,7 +1303,9 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 ParameterSetName = "Config",
                 ConfigPath = configPath,
                 CurrentPath = root.FullName,
-                ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path))
+                ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                JsonOnly = true,
+                JsonPath = "out.json"
             });
 
             Assert.Equal("PowerTierBridge", prepared.ModuleName);
@@ -1266,6 +1318,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(Path.Combine(root.FullName, "TierBridge.PowerShell", "TierBridge.PowerShell.csproj"), prepared.PipelineSpec.Build.CsprojPath);
             Assert.Equal(Path.Combine(root.FullName, "Sources", "Demo", "bin"), prepared.PipelineSpec.Build.DevelopmentBinariesPath);
             Assert.Equal(Path.Combine(configDir.FullName, ".powerforge", "module-baseline.json"), prepared.PipelineSpec.Diagnostics.BaselinePath);
+            Assert.Equal(Path.Combine(root.FullName, "out.json"), prepared.JsonOutputPath);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -1194,6 +1194,51 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     }
 
     [Fact]
+    public void WritePipelineSpecJson_resolves_relative_diagnostics_baseline_from_project_root()
+    {
+        var parent = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-diagnostics-" + Guid.NewGuid().ToString("N")));
+        var previousCurrentDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(parent.FullName, "SampleModule"));
+            var jsonPath = Path.Combine(moduleRoot.FullName, ".powerforge", "powerforge.json");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = moduleRoot.FullName
+                },
+                Diagnostics = new ModulePipelineDiagnosticsOptions
+                {
+                    BaselinePath = "Build/diagnostics.json"
+                }
+            };
+
+            Directory.SetCurrentDirectory(parent.FullName);
+
+            var service = new ModuleBuildPreparationService();
+            service.WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            Assert.Contains("\"BaselinePath\": \"../Build/diagnostics.json\"", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"BaselinePath\": \"../../Build/diagnostics.json\"", json, StringComparison.Ordinal);
+
+            var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
+            Assert.NotNull(jsonSpec);
+
+            service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
+            Assert.Equal(Path.Combine(moduleRoot.FullName, "Build", "diagnostics.json"), jsonSpec!.Diagnostics!.BaselinePath);
+        }
+        finally
+        {
+            try { Directory.SetCurrentDirectory(previousCurrentDirectory); } catch { }
+            try { parent.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void WritePipelineSpecJson_keeps_package_build_paths_relative_to_project_root()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-packages-" + Guid.NewGuid().ToString("N")));
@@ -1520,6 +1565,68 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(actionFile, action.Configuration.FilePath);
             Assert.Equal(actionWorkingDirectory, action.Configuration.WorkingDirectory);
             Assert.Equal(releaseRoot, release.Configuration.StageRoot);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void WritePipelineSpecJson_keeps_tokenized_artefact_layout_paths_output_relative()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-artefact-token-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var jsonPath = Path.Combine(root.FullName, ".powerforge", "powerforge.json");
+            var artefactRoot = Path.Combine(root.FullName, "Artefacts", "Unpacked");
+            var requiredModulesPath = Path.Combine(artefactRoot, "<TagModuleVersionWithPreRelease>", "RequiredModules");
+            var modulesPath = Path.Combine(artefactRoot, "<TagModuleVersionWithPreRelease>", "Modules");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = root.FullName
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Unpacked,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = artefactRoot,
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                Path = requiredModulesPath,
+                                ModulesPath = modulesPath
+                            }
+                        }
+                    }
+                }
+            };
+
+            var service = new ModuleBuildPreparationService();
+            service.WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            Assert.Contains("\"Path\": \"Artefacts/Unpacked\"", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"Path\": \"Artefacts/Unpacked/<TagModuleVersionWithPreRelease>/RequiredModules\"", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"ModulesPath\": \"Artefacts/Unpacked/<TagModuleVersionWithPreRelease>/Modules\"", json, StringComparison.Ordinal);
+
+            var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
+            Assert.NotNull(jsonSpec);
+            var exportedArtefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec!.Segments[0]);
+            Assert.Equal("<TagModuleVersionWithPreRelease>/RequiredModules", exportedArtefact.Configuration.RequiredModules.Path);
+            Assert.Equal("<TagModuleVersionWithPreRelease>/Modules", exportedArtefact.Configuration.RequiredModules.ModulesPath);
+
+            service.ResolvePipelineSpecPaths(jsonSpec, jsonPath);
+            var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[0]);
+            Assert.Equal(artefactRoot, artefact.Configuration.Path);
+            Assert.Equal("<TagModuleVersionWithPreRelease>/RequiredModules", artefact.Configuration.RequiredModules.Path);
+            Assert.Equal("<TagModuleVersionWithPreRelease>/Modules", artefact.Configuration.RequiredModules.ModulesPath);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -217,7 +217,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     EnableSpecified = $true
     Enable = $true
     Path = 'Module/Artefacts/WorkspaceFileBacked/<TagModuleVersionWithPreRelease>'
-    PreScriptMergePath = 'Module/Build/workspace-header.ps1'
+    PreScriptMergePath = '.\Module\Build\workspace-header.ps1'
 })
 [PowerForge.ConfigurationAppleAppSegment]@{
     Configuration = [PowerForge.AppleAppConfiguration]@{
@@ -889,9 +889,11 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var installRoot = Path.Combine(root.FullName, "Artifacts", "Modules");
             var externalInstallRoot = Path.Combine(Path.GetTempPath(), "PowerShell", "Modules");
             var diagnosticsBaselinePath = Path.Combine(root.FullName, "Build", "diagnostics.json");
-            var netProject = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "SampleModule.PowerShell.csproj");
             var developmentBinaries = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "bin");
+            var externalNetProject = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalProject-" + Guid.NewGuid().ToString("N"), "External.PowerShell.csproj");
+            var externalDevelopmentBinaries = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalBinaries-" + Guid.NewGuid().ToString("N"));
             var packageRoot = Path.Combine(root.FullName, "Sources");
+            var externalPackageOutputPath = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalPackageOutput-" + Guid.NewGuid().ToString("N"));
             var stagingRoot = Path.Combine(root.FullName, "Artifacts", "Packages", "Staging");
             var packagePublishKey = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "nuget.key");
             var packageCredentialSecret = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "nuget.secret");
@@ -900,10 +902,12 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var artefactRoot = Path.Combine(root.FullName, "Module", "Artefacts", "Packed");
             var artefactRequiredModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules");
             var artefactModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules");
+            var externalArtefactRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalArtefacts-" + Guid.NewGuid().ToString("N"));
             var publishKey = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "psgallery.key");
             var actionFile = Path.Combine(Path.GetTempPath(), "PowerForge", "Actions-" + Guid.NewGuid().ToString("N"), "Test-ReleaseReady.ps1");
             var actionWorkingDirectory = Path.Combine(Path.GetTempPath(), "PowerForge", "Actions-" + Guid.NewGuid().ToString("N"));
-            var testsPath = Path.Combine(root.FullName, "Tests");
+            var externalTestsPath = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalTests-" + Guid.NewGuid().ToString("N"));
+            var externalValidationTestsPath = Path.Combine(Path.GetTempPath(), "PowerForge", "ExternalValidationTests-" + Guid.NewGuid().ToString("N"));
             var signingPfxPath = Path.Combine(Path.GetTempPath(), "PowerForge", "Secrets-" + Guid.NewGuid().ToString("N"), "cert.pfx");
             var documentationPath = Path.Combine(root.FullName, "Module", "Docs");
             var documentationReadmePath = Path.Combine(root.FullName, "README.md");
@@ -914,7 +918,6 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var projectOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "ProjectBuild", "options");
             var projectOptionsPlanPath = Path.Combine(root.FullName, "Build", "project-options-plan.json");
             var packageOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "PackageBuild", "options");
-            var packageOptionsPlanPath = Path.Combine(root.FullName, "Build", "package-options-plan.json");
             var packageOptionsCredentialPath = Path.Combine(Path.GetTempPath(), "PowerForge", "OptionSecrets-" + Guid.NewGuid().ToString("N"), "nuget-option.key");
             var spec = new ModulePipelineSpec
             {
@@ -954,7 +957,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                     {
                         BuildLibraries = new BuildLibrariesConfiguration
                         {
-                            NETProjectPath = netProject,
+                            NETProjectPath = externalNetProject,
+                            DevelopmentBinariesPath = externalDevelopmentBinaries,
                             NETDevelopmentBinariesPath = developmentBinaries
                         }
                     },
@@ -964,7 +968,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                         {
                             RootPath = packageRoot,
                             StagingPath = stagingRoot,
-                            OutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "NuGet"),
+                            OutputPath = externalPackageOutputPath,
                             PlanOutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "plan.json"),
                             PublishApiKeyFilePath = packagePublishKey,
                             NugetCredentialSecretFilePath = packageCredentialSecret,
@@ -972,7 +976,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             Options = new Dictionary<string, object?>
                             {
                                 ["OutputPath"] = packageOptionsOutputPath,
-                                ["PlanOutputPath"] = packageOptionsPlanPath,
+                                ["PlanOutputPath"] = externalPackageOutputPath,
                                 ["PublishApiKeyFilePath"] = packageOptionsCredentialPath
                             }
                         }
@@ -1011,11 +1015,19 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             }
                         }
                     },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = externalArtefactRoot
+                        }
+                    },
                     new ConfigurationTestSegment
                     {
                         Configuration = new TestConfiguration
                         {
-                            TestsPath = testsPath
+                            TestsPath = externalTestsPath
                         }
                     },
                     new ConfigurationOptionsSegment
@@ -1052,7 +1064,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                             Tests = new TestSuiteValidationSettings
                             {
                                 Enable = true,
-                                TestPath = testsPath
+                                TestPath = externalValidationTestsPath
                             }
                         }
                     },
@@ -1096,29 +1108,32 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"Artifacts/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"BaselinePath\": \"../Build/diagnostics.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ConfigPath\": \"Build/project.build.json\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"NETProjectPath\": \"Sources/SampleModule.PowerShell/SampleModule.PowerShell.csproj\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"NETProjectPath\": \"{externalNetProject.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"\"DevelopmentBinariesPath\": \"{externalDevelopmentBinaries.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"NETDevelopmentBinariesPath\": \"Sources/SampleModule.PowerShell/bin\"", json, StringComparison.Ordinal);
             Assert.Contains("\"RootPath\": \"Sources\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StagingPath\": \"Artifacts/Packages/Staging\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"OutputPath\": \"{externalPackageOutputPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"PlanOutputPath\": \"Artifacts/Packages/plan.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"OutputPath\": \"Artifacts/ProjectBuild/options\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PlanOutputPath\": \"Build/project-options-plan.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"OutputPath\": \"Artifacts/PackageBuild/options\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"PlanOutputPath\": \"Build/package-options-plan.json\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"PlanOutputPath\": \"{externalPackageOutputPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"PublishApiKeyFilePath\": \"{packagePublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"NugetCredentialSecretFilePath\": \"{packageCredentialSecret.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"GitHubAccessTokenFilePath\": \"{packageGitHubToken.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"PublishApiKeyFilePath\": \"{packageOptionsCredentialPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"Path\": \"Module/Artefacts/Packed/RequiredModules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ModulesPath\": \"Module/Artefacts/Packed/Modules\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"Path\": \"{externalArtefactRoot.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"Source\": \"Build/Templates\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/NOTICE.txt\"", json, StringComparison.Ordinal);
             Assert.Contains($"\"Source\": \"{externalCopyFileSource.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("\"TestsPath\": \"Tests\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"TestsPath\": \"{externalTestsPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains($"\"CertificatePFXPath\": \"{signingPfxPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"Path\": \"Module/Docs\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PathReadme\": \"README.md\"", json, StringComparison.Ordinal);
-            Assert.Contains("\"TestPath\": \"Tests\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"TestPath\": \"{externalValidationTestsPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("\"AboutTopicsSourcePath\": [", json, StringComparison.Ordinal);
             Assert.Contains("\"Help/About\"", json, StringComparison.Ordinal);
             Assert.Contains($"\"ApiKeyFilePath\": \"{publishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
@@ -1141,26 +1156,29 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(jsonSpec.Segments[1]);
             var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[2]);
             var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[3]);
-            var test = Assert.IsType<ConfigurationTestSegment>(jsonSpec.Segments[4]);
-            var options = Assert.IsType<ConfigurationOptionsSegment>(jsonSpec.Segments[5]);
-            var documentation = Assert.IsType<ConfigurationDocumentationSegment>(jsonSpec.Segments[6]);
-            var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(jsonSpec.Segments[7]);
-            var validation = Assert.IsType<ConfigurationValidationSegment>(jsonSpec.Segments[8]);
-            var publish = Assert.IsType<ConfigurationPublishSegment>(jsonSpec.Segments[9]);
-            var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[10]);
-            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[11]);
+            var externalArtefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[4]);
+            var test = Assert.IsType<ConfigurationTestSegment>(jsonSpec.Segments[5]);
+            var options = Assert.IsType<ConfigurationOptionsSegment>(jsonSpec.Segments[6]);
+            var documentation = Assert.IsType<ConfigurationDocumentationSegment>(jsonSpec.Segments[7]);
+            var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(jsonSpec.Segments[8]);
+            var validation = Assert.IsType<ConfigurationValidationSegment>(jsonSpec.Segments[9]);
+            var publish = Assert.IsType<ConfigurationPublishSegment>(jsonSpec.Segments[10]);
+            var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[11]);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[12]);
             Assert.Equal(projectConfig, projectBuild.Configuration.ConfigPath);
             Assert.Equal(projectOptionsOutputPath, projectBuild.Configuration.Options!["OutputPath"]);
             Assert.Equal(projectOptionsPlanPath, projectBuild.Configuration.Options["PlanOutputPath"]);
-            Assert.Equal(netProject, buildLibraries.BuildLibraries.NETProjectPath);
+            Assert.Equal(externalNetProject, buildLibraries.BuildLibraries.NETProjectPath);
+            Assert.Equal(externalDevelopmentBinaries, buildLibraries.BuildLibraries.DevelopmentBinariesPath);
             Assert.Equal(developmentBinaries, buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
             Assert.Equal(packageRoot, packageBuild.Configuration.RootPath);
             Assert.Equal(stagingRoot, packageBuild.Configuration.StagingPath);
+            Assert.Equal(externalPackageOutputPath, packageBuild.Configuration.OutputPath);
             Assert.Equal(packagePublishKey, packageBuild.Configuration.PublishApiKeyFilePath);
             Assert.Equal(packageCredentialSecret, packageBuild.Configuration.NugetCredentialSecretFilePath);
             Assert.Equal(packageGitHubToken, packageBuild.Configuration.GitHubAccessTokenFilePath);
             Assert.Equal(packageOptionsOutputPath, packageBuild.Configuration.Options!["OutputPath"]);
-            Assert.Equal(packageOptionsPlanPath, packageBuild.Configuration.Options["PlanOutputPath"]);
+            Assert.Equal(externalPackageOutputPath.Replace('\\', '/'), packageBuild.Configuration.Options["PlanOutputPath"]);
             Assert.Equal(packageOptionsCredentialPath.Replace('\\', '/'), packageBuild.Configuration.Options["PublishApiKeyFilePath"]);
             Assert.Equal(artefactRoot, artefact.Configuration.Path);
             Assert.Equal(artefactRequiredModules, artefact.Configuration.RequiredModules.Path);
@@ -1171,12 +1189,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
             Assert.Equal(externalCopyFileSource.Replace('\\', '/'), artefact.Configuration.FilesOutput[1].Source);
             Assert.Equal("ExternalNotice.txt", artefact.Configuration.FilesOutput[1].Destination);
-            Assert.Equal(testsPath, test.Configuration.TestsPath);
+            Assert.Equal(externalArtefactRoot, externalArtefact.Configuration.Path);
+            Assert.Equal(externalTestsPath, test.Configuration.TestsPath);
             Assert.Equal(signingPfxPath, options.Options.Signing!.CertificatePFXPath);
             Assert.Equal(documentationPath, documentation.Configuration.Path);
             Assert.Equal(documentationReadmePath, documentation.Configuration.PathReadme);
             Assert.Equal("Help/About", buildDocumentation.Configuration.AboutTopicsSourcePath[0]);
-            Assert.Equal(testsPath, validation.Settings.Tests.TestPath);
+            Assert.Equal(externalValidationTestsPath, validation.Settings.Tests.TestPath);
             Assert.Equal(publishKey, publish.Configuration.ApiKeyFilePath);
             Assert.Equal(actionFile, action.Configuration.FilePath);
             Assert.Equal(actionWorkingDirectory, action.Configuration.WorkingDirectory);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -295,13 +295,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Build", "LICENSE"), artefact.Configuration.DirectoryOutput![0].Source);
                 Assert.Equal("LICENSE", artefact.Configuration.DirectoryOutput[0].Destination);
-                Assert.Equal("Build/Templates", artefact.Configuration.DirectoryOutput[1].Source);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "Templates"), artefact.Configuration.DirectoryOutput[1].Source);
                 Assert.Equal("Templates", artefact.Configuration.DirectoryOutput[1].Destination);
                 Assert.Equal("Docs/Help", artefact.Configuration.DirectoryOutput[2].Source);
                 Assert.Equal("Help", artefact.Configuration.DirectoryOutput[2].Destination);
                 Assert.Equal("Examples/NOTICE.txt", artefact.Configuration.FilesOutput![0].Source);
                 Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
-                Assert.Equal("Build/NOTICE.txt", artefact.Configuration.FilesOutput[1].Source);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "NOTICE.txt"), artefact.Configuration.FilesOutput[1].Source);
                 Assert.Equal("RepoNotice.txt", artefact.Configuration.FilesOutput[1].Destination);
                 Assert.Equal("Artefacts/ProjectBuild/packages/Foo.nupkg", artefact.Configuration.FilesOutput[2].Source);
                 Assert.Equal("Packages/Foo.nupkg", artefact.Configuration.FilesOutput[2].Destination);
@@ -561,6 +561,59 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 var action = Assert.IsType<ConfigurationActionSegment>(prepared.PipelineSpec.Segments[3]);
                 Assert.Equal(Path.Combine(moduleRoot.FullName, "Build", "Test-DocsShape.ps1"), action.Configuration.FilePath);
                 Assert.Equal(Path.Combine(moduleRoot.FullName, "Build"), action.Configuration.WorkingDirectory);
+            }
+            finally
+            {
+                Runspace.DefaultRunspace = previousRunspace;
+            }
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_restores_nonfilesystem_runspace_location_after_collecting_settings()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-runspace-location-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "SampleModule"));
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "SampleModule.psd1"), "@{ ModuleVersion = '1.0.0' }");
+
+            var settings = ScriptBlock.Create("""
+[PowerForge.ConfigurationTestSegment]@{
+    Configuration = [PowerForge.TestConfiguration]@{
+        TestsPath = 'Tests'
+    }
+}
+""");
+
+            using var runspace = RunspaceFactory.CreateRunspace();
+            runspace.Open();
+            var previousRunspace = Runspace.DefaultRunspace;
+            Runspace.DefaultRunspace = runspace;
+            try
+            {
+                runspace.SessionStateProxy.Path.SetLocation("Env:");
+                var originalLocation = runspace.SessionStateProxy.Path.CurrentLocation.Path;
+
+                _ = new ModuleBuildPreparationService().Prepare(new ModuleBuildPreparationRequest
+                {
+                    ParameterSetName = "Modern",
+                    ModuleName = "SampleModule",
+                    InputPath = root.FullName,
+                    Settings = settings,
+                    CurrentPath = root.FullName,
+                    ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                    DotNetFramework = Array.Empty<string>(),
+                    ExcludeDirectories = Array.Empty<string>(),
+                    ExcludeFiles = Array.Empty<string>()
+                });
+
+                Assert.Equal(originalLocation, runspace.SessionStateProxy.Path.CurrentLocation.Path);
             }
             finally
             {
@@ -893,6 +946,69 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(externalReadme, documentation.Configuration.PathReadme);
             Assert.Equal("Help/About", buildDocumentation.Configuration.AboutTopicsSourcePath[0]);
             Assert.Equal(externalAboutTopics, buildDocumentation.Configuration.AboutTopicsSourcePath[1]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void WritePipelineSpecJson_preserves_workspace_sibling_documentation_paths()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-workspace-docs-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            MarkRepositoryRoot(root.FullName);
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var buildRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            File.WriteAllText(Path.Combine(buildRoot.FullName, "Build-Module.ps1"), string.Empty);
+            var docsPath = Path.Combine(root.FullName, "Docs");
+            var aboutTopicsPath = Path.Combine(root.FullName, "Help", "About");
+            var jsonPath = Path.Combine(root.FullName, "Build", "powerforge.json");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = moduleRoot.FullName
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationDocumentationSegment
+                    {
+                        Configuration = new DocumentationConfiguration
+                        {
+                            Path = docsPath
+                        }
+                    },
+                    new ConfigurationBuildDocumentationSegment
+                    {
+                        Configuration = new BuildDocumentationConfiguration
+                        {
+                            Enable = true,
+                            AboutTopicsSourcePath = new[] { aboutTopicsPath }
+                        }
+                    }
+                }
+            };
+
+            var service = new ModuleBuildPreparationService();
+            service.WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            Assert.Contains($"\"Path\": \"{docsPath.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(aboutTopicsPath.Replace('\\', '/'), json, StringComparison.OrdinalIgnoreCase);
+
+            var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
+            Assert.NotNull(jsonSpec);
+
+            service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
+            var documentation = Assert.IsType<ConfigurationDocumentationSegment>(jsonSpec!.Segments[0]);
+            var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(jsonSpec.Segments[1]);
+            Assert.Equal(docsPath, documentation.Configuration.Path);
+            Assert.Equal(aboutTopicsPath, buildDocumentation.Configuration.AboutTopicsSourcePath[0]);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -78,13 +78,14 @@ $packageOptions['OutputPath'] = 'Artefacts/PackageBuild/options'
 $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationBuildLibrariesSegment]@{
     BuildLibraries = [PowerForge.BuildLibrariesConfiguration]@{
-        NETProjectPath = 'DbaClientX.PowerShell/DbaClientX.PowerShell.csproj'
-        NETDevelopmentBinariesPath = 'DbaClientX.PowerShell/bin'
+        NETProjectPath = '../DbaClientX.PowerShell/DbaClientX.PowerShell.csproj'
+        DevelopmentBinariesPath = 'Sources/Local/bin'
+        NETDevelopmentBinariesPath = '../DbaClientX.PowerShell/bin'
     }
 }
 [PowerForge.ConfigurationProjectBuildSegment]@{
     Configuration = [PowerForge.ProjectBuildConfigurationReference]@{
-        ConfigPath = 'Build/project.build.json'
+        ConfigPath = '../Build/project.build.json'
         BuildBeforeModule = $true
         Options = $projectOptions
     }
@@ -267,11 +268,12 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Build", "powerforge.json"), prepared.JsonOutputPath);
 
                 var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
-                Assert.Equal(Path.Combine(root.FullName, "DbaClientX.PowerShell", "DbaClientX.PowerShell.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
-                Assert.Equal(Path.Combine(root.FullName, "DbaClientX.PowerShell", "bin"), buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
+                Assert.Equal("../DbaClientX.PowerShell/DbaClientX.PowerShell.csproj", buildLibraries.BuildLibraries.NETProjectPath);
+                Assert.Equal("Sources/Local/bin", buildLibraries.BuildLibraries.DevelopmentBinariesPath);
+                Assert.Equal("../DbaClientX.PowerShell/bin", buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
 
                 var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(prepared.PipelineSpec.Segments[1]);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "project.build.json"), projectBuild.Configuration.ConfigPath);
+                Assert.Equal("../Build/project.build.json", projectBuild.Configuration.ConfigPath);
                 Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "options"), projectBuild.Configuration.Options!["OutputPath"]);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "project-options-plan.json"), projectBuild.Configuration.Options["PlanOutputPath"]);
 
@@ -572,6 +574,87 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"StagingPath\": \"../staging\"", json, StringComparison.Ordinal);
             Assert.Contains("\"CsprojPath\": \"../src/SampleModule.csproj\"", json, StringComparison.Ordinal);
             Assert.Contains("\"BaselinePath\": \"baseline.json\"", json, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void WritePipelineSpecJson_keeps_workspace_paths_portable_from_module_root()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-json-workspace-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var jsonPath = Path.Combine(root.FullName, "Build", "powerforge.json");
+            var externalRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "External-" + Guid.NewGuid().ToString("N"));
+            var externalPublishKey = Path.Combine(externalRoot, "psgallery.key");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = moduleRoot.FullName,
+                    BinaryConflictSearchRoots = new[] { Path.Combine(root.FullName, "Modules") }
+                },
+                Install = new ModulePipelineInstallOptions
+                {
+                    Roots = new[] { Path.Combine(root.FullName, "Artefacts", "Modules") }
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationOptionsSegment
+                    {
+                        Options = new ConfigurationOptions
+                        {
+                            Signing = new SigningOptionsConfiguration
+                            {
+                                CertificatePFXPath = Path.Combine(root.FullName, "Build", "cert.pfx")
+                            }
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Destination = PublishDestination.PowerShellGallery,
+                            ApiKeyFilePath = Path.Combine(root.FullName, "Build", "psgallery.key")
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Destination = PublishDestination.PowerShellGallery,
+                            ApiKeyFilePath = externalPublishKey
+                        }
+                    },
+                    new ConfigurationActionSegment
+                    {
+                        Configuration = new ModulePipelineActionConfiguration
+                        {
+                            FilePath = Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1"),
+                            WorkingDirectory = Path.Combine(root.FullName, "Build")
+                        }
+                    }
+                }
+            };
+
+            new ModuleBuildPreparationService().WritePipelineSpecJson(spec, jsonPath);
+
+            var json = File.ReadAllText(jsonPath);
+            Assert.Contains("\"SourcePath\": \"../Module\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"../Modules\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Roots\": [", json, StringComparison.Ordinal);
+            Assert.Contains("\"../Artefacts/Modules\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"CertificatePFXPath\": \"../Build/cert.pfx\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"ApiKeyFilePath\": \"../Build/psgallery.key\"", json, StringComparison.Ordinal);
+            Assert.Contains($"\"ApiKeyFilePath\": \"{externalPublishKey.Replace('\\', '/')}\"", json, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"FilePath\": \"../Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"WorkingDirectory\": \"../Build\"", json, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -80,6 +80,28 @@ public sealed class ModuleBuildPreparationServiceTests
             Path = 'Module/Artefacts/Packed/RequiredModules'
             ModulesPath = 'Module/Artefacts/Packed/Modules'
         }
+        DirectoryOutput = [PowerForge.ArtefactCopyMapping[]]@(
+            [PowerForge.ArtefactCopyMapping]@{
+                Source = 'Build/LICENSE'
+                Destination = 'LICENSE'
+            }
+        )
+        FilesOutput = [PowerForge.ArtefactCopyMapping[]]@(
+            [PowerForge.ArtefactCopyMapping]@{
+                Source = 'Build/NOTICE.txt'
+                Destination = 'NOTICE.txt'
+            }
+        )
+    }
+}
+[PowerForge.ConfigurationArtefactSegment]@{
+    ArtefactType = [PowerForge.ArtefactType]::Unpacked
+    Configuration = [PowerForge.ArtefactConfiguration]@{
+        Path = 'Module/Artefacts/Unpacked'
+        RequiredModules = [PowerForge.ArtefactRequiredModulesConfiguration]@{
+            Path = 'Modules'
+            ModulesPath = 'Payload/MainModules'
+        }
     }
 }
 [PowerForge.ConfigurationPackageBuildSegment]@{
@@ -89,6 +111,18 @@ public sealed class ModuleBuildPreparationServiceTests
         PublishApiKeyFilePath = 'Build/nuget.key'
         NugetCredentialSecretFilePath = 'Build/nuget.secret'
         GitHubAccessTokenFilePath = 'Build/github.token'
+    }
+}
+[PowerForge.ConfigurationPublishSegment]@{
+    Configuration = [PowerForge.PublishConfiguration]@{
+        Destination = [PowerForge.PublishDestination]::PowerShellGallery
+        ApiKeyFilePath = 'Build/psgallery.key'
+    }
+}
+[PowerForge.ConfigurationActionSegment]@{
+    Configuration = [PowerForge.ModulePipelineActionConfiguration]@{
+        FilePath = 'Build/Test-ReleaseReady.ps1'
+        WorkingDirectory = 'Build'
     }
 }
 [PowerForge.ConfigurationReleaseSegment]@{
@@ -131,8 +165,17 @@ public sealed class ModuleBuildPreparationServiceTests
 
                 var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[2]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "LICENSE"), artefact.Configuration.DirectoryOutput![0].Source);
+                Assert.Equal("LICENSE", artefact.Configuration.DirectoryOutput[0].Destination);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "NOTICE.txt"), artefact.Configuration.FilesOutput![0].Source);
+                Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
 
-                var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(prepared.PipelineSpec.Segments[3]);
+                var artefactWithRelativeLayout = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[3]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Unpacked"), artefactWithRelativeLayout.Configuration.Path);
+                Assert.Equal("Modules", artefactWithRelativeLayout.Configuration.RequiredModules.Path);
+                Assert.Equal("Payload/MainModules", artefactWithRelativeLayout.Configuration.RequiredModules.ModulesPath);
+
+                var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(prepared.PipelineSpec.Segments[4]);
                 Assert.Equal(Path.Combine(root.FullName, "Sources"), packageBuild.Configuration.RootPath);
                 Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "packages"), packageBuild.Configuration.OutputPath);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.key"), packageBuild.Configuration.PublishApiKeyFilePath);
@@ -142,7 +185,14 @@ public sealed class ModuleBuildPreparationServiceTests
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules"), artefact.Configuration.RequiredModules.Path);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules"), artefact.Configuration.RequiredModules.ModulesPath);
 
-                var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[4]);
+                var publish = Assert.IsType<ConfigurationPublishSegment>(prepared.PipelineSpec.Segments[5]);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "psgallery.key"), publish.Configuration.ApiKeyFilePath);
+
+                var action = Assert.IsType<ConfigurationActionSegment>(prepared.PipelineSpec.Segments[6]);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1"), action.Configuration.FilePath);
+                Assert.Equal(Path.Combine(root.FullName, "Build"), action.Configuration.WorkingDirectory);
+
+                var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[7]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "UploadReady"), release.Configuration.StageRoot);
             }
             finally
@@ -420,6 +470,11 @@ public sealed class ModuleBuildPreparationServiceTests
             var artefactRoot = Path.Combine(root.FullName, "Module", "Artefacts", "Packed");
             var artefactRequiredModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules");
             var artefactModules = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules");
+            var publishKey = Path.Combine(root.FullName, "Build", "psgallery.key");
+            var actionFile = Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1");
+            var actionWorkingDirectory = Path.Combine(root.FullName, "Build");
+            var copyDirectorySource = Path.Combine(root.FullName, "Build", "Templates");
+            var copyFileSource = Path.Combine(root.FullName, "Build", "NOTICE.txt");
             var spec = new ModulePipelineSpec
             {
                 Build = new ModuleBuildSpec
@@ -468,7 +523,39 @@ public sealed class ModuleBuildPreparationServiceTests
                             {
                                 Path = artefactRequiredModules,
                                 ModulesPath = artefactModules
+                            },
+                            DirectoryOutput = new[]
+                            {
+                                new ArtefactCopyMapping
+                                {
+                                    Source = copyDirectorySource,
+                                    Destination = "Templates"
+                                }
+                            },
+                            FilesOutput = new[]
+                            {
+                                new ArtefactCopyMapping
+                                {
+                                    Source = copyFileSource,
+                                    Destination = "NOTICE.txt"
+                                }
                             }
+                        }
+                    },
+                    new ConfigurationPublishSegment
+                    {
+                        Configuration = new PublishConfiguration
+                        {
+                            Destination = PublishDestination.PowerShellGallery,
+                            ApiKeyFilePath = publishKey
+                        }
+                    },
+                    new ConfigurationActionSegment
+                    {
+                        Configuration = new ModulePipelineActionConfiguration
+                        {
+                            FilePath = actionFile,
+                            WorkingDirectory = actionWorkingDirectory
                         }
                     },
                     new ConfigurationReleaseSegment
@@ -498,6 +585,11 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Contains("\"Path\": \"Module/Artefacts/Packed\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Path\": \"Module/Artefacts/Packed/RequiredModules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ModulesPath\": \"Module/Artefacts/Packed/Modules\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Source\": \"Build/Templates\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Source\": \"Build/NOTICE.txt\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"ApiKeyFilePath\": \"Build/psgallery.key\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"FilePath\": \"Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"WorkingDirectory\": \"Build\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StageRoot\": \"Artifacts/Release\"", json, StringComparison.Ordinal);
 
             var jsonSpec = JsonSerializer.Deserialize<ModulePipelineSpec>(json, CreateJsonOptions());
@@ -508,7 +600,9 @@ public sealed class ModuleBuildPreparationServiceTests
             var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(jsonSpec.Segments[1]);
             var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[2]);
             var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[3]);
-            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[4]);
+            var publish = Assert.IsType<ConfigurationPublishSegment>(jsonSpec.Segments[4]);
+            var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[5]);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[6]);
             Assert.Equal(projectConfig, projectBuild.Configuration.ConfigPath);
             Assert.Equal(netProject, buildLibraries.BuildLibraries.NETProjectPath);
             Assert.Equal(developmentBinaries, buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
@@ -520,7 +614,78 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Equal(artefactRoot, artefact.Configuration.Path);
             Assert.Equal(artefactRequiredModules, artefact.Configuration.RequiredModules.Path);
             Assert.Equal(artefactModules, artefact.Configuration.RequiredModules.ModulesPath);
+            Assert.Equal(copyDirectorySource, artefact.Configuration.DirectoryOutput![0].Source);
+            Assert.Equal("Templates", artefact.Configuration.DirectoryOutput[0].Destination);
+            Assert.Equal(copyFileSource, artefact.Configuration.FilesOutput![0].Source);
+            Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
+            Assert.Equal(publishKey, publish.Configuration.ApiKeyFilePath);
+            Assert.Equal(actionFile, action.Configuration.FilePath);
+            Assert.Equal(actionWorkingDirectory, action.Configuration.WorkingDirectory);
             Assert.Equal(releaseRoot, release.Configuration.StageRoot);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ResolvePipelineSpecPaths_preserves_artefact_relative_required_module_paths()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-artefact-layout-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var jsonPath = Path.Combine(root.FullName, ".powerforge", "powerforge.json");
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = "SampleModule",
+                    SourcePath = root.FullName
+                },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Unpacked,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = "Artefacts/Unpacked",
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                Path = "Modules",
+                                ModulesPath = "Payload/MainModules"
+                            }
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = "Artefacts/Packed",
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                Path = "Artefacts/Packed/RequiredModules",
+                                ModulesPath = "Artefacts/Packed/Modules"
+                            }
+                        }
+                    }
+                }
+            };
+
+            new ModuleBuildPreparationService().ResolvePipelineSpecPaths(spec, jsonPath);
+
+            var relativeLayout = Assert.IsType<ConfigurationArtefactSegment>(spec.Segments[0]);
+            Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Unpacked"), relativeLayout.Configuration.Path);
+            Assert.Equal("Modules", relativeLayout.Configuration.RequiredModules.Path);
+            Assert.Equal("Payload/MainModules", relativeLayout.Configuration.RequiredModules.ModulesPath);
+
+            var workspaceQualifiedLayout = Assert.IsType<ConfigurationArtefactSegment>(spec.Segments[1]);
+            Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed"), workspaceQualifiedLayout.Configuration.Path);
+            Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed", "RequiredModules"), workspaceQualifiedLayout.Configuration.RequiredModules.Path);
+            Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed", "Modules"), workspaceQualifiedLayout.Configuration.RequiredModules.ModulesPath);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -60,6 +60,12 @@ public sealed class ModuleBuildPreparationServiceTests
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "DbaClientX.psd1"), "@{ ModuleVersion = '1.0.0' }");
 
             var settings = ScriptBlock.Create("""
+$projectOptions = [System.Collections.Generic.Dictionary[string,object]]::new()
+$projectOptions['OutputPath'] = 'Artefacts/ProjectBuild/options'
+$projectOptions['PlanOutputPath'] = 'Build/project-options-plan.json'
+$packageOptions = [System.Collections.Generic.Dictionary[string,object]]::new()
+$packageOptions['OutputPath'] = 'Artefacts/PackageBuild/options'
+$packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationBuildLibrariesSegment]@{
     BuildLibraries = [PowerForge.BuildLibrariesConfiguration]@{
         NETProjectPath = 'DbaClientX.PowerShell/DbaClientX.PowerShell.csproj'
@@ -70,6 +76,7 @@ public sealed class ModuleBuildPreparationServiceTests
     Configuration = [PowerForge.ProjectBuildConfigurationReference]@{
         ConfigPath = 'Build/project.build.json'
         BuildBeforeModule = $true
+        Options = $projectOptions
     }
 }
 [PowerForge.ConfigurationArtefactSegment]@{
@@ -111,6 +118,19 @@ public sealed class ModuleBuildPreparationServiceTests
         PublishApiKeyFilePath = 'Build/nuget.key'
         NugetCredentialSecretFilePath = 'Build/nuget.secret'
         GitHubAccessTokenFilePath = 'Build/github.token'
+        Options = $packageOptions
+    }
+}
+[PowerForge.ConfigurationTestSegment]@{
+    Configuration = [PowerForge.TestConfiguration]@{
+        TestsPath = 'Tests'
+    }
+}
+[PowerForge.ConfigurationOptionsSegment]@{
+    Options = [PowerForge.ConfigurationOptions]@{
+        Signing = [PowerForge.SigningOptionsConfiguration]@{
+            CertificatePFXPath = 'Build/cert.pfx'
+        }
     }
 }
 [PowerForge.ConfigurationPublishSegment]@{
@@ -162,6 +182,8 @@ public sealed class ModuleBuildPreparationServiceTests
 
                 var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(prepared.PipelineSpec.Segments[1]);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "project.build.json"), projectBuild.Configuration.ConfigPath);
+                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "options"), projectBuild.Configuration.Options!["OutputPath"]);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "project-options-plan.json"), projectBuild.Configuration.Options["PlanOutputPath"]);
 
                 var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[2]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
@@ -181,18 +203,26 @@ public sealed class ModuleBuildPreparationServiceTests
                 Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.key"), packageBuild.Configuration.PublishApiKeyFilePath);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.secret"), packageBuild.Configuration.NugetCredentialSecretFilePath);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "github.token"), packageBuild.Configuration.GitHubAccessTokenFilePath);
+                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "PackageBuild", "options"), packageBuild.Configuration.Options!["OutputPath"]);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "package-options-plan.json"), packageBuild.Configuration.Options["PlanOutputPath"]);
 
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules"), artefact.Configuration.RequiredModules.Path);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules"), artefact.Configuration.RequiredModules.ModulesPath);
 
-                var publish = Assert.IsType<ConfigurationPublishSegment>(prepared.PipelineSpec.Segments[5]);
+                var test = Assert.IsType<ConfigurationTestSegment>(prepared.PipelineSpec.Segments[5]);
+                Assert.Equal(Path.Combine(root.FullName, "Tests"), test.Configuration.TestsPath);
+
+                var options = Assert.IsType<ConfigurationOptionsSegment>(prepared.PipelineSpec.Segments[6]);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "cert.pfx"), options.Options.Signing!.CertificatePFXPath);
+
+                var publish = Assert.IsType<ConfigurationPublishSegment>(prepared.PipelineSpec.Segments[7]);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "psgallery.key"), publish.Configuration.ApiKeyFilePath);
 
-                var action = Assert.IsType<ConfigurationActionSegment>(prepared.PipelineSpec.Segments[6]);
+                var action = Assert.IsType<ConfigurationActionSegment>(prepared.PipelineSpec.Segments[8]);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1"), action.Configuration.FilePath);
                 Assert.Equal(Path.Combine(root.FullName, "Build"), action.Configuration.WorkingDirectory);
 
-                var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[7]);
+                var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[9]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "UploadReady"), release.Configuration.StageRoot);
             }
             finally
@@ -473,8 +503,14 @@ public sealed class ModuleBuildPreparationServiceTests
             var publishKey = Path.Combine(root.FullName, "Build", "psgallery.key");
             var actionFile = Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1");
             var actionWorkingDirectory = Path.Combine(root.FullName, "Build");
+            var testsPath = Path.Combine(root.FullName, "Tests");
+            var signingPfxPath = Path.Combine(root.FullName, "Build", "cert.pfx");
             var copyDirectorySource = Path.Combine(root.FullName, "Build", "Templates");
             var copyFileSource = Path.Combine(root.FullName, "Build", "NOTICE.txt");
+            var projectOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "ProjectBuild", "options");
+            var projectOptionsPlanPath = Path.Combine(root.FullName, "Build", "project-options-plan.json");
+            var packageOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "PackageBuild", "options");
+            var packageOptionsPlanPath = Path.Combine(root.FullName, "Build", "package-options-plan.json");
             var spec = new ModulePipelineSpec
             {
                 Build = new ModuleBuildSpec
@@ -489,7 +525,12 @@ public sealed class ModuleBuildPreparationServiceTests
                         Configuration = new ProjectBuildConfigurationReference
                         {
                             ConfigPath = projectConfig,
-                            BuildBeforeModule = true
+                            BuildBeforeModule = true,
+                            Options = new Dictionary<string, object?>
+                            {
+                                ["OutputPath"] = projectOptionsOutputPath,
+                                ["PlanOutputPath"] = projectOptionsPlanPath
+                            }
                         }
                     },
                     new ConfigurationBuildLibrariesSegment
@@ -510,7 +551,12 @@ public sealed class ModuleBuildPreparationServiceTests
                             PlanOutputPath = Path.Combine(root.FullName, "Artifacts", "Packages", "plan.json"),
                             PublishApiKeyFilePath = Path.Combine(root.FullName, "Build", "nuget.key"),
                             NugetCredentialSecretFilePath = Path.Combine(root.FullName, "Build", "nuget.secret"),
-                            GitHubAccessTokenFilePath = Path.Combine(root.FullName, "Build", "github.token")
+                            GitHubAccessTokenFilePath = Path.Combine(root.FullName, "Build", "github.token"),
+                            Options = new Dictionary<string, object?>
+                            {
+                                ["OutputPath"] = packageOptionsOutputPath,
+                                ["PlanOutputPath"] = packageOptionsPlanPath
+                            }
                         }
                     },
                     new ConfigurationArtefactSegment
@@ -539,6 +585,23 @@ public sealed class ModuleBuildPreparationServiceTests
                                     Source = copyFileSource,
                                     Destination = "NOTICE.txt"
                                 }
+                            }
+                        }
+                    },
+                    new ConfigurationTestSegment
+                    {
+                        Configuration = new TestConfiguration
+                        {
+                            TestsPath = testsPath
+                        }
+                    },
+                    new ConfigurationOptionsSegment
+                    {
+                        Options = new ConfigurationOptions
+                        {
+                            Signing = new SigningOptionsConfiguration
+                            {
+                                CertificatePFXPath = signingPfxPath
                             }
                         }
                     },
@@ -579,6 +642,10 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Contains("\"RootPath\": \"Sources\"", json, StringComparison.Ordinal);
             Assert.Contains("\"StagingPath\": \"Artifacts/Packages/Staging\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PlanOutputPath\": \"Artifacts/Packages/plan.json\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"OutputPath\": \"Artifacts/ProjectBuild/options\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"PlanOutputPath\": \"Build/project-options-plan.json\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"OutputPath\": \"Artifacts/PackageBuild/options\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"PlanOutputPath\": \"Build/package-options-plan.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"PublishApiKeyFilePath\": \"Build/nuget.key\"", json, StringComparison.Ordinal);
             Assert.Contains("\"NugetCredentialSecretFilePath\": \"Build/nuget.secret\"", json, StringComparison.Ordinal);
             Assert.Contains("\"GitHubAccessTokenFilePath\": \"Build/github.token\"", json, StringComparison.Ordinal);
@@ -587,6 +654,8 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Contains("\"ModulesPath\": \"Module/Artefacts/Packed/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/Templates\"", json, StringComparison.Ordinal);
             Assert.Contains("\"Source\": \"Build/NOTICE.txt\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"TestsPath\": \"Tests\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"CertificatePFXPath\": \"Build/cert.pfx\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ApiKeyFilePath\": \"Build/psgallery.key\"", json, StringComparison.Ordinal);
             Assert.Contains("\"FilePath\": \"Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
             Assert.Contains("\"WorkingDirectory\": \"Build\"", json, StringComparison.Ordinal);
@@ -600,10 +669,14 @@ public sealed class ModuleBuildPreparationServiceTests
             var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(jsonSpec.Segments[1]);
             var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[2]);
             var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[3]);
-            var publish = Assert.IsType<ConfigurationPublishSegment>(jsonSpec.Segments[4]);
-            var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[5]);
-            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[6]);
+            var test = Assert.IsType<ConfigurationTestSegment>(jsonSpec.Segments[4]);
+            var options = Assert.IsType<ConfigurationOptionsSegment>(jsonSpec.Segments[5]);
+            var publish = Assert.IsType<ConfigurationPublishSegment>(jsonSpec.Segments[6]);
+            var action = Assert.IsType<ConfigurationActionSegment>(jsonSpec.Segments[7]);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[8]);
             Assert.Equal(projectConfig, projectBuild.Configuration.ConfigPath);
+            Assert.Equal(projectOptionsOutputPath, projectBuild.Configuration.Options!["OutputPath"]);
+            Assert.Equal(projectOptionsPlanPath, projectBuild.Configuration.Options["PlanOutputPath"]);
             Assert.Equal(netProject, buildLibraries.BuildLibraries.NETProjectPath);
             Assert.Equal(developmentBinaries, buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
             Assert.Equal(packageRoot, packageBuild.Configuration.RootPath);
@@ -611,6 +684,8 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.key"), packageBuild.Configuration.PublishApiKeyFilePath);
             Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.secret"), packageBuild.Configuration.NugetCredentialSecretFilePath);
             Assert.Equal(Path.Combine(root.FullName, "Build", "github.token"), packageBuild.Configuration.GitHubAccessTokenFilePath);
+            Assert.Equal(packageOptionsOutputPath, packageBuild.Configuration.Options!["OutputPath"]);
+            Assert.Equal(packageOptionsPlanPath, packageBuild.Configuration.Options["PlanOutputPath"]);
             Assert.Equal(artefactRoot, artefact.Configuration.Path);
             Assert.Equal(artefactRequiredModules, artefact.Configuration.RequiredModules.Path);
             Assert.Equal(artefactModules, artefact.Configuration.RequiredModules.ModulesPath);
@@ -618,6 +693,8 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Equal("Templates", artefact.Configuration.DirectoryOutput[0].Destination);
             Assert.Equal(copyFileSource, artefact.Configuration.FilesOutput![0].Source);
             Assert.Equal("NOTICE.txt", artefact.Configuration.FilesOutput[0].Destination);
+            Assert.Equal(testsPath, test.Configuration.TestsPath);
+            Assert.Equal(signingPfxPath, options.Options.Signing!.CertificatePFXPath);
             Assert.Equal(publishKey, publish.Configuration.ApiKeyFilePath);
             Assert.Equal(actionFile, action.Configuration.FilePath);
             Assert.Equal(actionWorkingDirectory, action.Configuration.WorkingDirectory);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -66,6 +66,7 @@ public sealed class ModuleBuildPreparationServiceTests
             Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Examples"));
             File.WriteAllText(Path.Combine(root.FullName, "Build", "header.ps1"), "Write-Output 'repo header'");
             File.WriteAllText(Path.Combine(scriptRoot.FullName, "header.ps1"), "Write-Output 'module header'");
+            File.WriteAllText(Path.Combine(scriptRoot.FullName, "workspace-header.ps1"), "Write-Output 'workspace-qualified module header'");
             File.WriteAllText(Path.Combine(root.FullName, "Build", "NOTICE.txt"), "notice");
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "Examples", "NOTICE.txt"), "module notice");
             File.WriteAllText(Path.Combine(moduleRoot.FullName, "DbaClientX.psd1"), "@{ ModuleVersion = '1.0.0' }");
@@ -211,6 +212,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
     Path = 'Module/Artefacts/FileBacked/<TagModuleVersionWithPreRelease>'
     PreScriptMergePath = 'Build/header.ps1'
 })
+[PowerForge.ArtefactConfigurationFactory]::new([PowerForge.NullLogger]::new()).Create([PowerForge.ArtefactConfigurationRequest]@{
+    Type = [PowerForge.ArtefactType]::Packed
+    EnableSpecified = $true
+    Enable = $true
+    Path = 'Module/Artefacts/WorkspaceFileBacked/<TagModuleVersionWithPreRelease>'
+    PreScriptMergePath = 'Module/Build/workspace-header.ps1'
+})
 [PowerForge.ConfigurationAppleAppSegment]@{
     Configuration = [PowerForge.AppleAppConfiguration]@{
         ProjectPath = '.\Tactra.xcodeproj'
@@ -343,10 +351,14 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Contains("module header", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
                 Assert.DoesNotContain("repo header", fileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
 
-                var appleApp = Assert.IsType<ConfigurationAppleAppSegment>(prepared.PipelineSpec.Segments[14]);
+                var workspaceFileBackedArtefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[14]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "WorkspaceFileBacked", "<TagModuleVersionWithPreRelease>"), workspaceFileBackedArtefact.Configuration.Path);
+                Assert.Contains("workspace-qualified module header", workspaceFileBackedArtefact.Configuration.PreScriptMerge, StringComparison.Ordinal);
+
+                var appleApp = Assert.IsType<ConfigurationAppleAppSegment>(prepared.PipelineSpec.Segments[15]);
                 Assert.Equal(".\\Tactra.xcodeproj", appleApp.Configuration.ProjectPath);
 
-                var xcodeProject = Assert.IsType<ConfigurationXcodeProjectVersionSegment>(prepared.PipelineSpec.Segments[15]);
+                var xcodeProject = Assert.IsType<ConfigurationXcodeProjectVersionSegment>(prepared.PipelineSpec.Segments[16]);
                 Assert.Equal("Mac\\TactraMac.xcodeproj", xcodeProject.Configuration.Path);
             }
             finally
@@ -721,7 +733,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(jsonSpec.Segments[1]);
             Assert.Equal(externalDocs, documentation.Configuration.Path);
             Assert.Equal(externalReadme, documentation.Configuration.PathReadme);
-            Assert.Equal(projectAboutTopics, buildDocumentation.Configuration.AboutTopicsSourcePath[0]);
+            Assert.Equal("Help/About", buildDocumentation.Configuration.AboutTopicsSourcePath[0]);
             Assert.Equal(externalAboutTopics, buildDocumentation.Configuration.AboutTopicsSourcePath[1]);
         }
         finally
@@ -752,7 +764,27 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                         ArtefactType = ArtefactType.Packed,
                         Configuration = new ArtefactConfiguration
                         {
-                            Path = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>")
+                            Path = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>"),
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                Path = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>", "RequiredModules"),
+                                ModulesPath = Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>", "Modules")
+                            }
+                        }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = Path.Combine(root.FullName, "Module", "Artefacts", "Packed-<TagModuleVersionWithPreRelease>")
+                        }
+                    },
+                    new ConfigurationReleaseSegment
+                    {
+                        Configuration = new ReleaseConfiguration
+                        {
+                            StageRoot = Path.Combine(root.FullName, "Artefacts", "UploadReady-<ModuleVersion>")
                         }
                     }
                 }
@@ -766,6 +798,12 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 
             var artefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec!.Segments[0]);
             Assert.Equal("Module/Artefacts/Packed/<TagModuleVersionWithPreRelease>", artefact.Configuration.Path);
+            Assert.Equal("Module/Artefacts/Packed/<TagModuleVersionWithPreRelease>/RequiredModules", artefact.Configuration.RequiredModules.Path);
+            Assert.Equal("Module/Artefacts/Packed/<TagModuleVersionWithPreRelease>/Modules", artefact.Configuration.RequiredModules.ModulesPath);
+            var embeddedTokenArtefact = Assert.IsType<ConfigurationArtefactSegment>(jsonSpec.Segments[1]);
+            Assert.Equal("Module/Artefacts/Packed-<TagModuleVersionWithPreRelease>", embeddedTokenArtefact.Configuration.Path);
+            var release = Assert.IsType<ConfigurationReleaseSegment>(jsonSpec.Segments[2]);
+            Assert.Equal("Artefacts/UploadReady-<ModuleVersion>", release.Configuration.StageRoot);
         }
         finally
         {
@@ -1137,7 +1175,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(signingPfxPath, options.Options.Signing!.CertificatePFXPath);
             Assert.Equal(documentationPath, documentation.Configuration.Path);
             Assert.Equal(documentationReadmePath, documentation.Configuration.PathReadme);
-            Assert.Equal(Path.Combine(root.FullName, "Help", "About"), Path.GetFullPath(buildDocumentation.Configuration.AboutTopicsSourcePath[0]));
+            Assert.Equal("Help/About", buildDocumentation.Configuration.AboutTopicsSourcePath[0]);
             Assert.Equal(testsPath, validation.Settings.Tests.TestPath);
             Assert.Equal(publishKey, publish.Configuration.ApiKeyFilePath);
             Assert.Equal(actionFile, action.Configuration.FilePath);
@@ -1192,6 +1230,19 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                                 ModulesPath = "Artefacts/Packed/Modules"
                             }
                         }
+                    },
+                    new ConfigurationArtefactSegment
+                    {
+                        ArtefactType = ArtefactType.Packed,
+                        Configuration = new ArtefactConfiguration
+                        {
+                            Path = "Artefacts/Packed/<TagModuleVersionWithPreRelease>",
+                            RequiredModules = new ArtefactRequiredModulesConfiguration
+                            {
+                                Path = "Artefacts/Packed/<TagModuleVersionWithPreRelease>/RequiredModules",
+                                ModulesPath = "Artefacts/Packed/<TagModuleVersionWithPreRelease>/Modules"
+                            }
+                        }
                     }
                 }
             };
@@ -1207,6 +1258,11 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed"), workspaceQualifiedLayout.Configuration.Path);
             Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed", "RequiredModules"), workspaceQualifiedLayout.Configuration.RequiredModules.Path);
             Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed", "Modules"), workspaceQualifiedLayout.Configuration.RequiredModules.ModulesPath);
+
+            var tokenizedLayout = Assert.IsType<ConfigurationArtefactSegment>(spec.Segments[2]);
+            Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Packed", "<TagModuleVersionWithPreRelease>"), tokenizedLayout.Configuration.Path);
+            Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>/RequiredModules", tokenizedLayout.Configuration.RequiredModules.Path);
+            Assert.Equal("Artefacts/Packed/<TagModuleVersionWithPreRelease>/Modules", tokenizedLayout.Configuration.RequiredModules.ModulesPath);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using PowerForge;
@@ -39,6 +41,91 @@ public sealed class ModuleBuildPreparationServiceTests
             Assert.Contains(".gitignore", prepared.PipelineSpec.Build.ExcludeFiles);
             Assert.Contains("SampleModule.Tests.ps1", prepared.PipelineSpec.Build.ExcludeFiles);
             Assert.Equal(Path.Combine(root.FullName, "SampleModule", "powerforge.json"), prepared.JsonOutputPath);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Prepare_from_module_build_script_resolves_repo_level_paths_from_workspace_root()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-modulebuild-workspace-" + Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            var moduleRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Module"));
+            var scriptRoot = Directory.CreateDirectory(Path.Combine(moduleRoot.FullName, "Build"));
+            File.WriteAllText(Path.Combine(moduleRoot.FullName, "DbaClientX.psd1"), "@{ ModuleVersion = '1.0.0' }");
+
+            var settings = ScriptBlock.Create("""
+[PowerForge.ConfigurationBuildLibrariesSegment]@{
+    BuildLibraries = [PowerForge.BuildLibrariesConfiguration]@{
+        NETProjectPath = 'DbaClientX.PowerShell/DbaClientX.PowerShell.csproj'
+        NETDevelopmentBinariesPath = 'DbaClientX.PowerShell/bin'
+    }
+}
+[PowerForge.ConfigurationProjectBuildSegment]@{
+    Configuration = [PowerForge.ProjectBuildConfigurationReference]@{
+        ConfigPath = 'Build/project.build.json'
+        BuildBeforeModule = $true
+    }
+}
+[PowerForge.ConfigurationArtefactSegment]@{
+    ArtefactType = [PowerForge.ArtefactType]::Packed
+    Configuration = [PowerForge.ArtefactConfiguration]@{
+        Path = 'Module/Artefacts/Packed'
+    }
+}
+[PowerForge.ConfigurationReleaseSegment]@{
+    Configuration = [PowerForge.ReleaseConfiguration]@{
+        StageRoot = 'Module/Artefacts/UploadReady'
+        VersionSource = [PowerForge.ReleaseVersionSource]::ProjectBuild
+    }
+}
+""");
+
+            using var runspace = RunspaceFactory.CreateRunspace();
+            runspace.Open();
+            var previousRunspace = Runspace.DefaultRunspace;
+            Runspace.DefaultRunspace = runspace;
+            try
+            {
+                var prepared = new ModuleBuildPreparationService().Prepare(new ModuleBuildPreparationRequest
+                {
+                    ParameterSetName = "Modern",
+                    ModuleName = "DbaClientX",
+                    Settings = settings,
+                    CurrentPath = root.FullName,
+                    ScriptRoot = scriptRoot.FullName,
+                    ResolvePath = path => Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(root.FullName, path)),
+                    DotNetFramework = Array.Empty<string>(),
+                    ExcludeDirectories = Array.Empty<string>(),
+                    ExcludeFiles = Array.Empty<string>()
+                });
+
+                Assert.Equal(moduleRoot.FullName, prepared.ProjectRoot);
+                Assert.Null(prepared.BasePathForScaffold);
+                Assert.Equal(moduleRoot.FullName, prepared.PipelineSpec.Build.SourcePath);
+
+                var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
+                Assert.Equal(Path.Combine(root.FullName, "DbaClientX.PowerShell", "DbaClientX.PowerShell.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
+                Assert.Equal(Path.Combine(root.FullName, "DbaClientX.PowerShell", "bin"), buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
+
+                var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(prepared.PipelineSpec.Segments[1]);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "project.build.json"), projectBuild.Configuration.ConfigPath);
+
+                var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[2]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
+
+                var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[3]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "UploadReady"), release.Configuration.StageRoot);
+            }
+            finally
+            {
+                Runspace.DefaultRunspace = previousRunspace;
+            }
         }
         finally
         {

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -171,7 +171,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationBuildDocumentationSegment]@{
     Configuration = [PowerForge.BuildDocumentationConfiguration]@{
         Enable = $true
-        AboutTopicsSourcePath = @('Module/Docs/About')
+        AboutTopicsSourcePath = @('Help/About')
     }
 }
 [PowerForge.ArtefactConfigurationFactory]::new([PowerForge.NullLogger]::new()).Create([PowerForge.ArtefactConfigurationRequest]@{
@@ -205,6 +205,11 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                     StagingPath = "Artefacts/Staging",
                     CsprojPath = "Sources/TopLevel/TopLevel.csproj",
                     DiagnosticsBaselinePath = "Build/diagnostics.json",
+                    DiagnosticsBinaryConflictSearchRoot = new[] { "Modules" },
+                    InstallRootsWasBound = true,
+                    InstallRoots = new[] { "Artefacts/Modules" },
+                    JsonOnly = true,
+                    JsonPath = "Build/powerforge.json",
                     DotNetFramework = Array.Empty<string>(),
                     ExcludeDirectories = Array.Empty<string>(),
                     ExcludeFiles = Array.Empty<string>()
@@ -216,6 +221,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Artefacts", "Staging"), prepared.PipelineSpec.Build.StagingPath);
                 Assert.Equal(Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj"), prepared.PipelineSpec.Build.CsprojPath);
                 Assert.Equal(Path.Combine(root.FullName, "Build", "diagnostics.json"), prepared.PipelineSpec.Diagnostics.BaselinePath);
+                Assert.Equal(new[] { Path.Combine(root.FullName, "Modules") }, prepared.PipelineSpec.Build.BinaryConflictSearchRoots);
+                Assert.Equal(new[] { Path.Combine(root.FullName, "Modules") }, prepared.PipelineSpec.Diagnostics.BinaryConflictSearchRoots);
+                Assert.Equal(new[] { Path.Combine(root.FullName, "Artefacts", "Modules") }, prepared.PipelineSpec.Install.Roots);
+                Assert.Equal(Path.Combine(root.FullName, "Build", "powerforge.json"), prepared.JsonOutputPath);
 
                 var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
                 Assert.Equal(Path.Combine(root.FullName, "DbaClientX.PowerShell", "DbaClientX.PowerShell.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
@@ -274,7 +283,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "README.md"), documentation.Configuration.PathReadme);
 
                 var buildDocumentation = Assert.IsType<ConfigurationBuildDocumentationSegment>(prepared.PipelineSpec.Segments[12]);
-                Assert.Equal(new[] { Path.Combine(root.FullName, "Module", "Docs", "About") }, buildDocumentation.Configuration.AboutTopicsSourcePath);
+                Assert.Equal(new[] { "Help/About" }, buildDocumentation.Configuration.AboutTopicsSourcePath);
 
                 var fileBackedArtefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[13]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "FileBacked"), fileBackedArtefact.Configuration.Path);
@@ -551,6 +560,8 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var projectConfig = Path.Combine(root.FullName, "Build", "project.build.json");
             var buildStagingPath = Path.Combine(root.FullName, "Artifacts", "Module", "Staging");
             var buildCsprojPath = Path.Combine(root.FullName, "Sources", "TopLevel", "TopLevel.csproj");
+            var binaryConflictSearchRoot = Path.Combine(root.FullName, "Modules");
+            var installRoot = Path.Combine(root.FullName, "Artifacts", "Modules");
             var diagnosticsBaselinePath = Path.Combine(root.FullName, "Build", "diagnostics.json");
             var netProject = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "SampleModule.PowerShell.csproj");
             var developmentBinaries = Path.Combine(root.FullName, "Sources", "SampleModule.PowerShell", "bin");
@@ -567,7 +578,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var signingPfxPath = Path.Combine(root.FullName, "Build", "cert.pfx");
             var documentationPath = Path.Combine(root.FullName, "Module", "Docs");
             var documentationReadmePath = Path.Combine(root.FullName, "README.md");
-            var aboutTopicsPath = Path.Combine(root.FullName, "Module", "Docs", "About");
+            const string aboutTopicsPath = "Help/About";
             var copyDirectorySource = Path.Combine(root.FullName, "Build", "Templates");
             var copyFileSource = Path.Combine(root.FullName, "Build", "NOTICE.txt");
             var projectOptionsOutputPath = Path.Combine(root.FullName, "Artifacts", "ProjectBuild", "options");
@@ -581,11 +592,17 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                     Name = "SampleModule",
                     SourcePath = root.FullName,
                     StagingPath = buildStagingPath,
-                    CsprojPath = buildCsprojPath
+                    CsprojPath = buildCsprojPath,
+                    BinaryConflictSearchRoots = new[] { binaryConflictSearchRoot }
+                },
+                Install = new ModulePipelineInstallOptions
+                {
+                    Roots = new[] { installRoot }
                 },
                 Diagnostics = new ModulePipelineDiagnosticsOptions
                 {
-                    BaselinePath = diagnosticsBaselinePath
+                    BaselinePath = diagnosticsBaselinePath,
+                    BinaryConflictSearchRoots = new[] { binaryConflictSearchRoot }
                 },
                 Segments = new IConfigurationSegment[]
                 {
@@ -735,6 +752,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             var json = File.ReadAllText(jsonPath);
             Assert.Contains("\"StagingPath\": \"../Artifacts/Module/Staging\"", json, StringComparison.Ordinal);
             Assert.Contains("\"CsprojPath\": \"../Sources/TopLevel/TopLevel.csproj\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"BinaryConflictSearchRoots\": [", json, StringComparison.Ordinal);
+            Assert.Contains("\"Modules\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Roots\": [", json, StringComparison.Ordinal);
+            Assert.Contains("\"Artifacts/Modules\"", json, StringComparison.Ordinal);
             Assert.Contains("\"BaselinePath\": \"../Build/diagnostics.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ConfigPath\": \"Build/project.build.json\"", json, StringComparison.Ordinal);
             Assert.Contains("\"NETProjectPath\": \"Sources/SampleModule.PowerShell/SampleModule.PowerShell.csproj\"", json, StringComparison.Ordinal);
@@ -760,7 +781,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             Assert.Contains("\"PathReadme\": \"README.md\"", json, StringComparison.Ordinal);
             Assert.Contains("\"TestPath\": \"Tests\"", json, StringComparison.Ordinal);
             Assert.Contains("\"AboutTopicsSourcePath\": [", json, StringComparison.Ordinal);
-            Assert.Contains("\"Module/Docs/About\"", json, StringComparison.Ordinal);
+            Assert.Contains("\"Help/About\"", json, StringComparison.Ordinal);
             Assert.Contains("\"ApiKeyFilePath\": \"Build/psgallery.key\"", json, StringComparison.Ordinal);
             Assert.Contains("\"FilePath\": \"Build/Test-ReleaseReady.ps1\"", json, StringComparison.Ordinal);
             Assert.Contains("\"WorkingDirectory\": \"Build\"", json, StringComparison.Ordinal);
@@ -772,7 +793,10 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
             service.ResolvePipelineSpecPaths(jsonSpec!, jsonPath);
             Assert.Equal(buildStagingPath, jsonSpec!.Build.StagingPath);
             Assert.Equal(buildCsprojPath, jsonSpec.Build.CsprojPath);
+            Assert.Equal(new[] { binaryConflictSearchRoot }, jsonSpec.Build.BinaryConflictSearchRoots);
+            Assert.Equal(new[] { installRoot }, jsonSpec.Install.Roots);
             Assert.Equal(diagnosticsBaselinePath, jsonSpec.Diagnostics!.BaselinePath);
+            Assert.Equal(new[] { binaryConflictSearchRoot }, jsonSpec.Diagnostics.BinaryConflictSearchRoots);
             var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(jsonSpec!.Segments[0]);
             var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(jsonSpec.Segments[1]);
             var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(jsonSpec.Segments[2]);

--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -78,14 +78,14 @@ $packageOptions['OutputPath'] = 'Artefacts/PackageBuild/options'
 $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
 [PowerForge.ConfigurationBuildLibrariesSegment]@{
     BuildLibraries = [PowerForge.BuildLibrariesConfiguration]@{
-        NETProjectPath = '../DbaClientX.PowerShell/DbaClientX.PowerShell.csproj'
+        NETProjectPath = 'Module/Sources/Foo/Foo.csproj'
         DevelopmentBinariesPath = 'Sources/Local/bin'
         NETDevelopmentBinariesPath = '../DbaClientX.PowerShell/bin'
     }
 }
 [PowerForge.ConfigurationProjectBuildSegment]@{
     Configuration = [PowerForge.ProjectBuildConfigurationReference]@{
-        ConfigPath = '../Build/project.build.json'
+        ConfigPath = 'Module/Build/project.build.json'
         BuildBeforeModule = $true
         Options = $projectOptions
     }
@@ -268,14 +268,14 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal(Path.Combine(root.FullName, "Build", "powerforge.json"), prepared.JsonOutputPath);
 
                 var buildLibraries = Assert.IsType<ConfigurationBuildLibrariesSegment>(prepared.PipelineSpec.Segments[0]);
-                Assert.Equal("../DbaClientX.PowerShell/DbaClientX.PowerShell.csproj", buildLibraries.BuildLibraries.NETProjectPath);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Sources", "Foo", "Foo.csproj"), buildLibraries.BuildLibraries.NETProjectPath);
                 Assert.Equal("Sources/Local/bin", buildLibraries.BuildLibraries.DevelopmentBinariesPath);
                 Assert.Equal("../DbaClientX.PowerShell/bin", buildLibraries.BuildLibraries.NETDevelopmentBinariesPath);
 
                 var projectBuild = Assert.IsType<ConfigurationProjectBuildSegment>(prepared.PipelineSpec.Segments[1]);
-                Assert.Equal("../Build/project.build.json", projectBuild.Configuration.ConfigPath);
-                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "options"), projectBuild.Configuration.Options!["OutputPath"]);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "project-options-plan.json"), projectBuild.Configuration.Options["PlanOutputPath"]);
+                Assert.Equal(Path.Combine(root.FullName, "Module", "Build", "project.build.json"), projectBuild.Configuration.ConfigPath);
+                Assert.Equal("Artefacts/ProjectBuild/options", projectBuild.Configuration.Options!["OutputPath"]);
+                Assert.Equal("Build/project-options-plan.json", projectBuild.Configuration.Options["PlanOutputPath"]);
 
                 var artefact = Assert.IsType<ConfigurationArtefactSegment>(prepared.PipelineSpec.Segments[2]);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed"), artefact.Configuration.Path);
@@ -300,13 +300,13 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal("Payload/MainModules", artefactWithRelativeLayout.Configuration.RequiredModules.ModulesPath);
 
                 var packageBuild = Assert.IsType<ConfigurationPackageBuildSegment>(prepared.PipelineSpec.Segments[4]);
-                Assert.Equal(Path.Combine(root.FullName, "Sources"), packageBuild.Configuration.RootPath);
-                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "ProjectBuild", "packages"), packageBuild.Configuration.OutputPath);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.key"), packageBuild.Configuration.PublishApiKeyFilePath);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "nuget.secret"), packageBuild.Configuration.NugetCredentialSecretFilePath);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "github.token"), packageBuild.Configuration.GitHubAccessTokenFilePath);
-                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "PackageBuild", "options"), packageBuild.Configuration.Options!["OutputPath"]);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "package-options-plan.json"), packageBuild.Configuration.Options["PlanOutputPath"]);
+                Assert.Equal("Sources", packageBuild.Configuration.RootPath);
+                Assert.Equal("Artefacts/ProjectBuild/packages", packageBuild.Configuration.OutputPath);
+                Assert.Equal("Build/nuget.key", packageBuild.Configuration.PublishApiKeyFilePath);
+                Assert.Equal("Build/nuget.secret", packageBuild.Configuration.NugetCredentialSecretFilePath);
+                Assert.Equal("Build/github.token", packageBuild.Configuration.GitHubAccessTokenFilePath);
+                Assert.Equal("Artefacts/PackageBuild/options", packageBuild.Configuration.Options!["OutputPath"]);
+                Assert.Equal("Build/package-options-plan.json", packageBuild.Configuration.Options["PlanOutputPath"]);
 
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "RequiredModules"), artefact.Configuration.RequiredModules.Path);
                 Assert.Equal(Path.Combine(root.FullName, "Module", "Artefacts", "Packed", "Modules"), artefact.Configuration.RequiredModules.ModulesPath);
@@ -315,17 +315,17 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 Assert.Equal("Tests", test.Configuration.TestsPath);
 
                 var options = Assert.IsType<ConfigurationOptionsSegment>(prepared.PipelineSpec.Segments[6]);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "cert.pfx"), options.Options.Signing!.CertificatePFXPath);
+                Assert.Equal("Build/cert.pfx", options.Options.Signing!.CertificatePFXPath);
 
                 var publish = Assert.IsType<ConfigurationPublishSegment>(prepared.PipelineSpec.Segments[7]);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "psgallery.key"), publish.Configuration.ApiKeyFilePath);
+                Assert.Equal("Build/psgallery.key", publish.Configuration.ApiKeyFilePath);
 
                 var action = Assert.IsType<ConfigurationActionSegment>(prepared.PipelineSpec.Segments[8]);
-                Assert.Equal(Path.Combine(root.FullName, "Build", "Test-ReleaseReady.ps1"), action.Configuration.FilePath);
-                Assert.Equal(Path.Combine(root.FullName, "Build"), action.Configuration.WorkingDirectory);
+                Assert.Equal("Build/Test-ReleaseReady.ps1", action.Configuration.FilePath);
+                Assert.Equal("Build", action.Configuration.WorkingDirectory);
 
                 var release = Assert.IsType<ConfigurationReleaseSegment>(prepared.PipelineSpec.Segments[9]);
-                Assert.Equal(Path.Combine(root.FullName, "Artefacts", "UploadReady", "<ModuleVersion>"), release.Configuration.StageRoot);
+                Assert.Equal("Artefacts/UploadReady/<ModuleVersion>", release.Configuration.StageRoot);
 
                 var validation = Assert.IsType<ConfigurationValidationSegment>(prepared.PipelineSpec.Segments[10]);
                 Assert.Equal("Tests", validation.Settings.Tests.TestPath);


### PR DESCRIPTION
## What changed
- Centralize module build path handling in a shared `ModuleBuildPathPolicy` so tokenized paths, external rooted paths, workspace-relative paths, and JSON export/import use one policy.
- Detect the real `repo/Module/Build/Build-Module.ps1` wrapper layout while keeping standalone folders named `Module` rooted in themselves.
- Resolve wrapper paths from the right base: workspace-qualified values use the repository workspace, module-local values stay under `Module`, and referenced `project.build.json` option overrides stay relative to that config file.
- Preserve portable JSON for generated build specs, including tokenized artefact/release paths, external package/test/signing paths, module/staging-relative documentation paths, and caller-provided package option key casing.
- Add regression coverage for DbaClientX-style combined NuGet and PowerShell module builds plus the review-found path edge cases.

## Why it matters
Modules can keep thin `Import-Module PSPublishModule` / `Build-Module { ... } -ExitCode` wrappers without repo-local prelude variables, temporary compatibility probes, or consumer-side workarounds. The shared build layer now owns the path policy for module, package, documentation, test, signing, release, and JSON round-trip flows.

## Validation
- Focused module build/path tests passed locally.
- PSPublishModule multi-target build passed locally.
- GitHub CI passed on the latest pushed head; PrivateGalleryLiveValidation is skipped by design.