### PR TITLE
Add generated API reference SEO profile

### DIFF
--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -1071,6 +1071,7 @@ Notes:
   - rendered content leak checks for visible front matter, raw HTML dumps, or obvious Markdown syntax
 - `includeNoIndexPages` defaults to `false`, so `robots noindex` pages are skipped by default.
 - `checkContentLeaks` defaults to `true` and should stay enabled in CI to catch broken localized pages before deploy.
+- `applyGeneratedApiReferenceSeoProfile` defaults to `true`. Generated PowerForge API reference pages keep structural SEO checks, but generic editorial title/description length and required missing-hreflang warnings are relaxed because API symbol pages follow reference-page semantics.
 - Requirement flags are opt-in (default `false`): `requireCanonical`, `requireHreflang`, `requireHreflangXDefault`, `requireStructuredData`.
 - Baselines follow the same CI pattern as audit:
   - `baselineGenerate` / `baselineUpdate`

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -1450,6 +1450,100 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_AppliesGeneratedApiReferenceSeoProfile_FromGeneratorMarkerOutsideApiRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-api-profile-marker-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var apiRoot = Path.Combine(root, "projects", "officeimo", "api");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "officeimo-excel-range.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>OfficeIMO.Excel.OfficeExcelRangeWithVeryLongGeneratedSymbolName - OfficeIMO API Reference</title>
+                  <meta name="generator" content="PowerForge.Web API Docs" data-pf="api-docs" />
+                  <meta name="description" content="API reference for OfficeExcelRange." />
+                </head>
+                <body class="custom-docs-shell">
+                  <main class="api-content">
+                    <h1>OfficeIMO.Excel.OfficeExcelRange</h1>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                RequireHreflang = true
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "title-long");
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "description-short");
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "hreflang-missing");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_GeneratedApiReferenceSeoProfile_KeepsMalformedHreflangChecks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-api-profile-hreflang-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var apiRoot = Path.Combine(root, "api", "excel");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "officeimo-excel-range.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>OfficeIMO.Excel.OfficeExcelRangeWithVeryLongGeneratedSymbolName - OfficeIMO API Reference</title>
+                  <meta name="description" content="API reference for OfficeExcelRange." />
+                  <link rel="alternate" hreflang="en" />
+                </head>
+                <body class="pf-api-docs">
+                  <main class="api-content">
+                    <h1>OfficeIMO.Excel.OfficeExcelRange</h1>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                RequireHreflang = true
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "hreflang-missing");
+            Assert.Contains(result.Issues, issue => issue.Hint == "hreflang-href-missing");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_PageAssertions_ValidateRepresentativeLocalizedPageOutsideScannedSubset()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -1356,6 +1356,100 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_AppliesGeneratedApiReferenceSeoProfile_ToEditorialLengthAndRequiredHreflang()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-api-profile-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var apiRoot = Path.Combine(root, "api", "excel");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "officeimo-excel-range.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>OfficeIMO.Excel.OfficeExcelRangeWithVeryLongGeneratedSymbolName - OfficeIMO API Reference</title>
+                  <meta name="description" content="API reference for OfficeExcelRange." />
+                </head>
+                <body class="pf-api-docs">
+                  <main class="api-content">
+                    <h1>OfficeIMO.Excel.OfficeExcelRange</h1>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                RequireHreflang = true
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "title-long");
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "description-short");
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "hreflang-missing");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_CanDisableGeneratedApiReferenceSeoProfile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-api-profile-off-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var apiRoot = Path.Combine(root, "api", "excel");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "officeimo-excel-range.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>OfficeIMO.Excel.OfficeExcelRangeWithVeryLongGeneratedSymbolName - OfficeIMO API Reference</title>
+                  <meta name="description" content="API reference for OfficeExcelRange." />
+                </head>
+                <body class="pf-api-docs">
+                  <main class="api-content">
+                    <h1>OfficeIMO.Excel.OfficeExcelRange</h1>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                ApplyGeneratedApiReferenceSeoProfile = false,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                RequireHreflang = true
+            });
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "title-long");
+            Assert.Contains(result.Issues, issue => issue.Hint == "description-short");
+            Assert.Contains(result.Issues, issue => issue.Hint == "hreflang-missing");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_PageAssertions_ValidateRepresentativeLocalizedPageOutsideScannedSubset()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -1544,6 +1544,57 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_GeneratedApiReferenceSeoProfile_ReportsAlternateMissingHreflang()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-api-profile-hreflang-language-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var apiRoot = Path.Combine(root, "api", "excel");
+            Directory.CreateDirectory(apiRoot);
+            File.WriteAllText(Path.Combine(apiRoot, "officeimo-excel-range.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>OfficeIMO.Excel.OfficeExcelRangeWithVeryLongGeneratedSymbolName - OfficeIMO API Reference</title>
+                  <meta name="description" content="API reference for OfficeExcelRange." />
+                  <link rel="alternate" href="https://example.com/en/api/excel/officeimo-excel-range/" />
+                  <link rel="alternate" type="application/rss+xml" href="https://example.com/feed.xml" />
+                </head>
+                <body class="pf-api-docs">
+                  <main class="api-content">
+                    <h1>OfficeIMO.Excel.OfficeExcelRange</h1>
+                  </main>
+                </body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(new WebSeoDoctorOptions
+            {
+                SiteRoot = root,
+                CheckImageAlt = false,
+                CheckDuplicateTitles = false,
+                CheckOrphanPages = false,
+                CheckCanonical = false,
+                RequireHreflang = true
+            });
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "hreflang-missing");
+            Assert.Contains(result.Issues, issue =>
+                issue.Hint == "hreflang-language-missing" &&
+                issue.Message.Contains("missing a language value", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(result.Issues, issue =>
+                issue.Key.Contains("feed.xml", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_PageAssertions_ValidateRepresentativeLocalizedPageOutsideScannedSubset()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-page-assertions-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.SeoDoctor.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.SeoDoctor.cs
@@ -80,6 +80,11 @@ internal static partial class WebPipelineRunner
             CheckDuplicateTitles = GetBool(step, "checkDuplicateTitles") ?? true,
             CheckOrphanPages = GetBool(step, "checkOrphanPages") ?? true,
             CheckFocusKeyphrase = GetBool(step, "checkFocusKeyphrase") ?? false,
+            ApplyGeneratedApiReferenceSeoProfile = GetBool(step, "applyGeneratedApiReferenceSeoProfile") ??
+                                                   GetBool(step, "apply-generated-api-reference-seo-profile") ??
+                                                   GetBool(step, "generatedApiReferenceSeoProfile") ??
+                                                   GetBool(step, "generated-api-reference-seo-profile") ??
+                                                   true,
             CheckCanonical = GetBool(step, "checkCanonical") ?? GetBool(step, "check-canonical") ?? true,
             CheckHreflang = GetBool(step, "checkHreflang") ?? GetBool(step, "check-hreflang") ?? true,
             CheckStructuredData = GetBool(step, "checkStructuredData") ?? GetBool(step, "check-structured-data") ?? true,

--- a/PowerForge.Web/Assets/ApiDocs/docs-index.html
+++ b/PowerForge.Web/Assets/ApiDocs/docs-index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{TITLE}}</title>
+  <meta name="generator" content="PowerForge.Web API Docs" data-pf="api-docs" />
   {{DESCRIPTION_META}}
   {{OPEN_GRAPH_META}}
   {{HEAD_HTML}}

--- a/PowerForge.Web/Assets/ApiDocs/docs-type.html
+++ b/PowerForge.Web/Assets/ApiDocs/docs-type.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{TITLE}}</title>
+  <meta name="generator" content="PowerForge.Web API Docs" data-pf="api-docs" />
   {{DESCRIPTION_META}}
   {{OPEN_GRAPH_META}}
   {{HEAD_HTML}}

--- a/PowerForge.Web/Assets/ApiDocs/index.html
+++ b/PowerForge.Web/Assets/ApiDocs/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{TITLE}}</title>
+  <meta name="generator" content="PowerForge.Web API Docs" data-pf="api-docs" />
   {{DESCRIPTION_META}}
   {{OPEN_GRAPH_META}}
   {{CRITICAL_CSS}}

--- a/PowerForge.Web/Assets/ApiDocs/suite-portal.html
+++ b/PowerForge.Web/Assets/ApiDocs/suite-portal.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{TITLE}}</title>
+  <meta name="generator" content="PowerForge.Web API Docs" data-pf="api-docs" />
   {{DESCRIPTION_META}}
   {{OPEN_GRAPH_META}}
   {{HEAD_HTML}}

--- a/PowerForge.Web/Assets/ApiDocs/type.html
+++ b/PowerForge.Web/Assets/ApiDocs/type.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{TYPE_TITLE}}</title>
+  <meta name="generator" content="PowerForge.Web API Docs" data-pf="api-docs" />
   {{DESCRIPTION_META}}
   {{OPEN_GRAPH_META}}
   {{CRITICAL_CSS}}

