### PR TITLE
Sign ProjectBuild assemblies before packaging

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeDotNetReleaseBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetReleaseBuildCommand.cs
@@ -67,7 +67,6 @@ public sealed class InvokeDotNetReleaseBuildCommand : PSCmdlet
         var isVerbose = boundParameters?.ContainsKey("Verbose") == true;
         var logger = new CmdletLogger(this, isVerbose);
         var service = new DotNetReleaseBuildService(logger);
-        var signingService = new AuthenticodeSigningService(logger);
 
         var mappedStore = LocalStore == CertificateStoreLocation.LocalMachine
             ? PowerForge.CertificateStoreLocation.LocalMachine
@@ -125,27 +124,9 @@ public sealed class InvokeDotNetReleaseBuildCommand : PSCmdlet
                 continue;
             }
 
-            Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null;
-            if (!string.IsNullOrWhiteSpace(CertificateThumbprint))
-            {
-                signAssemblies = req =>
-                {
-                    var lookup = signingService.SelectCertificateFromStore(req.LocalStore, req.CertificateThumbprint);
-                    if (lookup.Certificate is null)
-                        throw new InvalidOperationException($"Certificate '{req.CertificateThumbprint}' not found in {req.LocalStore}\\My store.");
-
-                    var files = signingService.EnumerateFiles(req.ReleasePath, req.IncludePatterns);
-                    signingService.SignFiles(new AuthenticodeSignRequest
-                    {
-                        Certificate = lookup.Certificate,
-                        FilePaths = files,
-                        TimeStampServer = req.TimeStampServer,
-                        HashAlgorithm = "SHA256",
-                        WindowsIncludeChain = "All",
-                        NonWindowsIncludeChain = "WholeChain"
-                    });
-                };
-            }
+            var signAssemblies = !string.IsNullOrWhiteSpace(CertificateThumbprint)
+                ? DotNetAssemblySigningCallbackFactory.Create(logger)
+                : null;
 
             var result = service.Execute(spec, signAssemblies);
             WriteObject(result);

--- a/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
@@ -207,7 +207,8 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
         var executeBuild = ShouldProcess(preparation.RootPath, "Release .NET repository packages");
         var result = new DotNetRepositoryReleaseWorkflowService(
             logger,
-            signAssemblies: DotNetAssemblySigningCallbackFactory.Create(logger))
+            signAssemblies: DotNetAssemblySigningCallbackFactory.Create(logger),
+            validateAssemblySigning: DotNetAssemblySigningCallbackFactory.CreatePreflight(logger))
             .Execute(preparation, executeBuild);
         if (interactive)
         {

--- a/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
@@ -107,6 +107,14 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
     [Parameter]
     public string TimeStampServer { get; set; } = "http://timestamp.digicert.com";
 
+    /// <summary>Skip Authenticode signing of build outputs before packages are created.</summary>
+    [Parameter]
+    public SwitchParameter SkipAssemblySigning { get; set; }
+
+    /// <summary>Skip signing generated NuGet packages.</summary>
+    [Parameter]
+    public SwitchParameter SkipPackageSigning { get; set; }
+
     /// <summary>Skip dotnet pack step.</summary>
     [Parameter]
     public SwitchParameter SkipPack { get; set; }
@@ -184,6 +192,8 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
                 ? PowerForge.CertificateStoreLocation.LocalMachine
                 : PowerForge.CertificateStoreLocation.CurrentUser,
             TimeStampServer = TimeStampServer,
+            SignAssemblies = SkipAssemblySigning.IsPresent ? false : null,
+            SignPackages = SkipPackageSigning.IsPresent ? false : null,
             SkipPack = SkipPack.IsPresent,
             Publish = Publish.IsPresent,
             PublishSource = PublishSource,
@@ -195,7 +205,10 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
         });
 
         var executeBuild = ShouldProcess(preparation.RootPath, "Release .NET repository packages");
-        var result = new DotNetRepositoryReleaseWorkflowService(logger).Execute(preparation, executeBuild);
+        var result = new DotNetRepositoryReleaseWorkflowService(
+            logger,
+            signAssemblies: DotNetAssemblySigningCallbackFactory.Create(logger))
+            .Execute(preparation, executeBuild);
         if (interactive)
         {
             var summary = new DotNetRepositoryReleaseSummaryService().CreateSummary(result);

--- a/PSPublishModule/Cmdlets/InvokePowerForgeReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokePowerForgeReleaseCommand.cs
@@ -421,7 +421,11 @@ public sealed partial class InvokePowerForgeReleaseCommand : PSCmdlet
 
             var request = BuildRequest(configFullPath, requestDefaults, boundParameters);
 
-            var result = new PowerForgeReleaseService(logger).Execute(spec, request);
+            var result = new PowerForgeReleaseService(
+                logger,
+                DotNetAssemblySigningCallbackFactory.Create(logger),
+                DotNetAssemblySigningCallbackFactory.CreatePreflight(logger))
+                .Execute(spec, request);
             WriteObject(result);
 
             if (!result.Success)

--- a/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
@@ -106,7 +106,10 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
         }
 
         var executeBuild = !preparation.PlanOnly && ShouldProcess(preparation.RootPath, "Build project repository");
-        var workflow = new ProjectBuildWorkflowService(logger).Execute(config, configDir, preparation, executeBuild);
+        var workflow = new ProjectBuildWorkflowService(
+            logger,
+            signAssemblies: DotNetAssemblySigningCallbackFactory.Create(logger))
+            .Execute(config, configDir, preparation, executeBuild);
         if (interactive && workflow.GitHubPublishSummary is { PerProject: false } publishSummary)
             WriteGitHubSummary(false, publishSummary.SummaryTag, publishSummary.SummaryReleaseUrl, publishSummary.SummaryAssetsCount, workflow.Result.GitHub);
 

--- a/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectBuildCommand.cs
@@ -108,7 +108,8 @@ public sealed partial class InvokeProjectBuildCommand : PSCmdlet
         var executeBuild = !preparation.PlanOnly && ShouldProcess(preparation.RootPath, "Build project repository");
         var workflow = new ProjectBuildWorkflowService(
             logger,
-            signAssemblies: DotNetAssemblySigningCallbackFactory.Create(logger))
+            signAssemblies: DotNetAssemblySigningCallbackFactory.Create(logger),
+            validateAssemblySigning: DotNetAssemblySigningCallbackFactory.CreatePreflight(logger))
             .Execute(config, configDir, preparation, executeBuild);
         if (interactive && workflow.GitHubPublishSummary is { PerProject: false } publishSummary)
             WriteGitHubSummary(false, publishSummary.SummaryTag, publishSummary.SummaryReleaseUrl, publishSummary.SummaryAssetsCount, workflow.Result.GitHub);

--- a/PSPublishModule/Cmdlets/InvokeProjectReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeProjectReleaseCommand.cs
@@ -344,7 +344,11 @@ public sealed class InvokeProjectReleaseCommand : PSCmdlet
                 requestDefaults,
                 BuildInvocationOptions(boundParameters));
 
-            var result = new PowerForgeReleaseService(logger).Execute(spec, request);
+            var result = new PowerForgeReleaseService(
+                logger,
+                DotNetAssemblySigningCallbackFactory.Create(logger),
+                DotNetAssemblySigningCallbackFactory.CreatePreflight(logger))
+                .Execute(spec, request);
             WriteObject(result);
 
             if (!result.Success)

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -63,6 +63,14 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
     [Parameter]
     public SwitchParameter CreateReleaseZip { get; set; }
 
+    /// <summary>Whether assemblies should be signed before packages are created, overriding the referenced JSON when set.</summary>
+    [Parameter]
+    public SwitchParameter SignAssemblies { get; set; }
+
+    /// <summary>Whether generated NuGet packages should be signed, overriding the referenced JSON when set.</summary>
+    [Parameter]
+    public SwitchParameter SignPackages { get; set; }
+
     /// <summary>Additional project-build JSON overrides for less common fields.</summary>
     [Parameter]
     public IDictionary? Options { get; set; }
@@ -85,6 +93,8 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
                 PublishNuget = BoundSwitch(nameof(PublishNuget), PublishNuget),
                 PublishGitHub = BoundSwitch(nameof(PublishGitHub), PublishGitHub),
                 CreateReleaseZip = BoundSwitch(nameof(CreateReleaseZip), CreateReleaseZip),
