### PR TITLE
Improve agent readiness llms and markdown diagnostics

### DIFF
--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -787,6 +787,38 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void BuildMarkdownNegotiationMessage_ReportsFetchedArtifactMimeMismatch()
+    {
+        var message = WebAgentReadiness.BuildMarkdownNegotiationMessage(
+            negotiated: false,
+            requestSucceeded: true,
+            contentType: "text/html",
+            vary: "Accept",
+            cacheStatus: string.Empty,
+            cacheControl: "public, max-age=14400",
+            directMarkdownAvailable: false,
+            directMarkdownUrl: "https://example.test/agent.md",
+            directMarkdownFetched: true,
+            directMarkdownContentType: "text/plain");
+
+        Assert.Contains("was fetched", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Content-Type text/plain", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("https://example.test/agent.md", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveMarkdownAlternateUrl_ParsesRelationTokensAndMediaTypeParameters()
+    {
+        var linkHeader =
+            "</feed.xml>; rel=\"alternate\"; type=\"application/rss+xml\", " +
+            "</agent.md>; rel=\"canonical alternate\"; type=\"text/markdown; charset=utf-8\"";
+
+        var url = WebAgentReadiness.ResolveMarkdownAlternateUrl("https://example.test", linkHeader);
+
+        Assert.Equal("https://example.test/agent.md", url);
+    }
+
+    [Fact]
     public void Prepare_ReplacesExistingApacheManagedBlock()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-apache-idempotent-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -770,6 +770,23 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void BuildMarkdownNegotiationMessage_DoesNotTreatAcceptEncodingAsAccept()
+    {
+        var message = WebAgentReadiness.BuildMarkdownNegotiationMessage(
+            negotiated: false,
+            requestSucceeded: true,
+            contentType: "text/html",
+            vary: "Accept-Encoding",
+            cacheStatus: "HIT",
+            cacheControl: "public, max-age=14400",
+            directMarkdownAvailable: true,
+            directMarkdownUrl: "https://example.test/index.md");
+
+        Assert.Contains("does not declare Vary: Accept", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("may not be keying cached HTML by Accept", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Prepare_ReplacesExistingApacheManagedBlock()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-apache-idempotent-" + Guid.NewGuid().ToString("N"));
@@ -1253,7 +1270,66 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
-    public void Verify_FailsMalformedLlmsTxtWhenPresent()
+    public void Verify_WarnsForMinimalLlmsTxtWithoutRecommendedLinks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-minimal-llms-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "llms.txt"),
+                """
+                # Example
+
+                Example documentation and API reference.
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Example","sameAs":["https://example.test"],"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ContentSignals = new AgentContentSignalsSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
+                    MarkdownNegotiation = false
+                }
+            });
+
+            Assert.Contains(result.Checks, check =>
+                check.Id == "llms-txt" &&
+                check.Status == "warn" &&
+                check.Message.Contains("Recommended outline", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(result.Checks, check => string.Equals(check.Status, "fail", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Verify_FailsLlmsTxtWithoutH1WhenPresent()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-bad-llms-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -1268,8 +1344,9 @@ public class WebAgentReadinessTests
                 """);
             File.WriteAllText(Path.Combine(root, "llms.txt"),
                 """
-                # Example
-                - /api/index.json
+                Example
+
+                - [API index](/api/index.json): Machine-readable API data.
                 """);
             File.WriteAllText(Path.Combine(root, "index.html"),
                 """
@@ -1301,7 +1378,7 @@ public class WebAgentReadinessTests
             Assert.Contains(result.Checks, check =>
                 check.Id == "llms-txt" &&
                 check.Status == "fail" &&
-                check.Message.Contains("Markdown list link", StringComparison.OrdinalIgnoreCase));
+                check.Message.Contains("H1 heading", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -23,7 +23,13 @@ public class WebAgentReadinessTests
                 """);
             Directory.CreateDirectory(Path.Combine(root, "api"));
             File.WriteAllText(Path.Combine(root, "api", "index.json"), "{}");
-            File.WriteAllText(Path.Combine(root, "llms.txt"), "# Example");
+            File.WriteAllText(Path.Combine(root, "llms.txt"),
+                """
+                # Example
+
+                ## Documentation
+                - [API index](/api/index.json): Machine-readable API data.
+                """);
             File.WriteAllText(Path.Combine(root, "index.html"),
                 """
                 <!doctype html>
@@ -745,6 +751,25 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void BuildMarkdownNegotiationMessage_DiagnosesEdgeCacheWhenDirectArtifactWorks()
+    {
+        var message = WebAgentReadiness.BuildMarkdownNegotiationMessage(
+            negotiated: false,
+            requestSucceeded: true,
+            contentType: "text/html",
+            vary: "Accept-Encoding, Accept",
+            cacheStatus: "HIT",
+            cacheControl: "public, max-age=14400",
+            directMarkdownAvailable: true,
+            directMarkdownUrl: "https://example.test/index.md");
+
+        Assert.Contains("direct Markdown artifact is available", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("edge/cache layer", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("HIT", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("https://example.test/index.md", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Prepare_ReplacesExistingApacheManagedBlock()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-apache-idempotent-" + Guid.NewGuid().ToString("N"));
@@ -1220,6 +1245,63 @@ public class WebAgentReadinessTests
 
             Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
             Assert.DoesNotContain(result.Checks, check => string.Equals(check.Status, "fail", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Verify_FailsMalformedLlmsTxtWhenPresent()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-agent-ready-bad-llms-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/</loc></url>
+                </urlset>
+                """);
+            File.WriteAllText(Path.Combine(root, "llms.txt"),
+                """
+                # Example
+                - /api/index.json
+                """);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html lang="en">
+                <head><title>Example</title><meta name="robots" content="index,follow"><script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Example","sameAs":["https://example.test"],"dateModified":"2026-04-17"}</script></head>
+                <body><header><nav><a href="/">Home</a></nav></header><main><h1>Example</h1><p>Hello agents.</p></main><footer>Footer</footer></body>
+                </html>
+                """);
+
+            var result = WebAgentReadiness.Verify(new WebAgentReadinessVerifyOptions
+            {
+                SiteRoot = root,
+                BaseUrl = "https://example.test",
+                AgentReadiness = new AgentReadinessSpec
+                {
+                    Enabled = true,
+                    Robots = false,
+                    LinkHeaders = false,
+                    SecurityHeaders = new AgentSecurityHeadersSpec { Enabled = false },
+                    ContentSignals = new AgentContentSignalsSpec { Enabled = false },
+                    ApiCatalog = new AgentApiCatalogSpec { Enabled = false },
+                    AgentSkills = new AgentSkillsDiscoverySpec { Enabled = false },
+                    AgentsJson = new AgentDiscoveryDocumentSpec { Enabled = false },
+                    MarkdownNegotiation = false
+                }
+            });
+
+            Assert.Contains(result.Checks, check =>
+                check.Id == "llms-txt" &&
+                check.Status == "fail" &&
+                check.Message.Contains("Markdown list link", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -6,6 +6,36 @@ using Xunit;
 public class WebLlmsGeneratorTests
 {
     [Fact]
+    public void Generate_WritesRecommendedLlmsTxtMarkdownLinks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-markdown-links-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                Name = "Example Product",
+                PackageId = "Example.Product",
+                Overview = "Example Product publishes API docs and implementation guidance.",
+                ApiBase = "/projects/example/api/"
+            });
+
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            Assert.Contains("# Example Product", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("## Machine-friendly API data", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("- [API index](/projects/example/api/index.json):", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("- [API search](/projects/example/api/search.json):", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("- [API type template](/projects/example/api/types/{slug}.json):", llmsTxt, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Generate_UsesProjectDescription_WhenOverviewIsNotProvided()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-project-description-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -27,6 +27,9 @@ public static class WebAgentReadiness
     private static readonly Regex MarkdownTrailingWhitespaceRegex = new(@"[ \t]+\n", RegexOptions.Compiled);
     private static readonly Regex MarkdownBlankLinesRegex = new(@"\n{3,}", RegexOptions.Compiled);
     private static readonly Regex MarkdownRepeatedSpacesRegex = new(@"[ \t]{2,}", RegexOptions.Compiled);
+    private static readonly Regex MarkdownH1Regex = new(@"(?m)^#\s+\S", RegexOptions.Compiled);
+    private static readonly Regex MarkdownH2Regex = new(@"(?m)^##\s+\S", RegexOptions.Compiled);
+    private static readonly Regex MarkdownListLinkRegex = new(@"(?m)^\s*[-*]\s+\[[^\]\r\n]+\]\([^) \r\n]+[^)\r\n]*\)", RegexOptions.Compiled);
     private static readonly Regex SlugSeparatorRegex = new(@"[-_\s]+", RegexOptions.Compiled);
 
     /// <summary>Writes configured agent-readiness files under the site root.</summary>
@@ -201,6 +204,15 @@ public static class WebAgentReadiness
         AddCheck(checks, "sitemap", "discoverability", "sitemap.xml", ValidateSitemap(sitemapPath, out var sitemapMessage) ? "pass" : "fail",
             sitemapMessage, sitemapPath);
 
+        var llmsPath = Path.Combine(siteRoot, "llms.txt");
+        var llmsExists = File.Exists(llmsPath);
+        var llmsMessage = string.Empty;
+        var llmsValid = llmsExists && ValidateLlmsTxt(llmsPath, out llmsMessage);
+        AddCheck(checks, "llms-txt", "agent-accessibility", "llms.txt",
+            llmsExists ? (llmsValid ? "pass" : "fail") : "info",
+            llmsExists ? llmsMessage : "llms.txt is not present.",
+            llmsPath);
+
         var headersPath = ResolveSitePath(siteRoot, string.IsNullOrWhiteSpace(spec.HeadersPath) ? "_headers" : spec.HeadersPath!);
         var headersText = File.Exists(headersPath) ? File.ReadAllText(headersPath) : string.Empty;
         var apacheEnabled = spec.Apache?.Enabled == true;
@@ -339,14 +351,49 @@ public static class WebAgentReadiness
             sitemap.Success && LooksLikeSitemap(sitemap.Text) ? "sitemap.xml exists with valid structure." : sitemap.Message,
             CombineUrl(baseUrl, "/sitemap.xml"));
 
+        var llms = await TryGetTextAsync(http, CombineUrl(baseUrl, "/llms.txt"), null, cancellationToken).ConfigureAwait(false);
+        var llmsMessage = string.Empty;
+        var llmsValid = llms.Success && ValidateLlmsTxtText(llms.Text, out llmsMessage);
+        AddCheck(checks, "llms-txt", "agent-accessibility", "llms.txt",
+            llms.Success ? (llmsValid ? "pass" : "fail") : "info",
+            llms.Success ? llmsMessage : "llms.txt was not found.",
+            CombineUrl(baseUrl, "/llms.txt"));
+
         var markdown = await TryGetTextAsync(http, baseUrl, "text/markdown", cancellationToken).ConfigureAwait(false);
         var markdownContentType = markdown.Response?.Content.Headers.ContentType?.MediaType ?? string.Empty;
+        var markdownNegotiated = markdown.Success && IsMarkdownContentType(markdownContentType);
+        var markdownAlternateUrl = ResolveMarkdownAlternateUrl(baseUrl, linkHeader) ?? CombineUrl(baseUrl, "/index.md");
+        HttpTextResult? markdownAlternate = null;
+        var markdownAlternateContentType = string.Empty;
+        var markdownAlternateAvailable = false;
+        if (!markdownNegotiated && !string.IsNullOrWhiteSpace(markdownAlternateUrl))
+        {
+            markdownAlternate = await TryGetTextAsync(http, markdownAlternateUrl, null, cancellationToken).ConfigureAwait(false);
+            markdownAlternateContentType = markdownAlternate.Response?.Content.Headers.ContentType?.MediaType ?? string.Empty;
+            markdownAlternateAvailable = markdownAlternate.Success && IsMarkdownContentType(markdownAlternateContentType);
+        }
+
         AddCheck(checks, "markdown-negotiation", "content", "Markdown for Agents",
-            markdown.Success && markdownContentType.Contains("markdown", StringComparison.OrdinalIgnoreCase) ? "pass" : "fail",
-            markdown.Success && markdownContentType.Contains("markdown", StringComparison.OrdinalIgnoreCase)
-                ? "Accept: text/markdown returned markdown content."
-                : "Accept: text/markdown did not return Content-Type text/markdown.",
+            markdownNegotiated ? "pass" : "fail",
+            BuildMarkdownNegotiationMessage(
+                markdownNegotiated,
+                markdown.Success,
+                markdownContentType,
+                GetHeaderValue(markdown.Response, "Vary"),
+                GetHeaderValue(markdown.Response, "CF-Cache-Status"),
+                GetHeaderValue(markdown.Response, "Cache-Control"),
+                markdownAlternateAvailable,
+                markdownAlternateUrl),
             baseUrl);
+        if (!markdownNegotiated)
+        {
+            AddCheck(checks, "markdown-artifact-public", "content", "Direct Markdown artifact",
+                markdownAlternateAvailable ? "pass" : "info",
+                markdownAlternateAvailable
+                    ? $"Direct Markdown artifact is available at {markdownAlternateUrl}."
+                    : $"Direct Markdown artifact was not found at {markdownAlternateUrl}.",
+                markdownAlternateUrl);
+        }
 
         var apiCatalog = await TryGetTextAsync(http, CombineUrl(baseUrl, "/.well-known/api-catalog"), null, cancellationToken).ConfigureAwait(false);
         AddCheck(checks, "api-catalog", "api-auth-mcp-skill-discovery", "API Catalog (RFC 9727)",
@@ -1505,6 +1552,52 @@ public static class WebAgentReadiness
         }
     }
 
+    private static bool ValidateLlmsTxt(string path, out string message)
+    {
+        if (!File.Exists(path))
+        {
+            message = "llms.txt is missing.";
+            return false;
+        }
+
+        try
+        {
+            return ValidateLlmsTxtText(File.ReadAllText(path), out message);
+        }
+        catch (Exception ex)
+        {
+            message = $"llms.txt could not be read: {ex.Message}";
+            return false;
+        }
+    }
+
+    private static bool ValidateLlmsTxtText(string text, out string message)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            message = "llms.txt is empty.";
+            return false;
+        }
+
+        var hasH1 = MarkdownH1Regex.IsMatch(text);
+        var hasH2 = MarkdownH2Regex.IsMatch(text);
+        var hasMarkdownListLink = MarkdownListLinkRegex.IsMatch(text);
+
+        if (hasH1 && hasH2 && hasMarkdownListLink)
+        {
+            message = "llms.txt follows the recommended Markdown outline with linked resources.";
+            return true;
+        }
+
+        var missing = new List<string>();
+        if (!hasH1) missing.Add("an H1 heading");
+        if (!hasH2) missing.Add("at least one H2 section");
+        if (!hasMarkdownListLink) missing.Add("at least one Markdown list link");
+
+        message = "llms.txt is missing " + string.Join(", ", missing) + ".";
+        return false;
+    }
+
     private static bool ValidateApiCatalog(string path, out string message)
     {
         if (!File.Exists(path))
@@ -2160,6 +2253,87 @@ public static class WebAgentReadiness
         {
             return new HttpResponseResult(false, ex.Message, null);
         }
+    }
+
+    private static bool IsMarkdownContentType(string? contentType)
+        => !string.IsNullOrWhiteSpace(contentType) &&
+           contentType.Contains("markdown", StringComparison.OrdinalIgnoreCase);
+
+    private static string? ResolveMarkdownAlternateUrl(string baseUrl, string linkHeader)
+    {
+        if (string.IsNullOrWhiteSpace(linkHeader))
+            return null;
+
+        foreach (var segment in linkHeader.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!segment.Contains("rel=\"alternate\"", StringComparison.OrdinalIgnoreCase) ||
+                !segment.Contains("type=\"text/markdown\"", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var start = segment.IndexOf('<');
+            var end = segment.IndexOf('>');
+            if (start < 0 || end <= start)
+                continue;
+
+            var href = segment.Substring(start + 1, end - start - 1).Trim();
+            if (string.IsNullOrWhiteSpace(href))
+                continue;
+
+            return Uri.TryCreate(href, UriKind.Absolute, out _)
+                ? href
+                : CombineUrl(baseUrl, href);
+        }
+
+        return null;
+    }
+
+    private static string GetHeaderValue(HttpResponseMessage? response, string name)
+    {
+        if (response is null)
+            return string.Empty;
+
+        if (response.Headers.TryGetValues(name, out var headerValues))
+            return string.Join(", ", headerValues);
+
+        return response.Content.Headers.TryGetValues(name, out var contentHeaderValues)
+            ? string.Join(", ", contentHeaderValues)
+            : string.Empty;
+    }
+
+    internal static string BuildMarkdownNegotiationMessage(
+        bool negotiated,
+        bool requestSucceeded,
+        string contentType,
+        string vary,
+        string cacheStatus,
+        string cacheControl,
+        bool directMarkdownAvailable,
+        string? directMarkdownUrl)
+    {
+        if (negotiated)
+            return "Accept: text/markdown returned markdown content.";
+
+        var returned = string.IsNullOrWhiteSpace(contentType) ? "no Content-Type" : $"Content-Type {contentType}";
+        if (!requestSucceeded)
+            return $"Accept: text/markdown request failed and returned {returned}.";
+
+        var hasVaryAccept = vary.Contains("Accept", StringComparison.OrdinalIgnoreCase);
+        var hasEdgeCache = !string.IsNullOrWhiteSpace(cacheStatus);
+        if (directMarkdownAvailable)
+        {
+            var cacheDetail = hasEdgeCache
+                ? $" Edge cache status was {cacheStatus}."
+                : string.Empty;
+            var varyDetail = hasVaryAccept
+                ? " The response declares Vary: Accept, so the edge/cache layer may not be keying cached HTML by Accept."
+                : " The response does not declare Vary: Accept.";
+            return $"Accept: text/markdown returned {returned}, but the direct Markdown artifact is available at {directMarkdownUrl}.{varyDetail}{cacheDetail}";
+        }
+
+        var cacheControlDetail = string.IsNullOrWhiteSpace(cacheControl) ? string.Empty : $" Cache-Control was {cacheControl}.";
+        return $"Accept: text/markdown did not return Content-Type text/markdown; returned {returned}.{cacheControlDetail}";
     }
 
     private static string NormalizeBaseUrl(string? value)

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -365,12 +365,14 @@ public static class WebAgentReadiness
         var markdownAlternateUrl = ResolveMarkdownAlternateUrl(baseUrl, linkHeader) ?? CombineUrl(baseUrl, "/index.md");
         HttpTextResult? markdownAlternate = null;
         var markdownAlternateContentType = string.Empty;
-        var markdownAlternateAvailable = false;
+        var markdownAlternateFetched = false;
+        var markdownAlternateAvailableAsMarkdown = false;
         if (!markdownNegotiated && !string.IsNullOrWhiteSpace(markdownAlternateUrl))
         {
             markdownAlternate = await TryGetTextAsync(http, markdownAlternateUrl, null, cancellationToken).ConfigureAwait(false);
             markdownAlternateContentType = markdownAlternate.Response?.Content.Headers.ContentType?.MediaType ?? string.Empty;
-            markdownAlternateAvailable = markdownAlternate.Success && IsMarkdownContentType(markdownAlternateContentType);
+            markdownAlternateFetched = markdownAlternate.Success;
+            markdownAlternateAvailableAsMarkdown = markdownAlternateFetched && IsMarkdownContentType(markdownAlternateContentType);
         }
 
         AddCheck(checks, "markdown-negotiation", "content", "Markdown for Agents",
@@ -382,16 +384,20 @@ public static class WebAgentReadiness
                 GetHeaderValue(markdown.Response, "Vary"),
                 GetHeaderValue(markdown.Response, "CF-Cache-Status"),
                 GetHeaderValue(markdown.Response, "Cache-Control"),
-                markdownAlternateAvailable,
-                markdownAlternateUrl),
+                markdownAlternateAvailableAsMarkdown,
+                markdownAlternateUrl,
+                markdownAlternateFetched,
+                markdownAlternateContentType),
             baseUrl);
         if (!markdownNegotiated)
         {
             AddCheck(checks, "markdown-artifact-public", "content", "Direct Markdown artifact",
-                markdownAlternateAvailable ? "pass" : "info",
-                markdownAlternateAvailable
+                markdownAlternateAvailableAsMarkdown ? "pass" : (markdownAlternateFetched ? "warn" : "info"),
+                markdownAlternateAvailableAsMarkdown
                     ? $"Direct Markdown artifact is available at {markdownAlternateUrl}."
-                    : $"Direct Markdown artifact was not found at {markdownAlternateUrl}.",
+                    : (markdownAlternateFetched
+                        ? $"Direct Markdown artifact was fetched at {markdownAlternateUrl}, but returned {FormatContentTypeForMessage(markdownAlternateContentType)}. Configure the host MIME type as text/markdown."
+                        : $"Direct Markdown artifact was not found at {markdownAlternateUrl}."),
                 markdownAlternateUrl);
         }
 
@@ -2269,23 +2275,24 @@ public static class WebAgentReadiness
         => !string.IsNullOrWhiteSpace(contentType) &&
            contentType.Contains("markdown", StringComparison.OrdinalIgnoreCase);
 
-    private static string? ResolveMarkdownAlternateUrl(string baseUrl, string linkHeader)
+    internal static string? ResolveMarkdownAlternateUrl(string baseUrl, string linkHeader)
     {
         if (string.IsNullOrWhiteSpace(linkHeader))
             return null;
 
-        foreach (var segment in linkHeader.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        foreach (var segment in SplitHeaderValues(linkHeader))
         {
-            if (!segment.Contains("rel=\"alternate\"", StringComparison.OrdinalIgnoreCase) ||
-                !segment.Contains("type=\"text/markdown\"", StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
             var start = segment.IndexOf('<');
             var end = segment.IndexOf('>');
             if (start < 0 || end <= start)
                 continue;
+
+            var parameters = ParseLinkParameters(segment[(end + 1)..]);
+            if (!LinkRelContains(parameters.GetValueOrDefault("rel"), "alternate") ||
+                !IsMarkdownMediaType(parameters.GetValueOrDefault("type")))
+            {
+                continue;
+            }
 
             var href = segment.Substring(start + 1, end - start - 1).Trim();
             if (string.IsNullOrWhiteSpace(href))
@@ -2297,6 +2304,104 @@ public static class WebAgentReadiness
         }
 
         return null;
+    }
+
+    private static string[] SplitHeaderValues(string value)
+    {
+        var values = new List<string>();
+        var current = new StringBuilder();
+        var inQuote = false;
+        var inAngle = false;
+
+        foreach (var c in value)
+        {
+            if (c == '"')
+                inQuote = !inQuote;
+            else if (!inQuote && c == '<')
+                inAngle = true;
+            else if (!inQuote && c == '>')
+                inAngle = false;
+
+            if (c == ',' && !inQuote && !inAngle)
+            {
+                AddTrimmedValue(values, current);
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        AddTrimmedValue(values, current);
+        return values.ToArray();
+    }
+
+    private static string[] SplitHeaderParameters(string value)
+    {
+        var values = new List<string>();
+        var current = new StringBuilder();
+        var inQuote = false;
+
+        foreach (var c in value)
+        {
+            if (c == '"')
+                inQuote = !inQuote;
+
+            if (c == ';' && !inQuote)
+            {
+                AddTrimmedValue(values, current);
+                continue;
+            }
+
+            current.Append(c);
+        }
+
+        AddTrimmedValue(values, current);
+        return values.ToArray();
+    }
+
+    private static void AddTrimmedValue(List<string> values, StringBuilder current)
+    {
+        var value = current.ToString().Trim();
+        if (!string.IsNullOrWhiteSpace(value))
+            values.Add(value);
+        current.Clear();
+    }
+
+    private static Dictionary<string, string> ParseLinkParameters(string value)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var segment in SplitHeaderParameters(value))
+        {
+            var equalsIndex = segment.IndexOf('=');
+            if (equalsIndex <= 0)
+                continue;
+
+            var name = segment[..equalsIndex].Trim();
+            var parameterValue = TrimQuotedValue(segment[(equalsIndex + 1)..].Trim());
+            if (!string.IsNullOrWhiteSpace(name))
+                parameters[name] = parameterValue;
+        }
+
+        return parameters;
+    }
+
+    private static string TrimQuotedValue(string value)
+        => value.Length >= 2 && value[0] == '"' && value[^1] == '"'
+            ? value[1..^1]
+            : value;
+
+    private static bool LinkRelContains(string? rel, string expectedRel)
+        => !string.IsNullOrWhiteSpace(rel) &&
+           rel.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+               .Any(token => string.Equals(token, expectedRel, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsMarkdownMediaType(string? mediaType)
+    {
+        if (string.IsNullOrWhiteSpace(mediaType))
+            return false;
+
+        var type = mediaType.Split(';', 2, StringSplitOptions.TrimEntries)[0];
+        return string.Equals(type, "text/markdown", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string GetHeaderValue(HttpResponseMessage? response, string name)
@@ -2320,7 +2425,9 @@ public static class WebAgentReadiness
         string cacheStatus,
         string cacheControl,
         bool directMarkdownAvailable,
-        string? directMarkdownUrl)
+        string? directMarkdownUrl,
+        bool directMarkdownFetched = false,
+        string directMarkdownContentType = "")
     {
         if (negotiated)
             return "Accept: text/markdown returned markdown content.";
@@ -2342,9 +2449,17 @@ public static class WebAgentReadiness
             return $"Accept: text/markdown returned {returned}, but the direct Markdown artifact is available at {directMarkdownUrl}.{varyDetail}{cacheDetail}";
         }
 
+        if (directMarkdownFetched)
+        {
+            return $"Accept: text/markdown returned {returned}, and the direct Markdown artifact at {directMarkdownUrl} was fetched but returned {FormatContentTypeForMessage(directMarkdownContentType)}.";
+        }
+
         var cacheControlDetail = string.IsNullOrWhiteSpace(cacheControl) ? string.Empty : $" Cache-Control was {cacheControl}.";
         return $"Accept: text/markdown did not return Content-Type text/markdown; returned {returned}.{cacheControlDetail}";
     }
+
+    private static string FormatContentTypeForMessage(string contentType)
+        => string.IsNullOrWhiteSpace(contentType) ? "no Content-Type" : $"Content-Type {contentType}";
 
     private static bool HasHeaderToken(string value, string expectedToken)
         => value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -207,9 +207,9 @@ public static class WebAgentReadiness
         var llmsPath = Path.Combine(siteRoot, "llms.txt");
         var llmsExists = File.Exists(llmsPath);
         var llmsMessage = string.Empty;
-        var llmsValid = llmsExists && ValidateLlmsTxt(llmsPath, out llmsMessage);
+        var llmsStatus = llmsExists ? GetLlmsTxtStatus(llmsPath, out llmsMessage) : "info";
         AddCheck(checks, "llms-txt", "agent-accessibility", "llms.txt",
-            llmsExists ? (llmsValid ? "pass" : "fail") : "info",
+            llmsExists ? llmsStatus : "info",
             llmsExists ? llmsMessage : "llms.txt is not present.",
             llmsPath);
 
@@ -353,9 +353,9 @@ public static class WebAgentReadiness
 
         var llms = await TryGetTextAsync(http, CombineUrl(baseUrl, "/llms.txt"), null, cancellationToken).ConfigureAwait(false);
         var llmsMessage = string.Empty;
-        var llmsValid = llms.Success && ValidateLlmsTxtText(llms.Text, out llmsMessage);
+        var llmsStatus = llms.Success ? GetLlmsTxtTextStatus(llms.Text, out llmsMessage) : "info";
         AddCheck(checks, "llms-txt", "agent-accessibility", "llms.txt",
-            llms.Success ? (llmsValid ? "pass" : "fail") : "info",
+            llms.Success ? llmsStatus : "info",
             llms.Success ? llmsMessage : "llms.txt was not found.",
             CombineUrl(baseUrl, "/llms.txt"));
 
@@ -1552,31 +1552,31 @@ public static class WebAgentReadiness
         }
     }
 
-    private static bool ValidateLlmsTxt(string path, out string message)
+    private static string GetLlmsTxtStatus(string path, out string message)
     {
         if (!File.Exists(path))
         {
             message = "llms.txt is missing.";
-            return false;
+            return "info";
         }
 
         try
         {
-            return ValidateLlmsTxtText(File.ReadAllText(path), out message);
+            return GetLlmsTxtTextStatus(File.ReadAllText(path), out message);
         }
         catch (Exception ex)
         {
             message = $"llms.txt could not be read: {ex.Message}";
-            return false;
+            return "fail";
         }
     }
 
-    private static bool ValidateLlmsTxtText(string text, out string message)
+    private static string GetLlmsTxtTextStatus(string text, out string message)
     {
         if (string.IsNullOrWhiteSpace(text))
         {
             message = "llms.txt is empty.";
-            return false;
+            return "fail";
         }
 
         var hasH1 = MarkdownH1Regex.IsMatch(text);
@@ -1586,7 +1586,17 @@ public static class WebAgentReadiness
         if (hasH1 && hasH2 && hasMarkdownListLink)
         {
             message = "llms.txt follows the recommended Markdown outline with linked resources.";
-            return true;
+            return "pass";
+        }
+
+        if (hasH1)
+        {
+            var recommendations = new List<string>();
+            if (!hasH2) recommendations.Add("at least one H2 section");
+            if (!hasMarkdownListLink) recommendations.Add("at least one Markdown list link");
+
+            message = "llms.txt has an H1 heading. Recommended outline is missing " + string.Join(", ", recommendations) + ".";
+            return "warn";
         }
 
         var missing = new List<string>();
@@ -1595,7 +1605,7 @@ public static class WebAgentReadiness
         if (!hasMarkdownListLink) missing.Add("at least one Markdown list link");
 
         message = "llms.txt is missing " + string.Join(", ", missing) + ".";
-        return false;
+        return "fail";
     }
 
     private static bool ValidateApiCatalog(string path, out string message)
@@ -2319,7 +2329,7 @@ public static class WebAgentReadiness
         if (!requestSucceeded)
             return $"Accept: text/markdown request failed and returned {returned}.";
 
-        var hasVaryAccept = vary.Contains("Accept", StringComparison.OrdinalIgnoreCase);
+        var hasVaryAccept = HasHeaderToken(vary, "Accept");
         var hasEdgeCache = !string.IsNullOrWhiteSpace(cacheStatus);
         if (directMarkdownAvailable)
         {
@@ -2335,6 +2345,10 @@ public static class WebAgentReadiness
         var cacheControlDetail = string.IsNullOrWhiteSpace(cacheControl) ? string.Empty : $" Cache-Control was {cacheControl}.";
         return $"Accept: text/markdown did not return Content-Type text/markdown; returned {returned}.{cacheControlDetail}";
     }
+
+    private static bool HasHeaderToken(string value, string expectedToken)
+        => value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(token => string.Equals(token, expectedToken, StringComparison.OrdinalIgnoreCase));
 
     private static string NormalizeBaseUrl(string? value)
     {

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -72,7 +72,7 @@ public static class WebLlmsGenerator
         var overview = ResolveOverview(options, projectInfo, siteRoot, name);
         var apiBase = string.IsNullOrWhiteSpace(options.ApiBase) ? "/api" : options.ApiBase;
 
-        WriteLlmsTxt(llmsTxtPath, name, packageId, version, typeCount, apiBase, quickstart);
+        WriteLlmsTxt(llmsTxtPath, name, packageId, version, typeCount, apiBase, overview, quickstart);
         WriteLlmsJson(llmsJsonPath, name, packageId, version, apiBase, quickstart);
         WriteLlmsFull(llmsFullPath, name, packageId, version, typeCount, apiBase, overview, quickstart, options);
 
@@ -254,28 +254,34 @@ public static class WebLlmsGenerator
         string version,
         int? typeCount,
         string apiBase,
+        string overview,
         string[] quickstart)
     {
+        var normalizedApiBase = apiBase.TrimEnd('/');
         var lines = new List<string>
         {
             $"# {name}",
-            $"Version: {version}",
-            $"Package: {packageId}"
+            string.Empty,
+            $"> {overview}",
+            string.Empty,
+            "## Metadata",
+            $"- Version: {version}",
+            $"- Package: {packageId}"
         };
-        if (typeCount.HasValue) lines.Add($"API types: {typeCount.Value}");
+        if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
         lines.Add(string.Empty);
-        lines.Add("Install:");
+        lines.Add("## Install");
         lines.Add($"- dotnet add package {packageId}");
         lines.Add(string.Empty);
-        lines.Add("Quickstart:");
+        lines.Add("## Quickstart");
         lines.Add("```csharp");
         lines.AddRange(quickstart);
         lines.Add("```");
         lines.Add(string.Empty);
-        lines.Add("Machine-friendly API data:");
-        lines.Add($"- {apiBase.TrimEnd('/')}/index.json");
-        lines.Add($"- {apiBase.TrimEnd('/')}/search.json");
-        lines.Add($"- {apiBase.TrimEnd('/')}/types/{{slug}}.json");
+        lines.Add("## Machine-friendly API data");
+        lines.Add($"- [API index]({normalizedApiBase}/index.json): Type and package metadata.");
+        lines.Add($"- [API search]({normalizedApiBase}/search.json): Searchable API data.");
+        lines.Add($"- [API type template]({normalizedApiBase}/types/{{slug}}.json): Per-type API details.");
         lines.Add(string.Empty);
         lines.Add("Slug rule: lower-case, dots/symbols -> dashes.");
 
@@ -346,9 +352,9 @@ public static class WebLlmsGenerator
         lines.Add("```");
         lines.Add(string.Empty);
         lines.Add("## API Resources");
-        lines.Add($"- {apiBase.TrimEnd('/')}/index.json");
-        lines.Add($"- {apiBase.TrimEnd('/')}/search.json");
-        lines.Add($"- {apiBase.TrimEnd('/')}/types/{{slug}}.json");
+        lines.Add($"- [API index]({apiBase.TrimEnd('/')}/index.json): Type and package metadata.");
+        lines.Add($"- [API search]({apiBase.TrimEnd('/')}/search.json): Searchable API data.");
+        lines.Add($"- [API type template]({apiBase.TrimEnd('/')}/types/{{slug}}.json): Per-type API details.");
 
         AppendApiDetails(lines, options, apiBase);
 


### PR DESCRIPTION
## What changed

This improves PowerForge agent-readiness output and scans for static websites.

- `llms.txt` now follows the recommended Markdown shape with H2 sections and linked machine-readable resources.
- Agent readiness verification now checks existing `llms.txt` files for the expected H1, H2, and Markdown list links.
- Live scans now distinguish between missing Markdown support and an edge/cache layer serving cached HTML despite a working direct Markdown artifact.
- `llms-full.txt` now uses Markdown links for API resources as well.

## Why it matters

PageSpeed Insights now includes Agentic Browsing checks. The previous generated `llms.txt` had useful paths, but they were plain text paths rather than Markdown links, so scanners could report that the file contained no links.

The Markdown negotiation check is also more actionable. If Apache or another origin can serve `/index.md` but the public route still returns cached HTML for `Accept: text/markdown`, the scan now reports that as an edge/cache behavior instead of a vague Markdown failure.

## Release note

Sites need to rebuild with this PowerForge version before their generated `llms.txt` changes. If a site is behind an edge cache, the direct Markdown artifact can pass while `Accept: text/markdown` still needs host/cache configuration.

## Validation

- Focused PowerForge web agent readiness and `llms` generator tests pass.
- Live scans against `evotec.xyz` and `evotec.pl` now identify the current edge-cache behavior separately from the direct Markdown artifact availability.