### PR TITLE
Speed up managed module install pipeline

### DIFF
--- a/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
+++ b/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
@@ -316,6 +316,96 @@ function Join-BenchmarkOutputRoot {
     Join-Path $script:EffectiveOutputRoot $Leaf
 }
 
+function Get-CsvHeaderColumns {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return @()
+    }
+
+    $reader = [System.IO.StreamReader]::new($Path)
+    try {
+        $headerLine = $reader.ReadLine()
+    } finally {
+        $reader.Dispose()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($headerLine)) {
+        return @()
+    }
+
+    @($headerLine -split ',' | ForEach-Object {
+        $_.Trim().Trim('"').Replace('""', '"')
+    })
+}
+
+function Get-CsvRowColumns {
+    param([object[]] $Rows)
+
+    $columns = New-Object System.Collections.Generic.List[string]
+    foreach ($row in $Rows) {
+        foreach ($property in $row.PSObject.Properties) {
+            if (-not $columns.Contains($property.Name)) {
+                $columns.Add($property.Name)
+            }
+        }
+    }
+
+    $columns.ToArray()
+}
+
+function Join-CsvColumns {
+    param(
+        [string[]] $ExistingColumns,
+        [string[]] $NewColumns
+    )
+
+    $columns = New-Object System.Collections.Generic.List[string]
+    foreach ($column in @($ExistingColumns + $NewColumns)) {
+        if (-not [string]::IsNullOrWhiteSpace($column) -and -not $columns.Contains($column)) {
+            $columns.Add($column)
+        }
+    }
+
+    $columns.ToArray()
+}
+
+function Test-CsvColumnsEqual {
+    param(
+        [string[]] $Left,
+        [string[]] $Right
+    )
+
+    if ($Left.Count -ne $Right.Count) {
+        return $false
+    }
+
+    for ($index = 0; $index -lt $Left.Count; $index++) {
+        if (-not [string]::Equals($Left[$index], $Right[$index], [StringComparison]::Ordinal)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function ConvertTo-CsvRowsWithColumns {
+    param(
+        [object[]] $Rows,
+        [string[]] $Columns
+    )
+
+    foreach ($row in $Rows) {
+        $ordered = [ordered]@{}
+        foreach ($column in $Columns) {
+            $property = $row.PSObject.Properties[$column]
+            $ordered[$column] = if ($property) { $property.Value } else { $null }
+        }
+
+        [pscustomobject]$ordered
+    }
+}
+
 function Add-ResultCsv {
     param([string] $Path)
 
@@ -328,7 +418,22 @@ function Add-ResultCsv {
         return
     }
 
-    if ($Append.IsPresent -or (Test-Path -LiteralPath $OutputPath)) {
+    $outputExists = Test-Path -LiteralPath $OutputPath
+    if ($Append.IsPresent -or $outputExists) {
+        if ($outputExists) {
+            $existingColumns = Get-CsvHeaderColumns -Path $OutputPath
+            $newColumns = Get-CsvRowColumns -Rows $rows
+            if ($existingColumns.Count -gt 0 -and -not (Test-CsvColumnsEqual -Left $existingColumns -Right $newColumns)) {
+                $columns = Join-CsvColumns -ExistingColumns $existingColumns -NewColumns $newColumns
+                $existingRows = @(Import-Csv -LiteralPath $OutputPath)
+                @(
+                    ConvertTo-CsvRowsWithColumns -Rows $existingRows -Columns $columns
+                    ConvertTo-CsvRowsWithColumns -Rows $rows -Columns $columns
+                ) | Export-Csv -LiteralPath $OutputPath -NoTypeInformation
+                return
+            }
+        }
+
         $rows | Export-Csv -LiteralPath $OutputPath -NoTypeInformation -Append
     } else {
         $rows | Export-Csv -LiteralPath $OutputPath -NoTypeInformation

--- a/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
+++ b/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
@@ -10,7 +10,7 @@ param(
     [string[]] $Operation = @('Find', 'Install', 'Save'),
 
     [ValidateSet('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet')]
-    [string[]] $Engine = @('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet'),
+    [string[]] $Engine = @(),
 
     [int] $RepeatCount = 1,
 
@@ -403,10 +403,14 @@ if ([string]::IsNullOrWhiteSpace($script:EffectiveOutputRoot) -and $script:Bench
 
 if ($ComparisonProfile -eq 'ManagedVsModuleFast') {
     $Operation = @('Install')
-    $Engine = @('Managed', 'ModuleFast')
+    if (-not $PSBoundParameters.ContainsKey('Engine') -or $Engine.Count -eq 0) {
+        $Engine = @('Managed', 'ModuleFast')
+    }
     if ($BenchmarkHost -ne 'PowerShell7') {
         Write-Warning "ManagedVsModuleFast compares ModuleFast on PowerShell 7; rerun with -BenchmarkHost PowerShell7 for a direct row."
     }
+} elseif (-not $PSBoundParameters.ContainsKey('Engine') -or $Engine.Count -eq 0) {
+    $Engine = @('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet')
 }
 
 $safeOperations = @($Operation | Where-Object { $_ -ne 'Install' })

--- a/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
+++ b/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
@@ -48,28 +48,73 @@ function Test-IsWindowsAdministrator {
     $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
+function Get-PowerShellExecutableVersion {
+    param([string] $Path)
+
+    try {
+        $versionText = & $Path -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()' 2>$null |
+            Select-Object -First 1
+        if ([string]::IsNullOrWhiteSpace($versionText)) {
+            return $null
+        }
+
+        return [version]$versionText
+    } catch {
+        return $null
+    }
+}
+
+function Resolve-PowerShell7Executable {
+    $candidatePaths = New-Object System.Collections.Generic.List[string]
+    foreach ($command in @(Get-Command pwsh -All -ErrorAction SilentlyContinue)) {
+        if (-not [string]::IsNullOrWhiteSpace($command.Source)) {
+            $candidatePaths.Add($command.Source)
+        }
+    }
+
+    if (Test-Path -LiteralPath 'C:\Program Files\PowerShell\7\pwsh.exe') {
+        $candidatePaths.Add('C:\Program Files\PowerShell\7\pwsh.exe')
+    }
+
+    $candidates = @($candidatePaths |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique |
+        ForEach-Object {
+            $version = Get-PowerShellExecutableVersion -Path $_
+            if ($version -and $version.Major -ge 7) {
+                [pscustomobject]@{
+                    Path = $_
+                    Version = $version
+                }
+            }
+        })
+
+    if ($candidates.Count -gt 0) {
+        return ($candidates | Sort-Object Version -Descending | Select-Object -First 1).Path
+    }
+
+    return (Get-Command pwsh -ErrorAction Stop).Source
+}
+
 function Resolve-BenchmarkHostExecutable {
     switch ($BenchmarkHost) {
         'WindowsPowerShell' {
             return "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
         }
         'PowerShell7' {
-            if (Test-Path -LiteralPath 'C:\Program Files\PowerShell\7\pwsh.exe') {
-                return 'C:\Program Files\PowerShell\7\pwsh.exe'
-            }
-
-            return (Get-Command pwsh -ErrorAction Stop).Source
+            return Resolve-PowerShell7Executable
         }
         default {
             if ($PSVersionTable.PSEdition -eq 'Desktop') {
                 return (Join-Path $PSHOME 'powershell.exe')
             }
 
-            if (Test-Path -LiteralPath 'C:\Program Files\PowerShell\7\pwsh.exe') {
-                return 'C:\Program Files\PowerShell\7\pwsh.exe'
+            $currentPwsh = Join-Path $PSHOME 'pwsh.exe'
+            if (Test-Path -LiteralPath $currentPwsh) {
+                return $currentPwsh
             }
 
-            return (Get-Command pwsh -ErrorAction Stop).Source
+            return Resolve-PowerShell7Executable
         }
     }
 }

--- a/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
+++ b/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
@@ -1,5 +1,8 @@
 #requires -Version 5.1
 param(
+    [ValidateSet('Full', 'ManagedVsModuleFast')]
+    [string] $ComparisonProfile = 'Full',
+
     [ValidateSet('SingleModule', 'GraphAuthentication', 'Graph', 'AzAccounts', 'Az')]
     [string[]] $ScenarioName = @('SingleModule', 'GraphAuthentication', 'Graph', 'AzAccounts', 'Az'),
 
@@ -19,7 +22,7 @@ param(
 
     [string] $RepositoryUri = 'https://www.powershellgallery.com/api/v2',
 
-    [string] $ModuleFastSource,
+    [string] $ModuleFastSource = 'https://pwsh.gallery/index.json',
 
     [string] $ManagedModuleBinary,
 
@@ -345,6 +348,14 @@ $script:BenchmarkHostExecutable = Resolve-BenchmarkHostExecutable
 $script:EffectiveOutputRoot = $OutputRoot
 if ([string]::IsNullOrWhiteSpace($script:EffectiveOutputRoot) -and $script:BenchmarkHostExecutable -notlike '*\WindowsPowerShell\*') {
     $script:EffectiveOutputRoot = Join-Path $PSScriptRoot '..\..\Ignore\Benchmarks\ManagedModules\Runs'
+}
+
+if ($ComparisonProfile -eq 'ManagedVsModuleFast') {
+    $Operation = @('Install')
+    $Engine = @('Managed', 'ModuleFast')
+    if ($BenchmarkHost -ne 'PowerShell7') {
+        Write-Warning "ManagedVsModuleFast compares ModuleFast on PowerShell 7; rerun with -BenchmarkHost PowerShell7 for a direct row."
+    }
 }
 
 $safeOperations = @($Operation | Where-Object { $_ -ne 'Install' })

--- a/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
+++ b/Benchmarks/ManagedModules/Invoke-ManagedModuleBenchmarkMatrix.ps1
@@ -1,7 +1,7 @@
 #requires -Version 5.1
 param(
     [ValidateSet('Full', 'ManagedVsModuleFast')]
-    [string] $ComparisonProfile = 'Full',
+    [string] $ComparisonProfile = 'ManagedVsModuleFast',
 
     [ValidateSet('SingleModule', 'GraphAuthentication', 'Graph', 'AzAccounts', 'Az')]
     [string[]] $ScenarioName = @('SingleModule', 'GraphAuthentication', 'Graph', 'AzAccounts', 'Az'),
@@ -23,6 +23,8 @@ param(
     [string] $RepositoryUri = 'https://www.powershellgallery.com/api/v2',
 
     [string] $ModuleFastSource = 'https://pwsh.gallery/index.json',
+
+    [string] $ModuleFastModulePath = '',
 
     [string] $ManagedModuleBinary,
 
@@ -133,6 +135,7 @@ function New-MeasureCommand {
     $outputPathLiteral = ConvertTo-SingleQuotedLiteral $SelectedOutputPath
     $outputRootLiteral = ConvertTo-SingleQuotedLiteral $SelectedOutputRoot
     $moduleFastSourceLiteral = ConvertTo-SingleQuotedLiteral $ModuleFastSource
+    $moduleFastModulePathLiteral = ConvertTo-SingleQuotedLiteral $ModuleFastModulePath
     $managedModuleBinaryLiteral = ConvertTo-SingleQuotedLiteral $ManagedModuleBinary
     $appendSwitch = if ($AppendOutput.IsPresent) { ' -Append' } else { '' }
     $skipSwitch = if ($SkipNativeCurrentUserInstall.IsPresent) { ' -SkipNativeCurrentUserInstall' } else { '' }
@@ -146,6 +149,9 @@ function New-MeasureCommand {
     $command = "`$ErrorActionPreference = 'Stop'; $prefix& $measureLiteral -ScenarioName $scenarioLiteral -Operation $operationLiteral -Engine $engineLiteral -RepeatCount $RepeatCount -OutputPath $outputPathLiteral -OutputRoot $outputRootLiteral -Repository $repositoryLiteral -RepositoryUri $repositoryUriLiteral$appendSwitch$skipSwitch"
     if (-not [string]::IsNullOrWhiteSpace($ModuleFastSource)) {
         $command += " -ModuleFastSource $moduleFastSourceLiteral"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ModuleFastModulePath)) {
+        $command += " -ModuleFastModulePath $moduleFastModulePathLiteral"
     }
     if (-not [string]::IsNullOrWhiteSpace($ManagedModuleBinary)) {
         $command += " -ManagedModuleBinary $managedModuleBinaryLiteral"

--- a/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
+++ b/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
@@ -5,10 +5,10 @@ param(
     [string[]] $ScenarioName = @('SingleModule', 'GraphAuthentication', 'Graph', 'AzAccounts', 'Az'),
 
     [ValidateSet('Find', 'Install', 'Save')]
-    [string[]] $Operation = @('Find', 'Install', 'Save'),
+    [string[]] $Operation = @('Install'),
 
     [ValidateSet('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet')]
-    [string[]] $Engine = @('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet'),
+    [string[]] $Engine = @('Managed', 'ModuleFast'),
 
     [int] $RepeatCount = 1,
 

--- a/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
+++ b/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
@@ -418,6 +418,96 @@ function New-ManagedBenchmarkMetrics {
     }
 }
 
+function Get-CsvHeaderColumns {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return @()
+    }
+
+    $reader = [System.IO.StreamReader]::new($Path)
+    try {
+        $headerLine = $reader.ReadLine()
+    } finally {
+        $reader.Dispose()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($headerLine)) {
+        return @()
+    }
+
+    @($headerLine -split ',' | ForEach-Object {
+        $_.Trim().Trim('"').Replace('""', '"')
+    })
+}
+
+function Get-CsvRowColumns {
+    param([object[]] $Rows)
+
+    $columns = New-Object System.Collections.Generic.List[string]
+    foreach ($row in $Rows) {
+        foreach ($property in $row.PSObject.Properties) {
+            if (-not $columns.Contains($property.Name)) {
+                $columns.Add($property.Name)
+            }
+        }
+    }
+
+    $columns.ToArray()
+}
+
+function Join-CsvColumns {
+    param(
+        [string[]] $ExistingColumns,
+        [string[]] $NewColumns
+    )
+
+    $columns = New-Object System.Collections.Generic.List[string]
+    foreach ($column in @($ExistingColumns + $NewColumns)) {
+        if (-not [string]::IsNullOrWhiteSpace($column) -and -not $columns.Contains($column)) {
+            $columns.Add($column)
+        }
+    }
+
+    $columns.ToArray()
+}
+
+function Test-CsvColumnsEqual {
+    param(
+        [string[]] $Left,
+        [string[]] $Right
+    )
+
+    if ($Left.Count -ne $Right.Count) {
+        return $false
+    }
+
+    for ($index = 0; $index -lt $Left.Count; $index++) {
+        if (-not [string]::Equals($Left[$index], $Right[$index], [StringComparison]::Ordinal)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function ConvertTo-CsvRowsWithColumns {
+    param(
+        [object[]] $Rows,
+        [string[]] $Columns
+    )
+
+    foreach ($row in $Rows) {
+        $ordered = [ordered]@{}
+        foreach ($column in $Columns) {
+            $property = $row.PSObject.Properties[$column]
+            $ordered[$column] = if ($property) { $property.Value } else { $null }
+        }
+
+        [pscustomobject]$ordered
+    }
+}
+
 function Write-MeasurementResult {
     param(
         [object] $Result
@@ -425,6 +515,19 @@ function Write-MeasurementResult {
 
     $results.Add($Result) | Out-Null
     if ($script:BenchmarkOutputHasRows) {
+        $existingColumns = Get-CsvHeaderColumns -Path $OutputPath
+        $newRows = @($Result)
+        $newColumns = Get-CsvRowColumns -Rows $newRows
+        if ($existingColumns.Count -gt 0 -and -not (Test-CsvColumnsEqual -Left $existingColumns -Right $newColumns)) {
+            $columns = Join-CsvColumns -ExistingColumns $existingColumns -NewColumns $newColumns
+            $existingRows = @(Import-Csv -LiteralPath $OutputPath)
+            @(
+                ConvertTo-CsvRowsWithColumns -Rows $existingRows -Columns $columns
+                ConvertTo-CsvRowsWithColumns -Rows $newRows -Columns $columns
+            ) | Export-Csv -LiteralPath $OutputPath -NoTypeInformation
+            return
+        }
+
         $Result | Export-Csv -LiteralPath $OutputPath -NoTypeInformation -Append
     } else {
         $Result | Export-Csv -LiteralPath $OutputPath -NoTypeInformation

--- a/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
+++ b/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
@@ -123,13 +123,15 @@ function New-MeasurementResult {
         [int] $Iteration,
         [string] $Status,
         [double] $Milliseconds,
-        [string] $Reason
+        [string] $Reason,
+        [object] $ManagedResult = $null
     )
 
     $roundedMilliseconds = [Math]::Round($Milliseconds, 2)
     $roundedSeconds = [Math]::Round($Milliseconds / 1000, 3)
 
-    [pscustomobject]@{
+    $managedMetrics = New-ManagedBenchmarkMetrics -ManagedResult $ManagedResult
+    $row = [ordered]@{
         TimestampUtc = [DateTime]::UtcNow.ToString('o')
         Host = Get-CurrentHostLabel
         Scenario = $Scenario.Name
@@ -143,6 +145,201 @@ function New-MeasurementResult {
         Milliseconds = $roundedMilliseconds.ToString('0.##', [Globalization.CultureInfo]::InvariantCulture)
         Seconds = $roundedSeconds.ToString('0.###', [Globalization.CultureInfo]::InvariantCulture)
         Reason = $Reason
+    }
+
+    foreach ($metric in $managedMetrics.GetEnumerator()) {
+        $row[$metric.Key] = $metric.Value
+    }
+
+    [pscustomobject]$row
+}
+
+function Format-BenchmarkNumber {
+    param([double] $Value)
+
+    [Math]::Round($Value, 2).ToString('0.##', [Globalization.CultureInfo]::InvariantCulture)
+}
+
+function ConvertTo-BenchmarkMilliseconds {
+    param([object] $Value)
+
+    if ($null -eq $Value) {
+        return 0
+    }
+
+    if ($Value -is [TimeSpan]) {
+        return $Value.TotalMilliseconds
+    }
+
+    if ($Value.PSObject.Properties['TotalMilliseconds']) {
+        return [double]$Value.TotalMilliseconds
+    }
+
+    0
+}
+
+function Add-ManagedInstallResultNode {
+    param(
+        [object] $Node,
+        [System.Collections.Generic.List[object]] $Nodes
+    )
+
+    if ($null -eq $Node) {
+        return
+    }
+
+    $Nodes.Add($Node) | Out-Null
+    if ($Node.PSObject.Properties['DependencyResults'] -and $null -ne $Node.DependencyResults) {
+        foreach ($dependency in @($Node.DependencyResults)) {
+            Add-ManagedInstallResultNode -Node $dependency -Nodes $Nodes
+        }
+    }
+}
+
+function New-ManagedBenchmarkMetrics {
+    param([object] $ManagedResult)
+
+    $empty = [ordered]@{
+        ManagedPackageCount = ''
+        ManagedInstalledCount = ''
+        ManagedAlreadyInstalledCount = ''
+        ManagedFileCount = ''
+        ManagedDownloadedBytes = ''
+        ManagedExtractedBytes = ''
+        ManagedPackageRepositoryRequests = ''
+        ManagedPackageRepositoryRedirects = ''
+        ManagedVersionResolutionMillisecondsSum = ''
+        ManagedVersionSelectionWaitMillisecondsSum = ''
+        ManagedDownloadMillisecondsSum = ''
+        ManagedDownloadMillisecondsMax = ''
+        ManagedExtractionMillisecondsSum = ''
+        ManagedExtractionMillisecondsMax = ''
+        ManagedExtractionCacheLockWaitMillisecondsSum = ''
+        ManagedDependencyMillisecondsRoot = ''
+        ManagedDependencyQueueWaitMillisecondsSum = ''
+        ManagedDependencyBranchMillisecondsMax = ''
+        ManagedPromotionMillisecondsSum = ''
+        ManagedPromotionMillisecondsMax = ''
+        ManagedPromotionLockWaitMillisecondsSum = ''
+        ManagedInstallLockWaitMillisecondsSum = ''
+        ManagedCoalescedWaitMillisecondsSum = ''
+        ManagedAuthenticodeCheckedFiles = ''
+        ManagedAuthenticodeCatalogFiles = ''
+    }
+
+    if ($null -eq $ManagedResult -or -not $ManagedResult.PSObject.Properties['DependencyResults']) {
+        return $empty
+    }
+
+    $nodes = [System.Collections.Generic.List[object]]::new()
+    Add-ManagedInstallResultNode -Node $ManagedResult -Nodes $nodes
+
+    $installedCount = 0
+    $alreadyInstalledCount = 0
+    $fileCount = 0
+    [long] $downloadedBytes = 0
+    [long] $extractedBytes = 0
+    [long] $packageRepositoryRequests = 0
+    [long] $packageRepositoryRedirects = 0
+    [double] $versionResolutionMillisecondsSum = 0
+    [double] $versionSelectionWaitMillisecondsSum = 0
+    [double] $downloadMillisecondsSum = 0
+    [double] $downloadMillisecondsMax = 0
+    [double] $extractionMillisecondsSum = 0
+    [double] $extractionMillisecondsMax = 0
+    [double] $extractionCacheLockWaitMillisecondsSum = 0
+    [double] $dependencyQueueWaitMillisecondsSum = 0
+    [double] $dependencyBranchMillisecondsMax = 0
+    [double] $promotionMillisecondsSum = 0
+    [double] $promotionMillisecondsMax = 0
+    [double] $promotionLockWaitMillisecondsSum = 0
+    [double] $installLockWaitMillisecondsSum = 0
+    [double] $coalescedWaitMillisecondsSum = 0
+    $authenticodeCheckedFiles = 0
+    $authenticodeCatalogFiles = 0
+
+    foreach ($node in $nodes) {
+        $status = [string]$node.Status
+        if ($status.Equals('Installed', [StringComparison]::OrdinalIgnoreCase)) {
+            $installedCount++
+        } elseif ($status.Equals('AlreadyInstalled', [StringComparison]::OrdinalIgnoreCase)) {
+            $alreadyInstalledCount++
+        }
+
+        $fileCount += [int]$node.FileCount
+        $extractedBytes += [long]$node.ExtractedBytes
+        $packageRepositoryRequests += [long]$node.PackageRepositoryRequestCount
+        $packageRepositoryRedirects += [long]$node.PackageRepositoryRedirectCount
+
+        if ($null -ne $node.Download) {
+            $downloadedBytes += [long]$node.Download.BytesWritten
+        }
+
+        $versionResolutionMillisecondsSum += ConvertTo-BenchmarkMilliseconds $node.VersionResolutionElapsed
+        $versionSelectionWaitMillisecondsSum += ConvertTo-BenchmarkMilliseconds $node.VersionSelectionWaitElapsed
+
+        $downloadMilliseconds = ConvertTo-BenchmarkMilliseconds $node.DownloadElapsed
+        $downloadMillisecondsSum += $downloadMilliseconds
+        if ($downloadMilliseconds -gt $downloadMillisecondsMax) {
+            $downloadMillisecondsMax = $downloadMilliseconds
+        }
+
+        $extractionMilliseconds = ConvertTo-BenchmarkMilliseconds $node.ExtractionElapsed
+        $extractionMillisecondsSum += $extractionMilliseconds
+        if ($extractionMilliseconds -gt $extractionMillisecondsMax) {
+            $extractionMillisecondsMax = $extractionMilliseconds
+        }
+
+        $extractionCacheLockWaitMillisecondsSum += ConvertTo-BenchmarkMilliseconds $node.ExtractionCacheLockWaitElapsed
+        $dependencyQueueWaitMillisecondsSum += ConvertTo-BenchmarkMilliseconds $node.DependencyQueueWaitElapsed
+
+        $dependencyBranchMilliseconds = ConvertTo-BenchmarkMilliseconds $node.DependencyBranchElapsed
+        if ($dependencyBranchMilliseconds -gt $dependencyBranchMillisecondsMax) {
+            $dependencyBranchMillisecondsMax = $dependencyBranchMilliseconds
+        }
+
+        $promotionMilliseconds = ConvertTo-BenchmarkMilliseconds $node.PromotionElapsed
+        $promotionMillisecondsSum += $promotionMilliseconds
+        if ($promotionMilliseconds -gt $promotionMillisecondsMax) {
+            $promotionMillisecondsMax = $promotionMilliseconds
+        }
+
+        $promotionLockWaitMillisecondsSum += ConvertTo-BenchmarkMilliseconds $node.PromotionLockWaitElapsed
+        $installLockWaitMillisecondsSum += ConvertTo-BenchmarkMilliseconds $node.InstallLockWaitElapsed
+        $coalescedWaitMillisecondsSum += ConvertTo-BenchmarkMilliseconds $node.CoalescedWaitElapsed
+
+        if ($null -ne $node.AuthenticodeVerification) {
+            $authenticodeCheckedFiles += [int]$node.AuthenticodeVerification.CheckedFiles
+            $authenticodeCatalogFiles += [int]$node.AuthenticodeVerification.CatalogFiles
+        }
+    }
+
+    [ordered]@{
+        ManagedPackageCount = $nodes.Count.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedInstalledCount = $installedCount.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedAlreadyInstalledCount = $alreadyInstalledCount.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedFileCount = $fileCount.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedDownloadedBytes = $downloadedBytes.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedExtractedBytes = $extractedBytes.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedPackageRepositoryRequests = $packageRepositoryRequests.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedPackageRepositoryRedirects = $packageRepositoryRedirects.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedVersionResolutionMillisecondsSum = Format-BenchmarkNumber $versionResolutionMillisecondsSum
+        ManagedVersionSelectionWaitMillisecondsSum = Format-BenchmarkNumber $versionSelectionWaitMillisecondsSum
+        ManagedDownloadMillisecondsSum = Format-BenchmarkNumber $downloadMillisecondsSum
+        ManagedDownloadMillisecondsMax = Format-BenchmarkNumber $downloadMillisecondsMax
+        ManagedExtractionMillisecondsSum = Format-BenchmarkNumber $extractionMillisecondsSum
+        ManagedExtractionMillisecondsMax = Format-BenchmarkNumber $extractionMillisecondsMax
+        ManagedExtractionCacheLockWaitMillisecondsSum = Format-BenchmarkNumber $extractionCacheLockWaitMillisecondsSum
+        ManagedDependencyMillisecondsRoot = Format-BenchmarkNumber (ConvertTo-BenchmarkMilliseconds $ManagedResult.DependencyElapsed)
+        ManagedDependencyQueueWaitMillisecondsSum = Format-BenchmarkNumber $dependencyQueueWaitMillisecondsSum
+        ManagedDependencyBranchMillisecondsMax = Format-BenchmarkNumber $dependencyBranchMillisecondsMax
+        ManagedPromotionMillisecondsSum = Format-BenchmarkNumber $promotionMillisecondsSum
+        ManagedPromotionMillisecondsMax = Format-BenchmarkNumber $promotionMillisecondsMax
+        ManagedPromotionLockWaitMillisecondsSum = Format-BenchmarkNumber $promotionLockWaitMillisecondsSum
+        ManagedInstallLockWaitMillisecondsSum = Format-BenchmarkNumber $installLockWaitMillisecondsSum
+        ManagedCoalescedWaitMillisecondsSum = Format-BenchmarkNumber $coalescedWaitMillisecondsSum
+        ManagedAuthenticodeCheckedFiles = $authenticodeCheckedFiles.ToString([Globalization.CultureInfo]::InvariantCulture)
+        ManagedAuthenticodeCatalogFiles = $authenticodeCatalogFiles.ToString([Globalization.CultureInfo]::InvariantCulture)
     }
 }
 
@@ -240,7 +437,7 @@ function Invoke-BenchmarkCommand {
                     }
                     if (-not [string]::IsNullOrWhiteSpace($version)) { $parameters.Version = $version }
                     if ($acceptLicense) { $parameters.AcceptLicense = $true }
-                    Install-ManagedModule @parameters | Out-Null
+                    $script:LastManagedBenchmarkResult = Install-ManagedModule @parameters
                 }
                 'Save' {
                     $parameters = @{
@@ -252,7 +449,7 @@ function Invoke-BenchmarkCommand {
                     }
                     if (-not [string]::IsNullOrWhiteSpace($version)) { $parameters.Version = $version }
                     if ($acceptLicense) { $parameters.AcceptLicense = $true }
-                    Save-ManagedModule @parameters | Out-Null
+                    $script:LastManagedBenchmarkResult = Save-ManagedModule @parameters
                 }
             }
         }
@@ -380,6 +577,7 @@ if ($PSVersionTable.PSEdition -eq 'Desktop') {
 }
 
 $results = [System.Collections.Generic.List[object]]::new()
+$script:LastManagedBenchmarkResult = $null
 foreach ($scenario in $selectedScenarios) {
     foreach ($operationName in $Operation) {
         foreach ($engineName in $Engine) {
@@ -390,10 +588,11 @@ foreach ($scenario in $selectedScenarios) {
                 New-Item -ItemType Directory -Path $installRoot, $saveRoot -Force | Out-Null
 
                 try {
+                    $script:LastManagedBenchmarkResult = $null
                     $elapsed = Invoke-MeasuredBlock {
                         Invoke-BenchmarkCommand -Scenario $scenario -OperationName $operationName -EngineName $engineName -InstallRoot $installRoot -SaveRoot $saveRoot
                     }
-                    Write-MeasurementResult -Result (New-MeasurementResult -Scenario $scenario -OperationName $operationName -EngineName $engineName -Iteration $iteration -Status 'Succeeded' -Milliseconds $elapsed -Reason '')
+                    Write-MeasurementResult -Result (New-MeasurementResult -Scenario $scenario -OperationName $operationName -EngineName $engineName -Iteration $iteration -Status 'Succeeded' -Milliseconds $elapsed -Reason '' -ManagedResult $script:LastManagedBenchmarkResult)
                 } catch {
                     $message = $_.Exception.Message
                     $status = if ($message.StartsWith('NotEquivalent:', [StringComparison]::OrdinalIgnoreCase)) {

--- a/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
+++ b/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
@@ -131,6 +131,7 @@ function New-MeasurementResult {
     $roundedSeconds = [Math]::Round($Milliseconds / 1000, 3)
 
     $managedMetrics = New-ManagedBenchmarkMetrics -ManagedResult $ManagedResult
+    $engineMetadata = Get-BenchmarkEngineMetadata -EngineName $EngineName
     $row = [ordered]@{
         TimestampUtc = [DateTime]::UtcNow.ToString('o')
         Host = Get-CurrentHostLabel
@@ -145,6 +146,11 @@ function New-MeasurementResult {
         Milliseconds = $roundedMilliseconds.ToString('0.##', [Globalization.CultureInfo]::InvariantCulture)
         Seconds = $roundedSeconds.ToString('0.###', [Globalization.CultureInfo]::InvariantCulture)
         Reason = $Reason
+        Repository = $Repository
+        RepositoryUri = $RepositoryUri
+        ModuleFastSource = if ($EngineName -eq 'ModuleFast') { $ModuleFastSource } else { '' }
+        EngineCommandPath = $engineMetadata.CommandPath
+        EngineModuleVersion = $engineMetadata.ModuleVersion
     }
 
     foreach ($metric in $managedMetrics.GetEnumerator()) {
@@ -152,6 +158,43 @@ function New-MeasurementResult {
     }
 
     [pscustomobject]$row
+}
+
+function Get-BenchmarkEngineMetadata {
+    param([string] $EngineName)
+
+    $commandName = switch ($EngineName) {
+        'Managed' { 'Install-ManagedModule' }
+        'ModuleFast' { 'Install-ModuleFast' }
+        'PSResourceGet' { 'Install-PSResource' }
+        'PowerShellGet' { 'Install-Module' }
+        default { '' }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($commandName)) {
+        return [pscustomobject]@{ CommandPath = ''; ModuleVersion = '' }
+    }
+
+    $command = Get-Command -Name $commandName -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $command) {
+        return [pscustomobject]@{ CommandPath = ''; ModuleVersion = '' }
+    }
+
+    $moduleVersion = ''
+    if (-not [string]::IsNullOrWhiteSpace($command.ModuleName)) {
+        $module = Get-Module -Name $command.ModuleName -ErrorAction SilentlyContinue | Sort-Object Version -Descending | Select-Object -First 1
+        if ($null -eq $module) {
+            $module = Get-Module -ListAvailable -Name $command.ModuleName -ErrorAction SilentlyContinue | Sort-Object Version -Descending | Select-Object -First 1
+        }
+        if ($null -ne $module) {
+            $moduleVersion = [string]$module.Version
+        }
+    }
+
+    [pscustomobject]@{
+        CommandPath = [string]$command.Source
+        ModuleVersion = $moduleVersion
+    }
 }
 
 function Format-BenchmarkNumber {

--- a/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
+++ b/Benchmarks/ManagedModules/Measure-ManagedModuleBenchmark.ps1
@@ -18,6 +18,8 @@ param(
 
     [string] $ModuleFastSource = 'https://pwsh.gallery/index.json',
 
+    [string] $ModuleFastModulePath = '',
+
     [string] $OutputPath = '',
 
     [string] $OutputRoot = '',
@@ -149,7 +151,9 @@ function New-MeasurementResult {
         Repository = $Repository
         RepositoryUri = $RepositoryUri
         ModuleFastSource = if ($EngineName -eq 'ModuleFast') { $ModuleFastSource } else { '' }
+        ModuleFastModulePath = if ($EngineName -eq 'ModuleFast') { $ModuleFastModulePath } else { '' }
         EngineCommandPath = $engineMetadata.CommandPath
+        EngineModuleBase = $engineMetadata.ModuleBase
         EngineModuleVersion = $engineMetadata.ModuleVersion
     }
 
@@ -172,14 +176,15 @@ function Get-BenchmarkEngineMetadata {
     }
 
     if ([string]::IsNullOrWhiteSpace($commandName)) {
-        return [pscustomobject]@{ CommandPath = ''; ModuleVersion = '' }
+        return [pscustomobject]@{ CommandPath = ''; ModuleBase = ''; ModuleVersion = '' }
     }
 
     $command = Get-Command -Name $commandName -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($null -eq $command) {
-        return [pscustomobject]@{ CommandPath = ''; ModuleVersion = '' }
+        return [pscustomobject]@{ CommandPath = ''; ModuleBase = ''; ModuleVersion = '' }
     }
 
+    $moduleBase = ''
     $moduleVersion = ''
     if (-not [string]::IsNullOrWhiteSpace($command.ModuleName)) {
         $module = Get-Module -Name $command.ModuleName -ErrorAction SilentlyContinue | Sort-Object Version -Descending | Select-Object -First 1
@@ -187,14 +192,41 @@ function Get-BenchmarkEngineMetadata {
             $module = Get-Module -ListAvailable -Name $command.ModuleName -ErrorAction SilentlyContinue | Sort-Object Version -Descending | Select-Object -First 1
         }
         if ($null -ne $module) {
+            $moduleBase = [string]$module.ModuleBase
             $moduleVersion = [string]$module.Version
         }
     }
 
     [pscustomobject]@{
         CommandPath = [string]$command.Source
+        ModuleBase = $moduleBase
         ModuleVersion = $moduleVersion
     }
+}
+
+function Resolve-ModuleFastImportPath {
+    param([string] $Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ''
+    }
+
+    $resolved = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    if (-not (Test-Path -LiteralPath $resolved -PathType Container)) {
+        return $resolved
+    }
+
+    $manifest = Join-Path $resolved 'ModuleFast.psd1'
+    if (Test-Path -LiteralPath $manifest -PathType Leaf) {
+        return $manifest
+    }
+
+    $scriptModule = Join-Path $resolved 'ModuleFast.psm1'
+    if (Test-Path -LiteralPath $scriptModule -PathType Leaf) {
+        return $scriptModule
+    }
+
+    return $resolved
 }
 
 function Format-BenchmarkNumber {
@@ -504,7 +536,11 @@ function Invoke-BenchmarkCommand {
                 throw 'NotAvailable: ModuleFast requires PowerShell 7.2 or newer.'
             }
 
-            Import-ProviderCommand -CommandName 'Install-ModuleFast' -ModuleName 'ModuleFast'
+            if (-not [string]::IsNullOrWhiteSpace($ModuleFastModulePath)) {
+                Import-Module -Name (Resolve-ModuleFastImportPath -Path $ModuleFastModulePath) -Force -ErrorAction Stop
+            } else {
+                Import-ProviderCommand -CommandName 'Install-ModuleFast' -ModuleName 'ModuleFast'
+            }
             $specification = if ([string]::IsNullOrWhiteSpace($version)) { $name } else { '{0}={1}' -f $name, $version }
             $parameters = @{
                 Specification = $specification

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -67,6 +67,9 @@ Run the default focused Managed-vs-ModuleFast install comparison:
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1
 ```
 
+`-BenchmarkHost PowerShell7` selects the highest available `pwsh` 7 executable
+instead of assuming `C:\Program Files\PowerShell\7\pwsh.exe` is the newest host.
+
 That default profile skips PSResourceGet/PowerShellGet native install baselines
 and only runs the install rows where ModuleFast has an equivalent public
 command. Use it for the active performance loop; the native-provider matrix is

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -32,7 +32,9 @@ What the benchmark is trying to prove:
 - ModuleFast is a useful comparison, but it uses `pwsh.gallery`, a community
   NuGet v3 mirror used by ModuleFast rather than the normal PSGallery provider
   path. If that mirror is missing a dependency, mark the row as a source/index
-  miss instead of comparing elapsed time.
+  miss instead of comparing elapsed time. The matrix wrapper passes
+  `-ModuleFastSource https://pwsh.gallery/index.json` by default so the source
+  is explicit in both the command line and result CSV.
 - Native `Install-Module` and `Install-PSResource` rows are real
   `CurrentUser` installs against a temporary Windows user. The runner stages
   only the native provider modules for that account, runs the measured install
@@ -64,6 +66,20 @@ Run PowerShell 7:
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1
 ```
+
+Run the focused Managed-vs-ModuleFast install comparison:
+
+```powershell
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -ComparisonProfile ManagedVsModuleFast -BenchmarkHost PowerShell7 -RepeatCount 1 -OutputPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast.csv -OutputRoot .\Ignore\Benchmarks\ManagedModules\ManagedVsModuleFast
+```
+
+Use the focused profile while tuning install throughput. It skips
+PSResourceGet/PowerShellGet native install baselines and only runs the install
+rows where ModuleFast has an equivalent public command. To compare a local or
+development ModuleFast build, install that build into the benchmark host first
+or pass its supported source with `-ModuleFastSource`; the result CSV records
+`ModuleFastSource`, `EngineCommandPath`, and `EngineModuleVersion` for each
+row.
 
 Append Windows PowerShell 5.1 results:
 

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -69,18 +69,19 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModule
 
 That default profile skips PSResourceGet/PowerShellGet native install baselines
 and only runs the install rows where ModuleFast has an equivalent public
-command. The full native-provider matrix is still available when you need a
-fresh baseline:
+command. Use it for the active performance loop; the native-provider matrix is
+kept only for occasional baseline refreshes because those rows are much slower:
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -ComparisonProfile Full -BenchmarkHost PowerShell7 -RepeatCount 1
 ```
 
 Use the focused profile while tuning install throughput. By default it compares
-the managed engine with the `Install-ModuleFast` command visible in the
-benchmark PowerShell host, usually the installed ModuleFast module from the
-user/module path. To compare a local or development ModuleFast build, pass its
-manifest, script module, or module folder:
+the development managed engine in this worktree with the `Install-ModuleFast`
+command visible in the benchmark PowerShell host, usually the installed
+ModuleFast module from the user/module path. To compare against the refreshed
+C# ModuleFast branch instead, pass that branch's manifest, script module, or
+module folder:
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1 -ModuleFastModulePath .\Ignore\External\ModuleFast-csharp\ModuleFast.psd1 -OutputPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast-dev.csv -OutputRoot .\Ignore\Benchmarks\ManagedModules\ManagedVsModuleFastDev

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -49,6 +49,16 @@ provider path inside a temporary Windows user. Use
 `-SkipTemporaryUserNativeInstall` only when a machine cannot create a temporary
 local benchmark account.
 
+Managed `Install` and `Save` rows also include phase columns that make
+performance triage less speculative. The wall-clock `Seconds` column stays the
+scoreboard value; `ManagedDownloadMillisecondsSum`,
+`ManagedExtractionMillisecondsSum`, `ManagedDependencyMillisecondsRoot`,
+`ManagedPromotionMillisecondsSum`, request counts, byte counts, and matching
+max/wait columns show where the managed engine spent time. Sum columns can be
+larger than wall-clock time because dependency downloads and extraction run in
+parallel; the max and root elapsed columns are usually better indicators for
+the critical path.
+
 Run PowerShell 7:
 
 ```powershell

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -61,25 +61,36 @@ larger than wall-clock time because dependency downloads and extraction run in
 parallel; the max and root elapsed columns are usually better indicators for
 the critical path.
 
-Run PowerShell 7:
+Run the default focused Managed-vs-ModuleFast install comparison:
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1
 ```
 
-Run the focused Managed-vs-ModuleFast install comparison:
+That default profile skips PSResourceGet/PowerShellGet native install baselines
+and only runs the install rows where ModuleFast has an equivalent public
+command. The full native-provider matrix is still available when you need a
+fresh baseline:
 
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -ComparisonProfile ManagedVsModuleFast -BenchmarkHost PowerShell7 -RepeatCount 1 -OutputPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast.csv -OutputRoot .\Ignore\Benchmarks\ManagedModules\ManagedVsModuleFast
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -ComparisonProfile Full -BenchmarkHost PowerShell7 -RepeatCount 1
 ```
 
-Use the focused profile while tuning install throughput. It skips
-PSResourceGet/PowerShellGet native install baselines and only runs the install
-rows where ModuleFast has an equivalent public command. To compare a local or
-development ModuleFast build, install that build into the benchmark host first
-or pass its supported source with `-ModuleFastSource`; the result CSV records
-`ModuleFastSource`, `EngineCommandPath`, and `EngineModuleVersion` for each
-row.
+Use the focused profile while tuning install throughput. By default it compares
+the managed engine with the `Install-ModuleFast` command visible in the
+benchmark PowerShell host, usually the installed ModuleFast module from the
+user/module path. To compare a local or development ModuleFast build, pass its
+manifest, script module, or module folder:
+
+```powershell
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1 -ModuleFastModulePath .\Ignore\External\ModuleFast-csharp\ModuleFast.psd1 -OutputPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast-dev.csv -OutputRoot .\Ignore\Benchmarks\ManagedModules\ManagedVsModuleFastDev
+```
+
+`-ModuleFastSource` only changes the package source passed to ModuleFast; it
+does not select a different ModuleFast implementation. The result CSV records
+`ModuleFastSource`, `ModuleFastModulePath`, `EngineCommandPath`,
+`EngineModuleBase`, and `EngineModuleVersion` for each row so installed-gallery
+and development-branch comparisons stay separate.
 
 Append Windows PowerShell 5.1 results:
 

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -61,12 +61,14 @@ larger than wall-clock time because dependency downloads and extraction run in
 parallel; the max and root elapsed columns are usually better indicators for
 the critical path.
 
-Run the default focused Managed-vs-ModuleFast install comparison. This is the
-normal tuning loop now; it skips PSResourceGet and PowerShellGet because those
-provider baselines are already much slower and make every iteration expensive:
+Run the focused Managed-vs-ModuleFast install comparison. This is the normal
+tuning loop now; it skips PSResourceGet and PowerShellGet because those provider
+baselines are already much slower and make every iteration expensive. For the
+fair current comparison, pass the refreshed C# ModuleFast branch through
+`-ModuleFastModulePath`:
 
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1 -ModuleFastModulePath .\Ignore\External\ModuleFast-csharp\ModuleFast.psd1
 ```
 
 `-BenchmarkHost PowerShell7` selects the highest available `pwsh` 7 executable
@@ -80,12 +82,13 @@ or release-baseline refreshes:
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -ComparisonProfile Full -BenchmarkHost PowerShell7 -RepeatCount 1
 ```
 
-Use the focused profile while tuning install throughput. By default it compares
-the development managed engine in this worktree with the `Install-ModuleFast`
-command visible in the benchmark PowerShell host, usually the installed
-PSGallery ModuleFast module from the user/module path. To compare against the
-refreshed development C# ModuleFast branch, pass that branch's manifest, script
-module, or module folder:
+If `-ModuleFastModulePath` is omitted, the focused profile still skips the
+native providers, but it compares the development managed engine in this
+worktree with whatever `Install-ModuleFast` command is visible in the benchmark
+PowerShell host, usually the installed PSGallery ModuleFast module from the
+user/module path. That is a smoke comparison, not the development C# ModuleFast
+race. To compare against the refreshed development C# ModuleFast branch, pass
+that branch's manifest, script module, or module folder:
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1 -ModuleFastModulePath .\Ignore\External\ModuleFast-csharp\ModuleFast.psd1 -OutputPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast-dev.csv -OutputRoot .\Ignore\Benchmarks\ManagedModules\ManagedVsModuleFastDev

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -61,7 +61,9 @@ larger than wall-clock time because dependency downloads and extraction run in
 parallel; the max and root elapsed columns are usually better indicators for
 the critical path.
 
-Run the default focused Managed-vs-ModuleFast install comparison:
+Run the default focused Managed-vs-ModuleFast install comparison. This is the
+normal tuning loop now; it skips PSResourceGet and PowerShellGet because those
+provider baselines are already much slower and make every iteration expensive:
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1
@@ -70,10 +72,9 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModule
 `-BenchmarkHost PowerShell7` selects the highest available `pwsh` 7 executable
 instead of assuming `C:\Program Files\PowerShell\7\pwsh.exe` is the newest host.
 
-That default profile skips PSResourceGet/PowerShellGet native install baselines
-and only runs the install rows where ModuleFast has an equivalent public
-command. Use it for the active performance loop; the native-provider matrix is
-kept only for occasional baseline refreshes because those rows are much slower:
+That default profile only runs install rows where ModuleFast has an equivalent
+public command. Use the native-provider matrix only for occasional compatibility
+or release-baseline refreshes:
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -ComparisonProfile Full -BenchmarkHost PowerShell7 -RepeatCount 1
@@ -82,9 +83,9 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModule
 Use the focused profile while tuning install throughput. By default it compares
 the development managed engine in this worktree with the `Install-ModuleFast`
 command visible in the benchmark PowerShell host, usually the installed
-ModuleFast module from the user/module path. To compare against the refreshed
-C# ModuleFast branch instead, pass that branch's manifest, script module, or
-module folder:
+PSGallery ModuleFast module from the user/module path. To compare against the
+refreshed development C# ModuleFast branch, pass that branch's manifest, script
+module, or module folder:
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1 -ModuleFastModulePath .\Ignore\External\ModuleFast-csharp\ModuleFast.psd1 -OutputPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast-dev.csv -OutputRoot .\Ignore\Benchmarks\ManagedModules\ManagedVsModuleFastDev
@@ -94,7 +95,8 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModule
 does not select a different ModuleFast implementation. The result CSV records
 `ModuleFastSource`, `ModuleFastModulePath`, `EngineCommandPath`,
 `EngineModuleBase`, and `EngineModuleVersion` for each row so installed-gallery
-and development-branch comparisons stay separate.
+and development-branch comparisons stay separate. If `ModuleFastModulePath` is
+blank, the row is not a C# ModuleFast development-branch comparison.
 
 Append Windows PowerShell 5.1 results:
 

--- a/Benchmarks/ManagedModules/Update-ManagedModuleBenchmarkReadme.ps1
+++ b/Benchmarks/ManagedModules/Update-ManagedModuleBenchmarkReadme.ps1
@@ -4,7 +4,10 @@ param(
     [Parameter(Mandatory)]
     [string] $ResultPath,
 
-    [string] $ReadmePath = (Join-Path $PSScriptRoot '..\..\README.MD')
+    [string] $ReadmePath = (Join-Path $PSScriptRoot '..\..\README.MD'),
+
+    [ValidateSet('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet')]
+    [string[]] $Engine = @()
 )
 
 Set-StrictMode -Version Latest
@@ -138,13 +141,32 @@ function ConvertTo-BenchmarkSummaryRows {
 }
 
 function ConvertTo-BenchmarkMarkdown {
-    param([object[]] $Rows)
+    param(
+        [object[]] $Rows,
+        [string[]] $SelectedEngine
+    )
 
     $Rows = @(ConvertTo-BenchmarkSummaryRows -Rows $Rows)
-    $engines = @('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet')
+    $knownEngines = @('Managed', 'ModuleFast', 'PSResourceGet', 'PowerShellGet')
+    $presentEngines = @($Rows | ForEach-Object { $_.Engine } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+    $engines = if ($SelectedEngine.Count -gt 0) {
+        @($SelectedEngine)
+    } else {
+        @($knownEngines | Where-Object { $presentEngines -contains $_ })
+    }
+
+    $extraEngines = @($presentEngines | Where-Object { $engines -notcontains $_ } | Sort-Object)
+    if ($extraEngines.Count -gt 0) {
+        $engines += $extraEngines
+    }
+
+    if ($engines.Count -eq 0) {
+        throw 'No benchmark engines were found in the result CSV.'
+    }
+
     $lines = [System.Collections.Generic.List[string]]::new()
-    $lines.Add('| Scenario | Host | Operation | Managed | ModuleFast | PSResourceGet | PowerShellGet | Result |') | Out-Null
-    $lines.Add('| --- | --- | --- | --- | --- | --- | --- | --- |') | Out-Null
+    $lines.Add(('| Scenario | Host | Operation | {0} | Result |' -f ($engines -join ' | '))) | Out-Null
+    $lines.Add(('| --- | --- | --- | {0} | --- |' -f (@($engines | ForEach-Object { '---' }) -join ' | '))) | Out-Null
 
     $groups = $Rows |
         Group-Object ScenarioLabel, Host, Operation |
@@ -163,14 +185,11 @@ function ConvertTo-BenchmarkMarkdown {
             Format-BenchmarkCell -Row $row -ManagedSeconds $managedSeconds
         }
         $result = Get-ManagedResultText -Rows $items -ManagedRow $managed
-        $lines.Add(('| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} |' -f
+        $lines.Add(('| {0} | {1} | {2} | {3} | {4} |' -f
             $first.ScenarioLabel,
             $first.Host,
             $first.Operation,
-            $cells[0],
-            $cells[1],
-            $cells[2],
-            $cells[3],
+            ($cells -join ' | '),
             $result)) | Out-Null
     }
 
@@ -182,7 +201,7 @@ if ($rows.Count -eq 0) {
     throw "No benchmark rows were found in '$ResultPath'."
 }
 
-$table = ConvertTo-BenchmarkMarkdown -Rows $rows
+$table = ConvertTo-BenchmarkMarkdown -Rows $rows -SelectedEngine $Engine
 $readme = Get-Content -LiteralPath $ReadmePath -Raw
 $start = '<!-- managed-module-benchmark-table:start -->'
 $end = '<!-- managed-module-benchmark-table:end -->'

--- a/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
+++ b/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Concurrent;
+using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PSPublishModule;
+
+/// <summary>
+/// Base class for cmdlets that await asynchronous engine work while routing PowerShell pipeline writes
+/// back through the synchronous cmdlet pipeline thread.
+/// </summary>
+public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
+{
+    private enum PipelineType
+    {
+        Output,
+        OutputEnumerate,
+        Error,
+        Warning,
+        Verbose,
+        Debug,
+        Information,
+        Progress,
+        ShouldProcess,
+        PromptForCredential
+    }
+
+    private readonly CancellationTokenSource _cancelSource = new();
+    private BlockingCollection<(object? Value, PipelineType Type)>? _currentOutPipe;
+    private BlockingCollection<object?>? _currentReplyPipe;
+    private int _pipelineThreadId;
+
+    /// <summary>Cancellation token triggered when PowerShell stops the cmdlet.</summary>
+    protected internal CancellationToken CancelToken => _cancelSource.Token;
+
+    /// <inheritdoc />
+    protected override void BeginProcessing()
+        => RunBlockInAsync(BeginProcessingAsync);
+
+    /// <summary>Asynchronous begin hook.</summary>
+    protected virtual Task BeginProcessingAsync()
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    protected override void ProcessRecord()
+        => RunBlockInAsync(ProcessRecordAsync);
+
+    /// <summary>Asynchronous process-record hook.</summary>
+    protected virtual Task ProcessRecordAsync()
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    protected override void EndProcessing()
+        => RunBlockInAsync(EndProcessingAsync);
+
+    /// <summary>Asynchronous end hook.</summary>
+    protected virtual Task EndProcessingAsync()
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    protected override void StopProcessing()
+        => _cancelSource.Cancel();
+
+    /// <summary>Thread-safe ShouldProcess bridge for asynchronous cmdlet code.</summary>
+    public new bool ShouldProcess(string? target, string action)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread)
+            return base.ShouldProcess(target ?? string.Empty, action);
+
+        _currentOutPipe.Add(((target ?? string.Empty, action), PipelineType.ShouldProcess), CancelToken);
+        return (bool)_currentReplyPipe.Take(CancelToken)!;
+    }
+
+    /// <summary>Thread-safe credential prompt bridge for asynchronous cmdlet code.</summary>
+    public PSCredential? PromptForCredential(string caption, string message, string userName, string targetName)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread)
+            return Host.UI.PromptForCredential(caption, message, userName, targetName);
+
+        _currentOutPipe.Add(((caption, message, userName, targetName), PipelineType.PromptForCredential), CancelToken);
+        return (PSCredential?)_currentReplyPipe.Take(CancelToken);
+    }
+
+    /// <summary>Thread-safe output bridge for asynchronous cmdlet code.</summary>
+    public new void WriteObject(object? sendToPipeline)
+        => WriteObject(sendToPipeline, enumerateCollection: false);
+
+    /// <summary>Thread-safe output bridge for asynchronous cmdlet code.</summary>
+    public new void WriteObject(object? sendToPipeline, bool enumerateCollection)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || IsPipelineThread)
+        {
+            base.WriteObject(sendToPipeline, enumerateCollection);
+            return;
+        }
+
+        _currentOutPipe.Add((sendToPipeline, enumerateCollection ? PipelineType.OutputEnumerate : PipelineType.Output), CancelToken);
+    }
+
+    /// <summary>Thread-safe error bridge for asynchronous cmdlet code.</summary>
+    public new void WriteError(ErrorRecord errorRecord)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || IsPipelineThread)
+        {
+            base.WriteError(errorRecord);
+            return;
+        }
+
+        _currentOutPipe.Add((errorRecord, PipelineType.Error), CancelToken);
+    }
+
+    /// <summary>Thread-safe warning bridge for asynchronous cmdlet code.</summary>
+    public new void WriteWarning(string text)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || IsPipelineThread)
+        {
+            base.WriteWarning(text);
+            return;
+        }
+
+        _currentOutPipe.Add((text, PipelineType.Warning), CancelToken);
+    }
+
+    /// <summary>Thread-safe verbose bridge for asynchronous cmdlet code.</summary>
+    public new void WriteVerbose(string text)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || IsPipelineThread)
+        {
+            base.WriteVerbose(text);
+            return;
+        }
+
+        _currentOutPipe.Add((text, PipelineType.Verbose), CancelToken);
+    }
+
+    /// <summary>Thread-safe debug bridge for asynchronous cmdlet code.</summary>
+    public new void WriteDebug(string text)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || IsPipelineThread)
+        {
+            base.WriteDebug(text);
+            return;
+        }
+
+        _currentOutPipe.Add((text, PipelineType.Debug), CancelToken);
+    }
+
+    /// <summary>Thread-safe information bridge for asynchronous cmdlet code.</summary>
+    public new void WriteInformation(InformationRecord informationRecord)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || IsPipelineThread)
+        {
+            base.WriteInformation(informationRecord);
+            return;
+        }
+
+        _currentOutPipe.Add((informationRecord, PipelineType.Information), CancelToken);
+    }
+
+    /// <summary>Thread-safe progress bridge for asynchronous cmdlet code.</summary>
+    public new void WriteProgress(ProgressRecord progressRecord)
+    {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || IsPipelineThread)
+        {
+            base.WriteProgress(progressRecord);
+            return;
+        }
+
+        _currentOutPipe.Add((progressRecord, PipelineType.Progress), CancelToken);
+    }
+
+    /// <summary>Throws when PowerShell has requested cancellation.</summary>
+    internal void ThrowIfStopped()
+    {
+        if (_cancelSource.IsCancellationRequested)
+            throw new PipelineStoppedException();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+        => _cancelSource.Dispose();
+
+    private bool IsPipelineThread
+        => _pipelineThreadId != 0 && Environment.CurrentManagedThreadId == _pipelineThreadId;
+
+    private void RunBlockInAsync(Func<Task> task)
+    {
+        using var outPipe = new BlockingCollection<(object? Value, PipelineType Type)>();
+        using var replyPipe = new BlockingCollection<object?>();
+        Task blockTask;
+
+        void ClearPipes()
+        {
+            _currentOutPipe = null;
+            _currentReplyPipe = null;
+            _pipelineThreadId = 0;
+            outPipe.CompleteAdding();
+            replyPipe.CompleteAdding();
+        }
+
+        _pipelineThreadId = Environment.CurrentManagedThreadId;
+        _currentOutPipe = outPipe;
+        _currentReplyPipe = replyPipe;
+
+        try
+        {
+            blockTask = task();
+        }
+        catch
+        {
+            ClearPipes();
+            throw;
+        }
+
+        if (blockTask.IsCompleted)
+        {
+            ClearPipes();
+            blockTask.GetAwaiter().GetResult();
+            return;
+        }
+
+        _ = blockTask.ContinueWith(
+            completed => ClearPipes(),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        foreach (var item in outPipe.GetConsumingEnumerable(CancelToken))
+        {
+            switch (item.Type)
+            {
+                case PipelineType.Output:
+                    base.WriteObject(item.Value);
+                    break;
+                case PipelineType.OutputEnumerate:
+                    base.WriteObject(item.Value, enumerateCollection: true);
+                    break;
+                case PipelineType.Error:
+                    base.WriteError((ErrorRecord)item.Value!);
+                    break;
+                case PipelineType.Warning:
+                    base.WriteWarning((string)item.Value!);
+                    break;
+                case PipelineType.Verbose:
+                    base.WriteVerbose((string)item.Value!);
+                    break;
+                case PipelineType.Debug:
+                    base.WriteDebug((string)item.Value!);
+                    break;
+                case PipelineType.Information:
+                    base.WriteInformation((InformationRecord)item.Value!);
+                    break;
+                case PipelineType.Progress:
+                    base.WriteProgress((ProgressRecord)item.Value!);
+                    break;
+                case PipelineType.ShouldProcess:
+                    var should = ((string Target, string Action))item.Value!;
+                    replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
+                    break;
+                case PipelineType.PromptForCredential:
+                    var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
+                    replyPipe.Add(
+                        Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
+                        CancelToken);
+                    break;
+            }
+        }
+
+        blockTask.GetAwaiter().GetResult();
+    }
+}

--- a/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
+++ b/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
@@ -235,45 +235,62 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
 
-        foreach (var item in outPipe.GetConsumingEnumerable(CancelToken))
+        try
         {
-            switch (item.Type)
+            foreach (var item in outPipe.GetConsumingEnumerable(CancelToken))
             {
-                case PipelineType.Output:
-                    base.WriteObject(item.Value);
-                    break;
-                case PipelineType.OutputEnumerate:
-                    base.WriteObject(item.Value, enumerateCollection: true);
-                    break;
-                case PipelineType.Error:
-                    base.WriteError((ErrorRecord)item.Value!);
-                    break;
-                case PipelineType.Warning:
-                    base.WriteWarning((string)item.Value!);
-                    break;
-                case PipelineType.Verbose:
-                    base.WriteVerbose((string)item.Value!);
-                    break;
-                case PipelineType.Debug:
-                    base.WriteDebug((string)item.Value!);
-                    break;
-                case PipelineType.Information:
-                    base.WriteInformation((InformationRecord)item.Value!);
-                    break;
-                case PipelineType.Progress:
-                    base.WriteProgress((ProgressRecord)item.Value!);
-                    break;
-                case PipelineType.ShouldProcess:
-                    var should = ((string Target, string Action))item.Value!;
-                    replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
-                    break;
-                case PipelineType.PromptForCredential:
-                    var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
-                    replyPipe.Add(
-                        Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
-                        CancelToken);
-                    break;
+                switch (item.Type)
+                {
+                    case PipelineType.Output:
+                        base.WriteObject(item.Value);
+                        break;
+                    case PipelineType.OutputEnumerate:
+                        base.WriteObject(item.Value, enumerateCollection: true);
+                        break;
+                    case PipelineType.Error:
+                        base.WriteError((ErrorRecord)item.Value!);
+                        break;
+                    case PipelineType.Warning:
+                        base.WriteWarning((string)item.Value!);
+                        break;
+                    case PipelineType.Verbose:
+                        base.WriteVerbose((string)item.Value!);
+                        break;
+                    case PipelineType.Debug:
+                        base.WriteDebug((string)item.Value!);
+                        break;
+                    case PipelineType.Information:
+                        base.WriteInformation((InformationRecord)item.Value!);
+                        break;
+                    case PipelineType.Progress:
+                        base.WriteProgress((ProgressRecord)item.Value!);
+                        break;
+                    case PipelineType.ShouldProcess:
+                        var should = ((string Target, string Action))item.Value!;
+                        replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
+                        break;
+                    case PipelineType.PromptForCredential:
+                        var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
+                        replyPipe.Add(
+                            Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
+                            CancelToken);
+                        break;
+                }
             }
+        }
+        catch
+        {
+            _cancelSource.Cancel();
+            outPipe.CompleteAdding();
+            try
+            {
+                blockTask.GetAwaiter().GetResult();
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or PipelineStoppedException)
+            {
+            }
+
+            throw;
         }
 
         blockTask.GetAwaiter().GetResult();

--- a/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
+++ b/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
@@ -204,8 +204,61 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             _currentOutPipe = null;
             _currentReplyPipe = null;
             _pipelineThreadId = 0;
-            outPipe.CompleteAdding();
-            replyPipe.CompleteAdding();
+            CompleteAddingIfNeeded(outPipe);
+            CompleteAddingIfNeeded(replyPipe);
+        }
+
+        static void CompleteAddingIfNeeded<T>(BlockingCollection<T> pipe)
+        {
+            if (!pipe.IsAddingCompleted)
+                pipe.CompleteAdding();
+        }
+
+        void PumpItem((object? Value, PipelineType Type) item)
+        {
+            switch (item.Type)
+            {
+                case PipelineType.Output:
+                    base.WriteObject(item.Value);
+                    break;
+                case PipelineType.OutputEnumerate:
+                    base.WriteObject(item.Value, enumerateCollection: true);
+                    break;
+                case PipelineType.Error:
+                    base.WriteError((ErrorRecord)item.Value!);
+                    break;
+                case PipelineType.Warning:
+                    base.WriteWarning((string)item.Value!);
+                    break;
+                case PipelineType.Verbose:
+                    base.WriteVerbose((string)item.Value!);
+                    break;
+                case PipelineType.Debug:
+                    base.WriteDebug((string)item.Value!);
+                    break;
+                case PipelineType.Information:
+                    base.WriteInformation((InformationRecord)item.Value!);
+                    break;
+                case PipelineType.Progress:
+                    base.WriteProgress((ProgressRecord)item.Value!);
+                    break;
+                case PipelineType.ShouldProcess:
+                    var should = ((string Target, string Action))item.Value!;
+                    replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
+                    break;
+                case PipelineType.PromptForCredential:
+                    var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
+                    replyPipe.Add(
+                        Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
+                        CancelToken);
+                    break;
+            }
+        }
+
+        void PumpQueuedItems()
+        {
+            while (outPipe.TryTake(out var item))
+                PumpItem(item);
         }
 
         _pipelineThreadId = Environment.CurrentManagedThreadId;
@@ -224,6 +277,8 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
 
         if (blockTask.IsCompleted)
         {
+            CompleteAddingIfNeeded(outPipe);
+            PumpQueuedItems();
             ClearPipes();
             blockTask.GetAwaiter().GetResult();
             return;
@@ -239,49 +294,13 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
         {
             foreach (var item in outPipe.GetConsumingEnumerable(CancelToken))
             {
-                switch (item.Type)
-                {
-                    case PipelineType.Output:
-                        base.WriteObject(item.Value);
-                        break;
-                    case PipelineType.OutputEnumerate:
-                        base.WriteObject(item.Value, enumerateCollection: true);
-                        break;
-                    case PipelineType.Error:
-                        base.WriteError((ErrorRecord)item.Value!);
-                        break;
-                    case PipelineType.Warning:
-                        base.WriteWarning((string)item.Value!);
-                        break;
-                    case PipelineType.Verbose:
-                        base.WriteVerbose((string)item.Value!);
-                        break;
-                    case PipelineType.Debug:
-                        base.WriteDebug((string)item.Value!);
-                        break;
-                    case PipelineType.Information:
-                        base.WriteInformation((InformationRecord)item.Value!);
-                        break;
-                    case PipelineType.Progress:
-                        base.WriteProgress((ProgressRecord)item.Value!);
-                        break;
-                    case PipelineType.ShouldProcess:
-                        var should = ((string Target, string Action))item.Value!;
-                        replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
-                        break;
-                    case PipelineType.PromptForCredential:
-                        var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
-                        replyPipe.Add(
-                            Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
-                            CancelToken);
-                        break;
-                }
+                PumpItem(item);
             }
         }
         catch
         {
             _cancelSource.Cancel();
-            outPipe.CompleteAdding();
+            CompleteAddingIfNeeded(outPipe);
             try
             {
                 blockTask.GetAwaiter().GetResult();

--- a/PSPublishModule/Cmdlets/InstallManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/InstallManagedModuleCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -23,7 +24,7 @@ namespace PSPublishModule;
 /// </example>
 [Cmdlet(VerbsLifecycle.Install, "ManagedModule", SupportsShouldProcess = true)]
 [OutputType(typeof(ManagedModuleInstallResult), typeof(ManagedModuleInstallPlan))]
-public sealed class InstallManagedModuleCommand : PSCmdlet
+public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
 {
     /// <summary>Module names to install.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipelineByPropertyName = true)]
@@ -175,7 +176,7 @@ public sealed class InstallManagedModuleCommand : PSCmdlet
     public SwitchParameter ShowSummary { get; set; }
 
     /// <summary>Installs the requested modules.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var moduleRoot = ManagedModuleCommandSupport.ResolveProviderPath(this, ModuleRoot);
         var repository = ManagedModuleCommandSupport.CreateRepository(
@@ -219,7 +220,7 @@ public sealed class InstallManagedModuleCommand : PSCmdlet
 
             if (Plan.IsPresent)
             {
-                var plan = service.PlanInstallAsync(request).GetAwaiter().GetResult();
+                var plan = await service.PlanInstallAsync(request, CancelToken).ConfigureAwait(false);
                 WriteObject(plan);
                 if (ShowSummary.IsPresent)
                     ManagedModuleSummaryWriter.Write(plan);
@@ -229,7 +230,7 @@ public sealed class InstallManagedModuleCommand : PSCmdlet
             if (!ShouldProcess(moduleName, $"Install managed module from repository '{repository.Name}'"))
                 continue;
 
-            var result = service.InstallAsync(request).GetAwaiter().GetResult();
+            var result = await service.InstallAsync(request, CancelToken).ConfigureAwait(false);
 
             WriteObject(result);
             if (ShowSummary.IsPresent)

--- a/PSPublishModule/Cmdlets/InstallManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/InstallManagedModuleCommand.cs
@@ -179,6 +179,7 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
     protected override async Task ProcessRecordAsync()
     {
         var moduleRoot = ManagedModuleCommandSupport.ResolveProviderPath(this, ModuleRoot);
+        var packageCacheDirectory = ManagedModuleCommandSupport.ResolveProviderPath(this, PackageCacheDirectory);
         var repository = ManagedModuleCommandSupport.CreateRepository(
             this,
             RepositoryName,
@@ -206,7 +207,7 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
                 Scope = string.IsNullOrWhiteSpace(moduleRoot) ? Scope : ManagedModuleInstallScope.Custom,
                 ShellEdition = ShellEdition,
                 ModuleRoot = moduleRoot,
-                PackageCacheDirectory = ManagedModuleCommandSupport.ResolveProviderPath(this, PackageCacheDirectory),
+                PackageCacheDirectory = packageCacheDirectory,
                 DependencyConcurrency = DependencyConcurrency,
                 ExpectedPackageSha256 = ExpectedPackageSha256,
                 TrustPolicy = trustPolicy,

--- a/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -33,7 +34,7 @@ namespace PSPublishModule;
 /// </example>
 [Cmdlet(VerbsDiagnostic.Repair, "ManagedModule", SupportsShouldProcess = true)]
 [OutputType(typeof(ModuleStateWorkflowResult))]
-public sealed class RepairManagedModuleCommand : PSCmdlet
+public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
 {
     /// <summary>Optional module names to repair. When omitted, all installed modules in scope are considered.</summary>
     [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
@@ -170,7 +171,7 @@ public sealed class RepairManagedModuleCommand : PSCmdlet
     public string? CredentialSecretFilePath { get; set; }
 
     /// <summary>Repairs managed modules.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         try
         {
@@ -192,10 +193,10 @@ public sealed class RepairManagedModuleCommand : PSCmdlet
             ApplySelectedInventoryTargets(plan, selectedModules);
             ApplyLatestUpdateIntent(plan);
             ApplyForceRepairIntent(plan);
-            EnrichManagedLicenseMetadata(plan);
+            await EnrichManagedLicenseMetadataAsync(plan).ConfigureAwait(false);
 
             var test = ModuleStateTestResult.FromPlan(plan);
-            var applyResult = PrepareApply(plan, inventory);
+            var applyResult = await PrepareApplyAsync(plan, inventory).ConfigureAwait(false);
             var workflow = new ModuleStateWorkflowResult
             {
                 Inventory = inventory,
@@ -377,7 +378,7 @@ public sealed class RepairManagedModuleCommand : PSCmdlet
             : "=" + selected.Version.Trim();
     }
 
-    private ModuleStateApplyResult PrepareApply(ModuleStatePlanResult plan, ModuleStateInventoryResult inventory)
+    private async Task<ModuleStateApplyResult> PrepareApplyAsync(ModuleStatePlanResult plan, ModuleStateInventoryResult inventory)
     {
         var deliveryOptions = new ModuleStateDeliveryOptions(
             ProfileName,
@@ -397,7 +398,7 @@ public sealed class RepairManagedModuleCommand : PSCmdlet
         var executionResults = Array.Empty<ModuleStateDeliveryExecutionResult>();
 
         if (!Plan.IsPresent && result.Receipt.CanApply && ShouldProcess("managed module estate", "Repair managed modules"))
-            executionResults = ExecuteDelivery(result, inventory);
+            executionResults = await ExecuteDeliveryAsync(result, inventory).ConfigureAwait(false);
 
         return ModuleStateApplyResultMapper.ToCmdletResult(
             result,
@@ -408,13 +409,14 @@ public sealed class RepairManagedModuleCommand : PSCmdlet
             postApplyInventory: null);
     }
 
-    private ModuleStateDeliveryExecutionResult[] ExecuteDelivery(PowerForge.ModuleStateApplyResult result, ModuleStateInventoryResult inventory)
+    private async Task<ModuleStateDeliveryExecutionResult[]> ExecuteDeliveryAsync(PowerForge.ModuleStateApplyResult result, ModuleStateInventoryResult inventory)
     {
         if (Transport == ModuleStateDeliveryTransport.ManagedModule)
         {
-            return new ModuleStateManagedDeliveryService(this).Execute(
+            return await new ModuleStateManagedDeliveryService(this).ExecuteAsync(
                 result,
-                CreateManagedDeliveryOptions(inventory));
+                CreateManagedDeliveryOptions(inventory),
+                CancelToken).ConfigureAwait(false);
         }
 
         return new ModuleStatePrivateDeliveryService(this).Execute(
@@ -438,14 +440,16 @@ public sealed class RepairManagedModuleCommand : PSCmdlet
             });
     }
 
-    private void EnrichManagedLicenseMetadata(ModuleStatePlanResult plan)
+    private async Task EnrichManagedLicenseMetadataAsync(ModuleStatePlanResult plan)
     {
         if (Transport != ModuleStateDeliveryTransport.ManagedModule)
             return;
 
         try
         {
-            new ModuleStateManagedPlanLicenseEnricher(this).Enrich(plan, CreateManagedDeliveryOptions());
+            await new ModuleStateManagedPlanLicenseEnricher(this)
+                .EnrichAsync(plan, CreateManagedDeliveryOptions(), CancelToken)
+                .ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or NotSupportedException or UriFormatException)
         {

--- a/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
@@ -182,12 +182,6 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             ValidateVersionPolicy();
             var deliveryModuleRoot = ResolveManagedDeliveryModuleRoot();
             var credentialSecretFilePath = ResolveCredentialSecretFilePath();
-            var repositoryCredential = ManagedModuleCommandSupport.ResolveCredential(
-                this,
-                Credential,
-                CredentialUserName,
-                CredentialSecret,
-                credentialSecretFilePath);
 
             var inventory = ResolveInventory();
             var selectedModules = SelectBaselineModules(inventory).ToArray();
@@ -201,11 +195,13 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             ApplySelectedInventoryTargets(plan, selectedModules);
             ApplyLatestUpdateIntent(plan);
             ApplyForceRepairIntent(plan);
-            var managedDeliveryOptions = CreateManagedDeliveryOptions(inventory, deliveryModuleRoot, repositoryCredential);
+            var managedDeliveryOptions = CreateManagedDeliveryOptions(inventory, deliveryModuleRoot);
             var repositoriesResolved = PreResolveManagedDeliveryRepositories(
                 plan,
                 managedDeliveryOptions,
                 required: !Plan.IsPresent);
+            if (repositoriesResolved && ShouldResolveManagedCredential(plan))
+                managedDeliveryOptions.Credential = ResolveRepositoryCredential(credentialSecretFilePath);
             if (repositoriesResolved)
                 await EnrichManagedLicenseMetadataAsync(plan, managedDeliveryOptions).ConfigureAwait(false);
 
@@ -555,6 +551,22 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             Credential = credential,
             LoadedModules = ResolveLoadedModules(inventory)
         };
+
+    private RepositoryCredential? ResolveRepositoryCredential(string? credentialSecretFilePath)
+        => ManagedModuleCommandSupport.ResolveCredential(
+            this,
+            Credential,
+            CredentialUserName,
+            CredentialSecret,
+            credentialSecretFilePath);
+
+    private bool ShouldResolveManagedCredential(ModuleStatePlanResult plan)
+        => Transport == ModuleStateDeliveryTransport.ManagedModule &&
+           HasDeliveryActions(plan);
+
+    private static bool HasDeliveryActions(ModuleStatePlanResult plan)
+        => (plan.Actions ?? Array.Empty<ModuleStatePlanActionResult>())
+            .Any(static action => action.Kind is "Install" or "Update" or "Save");
 
     private string? ResolveCredentialSecretFilePath()
         => ManagedModuleCommandSupport.ResolveProviderPath(this, CredentialSecretFilePath);

--- a/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
@@ -180,6 +180,14 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             if (!string.IsNullOrWhiteSpace(InventoryPath) && Inventory is not null)
                 throw new InvalidOperationException("Specify either Inventory or InventoryPath, not both.");
             ValidateVersionPolicy();
+            var deliveryModuleRoot = ResolveManagedDeliveryModuleRoot();
+            var credentialSecretFilePath = ResolveCredentialSecretFilePath();
+            var repositoryCredential = ManagedModuleCommandSupport.ResolveCredential(
+                this,
+                Credential,
+                CredentialUserName,
+                CredentialSecret,
+                credentialSecretFilePath);
 
             var inventory = ResolveInventory();
             var selectedModules = SelectBaselineModules(inventory).ToArray();
@@ -193,10 +201,15 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             ApplySelectedInventoryTargets(plan, selectedModules);
             ApplyLatestUpdateIntent(plan);
             ApplyForceRepairIntent(plan);
-            await EnrichManagedLicenseMetadataAsync(plan).ConfigureAwait(false);
+            await EnrichManagedLicenseMetadataAsync(plan, deliveryModuleRoot, repositoryCredential).ConfigureAwait(false);
 
             var test = ModuleStateTestResult.FromPlan(plan);
-            var applyResult = await PrepareApplyAsync(plan, inventory).ConfigureAwait(false);
+            var applyResult = await PrepareApplyAsync(
+                plan,
+                inventory,
+                deliveryModuleRoot,
+                credentialSecretFilePath,
+                repositoryCredential).ConfigureAwait(false);
             var workflow = new ModuleStateWorkflowResult
             {
                 Inventory = inventory,
@@ -378,7 +391,12 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             : "=" + selected.Version.Trim();
     }
 
-    private async Task<ModuleStateApplyResult> PrepareApplyAsync(ModuleStatePlanResult plan, ModuleStateInventoryResult inventory)
+    private async Task<ModuleStateApplyResult> PrepareApplyAsync(
+        ModuleStatePlanResult plan,
+        ModuleStateInventoryResult inventory,
+        string? deliveryModuleRoot,
+        string? credentialSecretFilePath,
+        RepositoryCredential? repositoryCredential)
     {
         var deliveryOptions = new ModuleStateDeliveryOptions(
             ProfileName,
@@ -389,7 +407,7 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             acceptLicense: AcceptLicense.IsPresent,
             allowErrorFindings: AllowConflict.IsPresent,
             allowClobber: AllowClobber.IsPresent,
-            moduleRoot: ManagedModuleCommandSupport.ResolveProviderPath(this, ModuleRoot),
+            moduleRoot: deliveryModuleRoot,
             transport: Transport,
             profileRepository: ResolveProfileRepositoryName());
         var service = new ModuleStateApplyService();
@@ -398,7 +416,12 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
         var executionResults = Array.Empty<ModuleStateDeliveryExecutionResult>();
 
         if (!Plan.IsPresent && result.Receipt.CanApply && ShouldProcess("managed module estate", "Repair managed modules"))
-            executionResults = await ExecuteDeliveryAsync(result, inventory).ConfigureAwait(false);
+            executionResults = await ExecuteDeliveryAsync(
+                result,
+                inventory,
+                deliveryModuleRoot,
+                credentialSecretFilePath,
+                repositoryCredential).ConfigureAwait(false);
 
         return ModuleStateApplyResultMapper.ToCmdletResult(
             result,
@@ -409,13 +432,18 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             postApplyInventory: null);
     }
 
-    private async Task<ModuleStateDeliveryExecutionResult[]> ExecuteDeliveryAsync(PowerForge.ModuleStateApplyResult result, ModuleStateInventoryResult inventory)
+    private async Task<ModuleStateDeliveryExecutionResult[]> ExecuteDeliveryAsync(
+        PowerForge.ModuleStateApplyResult result,
+        ModuleStateInventoryResult inventory,
+        string? deliveryModuleRoot,
+        string? credentialSecretFilePath,
+        RepositoryCredential? repositoryCredential)
     {
         if (Transport == ModuleStateDeliveryTransport.ManagedModule)
         {
             return await new ModuleStateManagedDeliveryService(this).ExecuteAsync(
                 result,
-                CreateManagedDeliveryOptions(inventory),
+                CreateManagedDeliveryOptions(inventory, deliveryModuleRoot, repositoryCredential),
                 CancelToken).ConfigureAwait(false);
         }
 
@@ -431,16 +459,19 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
                 DeliveryTransport = Transport,
                 CredentialUserName = Credential?.UserName ?? CredentialUserName,
                 CredentialSecret = Credential?.GetNetworkCredential().Password ?? CredentialSecret,
-                CredentialSecretFilePath = CredentialSecretFilePath,
+                CredentialSecretFilePath = credentialSecretFilePath,
                 PromptForCredential = false,
-                ManagedModuleRoot = ResolveManagedDeliveryModuleRoot(),
+                ManagedModuleRoot = deliveryModuleRoot,
                 ManagedAllowClobber = AllowClobber.IsPresent,
                 ManagedAcceptLicense = AcceptLicense.IsPresent,
                 LoadedModules = ResolveLoadedModules(inventory)
             });
     }
 
-    private async Task EnrichManagedLicenseMetadataAsync(ModuleStatePlanResult plan)
+    private async Task EnrichManagedLicenseMetadataAsync(
+        ModuleStatePlanResult plan,
+        string? deliveryModuleRoot,
+        RepositoryCredential? repositoryCredential)
     {
         if (Transport != ModuleStateDeliveryTransport.ManagedModule)
             return;
@@ -448,7 +479,7 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
         try
         {
             await new ModuleStateManagedPlanLicenseEnricher(this)
-                .EnrichAsync(plan, CreateManagedDeliveryOptions(), CancelToken)
+                .EnrichAsync(plan, CreateManagedDeliveryOptions(moduleRoot: deliveryModuleRoot, credential: repositoryCredential), CancelToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or NotSupportedException or UriFormatException)
@@ -457,7 +488,10 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
         }
     }
 
-    private ModuleStateManagedDeliveryOptions CreateManagedDeliveryOptions(ModuleStateInventoryResult? inventory = null)
+    private ModuleStateManagedDeliveryOptions CreateManagedDeliveryOptions(
+        ModuleStateInventoryResult? inventory = null,
+        string? moduleRoot = null,
+        RepositoryCredential? credential = null)
         => new()
         {
             ProfileName = ProfileName,
@@ -466,15 +500,13 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             Force = Force.IsPresent,
             AllowClobber = AllowClobber.IsPresent,
             AcceptLicense = AcceptLicense.IsPresent,
-            ModuleRoot = ResolveManagedDeliveryModuleRoot(),
-            Credential = ManagedModuleCommandSupport.ResolveCredential(
-                this,
-                Credential,
-                CredentialUserName,
-                CredentialSecret,
-                CredentialSecretFilePath),
+            ModuleRoot = moduleRoot,
+            Credential = credential,
             LoadedModules = ResolveLoadedModules(inventory)
         };
+
+    private string? ResolveCredentialSecretFilePath()
+        => ManagedModuleCommandSupport.ResolveProviderPath(this, CredentialSecretFilePath);
 
     private string? ResolveManagedDeliveryModuleRoot()
     {

--- a/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/RepairManagedModuleCommand.cs
@@ -201,7 +201,13 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
             ApplySelectedInventoryTargets(plan, selectedModules);
             ApplyLatestUpdateIntent(plan);
             ApplyForceRepairIntent(plan);
-            await EnrichManagedLicenseMetadataAsync(plan, deliveryModuleRoot, repositoryCredential).ConfigureAwait(false);
+            var managedDeliveryOptions = CreateManagedDeliveryOptions(inventory, deliveryModuleRoot, repositoryCredential);
+            var repositoriesResolved = PreResolveManagedDeliveryRepositories(
+                plan,
+                managedDeliveryOptions,
+                required: !Plan.IsPresent);
+            if (repositoriesResolved)
+                await EnrichManagedLicenseMetadataAsync(plan, managedDeliveryOptions).ConfigureAwait(false);
 
             var test = ModuleStateTestResult.FromPlan(plan);
             var applyResult = await PrepareApplyAsync(
@@ -209,7 +215,7 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
                 inventory,
                 deliveryModuleRoot,
                 credentialSecretFilePath,
-                repositoryCredential).ConfigureAwait(false);
+                managedDeliveryOptions).ConfigureAwait(false);
             var workflow = new ModuleStateWorkflowResult
             {
                 Inventory = inventory,
@@ -396,7 +402,7 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
         ModuleStateInventoryResult inventory,
         string? deliveryModuleRoot,
         string? credentialSecretFilePath,
-        RepositoryCredential? repositoryCredential)
+        ModuleStateManagedDeliveryOptions managedDeliveryOptions)
     {
         var deliveryOptions = new ModuleStateDeliveryOptions(
             ProfileName,
@@ -421,7 +427,7 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
                 inventory,
                 deliveryModuleRoot,
                 credentialSecretFilePath,
-                repositoryCredential).ConfigureAwait(false);
+                managedDeliveryOptions).ConfigureAwait(false);
 
         return ModuleStateApplyResultMapper.ToCmdletResult(
             result,
@@ -437,13 +443,13 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
         ModuleStateInventoryResult inventory,
         string? deliveryModuleRoot,
         string? credentialSecretFilePath,
-        RepositoryCredential? repositoryCredential)
+        ModuleStateManagedDeliveryOptions managedDeliveryOptions)
     {
         if (Transport == ModuleStateDeliveryTransport.ManagedModule)
         {
             return await new ModuleStateManagedDeliveryService(this).ExecuteAsync(
                 result,
-                CreateManagedDeliveryOptions(inventory, deliveryModuleRoot, repositoryCredential),
+                managedDeliveryOptions,
                 CancelToken).ConfigureAwait(false);
         }
 
@@ -470,8 +476,7 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
 
     private async Task EnrichManagedLicenseMetadataAsync(
         ModuleStatePlanResult plan,
-        string? deliveryModuleRoot,
-        RepositoryCredential? repositoryCredential)
+        ModuleStateManagedDeliveryOptions managedDeliveryOptions)
     {
         if (Transport != ModuleStateDeliveryTransport.ManagedModule)
             return;
@@ -479,12 +484,58 @@ public sealed class RepairManagedModuleCommand : AsyncPSCmdlet
         try
         {
             await new ModuleStateManagedPlanLicenseEnricher(this)
-                .EnrichAsync(plan, CreateManagedDeliveryOptions(moduleRoot: deliveryModuleRoot, credential: repositoryCredential), CancelToken)
+                .EnrichAsync(plan, managedDeliveryOptions, CancelToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or NotSupportedException or UriFormatException)
         {
             WriteVerbose("Managed module license preflight skipped: " + ex.Message);
+        }
+    }
+
+    private bool PreResolveManagedDeliveryRepositories(
+        ModuleStatePlanResult plan,
+        ModuleStateManagedDeliveryOptions options,
+        bool required)
+    {
+        if (Transport != ModuleStateDeliveryTransport.ManagedModule)
+            return true;
+
+        var actions = (plan.Actions ?? Array.Empty<ModuleStatePlanActionResult>())
+            .Where(static action => action.Kind is "Install" or "Update" or "Save")
+            .ToArray();
+        if (actions.Length == 0)
+            return true;
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            foreach (var action in actions)
+            {
+                var key = ModuleStateManagedRepositoryResolver.CreateRepositoryKey(action.TargetRepository);
+                if (!seen.Add(key))
+                    continue;
+                if (key.Length == 0 &&
+                    string.IsNullOrWhiteSpace(options.Repository) &&
+                    string.IsNullOrWhiteSpace(options.ProfileName))
+                {
+                    continue;
+                }
+
+                options.ResolvedRepositories[key] = ModuleStateManagedRepositoryResolver.ResolveRepositoryForAction(
+                    this,
+                    action.TargetRepository,
+                    options,
+                    "Managed module delivery requires Repository, ProfileName, or action target repository.");
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (!required &&
+                                   (ex is InvalidOperationException or ArgumentException or NotSupportedException or UriFormatException))
+        {
+            WriteVerbose("Managed module license preflight skipped: " + ex.Message);
+            return false;
         }
     }
 

--- a/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -24,7 +25,7 @@ namespace PSPublishModule;
 /// </example>
 [Cmdlet(VerbsData.Save, "ManagedModule", SupportsShouldProcess = true)]
 [OutputType(typeof(ManagedModuleInstallResult), typeof(ManagedModuleInstallPlan))]
-public sealed class SaveManagedModuleCommand : PSCmdlet
+public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
 {
     private readonly List<ManagedModuleInstallResult> _results = new();
 
@@ -175,7 +176,7 @@ public sealed class SaveManagedModuleCommand : PSCmdlet
     public SwitchParameter ShowSummary { get; set; }
 
     /// <summary>Saves requested modules.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var moduleRoot = ManagedModuleCommandSupport.ResolveProviderPath(this, Path)!;
         var repository = ManagedModuleCommandSupport.CreateRepository(
@@ -218,7 +219,7 @@ public sealed class SaveManagedModuleCommand : PSCmdlet
 
             if (Plan.IsPresent)
             {
-                var plan = service.PlanInstallAsync(request).GetAwaiter().GetResult();
+                var plan = await service.PlanInstallAsync(request, CancelToken).ConfigureAwait(false);
                 WriteObject(plan);
                 if (ShowSummary.IsPresent)
                     ManagedModuleSummaryWriter.Write(plan);
@@ -228,7 +229,7 @@ public sealed class SaveManagedModuleCommand : PSCmdlet
             if (!ShouldProcess(moduleName, $"Save managed module to '{moduleRoot}'"))
                 continue;
 
-            var result = service.InstallAsync(request).GetAwaiter().GetResult();
+            var result = await service.InstallAsync(request, CancelToken).ConfigureAwait(false);
             _results.Add(result);
 
             WriteObject(result);
@@ -238,15 +239,16 @@ public sealed class SaveManagedModuleCommand : PSCmdlet
     }
 
     /// <summary>Writes optional offline bundle metadata after all save results are available.</summary>
-    protected override void EndProcessing()
+    protected override Task EndProcessingAsync()
     {
         if (Plan.IsPresent || string.IsNullOrWhiteSpace(BundleMetadataPath) || _results.Count == 0)
-            return;
+            return Task.CompletedTask;
 
         var metadataPath = ManagedModuleCommandSupport.ResolveProviderPath(this, BundleMetadataPath);
         if (!ShouldProcess(metadataPath, "Write managed module bundle metadata"))
-            return;
+            return Task.CompletedTask;
 
         new ManagedModuleBundleMetadataWriter().Write(metadataPath!, _results);
+        return Task.CompletedTask;
     }
 }

--- a/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
@@ -179,6 +179,7 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
     protected override async Task ProcessRecordAsync()
     {
         var moduleRoot = ManagedModuleCommandSupport.ResolveProviderPath(this, Path)!;
+        var packageCacheDirectory = ManagedModuleCommandSupport.ResolveProviderPath(this, PackageCacheDirectory);
         var repository = ManagedModuleCommandSupport.CreateRepository(
             this,
             RepositoryName,
@@ -205,7 +206,7 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
                 IncludePrerelease = Prerelease.IsPresent,
                 Scope = ManagedModuleInstallScope.Custom,
                 ModuleRoot = moduleRoot,
-                PackageCacheDirectory = ManagedModuleCommandSupport.ResolveProviderPath(this, PackageCacheDirectory),
+                PackageCacheDirectory = packageCacheDirectory,
                 DependencyConcurrency = DependencyConcurrency,
                 ExpectedPackageSha256 = ExpectedPackageSha256,
                 TrustPolicy = trustPolicy,

--- a/PSPublishModule/Cmdlets/UpdateManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/UpdateManagedModuleCommand.cs
@@ -216,6 +216,7 @@ public sealed class UpdateManagedModuleCommand : AsyncPSCmdlet
     protected override async Task ProcessRecordAsync()
     {
         var moduleRoot = ManagedModuleCommandSupport.ResolveProviderPath(this, ModuleRoot);
+        var packageCacheDirectory = ManagedModuleCommandSupport.ResolveProviderPath(this, PackageCacheDirectory);
         var repository = ManagedModuleCommandSupport.CreateRepository(
             this,
             RepositoryName,
@@ -254,7 +255,7 @@ public sealed class UpdateManagedModuleCommand : AsyncPSCmdlet
                     Scope = targetScope,
                     ShellEdition = ShellEdition,
                     ModuleRoot = moduleRoot,
-                    PackageCacheDirectory = ManagedModuleCommandSupport.ResolveProviderPath(this, PackageCacheDirectory),
+                    PackageCacheDirectory = packageCacheDirectory,
                     DependencyConcurrency = DependencyConcurrency,
                     ExpectedPackageSha256 = ExpectedPackageSha256,
                     TrustPolicy = trustPolicy,

--- a/PSPublishModule/Cmdlets/UpdateManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/UpdateManagedModuleCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -25,7 +26,7 @@ namespace PSPublishModule;
 /// </example>
 [Cmdlet(VerbsData.Update, "ManagedModule", SupportsShouldProcess = true)]
 [OutputType(typeof(ManagedModuleUpdateResult), typeof(ManagedModuleUpdatePlan))]
-public sealed class UpdateManagedModuleCommand : PSCmdlet
+public sealed class UpdateManagedModuleCommand : AsyncPSCmdlet
 {
     /// <summary>Module names to update.</summary>
     [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
@@ -212,7 +213,7 @@ public sealed class UpdateManagedModuleCommand : PSCmdlet
     public SwitchParameter ShowSummary { get; set; }
 
     /// <summary>Updates requested modules.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var moduleRoot = ManagedModuleCommandSupport.ResolveProviderPath(this, ModuleRoot);
         var repository = ManagedModuleCommandSupport.CreateRepository(
@@ -271,7 +272,7 @@ public sealed class UpdateManagedModuleCommand : PSCmdlet
 
                 if (Plan.IsPresent)
                 {
-                    var plan = service.PlanUpdateAsync(request).GetAwaiter().GetResult();
+                    var plan = await service.PlanUpdateAsync(request, CancelToken).ConfigureAwait(false);
                     WriteObject(plan);
                     if (ShowSummary.IsPresent)
                         ManagedModuleSummaryWriter.Write(plan);
@@ -281,7 +282,7 @@ public sealed class UpdateManagedModuleCommand : PSCmdlet
                 if (!ShouldProcess(moduleName, $"Update managed module from repository '{repository.Name}'"))
                     continue;
 
-                var result = service.UpdateAsync(request).GetAwaiter().GetResult();
+                var result = await service.UpdateAsync(request, CancelToken).ConfigureAwait(false);
 
                 WriteObject(result);
                 if (ShowSummary.IsPresent)

--- a/PSPublishModule/Services/CmdletLogger.cs
+++ b/PSPublishModule/Services/CmdletLogger.cs
@@ -16,18 +16,18 @@ internal sealed class CmdletLogger : ILogger
         IsVerbose = isVerbose;
     }
 
-    public void Info(string message) => _cmdlet.WriteVerbose(message);
-    public void Success(string message) => _cmdlet.WriteVerbose(message);
+    public void Info(string message) => WriteVerbose(message);
+    public void Success(string message) => WriteVerbose(message);
     public void Warn(string message)
     {
-        if (_warningsAsVerbose) _cmdlet.WriteVerbose(message);
-        else _cmdlet.WriteWarning(message);
+        if (_warningsAsVerbose) WriteVerbose(message);
+        else WriteWarning(message);
     }
     public void Error(string message)
     {
         try
         {
-            _cmdlet.WriteError(new ErrorRecord(
+            WriteError(new ErrorRecord(
                 exception: new InvalidOperationException(message),
                 errorId: "PowerForgeError",
                 errorCategory: ErrorCategory.NotSpecified,
@@ -36,14 +36,38 @@ internal sealed class CmdletLogger : ILogger
         catch
         {
             // Best effort fallbacks; never throw from logging.
-            try { _cmdlet.WriteWarning(message); } catch { }
+            try { WriteWarning(message); } catch { }
         }
     }
     public void Verbose(string message)
     {
         if (!IsVerbose) return;
-        _cmdlet.WriteVerbose(message);
+        WriteVerbose(message);
     }
 
     public bool IsVerbose { get; }
+
+    private void WriteVerbose(string message)
+    {
+        if (_cmdlet is AsyncPSCmdlet asyncCmdlet)
+            asyncCmdlet.WriteVerbose(message);
+        else
+            _cmdlet.WriteVerbose(message);
+    }
+
+    private void WriteWarning(string message)
+    {
+        if (_cmdlet is AsyncPSCmdlet asyncCmdlet)
+            asyncCmdlet.WriteWarning(message);
+        else
+            _cmdlet.WriteWarning(message);
+    }
+
+    private void WriteError(ErrorRecord errorRecord)
+    {
+        if (_cmdlet is AsyncPSCmdlet asyncCmdlet)
+            asyncCmdlet.WriteError(errorRecord);
+        else
+            _cmdlet.WriteError(errorRecord);
+    }
 }

--- a/PSPublishModule/Services/CmdletPrivateGalleryHost.cs
+++ b/PSPublishModule/Services/CmdletPrivateGalleryHost.cs
@@ -13,7 +13,10 @@ internal sealed class CmdletPrivateGalleryHost : IPrivateGalleryHost
         _cmdlet = cmdlet ?? throw new ArgumentNullException(nameof(cmdlet));
     }
 
-    public bool ShouldProcess(string target, string action) => _cmdlet.ShouldProcess(target, action);
+    public bool ShouldProcess(string target, string action)
+        => _cmdlet is AsyncPSCmdlet asyncCmdlet
+            ? asyncCmdlet.ShouldProcess(target, action)
+            : _cmdlet.ShouldProcess(target, action);
 
     public bool IsWhatIfRequested =>
         _cmdlet.MyInvocation.BoundParameters.TryGetValue("WhatIf", out var whatIfValue) &&
@@ -22,7 +25,9 @@ internal sealed class CmdletPrivateGalleryHost : IPrivateGalleryHost
 
     public RepositoryCredential? PromptForCredential(string caption, string message)
     {
-        var promptCredential = _cmdlet.Host.UI.PromptForCredential(caption, message, string.Empty, string.Empty);
+        var promptCredential = _cmdlet is AsyncPSCmdlet asyncCmdlet
+            ? asyncCmdlet.PromptForCredential(caption, message, string.Empty, string.Empty)
+            : _cmdlet.Host.UI.PromptForCredential(caption, message, string.Empty, string.Empty);
         if (promptCredential is null)
             return null;
 
@@ -33,7 +38,19 @@ internal sealed class CmdletPrivateGalleryHost : IPrivateGalleryHost
         };
     }
 
-    public void WriteVerbose(string message) => _cmdlet.WriteVerbose(message);
+    public void WriteVerbose(string message)
+    {
+        if (_cmdlet is AsyncPSCmdlet asyncCmdlet)
+            asyncCmdlet.WriteVerbose(message);
+        else
+            _cmdlet.WriteVerbose(message);
+    }
 
-    public void WriteWarning(string message) => _cmdlet.WriteWarning(message);
+    public void WriteWarning(string message)
+    {
+        if (_cmdlet is AsyncPSCmdlet asyncCmdlet)
+            asyncCmdlet.WriteWarning(message);
+        else
+            _cmdlet.WriteWarning(message);
+    }
 }

--- a/PSPublishModule/Services/ModuleStateManagedDeliveryService.cs
+++ b/PSPublishModule/Services/ModuleStateManagedDeliveryService.cs
@@ -244,51 +244,11 @@ internal sealed class ModuleStateManagedDeliveryService
     private ManagedModuleRepository ResolveRepository(
         ModuleStatePlanAction action,
         ModuleStateManagedDeliveryOptions options)
-    {
-        if (!string.IsNullOrWhiteSpace(options.ProfileName))
-        {
-            var profile = ModuleRepositoryProfileCommandSupport.TryResolve(options.ProfileName);
-            if (profile is not null &&
-                (string.IsNullOrWhiteSpace(action.TargetRepository) ||
-                 string.Equals(action.TargetRepository, profile.RepositoryName, StringComparison.OrdinalIgnoreCase)))
-            {
-                return ManagedModuleCommandSupport.CreateRepository(
-                    _cmdlet,
-                    ManagedModuleCommandSupport.DefaultRepositoryName,
-                    ManagedModuleCommandSupport.DefaultRepositorySource,
-                    options.ProfileName,
-                    repositoryWasBound: false);
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(action.TargetRepository))
-        {
-            var optionsRepository = ModuleStateManagedRepositoryResolver.TryResolveOptionsRepositoryForActionTarget(_cmdlet, action.TargetRepository, options);
-            if (optionsRepository is not null)
-                return optionsRepository;
-
-            return ManagedModuleCommandSupport.CreateRepository(
-                _cmdlet,
-                ManagedModuleCommandSupport.DefaultRepositoryName,
-                action.TargetRepository!);
-        }
-
-        if (!string.IsNullOrWhiteSpace(options.Repository))
-            return ManagedModuleCommandSupport.CreateRepository(
-                _cmdlet,
-                ManagedModuleCommandSupport.DefaultRepositoryName,
-                options.Repository!);
-
-        if (!string.IsNullOrWhiteSpace(options.ProfileName))
-            return ManagedModuleCommandSupport.CreateRepository(
-                _cmdlet,
-                ManagedModuleCommandSupport.DefaultRepositoryName,
-                ManagedModuleCommandSupport.DefaultRepositorySource,
-                options.ProfileName,
-                repositoryWasBound: false);
-
-        throw new InvalidOperationException("Managed module delivery requires Repository, ProfileName, or action target repository.");
-    }
+        => ModuleStateManagedRepositoryResolver.ResolveRepositoryForAction(
+            _cmdlet,
+            action.TargetRepository,
+            options,
+            "Managed module delivery requires Repository, ProfileName, or action target repository.");
 
     private static string? ResolveModuleRoot(ModuleStatePlanAction action, ModuleStateManagedDeliveryOptions options)
         => string.IsNullOrWhiteSpace(action.TargetPath) ? options.ModuleRoot : action.TargetPath;
@@ -365,6 +325,8 @@ internal sealed class ModuleStateManagedDeliveryOptions
     internal RepositoryCredential? Credential { get; set; }
 
     internal IReadOnlyList<ManagedModuleLoadedModule> LoadedModules { get; set; } = Array.Empty<ManagedModuleLoadedModule>();
+
+    internal Dictionary<string, ManagedModuleRepository> ResolvedRepositories { get; } = new(StringComparer.OrdinalIgnoreCase);
 }
 
 internal readonly struct ModuleStateManagedVersionPolicy

--- a/PSPublishModule/Services/ModuleStateManagedDeliveryService.cs
+++ b/PSPublishModule/Services/ModuleStateManagedDeliveryService.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -16,6 +18,12 @@ internal sealed class ModuleStateManagedDeliveryService
     internal ModuleStateDeliveryExecutionResult[] Execute(
         PowerForge.ModuleStateApplyResult applyResult,
         ModuleStateManagedDeliveryOptions options)
+        => ExecuteAsync(applyResult, options).GetAwaiter().GetResult();
+
+    internal async Task<ModuleStateDeliveryExecutionResult[]> ExecuteAsync(
+        PowerForge.ModuleStateApplyResult applyResult,
+        ModuleStateManagedDeliveryOptions options,
+        CancellationToken cancellationToken = default)
     {
         if (applyResult is null)
             throw new ArgumentNullException(nameof(applyResult));
@@ -36,28 +44,29 @@ internal sealed class ModuleStateManagedDeliveryService
         foreach (var action in actions)
         {
             var repository = ResolveRepository(action, options);
-            results.Add(action.Kind switch
+            results.Add(await (action.Kind switch
             {
-                ModuleStatePlanActionKind.Update => ExecuteUpdate(updateService, repository, action, options),
-                ModuleStatePlanActionKind.Save => ExecuteSave(installService, repository, action, options),
-                _ => ExecuteInstall(installService, repository, action, options)
-            });
+                ModuleStatePlanActionKind.Update => ExecuteUpdateAsync(updateService, repository, action, options, cancellationToken),
+                ModuleStatePlanActionKind.Save => ExecuteSaveAsync(installService, repository, action, options, cancellationToken),
+                _ => ExecuteInstallAsync(installService, repository, action, options, cancellationToken)
+            }).ConfigureAwait(false));
         }
 
         return results.ToArray();
     }
 
-    private ModuleStateDeliveryExecutionResult ExecuteInstall(
+    private async Task<ModuleStateDeliveryExecutionResult> ExecuteInstallAsync(
         ManagedModuleInstallService service,
         ManagedModuleRepository repository,
         ModuleStatePlanAction action,
-        ModuleStateManagedDeliveryOptions options)
+        ModuleStateManagedDeliveryOptions options,
+        CancellationToken cancellationToken)
     {
         var request = CreateInstallRequest(repository, action, options);
-        if (!_cmdlet.ShouldProcess(action.ModuleName, $"Install managed module from repository '{repository.Name}'"))
+        if (!ShouldProcess(action.ModuleName, $"Install managed module from repository '{repository.Name}'"))
             return CreateSkippedResult("Install", repository.Name, action);
 
-        var result = service.InstallAsync(request).GetAwaiter().GetResult();
+        var result = await service.InstallAsync(request, cancellationToken).ConfigureAwait(false);
         return new ModuleStateDeliveryExecutionResult
         {
             Operation = "Install",
@@ -82,17 +91,18 @@ internal sealed class ModuleStateManagedDeliveryService
         };
     }
 
-    private ModuleStateDeliveryExecutionResult ExecuteUpdate(
+    private async Task<ModuleStateDeliveryExecutionResult> ExecuteUpdateAsync(
         ManagedModuleUpdateService service,
         ManagedModuleRepository repository,
         ModuleStatePlanAction action,
-        ModuleStateManagedDeliveryOptions options)
+        ModuleStateManagedDeliveryOptions options,
+        CancellationToken cancellationToken)
     {
         var request = CreateUpdateRequest(repository, action, options);
-        if (!_cmdlet.ShouldProcess(action.ModuleName, $"Update managed module from repository '{repository.Name}'"))
+        if (!ShouldProcess(action.ModuleName, $"Update managed module from repository '{repository.Name}'"))
             return CreateSkippedResult("Update", repository.Name, action);
 
-        var result = service.UpdateAsync(request).GetAwaiter().GetResult();
+        var result = await service.UpdateAsync(request, cancellationToken).ConfigureAwait(false);
         return new ModuleStateDeliveryExecutionResult
         {
             Operation = "Update",
@@ -117,17 +127,18 @@ internal sealed class ModuleStateManagedDeliveryService
         };
     }
 
-    private ModuleStateDeliveryExecutionResult ExecuteSave(
+    private async Task<ModuleStateDeliveryExecutionResult> ExecuteSaveAsync(
         ManagedModuleInstallService service,
         ManagedModuleRepository repository,
         ModuleStatePlanAction action,
-        ModuleStateManagedDeliveryOptions options)
+        ModuleStateManagedDeliveryOptions options,
+        CancellationToken cancellationToken)
     {
         var request = CreateSaveRequest(repository, action, options);
-        if (!_cmdlet.ShouldProcess(action.ModuleName, $"Save managed module from repository '{repository.Name}'"))
+        if (!ShouldProcess(action.ModuleName, $"Save managed module from repository '{repository.Name}'"))
             return CreateSkippedResult("Save", repository.Name, action);
 
-        var result = service.InstallAsync(request).GetAwaiter().GetResult();
+        var result = await service.InstallAsync(request, cancellationToken).ConfigureAwait(false);
         return new ModuleStateDeliveryExecutionResult
         {
             Operation = "Save",
@@ -151,6 +162,11 @@ internal sealed class ModuleStateManagedDeliveryService
             }
         };
     }
+
+    private bool ShouldProcess(string target, string action)
+        => _cmdlet is AsyncPSCmdlet asyncCmdlet
+            ? asyncCmdlet.ShouldProcess(target, action)
+            : _cmdlet.ShouldProcess(target, action);
 
     private ManagedModuleInstallRequest CreateInstallRequest(
         ManagedModuleRepository repository,

--- a/PSPublishModule/Services/ModuleStateManagedPlanLicenseEnricher.cs
+++ b/PSPublishModule/Services/ModuleStateManagedPlanLicenseEnricher.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -13,6 +15,12 @@ internal sealed class ModuleStateManagedPlanLicenseEnricher
         => _cmdlet = cmdlet ?? throw new ArgumentNullException(nameof(cmdlet));
 
     internal void Enrich(ModuleStatePlanResult plan, ModuleStateManagedDeliveryOptions options)
+        => EnrichAsync(plan, options).GetAwaiter().GetResult();
+
+    internal async Task EnrichAsync(
+        ModuleStatePlanResult plan,
+        ModuleStateManagedDeliveryOptions options,
+        CancellationToken cancellationToken = default)
     {
         if (plan is null)
             throw new ArgumentNullException(nameof(plan));
@@ -36,12 +44,12 @@ internal sealed class ModuleStateManagedPlanLicenseEnricher
                 var repository = ResolveRepository(action, options);
                 if (string.Equals(action.Kind, "Update", StringComparison.OrdinalIgnoreCase))
                 {
-                    var updatePlan = updateService.PlanUpdateAsync(CreateUpdateRequest(repository, action, options)).GetAwaiter().GetResult();
+                    var updatePlan = await updateService.PlanUpdateAsync(CreateUpdateRequest(repository, action, options), cancellationToken).ConfigureAwait(false);
                     ApplyLicense(action, updatePlan.License, updatePlan.LicenseAcceptanceRequired, updatePlan.LicenseAccepted);
                 }
                 else
                 {
-                    var installPlan = installService.PlanInstallAsync(CreateInstallRequest(repository, action, options)).GetAwaiter().GetResult();
+                    var installPlan = await installService.PlanInstallAsync(CreateInstallRequest(repository, action, options), cancellationToken).ConfigureAwait(false);
                     ApplyLicense(action, installPlan.License, installPlan.LicenseAcceptanceRequired, installPlan.LicenseAccepted);
                 }
             }

--- a/PSPublishModule/Services/ModuleStateManagedPlanLicenseEnricher.cs
+++ b/PSPublishModule/Services/ModuleStateManagedPlanLicenseEnricher.cs
@@ -121,51 +121,11 @@ internal sealed class ModuleStateManagedPlanLicenseEnricher
     private ManagedModuleRepository ResolveRepository(
         ModuleStatePlanActionResult action,
         ModuleStateManagedDeliveryOptions options)
-    {
-        if (!string.IsNullOrWhiteSpace(options.ProfileName))
-        {
-            var profile = ModuleRepositoryProfileCommandSupport.TryResolve(options.ProfileName);
-            if (profile is not null &&
-                (string.IsNullOrWhiteSpace(action.TargetRepository) ||
-                 string.Equals(action.TargetRepository, profile.RepositoryName, StringComparison.OrdinalIgnoreCase)))
-            {
-                return ManagedModuleCommandSupport.CreateRepository(
-                    _cmdlet,
-                    ManagedModuleCommandSupport.DefaultRepositoryName,
-                    ManagedModuleCommandSupport.DefaultRepositorySource,
-                    options.ProfileName,
-                    repositoryWasBound: false);
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(action.TargetRepository))
-        {
-            var optionsRepository = ModuleStateManagedRepositoryResolver.TryResolveOptionsRepositoryForActionTarget(_cmdlet, action.TargetRepository, options);
-            if (optionsRepository is not null)
-                return optionsRepository;
-
-            return ManagedModuleCommandSupport.CreateRepository(
-                _cmdlet,
-                ManagedModuleCommandSupport.DefaultRepositoryName,
-                action.TargetRepository!);
-        }
-
-        if (!string.IsNullOrWhiteSpace(options.ProfileName))
-            return ManagedModuleCommandSupport.CreateRepository(
-                _cmdlet,
-                ManagedModuleCommandSupport.DefaultRepositoryName,
-                ManagedModuleCommandSupport.DefaultRepositorySource,
-                options.ProfileName,
-                repositoryWasBound: false);
-
-        if (!string.IsNullOrWhiteSpace(options.Repository))
-            return ManagedModuleCommandSupport.CreateRepository(
-                _cmdlet,
-                ManagedModuleCommandSupport.DefaultRepositoryName,
-                options.Repository!);
-
-        throw new InvalidOperationException("Managed module license preflight requires Repository, ProfileName, or action target repository.");
-    }
+        => ModuleStateManagedRepositoryResolver.ResolveRepositoryForAction(
+            _cmdlet,
+            action.TargetRepository,
+            options,
+            "Managed module license preflight requires Repository, ProfileName, or action target repository.");
 
     private static string? ResolveModuleRoot(ModuleStatePlanActionResult action, ModuleStateManagedDeliveryOptions options)
         => string.IsNullOrWhiteSpace(action.TargetPath) ? options.ModuleRoot : action.TargetPath;

--- a/PSPublishModule/Services/ModuleStateManagedRepositoryResolver.cs
+++ b/PSPublishModule/Services/ModuleStateManagedRepositoryResolver.cs
@@ -7,6 +7,9 @@ namespace PSPublishModule;
 
 internal static class ModuleStateManagedRepositoryResolver
 {
+    internal static string CreateRepositoryKey(string? repository)
+        => string.IsNullOrWhiteSpace(repository) ? string.Empty : repository!.Trim();
+
     internal static string? ResolveRepositoryIdentity(PSCmdlet cmdlet, string? repository)
     {
         if (string.IsNullOrWhiteSpace(repository))
@@ -18,6 +21,60 @@ internal static class ModuleStateManagedRepositoryResolver
                 ManagedModuleCommandSupport.DefaultRepositoryName,
                 repository!).Name
             : repository;
+    }
+
+    internal static ManagedModuleRepository ResolveRepositoryForAction(
+        PSCmdlet cmdlet,
+        string? targetRepository,
+        ModuleStateManagedDeliveryOptions options,
+        string missingRepositoryMessage)
+    {
+        if (options.ResolvedRepositories.TryGetValue(CreateRepositoryKey(targetRepository), out var resolved))
+            return resolved;
+
+        if (!string.IsNullOrWhiteSpace(options.ProfileName))
+        {
+            var profile = ModuleRepositoryProfileCommandSupport.TryResolve(options.ProfileName);
+            if (profile is not null &&
+                (string.IsNullOrWhiteSpace(targetRepository) ||
+                 string.Equals(targetRepository, profile.RepositoryName, StringComparison.OrdinalIgnoreCase)))
+            {
+                return ManagedModuleCommandSupport.CreateRepository(
+                    cmdlet,
+                    ManagedModuleCommandSupport.DefaultRepositoryName,
+                    ManagedModuleCommandSupport.DefaultRepositorySource,
+                    options.ProfileName,
+                    repositoryWasBound: false);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(targetRepository))
+        {
+            var optionsRepository = TryResolveOptionsRepositoryForActionTarget(cmdlet, targetRepository, options);
+            if (optionsRepository is not null)
+                return optionsRepository;
+
+            return ManagedModuleCommandSupport.CreateRepository(
+                cmdlet,
+                ManagedModuleCommandSupport.DefaultRepositoryName,
+                targetRepository!);
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Repository))
+            return ManagedModuleCommandSupport.CreateRepository(
+                cmdlet,
+                ManagedModuleCommandSupport.DefaultRepositoryName,
+                options.Repository!);
+
+        if (!string.IsNullOrWhiteSpace(options.ProfileName))
+            return ManagedModuleCommandSupport.CreateRepository(
+                cmdlet,
+                ManagedModuleCommandSupport.DefaultRepositoryName,
+                ManagedModuleCommandSupport.DefaultRepositorySource,
+                options.ProfileName,
+                repositoryWasBound: false);
+
+        throw new InvalidOperationException(missingRepositoryMessage);
     }
 
     internal static ManagedModuleRepository? TryResolveOptionsRepositoryForActionTarget(

--- a/PSPublishModule/Services/ModuleStatePrivateDeliveryService.cs
+++ b/PSPublishModule/Services/ModuleStatePrivateDeliveryService.cs
@@ -46,7 +46,7 @@ internal sealed class ModuleStatePrivateDeliveryService
         {
             var groupActions = group.ToArray();
             var request = CreateRequest(group.Key.Kind, group.Key.Repository, group.Key.Force, groupActions, options);
-            var workflowResult = service.Execute(request, (target, action) => _cmdlet.ShouldProcess(target, action));
+            var workflowResult = service.Execute(request, ShouldProcess);
             results.Add(new ModuleStateDeliveryExecutionResult
             {
                 Operation = group.Key.Kind.ToString(),
@@ -70,6 +70,11 @@ internal sealed class ModuleStatePrivateDeliveryService
 
         return results.ToArray();
     }
+
+    private bool ShouldProcess(string target, string action)
+        => _cmdlet is AsyncPSCmdlet asyncCmdlet
+            ? asyncCmdlet.ShouldProcess(target, action)
+            : _cmdlet.ShouldProcess(target, action);
 
     private static PrivateModuleWorkflowRequest CreateRequest(
         ModuleStatePlanActionKind actionKind,

--- a/PowerForge.Tests/AsyncPSCmdletTests.cs
+++ b/PowerForge.Tests/AsyncPSCmdletTests.cs
@@ -1,0 +1,63 @@
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Threading;
+using System.Threading.Tasks;
+using PSPublishModule;
+
+namespace PowerForge.Tests;
+
+public sealed class AsyncPSCmdletTests
+{
+    [Fact]
+    public void AsyncPSCmdlet_drains_worker_thread_writes_when_task_completes_synchronously()
+    {
+        var sessionState = InitialSessionState.CreateDefault();
+        sessionState.Commands.Add(new SessionStateCmdletEntry(
+            "Test-AsyncQueuedOutput",
+            typeof(TestAsyncQueuedOutputCommand),
+            helpFileName: null));
+
+        using var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        using var powerShell = PowerShell.Create();
+        powerShell.Runspace = runspace;
+        powerShell.AddCommand("Test-AsyncQueuedOutput");
+
+        var result = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
+        var item = Assert.Single(result);
+        Assert.Equal("queued-output", item.BaseObject);
+    }
+}
+
+[Cmdlet(VerbsDiagnostic.Test, "AsyncQueuedOutput")]
+public sealed class TestAsyncQueuedOutputCommand : AsyncPSCmdlet
+{
+    protected override Task ProcessRecordAsync()
+    {
+        using var ready = new ManualResetEventSlim();
+        Exception? workerException = null;
+        ThreadPool.QueueUserWorkItem(_ =>
+        {
+            try
+            {
+                WriteObject("queued-output");
+            }
+            catch (Exception ex)
+            {
+                workerException = ex;
+            }
+            finally
+            {
+                ready.Set();
+            }
+        });
+
+        Assert.True(ready.Wait(TimeSpan.FromSeconds(5)), "Worker thread did not write output in time.");
+        if (workerException is not null)
+            throw workerException;
+
+        return Task.CompletedTask;
+    }
+}

--- a/PowerForge.Tests/ManagedModuleArchiveExtractorTests.cs
+++ b/PowerForge.Tests/ManagedModuleArchiveExtractorTests.cs
@@ -39,6 +39,22 @@ public sealed class ManagedModuleArchiveExtractorTests
         Assert.False(File.Exists(Path.Combine(destination, "Company.Tools.nuspec")));
     }
 
+    [Fact]
+    public void ExtractPackage_uses_known_package_id_to_flatten_without_reading_nuspec()
+    {
+        using var temp = new TemporaryDirectory();
+        var packagePath = Path.Combine(temp.Path, "Company.Tools.1.0.0.nupkg");
+        var destination = Path.Combine(temp.Path, "out");
+        CreatePackageWithModuleRootFolderWithoutNuspec(packagePath);
+
+        var result = new ManagedModuleArchiveExtractor().ExtractPackage(packagePath, destination, "Company.Tools");
+
+        Assert.Equal(2, result.FileCount);
+        Assert.True(File.Exists(Path.Combine(destination, "Company.Tools.psd1")));
+        Assert.True(File.Exists(Path.Combine(destination, "Company.Tools.psm1")));
+        Assert.False(File.Exists(Path.Combine(destination, "Company.Tools", "Company.Tools.psd1")));
+    }
+
 #if !NET472
     [Fact]
     public async Task ExtractPackageAsync_preserves_module_package_directory()
@@ -75,6 +91,23 @@ public sealed class ManagedModuleArchiveExtractorTests
         Assert.False(File.Exists(Path.Combine(destination, "Company.Tools", "Company.Tools.psd1")));
         Assert.False(File.Exists(Path.Combine(destination, "Company.Tools.nuspec")));
     }
+
+    [Fact]
+    public async Task ExtractPackageAsync_uses_known_package_id_to_flatten_without_reading_nuspec()
+    {
+        using var temp = new TemporaryDirectory();
+        var packagePath = Path.Combine(temp.Path, "Company.Tools.1.0.0.nupkg");
+        var destination = Path.Combine(temp.Path, "out");
+        CreatePackageWithModuleRootFolderWithoutNuspec(packagePath);
+
+        await using var stream = File.OpenRead(packagePath);
+        var result = await new ManagedModuleArchiveExtractor().ExtractPackageAsync(stream, destination, "Company.Tools", CancellationToken.None);
+
+        Assert.Equal(2, result.FileCount);
+        Assert.True(File.Exists(Path.Combine(destination, "Company.Tools.psd1")));
+        Assert.True(File.Exists(Path.Combine(destination, "Company.Tools.psm1")));
+        Assert.False(File.Exists(Path.Combine(destination, "Company.Tools", "Company.Tools.psd1")));
+    }
 #endif
 
     private static void CreatePackageWithPackageFolder(string packagePath)
@@ -94,6 +127,13 @@ public sealed class ManagedModuleArchiveExtractorTests
         AddEntry(archive, "Company.Tools/Company.Tools.psd1", "@{ ModuleVersion = '1.0.0' }");
         AddEntry(archive, "Company.Tools/Company.Tools.psm1", string.Empty);
         AddEntry(archive, "Company.Tools/Company.Tools.nuspec", TestPackageFactory.CreateNuspec("Company.Tools", "1.0.0"));
+    }
+
+    private static void CreatePackageWithModuleRootFolderWithoutNuspec(string packagePath)
+    {
+        using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+        AddEntry(archive, "Company.Tools/Company.Tools.psd1", "@{ ModuleVersion = '1.0.0' }");
+        AddEntry(archive, "Company.Tools/Company.Tools.psm1", string.Empty);
     }
 
     private static void AddEntry(ZipArchive archive, string name, string content)

--- a/PowerForge.Tests/ManagedModuleDependencyConcurrencyTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyConcurrencyTests.cs
@@ -9,6 +9,7 @@ public sealed class ManagedModuleDependencyConcurrencyTests
     [Fact]
     public void Managed_module_default_concurrency_scales_with_host_without_exceeding_benchmark_cap()
     {
+        Assert.Equal(96, ManagedModuleConcurrencyDefaults.MaximumDefaultConcurrency);
         var expected = Math.Min(
             ManagedModuleConcurrencyDefaults.MaximumDefaultConcurrency,
             Math.Max(16, Environment.ProcessorCount * 8));

--- a/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
@@ -212,6 +212,7 @@ public sealed class ManagedModuleDependencyInstallServiceTests
         using var moduleRoot = new TemporaryDirectory();
         using var handler = new RootDependencyPrewarmFeedHandler();
         using var httpClient = new HttpClient(handler);
+        using var cancellation = new CancellationTokenSource();
         var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), httpClient);
         var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
 
@@ -222,7 +223,7 @@ public sealed class ManagedModuleDependencyInstallServiceTests
             Version = "1.0.0",
             Scope = ManagedModuleInstallScope.Custom,
             ModuleRoot = moduleRoot.Path
-        });
+        }, cancellation.Token);
 
         var dependency = Assert.Single(result.DependencyResults);
         Assert.Equal("Company.Core", dependency.Name);

--- a/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
@@ -145,6 +145,36 @@ public sealed class ManagedModuleDependencyInstallServiceTests
     }
 
     [Fact]
+    public async Task InstallAsync_falls_back_to_version_list_when_latest_dependency_lookup_is_empty()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        using var handler = new EmptyLatestDependencyFeedHandler();
+        using var httpClient = new HttpClient(handler);
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), httpClient);
+        var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository(
+                "Gallery",
+                "https://example.test/api/v2",
+                ManagedModuleRepositoryKind.NuGetV2),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal("1.2.0", dependency.Version);
+        Assert.Equal("1.0.0", dependency.DependencyVersionRange);
+        Assert.True(handler.LatestQueryCount >= 1);
+        Assert.True(handler.VersionQueryCount >= 1);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Core", "1.2.0", "Company.Core.psd1")));
+    }
+
+    [Fact]
     public async Task InstallAsync_keeps_parallel_dependency_request_counts_scoped()
     {
         using var moduleRoot = new TemporaryDirectory();
@@ -347,6 +377,81 @@ public sealed class ManagedModuleDependencyInstallServiceTests
             {
                 Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
             };
+
+        private static HttpResponseMessage Package(string id, string version, IReadOnlyList<TestDependency>? dependencies)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(CreatePackageBytes(id, version, dependencies))
+            };
+
+        private static byte[] CreatePackageBytes(string id, string version, IReadOnlyList<TestDependency>? dependencies)
+        {
+            using var directory = new TemporaryDirectory();
+            var packagePath = Path.Combine(directory.Path, id + "." + version + ".nupkg");
+            TestPackageFactory.Create(
+                packagePath,
+                id,
+                version,
+                dependencies,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [id + ".psd1"] = "@{ ModuleVersion = '" + version + "' }"
+                });
+            return File.ReadAllBytes(packagePath);
+        }
+    }
+
+    private sealed class EmptyLatestDependencyFeedHandler : HttpMessageHandler
+    {
+        private int _latestQueryCount;
+        private int _versionQueryCount;
+
+        public int LatestQueryCount => System.Threading.Volatile.Read(ref _latestQueryCount);
+
+        public int VersionQueryCount => System.Threading.Volatile.Read(ref _versionQueryCount);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri?.AbsoluteUri ?? string.Empty;
+            if (uri.Contains("/FindPackagesById()", StringComparison.OrdinalIgnoreCase) &&
+                uri.Contains("Company.Core", StringComparison.OrdinalIgnoreCase) &&
+                uri.Contains("$filter=IsLatestVersion", StringComparison.OrdinalIgnoreCase))
+            {
+                System.Threading.Interlocked.Increment(ref _latestQueryCount);
+                return Task.FromResult(XmlFeed());
+            }
+
+            if (uri.Contains("/FindPackagesById()", StringComparison.OrdinalIgnoreCase) &&
+                uri.Contains("Company.Core", StringComparison.OrdinalIgnoreCase))
+            {
+                System.Threading.Interlocked.Increment(ref _versionQueryCount);
+                return Task.FromResult(XmlFeed(
+                    XmlEntry("Company.Core", "1.0.0"),
+                    XmlEntry("Company.Core", "1.2.0")));
+            }
+
+            if (uri == "https://example.test/api/v2/package/Company.Tools/1.0.0")
+                return Task.FromResult(Package("Company.Tools", "1.0.0", new[] { new TestDependency("Company.Core", "1.0.0", null) }));
+
+            if (uri == "https://example.test/api/v2/package/Company.Core/1.2.0")
+                return Task.FromResult(Package("Company.Core", "1.2.0", dependencies: null));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage XmlFeed(params string[] entries)
+            => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">" +
+                    string.Concat(entries) +
+                    "</feed>",
+                    System.Text.Encoding.UTF8,
+                    "application/xml")
+            };
+
+        private static string XmlEntry(string id, string version)
+            => "<entry><d:Id>" + id + "</d:Id><d:Version>" + version + "</d:Version><d:Listed>true</d:Listed></entry>";
 
         private static HttpResponseMessage Package(string id, string version, IReadOnlyList<TestDependency>? dependencies)
             => new(HttpStatusCode.OK)

--- a/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
@@ -60,7 +60,7 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
         Assert.All(nestedCoreResults, dependency =>
         {
             Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, dependency.Status);
-            Assert.True(dependency.CoalescedWaitElapsed >= TimeSpan.Zero);
+            Assert.Equal(TimeSpan.Zero, dependency.CoalescedWaitElapsed);
         });
     }
 

--- a/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
@@ -5,6 +5,35 @@ namespace PowerForge.Tests;
 public sealed class ManagedModuleInstallDependencyFanoutTests
 {
     [Fact]
+    public void ShouldStartDependencyInstallBeforeExtraction_RequiresFastSafeInstallPath()
+    {
+        var metadata = new ManagedModulePackageMetadata
+        {
+            Dependencies = new[] { new ManagedModuleDependencyInfo { Id = "Company.Core", VersionRange = "[1.0.0]" } }
+        };
+        var request = new ManagedModuleInstallRequest
+        {
+            AllowClobber = true
+        };
+
+        Assert.True(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
+
+        request.AllowClobber = false;
+        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
+
+        request.AllowClobber = true;
+        request.AuthenticodeCheck = true;
+        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
+
+        request.AuthenticodeCheck = false;
+        request.SkipDependencyCheck = true;
+        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
+
+        request.SkipDependencyCheck = false;
+        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, new ManagedModulePackageMetadata()));
+    }
+
+    [Fact]
     public async Task InstallAsync_seeds_first_dependency_before_broad_parallel_fanout()
     {
         using var feed = new TemporaryDirectory();
@@ -69,4 +98,14 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
         {
             [moduleName + ".psd1"] = "@{ ModuleVersion = '" + version + "' }"
         };
+
+    private static bool InvokeShouldStartDependencyInstallBeforeExtraction(
+        ManagedModuleInstallRequest request,
+        ManagedModulePackageMetadata metadata)
+    {
+        var method = typeof(ManagedModuleInstallService).GetMethod(
+            "ShouldStartDependencyInstallBeforeExtraction",
+            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        return (bool)method!.Invoke(null, new object?[] { request, metadata })!;
+    }
 }

--- a/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
@@ -1,4 +1,5 @@
 using PowerForge;
+using System.Net;
 
 namespace PowerForge.Tests;
 
@@ -93,6 +94,28 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
         });
     }
 
+    [Fact]
+    public async Task InstallAsync_prewarms_dependency_versions_from_repository_metadata_before_root_download()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var handler = new RepositoryDependencyHintHandler();
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), new HttpClient(handler));
+        var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Feed", "https://example.test/api/v2"),
+            Name = "Company.Root",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path,
+            AllowClobber = true
+        });
+
+        Assert.Equal(ManagedModuleInstallStatus.Installed, result.Status);
+        Assert.True(handler.CoreLatestRequestedBeforeRootDownload);
+        Assert.Contains(handler.Requests, static request => request.EndsWith("id='Company.Core'&$filter=IsLatestVersion&$top=1&semVerLevel=2.0.0", StringComparison.Ordinal));
+    }
+
     private static IReadOnlyDictionary<string, string> CreateModuleFiles(string moduleName, string version)
         => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -107,5 +130,86 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
             "ShouldStartDependencyInstallBeforeExtraction",
             System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
         return (bool)method!.Invoke(null, new object?[] { request, metadata })!;
+    }
+
+    private sealed class RepositoryDependencyHintHandler : HttpMessageHandler
+    {
+        private readonly object _syncRoot = new();
+        private readonly List<string> _requests = new();
+
+        public bool CoreLatestRequestedBeforeRootDownload { get; private set; }
+
+        public IReadOnlyList<string> Requests
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _requests.ToArray();
+                }
+            }
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.AbsoluteUri;
+            lock (_syncRoot)
+            {
+                if (url.Equals("https://example.test/api/v2/package/Company.Root/1.0.0", StringComparison.OrdinalIgnoreCase))
+                    CoreLatestRequestedBeforeRootDownload = _requests.Any(static item => item.Contains("id='Company.Core'&$filter=IsLatestVersion", StringComparison.Ordinal));
+
+                _requests.Add(url);
+            }
+
+            if (url.Equals("https://example.test/api/v2/FindPackagesById()?id='Company.Root'&$filter=IsLatestVersion&$top=1&semVerLevel=2.0.0", StringComparison.OrdinalIgnoreCase))
+            {
+                return Xml(
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                    "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\" xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">" +
+                    "<entry><content><m:properties><d:Id>Company.Root</d:Id><d:Version>1.0.0</d:Version><d:Dependencies>Company.Core:[1.0.0, ):</d:Dependencies></m:properties></content></entry>" +
+                    "</feed>");
+            }
+
+            if (url.Equals("https://example.test/api/v2/FindPackagesById()?id='Company.Core'&$filter=IsLatestVersion&$top=1&semVerLevel=2.0.0", StringComparison.OrdinalIgnoreCase))
+            {
+                return Xml(
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                    "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\" xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">" +
+                    "<entry><content><m:properties><d:Id>Company.Core</d:Id><d:Version>1.0.0</d:Version></m:properties></content></entry>" +
+                    "</feed>");
+            }
+
+            if (url.Equals("https://example.test/api/v2/package/Company.Root/1.0.0", StringComparison.OrdinalIgnoreCase))
+            {
+                var bytes = TestPackageFactory.CreateBytes(
+                    "Company.Root",
+                    "1.0.0",
+                    files: CreateModuleFiles("Company.Root", "1.0.0"));
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(bytes)
+                });
+            }
+
+            if (url.Equals("https://example.test/api/v2/package/Company.Core/1.0.0", StringComparison.OrdinalIgnoreCase))
+            {
+                var bytes = TestPackageFactory.CreateBytes(
+                    "Company.Core",
+                    "1.0.0",
+                    files: CreateModuleFiles("Company.Core", "1.0.0"));
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(bytes)
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static Task<HttpResponseMessage> Xml(string xml)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(xml, System.Text.Encoding.UTF8, "application/xml")
+            });
     }
 }

--- a/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
@@ -6,35 +6,6 @@ namespace PowerForge.Tests;
 public sealed class ManagedModuleInstallDependencyFanoutTests
 {
     [Fact]
-    public void ShouldStartDependencyInstallBeforeExtraction_RequiresFastSafeInstallPath()
-    {
-        var metadata = new ManagedModulePackageMetadata
-        {
-            Dependencies = new[] { new ManagedModuleDependencyInfo { Id = "Company.Core", VersionRange = "[1.0.0]" } }
-        };
-        var request = new ManagedModuleInstallRequest
-        {
-            AllowClobber = true
-        };
-
-        Assert.True(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
-
-        request.AllowClobber = false;
-        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
-
-        request.AllowClobber = true;
-        request.AuthenticodeCheck = true;
-        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
-
-        request.AuthenticodeCheck = false;
-        request.SkipDependencyCheck = true;
-        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, metadata));
-
-        request.SkipDependencyCheck = false;
-        Assert.False(InvokeShouldStartDependencyInstallBeforeExtraction(request, new ManagedModulePackageMetadata()));
-    }
-
-    [Fact]
     public async Task InstallAsync_seeds_first_dependency_before_broad_parallel_fanout()
     {
         using var feed = new TemporaryDirectory();
@@ -121,16 +92,6 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
         {
             [moduleName + ".psd1"] = "@{ ModuleVersion = '" + version + "' }"
         };
-
-    private static bool InvokeShouldStartDependencyInstallBeforeExtraction(
-        ManagedModuleInstallRequest request,
-        ManagedModulePackageMetadata metadata)
-    {
-        var method = typeof(ManagedModuleInstallService).GetMethod(
-            "ShouldStartDependencyInstallBeforeExtraction",
-            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
-        return (bool)method!.Invoke(null, new object?[] { request, metadata })!;
-    }
 
     private sealed class RepositoryDependencyHintHandler : HttpMessageHandler
     {

--- a/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
@@ -141,6 +141,59 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
         Assert.Equal(1, handler.CorePackageDownloadCount);
         Assert.False(Directory.Exists(Path.Combine(moduleRoot.Path, "Company.Core")));
     }
+
+    [Fact]
+    public async Task InstallAsync_cancels_dependency_prefetch_when_root_package_fails()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var handler = new RepositoryDependencyHintHandler
+        {
+            DelayRootPackageUntilCorePackageRequested = true,
+            DelayCorePackageCompletionUntilCanceled = true,
+            RootPackageHasUnsafeEntry = true
+        };
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), new HttpClient(handler));
+        var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Feed", "https://example.test/api/v2"),
+            Name = "Company.Root",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path,
+            AllowClobber = true
+        }));
+
+        Assert.Contains("unsafe path", exception.Message, StringComparison.OrdinalIgnoreCase);
+        await WaitForConditionAsync(() => handler.CorePackageCancellationObserved, TimeSpan.FromSeconds(2));
+        Assert.Equal(1, handler.CorePackageDownloadCount);
+        Assert.False(Directory.Exists(Path.Combine(moduleRoot.Path, "Company.Core")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_does_not_prefetch_dependencies_when_selected_root_is_already_installed()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledModule(moduleRoot.Path, "Company.Root", "1.0.0");
+        var handler = new RepositoryDependencyHintHandler();
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), new HttpClient(handler));
+        var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Feed", "https://example.test/api/v2"),
+            Name = "Company.Root",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path,
+            AllowClobber = true
+        });
+
+        Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, result.Status);
+        Assert.Equal(0, handler.CorePackageDownloadCount);
+        Assert.DoesNotContain(handler.Requests, static request => request.Contains("id='Company.Core'", StringComparison.Ordinal));
+        Assert.DoesNotContain(handler.Requests, static request => request.EndsWith("/package/Company.Core/1.0.0", StringComparison.OrdinalIgnoreCase));
+    }
 #endif
 
     private static IReadOnlyDictionary<string, string> CreateModuleFiles(string moduleName, string version)
@@ -149,11 +202,35 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
             [moduleName + ".psd1"] = "@{ ModuleVersion = '" + version + "' }"
         };
 
+    private static void WriteInstalledModule(string moduleRoot, string moduleName, string version)
+    {
+        var modulePath = Path.Combine(moduleRoot, moduleName, version);
+        Directory.CreateDirectory(modulePath);
+        File.WriteAllText(
+            Path.Combine(modulePath, moduleName + ".psd1"),
+            "@{ ModuleVersion = '" + version + "' }");
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopAt = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < stopAt)
+        {
+            if (condition())
+                return;
+
+            await Task.Delay(TimeSpan.FromMilliseconds(15));
+        }
+
+        Assert.True(condition(), "The expected asynchronous condition was not observed before the timeout.");
+    }
+
     private sealed class RepositoryDependencyHintHandler : HttpMessageHandler
     {
         private readonly object _syncRoot = new();
         private readonly List<string> _requests = new();
         private readonly TaskCompletionSource<bool> _corePackageRequested = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private volatile bool _corePackageCancellationObserved;
 
         public bool CoreLatestRequestedBeforeRootDownload { get; private set; }
 
@@ -161,7 +238,11 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
 
         public bool RootPackageHasUnsafeEntry { get; init; }
 
+        public bool DelayCorePackageCompletionUntilCanceled { get; init; }
+
         public bool CorePackageRequestedBeforeRootPackageCompleted { get; private set; }
+
+        public bool CorePackageCancellationObserved => _corePackageCancellationObserved;
 
         public int CorePackageDownloadCount { get; private set; }
 
@@ -237,6 +318,19 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
                 }
 
                 _corePackageRequested.TrySetResult(true);
+                if (DelayCorePackageCompletionUntilCanceled)
+                {
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        _corePackageCancellationObserved = true;
+                        throw;
+                    }
+                }
+
                 var bytes = TestPackageFactory.CreateBytes(
                     "Company.Core",
                     "1.0.0",

--- a/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallDependencyFanoutTests.cs
@@ -1,4 +1,5 @@
 using PowerForge;
+using System.IO.Compression;
 using System.Net;
 
 namespace PowerForge.Tests;
@@ -87,6 +88,61 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
         Assert.Contains(handler.Requests, static request => request.EndsWith("id='Company.Core'&$filter=IsLatestVersion&$top=1&semVerLevel=2.0.0", StringComparison.Ordinal));
     }
 
+#if !NET472
+    [Fact]
+    public async Task InstallAsync_prefetches_dependency_package_before_root_download_completes()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var handler = new RepositoryDependencyHintHandler
+        {
+            DelayRootPackageUntilCorePackageRequested = true
+        };
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), new HttpClient(handler));
+        var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Feed", "https://example.test/api/v2"),
+            Name = "Company.Root",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path,
+            AllowClobber = true
+        });
+
+        Assert.Equal(ManagedModuleInstallStatus.Installed, result.Status);
+        Assert.True(handler.CorePackageRequestedBeforeRootPackageCompleted);
+        Assert.Equal(1, handler.CorePackageDownloadCount);
+        Assert.Equal(ManagedModuleInstallStatus.Installed, Assert.Single(result.DependencyResults).Status);
+    }
+
+    [Fact]
+    public async Task InstallAsync_prefetch_does_not_install_dependency_when_root_package_fails()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var handler = new RepositoryDependencyHintHandler
+        {
+            DelayRootPackageUntilCorePackageRequested = true,
+            RootPackageHasUnsafeEntry = true
+        };
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), new HttpClient(handler));
+        var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Feed", "https://example.test/api/v2"),
+            Name = "Company.Root",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path,
+            AllowClobber = true
+        }));
+
+        Assert.Contains("unsafe path", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.True(handler.CorePackageRequestedBeforeRootPackageCompleted);
+        Assert.Equal(1, handler.CorePackageDownloadCount);
+        Assert.False(Directory.Exists(Path.Combine(moduleRoot.Path, "Company.Core")));
+    }
+#endif
+
     private static IReadOnlyDictionary<string, string> CreateModuleFiles(string moduleName, string version)
         => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -97,8 +153,17 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
     {
         private readonly object _syncRoot = new();
         private readonly List<string> _requests = new();
+        private readonly TaskCompletionSource<bool> _corePackageRequested = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public bool CoreLatestRequestedBeforeRootDownload { get; private set; }
+
+        public bool DelayRootPackageUntilCorePackageRequested { get; init; }
+
+        public bool RootPackageHasUnsafeEntry { get; init; }
+
+        public bool CorePackageRequestedBeforeRootPackageCompleted { get; private set; }
+
+        public int CorePackageDownloadCount { get; private set; }
 
         public IReadOnlyList<string> Requests
         {
@@ -111,7 +176,7 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
             }
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var url = request.RequestUri!.AbsoluteUri;
             lock (_syncRoot)
@@ -124,7 +189,7 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
 
             if (url.Equals("https://example.test/api/v2/FindPackagesById()?id='Company.Root'&$filter=IsLatestVersion&$top=1&semVerLevel=2.0.0", StringComparison.OrdinalIgnoreCase))
             {
-                return Xml(
+                return CreateXmlResponse(
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                     "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\" xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">" +
                     "<entry><content><m:properties><d:Id>Company.Root</d:Id><d:Version>1.0.0</d:Version><d:Dependencies>Company.Core:[1.0.0, ):</d:Dependencies></m:properties></content></entry>" +
@@ -133,7 +198,7 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
 
             if (url.Equals("https://example.test/api/v2/FindPackagesById()?id='Company.Core'&$filter=IsLatestVersion&$top=1&semVerLevel=2.0.0", StringComparison.OrdinalIgnoreCase))
             {
-                return Xml(
+                return CreateXmlResponse(
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                     "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\" xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">" +
                     "<entry><content><m:properties><d:Id>Company.Core</d:Id><d:Version>1.0.0</d:Version></m:properties></content></entry>" +
@@ -142,35 +207,73 @@ public sealed class ManagedModuleInstallDependencyFanoutTests
 
             if (url.Equals("https://example.test/api/v2/package/Company.Root/1.0.0", StringComparison.OrdinalIgnoreCase))
             {
-                var bytes = TestPackageFactory.CreateBytes(
-                    "Company.Root",
-                    "1.0.0",
-                    files: CreateModuleFiles("Company.Root", "1.0.0"));
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                if (DelayRootPackageUntilCorePackageRequested)
+                {
+                    var completed = await Task.WhenAny(
+                            _corePackageRequested.Task,
+                            Task.Delay(TimeSpan.FromSeconds(5), cancellationToken))
+                        .ConfigureAwait(false);
+                    CorePackageRequestedBeforeRootPackageCompleted = ReferenceEquals(completed, _corePackageRequested.Task);
+                }
+
+                var bytes = RootPackageHasUnsafeEntry
+                    ? CreateUnsafeRootPackageBytes()
+                    : TestPackageFactory.CreateBytes(
+                        "Company.Root",
+                        "1.0.0",
+                        files: CreateModuleFiles("Company.Root", "1.0.0"),
+                        dependencies: new[] { new TestDependency("Company.Core", "[1.0.0, )", null) });
+                return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new ByteArrayContent(bytes)
-                });
+                };
             }
 
             if (url.Equals("https://example.test/api/v2/package/Company.Core/1.0.0", StringComparison.OrdinalIgnoreCase))
             {
+                lock (_syncRoot)
+                {
+                    CorePackageDownloadCount++;
+                }
+
+                _corePackageRequested.TrySetResult(true);
                 var bytes = TestPackageFactory.CreateBytes(
                     "Company.Core",
                     "1.0.0",
                     files: CreateModuleFiles("Company.Core", "1.0.0"));
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new ByteArrayContent(bytes)
-                });
+                };
             }
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
         }
 
-        private static Task<HttpResponseMessage> Xml(string xml)
-            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        private static HttpResponseMessage CreateXmlResponse(string xml)
+            => new(HttpStatusCode.OK)
             {
                 Content = new StringContent(xml, System.Text.Encoding.UTF8, "application/xml")
-            });
+            };
+
+        private static byte[] CreateUnsafeRootPackageBytes()
+        {
+            using var stream = new MemoryStream();
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var nuspec = archive.CreateEntry("Company.Root.nuspec");
+                using (var writer = new StreamWriter(nuspec.Open()))
+                {
+                    writer.Write(TestPackageFactory.CreateNuspec(
+                        "Company.Root",
+                        "1.0.0",
+                        new[] { new TestDependency("Company.Core", "[1.0.0, )", null) }));
+                }
+
+                archive.CreateEntry("../escape.ps1");
+            }
+
+            return stream.ToArray();
+        }
     }
 }

--- a/PowerForge.Tests/ManagedModuleInstallServiceCacheTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallServiceCacheTests.cs
@@ -5,6 +5,41 @@ namespace PowerForge.Tests;
 public sealed partial class ManagedModuleInstallServiceTests
 {
     [Fact]
+    public async Task InstallAsync_skips_extracted_package_cache_for_operation_local_dependency_cache()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateDependencyFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateModuleFiles("1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.False(dependency.ExtractionFromCache);
+        Assert.False(dependency.PromotionMaterializedDirectly);
+        Assert.Equal(TimeSpan.Zero, dependency.ExtractionCacheLockWaitElapsed);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Core", "1.0.0", "Company.Core.psd1")));
+    }
+
+    [Fact]
     public async Task InstallAsync_reuses_extracted_package_cache_when_package_cache_is_persistent()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModuleRepositoryClientCoalescingTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientCoalescingTests.cs
@@ -30,6 +30,30 @@ public sealed class ManagedModuleRepositoryClientCoalescingTests
     }
 
     [Fact]
+    public async Task GetVersionsAsync_does_not_cancel_shared_query_when_first_waiter_cancels()
+    {
+        using var handler = new CoalescingHandler();
+        using var client = new HttpClient(handler);
+        using var firstCancellation = new CancellationTokenSource();
+        using var secondCancellation = new CancellationTokenSource();
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+
+        var first = repositoryClient.GetVersionsAsync(repository, "Company.Tools", cancellationToken: firstCancellation.Token);
+        await handler.WaitForVersionRequestAsync();
+        var second = repositoryClient.GetVersionsAsync(repository, "Company.Tools", cancellationToken: secondCancellation.Token);
+        firstCancellation.Cancel();
+        handler.ReleaseVersionRequest();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => first);
+        var secondResult = await second;
+
+        Assert.Equal(new[] { "1.0.0", "1.1.0" }, secondResult.Select(version => version.Version));
+        Assert.Equal(1, handler.Count("https://example.test/v3/index.json"));
+        Assert.Equal(1, handler.Count("https://example.test/packages/company.tools/index.json"));
+    }
+
+    [Fact]
     public async Task GetVersionsAsync_keeps_credentialed_remote_queries_independent()
     {
         using var handler = new CoalescingHandler();

--- a/PowerForge.Tests/ManagedModuleRepositoryClientCoalescingTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientCoalescingTests.cs
@@ -54,6 +54,23 @@ public sealed class ManagedModuleRepositoryClientCoalescingTests
     }
 
     [Fact]
+    public async Task GetVersionsAsync_does_not_start_query_for_already_canceled_waiter()
+    {
+        using var handler = new CoalescingHandler();
+        using var client = new HttpClient(handler);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            repositoryClient.GetVersionsAsync(repository, "Company.Tools", cancellationToken: cancellation.Token));
+
+        Assert.Equal(0, handler.Count("https://example.test/v3/index.json"));
+        Assert.Equal(0, handler.Count("https://example.test/packages/company.tools/index.json"));
+    }
+
+    [Fact]
     public async Task GetVersionsAsync_keeps_credentialed_remote_queries_independent()
     {
         using var handler = new CoalescingHandler();

--- a/PowerForge.Tests/ManagedModuleRepositoryClientCoalescingTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientCoalescingTests.cs
@@ -11,12 +11,13 @@ public sealed class ManagedModuleRepositoryClientCoalescingTests
     {
         using var handler = new CoalescingHandler();
         using var client = new HttpClient(handler);
+        using var cancellation = new CancellationTokenSource();
         var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
         var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
 
-        var first = repositoryClient.GetVersionsAsync(repository, "Company.Tools");
+        var first = repositoryClient.GetVersionsAsync(repository, "Company.Tools", cancellationToken: cancellation.Token);
         await handler.WaitForVersionRequestAsync();
-        var second = repositoryClient.GetVersionsAsync(repository, "Company.Tools");
+        var second = repositoryClient.GetVersionsAsync(repository, "Company.Tools", cancellationToken: cancellation.Token);
         handler.ReleaseVersionRequest();
         await Task.WhenAll(first, second);
         var firstResult = await first;

--- a/PowerForge.Tests/ManagedModuleRepositoryClientHttpHandlerTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientHttpHandlerTests.cs
@@ -11,7 +11,7 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
     public void CreateDefaultHttpMessageHandler_applies_explicit_proxy_options()
     {
         var proxyAddress = new Uri("http://proxy.example.test:8080");
-        var handler = Assert.IsType<HttpClientHandler>(ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
+        var rawHandler = ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
             new ManagedModuleRepositoryClientOptions
             {
                 ProxyAddress = proxyAddress,
@@ -21,8 +21,13 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
                     UserName = "proxy-user",
                     Secret = "proxy-secret"
                 }
-            }));
+            });
 
+#if NET472
+        var handler = Assert.IsType<HttpClientHandler>(rawHandler);
+#else
+        var handler = Assert.IsType<SocketsHttpHandler>(rawHandler);
+#endif
         Assert.True(handler.UseProxy);
         Assert.NotNull(handler.Proxy);
         Assert.Equal(proxyAddress, handler.Proxy!.GetProxy(new Uri("https://example.test/v3/index.json")));
@@ -34,52 +39,92 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
     [Fact]
     public void CreateDefaultHttpMessageHandler_can_disable_proxy()
     {
-        var handler = Assert.IsType<HttpClientHandler>(ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
+        var rawHandler = ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
             new ManagedModuleRepositoryClientOptions
             {
                 UseProxy = false,
                 ProxyAddress = new Uri("http://proxy.example.test:8080")
-            }));
+            });
 
+#if NET472
+        var handler = Assert.IsType<HttpClientHandler>(rawHandler);
+#else
+        var handler = Assert.IsType<SocketsHttpHandler>(rawHandler);
+#endif
         Assert.False(handler.UseProxy);
     }
 
     [Fact]
     public void CreateDefaultHttpMessageHandler_applies_connection_limit_policy()
     {
-        var handler = Assert.IsType<HttpClientHandler>(ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
+        var rawHandler = ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
             new ManagedModuleRepositoryClientOptions
             {
                 MaxConnectionsPerServer = 48
-            }));
+            });
 
+#if NET472
+        var handler = Assert.IsType<HttpClientHandler>(rawHandler);
+#else
+        var handler = Assert.IsType<SocketsHttpHandler>(rawHandler);
+#endif
         Assert.Equal(48, handler.MaxConnectionsPerServer);
     }
 
     [Fact]
     public void CreateDefaultHttpMessageHandler_keeps_at_least_one_connection_per_server()
     {
-        var handler = Assert.IsType<HttpClientHandler>(ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
+        var rawHandler = ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
             new ManagedModuleRepositoryClientOptions
             {
                 MaxConnectionsPerServer = 0
-            }));
+            });
 
+#if NET472
+        var handler = Assert.IsType<HttpClientHandler>(rawHandler);
+#else
+        var handler = Assert.IsType<SocketsHttpHandler>(rawHandler);
+#endif
         Assert.Equal(1, handler.MaxConnectionsPerServer);
     }
 
     [Fact]
     public void CreateDefaultHttpMessageHandler_requests_compressed_repository_responses()
     {
-        var handler = Assert.IsType<HttpClientHandler>(ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
-            new ManagedModuleRepositoryClientOptions()));
+        var rawHandler = ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(new ManagedModuleRepositoryClientOptions());
 
+#if NET472
+        var handler = Assert.IsType<HttpClientHandler>(rawHandler);
+#else
+        var handler = Assert.IsType<SocketsHttpHandler>(rawHandler);
+#endif
         Assert.True(handler.AutomaticDecompression.HasFlag(DecompressionMethods.GZip));
         Assert.True(handler.AutomaticDecompression.HasFlag(DecompressionMethods.Deflate));
 #if !NET472
         Assert.True(handler.AutomaticDecompression.HasFlag(DecompressionMethods.Brotli));
 #endif
     }
+
+#if !NET472
+    [Fact]
+    public void CreateDefaultHttpMessageHandler_enables_multiple_http2_connections_on_modern_runtime()
+    {
+        var handler = Assert.IsType<SocketsHttpHandler>(ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(
+            new ManagedModuleRepositoryClientOptions()));
+
+        Assert.True(handler.EnableMultipleHttp2Connections);
+        Assert.Equal(16 * 1024 * 1024, handler.InitialHttp2StreamWindowSize);
+    }
+
+    [Fact]
+    public void CreateDefaultHttpClient_prefers_http2_or_higher_on_modern_runtime()
+    {
+        using var client = ManagedModuleRepositoryClient.CreateDefaultHttpClient(new ManagedModuleRepositoryClientOptions());
+
+        Assert.Equal(HttpVersion.Version20, client.DefaultRequestVersion);
+        Assert.Equal(HttpVersionPolicy.RequestVersionOrHigher, client.DefaultVersionPolicy);
+    }
+#endif
 
     [Fact]
     public void RedirectRequest_keeps_credentials_only_for_same_origin_redirects()

--- a/PowerForge.Tests/ManagedModuleRepositoryClientHttpHandlerTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientHttpHandlerTests.cs
@@ -137,6 +137,26 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
         Assert.Equal(HttpVersion.Version20, client.DefaultRequestVersion);
         Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, client.DefaultVersionPolicy);
     }
+
+    [Fact]
+    public void CreateRequest_sets_http2_policy_on_explicit_repository_messages()
+    {
+        var method = typeof(ManagedModuleRepositoryClient).GetMethod(
+            "CreateRequest",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        using var request = Assert.IsType<HttpRequestMessage>(method!.Invoke(null, new object[]
+        {
+            HttpMethod.Get,
+            new Uri("https://feed.example.test/v3/index.json"),
+            null!,
+            "application/json"
+        }));
+
+        Assert.Equal(HttpVersion.Version20, request.Version);
+        Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, request.VersionPolicy);
+    }
 #endif
 
     [Fact]
@@ -149,6 +169,10 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
         using var source = new HttpRequestMessage(HttpMethod.Get, "https://feed.example.test:8443/packages");
         source.Headers.Authorization = new AuthenticationHeaderValue("Basic", "secret");
         source.Headers.Add("X-NuGet-ApiKey", "api-secret");
+#if !NET472
+        source.Version = HttpVersion.Version20;
+        source.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+#endif
 
         using var sameOrigin = Assert.IsType<HttpRequestMessage>(method!.Invoke(null, new object[]
         {
@@ -168,6 +192,10 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
 
         Assert.NotNull(sameOrigin.Headers.Authorization);
         Assert.True(sameOrigin.Headers.Contains("X-NuGet-ApiKey"));
+#if !NET472
+        Assert.Equal(HttpVersion.Version20, sameOrigin.Version);
+        Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, sameOrigin.VersionPolicy);
+#endif
         Assert.Null(downgraded.Headers.Authorization);
         Assert.False(downgraded.Headers.Contains("X-NuGet-ApiKey"));
         Assert.Null(differentPort.Headers.Authorization);

--- a/PowerForge.Tests/ManagedModuleRepositoryClientHttpHandlerTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientHttpHandlerTests.cs
@@ -105,6 +105,19 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
 #endif
     }
 
+    [Fact]
+    public void CreateDefaultHttpMessageHandler_disables_automatic_redirects_for_repository_policy()
+    {
+        var rawHandler = ManagedModuleRepositoryClient.CreateDefaultHttpMessageHandler(new ManagedModuleRepositoryClientOptions());
+
+#if NET472
+        var handler = Assert.IsType<HttpClientHandler>(rawHandler);
+#else
+        var handler = Assert.IsType<SocketsHttpHandler>(rawHandler);
+#endif
+        Assert.False(handler.AllowAutoRedirect);
+    }
+
 #if !NET472
     [Fact]
     public void CreateDefaultHttpMessageHandler_enables_multiple_http2_connections_on_modern_runtime()
@@ -117,12 +130,12 @@ public sealed class ManagedModuleRepositoryClientHttpHandlerTests
     }
 
     [Fact]
-    public void CreateDefaultHttpClient_prefers_http2_or_higher_on_modern_runtime()
+    public void CreateDefaultHttpClient_prefers_http2_with_http11_fallback_on_modern_runtime()
     {
         using var client = ManagedModuleRepositoryClient.CreateDefaultHttpClient(new ManagedModuleRepositoryClientOptions());
 
         Assert.Equal(HttpVersion.Version20, client.DefaultRequestVersion);
-        Assert.Equal(HttpVersionPolicy.RequestVersionOrHigher, client.DefaultVersionPolicy);
+        Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, client.DefaultVersionPolicy);
     }
 #endif
 

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -611,6 +611,21 @@ public sealed class ManagedModuleRepositoryClientTests
     }
 
     [Fact]
+    public async Task DownloadPackageToMemoryAsync_uses_known_content_length_as_initial_capacity()
+    {
+        const int expectedCapacity = 1024 * 1024 + 123;
+        var requests = new List<RecordedRequest>();
+        using var client = new HttpClient(new ManagedModuleHandler(requests, companyToolsPackageContentLength: expectedCapacity));
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+
+        using var result = await repositoryClient.DownloadPackageToMemoryAsync(repository, "Company.Tools", "1.1.0");
+
+        Assert.Equal(expectedCapacity, result.PackageStream.Capacity);
+        Assert.True(result.PackageStream.Length < expectedCapacity);
+    }
+
+    [Fact]
     public async Task DownloadPackageToMemoryAsync_rejects_package_above_memory_cap_by_content_length()
     {
         var requests = new List<RecordedRequest>();

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -169,6 +169,10 @@ public sealed class ManagedModuleRepositoryClientTests
         var latest = Assert.Single(versions, version => version.Version == "1.1.0");
         Assert.True(latest.RequireLicenseAcceptance);
         Assert.Equal("https://licenses.example.test/company-tools", latest.License);
+        var dependency = Assert.Single(latest.Dependencies);
+        Assert.Equal("Company.Core", dependency.Id);
+        Assert.Equal("[2.0.0, )", dependency.VersionRange);
+        Assert.Equal("net8.0", dependency.TargetFramework);
         Assert.All(versions, version =>
         {
             Assert.Equal("Gallery", version.RepositoryName);
@@ -1279,7 +1283,7 @@ public sealed class ManagedModuleRepositoryClientTests
                     "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\">" +
                     "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><d:Version>1.0.0</d:Version></m:properties></content></entry>" +
                     "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><d:Version>1.1.0-beta1</d:Version></m:properties></content></entry>" +
-                    "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><d:Version>1.1.0</d:Version><d:RequireLicenseAcceptance>true</d:RequireLicenseAcceptance><d:LicenseUrl>https://licenses.example.test/company-tools</d:LicenseUrl></m:properties></content></entry>" +
+                    "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><d:Version>1.1.0</d:Version><d:RequireLicenseAcceptance>true</d:RequireLicenseAcceptance><d:LicenseUrl>https://licenses.example.test/company-tools</d:LicenseUrl><d:Dependencies>Company.Core:[2.0.0, ):net8.0</d:Dependencies></m:properties></content></entry>" +
                     "</feed>");
 
             if (uri.AbsoluteUri == "https://example.test/api/v2/FindPackagesById()?id='SameHost.Tools'&semVerLevel=2.0.0")

--- a/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
+++ b/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
@@ -125,6 +125,22 @@ public sealed class ManagedModuleSimpleBenchmarkScriptTests
     }
 
     [Fact]
+    public void BenchmarkMatrixScript_RewritesOutputWhenCsvColumnsChange()
+    {
+        var script = File.ReadAllText(Path.Combine(
+            RepoRootLocator.Find(),
+            "Benchmarks",
+            "ManagedModules",
+            "Invoke-ManagedModuleBenchmarkMatrix.ps1"));
+
+        Assert.Contains("Get-CsvHeaderColumns", script, StringComparison.Ordinal);
+        Assert.Contains("Join-CsvColumns", script, StringComparison.Ordinal);
+        Assert.Contains("Test-CsvColumnsEqual", script, StringComparison.Ordinal);
+        Assert.Contains("ConvertTo-CsvRowsWithColumns", script, StringComparison.Ordinal);
+        Assert.Contains("Export-Csv -LiteralPath $OutputPath -NoTypeInformation", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MeasureScript_EmitsBenchmarkProvenanceColumns()
     {
         var script = File.ReadAllText(Path.Combine(

--- a/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
+++ b/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
@@ -107,6 +107,36 @@ public sealed class ManagedModuleSimpleBenchmarkScriptTests
         Assert.Contains("LastManagedBenchmarkResult", script, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void BenchmarkMatrixScript_HasFocusedManagedModuleFastProfile()
+    {
+        var script = File.ReadAllText(Path.Combine(
+            RepoRootLocator.Find(),
+            "Benchmarks",
+            "ManagedModules",
+            "Invoke-ManagedModuleBenchmarkMatrix.ps1"));
+
+        Assert.Contains("ManagedVsModuleFast", script, StringComparison.Ordinal);
+        Assert.Contains("$Operation = @('Install')", script, StringComparison.Ordinal);
+        Assert.Contains("$Engine = @('Managed', 'ModuleFast')", script, StringComparison.Ordinal);
+        Assert.Contains("$ModuleFastSource = 'https://pwsh.gallery/index.json'", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MeasureScript_EmitsBenchmarkProvenanceColumns()
+    {
+        var script = File.ReadAllText(Path.Combine(
+            RepoRootLocator.Find(),
+            "Benchmarks",
+            "ManagedModules",
+            "Measure-ManagedModuleBenchmark.ps1"));
+
+        Assert.Contains("RepositoryUri = $RepositoryUri", script, StringComparison.Ordinal);
+        Assert.Contains("ModuleFastSource = if ($EngineName -eq 'ModuleFast')", script, StringComparison.Ordinal);
+        Assert.Contains("EngineCommandPath = $engineMetadata.CommandPath", script, StringComparison.Ordinal);
+        Assert.Contains("EngineModuleVersion = $engineMetadata.ModuleVersion", script, StringComparison.Ordinal);
+    }
+
     private static string BuildResultCsv()
         => string.Join(Environment.NewLine,
             "TimestampUtc,Host,Scenario,ScenarioLabel,ModuleName,Version,Operation,Engine,Iteration,Status,Milliseconds,Seconds,Reason",

--- a/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
+++ b/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
@@ -90,6 +90,23 @@ public sealed class ManagedModuleSimpleBenchmarkScriptTests
         Assert.DoesNotContain("PFBenchmarkBackup", script, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void MeasureScript_EmitsManagedPhaseColumnsForProfilerTriage()
+    {
+        var script = File.ReadAllText(Path.Combine(
+            RepoRootLocator.Find(),
+            "Benchmarks",
+            "ManagedModules",
+            "Measure-ManagedModuleBenchmark.ps1"));
+
+        Assert.Contains("ManagedPackageCount", script, StringComparison.Ordinal);
+        Assert.Contains("ManagedDownloadMillisecondsSum", script, StringComparison.Ordinal);
+        Assert.Contains("ManagedExtractionMillisecondsSum", script, StringComparison.Ordinal);
+        Assert.Contains("ManagedDependencyMillisecondsRoot", script, StringComparison.Ordinal);
+        Assert.Contains("ManagedPromotionMillisecondsSum", script, StringComparison.Ordinal);
+        Assert.Contains("LastManagedBenchmarkResult", script, StringComparison.Ordinal);
+    }
+
     private static string BuildResultCsv()
         => string.Join(Environment.NewLine,
             "TimestampUtc,Host,Scenario,ScenarioLabel,ModuleName,Version,Operation,Engine,Iteration,Status,Milliseconds,Seconds,Reason",

--- a/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
+++ b/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
@@ -120,6 +120,8 @@ public sealed class ManagedModuleSimpleBenchmarkScriptTests
         Assert.Contains("$Operation = @('Install')", script, StringComparison.Ordinal);
         Assert.Contains("$Engine = @('Managed', 'ModuleFast')", script, StringComparison.Ordinal);
         Assert.Contains("$ModuleFastSource = 'https://pwsh.gallery/index.json'", script, StringComparison.Ordinal);
+        Assert.Contains("[string] $ComparisonProfile = 'ManagedVsModuleFast'", script, StringComparison.Ordinal);
+        Assert.Contains("ModuleFastModulePath", script, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -133,7 +135,9 @@ public sealed class ManagedModuleSimpleBenchmarkScriptTests
 
         Assert.Contains("RepositoryUri = $RepositoryUri", script, StringComparison.Ordinal);
         Assert.Contains("ModuleFastSource = if ($EngineName -eq 'ModuleFast')", script, StringComparison.Ordinal);
+        Assert.Contains("ModuleFastModulePath = if ($EngineName -eq 'ModuleFast')", script, StringComparison.Ordinal);
         Assert.Contains("EngineCommandPath = $engineMetadata.CommandPath", script, StringComparison.Ordinal);
+        Assert.Contains("EngineModuleBase = $engineMetadata.ModuleBase", script, StringComparison.Ordinal);
         Assert.Contains("EngineModuleVersion = $engineMetadata.ModuleVersion", script, StringComparison.Ordinal);
     }
 

--- a/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
+++ b/PowerForge.Tests/ManagedModuleSimpleBenchmarkScriptTests.cs
@@ -141,6 +141,22 @@ public sealed class ManagedModuleSimpleBenchmarkScriptTests
     }
 
     [Fact]
+    public void MeasureScript_RewritesOutputWhenCsvColumnsChange()
+    {
+        var script = File.ReadAllText(Path.Combine(
+            RepoRootLocator.Find(),
+            "Benchmarks",
+            "ManagedModules",
+            "Measure-ManagedModuleBenchmark.ps1"));
+
+        Assert.Contains("Get-CsvHeaderColumns", script, StringComparison.Ordinal);
+        Assert.Contains("Join-CsvColumns", script, StringComparison.Ordinal);
+        Assert.Contains("Test-CsvColumnsEqual", script, StringComparison.Ordinal);
+        Assert.Contains("ConvertTo-CsvRowsWithColumns", script, StringComparison.Ordinal);
+        Assert.Contains("Export-Csv -LiteralPath $OutputPath -NoTypeInformation", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MeasureScript_EmitsBenchmarkProvenanceColumns()
     {
         var script = File.ReadAllText(Path.Combine(

--- a/PowerForge.Tests/ManagedModuleTestSupport.cs
+++ b/PowerForge.Tests/ManagedModuleTestSupport.cs
@@ -70,7 +70,8 @@ internal static class TestPackageFactory
         string id,
         string version,
         bool requireLicenseAcceptance = false,
-        IReadOnlyDictionary<string, string>? files = null)
+        IReadOnlyDictionary<string, string>? files = null,
+        IReadOnlyList<TestDependency>? dependencies = null)
     {
         using var stream = new MemoryStream();
         using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
@@ -78,7 +79,7 @@ internal static class TestPackageFactory
             var nuspec = archive.CreateEntry(id + ".nuspec");
             using (var writer = new StreamWriter(nuspec.Open()))
             {
-                writer.Write(CreateNuspec(id, version, requireLicenseAcceptance: requireLicenseAcceptance));
+                writer.Write(CreateNuspec(id, version, dependencies, requireLicenseAcceptance));
             }
 
             if (files is not null)

--- a/PowerForge.Tests/PrivateManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/PrivateManagedModuleCommandTests.cs
@@ -62,6 +62,39 @@ public sealed class PrivateManagedModuleCommandTests
     }
 
     [Fact]
+    public void InstallManagedModule_resolves_provider_cache_path_before_multiple_async_installs()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        using var cacheRoot = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.One.1.0.0.nupkg"),
+            "Company.One",
+            "1.0.0",
+            files: CreateModuleFiles("1.0.0", "Company.One"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Two.1.0.0.nupkg"),
+            "Company.Two",
+            "1.0.0",
+            files: CreateModuleFiles("1.0.0", "Company.Two"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Install-ManagedModule")
+            .AddParameter("Name", new[] { "Company.One", "Company.Two" })
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", moduleRoot.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("PackageCacheDirectory", "FileSystem::" + cacheRoot.Path);
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal(2, results.Count);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.One", "1.0.0", "Company.One.psd1")));
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Two", "1.0.0", "Company.Two.psd1")));
+    }
+
+    [Fact]
     public void InstallManagedModule_defaults_to_managed_transport_from_registered_repository_source()
     {
         using var feed = new TemporaryDirectory();
@@ -233,10 +266,10 @@ public sealed class PrivateManagedModuleCommandTests
         Assert.Contains("registered PowerShell repository name", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static IReadOnlyDictionary<string, string> CreateModuleFiles(string version)
+    private static IReadOnlyDictionary<string, string> CreateModuleFiles(string version, string moduleName = "Company.Tools")
         => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Company.Tools.psd1"] = "@{ ModuleVersion = '" + version + "' }"
+            [moduleName + ".psd1"] = "@{ ModuleVersion = '" + version + "' }"
         };
 
     private static void SaveProfile(string feedPath)

--- a/PowerForge.Tests/RepairManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/RepairManagedModuleCommandTests.cs
@@ -479,6 +479,34 @@ public sealed class RepairManagedModuleCommandTests
     }
 
     [Fact]
+    public void RepairManagedModule_PrivatePlanDoesNotResolveMissingCredentialSecretFile()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        CreateInstalledModule(moduleRoot.Path, "Company.Tools", "1.0.0");
+        var missingSecretPath = Path.Combine(moduleRoot.Path, "missing-feed-secret.txt");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Repair-ManagedModule")
+            .AddParameter("ModulePath", new[] { moduleRoot.Path })
+            .AddParameter("Name", new[] { "Company.Tools" })
+            .AddParameter("Version", "1.1.0")
+            .AddParameter("Repository", "CompanyModules")
+            .AddParameter("Transport", ModuleStateDeliveryTransport.PrivateModule)
+            .AddParameter("CredentialUserName", "build")
+            .AddParameter("CredentialSecretFilePath", missingSecretPath)
+            .AddParameter("Plan");
+
+        var result = Assert.IsType<ModuleStateWorkflowResult>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.False(result.Apply.ExecutionRequested);
+        Assert.Empty(result.Apply.ExecutionResults);
+        Assert.Contains(result.Apply.Commands, command =>
+            string.Equals(command.CommandName, "Repair-ManagedModule", StringComparison.OrdinalIgnoreCase) &&
+            command.Arguments.Contains("-Transport"));
+    }
+
+    [Fact]
     public void RepairManagedModule_PathRepositoryPlansAgainstResolvedRepositoryName()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge/Models/ManagedModules/ManagedModuleDownloadResult.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleDownloadResult.cs
@@ -36,6 +36,11 @@ public sealed class ManagedModuleDownloadResult
     public long BytesWritten { get; set; }
 
     /// <summary>
+    /// Number of repository HTTP request attempts used while delivering this package.
+    /// </summary>
+    public long RequestCount { get; set; }
+
+    /// <summary>
     /// Number of HTTP redirects followed while delivering this package.
     /// </summary>
     public long RedirectCount { get; set; }

--- a/PowerForge/Models/ManagedModules/ManagedModuleInstallRequest.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleInstallRequest.cs
@@ -60,6 +60,8 @@ public sealed class ManagedModuleInstallRequest
     /// </summary>
     public string? PackageCacheDirectory { get; set; }
 
+    internal bool PackageCacheDirectoryIsOperationLocal { get; set; }
+
     /// <summary>
     /// Maximum number of dependency branches to install concurrently. A value of 0 uses the engine default.
     /// </summary>

--- a/PowerForge/Models/ManagedModules/ManagedModuleVersionInfo.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleVersionInfo.cs
@@ -49,4 +49,9 @@ public sealed class ManagedModuleVersionInfo
     /// True when repository metadata indicates this package version requires explicit license acceptance.
     /// </summary>
     public bool RequireLicenseAcceptance { get; set; }
+
+    /// <summary>
+    /// Dependencies exposed by repository metadata when available.
+    /// </summary>
+    public IReadOnlyList<ManagedModuleDependencyInfo> Dependencies { get; set; } = Array.Empty<ManagedModuleDependencyInfo>();
 }

--- a/PowerForge/Services/ManagedModules/ManagedModuleArchiveExtractor.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleArchiveExtractor.cs
@@ -10,7 +10,10 @@ internal sealed class ManagedModuleArchiveExtractor
     private static readonly string[] PackageMetadataPrefixes = { "_rels/", "package/services/metadata/" };
     private static readonly string[] PackageMetadataFiles = { "[Content_Types].xml", ".signature.p7s" };
 
-    public ManagedModuleArchiveExtractionResult ExtractPackage(string packagePath, string destinationPath)
+    public ManagedModuleArchiveExtractionResult ExtractPackage(
+        string packagePath,
+        string destinationPath,
+        string? packageId = null)
     {
         if (string.IsNullOrWhiteSpace(packagePath))
             throw new ArgumentException("Package path is required.", nameof(packagePath));
@@ -28,7 +31,7 @@ internal sealed class ManagedModuleArchiveExtractor
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
         using var archive = ZipFile.OpenRead(packagePath);
-        var packageRoot = ResolvePackageRootFolder(archive);
+        var packageRoot = ResolvePackageRootFolder(archive, packageId);
         foreach (var entry in archive.Entries)
         {
             var normalized = Normalize(entry.FullName);
@@ -64,9 +67,16 @@ internal sealed class ManagedModuleArchiveExtractor
     }
 
 #if !NET472
+    public Task<ManagedModuleArchiveExtractionResult> ExtractPackageAsync(
+        Stream packageStream,
+        string destinationPath,
+        CancellationToken cancellationToken)
+        => ExtractPackageAsync(packageStream, destinationPath, packageId: null, cancellationToken);
+
     public async Task<ManagedModuleArchiveExtractionResult> ExtractPackageAsync(
         Stream packageStream,
         string destinationPath,
+        string? packageId,
         CancellationToken cancellationToken)
     {
         if (packageStream is null)
@@ -85,7 +95,7 @@ internal sealed class ManagedModuleArchiveExtractor
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
         using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
-        var packageRoot = ResolvePackageRootFolder(archive);
+        var packageRoot = ResolvePackageRootFolder(archive, packageId);
         foreach (var entry in archive.Entries)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -131,9 +141,9 @@ internal sealed class ManagedModuleArchiveExtractor
     private static string Normalize(string path)
         => path.Replace('\\', '/').Trim('/');
 
-    private static string? ResolvePackageRootFolder(ZipArchive archive)
+    private static string? ResolvePackageRootFolder(ZipArchive archive, string? packageId)
     {
-        var packageId = ReadPackageId(archive);
+        packageId = string.IsNullOrWhiteSpace(packageId) ? ReadPackageId(archive) : packageId!.Trim();
         if (string.IsNullOrWhiteSpace(packageId))
             return null;
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleConcurrencyDefaults.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleConcurrencyDefaults.cs
@@ -2,7 +2,7 @@ namespace PowerForge;
 
 internal static class ManagedModuleConcurrencyDefaults
 {
-    internal const int MaximumDefaultConcurrency = 128;
+    internal const int MaximumDefaultConcurrency = 96;
     private const int MinimumDefaultConcurrency = 16;
     private const int ConnectionsPerProcessor = 8;
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleExtractedPackageCache.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleExtractedPackageCache.cs
@@ -68,11 +68,12 @@ internal sealed class ManagedModuleExtractedPackageCache
         string packageCacheDirectory,
         string destinationPath,
         ManagedModuleArchiveExtractor extractor,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? packageId = null)
     {
         var normalizedSha256 = ManagedModulePackageIntegrity.NormalizeSha256(packageSha256);
         if (normalizedSha256 is null)
-            return extractor.ExtractPackage(packagePath, destinationPath);
+            return extractor.ExtractPackage(packagePath, destinationPath, packageId);
 
         var cacheRoot = GetCacheRoot(packageCacheDirectory, normalizedSha256);
         var payloadPath = Path.Combine(cacheRoot, PayloadDirectoryName);
@@ -110,7 +111,7 @@ internal sealed class ManagedModuleExtractedPackageCache
             DeleteDirectoryQuietly(cacheRoot);
         }
 
-        var extraction = extractor.ExtractPackage(packagePath, destinationPath);
+        var extraction = extractor.ExtractPackage(packagePath, destinationPath, packageId);
         TryPopulateCache(destinationPath, cacheRoot, normalizedSha256, extraction, cancellationToken);
         stopwatch.Stop();
         return new ManagedModuleArchiveExtractionResult(extraction.FileCount, extraction.BytesWritten, stopwatch.Elapsed, fromCache: false, cacheLockWaitElapsed);

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
@@ -4,6 +4,8 @@ namespace PowerForge;
 
 internal sealed class ManagedModuleInstallContext
 {
+    private const string MissingDependencyVersionSelection = "\0";
+
     private readonly HashSet<string> _active;
     private readonly HashSet<string> _ownedInstallKeys;
     private readonly ConcurrentDictionary<string, ManagedModuleInstallPending> _inFlightInstalls;
@@ -164,6 +166,19 @@ internal sealed class ManagedModuleInstallContext
             _ => newLazy);
 
         return CompleteDependencyVersionSelectionAsync(key, lazy, !ReferenceEquals(lazy, newLazy));
+    }
+
+    public async Task<ManagedModuleDependencyVersionSelection?> GetOrAddOptionalDependencyVersionSelection(string key, Func<Task<string?>> factory)
+    {
+        if (factory is null)
+            throw new ArgumentNullException(nameof(factory));
+
+        var selection = await GetOrAddDependencyVersionSelection(
+            key,
+            async () => await factory().ConfigureAwait(false) ?? MissingDependencyVersionSelection).ConfigureAwait(false);
+        return string.Equals(selection.Version, MissingDependencyVersionSelection, StringComparison.Ordinal)
+            ? null
+            : selection;
     }
 
     private static string CreateInstalledVersionKey(string moduleRoot, string moduleName)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 
 namespace PowerForge;
 
-internal sealed class ManagedModuleInstallContext
+internal sealed class ManagedModuleInstallContext : IDisposable
 {
     private const string MissingDependencyVersionSelection = "\0";
 
@@ -12,6 +12,11 @@ internal sealed class ManagedModuleInstallContext
     private readonly ConcurrentDictionary<string, ManagedModuleInstallResult> _completedInstalls;
     private readonly ConcurrentDictionary<string, string[]> _installedVersions;
     private readonly ConcurrentDictionary<string, Lazy<Task<string>>> _dependencyVersionSelections;
+#if !NET472
+    private readonly ConcurrentDictionary<string, Lazy<Task<ManagedModuleBufferedPackage>>> _bufferedPackagePrefetches;
+    private readonly SemaphoreSlim _bufferedPackagePrefetchGate;
+    private bool _disposed;
+#endif
 
     public ManagedModuleInstallContext()
         : this(
@@ -20,7 +25,13 @@ internal sealed class ManagedModuleInstallContext
             new ConcurrentDictionary<string, ManagedModuleInstallPending>(StringComparer.OrdinalIgnoreCase),
             new ConcurrentDictionary<string, ManagedModuleInstallResult>(StringComparer.OrdinalIgnoreCase),
             new ConcurrentDictionary<string, string[]>(StringComparer.OrdinalIgnoreCase),
-            new ConcurrentDictionary<string, Lazy<Task<string>>>(StringComparer.OrdinalIgnoreCase))
+            new ConcurrentDictionary<string, Lazy<Task<string>>>(StringComparer.OrdinalIgnoreCase)
+#if !NET472
+            ,
+            new ConcurrentDictionary<string, Lazy<Task<ManagedModuleBufferedPackage>>>(StringComparer.OrdinalIgnoreCase),
+            new SemaphoreSlim(8, 8)
+#endif
+            )
     {
     }
 
@@ -30,7 +41,13 @@ internal sealed class ManagedModuleInstallContext
         ConcurrentDictionary<string, ManagedModuleInstallPending> inFlightInstalls,
         ConcurrentDictionary<string, ManagedModuleInstallResult> completedInstalls,
         ConcurrentDictionary<string, string[]> installedVersions,
-        ConcurrentDictionary<string, Lazy<Task<string>>> dependencyVersionSelections)
+        ConcurrentDictionary<string, Lazy<Task<string>>> dependencyVersionSelections
+#if !NET472
+        ,
+        ConcurrentDictionary<string, Lazy<Task<ManagedModuleBufferedPackage>>> bufferedPackagePrefetches,
+        SemaphoreSlim bufferedPackagePrefetchGate
+#endif
+        )
     {
         _active = active;
         _ownedInstallKeys = ownedInstallKeys;
@@ -38,6 +55,10 @@ internal sealed class ManagedModuleInstallContext
         _completedInstalls = completedInstalls;
         _installedVersions = installedVersions;
         _dependencyVersionSelections = dependencyVersionSelections;
+#if !NET472
+        _bufferedPackagePrefetches = bufferedPackagePrefetches;
+        _bufferedPackagePrefetchGate = bufferedPackagePrefetchGate;
+#endif
     }
 
     public ManagedModuleInstallContext CreateBranch()
@@ -47,7 +68,13 @@ internal sealed class ManagedModuleInstallContext
             _inFlightInstalls,
             _completedInstalls,
             _installedVersions,
-            _dependencyVersionSelections);
+            _dependencyVersionSelections
+#if !NET472
+            ,
+            _bufferedPackagePrefetches,
+            _bufferedPackagePrefetchGate
+#endif
+            );
 
     public IDisposable Enter(string moduleName)
     {
@@ -180,6 +207,126 @@ internal sealed class ManagedModuleInstallContext
             ? null
             : selection;
     }
+
+#if !NET472
+    public void StartBufferedPackagePrefetch(
+        string key,
+        Func<CancellationToken, Task<ManagedModuleBufferedPackage>> factory,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Buffered package prefetch key is required.", nameof(key));
+        if (factory is null)
+            throw new ArgumentNullException(nameof(factory));
+        if (_disposed || cancellationToken.IsCancellationRequested)
+            return;
+
+        var newLazy = new Lazy<Task<ManagedModuleBufferedPackage>>(
+            async () =>
+            {
+                await _bufferedPackagePrefetchGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    return await factory(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _bufferedPackagePrefetchGate.Release();
+                }
+            },
+            LazyThreadSafetyMode.ExecutionAndPublication);
+        var lazy = _bufferedPackagePrefetches.GetOrAdd(key, _ => newLazy);
+        if (!ReferenceEquals(lazy, newLazy))
+            return;
+
+        _ = CompleteBufferedPackagePrefetchAsync(key, lazy);
+    }
+
+    public async Task<ManagedModuleBufferedPackage?> TryTakeBufferedPackagePrefetchAsync(
+        string key,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return null;
+
+        if (!_bufferedPackagePrefetches.TryRemove(key, out var lazy))
+            return null;
+
+        try
+        {
+            return await lazy.Value.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (ManagedModuleBufferedPackageTooLargeException)
+        {
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+#endif
+
+    public void Dispose()
+    {
+#if !NET472
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        foreach (var item in _bufferedPackagePrefetches.ToArray())
+        {
+            if (!_bufferedPackagePrefetches.TryRemove(item.Key, out var lazy) || !lazy.IsValueCreated)
+                continue;
+
+            DisposeBufferedPackageWhenComplete(lazy.Value);
+        }
+#endif
+    }
+
+#if !NET472
+    private async Task CompleteBufferedPackagePrefetchAsync(
+        string key,
+        Lazy<Task<ManagedModuleBufferedPackage>> lazy)
+    {
+        try
+        {
+            var package = await lazy.Value.ConfigureAwait(false);
+            if (_disposed)
+            {
+                package.Dispose();
+            }
+        }
+        catch
+        {
+            ((ICollection<KeyValuePair<string, Lazy<Task<ManagedModuleBufferedPackage>>>>)_bufferedPackagePrefetches)
+                .Remove(new KeyValuePair<string, Lazy<Task<ManagedModuleBufferedPackage>>>(key, lazy));
+        }
+    }
+
+    private static void DisposeBufferedPackageWhenComplete(Task<ManagedModuleBufferedPackage> task)
+    {
+        if (task.IsCompletedSuccessfully)
+        {
+            task.Result.Dispose();
+            return;
+        }
+
+        _ = task.ContinueWith(
+            static completed =>
+            {
+                if (completed.Status == TaskStatus.RanToCompletion)
+                    completed.Result.Dispose();
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+#endif
 
     private static string CreateInstalledVersionKey(string moduleRoot, string moduleName)
         => string.Join("|", NormalizePath(moduleRoot), moduleName.Trim());

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
@@ -15,6 +15,7 @@ internal sealed class ManagedModuleInstallContext : IDisposable
 #if !NET472
     private readonly ConcurrentDictionary<string, Lazy<Task<ManagedModuleBufferedPackage>>> _bufferedPackagePrefetches;
     private readonly SemaphoreSlim _bufferedPackagePrefetchGate;
+    private readonly CancellationTokenSource _bufferedPackagePrefetchCancellation;
     private bool _disposed;
 #endif
 
@@ -29,7 +30,8 @@ internal sealed class ManagedModuleInstallContext : IDisposable
 #if !NET472
             ,
             new ConcurrentDictionary<string, Lazy<Task<ManagedModuleBufferedPackage>>>(StringComparer.OrdinalIgnoreCase),
-            new SemaphoreSlim(8, 8)
+            new SemaphoreSlim(8, 8),
+            new CancellationTokenSource()
 #endif
             )
     {
@@ -45,7 +47,8 @@ internal sealed class ManagedModuleInstallContext : IDisposable
 #if !NET472
         ,
         ConcurrentDictionary<string, Lazy<Task<ManagedModuleBufferedPackage>>> bufferedPackagePrefetches,
-        SemaphoreSlim bufferedPackagePrefetchGate
+        SemaphoreSlim bufferedPackagePrefetchGate,
+        CancellationTokenSource bufferedPackagePrefetchCancellation
 #endif
         )
     {
@@ -58,6 +61,7 @@ internal sealed class ManagedModuleInstallContext : IDisposable
 #if !NET472
         _bufferedPackagePrefetches = bufferedPackagePrefetches;
         _bufferedPackagePrefetchGate = bufferedPackagePrefetchGate;
+        _bufferedPackagePrefetchCancellation = bufferedPackagePrefetchCancellation;
 #endif
     }
 
@@ -72,7 +76,8 @@ internal sealed class ManagedModuleInstallContext : IDisposable
 #if !NET472
             ,
             _bufferedPackagePrefetches,
-            _bufferedPackagePrefetchGate
+            _bufferedPackagePrefetchGate,
+            _bufferedPackagePrefetchCancellation
 #endif
             );
 
@@ -224,10 +229,14 @@ internal sealed class ManagedModuleInstallContext : IDisposable
         var newLazy = new Lazy<Task<ManagedModuleBufferedPackage>>(
             async () =>
             {
-                await _bufferedPackagePrefetchGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    _bufferedPackagePrefetchCancellation.Token);
+                var prefetchCancellationToken = linkedCancellation.Token;
+                await _bufferedPackagePrefetchGate.WaitAsync(prefetchCancellationToken).ConfigureAwait(false);
                 try
                 {
-                    return await factory(cancellationToken).ConfigureAwait(false);
+                    return await factory(prefetchCancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -278,6 +287,7 @@ internal sealed class ManagedModuleInstallContext : IDisposable
             return;
 
         _disposed = true;
+        _bufferedPackagePrefetchCancellation.Cancel();
         foreach (var item in _bufferedPackagePrefetches.ToArray())
         {
             if (!_bufferedPackagePrefetches.TryRemove(item.Key, out var lazy) || !lazy.IsValueCreated)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallLock.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallLock.cs
@@ -3,7 +3,7 @@ namespace PowerForge;
 internal sealed class ManagedModuleInstallLock : IDisposable
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
-    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(15);
 
     private readonly FileStream _stream;
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.BufferedPackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.BufferedPackage.cs
@@ -24,6 +24,7 @@ public sealed partial class ManagedModuleInstallService
         return await _extractor.ExtractPackageAsync(
                 bufferedPackage.PackageStream,
                 stageModulePath,
+                bufferedPackage.Download.Metadata?.Id,
                 cancellationToken)
             .ConfigureAwait(false);
     }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.BufferedPackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.BufferedPackage.cs
@@ -6,14 +6,28 @@ public sealed partial class ManagedModuleInstallService
     private async Task<ManagedModuleBufferedPackage> DownloadBufferedPackageForInstallAsync(
         ManagedModuleInstallRequest request,
         string version,
+        ManagedModuleInstallContext context,
         CancellationToken cancellationToken)
-        => await _repositoryClient.DownloadPackageToMemoryAsync(
+    {
+        var prefetchKey = TryCreateBufferedPackagePrefetchKey(request, version);
+        if (prefetchKey is not null)
+        {
+            var prefetched = await context.TryTakeBufferedPackagePrefetchAsync(
+                    prefetchKey,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (prefetched is not null)
+                return prefetched;
+        }
+
+        return await _repositoryClient.DownloadPackageToMemoryAsync(
                 request.Repository,
                 request.Name,
                 version,
                 request.Credential,
                 cancellationToken)
             .ConfigureAwait(false);
+    }
 
     private async Task<ManagedModuleArchiveExtractionResult> ExtractBufferedPackageForInstallAsync(
         ManagedModuleBufferedPackage bufferedPackage,
@@ -30,7 +44,7 @@ public sealed partial class ManagedModuleInstallService
     }
 
     private static bool ShouldUseBufferedPackageExtraction(ManagedModuleInstallRequest request, bool ownsCache)
-        => ownsCache &&
+        => (ownsCache || request.PackageCacheDirectoryIsOperationLocal) &&
            request.Repository.Kind is ManagedModuleRepositoryKind.NuGetV2 or ManagedModuleRepositoryKind.NuGetV3;
 #endif
 }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -2,6 +2,8 @@ namespace PowerForge;
 
 public sealed partial class ManagedModuleInstallService
 {
+    private const int SeedDependencyBeforeFanoutThreshold = 16;
+
     private void StartDependencyVersionSelectionPrewarm(
         ManagedModuleInstallRequest request,
         ManagedModulePackageMetadata? metadata,
@@ -91,16 +93,30 @@ public sealed partial class ManagedModuleInstallService
             return new[] { singleResult };
         }
 
-        var results = new ManagedModuleInstallResult[dependencies.Length];
         var concurrencyLimit = ResolveDependencyInstallConcurrency(request);
-        var concurrency = Math.Min(dependencies.Length, concurrencyLimit);
+        var results = new ManagedModuleInstallResult[dependencies.Length];
+        var fanoutStart = 0;
+
+        if (dependencies.Length >= SeedDependencyBeforeFanoutThreshold && concurrencyLimit > 1)
+        {
+            results[0] = await InstallDependencyBranchAsync(
+                request,
+                dependencies[0],
+                cacheDirectory,
+                context.CreateBranch(),
+                cancellationToken).ConfigureAwait(false);
+            fanoutStart = 1;
+        }
+
+        var concurrency = Math.Min(dependencies.Length - fanoutStart, concurrencyLimit);
 
         using var gate = new SemaphoreSlim(concurrency, concurrency);
         var tasks = dependencies
+            .Skip(fanoutStart)
             .Select((dependency, offset) => InstallDependencyWithGateAsync(
                 request,
                 dependency,
-                offset,
+                fanoutStart + offset,
                 cacheDirectory,
                 context.CreateBranch(),
                 gate,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -141,14 +141,6 @@ public sealed partial class ManagedModuleInstallService
         return results;
     }
 
-    internal static bool ShouldStartDependencyInstallBeforeExtraction(
-        ManagedModuleInstallRequest request,
-        ManagedModulePackageMetadata? metadata)
-        => request.AllowClobber &&
-           !request.AuthenticodeCheck &&
-           !request.SkipDependencyCheck &&
-           SelectDependencies(metadata).Any();
-
     private async Task InstallDependencyWithGateAsync(
         ManagedModuleInstallRequest request,
         ManagedModuleDependencyInfo dependency,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -349,15 +349,30 @@ public sealed partial class ManagedModuleInstallService
                 cancellationToken);
             if (latestCacheKey is not null)
             {
-                var latest = await context.GetOrAddDependencyVersionSelection(
+                var latest = await context.GetOrAddOptionalDependencyVersionSelection(
                     latestCacheKey,
-                    () => ResolveLatestDependencyVersionAsync(
+                    () => ResolveLatestDependencyVersionOrNullAsync(
                         request,
                         dependencyName,
                         includePrerelease,
                         cancellationToken)).ConfigureAwait(false);
-                if (range.IsSatisfiedBy(latest.Version))
-                    return latest;
+                if (latest.HasValue && range.IsSatisfiedBy(latest.Value.Version))
+                    return latest.Value;
+            }
+            else
+            {
+                var latestVersion = await _repositoryClient.GetLatestVersionAsync(
+                    request.Repository,
+                    dependencyName,
+                    includePrerelease,
+                    request.Credential,
+                    cancellationToken).ConfigureAwait(false);
+                if (latestVersion is not null)
+                {
+                    var latest = new ManagedModuleDependencyVersionSelection(latestVersion.Version, shared: false);
+                    if (range.IsSatisfiedBy(latest.Version))
+                        return latest;
+                }
             }
         }
 
@@ -388,7 +403,7 @@ public sealed partial class ManagedModuleInstallService
         return new ManagedModuleDependencyVersionSelection(version, shared: false);
     }
 
-    private async Task<string> ResolveLatestDependencyVersionAsync(
+    private async Task<string?> ResolveLatestDependencyVersionOrNullAsync(
         ManagedModuleInstallRequest request,
         string dependencyName,
         bool includePrerelease,
@@ -400,10 +415,8 @@ public sealed partial class ManagedModuleInstallService
             includePrerelease,
             request.Credential,
             cancellationToken).ConfigureAwait(false);
-        if (latestVersion is null)
-            throw new InvalidOperationException($"No dependency versions of '{dependencyName}' were found in repository '{request.Repository.Name}'.");
 
-        return latestVersion.Version;
+        return latestVersion?.Version;
     }
 
     private async Task<string> ResolveDependencyVersionUncachedAsync(

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -12,8 +12,7 @@ public sealed partial class ManagedModuleInstallService
     {
         if (request.SkipDependencyCheck ||
             request.AuthenticodeCheck ||
-            request.Credential is not null ||
-            cancellationToken.CanBeCanceled)
+            request.Credential is not null)
         {
             return;
         }
@@ -449,7 +448,7 @@ public sealed partial class ManagedModuleInstallService
         bool includePrerelease,
         CancellationToken cancellationToken)
     {
-        if (request.Credential is not null || cancellationToken.CanBeCanceled)
+        if (request.Credential is not null)
             return null;
 
         return string.Join(
@@ -468,7 +467,7 @@ public sealed partial class ManagedModuleInstallService
         bool includePrerelease,
         CancellationToken cancellationToken)
     {
-        if (request.Credential is not null || cancellationToken.CanBeCanceled)
+        if (request.Credential is not null)
             return null;
 
         return string.Join(

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -235,6 +235,8 @@ public sealed partial class ManagedModuleInstallService
                 ShellEdition = request.ShellEdition,
                 ModuleRoot = request.ModuleRoot,
                 PackageCacheDirectory = cacheDirectory,
+                PackageCacheDirectoryIsOperationLocal = request.PackageCacheDirectoryIsOperationLocal ||
+                                                        string.IsNullOrWhiteSpace(request.PackageCacheDirectory),
                 ExpectedPackageSha256 = null,
                 TrustPolicy = dependencyTrustPolicy,
                 Credential = request.Credential,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -141,6 +141,14 @@ public sealed partial class ManagedModuleInstallService
         return results;
     }
 
+    internal static bool ShouldStartDependencyInstallBeforeExtraction(
+        ManagedModuleInstallRequest request,
+        ManagedModulePackageMetadata? metadata)
+        => request.AllowClobber &&
+           !request.AuthenticodeCheck &&
+           !request.SkipDependencyCheck &&
+           SelectDependencies(metadata).Any();
+
     private async Task InstallDependencyWithGateAsync(
         ManagedModuleInstallRequest request,
         ManagedModuleDependencyInfo dependency,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.PackagePrefetch.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.PackagePrefetch.cs
@@ -1,0 +1,154 @@
+namespace PowerForge;
+
+public sealed partial class ManagedModuleInstallService
+{
+#if !NET472
+    private const int MaximumDependencyPackagePrefetchCount = 64;
+
+    private void StartDependencyPackagePrefetch(
+        ManagedModuleInstallRequest request,
+        ManagedModulePackageMetadata? metadata,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!ShouldUseDependencyPackagePrefetch(request) || cancellationToken.IsCancellationRequested)
+            return;
+
+        var dependencyTrustPolicy = ResolveDependencyTrustPolicy(request.TrustPolicy);
+        var dependencies = SelectDependencies(metadata)
+            .Take(MaximumDependencyPackagePrefetchCount)
+            .ToArray();
+        foreach (var dependency in dependencies)
+        {
+            StartDependencyPackagePrefetchCore(
+                request,
+                dependency,
+                dependencyTrustPolicy,
+                context,
+                cancellationToken);
+        }
+    }
+
+    private void StartDependencyPackagePrefetchCore(
+        ManagedModuleInstallRequest request,
+        ManagedModuleDependencyInfo dependency,
+        ManagedModuleTrustPolicy? dependencyTrustPolicy,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken)
+    {
+        var range = ManagedModuleVersionRange.Parse(dependency.VersionRange);
+        if (dependencyTrustPolicy is null && HasSatisfiedDependency(request, dependency.Id, range, context))
+            return;
+
+        _ = StartDependencyPackagePrefetchCoreAsync(
+            request,
+            dependency,
+            range,
+            context,
+            cancellationToken);
+    }
+
+    private async Task StartDependencyPackagePrefetchCoreAsync(
+        ManagedModuleInstallRequest request,
+        ManagedModuleDependencyInfo dependency,
+        ManagedModuleVersionRange range,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var versionSelection = await ResolveDependencyVersionAsync(
+                    request,
+                    dependency.Id,
+                    range,
+                    context,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            var prefetchKey = TryCreateBufferedPackagePrefetchKey(
+                request.Repository,
+                dependency.Id,
+                versionSelection.Version,
+                request.Credential);
+            if (prefetchKey is null)
+                return;
+
+            context.StartBufferedPackagePrefetch(
+                prefetchKey,
+                token => DownloadPrefetchedPackageAsync(
+                    request,
+                    dependency.Id,
+                    versionSelection.Version,
+                    token),
+                cancellationToken);
+        }
+        catch
+        {
+            // Prefetch is opportunistic. The normal install path reports actionable errors.
+        }
+    }
+
+    private static bool ShouldUseDependencyPackagePrefetch(ManagedModuleInstallRequest request)
+        => !request.SkipDependencyCheck &&
+           !request.AuthenticodeCheck &&
+           request.Credential is null &&
+           (string.IsNullOrWhiteSpace(request.PackageCacheDirectory) || request.PackageCacheDirectoryIsOperationLocal) &&
+           request.Repository.Kind is ManagedModuleRepositoryKind.NuGetV2 or ManagedModuleRepositoryKind.NuGetV3;
+
+    private async Task<ManagedModuleBufferedPackage> DownloadPrefetchedPackageAsync(
+        ManagedModuleInstallRequest request,
+        string packageId,
+        string version,
+        CancellationToken cancellationToken)
+    {
+        using var requestScope = _repositoryClient.BeginRequestScope();
+        var package = await _repositoryClient.DownloadPackageToMemoryAsync(
+                request.Repository,
+                packageId,
+                version,
+                request.Credential,
+                cancellationToken)
+            .ConfigureAwait(false);
+        package.Download.RequestCount = Math.Max(1, requestScope.Count);
+        package.Download.RedirectCount = requestScope.RedirectCount;
+        return package;
+    }
+
+    private static string? TryCreateBufferedPackagePrefetchKey(
+        ManagedModuleInstallRequest request,
+        string version)
+        => TryCreateBufferedPackagePrefetchKey(
+            request.Repository,
+            request.Name,
+            version,
+            request.Credential);
+
+    private static string? TryCreateBufferedPackagePrefetchKey(
+        ManagedModuleRepository repository,
+        string packageId,
+        string version,
+        RepositoryCredential? credential)
+    {
+        if (credential is not null ||
+            repository.Kind is not (ManagedModuleRepositoryKind.NuGetV2 or ManagedModuleRepositoryKind.NuGetV3))
+        {
+            return null;
+        }
+
+        return string.Join(
+            "|",
+            "buffered-package",
+            repository.Kind.ToString(),
+            NormalizeDependencyVersionCacheValue(repository.Source),
+            NormalizeDependencyVersionCacheValue(packageId),
+            NormalizeDependencyVersionCacheValue(version));
+    }
+#else
+    private static void StartDependencyPackagePrefetch(
+        ManagedModuleInstallRequest request,
+        ManagedModulePackageMetadata? metadata,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken)
+    {
+    }
+#endif
+}

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Promotion.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Promotion.cs
@@ -2,19 +2,6 @@ namespace PowerForge;
 
 public sealed partial class ManagedModuleInstallService
 {
-    private sealed class NoopDisposable : IDisposable
-    {
-        public static readonly NoopDisposable Instance = new();
-
-        private NoopDisposable()
-        {
-        }
-
-        public void Dispose()
-        {
-        }
-    }
-
     private readonly struct ManagedModulePromotionResult
     {
         public ManagedModulePromotionResult(
@@ -124,18 +111,9 @@ public sealed partial class ManagedModuleInstallService
 
     private static IDisposable AcquirePromotionLock(
         string moduleRoot,
-        bool allowClobber,
         CancellationToken cancellationToken,
         out TimeSpan waitElapsed)
-    {
-        if (allowClobber)
-        {
-            waitElapsed = TimeSpan.Zero;
-            return NoopDisposable.Instance;
-        }
-
-        return AcquireInstallLock(moduleRoot, ".promotion", cancellationToken, out waitElapsed);
-    }
+        => AcquireInstallLock(moduleRoot, ".promotion", cancellationToken, out waitElapsed);
 
     private static void RestoreBackup(string modulePath, string? backupPath)
     {

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Promotion.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Promotion.cs
@@ -2,6 +2,19 @@ namespace PowerForge;
 
 public sealed partial class ManagedModuleInstallService
 {
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+
+        private NoopDisposable()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
     private readonly struct ManagedModulePromotionResult
     {
         public ManagedModulePromotionResult(
@@ -107,6 +120,21 @@ public sealed partial class ManagedModuleInstallService
             RestoreBackup(modulePath, backupPath);
             throw;
         }
+    }
+
+    private static IDisposable AcquirePromotionLock(
+        string moduleRoot,
+        bool allowClobber,
+        CancellationToken cancellationToken,
+        out TimeSpan waitElapsed)
+    {
+        if (allowClobber)
+        {
+            waitElapsed = TimeSpan.Zero;
+            return NoopDisposable.Instance;
+        }
+
+        return AcquireInstallLock(moduleRoot, ".promotion", cancellationToken, out waitElapsed);
     }
 
     private static void RestoreBackup(string modulePath, string? backupPath)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -379,6 +379,7 @@ public sealed partial class ManagedModuleInstallService
         string modulePath)
     {
         var ownsCache = string.IsNullOrWhiteSpace(request.PackageCacheDirectory);
+        var useExtractedPackageCache = !ownsCache && !request.PackageCacheDirectoryIsOperationLocal;
         var cacheDirectory = ownsCache
             ? Path.Combine(Path.GetTempPath(), "PFMM.C", NewShortId())
             : Path.GetFullPath(request.PackageCacheDirectory!.Trim().Trim('"'));
@@ -456,7 +457,7 @@ public sealed partial class ManagedModuleInstallService
             StartDependencyVersionSelectionPrewarm(request, download.Metadata, context, cancellationToken);
             var validationModulePath = stageModulePath;
             ManagedModuleArchiveExtractionResult? extraction = null;
-            if (!ownsCache && !request.Force && !RequiresVerifiedPackage(request))
+            if (useExtractedPackageCache && !request.Force && !RequiresVerifiedPackage(request))
             {
                 directPayloadLease = _extractedPackageCache.TryAcquirePayload(
                     download.PackageSha256,
@@ -478,7 +479,7 @@ public sealed partial class ManagedModuleInstallService
                 }
                 else
 #endif
-                extraction = ownsCache
+                extraction = !useExtractedPackageCache
                     ? _extractor.ExtractPackage(download.PackagePath, stageModulePath, download.Metadata?.Id)
                     : _extractedPackageCache.MaterializePackage(
                         download.PackagePath,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -232,6 +232,7 @@ public sealed partial class ManagedModuleInstallService
             {
                 var result = await InstallResolvedAsync(
                     request,
+                    versionInfo,
                     context,
                     cancellationToken,
                     stopwatch,
@@ -278,6 +279,7 @@ public sealed partial class ManagedModuleInstallService
                         {
                             var result = await InstallResolvedAsync(
                                 request,
+                                versionInfo,
                                 context,
                                 cancellationToken,
                                 stopwatch,
@@ -302,6 +304,7 @@ public sealed partial class ManagedModuleInstallService
 
             return await InstallResolvedAsync(
                 request,
+                versionInfo,
                 context,
                 cancellationToken,
                 stopwatch,
@@ -368,6 +371,7 @@ public sealed partial class ManagedModuleInstallService
 
     private async Task<ManagedModuleInstallResult> InstallResolvedAsync(
         ManagedModuleInstallRequest request,
+        ManagedModuleVersionInfo versionInfo,
         ManagedModuleInstallContext context,
         CancellationToken cancellationToken,
         System.Diagnostics.Stopwatch stopwatch,
@@ -396,6 +400,12 @@ public sealed partial class ManagedModuleInstallService
 
         try
         {
+            StartDependencyVersionSelectionPrewarm(
+                request,
+                CreateRepositoryDependencyHintMetadata(versionInfo),
+                context,
+                cancellationToken);
+
             using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var resolvedLockWaitElapsed))
             {
                 installLockWaitElapsed += resolvedLockWaitElapsed;
@@ -834,8 +844,19 @@ public sealed partial class ManagedModuleInstallService
             IsPrerelease = versionInfo.IsPrerelease,
             Listed = versionInfo.Listed,
             License = metadata.License,
-            RequireLicenseAcceptance = metadata.RequireLicenseAcceptance
+            RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
+            Dependencies = metadata.Dependencies
         };
+
+    private static ManagedModulePackageMetadata? CreateRepositoryDependencyHintMetadata(ManagedModuleVersionInfo versionInfo)
+        => versionInfo.Dependencies is not { Count: > 0 }
+            ? null
+            : new ManagedModulePackageMetadata
+            {
+                Id = versionInfo.Name,
+                Version = versionInfo.Version,
+                Dependencies = versionInfo.Dependencies
+            };
 
     private static bool RequiresExactVersionNormalization(string version)
     {

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -387,6 +387,9 @@ public sealed partial class ManagedModuleInstallService
         var stageRoot = CreateStageRoot(moduleRoot, moduleName);
         var stageModulePath = CreateStageModulePath(stageRoot, moduleName, version);
         ManagedModuleExtractedPackageLease? directPayloadLease = null;
+        CancellationTokenSource? earlyDependencyCancellation = null;
+        Task<IReadOnlyList<ManagedModuleInstallResult>>? earlyDependencyTask = null;
+        System.Diagnostics.Stopwatch? earlyDependencyStopwatch = null;
 #if !NET472
         ManagedModuleBufferedPackage? bufferedPackage = null;
 #endif
@@ -455,6 +458,18 @@ public sealed partial class ManagedModuleInstallService
             ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, download.Metadata, request.TrustPolicy);
             ThrowIfLicenseAcceptanceRequired(download.Metadata, request);
             StartDependencyVersionSelectionPrewarm(request, download.Metadata, context, cancellationToken);
+            if (ShouldStartDependencyInstallBeforeExtraction(request, download.Metadata))
+            {
+                earlyDependencyCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                earlyDependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                earlyDependencyTask = InstallDependenciesAsync(
+                    request,
+                    download.Metadata,
+                    cacheDirectory,
+                    context,
+                    earlyDependencyCancellation.Token);
+            }
+
             var validationModulePath = stageModulePath;
             ManagedModuleArchiveExtractionResult? extraction = null;
             if (useExtractedPackageCache && !request.Force && !RequiresVerifiedPackage(request))
@@ -499,10 +514,24 @@ public sealed partial class ManagedModuleInstallService
             if (!request.AllowClobber)
                 ManagedModuleClobberDetector.ThrowIfConflicts(moduleRoot, request.Name.Trim(), validationModulePath);
 
-            var dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
-            var dependencyResults = request.SkipDependencyCheck
-                ? Array.Empty<ManagedModuleInstallResult>()
-                : await InstallDependenciesAsync(request, download.Metadata, cacheDirectory, context, cancellationToken).ConfigureAwait(false);
+            System.Diagnostics.Stopwatch dependencyStopwatch;
+            IReadOnlyList<ManagedModuleInstallResult> dependencyResults;
+            if (request.SkipDependencyCheck)
+            {
+                dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                dependencyResults = Array.Empty<ManagedModuleInstallResult>();
+            }
+            else if (earlyDependencyTask is not null)
+            {
+                dependencyStopwatch = earlyDependencyStopwatch ?? System.Diagnostics.Stopwatch.StartNew();
+                dependencyResults = await earlyDependencyTask.ConfigureAwait(false);
+            }
+            else
+            {
+                dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                dependencyResults = await InstallDependenciesAsync(request, download.Metadata, cacheDirectory, context, cancellationToken).ConfigureAwait(false);
+            }
+
             dependencyStopwatch.Stop();
 
             var promotionStopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -644,8 +673,26 @@ public sealed partial class ManagedModuleInstallService
             _receiptStore.WriteReceipt(request.Repository, result);
             return result;
         }
+        catch
+        {
+            if (earlyDependencyTask is not null)
+            {
+                earlyDependencyCancellation?.Cancel();
+                try
+                {
+                    await earlyDependencyTask.ConfigureAwait(false);
+                }
+                catch
+                {
+                    // The original package failure remains the actionable error.
+                }
+            }
+
+            throw;
+        }
         finally
         {
+            earlyDependencyCancellation?.Dispose();
 #if !NET472
             bufferedPackage?.Dispose();
 #endif

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -391,9 +391,6 @@ public sealed partial class ManagedModuleInstallService
         var stageRoot = CreateStageRoot(moduleRoot, moduleName);
         var stageModulePath = CreateStageModulePath(stageRoot, moduleName, version);
         ManagedModuleExtractedPackageLease? directPayloadLease = null;
-        CancellationTokenSource? earlyDependencyCancellation = null;
-        Task<IReadOnlyList<ManagedModuleInstallResult>>? earlyDependencyTask = null;
-        System.Diagnostics.Stopwatch? earlyDependencyStopwatch = null;
 #if !NET472
         ManagedModuleBufferedPackage? bufferedPackage = null;
 #endif
@@ -468,17 +465,6 @@ public sealed partial class ManagedModuleInstallService
             ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, download.Metadata, request.TrustPolicy);
             ThrowIfLicenseAcceptanceRequired(download.Metadata, request);
             StartDependencyVersionSelectionPrewarm(request, download.Metadata, context, cancellationToken);
-            if (ShouldStartDependencyInstallBeforeExtraction(request, download.Metadata))
-            {
-                earlyDependencyCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                earlyDependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
-                earlyDependencyTask = InstallDependenciesAsync(
-                    request,
-                    download.Metadata,
-                    cacheDirectory,
-                    context,
-                    earlyDependencyCancellation.Token);
-            }
 
             var validationModulePath = stageModulePath;
             ManagedModuleArchiveExtractionResult? extraction = null;
@@ -531,11 +517,6 @@ public sealed partial class ManagedModuleInstallService
                 dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
                 dependencyResults = Array.Empty<ManagedModuleInstallResult>();
             }
-            else if (earlyDependencyTask is not null)
-            {
-                dependencyStopwatch = earlyDependencyStopwatch ?? System.Diagnostics.Stopwatch.StartNew();
-                dependencyResults = await earlyDependencyTask.ConfigureAwait(false);
-            }
             else
             {
                 dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -571,7 +552,7 @@ public sealed partial class ManagedModuleInstallService
                     ManagedModuleClobberDetector.ThrowIfConflicts(moduleRoot, request.Name.Trim(), stageModulePath);
             }
 
-            using (AcquirePromotionLock(moduleRoot, request.AllowClobber, cancellationToken, out var promotionGateWaitElapsed))
+            using (AcquirePromotionLock(moduleRoot, cancellationToken, out var promotionGateWaitElapsed))
             {
                 promotionLockWaitElapsed += promotionGateWaitElapsed;
                 installLockWaitElapsed += promotionGateWaitElapsed;
@@ -683,26 +664,8 @@ public sealed partial class ManagedModuleInstallService
             _receiptStore.WriteReceipt(request.Repository, result);
             return result;
         }
-        catch
-        {
-            if (earlyDependencyTask is not null)
-            {
-                earlyDependencyCancellation?.Cancel();
-                try
-                {
-                    await earlyDependencyTask.ConfigureAwait(false);
-                }
-                catch
-                {
-                    // The original package failure remains the actionable error.
-                }
-            }
-
-            throw;
-        }
         finally
         {
-            earlyDependencyCancellation?.Dispose();
 #if !NET472
             bufferedPackage?.Dispose();
 #endif

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -479,14 +479,15 @@ public sealed partial class ManagedModuleInstallService
                 else
 #endif
                 extraction = ownsCache
-                    ? _extractor.ExtractPackage(download.PackagePath, stageModulePath)
+                    ? _extractor.ExtractPackage(download.PackagePath, stageModulePath, download.Metadata?.Id)
                     : _extractedPackageCache.MaterializePackage(
                         download.PackagePath,
                         download.PackageSha256,
                         cacheDirectory,
                         stageModulePath,
                         _extractor,
-                        cancellationToken);
+                        cancellationToken,
+                        download.Metadata?.Id);
             }
 
             var authenticode = request.AuthenticodeCheck
@@ -522,7 +523,8 @@ public sealed partial class ManagedModuleInstallService
                     cacheDirectory,
                     stageModulePath,
                     _extractor,
-                    cancellationToken);
+                    cancellationToken,
+                    download.Metadata?.Id);
                 if (request.AuthenticodeCheck)
                     authenticode = _authenticodeVerifier.VerifyDirectory(stageModulePath);
                 if (!request.AllowClobber)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -529,7 +529,7 @@ public sealed partial class ManagedModuleInstallService
                     ManagedModuleClobberDetector.ThrowIfConflicts(moduleRoot, request.Name.Trim(), stageModulePath);
             }
 
-            using (AcquireInstallLock(moduleRoot, ".promotion", cancellationToken, out var promotionGateWaitElapsed))
+            using (AcquirePromotionLock(moduleRoot, request.AllowClobber, cancellationToken, out var promotionGateWaitElapsed))
             {
                 promotionLockWaitElapsed += promotionGateWaitElapsed;
                 installLockWaitElapsed += promotionGateWaitElapsed;

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -400,17 +400,6 @@ public sealed partial class ManagedModuleInstallService
 
         try
         {
-            StartDependencyVersionSelectionPrewarm(
-                request,
-                CreateRepositoryDependencyHintMetadata(versionInfo),
-                context,
-                cancellationToken);
-            StartDependencyPackagePrefetch(
-                request,
-                CreateRepositoryDependencyHintMetadata(versionInfo),
-                context,
-                cancellationToken);
-
             using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var resolvedLockWaitElapsed))
             {
                 installLockWaitElapsed += resolvedLockWaitElapsed;
@@ -431,6 +420,18 @@ public sealed partial class ManagedModuleInstallService
                         installLockWaitElapsed);
                 }
             }
+
+            var repositoryDependencyHintMetadata = CreateRepositoryDependencyHintMetadata(versionInfo);
+            StartDependencyVersionSelectionPrewarm(
+                request,
+                repositoryDependencyHintMetadata,
+                context,
+                cancellationToken);
+            StartDependencyPackagePrefetch(
+                request,
+                repositoryDependencyHintMetadata,
+                context,
+                cancellationToken);
 
             var downloadStopwatch = System.Diagnostics.Stopwatch.StartNew();
             ManagedModuleDownloadResult download;

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -39,7 +39,10 @@ public sealed partial class ManagedModuleInstallService
     public async Task<ManagedModuleInstallResult> InstallAsync(
         ManagedModuleInstallRequest request,
         CancellationToken cancellationToken = default)
-        => await InstallAsync(request, new ManagedModuleInstallContext(), cancellationToken).ConfigureAwait(false);
+    {
+        using var context = new ManagedModuleInstallContext();
+        return await InstallAsync(request, context, cancellationToken).ConfigureAwait(false);
+    }
 
     /// <summary>
     /// Creates a non-mutating install plan for the requested module.
@@ -402,6 +405,11 @@ public sealed partial class ManagedModuleInstallService
                 CreateRepositoryDependencyHintMetadata(versionInfo),
                 context,
                 cancellationToken);
+            StartDependencyPackagePrefetch(
+                request,
+                CreateRepositoryDependencyHintMetadata(versionInfo),
+                context,
+                cancellationToken);
 
             using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var resolvedLockWaitElapsed))
             {
@@ -435,7 +443,7 @@ public sealed partial class ManagedModuleInstallService
                 {
                     try
                     {
-                        bufferedPackage = await DownloadBufferedPackageForInstallAsync(request, version, cancellationToken).ConfigureAwait(false);
+                        bufferedPackage = await DownloadBufferedPackageForInstallAsync(request, version, context, cancellationToken).ConfigureAwait(false);
                     }
                     catch (ManagedModuleBufferedPackageTooLargeException ex)
                     {
@@ -458,6 +466,14 @@ public sealed partial class ManagedModuleInstallService
                     cancellationToken).ConfigureAwait(false);
                 packageRepositoryRequestCount = packageRequestScope.Count;
                 packageRepositoryRedirectCount = packageRequestScope.RedirectCount;
+#if !NET472
+                if (packageRepositoryRequestCount == 0 && bufferedPackage is not null)
+                    packageRepositoryRequestCount = bufferedPackage.Download.RequestCount;
+                if (packageRepositoryRequestCount == 0 && bufferedPackage is not null && !bufferedPackage.Download.FromCache)
+                    packageRepositoryRequestCount = 1;
+                if (packageRepositoryRedirectCount == 0 && bufferedPackage is not null)
+                    packageRepositoryRedirectCount = bufferedPackage.Download.RedirectCount;
+#endif
             }
 
             downloadStopwatch.Stop();
@@ -465,6 +481,7 @@ public sealed partial class ManagedModuleInstallService
             ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, download.Metadata, request.TrustPolicy);
             ThrowIfLicenseAcceptanceRequired(download.Metadata, request);
             StartDependencyVersionSelectionPrewarm(request, download.Metadata, context, cancellationToken);
+            StartDependencyPackagePrefetch(request, download.Metadata, context, cancellationToken);
 
             var validationModulePath = stageModulePath;
             ManagedModuleArchiveExtractionResult? extraction = null;
@@ -655,7 +672,7 @@ public sealed partial class ManagedModuleInstallService
                 PromotionBackupCleanupElapsed = promotionBackupCleanupElapsed,
                 PromotionMaterializedDirectly = promotionMaterializedDirectly,
                 PromotionDirectMaterializationElapsed = promotionDirectMaterializationElapsed,
-                RepositoryRequestCount = requestScope.Count,
+                RepositoryRequestCount = Math.Max(requestScope.Count, packageRepositoryRequestCount),
                 PackageRepositoryRequestCount = packageRepositoryRequestCount,
                 PackageRepositoryRedirectCount = packageRepositoryRedirectCount,
                 DependencyResults = dependencyResults

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
@@ -54,11 +54,13 @@ public sealed partial class ManagedModuleRepositoryClient
         CancellationToken cancellationToken,
         Func<CancellationToken, Task<T>> factory)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var lazy = tasks.GetOrAdd(
             key,
             _ => new Lazy<Task<T>>(
                 () => factory(CancellationToken.None),
                 LazyThreadSafetyMode.ExecutionAndPublication));
+        cancellationToken.ThrowIfCancellationRequested();
         var sharedTask = lazy.Value;
         _ = sharedTask.ContinueWith(
             _ => ((ICollection<KeyValuePair<string, Lazy<Task<T>>>>)tasks)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
@@ -11,12 +11,12 @@ public sealed partial class ManagedModuleRepositoryClient
         bool includePrerelease,
         RepositoryCredential? credential,
         CancellationToken cancellationToken,
-        Func<Task<IReadOnlyList<ManagedModuleVersionInfo>>> factory)
+        Func<CancellationToken, Task<IReadOnlyList<ManagedModuleVersionInfo>>> factory)
     {
         var key = BuildCoalescedQueryKey("versions", repository, packageId, includePrerelease, take: null, credential, cancellationToken);
         return key is null
-            ? factory()
-            : ExecuteCoalescedAsync(_versionQueryTasks, key, factory);
+            ? factory(cancellationToken)
+            : ExecuteCoalescedAsync(_versionQueryTasks, key, cancellationToken, factory);
     }
 
     private Task<ManagedModuleVersionInfo?> ExecuteCoalescedLatestVersionQueryAsync(
@@ -25,12 +25,12 @@ public sealed partial class ManagedModuleRepositoryClient
         bool includePrerelease,
         RepositoryCredential? credential,
         CancellationToken cancellationToken,
-        Func<Task<ManagedModuleVersionInfo?>> factory)
+        Func<CancellationToken, Task<ManagedModuleVersionInfo?>> factory)
     {
         var key = BuildCoalescedQueryKey("latest", repository, packageId, includePrerelease, take: null, credential, cancellationToken);
         return key is null
-            ? factory()
-            : ExecuteCoalescedAsync(_latestVersionQueryTasks, key, factory);
+            ? factory(cancellationToken)
+            : ExecuteCoalescedAsync(_latestVersionQueryTasks, key, cancellationToken, factory);
     }
 
     private Task<IReadOnlyList<ManagedModuleVersionInfo>> ExecuteCoalescedSearchQueryAsync(
@@ -40,31 +40,50 @@ public sealed partial class ManagedModuleRepositoryClient
         int take,
         RepositoryCredential? credential,
         CancellationToken cancellationToken,
-        Func<Task<IReadOnlyList<ManagedModuleVersionInfo>>> factory)
+        Func<CancellationToken, Task<IReadOnlyList<ManagedModuleVersionInfo>>> factory)
     {
         var key = BuildCoalescedQueryKey("search", repository, query, includePrerelease, take, credential, cancellationToken);
         return key is null
-            ? factory()
-            : ExecuteCoalescedAsync(_searchQueryTasks, key, factory);
+            ? factory(cancellationToken)
+            : ExecuteCoalescedAsync(_searchQueryTasks, key, cancellationToken, factory);
     }
 
     private static async Task<T> ExecuteCoalescedAsync<T>(
         ConcurrentDictionary<string, Lazy<Task<T>>> tasks,
         string key,
-        Func<Task<T>> factory)
+        CancellationToken cancellationToken,
+        Func<CancellationToken, Task<T>> factory)
     {
         var lazy = tasks.GetOrAdd(
             key,
-            _ => new Lazy<Task<T>>(factory, LazyThreadSafetyMode.ExecutionAndPublication));
-        try
-        {
-            return await lazy.Value.ConfigureAwait(false);
-        }
-        finally
-        {
-            ((ICollection<KeyValuePair<string, Lazy<Task<T>>>>)tasks)
-                .Remove(new KeyValuePair<string, Lazy<Task<T>>>(key, lazy));
-        }
+            _ => new Lazy<Task<T>>(
+                () => factory(CancellationToken.None),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        var sharedTask = lazy.Value;
+        _ = sharedTask.ContinueWith(
+            _ => ((ICollection<KeyValuePair<string, Lazy<Task<T>>>>)tasks)
+                .Remove(new KeyValuePair<string, Lazy<Task<T>>>(key, lazy)),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return await WaitForSharedTaskAsync(sharedTask, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<T> WaitForSharedTaskAsync<T>(Task<T> task, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+            return await task.ConfigureAwait(false);
+
+        var canceled = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(
+            static state => ((TaskCompletionSource<object?>)state!).TrySetResult(null),
+            canceled);
+        var completed = await Task.WhenAny(task, canceled.Task).ConfigureAwait(false);
+        if (!ReferenceEquals(completed, task))
+            throw new OperationCanceledException(cancellationToken);
+
+        return await task.ConfigureAwait(false);
     }
 
     private static string? BuildCoalescedQueryKey(

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
@@ -76,7 +76,7 @@ public sealed partial class ManagedModuleRepositoryClient
         RepositoryCredential? credential,
         CancellationToken cancellationToken)
     {
-        if (credential is not null || cancellationToken.CanBeCanceled)
+        if (credential is not null)
             return null;
 
         return string.Join(

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Download.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Download.cs
@@ -190,6 +190,7 @@ public sealed partial class ManagedModuleRepositoryClient
                     source,
                     _options.MaxPackageBytes,
                     MaximumBufferedPackageBytes,
+                    contentLength,
                     packageId,
                     version,
                     cancellationToken)
@@ -216,13 +217,14 @@ public sealed partial class ManagedModuleRepositoryClient
         Stream source,
         long maxPackageBytes,
         long maxBufferedBytes,
+        long? expectedBytes,
         string packageId,
         string version,
         CancellationToken cancellationToken)
     {
         using var sha256 = SHA256.Create();
         var buffer = new byte[PackageCopyBufferSize];
-        var destination = new MemoryStream();
+        var destination = CreateBufferedPackageStream(expectedBytes, maxPackageBytes, maxBufferedBytes);
         long bytesWritten = 0;
 
         try
@@ -270,6 +272,23 @@ public sealed partial class ManagedModuleRepositoryClient
         {
             // Best effort cleanup after refusing an oversized package payload.
         }
+    }
+
+    private static MemoryStream CreateBufferedPackageStream(
+        long? expectedBytes,
+        long maxPackageBytes,
+        long maxBufferedBytes)
+    {
+        if (!expectedBytes.HasValue || expectedBytes.Value <= 0)
+            return new MemoryStream();
+        if (maxPackageBytes > 0 && expectedBytes.Value > maxPackageBytes)
+            return new MemoryStream();
+        if (maxBufferedBytes > 0 && expectedBytes.Value > maxBufferedBytes)
+            return new MemoryStream();
+        if (expectedBytes.Value > int.MaxValue)
+            return new MemoryStream();
+
+        return new MemoryStream((int)expectedBytes.Value);
     }
 
     private static string FormatSha256(byte[]? hash)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Http.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Http.cs
@@ -10,7 +10,7 @@ public sealed partial class ManagedModuleRepositoryClient
         var client = new HttpClient(CreateDefaultHttpMessageHandler(options));
 #if !NET472
         client.DefaultRequestVersion = HttpVersion.Version20;
-        client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+        client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
 #endif
         return client;
     }
@@ -35,6 +35,7 @@ public sealed partial class ManagedModuleRepositoryClient
         var handler = new SocketsHttpHandler
         {
             UseProxy = options.UseProxy,
+            AllowAutoRedirect = false,
             AutomaticDecompression = decompression,
             MaxConnectionsPerServer = Math.Max(1, options.MaxConnectionsPerServer),
             EnableMultipleHttp2Connections = true,

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Http.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Http.cs
@@ -176,7 +176,13 @@ public sealed partial class ManagedModuleRepositoryClient
 
     private static HttpRequestMessage CreateRedirectRequest(HttpRequestMessage source, Uri redirectUri)
     {
-        var request = new HttpRequestMessage(source.Method, redirectUri);
+        var request = new HttpRequestMessage(source.Method, redirectUri)
+        {
+            Version = source.Version
+        };
+#if !NET472
+        request.VersionPolicy = source.VersionPolicy;
+#endif
         foreach (var header in source.Headers.Accept)
             request.Headers.Accept.Add(header);
         foreach (var header in source.Headers.UserAgent)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Http.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Http.cs
@@ -5,12 +5,51 @@ namespace PowerForge;
 
 public sealed partial class ManagedModuleRepositoryClient
 {
+    internal static HttpClient CreateDefaultHttpClient(ManagedModuleRepositoryClientOptions options)
+    {
+        var client = new HttpClient(CreateDefaultHttpMessageHandler(options));
+#if !NET472
+        client.DefaultRequestVersion = HttpVersion.Version20;
+        client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+        return client;
+    }
+
     internal static HttpMessageHandler CreateDefaultHttpMessageHandler(ManagedModuleRepositoryClientOptions options)
     {
         var decompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
 #if !NET472
         decompression |= DecompressionMethods.Brotli;
+        return CreateSocketsHttpMessageHandler(options, decompression);
+#else
+        return CreateLegacyHttpMessageHandler(options, decompression);
 #endif
+    }
+
+#if !NET472
+    private static HttpMessageHandler CreateSocketsHttpMessageHandler(
+        ManagedModuleRepositoryClientOptions options,
+        DecompressionMethods decompression)
+    {
+        AppContext.SetSwitch("System.Net.SocketsHttpHandler.Http3Support", true);
+        var handler = new SocketsHttpHandler
+        {
+            UseProxy = options.UseProxy,
+            AutomaticDecompression = decompression,
+            MaxConnectionsPerServer = Math.Max(1, options.MaxConnectionsPerServer),
+            EnableMultipleHttp2Connections = true,
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            InitialHttp2StreamWindowSize = 16 * 1024 * 1024
+        };
+        ConfigureProxy(handler, options);
+        return handler;
+    }
+#endif
+
+    private static HttpMessageHandler CreateLegacyHttpMessageHandler(
+        ManagedModuleRepositoryClientOptions options,
+        DecompressionMethods decompression)
+    {
         var handler = new HttpClientHandler
         {
             UseProxy = options.UseProxy,
@@ -18,15 +57,40 @@ public sealed partial class ManagedModuleRepositoryClient
             AutomaticDecompression = decompression,
             MaxConnectionsPerServer = Math.Max(1, options.MaxConnectionsPerServer)
         };
+        ConfigureProxy(handler, options);
+        return handler;
+    }
+
+    private static WebProxy? CreateProxy(ManagedModuleRepositoryClientOptions options)
+    {
         if (!options.UseProxy || options.ProxyAddress is null)
-            return handler;
+            return null;
 
         var proxy = new WebProxy(options.ProxyAddress, options.BypassProxyOnLocal);
         if (options.ProxyCredential is not null)
             proxy.Credentials = ToNetworkCredential(options.ProxyCredential);
 
+        return proxy;
+    }
+
+#if !NET472
+    private static void ConfigureProxy(SocketsHttpHandler handler, ManagedModuleRepositoryClientOptions options)
+    {
+        var proxy = CreateProxy(options);
+        if (proxy is null)
+            return;
+
         handler.Proxy = proxy;
-        return handler;
+    }
+#endif
+
+    private static void ConfigureProxy(HttpClientHandler handler, ManagedModuleRepositoryClientOptions options)
+    {
+        var proxy = CreateProxy(options);
+        if (proxy is null)
+            return;
+
+        handler.Proxy = proxy;
     }
 
     private async Task<HttpResponseMessage> SendWithPolicyAsync(

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
@@ -257,6 +257,7 @@ public sealed partial class ManagedModuleRepositoryClient
         var trimmedVersion = version!.Trim();
         var license = ReadNuGetV2String(entry, data, "LicenseExpression") ??
                       ReadNuGetV2String(entry, data, "LicenseUrl");
+        var dependencies = ReadNuGetV2Dependencies(entry, data);
         return new ManagedModuleVersionInfo
         {
             Name = trimmedId,
@@ -267,7 +268,8 @@ public sealed partial class ManagedModuleRepositoryClient
             IsPrerelease = ManagedModuleVersionComparer.IsPrerelease(trimmedVersion),
             Listed = ReadNuGetV2Listed(entry, data),
             License = license,
-            RequireLicenseAcceptance = ReadNuGetV2Boolean(entry, data, "RequireLicenseAcceptance")
+            RequireLicenseAcceptance = ReadNuGetV2Boolean(entry, data, "RequireLicenseAcceptance"),
+            Dependencies = dependencies
         };
     }
 
@@ -284,6 +286,30 @@ public sealed partial class ManagedModuleRepositoryClient
     {
         var value = ReadNuGetV2String(entry, data, "Listed");
         return !bool.TryParse(value, out var parsed) || parsed;
+    }
+
+    private static IReadOnlyList<ManagedModuleDependencyInfo> ReadNuGetV2Dependencies(XElement entry, XNamespace data)
+    {
+        var value = ReadNuGetV2String(entry, data, "Dependencies");
+        if (string.IsNullOrWhiteSpace(value))
+            return Array.Empty<ManagedModuleDependencyInfo>();
+
+        var dependencies = new List<ManagedModuleDependencyInfo>();
+        foreach (var dependencyText in value!.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = dependencyText.Split(new[] { ':' }, 3);
+            if (parts.Length == 0 || string.IsNullOrWhiteSpace(parts[0]))
+                continue;
+
+            dependencies.Add(new ManagedModuleDependencyInfo
+            {
+                Id = parts[0].Trim(),
+                VersionRange = parts.Length > 1 && !string.IsNullOrWhiteSpace(parts[1]) ? parts[1].Trim() : null,
+                TargetFramework = parts.Length > 2 && !string.IsNullOrWhiteSpace(parts[2]) ? parts[2].Trim() : null
+            });
+        }
+
+        return dependencies.Count == 0 ? Array.Empty<ManagedModuleDependencyInfo>() : dependencies;
     }
 
     private static Uri BuildNuGetV2PackageUri(string source, string packageId, string version)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -482,7 +482,8 @@ public sealed partial class ManagedModuleRepositoryClient
                 PackageSource = file,
                 IsPrerelease = metadata.IsPrerelease,
                 License = metadata.License,
-                RequireLicenseAcceptance = metadata.RequireLicenseAcceptance
+                RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
+                Dependencies = metadata.Dependencies
             });
         }
 
@@ -1081,8 +1082,42 @@ public sealed partial class ManagedModuleRepositoryClient
             Listed = !item.TryGetProperty("listed", out var listedElement) || listedElement.ValueKind != JsonValueKind.False,
             License = ReadOptionalString(item, "licenseExpression") ??
                       ReadOptionalString(item, "licenseUrl"),
-            RequireLicenseAcceptance = ReadOptionalBoolean(item, "requireLicenseAcceptance")
+            RequireLicenseAcceptance = ReadOptionalBoolean(item, "requireLicenseAcceptance"),
+            Dependencies = ReadSearchDependencies(item)
         };
+    }
+
+    private static IReadOnlyList<ManagedModuleDependencyInfo> ReadSearchDependencies(JsonElement item)
+    {
+        if (!item.TryGetProperty("dependencyGroups", out var groups) || groups.ValueKind != JsonValueKind.Array)
+            return Array.Empty<ManagedModuleDependencyInfo>();
+
+        var dependencies = new List<ManagedModuleDependencyInfo>();
+        foreach (var group in groups.EnumerateArray())
+        {
+            var targetFramework = ReadOptionalString(group, "targetFramework");
+            if (!group.TryGetProperty("dependencies", out var dependencyItems) ||
+                dependencyItems.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var dependency in dependencyItems.EnumerateArray())
+            {
+                var id = ReadOptionalString(dependency, "id");
+                if (string.IsNullOrWhiteSpace(id))
+                    continue;
+
+                dependencies.Add(new ManagedModuleDependencyInfo
+                {
+                    Id = id!,
+                    VersionRange = ReadOptionalString(dependency, "range"),
+                    TargetFramework = targetFramework
+                });
+            }
+        }
+
+        return dependencies.Count == 0 ? Array.Empty<ManagedModuleDependencyInfo>() : dependencies;
     }
 
     private static string? ReadSearchVersion(JsonElement item)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -230,6 +230,7 @@ public sealed partial class ManagedModuleRepositoryClient
                 ManagedModuleRepositoryKind.NuGetV2 => await DownloadNuGetV2PackageAsync(repository, packageId, version, destinationDirectory, credential, cancellationToken).ConfigureAwait(false),
                 _ => throw new NotSupportedException($"Repository kind '{repository.Kind}' is not supported.")
             };
+            result.RequestCount = downloadRequestScope.Count;
             result.RedirectCount = downloadRequestScope.RedirectCount;
             return result;
         }

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -43,7 +43,7 @@ public sealed partial class ManagedModuleRepositoryClient
     {
         _logger = logger ?? new NullLogger();
         _options = options ?? new ManagedModuleRepositoryClientOptions();
-        _httpClient = httpClient ?? new HttpClient(CreateDefaultHttpMessageHandler(_options));
+        _httpClient = httpClient ?? CreateDefaultHttpClient(_options);
         _packageReader = packageReader ?? new ManagedModulePackageReader();
     }
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -82,14 +82,14 @@ public sealed partial class ManagedModuleRepositoryClient
                 includePrerelease,
                 credential,
                 cancellationToken,
-                () => GetNuGetVersionsWithPowerShellGalleryReadApiAsync(repository, packageId, includePrerelease, credential, cancellationToken)).ConfigureAwait(false),
+                token => GetNuGetVersionsWithPowerShellGalleryReadApiAsync(repository, packageId, includePrerelease, credential, token)).ConfigureAwait(false),
             ManagedModuleRepositoryKind.NuGetV2 => await ExecuteCoalescedVersionQueryAsync(
                 repository,
                 packageId,
                 includePrerelease,
                 credential,
                 cancellationToken,
-                () => GetNuGetV2VersionsAsync(repository, packageId, includePrerelease, credential, cancellationToken)).ConfigureAwait(false),
+                token => GetNuGetV2VersionsAsync(repository, packageId, includePrerelease, credential, token)).ConfigureAwait(false),
             _ => throw new NotSupportedException($"Repository kind '{repository.Kind}' is not supported.")
         };
     }
@@ -124,14 +124,14 @@ public sealed partial class ManagedModuleRepositoryClient
                 includePrerelease,
                 credential,
                 cancellationToken,
-                () => GetLatestNuGetVersionWithPowerShellGalleryReadApiAsync(repository, packageId, includePrerelease, credential, cancellationToken)).ConfigureAwait(false),
+                token => GetLatestNuGetVersionWithPowerShellGalleryReadApiAsync(repository, packageId, includePrerelease, credential, token)).ConfigureAwait(false),
             ManagedModuleRepositoryKind.NuGetV2 => await ExecuteCoalescedLatestVersionQueryAsync(
                 repository,
                 packageId,
                 includePrerelease,
                 credential,
                 cancellationToken,
-                () => GetLatestNuGetV2VersionAsync(repository, packageId, includePrerelease, credential, cancellationToken)).ConfigureAwait(false),
+                token => GetLatestNuGetV2VersionAsync(repository, packageId, includePrerelease, credential, token)).ConfigureAwait(false),
             _ => throw new NotSupportedException($"Repository kind '{repository.Kind}' is not supported.")
         };
     }
@@ -169,7 +169,7 @@ public sealed partial class ManagedModuleRepositoryClient
                 take,
                 credential,
                 cancellationToken,
-                () => SearchNuGetPackagesWithPowerShellGalleryReadApiAsync(repository, query, includePrerelease, credential, take, cancellationToken)).ConfigureAwait(false),
+                token => SearchNuGetPackagesWithPowerShellGalleryReadApiAsync(repository, query, includePrerelease, credential, take, token)).ConfigureAwait(false),
             ManagedModuleRepositoryKind.NuGetV2 => await ExecuteCoalescedSearchQueryAsync(
                 repository,
                 query,
@@ -177,7 +177,7 @@ public sealed partial class ManagedModuleRepositoryClient
                 take,
                 credential,
                 cancellationToken,
-                () => SearchNuGetV2PackagesAsync(repository, query, includePrerelease, credential, take, cancellationToken)).ConfigureAwait(false),
+                token => SearchNuGetV2PackagesAsync(repository, query, includePrerelease, credential, take, token)).ConfigureAwait(false),
             _ => throw new NotSupportedException($"Repository kind '{repository.Kind}' is not supported.")
         };
     }

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
@@ -974,6 +975,10 @@ public sealed partial class ManagedModuleRepositoryClient
     private static HttpRequestMessage CreateRequest(HttpMethod method, Uri uri, RepositoryCredential? credential, string accept)
     {
         var request = new HttpRequestMessage(method, uri);
+#if !NET472
+        request.Version = HttpVersion.Version20;
+        request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+#endif
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
         request.Headers.UserAgent.ParseAdd("PowerForge-ManagedModule/1.0");
         ApplyCredential(request, credential);

--- a/README.MD
+++ b/README.MD
@@ -415,56 +415,32 @@ importing the small CSV result, and deleting the account/profile afterward. Use
 `-SkipTemporaryUserNativeInstall` only when a machine cannot create a temporary
 local benchmark account.
 
-The full table below was refreshed on July 1, 2026 from one complete public
-PowerShell Gallery matrix run on PowerShell 7 and Windows PowerShell 5.1.
-Managed is fastest in 24 of 30 scenario/host/operation groups. Provider-backed
-rows can still be noisy because they use the live public gallery path; when
-repeated rows exist, the README updater writes the median timing for that
-scenario/tool row. While optimizing install throughput, prefer refreshing the
-focused Managed-vs-ModuleFast rows instead of re-running the native-provider
-10x/30x cases unless a fresh compatibility baseline is needed.
+The focused table below was refreshed on July 1, 2026 from the active
+development comparison: the managed C# engine from this worktree against the
+refreshed C# ModuleFast branch at commit `fa2f2d0`. Managed uses the official
+PowerShell Gallery package path, while ModuleFast is passed
+`https://pwsh.gallery/index.json`. That makes this the current install
+throughput race, not a PSResourceGet/PowerShellGet provider baseline.
+Provider-backed rows are intentionally omitted from the normal tuning loop now
+because those 10x/30x cases are already understood and make iteration much
+slower. Re-run the `Full` profile only when a fresh compatibility baseline is
+needed.
 
 <!-- managed-module-benchmark-table:start -->
-| Scenario | Host | Operation | Managed | ModuleFast | PSResourceGet | PowerShellGet | Result |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Az.Accounts | PowerShell 7 | Find | 1.00x (0.22s) | NotEquivalent | 1.18x (0.26s) | 3.65x (0.80s) | Managed fastest |
-| Az.Accounts | PowerShell 7 | Install | 1.00x (0.43s) | 2.04x (0.88s) | 2.76x (1.18s) | 7.28x (3.12s) | Managed fastest |
-| Az.Accounts | PowerShell 7 | Save | 1.00x (0.45s) | NotEquivalent | 10.07x (4.49s) | 22.70x (10.13s) | Managed fastest |
-| Az.Accounts | Windows PowerShell 5.1 | Find | 1.00x (0.34s) | NotEquivalent | 1.17x (0.40s) | 3.00x (1.03s) | Managed fastest |
-| Az.Accounts | Windows PowerShell 5.1 | Install | 1.00x (0.55s) | NotAvailable | 6.64x (3.63s) | 6.29x (3.44s) | Managed fastest |
-| Az.Accounts | Windows PowerShell 5.1 | Save | 1.00x (0.99s) | NotEquivalent | 1.61x (1.60s) | 4.15x (4.13s) | Managed fastest |
-| Az | PowerShell 7 | Find | 1.00x (0.41s) | NotEquivalent | 2.30x (0.95s) | 4.71x (1.94s) | Managed fastest |
-| Az | PowerShell 7 | Install | 1.00x (3.69s) | Failed | 32.37x (119.52s) | 35.93x (132.65s) | Managed fastest |
-| Az | PowerShell 7 | Save | 1.00x (3.89s) | NotEquivalent | 144.35x (562.08s) | 174.60x (679.91s) | Managed fastest |
-| Az | Windows PowerShell 5.1 | Find | 1.00x (0.35s) | NotEquivalent | 1.18x (0.42s) | 5.78x (2.05s) | Managed fastest |
-| Az | Windows PowerShell 5.1 | Install | 1.00x (5.49s) | NotAvailable | 52.89x (290.31s) | 28.24x (155.02s) | Managed fastest |
-| Az | Windows PowerShell 5.1 | Save | 1.00x (7.03s) | NotEquivalent | 23.13x (162.58s) | 114.76x (806.50s) | Managed fastest |
-| Graph.Authentication | PowerShell 7 | Find | 1.00x (0.21s) | NotEquivalent | 15.15x (3.20s) | 3.38x (0.71s) | Managed fastest |
-| Graph.Authentication | PowerShell 7 | Install | 1.00x (4.14s) | 0.30x (1.23s) | 1.04x (4.30s) | 0.94x (3.91s) | Managed slower than ModuleFast |
-| Graph.Authentication | PowerShell 7 | Save | 1.00x (0.41s) | NotEquivalent | 28.33x (11.53s) | 55.26x (22.49s) | Managed fastest |
-| Graph.Authentication | Windows PowerShell 5.1 | Find | 1.00x (1.21s) | NotEquivalent | 0.25x (0.30s) | 0.50x (0.60s) | Managed slower than PSResourceGet |
-| Graph.Authentication | Windows PowerShell 5.1 | Install | 1.00x (0.53s) | NotAvailable | 6.26x (3.33s) | 9.88x (5.25s) | Managed fastest |
-| Graph.Authentication | Windows PowerShell 5.1 | Save | 1.00x (1.50s) | NotEquivalent | 0.94x (1.41s) | 2.17x (3.25s) | Managed slower than PSResourceGet |
-| Graph | PowerShell 7 | Find | 1.00x (0.34s) | NotEquivalent | 5.10x (1.74s) | 2.73x (0.93s) | Managed fastest |
-| Graph | PowerShell 7 | Install | 1.00x (9.79s) | 0.97x (9.48s) | 10.88x (106.51s) | 7.33x (71.71s) | Managed slower than ModuleFast |
-| Graph | PowerShell 7 | Save | 1.00x (6.76s) | NotEquivalent | 47.63x (321.93s) | 39.52x (267.09s) | Managed fastest |
-| Graph | Windows PowerShell 5.1 | Find | 1.00x (0.23s) | NotEquivalent | 1.20x (0.27s) | 3.39x (0.77s) | Managed fastest |
-| Graph | Windows PowerShell 5.1 | Install | 1.00x (9.07s) | NotAvailable | 25.49x (231.36s) | 9.85x (89.35s) | Managed fastest |
-| Graph | Windows PowerShell 5.1 | Save | 1.00x (6.46s) | NotEquivalent | 7.90x (50.98s) | 10.28x (66.38s) | Managed fastest |
-| PSScriptAnalyzer | PowerShell 7 | Find | 1.00x (8.32s) | NotEquivalent | 0.13x (1.08s) | 0.52x (4.35s) | Managed slower than PSResourceGet |
-| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (3.91s) | 1.47x (5.76s) | 1.35x (5.28s) | 1.62x (6.34s) | Managed fastest |
-| PSScriptAnalyzer | PowerShell 7 | Save | 1.00x (0.69s) | NotEquivalent | 81.41x (56.25s) | 18.88x (13.04s) | Managed fastest |
-| PSScriptAnalyzer | Windows PowerShell 5.1 | Find | 1.00x (0.28s) | NotEquivalent | 1.80x (0.49s) | 9.52x (2.62s) | Managed fastest |
-| PSScriptAnalyzer | Windows PowerShell 5.1 | Install | 1.00x (1.34s) | NotAvailable | 3.74x (5.02s) | 46.35x (62.21s) | Managed fastest |
-| PSScriptAnalyzer | Windows PowerShell 5.1 | Save | 1.00x (3.40s) | NotEquivalent | 0.70x (2.39s) | 1.10x (3.75s) | Managed slower than PSResourceGet |
+| Scenario | Host | Operation | Managed | ModuleFast | Result |
+| --- | --- | --- | --- | --- | --- |
+| Az.Accounts | PowerShell 7 | Install | 1.00x (0.76s) | 1.59x (1.20s) | Managed fastest |
+| Az | PowerShell 7 | Install | 1.00x (5.87s) | Failed | Managed only successful |
+| Graph.Authentication | PowerShell 7 | Install | 1.00x (0.45s) | 1.96x (0.89s) | Managed fastest |
+| Graph | PowerShell 7 | Install | 1.00x (5.38s) | 0.73x (3.93s) | Managed slower than ModuleFast |
+| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (1.71s) | 0.91x (1.56s) | Managed slower than ModuleFast |
 <!-- managed-module-benchmark-table:end -->
 
 Refresh the table with:
 
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost WindowsPowerShell -RepeatCount 1 -Append
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Update-ManagedModuleBenchmarkReadme.ps1 -ResultPath .\Ignore\Benchmarks\ManagedModules\managed-module-benchmark.csv
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Invoke-ManagedModuleBenchmarkMatrix.ps1 -BenchmarkHost PowerShell7 -RepeatCount 1 -ModuleFastModulePath .\Ignore\External\ModuleFast-csharp\ModuleFast.psd1 -OutputPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast-dev.csv -OutputRoot .\Ignore\Benchmarks\ManagedModules\ManagedVsModuleFastDev
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\ManagedModules\Update-ManagedModuleBenchmarkReadme.ps1 -ResultPath .\Ignore\Benchmarks\ManagedModules\managed-vs-modulefast-dev.csv
 ```
 
 Native `Install-Module` and `Install-PSResource` install into the user module

--- a/README.MD
+++ b/README.MD
@@ -429,11 +429,11 @@ needed.
 <!-- managed-module-benchmark-table:start -->
 | Scenario | Host | Operation | Managed | ModuleFast | Result |
 | --- | --- | --- | --- | --- | --- |
-| Az.Accounts | PowerShell 7 | Install | 1.00x (0.76s) | 1.59x (1.20s) | Managed fastest |
-| Az | PowerShell 7 | Install | 1.00x (5.87s) | Failed | Managed only successful |
-| Graph.Authentication | PowerShell 7 | Install | 1.00x (0.45s) | 1.96x (0.89s) | Managed fastest |
-| Graph | PowerShell 7 | Install | 1.00x (5.38s) | 0.73x (3.93s) | Managed slower than ModuleFast |
-| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (1.71s) | 0.91x (1.56s) | Managed slower than ModuleFast |
+| Az.Accounts | PowerShell 7 | Install | 1.00x (0.61s) | 1.24x (0.75s) | Managed fastest |
+| Az | PowerShell 7 | Install | 1.00x (6.21s) | Failed | Managed only successful |
+| Graph.Authentication | PowerShell 7 | Install | 1.00x (0.58s) | 1.03x (0.59s) | Managed fastest |
+| Graph | PowerShell 7 | Install | 1.00x (14.53s) | 0.26x (3.84s) | Managed slower than ModuleFast |
+| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (1.10s) | 1.13x (1.24s) | Managed fastest |
 <!-- managed-module-benchmark-table:end -->
 
 Refresh the table with:

--- a/README.MD
+++ b/README.MD
@@ -334,13 +334,16 @@ Repair-ManagedModule -Latest -Repository PSGallery -ShowSummary
 ### Benchmarks
 
 The managed module benchmark answers a narrow question: how long does each
-tool take to run the public command a user would normally run? The script in
-[Benchmarks/ManagedModules](Benchmarks/ManagedModules) measures `Find`,
-`Install`, and `Save` for PSScriptAnalyzer, Microsoft.Graph.Authentication,
-Microsoft.Graph, Az.Accounts, and Az against Managed, ModuleFast,
-PSResourceGet, and PowerShellGet where an equivalent command exists. Repair is
-not included because the other tools do not expose an equivalent module-estate
-repair command.
+tool take to run the public command a user would normally run? The default
+script profile in [Benchmarks/ManagedModules](Benchmarks/ManagedModules) now
+focuses on Managed versus ModuleFast install rows because those are the useful
+throughput race while tuning the engine. The older `Full` profile still
+measures `Find`, `Install`, and `Save` for PSScriptAnalyzer,
+Microsoft.Graph.Authentication, Microsoft.Graph, Az.Accounts, and Az against
+Managed, ModuleFast, PSResourceGet, and PowerShellGet where an equivalent
+command exists, but it is an explicit baseline run rather than the normal fast
+loop. Repair is not included because the other tools do not expose an
+equivalent module-estate repair command.
 
 Managed is the `1.00x` baseline for each completed row. Other values show how
 many times slower that tool was for the same scenario, with measured time in
@@ -384,6 +387,14 @@ dependency graph, ModuleFast can be very fast. When the mirror is missing a
 dependency that the official Gallery resolves, the ModuleFast row should be
 treated as a source/index miss rather than a managed engine failure.
 
+ModuleFast implementation provenance matters too. A normal benchmark run uses
+the `Install-ModuleFast` command visible in the benchmark host, which is usually
+the installed PSGallery/user-path ModuleFast module. To compare Justin Grote's
+development C# branch or another local build, pass `-ModuleFastModulePath` to
+the benchmark wrapper. The CSV records `ModuleFastSource`,
+`ModuleFastModulePath`, `EngineModuleBase`, and `EngineModuleVersion` so those
+runs stay separate.
+
 The comparison is therefore split into capability and timing:
 
 | Tool | Source path used here | Equivalent rows | Integrity and safety posture |
@@ -409,7 +420,9 @@ PowerShell Gallery matrix run on PowerShell 7 and Windows PowerShell 5.1.
 Managed is fastest in 24 of 30 scenario/host/operation groups. Provider-backed
 rows can still be noisy because they use the live public gallery path; when
 repeated rows exist, the README updater writes the median timing for that
-scenario/tool row.
+scenario/tool row. While optimizing install throughput, prefer refreshing the
+focused Managed-vs-ModuleFast rows instead of re-running the native-provider
+10x/30x cases unless a fresh compatibility baseline is needed.
 
 <!-- managed-module-benchmark-table:start -->
 | Scenario | Host | Operation | Managed | ModuleFast | PSResourceGet | PowerShellGet | Result |

--- a/README.MD
+++ b/README.MD
@@ -429,11 +429,11 @@ needed.
 <!-- managed-module-benchmark-table:start -->
 | Scenario | Host | Operation | Managed | ModuleFast | Result |
 | --- | --- | --- | --- | --- | --- |
-| Az.Accounts | PowerShell 7 | Install | 1.00x (0.61s) | 1.24x (0.75s) | Managed fastest |
-| Az | PowerShell 7 | Install | 1.00x (6.21s) | Failed | Managed only successful |
-| Graph.Authentication | PowerShell 7 | Install | 1.00x (0.58s) | 1.03x (0.59s) | Managed fastest |
-| Graph | PowerShell 7 | Install | 1.00x (14.53s) | 0.26x (3.84s) | Managed slower than ModuleFast |
-| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (1.10s) | 1.13x (1.24s) | Managed fastest |
+| Az.Accounts | PowerShell 7 | Install | 1.00x (0.83s) | 1.12x (0.93s) | Managed fastest |
+| Az | PowerShell 7 | Install | 1.00x (5.19s) | Failed | Managed only successful |
+| Graph.Authentication | PowerShell 7 | Install | 1.00x (2.48s) | 0.41x (1.01s) | Managed slower than ModuleFast |
+| Graph | PowerShell 7 | Install | 1.00x (6.58s) | 0.84x (5.55s) | Managed slower than ModuleFast |
+| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (2.15s) | 0.92x (1.97s) | Managed slower than ModuleFast |
 <!-- managed-module-benchmark-table:end -->
 
 Refresh the table with:

--- a/README.MD
+++ b/README.MD
@@ -404,45 +404,46 @@ importing the small CSV result, and deleting the account/profile afterward. Use
 `-SkipTemporaryUserNativeInstall` only when a machine cannot create a temporary
 local benchmark account.
 
-The full table below was refreshed on June 30, 2026 from one complete matrix
-run on PowerShell 7 and Windows PowerShell 5.1. The PowerShell 7
-PSScriptAnalyzer find row also includes three extra Managed repeats after one
-transient first-result outlier; when repeated rows exist, the README updater
-writes the median timing for that scenario/tool row.
+The full table below was refreshed on July 1, 2026 from one complete public
+PowerShell Gallery matrix run on PowerShell 7 and Windows PowerShell 5.1.
+Managed is fastest in 24 of 30 scenario/host/operation groups. Provider-backed
+rows can still be noisy because they use the live public gallery path; when
+repeated rows exist, the README updater writes the median timing for that
+scenario/tool row.
 
 <!-- managed-module-benchmark-table:start -->
 | Scenario | Host | Operation | Managed | ModuleFast | PSResourceGet | PowerShellGet | Result |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Az.Accounts | PowerShell 7 | Find | 1.00x (0.19s) | NotEquivalent | 1.67x (0.32s) | 2.91x (0.55s) | Managed fastest |
-| Az.Accounts | PowerShell 7 | Install | 1.00x (0.43s) | 1.80x (0.77s) | 4.05x (1.73s) | 10.23x (4.37s) | Managed fastest |
-| Az.Accounts | PowerShell 7 | Save | 1.00x (0.59s) | NotEquivalent | 4.59x (2.70s) | 8.32x (4.90s) | Managed fastest |
-| Az.Accounts | Windows PowerShell 5.1 | Find | 1.00x (0.18s) | NotEquivalent | 1.64x (0.29s) | 5.19x (0.92s) | Managed fastest |
-| Az.Accounts | Windows PowerShell 5.1 | Install | 1.00x (0.63s) | NotAvailable | 2.47x (1.55s) | 5.85x (3.66s) | Managed fastest |
-| Az.Accounts | Windows PowerShell 5.1 | Save | 1.00x (0.75s) | NotEquivalent | 2.24x (1.68s) | 12.13x (9.07s) | Managed fastest |
-| Az | PowerShell 7 | Find | 1.00x (0.18s) | NotEquivalent | 1.89x (0.33s) | 3.11x (0.55s) | Managed fastest |
-| Az | PowerShell 7 | Install | 1.00x (16.06s) | Failed | 9.92x (159.21s) | 7.75x (124.51s) | Managed fastest |
-| Az | PowerShell 7 | Save | 1.00x (7.82s) | NotEquivalent | 20.66x (161.60s) | 18.83x (147.31s) | Managed fastest |
-| Az | Windows PowerShell 5.1 | Find | 1.00x (0.27s) | NotEquivalent | 1.55x (0.42s) | 4.14x (1.11s) | Managed fastest |
-| Az | Windows PowerShell 5.1 | Install | 1.00x (8.29s) | NotAvailable | 16.74x (138.79s) | 18.04x (149.54s) | Managed fastest |
-| Az | Windows PowerShell 5.1 | Save | 1.00x (19.26s) | NotEquivalent | 7.06x (136.04s) | 6.76x (130.28s) | Managed fastest |
-| Graph.Authentication | PowerShell 7 | Find | 1.00x (0.20s) | NotEquivalent | 6.06x (1.19s) | 2.83x (0.55s) | Managed fastest |
-| Graph.Authentication | PowerShell 7 | Install | 1.00x (0.51s) | 1.79x (0.91s) | 2.66x (1.34s) | 8.46x (4.28s) | Managed fastest |
-| Graph.Authentication | PowerShell 7 | Save | 1.00x (0.61s) | NotEquivalent | 12.77x (7.85s) | 24.43x (15.02s) | Managed fastest |
-| Graph.Authentication | Windows PowerShell 5.1 | Find | 1.00x (0.27s) | NotEquivalent | 1.72x (0.46s) | 2.90x (0.78s) | Managed fastest |
-| Graph.Authentication | Windows PowerShell 5.1 | Install | 1.00x (0.71s) | NotAvailable | 2.87x (2.05s) | 4.61x (3.30s) | Managed fastest |
-| Graph.Authentication | Windows PowerShell 5.1 | Save | 1.00x (0.68s) | NotEquivalent | 3.02x (2.06s) | 5.10x (3.48s) | Managed fastest |
-| Graph | PowerShell 7 | Find | 1.00x (0.24s) | NotEquivalent | 4.59x (1.10s) | 2.49x (0.59s) | Managed fastest |
-| Graph | PowerShell 7 | Install | 1.00x (6.60s) | 0.88x (5.81s) | 8.10x (53.46s) | 11.19x (73.84s) | Managed slower than ModuleFast |
-| Graph | PowerShell 7 | Save | 1.00x (3.55s) | NotEquivalent | 92.31x (327.79s) | 53.15x (188.73s) | Managed fastest |
-| Graph | Windows PowerShell 5.1 | Find | 1.00x (0.31s) | NotEquivalent | 2.56x (0.80s) | 3.69x (1.16s) | Managed fastest |
-| Graph | Windows PowerShell 5.1 | Install | 1.00x (11.54s) | NotAvailable | 4.93x (56.87s) | 6.88x (79.40s) | Managed fastest |
-| Graph | Windows PowerShell 5.1 | Save | 1.00x (4.65s) | NotEquivalent | 15.22x (70.76s) | 21.69x (100.80s) | Managed fastest |
-| PSScriptAnalyzer | PowerShell 7 | Find | 1.00x (0.65s) | NotEquivalent | 1.30x (0.84s) | 7.14x (4.62s) | Managed fastest |
-| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (0.82s) | 2.71x (2.23s) | 2.70x (2.23s) | 14.42x (11.90s) | Managed fastest |
-| PSScriptAnalyzer | PowerShell 7 | Save | 1.00x (1.24s) | NotEquivalent | 5.94x (7.35s) | 8.87x (10.97s) | Managed fastest |
-| PSScriptAnalyzer | Windows PowerShell 5.1 | Find | 1.00x (0.89s) | NotEquivalent | 1.56x (1.39s) | 3.50x (3.12s) | Managed fastest |
-| PSScriptAnalyzer | Windows PowerShell 5.1 | Install | 1.00x (1.58s) | NotAvailable | 2.71x (4.27s) | 4.51x (7.12s) | Managed fastest |
-| PSScriptAnalyzer | Windows PowerShell 5.1 | Save | 1.00x (1.25s) | NotEquivalent | 2.93x (3.67s) | 3.21x (4.02s) | Managed fastest |
+| Az.Accounts | PowerShell 7 | Find | 1.00x (0.22s) | NotEquivalent | 1.18x (0.26s) | 3.65x (0.80s) | Managed fastest |
+| Az.Accounts | PowerShell 7 | Install | 1.00x (0.43s) | 2.04x (0.88s) | 2.76x (1.18s) | 7.28x (3.12s) | Managed fastest |
+| Az.Accounts | PowerShell 7 | Save | 1.00x (0.45s) | NotEquivalent | 10.07x (4.49s) | 22.70x (10.13s) | Managed fastest |
+| Az.Accounts | Windows PowerShell 5.1 | Find | 1.00x (0.34s) | NotEquivalent | 1.17x (0.40s) | 3.00x (1.03s) | Managed fastest |
+| Az.Accounts | Windows PowerShell 5.1 | Install | 1.00x (0.55s) | NotAvailable | 6.64x (3.63s) | 6.29x (3.44s) | Managed fastest |
+| Az.Accounts | Windows PowerShell 5.1 | Save | 1.00x (0.99s) | NotEquivalent | 1.61x (1.60s) | 4.15x (4.13s) | Managed fastest |
+| Az | PowerShell 7 | Find | 1.00x (0.41s) | NotEquivalent | 2.30x (0.95s) | 4.71x (1.94s) | Managed fastest |
+| Az | PowerShell 7 | Install | 1.00x (3.69s) | Failed | 32.37x (119.52s) | 35.93x (132.65s) | Managed fastest |
+| Az | PowerShell 7 | Save | 1.00x (3.89s) | NotEquivalent | 144.35x (562.08s) | 174.60x (679.91s) | Managed fastest |
+| Az | Windows PowerShell 5.1 | Find | 1.00x (0.35s) | NotEquivalent | 1.18x (0.42s) | 5.78x (2.05s) | Managed fastest |
+| Az | Windows PowerShell 5.1 | Install | 1.00x (5.49s) | NotAvailable | 52.89x (290.31s) | 28.24x (155.02s) | Managed fastest |
+| Az | Windows PowerShell 5.1 | Save | 1.00x (7.03s) | NotEquivalent | 23.13x (162.58s) | 114.76x (806.50s) | Managed fastest |
+| Graph.Authentication | PowerShell 7 | Find | 1.00x (0.21s) | NotEquivalent | 15.15x (3.20s) | 3.38x (0.71s) | Managed fastest |
+| Graph.Authentication | PowerShell 7 | Install | 1.00x (4.14s) | 0.30x (1.23s) | 1.04x (4.30s) | 0.94x (3.91s) | Managed slower than ModuleFast |
+| Graph.Authentication | PowerShell 7 | Save | 1.00x (0.41s) | NotEquivalent | 28.33x (11.53s) | 55.26x (22.49s) | Managed fastest |
+| Graph.Authentication | Windows PowerShell 5.1 | Find | 1.00x (1.21s) | NotEquivalent | 0.25x (0.30s) | 0.50x (0.60s) | Managed slower than PSResourceGet |
+| Graph.Authentication | Windows PowerShell 5.1 | Install | 1.00x (0.53s) | NotAvailable | 6.26x (3.33s) | 9.88x (5.25s) | Managed fastest |
+| Graph.Authentication | Windows PowerShell 5.1 | Save | 1.00x (1.50s) | NotEquivalent | 0.94x (1.41s) | 2.17x (3.25s) | Managed slower than PSResourceGet |
+| Graph | PowerShell 7 | Find | 1.00x (0.34s) | NotEquivalent | 5.10x (1.74s) | 2.73x (0.93s) | Managed fastest |
+| Graph | PowerShell 7 | Install | 1.00x (9.79s) | 0.97x (9.48s) | 10.88x (106.51s) | 7.33x (71.71s) | Managed slower than ModuleFast |
+| Graph | PowerShell 7 | Save | 1.00x (6.76s) | NotEquivalent | 47.63x (321.93s) | 39.52x (267.09s) | Managed fastest |
+| Graph | Windows PowerShell 5.1 | Find | 1.00x (0.23s) | NotEquivalent | 1.20x (0.27s) | 3.39x (0.77s) | Managed fastest |
+| Graph | Windows PowerShell 5.1 | Install | 1.00x (9.07s) | NotAvailable | 25.49x (231.36s) | 9.85x (89.35s) | Managed fastest |
+| Graph | Windows PowerShell 5.1 | Save | 1.00x (6.46s) | NotEquivalent | 7.90x (50.98s) | 10.28x (66.38s) | Managed fastest |
+| PSScriptAnalyzer | PowerShell 7 | Find | 1.00x (8.32s) | NotEquivalent | 0.13x (1.08s) | 0.52x (4.35s) | Managed slower than PSResourceGet |
+| PSScriptAnalyzer | PowerShell 7 | Install | 1.00x (3.91s) | 1.47x (5.76s) | 1.35x (5.28s) | 1.62x (6.34s) | Managed fastest |
+| PSScriptAnalyzer | PowerShell 7 | Save | 1.00x (0.69s) | NotEquivalent | 81.41x (56.25s) | 18.88x (13.04s) | Managed fastest |
+| PSScriptAnalyzer | Windows PowerShell 5.1 | Find | 1.00x (0.28s) | NotEquivalent | 1.80x (0.49s) | 9.52x (2.62s) | Managed fastest |
+| PSScriptAnalyzer | Windows PowerShell 5.1 | Install | 1.00x (1.34s) | NotAvailable | 3.74x (5.02s) | 46.35x (62.21s) | Managed fastest |
+| PSScriptAnalyzer | Windows PowerShell 5.1 | Save | 1.00x (3.40s) | NotEquivalent | 0.70x (2.39s) | 1.10x (3.75s) | Managed slower than PSResourceGet |
 <!-- managed-module-benchmark-table:end -->
 
 Refresh the table with:

--- a/README.MD
+++ b/README.MD
@@ -387,13 +387,13 @@ dependency graph, ModuleFast can be very fast. When the mirror is missing a
 dependency that the official Gallery resolves, the ModuleFast row should be
 treated as a source/index miss rather than a managed engine failure.
 
-ModuleFast implementation provenance matters too. A normal benchmark run uses
-the `Install-ModuleFast` command visible in the benchmark host, which is usually
-the installed PSGallery/user-path ModuleFast module. To compare Justin Grote's
-development C# branch or another local build, pass `-ModuleFastModulePath` to
-the benchmark wrapper. The CSV records `ModuleFastSource`,
-`ModuleFastModulePath`, `EngineModuleBase`, and `EngineModuleVersion` so those
-runs stay separate.
+ModuleFast implementation provenance matters too. The current PR table compares
+against Justin Grote's refreshed development C# branch by passing
+`-ModuleFastModulePath` to the benchmark wrapper. If that parameter is omitted,
+the run uses whatever `Install-ModuleFast` command is visible in the benchmark
+host, usually the installed PSGallery/user-path ModuleFast module. The CSV
+records `ModuleFastSource`, `ModuleFastModulePath`, `EngineModuleBase`, and
+`EngineModuleVersion` so those runs stay separate.
 
 The comparison is therefore split into capability and timing:
 


### PR DESCRIPTION
## Summary

- route managed install/save/update/repair through awaited engine calls using a PowerShell-safe async cmdlet base
- improve the managed repository path with modern HTTP handler settings on non-net472 while preserving the Windows PowerShell 5.1/net472 path
- reduce broad dependency graph contention with repository query coalescing, dependency prewarm, safe operation-local package prefetch, leaner package extraction/cache work, and shorter install-lock retry waits
- keep install safety gates intact: dependency packages may be prefetched for real installs, but dependency work is skipped for no-op roots and outstanding prefetches are canceled when the root operation aborts
- make benchmark CSV aggregation schema-aware so reruns against older result files preserve newly added phase/provenance columns
- focus the normal benchmark loop on Managed vs ModuleFast install throughput; PSResourceGet and PowerShellGet remain available only through the explicit `Full` profile for occasional compatibility baselines
- clarify that the current comparison table is development Managed C# versus the local development C# ModuleFast branch supplied through `-ModuleFastModulePath`

## Current focused comparison

Focused install-only run from 2026-07-01, PowerShell 7, Managed from this PR worktree, ModuleFast from the local C# branch at `fa2f2d0` through `-ModuleFastModulePath`, with ModuleFast using `https://pwsh.gallery/index.json`.

| Scenario | Managed | C# ModuleFast | Result |
| --- | ---: | ---: | --- |
| Az.Accounts | 0.826s | 0.925s | Managed fastest |
| Az | 5.192s | Failed | Managed only successful; ModuleFast mirror missed `Az.DataTransfer(1.0.0)` |
| Graph.Authentication | 2.483s | 1.009s | ModuleFast faster |
| Graph | 6.583s | 5.552s | ModuleFast faster, but the gap is now much smaller after safe package prefetch |
| PSScriptAnalyzer | 2.145s | 1.972s | Near tie |

The old 10x/30x PSResourceGet and PowerShellGet provider rows are intentionally out of the normal tuning loop now. They are useful as occasional compatibility baselines, not as the repeated optimization target.

## Evidence

- focused prefetch/benchmark tests passed: 14
- broader managed/module-state/benchmark filter passed: 593
- `PSPublishModule` Release builds passed for `net10.0`, `net8.0`, and `net472`
- benchmark wrapper parsed cleanly under PowerShell 7 and Windows PowerShell 5.1
- `git diff --check` passed
- earlier full matrix completed successfully with Managed fastest in 24 of 30 scenario/host/operation groups

## Notes

This PR is stacked on PR #476 (`codex/module-state`) so the speed work can be reviewed separately from the larger managed-module state work.