+                SignAssemblies = BoundSwitch(nameof(SignAssemblies), SignAssemblies),
+                SignPackages = BoundSwitch(nameof(SignPackages), SignPackages),
                 Options = PackageBuildConfiguration.ToObjectDictionary(Options)
             }
         });
@@ -233,6 +243,12 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
     /// <summary>Timestamp server URL for package signing.</summary>
     [Parameter] public string? TimeStampServer { get; set; }
 
+    /// <summary>Whether assemblies should be signed before packages are created.</summary>
+    [Parameter] public SwitchParameter SignAssemblies { get; set; }
+
+    /// <summary>Whether generated NuGet packages should be signed.</summary>
+    [Parameter] public SwitchParameter SignPackages { get; set; }
+
     /// <summary>NuGet version lookup credential user name.</summary>
     [Parameter] public string? NugetCredentialUserName { get; set; }
 
@@ -337,6 +353,8 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
                 CertificateThumbprint = Normalize(CertificateThumbprint),
                 CertificateStore = Normalize(CertificateStore),
                 TimeStampServer = Normalize(TimeStampServer),
+                SignAssemblies = BoundSwitch(nameof(SignAssemblies), SignAssemblies),
+                SignPackages = BoundSwitch(nameof(SignPackages), SignPackages),
                 NugetCredentialUserName = Normalize(NugetCredentialUserName),
                 NugetCredentialSecret = NugetCredentialSecret,
                 NugetCredentialSecretFilePath = Normalize(NugetCredentialSecretFilePath),

--- a/PowerForge.PowerShell/Services/AuthenticodeSigningService.cs
+++ b/PowerForge.PowerShell/Services/AuthenticodeSigningService.cs
@@ -161,16 +161,26 @@ public sealed class AuthenticodeSigningService
         if (files.Length == 0)
             return Array.Empty<PSObject>();
 
+        EnsureSigningCommandsAvailable();
+        return IsWindows()
+            ? SignWithWindowsAuthenticode(files, request)
+            : SignWithOpenAuthenticode(files, request);
+    }
+
+    /// <summary>
+    /// Ensures that the platform-specific Authenticode signing commands are available.
+    /// </summary>
+    public void EnsureSigningCommandsAvailable()
+    {
         if (IsWindows())
         {
             EnsureCommandAvailable("Get-AuthenticodeSignature");
             EnsureCommandAvailable("Set-AuthenticodeSignature");
-            return SignWithWindowsAuthenticode(files, request);
+            return;
         }
 
         EnsureCommandAvailable("Get-OpenAuthenticodeSignature");
         EnsureCommandAvailable("Set-OpenAuthenticodeSignature");
-        return SignWithOpenAuthenticode(files, request);
     }
 
     private IReadOnlyList<PSObject> SignWithWindowsAuthenticode(string[] files, AuthenticodeSignRequest request)

