### PR TITLE
Report direct Markdown fallback as agent-ready warning

### DIFF
--- a/Docs/PowerForge.Web.AgentReadiness.md
+++ b/Docs/PowerForge.Web.AgentReadiness.md
@@ -92,6 +92,10 @@ PowerForge can also generate Markdown artifacts itself. This is separate from
 live HTTP negotiation: the static site can contain `/index.md` and
 `/docs/index.md`, but the deployed host or edge still needs a rule if the same
 HTML route should return Markdown for `Accept: text/markdown`.
+When a live scan sees a valid direct Markdown artifact but the homepage still
+returns HTML for `Accept: text/markdown`, PowerForge reports the negotiation as
+a warning instead of a failure so sites without header-aware edge caching can
+still pass on the portable direct-artifact path.
 
 ## Site Configuration
 

--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -770,6 +770,14 @@ public class WebAgentReadinessTests
     }
 
     [Fact]
+    public void GetMarkdownNegotiationStatus_WarnsWhenDirectArtifactWorks()
+    {
+        Assert.Equal("pass", WebAgentReadiness.GetMarkdownNegotiationStatus(negotiated: true, directMarkdownAvailable: false));
+        Assert.Equal("warn", WebAgentReadiness.GetMarkdownNegotiationStatus(negotiated: false, directMarkdownAvailable: true));
+        Assert.Equal("fail", WebAgentReadiness.GetMarkdownNegotiationStatus(negotiated: false, directMarkdownAvailable: false));
+    }
+
+    [Fact]
     public void BuildMarkdownNegotiationMessage_DoesNotTreatAcceptEncodingAsAccept()
     {
         var message = WebAgentReadiness.BuildMarkdownNegotiationMessage(

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -376,7 +376,7 @@ public static class WebAgentReadiness
         }
 
         AddCheck(checks, "markdown-negotiation", "content", "Markdown for Agents",
-            markdownNegotiated ? "pass" : "fail",
+            GetMarkdownNegotiationStatus(markdownNegotiated, markdownAlternateAvailableAsMarkdown),
             BuildMarkdownNegotiationMessage(
                 markdownNegotiated,
                 markdown.Success,
@@ -2456,6 +2456,14 @@ public static class WebAgentReadiness
 
         var cacheControlDetail = string.IsNullOrWhiteSpace(cacheControl) ? string.Empty : $" Cache-Control was {cacheControl}.";
         return $"Accept: text/markdown did not return Content-Type text/markdown; returned {returned}.{cacheControlDetail}";
+    }
+
+    internal static string GetMarkdownNegotiationStatus(bool negotiated, bool directMarkdownAvailable)
+    {
+        if (negotiated)
+            return "pass";
+
+        return directMarkdownAvailable ? "warn" : "fail";
     }
 
     private static string FormatContentTypeForMessage(string contentType)


### PR DESCRIPTION
## Summary
- report homepage Accept: text/markdown negotiation as a warning when the direct Markdown artifact is available
- keep the scan failing when neither negotiation nor a valid direct Markdown fallback works
- document the direct-artifact fallback behavior for Cloudflare and other edge environments without header-aware cache keys

## Validation
- dotnet restore PowerForge.Tests\\PowerForge.Tests.csproj
- dotnet test PowerForge.Tests\\PowerForge.Tests.csproj --filter FullyQualifiedName~WebAgentReadinessTests --no-restore --verbosity normal
- git diff --check