--- a/PowerForge.Web/Models/WebSeoDoctorOptions.cs
+++ b/PowerForge.Web/Models/WebSeoDoctorOptions.cs
@@ -44,6 +44,8 @@ public sealed class WebSeoDoctorOptions
     public bool CheckOrphanPages { get; set; } = true;
     /// <summary>When true, evaluate focus keyphrase hints from page metadata.</summary>
     public bool CheckFocusKeyphrase { get; set; }
+    /// <summary>When true, relax generic editorial checks on generated API reference pages while keeping structural SEO checks.</summary>
+    public bool ApplyGeneratedApiReferenceSeoProfile { get; set; } = true;
     /// <summary>When true, validate canonical link tags.</summary>
     public bool CheckCanonical { get; set; } = true;
     /// <summary>When true, validate hreflang alternate link tags.</summary>

--- a/PowerForge.Web/Services/WebSeoDoctor.GeneratedApiReference.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.GeneratedApiReference.cs
@@ -1,0 +1,40 @@
+using AngleSharp.Dom;
+
+namespace PowerForge.Web;
+
+/// <summary>Runs SEO-focused checks on generated HTML output.</summary>
+public static partial class WebSeoDoctor
+{
+    private static bool IsGeneratedApiReferencePage(string relativePath, IDocument doc)
+    {
+        if (doc.Body is null)
+            return false;
+
+        if (ContainsClassToken(doc.Body.GetAttribute("class"), "pf-api-docs"))
+            return true;
+
+        return HasPowerForgeApiDocsMarker(doc) && IsApiReferenceRoute(relativePath);
+    }
+
+    private static bool HasPowerForgeApiDocsMarker(IDocument doc)
+    {
+        return doc.Head?.QuerySelector("meta[name='generator'][data-pf='api-docs']") is not null;
+    }
+
+    private static bool IsApiReferenceRoute(string relativePath)
+    {
+        var normalized = (relativePath ?? string.Empty).Replace('\\', '/').TrimStart('/');
+        return normalized.StartsWith("api/", StringComparison.OrdinalIgnoreCase) ||
+               normalized.StartsWith("docs/api/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ContainsClassToken(string? classValue, string expectedToken)
+    {
+        if (string.IsNullOrWhiteSpace(classValue) || string.IsNullOrWhiteSpace(expectedToken))
+            return false;
+
+        return classValue
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(token => token.Equals(expectedToken, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/PowerForge.Web/Services/WebSeoDoctor.GeneratedApiReference.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.GeneratedApiReference.cs
@@ -10,22 +10,13 @@ public static partial class WebSeoDoctor
         if (doc.Body is null)
             return false;
 
-        if (ContainsClassToken(doc.Body.GetAttribute("class"), "pf-api-docs"))
-            return true;
-
-        return HasPowerForgeApiDocsMarker(doc) && IsApiReferenceRoute(relativePath);
+        return ContainsClassToken(doc.Body.GetAttribute("class"), "pf-api-docs") ||
+               HasPowerForgeApiDocsMarker(doc);
     }
 
     private static bool HasPowerForgeApiDocsMarker(IDocument doc)
     {
         return doc.Head?.QuerySelector("meta[name='generator'][data-pf='api-docs']") is not null;
-    }
-
-    private static bool IsApiReferenceRoute(string relativePath)
-    {
-        var normalized = (relativePath ?? string.Empty).Replace('\\', '/').TrimStart('/');
-        return normalized.StartsWith("api/", StringComparison.OrdinalIgnoreCase) ||
-               normalized.StartsWith("docs/api/", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool ContainsClassToken(string? classValue, string expectedToken)

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -5,7 +5,7 @@ using HtmlTinkerX;
 namespace PowerForge.Web;
 
 /// <summary>Runs SEO-focused checks on generated HTML output.</summary>
-public static class WebSeoDoctor
+public static partial class WebSeoDoctor
 {
     private static readonly string[] DefaultExcludePatterns =
     {
@@ -187,6 +187,8 @@ public static class WebSeoDoctor
                 .Select(image => (image.GetAttribute("src") ?? string.Empty).Trim())
                 .Where(src => !string.IsNullOrWhiteSpace(src))
                 .ToArray();
+            var isGeneratedApiReferencePage = options.ApplyGeneratedApiReferenceSeoProfile &&
+                IsGeneratedApiReferencePage(relativePath, doc);
 
             if (options.CheckContentLeaks)
             {
@@ -234,7 +236,7 @@ public static class WebSeoDoctor
                 {
                     AddIssue("warning", "title", relativePath, "missing <title>.", "title-missing");
                 }
-                else
+                else if (!isGeneratedApiReferencePage)
                 {
                     if (title.Length < titleMin)
                     {
@@ -258,7 +260,7 @@ public static class WebSeoDoctor
                 {
                     AddIssue("warning", "description", relativePath, "missing meta description.", "description-missing");
                 }
-                else
+                else if (!isGeneratedApiReferencePage)
                 {
                     if (description.Length < descriptionMin)
                     {
@@ -344,7 +346,7 @@ public static class WebSeoDoctor
             {
                 ValidateHreflang(
                     relativePath,
-                    options.RequireHreflang,
+                    options.RequireHreflang && !isGeneratedApiReferencePage,
                     options.RequireHreflangXDefault,
                     hreflangAlternates,
                     AddIssue);

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -169,8 +169,12 @@ public static partial class WebSeoDoctor
             var title = NormalizeWhitespace(doc.Title);
             var description = GetMetaNameValue(doc, "description");
             var bodyText = GetVisibleBodyText(doc.Body);
+            var isGeneratedApiReferencePage = options.ApplyGeneratedApiReferenceSeoProfile &&
+                IsGeneratedApiReferencePage(relativePath, doc);
             var canonicalLinks = GetCanonicalLinks(doc);
-            var hreflangAlternates = GetHreflangAlternates(doc);
+            var hreflangAlternates = GetHreflangAlternates(
+                doc,
+                includeMalformedAlternateCandidates: options.RequireHreflang || isGeneratedApiReferencePage);
             var titleTagCount = doc.QuerySelectorAll("title").Count();
             var visibleH1Count = doc.QuerySelectorAll("h1")
                 .Count(heading => !IsElementHidden(heading));
@@ -187,8 +191,6 @@ public static partial class WebSeoDoctor
                 .Select(image => (image.GetAttribute("src") ?? string.Empty).Trim())
                 .Where(src => !string.IsNullOrWhiteSpace(src))
                 .ToArray();
-            var isGeneratedApiReferencePage = options.ApplyGeneratedApiReferenceSeoProfile &&
-                IsGeneratedApiReferencePage(relativePath, doc);
 
             if (options.CheckContentLeaks)
             {
@@ -759,19 +761,37 @@ public static partial class WebSeoDoctor
         }
     }
 
-    private static HreflangAlternateScan[] GetHreflangAlternates(AngleSharp.Dom.IDocument doc)
+    private static HreflangAlternateScan[] GetHreflangAlternates(
+        AngleSharp.Dom.IDocument doc,
+        bool includeMalformedAlternateCandidates = false)
     {
         if (doc.Head is null)
             return Array.Empty<HreflangAlternateScan>();
 
-        return doc.Head.QuerySelectorAll("link[rel][hreflang]")
+        return doc.Head.QuerySelectorAll("link[rel]")
             .Where(link => ContainsRelToken(link.GetAttribute("rel"), "alternate"))
+            .Where(link => link.HasAttribute("hreflang") ||
+                           (includeMalformedAlternateCandidates && IsLikelyHreflangAlternate(link)))
             .Select(link => new HreflangAlternateScan
             {
                 HrefLang = NormalizeWhitespace(link.GetAttribute("hreflang")).ToLowerInvariant(),
                 Href = NormalizeWhitespace(link.GetAttribute("href"))
             })
             .ToArray();
+    }
+
+    private static bool IsLikelyHreflangAlternate(AngleSharp.Dom.IElement link)
+    {
+        if (link.HasAttribute("type") ||
+            link.HasAttribute("media") ||
+            link.HasAttribute("title") ||
+            link.HasAttribute("sizes"))
+        {
+            return false;
+        }
+
+        var href = NormalizeWhitespace(link.GetAttribute("href"));
+        return !string.IsNullOrWhiteSpace(href);
     }
 
     private static void ValidateHreflang(

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -346,7 +346,8 @@ public static partial class WebSeoDoctor
             {
                 ValidateHreflang(
                     relativePath,
-                    options.RequireHreflang && !isGeneratedApiReferencePage,
+                    options.RequireHreflang,
+                    suppressMissingHreflang: isGeneratedApiReferencePage,
                     options.RequireHreflangXDefault,
                     hreflangAlternates,
                     AddIssue);
@@ -763,20 +764,20 @@ public static partial class WebSeoDoctor
         if (doc.Head is null)
             return Array.Empty<HreflangAlternateScan>();
 
-        return doc.Head.QuerySelectorAll("link[rel][hreflang][href]")
+        return doc.Head.QuerySelectorAll("link[rel][hreflang]")
             .Where(link => ContainsRelToken(link.GetAttribute("rel"), "alternate"))
             .Select(link => new HreflangAlternateScan
             {
                 HrefLang = NormalizeWhitespace(link.GetAttribute("hreflang")).ToLowerInvariant(),
                 Href = NormalizeWhitespace(link.GetAttribute("href"))
             })
-            .Where(value => !string.IsNullOrWhiteSpace(value.HrefLang) && !string.IsNullOrWhiteSpace(value.Href))
             .ToArray();
     }
 
     private static void ValidateHreflang(
         string relativePath,
         bool requireHreflang,
+        bool suppressMissingHreflang,
         bool requireXDefault,
         HreflangAlternateScan[] alternates,
         Action<string, string, string?, string, string?, string?> addIssue)
@@ -785,12 +786,13 @@ public static partial class WebSeoDoctor
 
         if (alternates.Length == 0)
         {
-            if (requireHreflang)
+            if (requireHreflang && !suppressMissingHreflang)
                 addIssue("warning", "hreflang", relativePath, "missing hreflang alternates.", "hreflang-missing", null);
             return;
         }
 
         var duplicateLanguageGroups = alternates
+            .Where(value => !string.IsNullOrWhiteSpace(value.HrefLang))
             .GroupBy(value => value.HrefLang, StringComparer.OrdinalIgnoreCase)
             .Where(group => group.Count() > 1)
             .OrderBy(group => group.Key, StringComparer.OrdinalIgnoreCase)
@@ -805,7 +807,14 @@ public static partial class WebSeoDoctor
 
         foreach (var alternate in alternates)
         {
-            if (!HreflangTokenPattern.IsMatch(alternate.HrefLang))
+            if (string.IsNullOrWhiteSpace(alternate.HrefLang))
+            {
+                addIssue("warning", "hreflang", relativePath,
+                    "hreflang alternate is missing a language value.",
+                    "hreflang-language-missing",
+                    alternate.Href);
+            }
+            else if (!HreflangTokenPattern.IsMatch(alternate.HrefLang))
             {
                 addIssue("warning", "hreflang", relativePath,
                     $"invalid hreflang value '{alternate.HrefLang}'.",
@@ -813,7 +822,14 @@ public static partial class WebSeoDoctor
                     alternate.HrefLang);
             }
 
-            if (!IsAbsoluteHttpUrl(alternate.Href))
+            if (string.IsNullOrWhiteSpace(alternate.Href))
+            {
+                addIssue("warning", "hreflang", relativePath,
+                    $"hreflang '{alternate.HrefLang}' is missing an href value.",
+                    "hreflang-href-missing",
+                    alternate.HrefLang);
+            }
+            else if (!IsAbsoluteHttpUrl(alternate.Href))
             {
                 addIssue("warning", "hreflang", relativePath,
                     $"hreflang '{alternate.HrefLang}' should use an absolute http(s) URL but was '{alternate.Href}'.",

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -3999,6 +3999,22 @@
         "checkDuplicateTitles": { "type": "boolean" },
         "checkOrphanPages": { "type": "boolean" },
         "checkFocusKeyphrase": { "type": "boolean" },
+        "applyGeneratedApiReferenceSeoProfile": {
+          "type": "boolean",
+          "description": "When true, relax generic editorial title/description length and missing-hreflang requirements on generated API reference pages while keeping structural SEO checks."
+        },
+        "apply-generated-api-reference-seo-profile": {
+          "type": "boolean",
+          "description": "Alias for applyGeneratedApiReferenceSeoProfile."
+        },
+        "generatedApiReferenceSeoProfile": {
+          "type": "boolean",
+          "description": "Alias for applyGeneratedApiReferenceSeoProfile."
+        },
+        "generated-api-reference-seo-profile": {
+          "type": "boolean",
+          "description": "Alias for applyGeneratedApiReferenceSeoProfile."
+        },
         "checkCanonical": { "type": "boolean" },
         "check-canonical": { "type": "boolean", "description": "Alias for checkCanonical." },
         "checkHreflang": { "type": "boolean" },


### PR DESCRIPTION
## What changed
- Adds a default-on SEO doctor profile for generated PowerForge API reference pages.
- Keeps structural checks active, including missing title/description, canonical validation, malformed hreflang, content leaks, structured data, links, headings, and image checks.
- Relaxes generic editorial title/description length and missing-hreflang requirements on generated API reference pages, because symbol reference pages do not behave like marketing or article pages.
- Adds a generator marker to API docs templates and exposes the profile through pipeline JSON/schema with opt-out aliases.

## Why
OfficeIMO generated API docs were producing recurring baseline churn for `title-long`, `description-short`, and `hreflang-missing` keys. Those warnings are valid for editorial pages, but they are mostly noise for generated API symbol pages. This moves the policy into PowerForge so other generated API reference consumers get the same clean behavior.

## Review follow-up
- The profile now trusts the PowerForge API-docs marker even when generated project API pages live under paths such as `projects/<slug>/api` and use a custom body class.
- Malformed hreflang tags remain visible: missing API-page hreflang alternates can be relaxed, but broken alternate tags are still reported, including alternate links missing `href` or missing `hreflang`.

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~WebSeoDoctorTests|FullyQualifiedName~WebPipelineRunnerSeoDoctorTests"` (41 passed)
- OfficeIMO website CI-mode pipeline with the local PowerForge worktree before the review fixes: `1959 pages, 0 errors, 222 warnings, 0 new issues`; SEO doctor and audit both passed.