--- a/PowerForge.PowerShell/Services/DotNetAssemblySigningCallbackFactory.cs
+++ b/PowerForge.PowerShell/Services/DotNetAssemblySigningCallbackFactory.cs
@@ -8,6 +8,30 @@ namespace PowerForge;
 public static class DotNetAssemblySigningCallbackFactory
 {
     /// <summary>
+    /// Creates a callback that validates Authenticode assembly-signing prerequisites.
+    /// </summary>
+    /// <param name="logger">Logger used by the signing service.</param>
+    /// <returns>Assembly-signing preflight callback suitable for .NET release services.</returns>
+    public static Action<DotNetReleaseBuildAssemblySigningPreflightRequest> CreatePreflight(ILogger logger)
+    {
+        if (logger is null)
+            throw new ArgumentNullException(nameof(logger));
+
+        var signingService = new AuthenticodeSigningService(logger);
+        return req =>
+        {
+            if (req is null)
+                throw new ArgumentNullException(nameof(req));
+
+            var lookup = signingService.SelectCertificateFromStore(req.LocalStore, req.CertificateThumbprint);
+            if (lookup.Certificate is null)
+                throw new InvalidOperationException($"Certificate '{req.CertificateThumbprint}' not found in {req.LocalStore}\\My store.");
+
+            signingService.EnsureSigningCommandsAvailable();
+        };
+    }
+
+    /// <summary>
     /// Creates a callback that signs release assemblies with Authenticode.
     /// </summary>
     /// <param name="logger">Logger used by the signing service.</param>
@@ -27,7 +51,9 @@ public static class DotNetAssemblySigningCallbackFactory
             if (lookup.Certificate is null)
                 throw new InvalidOperationException($"Certificate '{req.CertificateThumbprint}' not found in {req.LocalStore}\\My store.");
 
-            var files = signingService.EnumerateFiles(req.ReleasePath, req.IncludePatterns);
+            var files = req.FilePaths is { Length: > 0 }
+                ? req.FilePaths
+                : signingService.EnumerateFiles(req.ReleasePath, req.IncludePatterns);
             signingService.SignFiles(new AuthenticodeSignRequest
             {
                 Certificate = lookup.Certificate,

--- a/PowerForge.PowerShell/Services/DotNetAssemblySigningCallbackFactory.cs
+++ b/PowerForge.PowerShell/Services/DotNetAssemblySigningCallbackFactory.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace PowerForge;
+
+/// <summary>
+/// Creates assembly-signing callbacks for .NET release workflows.
+/// </summary>
+public static class DotNetAssemblySigningCallbackFactory
+{
+    /// <summary>
+    /// Creates a callback that signs release assemblies with Authenticode.
+    /// </summary>
+    /// <param name="logger">Logger used by the signing service.</param>
+    /// <returns>Assembly-signing callback suitable for .NET release services.</returns>
+    public static Action<DotNetReleaseBuildAssemblySigningRequest> Create(ILogger logger)
+    {
+        if (logger is null)
+            throw new ArgumentNullException(nameof(logger));
+
+        var signingService = new AuthenticodeSigningService(logger);
+        return req =>
+        {
+            if (req is null)
+                throw new ArgumentNullException(nameof(req));
+
+            var lookup = signingService.SelectCertificateFromStore(req.LocalStore, req.CertificateThumbprint);
+            if (lookup.Certificate is null)
+                throw new InvalidOperationException($"Certificate '{req.CertificateThumbprint}' not found in {req.LocalStore}\\My store.");
+
+            var files = signingService.EnumerateFiles(req.ReleasePath, req.IncludePatterns);
+            signingService.SignFiles(new AuthenticodeSignRequest
+            {
+                Certificate = lookup.Certificate,
+                FilePaths = files,
+                TimeStampServer = req.TimeStampServer,
+                HashAlgorithm = "SHA256",
+                WindowsIncludeChain = "All",
+                NonWindowsIncludeChain = "WholeChain"
+            });
+        };
+    }
+}

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -264,6 +264,10 @@ public sealed partial class ModulePipelineRunner
             target.PublishGitHub = reference.PublishGitHub;
         if (reference.CreateReleaseZip is not null)
             target.CreateReleaseZip = reference.CreateReleaseZip;
+        if (reference.SignAssemblies is not null)
+            target.SignAssemblies = reference.SignAssemblies;
+        if (reference.SignPackages is not null)
+            target.SignPackages = reference.SignPackages;
     }
 
     private static void ApplyProjectBuildGateDefaults(
@@ -519,6 +523,8 @@ public sealed partial class ModulePipelineRunner
             CertificateThumbprint = source.CertificateThumbprint,
             CertificateStore = source.CertificateStore,
             TimeStampServer = source.TimeStampServer,
+            SignAssemblies = source.SignAssemblies,
+            SignPackages = source.SignPackages,
             NugetCredentialUserName = source.NugetCredentialUserName,
             NugetCredentialSecret = source.NugetCredentialSecret,
             NugetCredentialSecretFilePath = source.NugetCredentialSecretFilePath,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
@@ -35,7 +35,10 @@ internal static class ModulePipelineRunnerDefaults
             scriptFunctionExportDetector ?? new PowerShellScriptFunctionExportDetector(),
             packageBuildExecutor ?? ((request, configuration, configPath) =>
             {
-                var service = new ProjectBuildHostService(logger, DotNetAssemblySigningCallbackFactory.Create(logger));
+                var service = new ProjectBuildHostService(
+                    logger,
+                    DotNetAssemblySigningCallbackFactory.Create(logger),
+                    DotNetAssemblySigningCallbackFactory.CreatePreflight(logger));
                 return configuration is null
                     ? service.Execute(request)
                     : service.Execute(request, configuration, configPath ?? request.ConfigPath);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
@@ -35,7 +35,7 @@ internal static class ModulePipelineRunnerDefaults
             scriptFunctionExportDetector ?? new PowerShellScriptFunctionExportDetector(),
             packageBuildExecutor ?? ((request, configuration, configPath) =>
             {
-                var service = new ProjectBuildHostService(logger);
+                var service = new ProjectBuildHostService(logger, DotNetAssemblySigningCallbackFactory.Create(logger));
                 return configuration is null
                     ? service.Execute(request)
                     : service.Execute(request, configuration, configPath ?? request.ConfigPath);

--- a/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
@@ -31,6 +31,8 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
                 OutputPath = "artifacts",
                 CertificateStore = CertificateStoreLocation.LocalMachine,
                 TimeStampServer = "http://timestamp.test",
+                SignAssemblies = false,
+                SignPackages = false,
                 Publish = true,
                 PublishFailFast = true,
                 SkipDuplicate = true
@@ -47,6 +49,8 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
             Assert.Equal("publish-from-env", context.Spec.PublishApiKey);
             Assert.Equal(Path.Combine(root.FullName, "repo", "artifacts"), context.Spec.OutputPath);
             Assert.Equal(PowerForge.CertificateStoreLocation.LocalMachine, context.Spec.CertificateStore);
+            Assert.False(context.Spec.SignAssemblies);
+            Assert.False(context.Spec.SignPackages);
             Assert.Equal("Debug", context.Spec.Configuration);
             Assert.True(context.Spec.Publish);
             Assert.True(context.Spec.PublishFailFast);
@@ -56,6 +60,21 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
             Environment.SetEnvironmentVariable(envName, null);
             try { root.Delete(recursive: true); } catch { }
         }
+    }
+
+    [Fact]
+    public void Prepare_enables_signing_by_default_when_certificate_is_configured()
+    {
+        var request = new DotNetRepositoryReleasePreparationRequest
+        {
+            CurrentPath = Directory.GetCurrentDirectory(),
+            CertificateThumbprint = "ABC123"
+        };
+
+        var context = new DotNetRepositoryReleasePreparationService().Prepare(request);
+
+        Assert.True(context.Spec.SignAssemblies);
+        Assert.True(context.Spec.SignPackages);
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -314,6 +314,110 @@ public sealed class DotNetRepositoryReleaseServiceTests
         }
     }
 
+    [Fact]
+    public void Execute_WithAssemblySigning_SignsBuildOutputsBeforePacking()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"signed\"; }");
+
+            var signedMarker = string.Empty;
+            var signingCalls = 0;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                ReleaseZipOutputPath = Path.Combine(root.FullName, "releases"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = true,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec, request =>
+            {
+                signingCalls++;
+                Assert.Equal(CertificateStoreLocation.CurrentUser, request.LocalStore);
+                Assert.Equal("ABC123", request.CertificateThumbprint);
+                var assembly = Directory.EnumerateFiles(request.ReleasePath, "Sample.Package.dll", SearchOption.AllDirectories)
+                    .SingleOrDefault();
+                Assert.False(string.IsNullOrWhiteSpace(assembly));
+                signedMarker = Path.Combine(Path.GetDirectoryName(assembly!)!, "signed.marker");
+                File.WriteAllText(signedMarker, "signed-before-pack");
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(1, signingCalls);
+            Assert.True(File.Exists(signedMarker));
+            var project = Assert.Single(result.Projects, item => item.IsPackable);
+            Assert.Single(project.Packages);
+            Assert.True(File.Exists(project.Packages[0]));
+            Assert.True(File.Exists(project.ReleaseZipPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_FailsClearlyWhenAssemblySigningIsRequestedWithoutHandler()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec);
+
+            Assert.False(result.Success);
+            Assert.Contains("assembly signing handler", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
     [InlineData(5_400_000, "1h 30.0m")]
     [InlineData(65_000, "1.1m")]

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -9,6 +9,15 @@ namespace PowerForge.Tests;
 public sealed class DotNetRepositoryReleaseServiceTests
 {
     [Fact]
+    public void Execute_preserves_one_argument_public_overload()
+    {
+        var overload = typeof(DotNetRepositoryReleaseService)
+            .GetMethod(nameof(DotNetRepositoryReleaseService.Execute), new[] { typeof(DotNetRepositoryReleaseSpec) });
+
+        Assert.NotNull(overload);
+    }
+
+    [Fact]
     public void Execute_WhatIfPublish_DoesNotRequirePackageFilesOnDisk()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -351,17 +360,24 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 SignPackages = false
             };
 
-            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec, request =>
-            {
-                signingCalls++;
-                Assert.Equal(CertificateStoreLocation.CurrentUser, request.LocalStore);
-                Assert.Equal("ABC123", request.CertificateThumbprint);
-                var assembly = Directory.EnumerateFiles(request.ReleasePath, "Sample.Package.dll", SearchOption.AllDirectories)
-                    .SingleOrDefault();
-                Assert.False(string.IsNullOrWhiteSpace(assembly));
-                signedMarker = Path.Combine(Path.GetDirectoryName(assembly!)!, "signed.marker");
-                File.WriteAllText(signedMarker, "signed-before-pack");
-            });
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request =>
+                {
+                    signingCalls++;
+                    Assert.Equal(CertificateStoreLocation.CurrentUser, request.LocalStore);
+                    Assert.Equal("ABC123", request.CertificateThumbprint);
+                    var assembly = Directory.EnumerateFiles(request.ReleasePath, "Sample.Package.dll", SearchOption.AllDirectories)
+                        .SingleOrDefault();
+                    Assert.False(string.IsNullOrWhiteSpace(assembly));
+                    signedMarker = Path.Combine(Path.GetDirectoryName(assembly!)!, "signed.marker");
+                    File.WriteAllText(signedMarker, "signed-before-pack");
+                },
+                request =>
+                {
+                    Assert.Equal(CertificateStoreLocation.CurrentUser, request.LocalStore);
+                    Assert.Equal("ABC123", request.CertificateThumbprint);
+                });
 
             Assert.True(result.Success, result.ErrorMessage);
             Assert.Equal(1, signingCalls);
@@ -370,6 +386,112 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.Single(project.Packages);
             Assert.True(File.Exists(project.Packages[0]));
             Assert.True(File.Exists(project.ReleaseZipPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_WithAssemblySigning_UsesCustomBuildOutputDirectory()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            var customOutput = Path.Combine(root.FullName, "custom-output");
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                $"    <OutputPath>{customOutput}</OutputPath>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"custom\"; }");
+
+            var signedPath = string.Empty;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request =>
+                {
+                    Assert.Contains("custom-output", request.ReleasePath, StringComparison.OrdinalIgnoreCase);
+                    var assembly = Directory.EnumerateFiles(request.ReleasePath, "Sample.Package.dll", SearchOption.AllDirectories)
+                        .SingleOrDefault();
+                    Assert.False(string.IsNullOrWhiteSpace(assembly));
+                    signedPath = assembly!;
+                },
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.True(File.Exists(signedPath));
+            var project = Assert.Single(result.Projects, item => item.IsPackable);
+            Assert.Single(project.Packages);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_WithAssemblySigning_PreflightsBeforeEditingProjectVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            var csprojPath = Path.Combine(projectDir.FullName, "Sample.Package.csproj");
+            File.WriteAllText(csprojPath, string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                ExpectedVersion = "1.2.4",
+                Pack = true,
+                Publish = false,
+                UpdateVersions = true,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                _ => throw new InvalidOperationException("Signing should not run."),
+                _ => throw new InvalidOperationException("missing signing prerequisites"));
+
+            Assert.False(result.Success);
+            Assert.Contains("preflight", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<VersionPrefix>1.2.3</VersionPrefix>", File.ReadAllText(csprojPath), StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
@@ -818,6 +818,80 @@ public sealed partial class ModulePipelinePackageBuildTests
     }
 
     [Fact]
+    public void Run_InlinePackageBuild_PreservesSigningPhaseOptions()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var calls = new List<PackageBuildCall>();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    calls.Add(new PackageBuildCall(request, configuration, configPath));
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        Result = new ProjectBuildResult { Success = true }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0",
+                    StagingPath = stagingPath
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "InlinePackages",
+                            RootPath = "Sources",
+                            CertificateThumbprint = "ABC123",
+                            SignAssemblies = false,
+                            SignPackages = false,
+                            BuildBeforeModule = true,
+                            Build = true
+                        }
+                    }
+                }
+            };
+
+            var result = runner.Run(spec);
+
+            var call = Assert.Single(calls);
+            Assert.Single(result.ProjectBuildResults);
+            Assert.Equal("ABC123", call.Configuration?.CertificateThumbprint);
+            Assert.False(call.Configuration?.SignAssemblies);
+            Assert.False(call.Configuration?.SignPackages);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Run_ExecutesPostModulePackageBuildsBeforeUnifiedReleaseStaging()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -119,6 +119,46 @@ public sealed class ProjectBuildPreparationServiceTests
     }
 
     [Fact]
+    public void Prepare_enables_assembly_and_package_signing_by_default_when_certificate_is_configured()
+    {
+        var service = new ProjectBuildPreparationService();
+
+        var context = service.Prepare(
+            new ProjectBuildConfiguration
+            {
+                CertificateThumbprint = "ABC123",
+                Build = true
+            },
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions());
+
+        Assert.True(context.Spec.SignAssemblies);
+        Assert.True(context.Spec.SignPackages);
+    }
+
+    [Fact]
+    public void Prepare_honors_explicit_signing_opt_outs()
+    {
+        var service = new ProjectBuildPreparationService();
+
+        var context = service.Prepare(
+            new ProjectBuildConfiguration
+            {
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = false,
+                SignPackages = false,
+                Build = true
+            },
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions());
+
+        Assert.False(context.Spec.SignAssemblies);
+        Assert.False(context.Spec.SignPackages);
+    }
+
+    [Fact]
     public void Prepare_resolves_github_packages_feed_from_shared_settings()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-githubpackages-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -53,6 +53,12 @@ public sealed class ProjectBuildConfigurationReference
     /// <summary>Whether release ZIPs should be created, overriding the referenced JSON when set.</summary>
     public bool? CreateReleaseZip { get; set; }
 
+    /// <summary>Whether assemblies should be signed before packages are created, overriding the referenced JSON when set.</summary>
+    public bool? SignAssemblies { get; set; }
+
+    /// <summary>Whether generated NuGet packages should be signed, overriding the referenced JSON when set.</summary>
+    public bool? SignPackages { get; set; }
+
     /// <summary>Additional project-build JSON overrides for less common fields.</summary>
     public Dictionary<string, object?>? Options { get; set; }
 }
@@ -193,6 +199,12 @@ public sealed class PackageBuildConfiguration
 
     /// <summary>Timestamp server URL for package signing.</summary>
     public string? TimeStampServer { get; set; }
+
+    /// <summary>Whether assemblies should be signed before packages are created.</summary>
+    public bool? SignAssemblies { get; set; }
+
+    /// <summary>Whether generated NuGet packages should be signed.</summary>
+    public bool? SignPackages { get; set; }
 
     /// <summary>NuGet version lookup credential user name.</summary>
     public string? NugetCredentialUserName { get; set; }

--- a/PowerForge/Models/DotNetReleaseBuildAssemblySigningPreflightRequest.cs
+++ b/PowerForge/Models/DotNetReleaseBuildAssemblySigningPreflightRequest.cs
@@ -1,0 +1,16 @@
+namespace PowerForge;
+
+/// <summary>
+/// Request used to validate assembly signing prerequisites before mutable release steps run.
+/// </summary>
+public sealed class DotNetReleaseBuildAssemblySigningPreflightRequest
+{
+    /// <summary>Certificate store location used when searching for the signing certificate.</summary>
+    public CertificateStoreLocation LocalStore { get; set; } = CertificateStoreLocation.CurrentUser;
+
+    /// <summary>Certificate thumbprint used to select the signing certificate.</summary>
+    public string CertificateThumbprint { get; set; } = string.Empty;
+
+    /// <summary>RFC3161 timestamp server URL used during signing.</summary>
+    public string TimeStampServer { get; set; } = string.Empty;
+}

--- a/PowerForge/Models/DotNetReleaseBuildAssemblySigningRequest.cs
+++ b/PowerForge/Models/DotNetReleaseBuildAssemblySigningRequest.cs
@@ -19,5 +19,7 @@ public sealed class DotNetReleaseBuildAssemblySigningRequest
 
     /// <summary>Glob patterns used to select which files should be signed.</summary>
     public string[] IncludePatterns { get; set; } = Array.Empty<string>();
-}
 
+    /// <summary>Explicit files to sign. When set, signing services can use these instead of enumerating <see cref="ReleasePath"/>.</summary>
+    public string[]? FilePaths { get; set; }
+}

--- a/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
+++ b/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
@@ -24,6 +24,8 @@ internal sealed class DotNetRepositoryReleasePreparationRequest
     public string? CertificateThumbprint { get; set; }
     public CertificateStoreLocation CertificateStore { get; set; } = CertificateStoreLocation.CurrentUser;
     public string? TimeStampServer { get; set; }
+    public bool? SignAssemblies { get; set; }
+    public bool? SignPackages { get; set; }
     public bool SkipPack { get; set; }
     public bool Publish { get; set; }
     public string? PublishSource { get; set; }

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -71,14 +71,20 @@ public sealed class DotNetRepositoryReleaseSpec
     /// <summary>Optional output path for release zips.</summary>
     public string? ReleaseZipOutputPath { get; set; }
 
-    /// <summary>Certificate thumbprint used for signing packages (optional).</summary>
+    /// <summary>Certificate thumbprint used for signing assemblies and packages (optional).</summary>
     public string? CertificateThumbprint { get; set; }
 
     /// <summary>Certificate store location used to resolve the signing certificate.</summary>
     public CertificateStoreLocation CertificateStore { get; set; } = CertificateStoreLocation.CurrentUser;
 
-    /// <summary>Timestamp server URL used during package signing.</summary>
+    /// <summary>Timestamp server URL used during signing.</summary>
     public string? TimeStampServer { get; set; }
+
+    /// <summary>When true and a certificate is configured, signs build outputs before packing.</summary>
+    public bool SignAssemblies { get; set; } = true;
+
+    /// <summary>When true and a certificate is configured, signs generated NuGet packages.</summary>
+    public bool SignPackages { get; set; } = true;
 
     /// <summary>When true, publishes packages with dotnet nuget push.</summary>
     public bool Publish { get; set; }

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -42,6 +42,8 @@ internal sealed class ProjectBuildConfiguration
     public string? CertificateThumbprint { get; set; }
     public string? CertificateStore { get; set; }
     public string? TimeStampServer { get; set; }
+    public bool? SignAssemblies { get; set; }
+    public bool? SignPackages { get; set; }
     public string? NugetCredentialUserName { get; set; }
     public string? NugetCredentialSecret { get; set; }
     public string? NugetCredentialSecretFilePath { get; set; }

--- a/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
@@ -60,6 +60,8 @@ internal sealed class DotNetRepositoryReleasePreparationService
                 CertificateThumbprint = request.CertificateThumbprint,
                 CertificateStore = mappedStore,
                 TimeStampServer = request.TimeStampServer,
+                SignAssemblies = ResolveSigningEnabled(request.SignAssemblies, request.CertificateThumbprint),
+                SignPackages = ResolveSigningEnabled(request.SignPackages, request.CertificateThumbprint),
                 Pack = !request.SkipPack,
                 Publish = request.Publish,
                 PublishSource = request.PublishSource,
@@ -69,6 +71,9 @@ internal sealed class DotNetRepositoryReleasePreparationService
             }
         };
     }
+
+    private static bool ResolveSigningEnabled(bool? configuredValue, string? certificateThumbprint)
+        => configuredValue ?? !string.IsNullOrWhiteSpace(certificateThumbprint);
 
     private static Dictionary<string, string> ParseExpectedVersionMap(IDictionary? entries)
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -15,9 +15,16 @@ public sealed partial class DotNetRepositoryReleaseService
     /// <summary>
     /// Executes the repository release workflow.
     /// </summary>
+    public DotNetRepositoryReleaseResult Execute(DotNetRepositoryReleaseSpec spec)
+        => Execute(spec, signAssemblies: null, validateAssemblySigning: null);
+
+    /// <summary>
+    /// Executes the repository release workflow with optional assembly signing callbacks.
+    /// </summary>
     public DotNetRepositoryReleaseResult Execute(
         DotNetRepositoryReleaseSpec spec,
-        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies,
+        Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? validateAssemblySigning)
     {
         var result = new DotNetRepositoryReleaseResult();
 
@@ -183,6 +190,32 @@ public sealed partial class DotNetRepositoryReleaseService
                 result.Success = false;
                 result.ErrorMessage = "Assembly signing was requested, but no assembly signing handler was provided.";
                 return result;
+            }
+
+            if (signAssemblyOutputs && validateAssemblySigning is null)
+            {
+                result.Success = false;
+                result.ErrorMessage = "Assembly signing was requested, but no assembly signing preflight handler was provided.";
+                return result;
+            }
+
+            if (signAssemblyOutputs)
+            {
+                try
+                {
+                    validateAssemblySigning!(new DotNetReleaseBuildAssemblySigningPreflightRequest
+                    {
+                        LocalStore = spec.CertificateStore,
+                        CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
+                        TimeStampServer = spec.TimeStampServer!
+                    });
+                }
+                catch (Exception ex)
+                {
+                    result.Success = false;
+                    result.ErrorMessage = $"Assembly signing preflight failed. {ex.Message}";
+                    return result;
+                }
             }
 
             if (signNuGetPackages)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -15,7 +15,9 @@ public sealed partial class DotNetRepositoryReleaseService
     /// <summary>
     /// Executes the repository release workflow.
     /// </summary>
-    public DotNetRepositoryReleaseResult Execute(DotNetRepositoryReleaseSpec spec)
+    public DotNetRepositoryReleaseResult Execute(
+        DotNetRepositoryReleaseSpec spec,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
     {
         var result = new DotNetRepositoryReleaseResult();
 
@@ -164,14 +166,27 @@ public sealed partial class DotNetRepositoryReleaseService
 
             _logger.Info($"Discovered {projects.Count} project(s), {packable.Length} packable.");
 
+            var hasSigningCertificate = spec.Pack && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
+            var signAssemblyOutputs = hasSigningCertificate && spec.SignAssemblies;
+            var signNuGetPackages = hasSigningCertificate && spec.SignPackages;
             string? signingSha256 = null;
-            if (spec.Pack && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint))
+            if (signAssemblyOutputs || signNuGetPackages)
             {
                 var stamp = string.IsNullOrWhiteSpace(spec.TimeStampServer)
                     ? "http://timestamp.digicert.com"
                     : spec.TimeStampServer!.Trim();
                 spec.TimeStampServer = stamp;
+            }
 
+            if (signAssemblyOutputs && signAssemblies is null)
+            {
+                result.Success = false;
+                result.ErrorMessage = "Assembly signing was requested, but no assembly signing handler was provided.";
+                return result;
+            }
+
+            if (signNuGetPackages)
+            {
                 signingSha256 = GetCertificateSha256(spec.CertificateThumbprint!.Trim(), spec.CertificateStore);
                 if (signingSha256 is null)
                 {
@@ -182,6 +197,8 @@ public sealed partial class DotNetRepositoryReleaseService
 
                 _logger.Info($"Package signing enabled (store {spec.CertificateStore}, thumbprint {spec.CertificateThumbprint}).");
             }
+            if (signAssemblyOutputs)
+                _logger.Info($"Assembly signing enabled (store {spec.CertificateStore}, thumbprint {spec.CertificateThumbprint}).");
 
             var expectedGlobal = string.IsNullOrWhiteSpace(spec.ExpectedVersion) ? null : spec.ExpectedVersion!.Trim();
             if (!string.IsNullOrWhiteSpace(expectedGlobal))
@@ -268,7 +285,9 @@ public sealed partial class DotNetRepositoryReleaseService
             {
                 DotNetPackResult? batchPackResult = null;
                 HashSet<DotNetRepositoryProjectResult>? batchCandidateSet = null;
-                var batchPackRequested = spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf;
+                var batchPackRequested = spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf && !signAssemblyOutputs;
+                if (spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf && signAssemblyOutputs)
+                    _logger.Info("Assembly signing enabled; using per-project pack so build outputs can be signed before packages are created.");
                 if (batchPackRequested)
                 {
                     var batchCandidates = packable
@@ -348,7 +367,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     else
                         _logger.Info($"Packing {project.ProjectName}...");
 
-                    var packResult = useBatchPackResult ? batchPackResult! : PackProject(project, spec, _logger);
+                    var packResult = useBatchPackResult ? batchPackResult! : PackProject(project, spec, _logger, signAssemblyOutputs ? signAssemblies : null);
                     if (!useBatchPackResult && !packResult.Success)
                     {
                         project.ErrorMessage = packResult.ErrorMessage;
@@ -385,7 +404,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         _logger.Success($"{project.ProjectName}: packed {filtered.Count} package(s){packTiming}.");
                     }
 
-                    if (signingSha256 is not null)
+                    if (signNuGetPackages && signingSha256 is not null)
                     {
                         if (project.Packages.Count == 0)
                         {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -88,14 +88,18 @@ public sealed partial class DotNetRepositoryReleaseService
 
             try
             {
-                signAssemblies!(new DotNetReleaseBuildAssemblySigningRequest
+                var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger);
+                foreach (var outputDirectory in outputDirectories)
                 {
-                    ReleasePath = Path.Combine(csprojDir, "bin", configuration),
-                    LocalStore = spec.CertificateStore,
-                    CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
-                    TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
-                    IncludePatterns = new[] { "*.dll", "*.exe" }
-                });
+                    signAssemblies!(new DotNetReleaseBuildAssemblySigningRequest
+                    {
+                        ReleasePath = outputDirectory,
+                        LocalStore = spec.CertificateStore,
+                        CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
+                        TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
+                        IncludePatterns = new[] { "*.dll", "*.exe" }
+                    });
+                }
             }
             catch (Exception ex)
             {
@@ -355,6 +359,86 @@ public sealed partial class DotNetRepositoryReleaseService
         return exitCode;
     }
 
+    private static string[] ResolveBuildOutputDirectories(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string projectName,
+        ILogger logger)
+    {
+        var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var targetFramework in ReadTargetFrameworks(csproj))
+        {
+            var exitCode = RunDotnetMsBuildGetProperty(
+                csproj,
+                workingDirectory,
+                configuration,
+                targetFramework,
+                "TargetDir",
+                projectName,
+                logger,
+                out var value,
+                out var stdErr,
+                out var stdOut,
+                out var duration);
+
+            if (exitCode == 0 && !string.IsNullOrWhiteSpace(value))
+            {
+                var resolved = Path.GetFullPath(value!.Trim().Trim('"'));
+                if (Directory.Exists(resolved))
+                    directories.Add(resolved);
+            }
+            else
+            {
+                logger.Verbose($"{projectName}: unable to resolve MSBuild TargetDir for signing in {FormatDuration(duration)}. {SummarizeProcessFailureOutput(stdErr, stdOut)}");
+            }
+        }
+
+        if (directories.Count == 0)
+        {
+            var fallback = Path.Combine(workingDirectory, "bin", configuration);
+            if (Directory.Exists(fallback))
+                directories.Add(fallback);
+        }
+
+        if (directories.Count == 0)
+            throw new DirectoryNotFoundException($"No build output directory found for {projectName}.");
+
+        return directories.ToArray();
+    }
+
+    private static string?[] ReadTargetFrameworks(string csproj)
+    {
+        try
+        {
+            var document = XDocument.Load(csproj);
+            var targetFrameworks = document.Descendants()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "TargetFrameworks", StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+            if (!string.IsNullOrWhiteSpace(targetFrameworks))
+            {
+                return targetFrameworks!
+                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(static value => value.Trim())
+                    .Where(static value => !string.IsNullOrWhiteSpace(value))
+                    .Cast<string?>()
+                    .ToArray();
+            }
+
+            var targetFramework = document.Descendants()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "TargetFramework", StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+            if (!string.IsNullOrWhiteSpace(targetFramework))
+                return new string?[] { targetFramework!.Trim() };
+        }
+        catch
+        {
+            // Fall back to a configuration-level output directory when project XML cannot be read.
+        }
+
+        return new string?[] { null };
+    }
+
     private static int RunDotnetMsBuildPack(
         string traversalProject,
         string workingDirectory,
@@ -407,6 +491,97 @@ public sealed partial class DotNetRepositoryReleaseService
             out duration);
         LogProcessOutput(logger, "MSBuild batch", "dotnet msbuild pack", stdOut, stdErr);
         return exitCode;
+    }
+
+    private static int RunDotnetMsBuildGetProperty(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        string propertyName,
+        string projectName,
+        ILogger logger,
+        out string? value,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        value = null;
+        stdErr = string.Empty;
+        stdOut = string.Empty;
+        duration = TimeSpan.Zero;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+        var args = new List<string>
+        {
+            "msbuild",
+            csproj,
+            "-nologo",
+            $"-getProperty:{propertyName}",
+            $"-p:Configuration={configuration}"
+        };
+        if (!string.IsNullOrWhiteSpace(targetFramework))
+            args.Add($"-p:TargetFramework={targetFramework!.Trim()}");
+
+#if NET472
+        psi.Arguments = BuildWindowsArgumentString(args);
+#else
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+#endif
+
+        var exitCode = RunProcessWithHeartbeat(
+            psi,
+            logger,
+            elapsed => $"{projectName}: dotnet msbuild {propertyName} still running ({FormatDuration(elapsed)} elapsed).",
+            out stdErr,
+            out stdOut,
+            out duration);
+        LogProcessOutput(logger, projectName, $"dotnet msbuild {propertyName}", stdOut, stdErr);
+        value = ExtractMsBuildPropertyValue(stdOut, propertyName);
+        return exitCode;
+    }
+
+    private static string? ExtractMsBuildPropertyValue(string stdOut, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(stdOut))
+            return null;
+
+        var lines = stdOut.Replace("\r\n", "\n").Split('\n')
+            .Select(static line => line.Trim())
+            .Where(static line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+        if (lines.Length == 0)
+            return null;
+
+        var xmlStart = Array.FindIndex(lines, static line => line.StartsWith("<", StringComparison.Ordinal));
+        if (xmlStart >= 0)
+        {
+            try
+            {
+                var xml = string.Join(Environment.NewLine, lines.Skip(xmlStart));
+                var document = XDocument.Parse(xml);
+                return document.Descendants()
+                    .FirstOrDefault(element => string.Equals(element.Name.LocalName, propertyName, StringComparison.OrdinalIgnoreCase))
+                    ?.Value;
+            }
+            catch
+            {
+                // Fall back to the last non-empty line for older MSBuild output shapes.
+            }
+        }
+
+        return lines[lines.Length - 1];
     }
 
     internal static PackagePushResult ClassifyNuGetPushOutcome(int exitCode, bool skipDuplicate, string stdErr, string stdOut)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -52,7 +52,11 @@ public sealed partial class DotNetRepositoryReleaseService
         return VersionPatternStepper.Step(expectedVersion!, current);
     }
 
-    private static DotNetPackResult PackProject(DotNetRepositoryProjectResult project, DotNetRepositoryReleaseSpec spec, ILogger logger)
+    private static DotNetPackResult PackProject(
+        DotNetRepositoryProjectResult project,
+        DotNetRepositoryReleaseSpec spec,
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies)
     {
         var result = new DotNetPackResult();
 
@@ -71,8 +75,37 @@ public sealed partial class DotNetRepositoryReleaseService
         var packageRoot = outputPath ?? Path.Combine(csprojDir, "bin", configuration);
         var existingPackages = SnapshotPackages(packageRoot);
 
-        var exitCode = RunDotnetPack(project.CsprojPath, csprojDir, configuration, outputPath, project.ProjectName, logger, out var stdErr, out var stdOut, out var duration);
-        result.Duration = duration;
+        var shouldSignAssemblies = signAssemblies is not null && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
+        if (shouldSignAssemblies)
+        {
+            var buildExitCode = RunDotnetBuild(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, out var buildStdErr, out var buildStdOut, out var buildDuration);
+            result.Duration += buildDuration;
+            if (buildExitCode != 0)
+            {
+                result.ErrorMessage = $"dotnet build failed for {project.ProjectName} (exit {buildExitCode}). {SummarizeProcessFailureOutput(buildStdErr, buildStdOut)}".Trim();
+                return result;
+            }
+
+            try
+            {
+                signAssemblies!(new DotNetReleaseBuildAssemblySigningRequest
+                {
+                    ReleasePath = Path.Combine(csprojDir, "bin", configuration),
+                    LocalStore = spec.CertificateStore,
+                    CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
+                    TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
+                    IncludePatterns = new[] { "*.dll", "*.exe" }
+                });
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = $"Assembly signing failed for {project.ProjectName}. {ex.Message}";
+                return result;
+            }
+        }
+
+        var exitCode = RunDotnetPack(project.CsprojPath, csprojDir, configuration, outputPath, project.ProjectName, logger, shouldSignAssemblies, out var stdErr, out var stdOut, out var duration);
+        result.Duration += duration;
         if (exitCode != 0)
         {
             result.ErrorMessage = $"dotnet pack failed for {project.ProjectName} (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
@@ -222,6 +255,7 @@ public sealed partial class DotNetRepositoryReleaseService
         string? outputPath,
         string projectName,
         ILogger logger,
+        bool noBuild,
         out string stdErr,
         out string stdOut,
         out TimeSpan duration)
@@ -243,6 +277,8 @@ public sealed partial class DotNetRepositoryReleaseService
 
 #if NET472
         var args = new List<string> { "pack", csproj, "--configuration", configuration };
+        if (noBuild)
+            args.Add("--no-build");
         if (!string.IsNullOrWhiteSpace(outputPath))
         {
             args.Add("-o");
@@ -254,6 +290,8 @@ public sealed partial class DotNetRepositoryReleaseService
         psi.ArgumentList.Add(csproj);
         psi.ArgumentList.Add("--configuration");
         psi.ArgumentList.Add(configuration);
+        if (noBuild)
+            psi.ArgumentList.Add("--no-build");
         if (!string.IsNullOrWhiteSpace(outputPath))
         {
             psi.ArgumentList.Add("-o");
@@ -269,6 +307,51 @@ public sealed partial class DotNetRepositoryReleaseService
             out stdOut,
             out duration);
         LogProcessOutput(logger, projectName, "dotnet pack", stdOut, stdErr);
+        return exitCode;
+    }
+
+    private static int RunDotnetBuild(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string projectName,
+        ILogger logger,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        stdErr = string.Empty;
+        stdOut = string.Empty;
+        duration = TimeSpan.Zero;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+#if NET472
+        psi.Arguments = BuildWindowsArgumentString(new[] { "build", csproj, "--configuration", configuration });
+#else
+        psi.ArgumentList.Add("build");
+        psi.ArgumentList.Add(csproj);
+        psi.ArgumentList.Add("--configuration");
+        psi.ArgumentList.Add(configuration);
+#endif
+
+        var exitCode = RunProcessWithHeartbeat(
+            psi,
+            logger,
+            elapsed => $"{projectName}: dotnet build still running ({FormatDuration(elapsed)} elapsed).",
+            out stdErr,
+            out stdOut,
+            out duration);
+        LogProcessOutput(logger, projectName, "dotnet build", stdOut, stdErr);
         return exitCode;
     }
 

--- a/PowerForge/Services/DotNetRepositoryReleaseWorkflowService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseWorkflowService.cs
@@ -2,16 +2,21 @@ namespace PowerForge;
 
 internal sealed class DotNetRepositoryReleaseWorkflowService
 {
-    private readonly Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult> _executeRelease;
+    private readonly Func<DotNetRepositoryReleaseSpec, Action<DotNetReleaseBuildAssemblySigningRequest>?, DotNetRepositoryReleaseResult> _executeRelease;
+    private readonly Action<DotNetReleaseBuildAssemblySigningRequest>? _signAssemblies;
 
     public DotNetRepositoryReleaseWorkflowService(
         ILogger logger,
-        Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? executeRelease = null)
+        Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? executeRelease = null,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
     {
         if (logger is null)
             throw new ArgumentNullException(nameof(logger));
 
-        _executeRelease = executeRelease ?? (spec => new DotNetRepositoryReleaseService(logger).Execute(spec));
+        _executeRelease = executeRelease is null
+            ? (spec, signing) => new DotNetRepositoryReleaseService(logger).Execute(spec, signing)
+            : (spec, _) => executeRelease(spec);
+        _signAssemblies = signAssemblies;
     }
 
     public DotNetRepositoryReleaseResult Execute(DotNetRepositoryReleasePreparedContext context, bool executeBuild)
@@ -22,11 +27,11 @@ internal sealed class DotNetRepositoryReleaseWorkflowService
             throw new ArgumentException("Prepared spec is required.", nameof(context));
 
         context.Spec.WhatIf = true;
-        var plan = _executeRelease(context.Spec);
+        var plan = _executeRelease(context.Spec, _signAssemblies);
         if (!executeBuild)
             return plan;
 
         context.Spec.WhatIf = false;
-        return _executeRelease(context.Spec);
+        return _executeRelease(context.Spec, _signAssemblies);
     }
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseWorkflowService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseWorkflowService.cs
@@ -2,21 +2,24 @@ namespace PowerForge;
 
 internal sealed class DotNetRepositoryReleaseWorkflowService
 {
-    private readonly Func<DotNetRepositoryReleaseSpec, Action<DotNetReleaseBuildAssemblySigningRequest>?, DotNetRepositoryReleaseResult> _executeRelease;
+    private readonly Func<DotNetRepositoryReleaseSpec, Action<DotNetReleaseBuildAssemblySigningRequest>?, Action<DotNetReleaseBuildAssemblySigningPreflightRequest>?, DotNetRepositoryReleaseResult> _executeRelease;
     private readonly Action<DotNetReleaseBuildAssemblySigningRequest>? _signAssemblies;
+    private readonly Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? _validateAssemblySigning;
 
     public DotNetRepositoryReleaseWorkflowService(
         ILogger logger,
         Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? executeRelease = null,
-        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null,
+        Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? validateAssemblySigning = null)
     {
         if (logger is null)
             throw new ArgumentNullException(nameof(logger));
 
         _executeRelease = executeRelease is null
-            ? (spec, signing) => new DotNetRepositoryReleaseService(logger).Execute(spec, signing)
-            : (spec, _) => executeRelease(spec);
+            ? (spec, signing, preflight) => new DotNetRepositoryReleaseService(logger).Execute(spec, signing, preflight)
+            : (spec, _, _) => executeRelease(spec);
         _signAssemblies = signAssemblies;
+        _validateAssemblySigning = validateAssemblySigning;
     }
 
     public DotNetRepositoryReleaseResult Execute(DotNetRepositoryReleasePreparedContext context, bool executeBuild)
@@ -27,11 +30,11 @@ internal sealed class DotNetRepositoryReleaseWorkflowService
             throw new ArgumentException("Prepared spec is required.", nameof(context));
 
         context.Spec.WhatIf = true;
-        var plan = _executeRelease(context.Spec, _signAssemblies);
+        var plan = _executeRelease(context.Spec, _signAssemblies, _validateAssemblySigning);
         if (!executeBuild)
             return plan;
 
         context.Spec.WhatIf = false;
-        return _executeRelease(context.Spec, _signAssemblies);
+        return _executeRelease(context.Spec, _signAssemblies, _validateAssemblySigning);
     }
 }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -67,9 +67,20 @@ internal sealed class PowerForgeReleaseService
     /// Creates a new unified release service.
     /// </summary>
     public PowerForgeReleaseService(ILogger logger)
+        : this(logger, signAssemblies: null, validateAssemblySigning: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new unified release service with optional package assembly signing callbacks.
+    /// </summary>
+    public PowerForgeReleaseService(
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies,
+        Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? validateAssemblySigning)
         : this(
             logger,
-            (request, config, configPath) => new ProjectBuildHostService(logger).Execute(request, config, configPath),
+            (request, config, configPath) => new ProjectBuildHostService(logger, signAssemblies, validateAssemblySigning).Execute(request, config, configPath),
             (spec, configPath, request) => new PowerForgeToolReleaseService(logger).Plan(spec, configPath, request),
             plan => new PowerForgeToolReleaseService(logger).Run(plan),
             LoadDotNetToolsSpec,

--- a/PowerForge/Services/ProjectBuildHostService.cs
+++ b/PowerForge/Services/ProjectBuildHostService.cs
@@ -9,6 +9,7 @@ public sealed class ProjectBuildHostService
     private readonly Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? _executeRelease;
     private readonly Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary>? _publishGitHub;
     private readonly Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? _validateGitHubPreflight;
+    private readonly Action<DotNetReleaseBuildAssemblySigningRequest>? _signAssemblies;
 
     /// <summary>
     /// Creates a new host service using a null logger.
@@ -23,20 +24,35 @@ public sealed class ProjectBuildHostService
     /// </summary>
     /// <param name="logger">Logger used by the underlying workflow.</param>
     public ProjectBuildHostService(ILogger logger)
+        : this(logger, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new host service using the provided logger and optional assembly signing handler.
+    /// </summary>
+    /// <param name="logger">Logger used by the underlying workflow.</param>
+    /// <param name="signAssemblies">Optional handler used to sign build outputs before packages are created.</param>
+    public ProjectBuildHostService(
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _signAssemblies = signAssemblies;
     }
 
     internal ProjectBuildHostService(
         ILogger logger,
         Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? executeRelease,
         Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary>? publishGitHub,
-        Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? validateGitHubPreflight)
+        Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? validateGitHubPreflight,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executeRelease = executeRelease;
         _publishGitHub = publishGitHub;
         _validateGitHubPreflight = validateGitHubPreflight;
+        _signAssemblies = signAssemblies;
     }
 
     /// <summary>
@@ -109,7 +125,8 @@ public sealed class ProjectBuildHostService
             _logger,
             _executeRelease,
             _publishGitHub,
-            _validateGitHubPreflight)
+            _validateGitHubPreflight,
+            _signAssemblies)
             .Execute(config, configDirectory, preparation, request.ExecuteBuild);
 
         return new ProjectBuildHostExecutionResult {

--- a/PowerForge/Services/ProjectBuildHostService.cs
+++ b/PowerForge/Services/ProjectBuildHostService.cs
@@ -10,6 +10,7 @@ public sealed class ProjectBuildHostService
     private readonly Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary>? _publishGitHub;
     private readonly Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? _validateGitHubPreflight;
     private readonly Action<DotNetReleaseBuildAssemblySigningRequest>? _signAssemblies;
+    private readonly Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? _validateAssemblySigning;
 
     /// <summary>
     /// Creates a new host service using a null logger.
@@ -33,12 +34,15 @@ public sealed class ProjectBuildHostService
     /// </summary>
     /// <param name="logger">Logger used by the underlying workflow.</param>
     /// <param name="signAssemblies">Optional handler used to sign build outputs before packages are created.</param>
+    /// <param name="validateAssemblySigning">Optional handler used to validate assembly signing before mutable release steps run.</param>
     public ProjectBuildHostService(
         ILogger logger,
-        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies)
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies,
+        Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? validateAssemblySigning = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _signAssemblies = signAssemblies;
+        _validateAssemblySigning = validateAssemblySigning;
     }
 
     internal ProjectBuildHostService(
@@ -46,13 +50,15 @@ public sealed class ProjectBuildHostService
         Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? executeRelease,
         Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary>? publishGitHub,
         Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? validateGitHubPreflight,
-        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null,
+        Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? validateAssemblySigning = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executeRelease = executeRelease;
         _publishGitHub = publishGitHub;
         _validateGitHubPreflight = validateGitHubPreflight;
         _signAssemblies = signAssemblies;
+        _validateAssemblySigning = validateAssemblySigning;
     }
 
     /// <summary>
@@ -126,7 +132,8 @@ public sealed class ProjectBuildHostService
             _executeRelease,
             _publishGitHub,
             _validateGitHubPreflight,
-            _signAssemblies)
+            _signAssemblies,
+            _validateAssemblySigning)
             .Execute(config, configDirectory, preparation, request.ExecuteBuild);
 
         return new ProjectBuildHostExecutionResult {

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -107,6 +107,8 @@ internal sealed class ProjectBuildPreparationService
             CertificateThumbprint = config.CertificateThumbprint,
             CertificateStore = ProjectBuildSupportService.ParseCertificateStore(config.CertificateStore),
             TimeStampServer = config.TimeStampServer,
+            SignAssemblies = ResolveSigningEnabled(config.SignAssemblies, config.CertificateThumbprint),
+            SignPackages = ResolveSigningEnabled(config.SignPackages, config.CertificateThumbprint),
             Pack = context.Build || context.PublishNuget || context.PublishGitHub,
             CreateReleaseZip = context.CreateReleaseZip,
             Publish = context.PublishNuget,
@@ -119,4 +121,7 @@ internal sealed class ProjectBuildPreparationService
 
         return context;
     }
+
+    private static bool ResolveSigningEnabled(bool? configuredValue, string? certificateThumbprint)
+        => configuredValue ?? !string.IsNullOrWhiteSpace(certificateThumbprint);
 }

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -4,27 +4,30 @@ internal sealed class ProjectBuildWorkflowService
 {
     private readonly ILogger _logger;
     private readonly ProjectBuildSupportService _support;
-    private readonly Func<DotNetRepositoryReleaseSpec, Action<DotNetReleaseBuildAssemblySigningRequest>?, DotNetRepositoryReleaseResult> _executeRelease;
+    private readonly Func<DotNetRepositoryReleaseSpec, Action<DotNetReleaseBuildAssemblySigningRequest>?, Action<DotNetReleaseBuildAssemblySigningPreflightRequest>?, DotNetRepositoryReleaseResult> _executeRelease;
     private readonly Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary> _publishGitHub;
     private readonly Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?> _validateGitHubPreflight;
     private readonly Action<DotNetReleaseBuildAssemblySigningRequest>? _signAssemblies;
+    private readonly Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? _validateAssemblySigning;
 
     public ProjectBuildWorkflowService(
         ILogger logger,
         Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? executeRelease = null,
         Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary>? publishGitHub = null,
         Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? validateGitHubPreflight = null,
-        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null,
+        Action<DotNetReleaseBuildAssemblySigningPreflightRequest>? validateAssemblySigning = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _support = new ProjectBuildSupportService(_logger);
         _executeRelease = executeRelease is null
-            ? (spec, signing) => new DotNetRepositoryReleaseService(_logger).Execute(spec, signing)
-            : (spec, _) => executeRelease(spec);
+            ? (spec, signing, preflight) => new DotNetRepositoryReleaseService(_logger).Execute(spec, signing, preflight)
+            : (spec, _, _) => executeRelease(spec);
         _publishGitHub = publishGitHub ?? (request => new ProjectBuildGitHubPublisher(_logger).Publish(request));
         _validateGitHubPreflight = validateGitHubPreflight ?? ((config, plan, token) =>
             new ProjectBuildGitHubPreflightService(_logger).Validate(config, plan, token));
         _signAssemblies = signAssemblies;
+        _validateAssemblySigning = validateAssemblySigning;
     }
 
     public ProjectBuildWorkflowResult Execute(
@@ -42,7 +45,7 @@ internal sealed class ProjectBuildWorkflowService
 
         var spec = preparation.Spec ?? throw new ArgumentException("Prepared spec is required.", nameof(preparation));
         spec.WhatIf = true;
-        var plan = _executeRelease(spec, _signAssemblies);
+        var plan = _executeRelease(spec, _signAssemblies, _validateAssemblySigning);
         var preflightErrors = new List<string>();
         if (!plan.Success)
             preflightErrors.Add(plan.ErrorMessage ?? "Plan/preflight validation failed.");
@@ -90,7 +93,7 @@ internal sealed class ProjectBuildWorkflowService
         _support.TryWritePlan(plan, preparation.PlanOutputPath);
 
         spec.WhatIf = false;
-        var release = _executeRelease(spec, _signAssemblies);
+        var release = _executeRelease(spec, _signAssemblies, _validateAssemblySigning);
         var result = new ProjectBuildResult { Release = release };
 
         if (release is null || !release.Success)

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -4,22 +4,27 @@ internal sealed class ProjectBuildWorkflowService
 {
     private readonly ILogger _logger;
     private readonly ProjectBuildSupportService _support;
-    private readonly Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult> _executeRelease;
+    private readonly Func<DotNetRepositoryReleaseSpec, Action<DotNetReleaseBuildAssemblySigningRequest>?, DotNetRepositoryReleaseResult> _executeRelease;
     private readonly Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary> _publishGitHub;
     private readonly Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?> _validateGitHubPreflight;
+    private readonly Action<DotNetReleaseBuildAssemblySigningRequest>? _signAssemblies;
 
     public ProjectBuildWorkflowService(
         ILogger logger,
         Func<DotNetRepositoryReleaseSpec, DotNetRepositoryReleaseResult>? executeRelease = null,
         Func<ProjectBuildGitHubPublishRequest, ProjectBuildGitHubPublishSummary>? publishGitHub = null,
-        Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? validateGitHubPreflight = null)
+        Func<ProjectBuildConfiguration, DotNetRepositoryReleaseResult, string, string?>? validateGitHubPreflight = null,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _support = new ProjectBuildSupportService(_logger);
-        _executeRelease = executeRelease ?? (spec => new DotNetRepositoryReleaseService(_logger).Execute(spec));
+        _executeRelease = executeRelease is null
+            ? (spec, signing) => new DotNetRepositoryReleaseService(_logger).Execute(spec, signing)
+            : (spec, _) => executeRelease(spec);
         _publishGitHub = publishGitHub ?? (request => new ProjectBuildGitHubPublisher(_logger).Publish(request));
         _validateGitHubPreflight = validateGitHubPreflight ?? ((config, plan, token) =>
             new ProjectBuildGitHubPreflightService(_logger).Validate(config, plan, token));
+        _signAssemblies = signAssemblies;
     }
 
     public ProjectBuildWorkflowResult Execute(
@@ -37,7 +42,7 @@ internal sealed class ProjectBuildWorkflowService
 
         var spec = preparation.Spec ?? throw new ArgumentException("Prepared spec is required.", nameof(preparation));
         spec.WhatIf = true;
-        var plan = _executeRelease(spec);
+        var plan = _executeRelease(spec, _signAssemblies);
         var preflightErrors = new List<string>();
         if (!plan.Success)
             preflightErrors.Add(plan.ErrorMessage ?? "Plan/preflight validation failed.");
@@ -85,7 +90,7 @@ internal sealed class ProjectBuildWorkflowService
         _support.TryWritePlan(plan, preparation.PlanOutputPath);
 
         spec.WhatIf = false;
-        var release = _executeRelease(spec);
+        var release = _executeRelease(spec, _signAssemblies);
         var result = new ProjectBuildResult { Release = release };
 
         if (release is null || !release.Success)

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -158,6 +158,14 @@
         "null"
       ]
     },
+    "SignAssemblies": {
+      "type": "boolean",
+      "description": "When true and CertificateThumbprint is configured, signs build outputs before NuGet packages and release ZIPs are created. Defaults to true when CertificateThumbprint is set."
+    },
+    "SignPackages": {
+      "type": "boolean",
+      "description": "When true and CertificateThumbprint is configured, signs generated NuGet packages. Defaults to true when CertificateThumbprint is set."
+    },
     "PublishSource": {
       "type": [
         "string",


### PR DESCRIPTION
## Summary
- sign ProjectBuild/.NET repository build outputs before NuGet packages and release ZIPs are created when `CertificateThumbprint` is configured
- keep package signing enabled by default and add explicit opt-outs: `SignAssemblies`, `SignPackages`, `-SkipAssemblySigning`, and `-SkipPackageSigning`
- wire assembly signing and preflight handlers through direct cmdlets, `Invoke-ProjectBuild`, Build-Module package build hosting, and unified `Invoke-PowerForgeRelease` / `Invoke-ProjectRelease` package lanes
- resolve actual MSBuild `TargetDir` values before signing so custom `OutputPath` / `BaseOutputPath` projects sign the files that will be packed

## Notes
- The existing certificate thumbprint is unchanged in this PR.
- Assembly-signing preflight validates certificate/tooling before csproj version edits.
- When assembly signing is enabled with the MSBuild batch pack strategy, the release path falls back to per-project pack so assemblies can be signed between build and pack.
- Generated `Module/Docs` were not regenerated here; cmdlet/source XML documentation and schema metadata are updated as the source of truth.

## Validation
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -m:1`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Debug --filter "FullyQualifiedName~ProjectBuildPreparationServiceTests|FullyQualifiedName~DotNetRepositoryReleasePreparationServiceTests|FullyQualifiedName~DotNetRepositoryReleaseServiceTests|FullyQualifiedName~ModulePipelinePackageBuildTests|FullyQualifiedName~PowerForgeReleaseServiceTests"`
- Earlier full `PowerForge.Tests` local run: 2519 passed, 1 unrelated `WebStaticServerTests.ServeWithPortFallback_UsesNextAvailablePort_AndServesContent` timeout