### PR TITLE
Repair managed module dependencies on existing installs

### DIFF
--- a/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
@@ -41,6 +41,38 @@ public sealed class ManagedModuleDependencyInstallServiceTests
     }
 
     [Fact]
+    public async Task InstallAsync_repairs_manifest_dependency_when_root_module_is_already_installed()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledRootWithRequiredModule(moduleRoot.Path, "Company.Tools", "1.0.0", "Company.Core", "1.0.0");
+        File.WriteAllText(Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0", "marker.txt"), "keep-root");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, result.Status);
+        Assert.Equal("keep-root", File.ReadAllText(Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0", "marker.txt")));
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal("1.0.0", dependency.Version);
+        Assert.Equal(ManagedModuleInstallStatus.Installed, dependency.Status);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Core", "1.0.0", "Company.Core.psd1")));
+    }
+
+    [Fact]
     public async Task InstallAsync_skips_dependency_version_query_for_satisfied_dependency_when_only_repository_trust_is_required()
     {
         using var moduleRoot = new TemporaryDirectory();
@@ -273,6 +305,20 @@ public sealed class ManagedModuleDependencyInstallServiceTests
         {
             ["Company.Core.psd1"] = "@{ ModuleVersion = '" + version + "' }"
         };
+
+    private static void WriteInstalledRootWithRequiredModule(
+        string moduleRoot,
+        string moduleName,
+        string version,
+        string dependencyName,
+        string dependencyVersion)
+    {
+        var modulePath = Path.Combine(moduleRoot, moduleName, version);
+        Directory.CreateDirectory(modulePath);
+        File.WriteAllText(
+            Path.Combine(modulePath, moduleName + ".psd1"),
+            "@{ ModuleVersion = '" + version + "'; RequiredModules = @(@{ ModuleName = '" + dependencyName + "'; RequiredVersion = '" + dependencyVersion + "'; }) }");
+    }
 
     private sealed class SatisfiedDependencyTrustFeedHandler : HttpMessageHandler
     {

--- a/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
@@ -264,6 +264,51 @@ public sealed class ManagedModuleDependencyInstallServiceTests
     }
 
     [Fact]
+    public async Task InstallAsync_does_not_reenter_already_active_satisfied_dependency_during_manifest_repair()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Tools",
+            "1.0.0",
+            "1.0.0",
+            ("Company.Core", "1.0.0"));
+        WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Core",
+            "1.0.0",
+            "1.0.0",
+            ("Company.Tools", "1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var plan = await service.PlanInstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.False(plan.WouldWriteFiles);
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, dependency.Status);
+        var cycleDependency = Assert.Single(dependency.DependencyResults);
+        Assert.Equal("Company.Tools", cycleDependency.Name);
+        Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, cycleDependency.Status);
+    }
+
+    [Fact]
     public async Task InstallAsync_repairs_manifest_dependency_from_flat_root_module_layout()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
@@ -73,6 +73,123 @@ public sealed class ManagedModuleDependencyInstallServiceTests
     }
 
     [Fact]
+    public async Task InstallAsync_does_not_repair_manifest_dependencies_marked_external()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        var modulePath = Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0");
+        Directory.CreateDirectory(modulePath);
+        File.WriteAllText(
+            Path.Combine(modulePath, "Company.Tools.psd1"),
+            "@{ ModuleVersion = '1.0.0'; RequiredModules = @(@{ ModuleName = 'External.Tools'; RequiredVersion = '9.0.0'; }); PrivateData = @{ PSData = @{ ExternalModuleDependencies = @('external.tools') } } }");
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, result.Status);
+        Assert.Empty(result.DependencyResults);
+        Assert.False(Directory.Exists(Path.Combine(moduleRoot.Path, "External.Tools")));
+    }
+
+    [Fact]
+    public async Task PlanInstallAsync_reports_manifest_dependency_repair_writes()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledRootWithRequiredModule(moduleRoot.Path, "Company.Tools", "1.0.0", "Company.Core", "1.0.0");
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var plan = await service.PlanInstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.True(plan.WouldWriteFiles);
+        Assert.False(Directory.Exists(Path.Combine(moduleRoot.Path, "Company.Core")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_repairs_manifest_dependencies_below_already_installed_dependency()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledRootWithRequiredModule(moduleRoot.Path, "Company.Tools", "1.0.0", "Company.Core", "1.0.0");
+        WriteInstalledRootWithRequiredModule(moduleRoot.Path, "Company.Core", "1.0.0", "Company.Leaf", "1.0.0");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Leaf.1.0.0.nupkg"),
+            "Company.Leaf",
+            "1.0.0",
+            files: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Company.Leaf.psd1"] = "@{ ModuleVersion = '1.0.0' }"
+            });
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        var directDependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", directDependency.Name);
+        Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, directDependency.Status);
+        var transitiveDependency = Assert.Single(directDependency.DependencyResults);
+        Assert.Equal("Company.Leaf", transitiveDependency.Name);
+        Assert.Equal(ManagedModuleInstallStatus.Installed, transitiveDependency.Status);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Leaf", "1.0.0", "Company.Leaf.psd1")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_repairs_manifest_dependency_from_flat_root_module_layout()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        var flatModulePath = Path.Combine(moduleRoot.Path, "Company.Tools");
+        Directory.CreateDirectory(flatModulePath);
+        File.WriteAllText(
+            Path.Combine(flatModulePath, "Company.Tools.psd1"),
+            "@{ ModuleVersion = '1.0.0'; RequiredModules = @(@{ ModuleName = 'Company.Core'; RequiredVersion = '1.0.0'; }) }");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(flatModulePath, result.ModulePath);
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal(ManagedModuleInstallStatus.Installed, dependency.Status);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Core", "1.0.0", "Company.Core.psd1")));
+    }
+
+    [Fact]
     public async Task InstallAsync_skips_dependency_version_query_for_satisfied_dependency_when_only_repository_trust_is_required()
     {
         using var moduleRoot = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
@@ -122,6 +122,33 @@ public sealed class ManagedModuleDependencyInstallServiceTests
     }
 
     [Fact]
+    public async Task PlanInstallAsync_reports_manifest_dependency_repair_from_normalized_version_directory()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Tools",
+            "1.0",
+            "1.0.0",
+            ("Company.Core", "1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var plan = await service.PlanInstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(Path.Combine(moduleRoot.Path, "Company.Tools", "1.0"), plan.ModulePath);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
     public async Task InstallAsync_repairs_manifest_dependencies_below_already_installed_dependency()
     {
         using var feed = new TemporaryDirectory();
@@ -154,6 +181,86 @@ public sealed class ManagedModuleDependencyInstallServiceTests
         Assert.Equal("Company.Leaf", transitiveDependency.Name);
         Assert.Equal(ManagedModuleInstallStatus.Installed, transitiveDependency.Status);
         Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Leaf", "1.0.0", "Company.Leaf.psd1")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_repairs_manifest_dependency_from_normalized_version_directory()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        var installedPath = WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Tools",
+            "1.0",
+            "1.0.0",
+            ("Company.Core", "1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(installedPath, result.ModulePath);
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal(ManagedModuleInstallStatus.Installed, dependency.Status);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Core", "1.0.0", "Company.Core.psd1")));
+    }
+
+    [Fact]
+    public async Task PlanInstallAsync_inspects_same_dependency_name_at_different_installed_paths()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Tools",
+            "1.0.0",
+            "1.0.0",
+            ("Company.BranchA", "1.0.0"),
+            ("Company.BranchB", "1.0.0"));
+        WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.BranchA",
+            "1.0.0",
+            "1.0.0",
+            ("Company.Shared", "1.0.0"));
+        WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.BranchB",
+            "1.0.0",
+            "1.0.0",
+            ("Company.Shared", "2.0.0"));
+        WriteInstalledModuleManifest(moduleRoot.Path, "Company.Shared", "1.0.0", "1.0.0");
+        WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Shared",
+            "2.0.0",
+            "2.0.0",
+            ("Company.Leaf", "1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var plan = await service.PlanInstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
     }
 
     [Fact]
@@ -429,12 +536,27 @@ public sealed class ManagedModuleDependencyInstallServiceTests
         string version,
         string dependencyName,
         string dependencyVersion)
+        => WriteInstalledModuleManifest(moduleRoot, moduleName, version, version, (dependencyName, dependencyVersion));
+
+    private static string WriteInstalledModuleManifest(
+        string moduleRoot,
+        string moduleName,
+        string directoryName,
+        string moduleVersion,
+        params (string Name, string Version)[] dependencies)
     {
-        var modulePath = Path.Combine(moduleRoot, moduleName, version);
+        var modulePath = Path.Combine(moduleRoot, moduleName, directoryName);
         Directory.CreateDirectory(modulePath);
+        var requiredModules = dependencies.Length == 0
+            ? string.Empty
+            : "; RequiredModules = @(" + string.Join(
+                ", ",
+                dependencies.Select(static dependency =>
+                    "@{ ModuleName = '" + dependency.Name + "'; RequiredVersion = '" + dependency.Version + "'; }")) + ")";
         File.WriteAllText(
             Path.Combine(modulePath, moduleName + ".psd1"),
-            "@{ ModuleVersion = '" + version + "'; RequiredModules = @(@{ ModuleName = '" + dependencyName + "'; RequiredVersion = '" + dependencyVersion + "'; }) }");
+            "@{ ModuleVersion = '" + moduleVersion + "'" + requiredModules + " }");
+        return modulePath;
     }
 
     private sealed class SatisfiedDependencyTrustFeedHandler : HttpMessageHandler

--- a/PowerForge/Models/ManagedModules/ManagedModuleInstallRequest.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleInstallRequest.cs
@@ -106,4 +106,6 @@ public sealed class ManagedModuleInstallRequest
     /// Skip installing dependencies declared by the package.
     /// </summary>
     public bool SkipDependencyCheck { get; set; }
+
+    internal bool RepairInstalledManifestDependencies { get; set; }
 }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
@@ -90,6 +90,9 @@ internal sealed class ManagedModuleInstallContext : IDisposable
         return new PopOnDispose(_active, normalized);
     }
 
+    public bool IsActive(string moduleName)
+        => _active.Contains(moduleName.Trim());
+
     public bool TryBeginInstall(
         string key,
         out Task<ManagedModuleInstallResult> existingInstall,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -209,9 +209,28 @@ public sealed partial class ManagedModuleInstallService
         satisfiedStopwatch.Stop();
         if (isSatisfied)
         {
-            satisfiedResult.Elapsed = satisfiedStopwatch.Elapsed;
-            satisfiedResult.DependencyVersionRange = dependency.VersionRange;
-            return satisfiedResult;
+            ManagedModuleInstallResult satisfiedInstallResult;
+            if (request.RepairInstalledManifestDependencies)
+            {
+                satisfiedInstallResult = await InstallAsync(
+                    CreateDependencyInstallRequest(
+                        request,
+                        dependency.Id,
+                        satisfiedResult.Version,
+                        cacheDirectory,
+                        dependencyTrustPolicy,
+                        range),
+                    context,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                satisfiedInstallResult = satisfiedResult;
+                satisfiedInstallResult.Elapsed = satisfiedStopwatch.Elapsed;
+            }
+
+            satisfiedInstallResult.DependencyVersionRange = dependency.VersionRange;
+            return satisfiedInstallResult;
         }
 
         var dependencyVersionStopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -224,29 +243,13 @@ public sealed partial class ManagedModuleInstallService
         dependencyVersionStopwatch.Stop();
 
         var result = await InstallAsync(
-            new ManagedModuleInstallRequest
-            {
-                Repository = request.Repository,
-                Name = dependency.Id,
-                Version = dependencyVersion.Version,
-                VersionPolicy = null,
-                IncludePrerelease = request.IncludePrerelease || range.AllowsPrerelease,
-                Scope = request.Scope,
-                ShellEdition = request.ShellEdition,
-                ModuleRoot = request.ModuleRoot,
-                PackageCacheDirectory = cacheDirectory,
-                PackageCacheDirectoryIsOperationLocal = request.PackageCacheDirectoryIsOperationLocal ||
-                                                        string.IsNullOrWhiteSpace(request.PackageCacheDirectory),
-                ExpectedPackageSha256 = null,
-                TrustPolicy = dependencyTrustPolicy,
-                Credential = request.Credential,
-                Force = false,
-                AllowClobber = request.AllowClobber,
-                AcceptLicense = request.AcceptLicense,
-                AuthenticodeCheck = request.AuthenticodeCheck,
-                DependencyConcurrency = request.DependencyConcurrency,
-                SkipDependencyCheck = false
-            },
+            CreateDependencyInstallRequest(
+                request,
+                dependency.Id,
+                dependencyVersion.Version,
+                cacheDirectory,
+                dependencyTrustPolicy,
+                range),
             context,
             cancellationToken).ConfigureAwait(false);
         result.DependencyVersionRange = dependency.VersionRange;
@@ -256,6 +259,38 @@ public sealed partial class ManagedModuleInstallService
             result.VersionResolutionElapsed += dependencyVersionStopwatch.Elapsed;
         return result;
     }
+
+    private static ManagedModuleInstallRequest CreateDependencyInstallRequest(
+        ManagedModuleInstallRequest request,
+        string dependencyName,
+        string dependencyVersion,
+        string cacheDirectory,
+        ManagedModuleTrustPolicy? dependencyTrustPolicy,
+        ManagedModuleVersionRange range)
+        => new()
+        {
+            Repository = request.Repository,
+            Name = dependencyName,
+            Version = dependencyVersion,
+            VersionPolicy = null,
+            IncludePrerelease = request.IncludePrerelease || range.AllowsPrerelease,
+            Scope = request.Scope,
+            ShellEdition = request.ShellEdition,
+            ModuleRoot = request.ModuleRoot,
+            PackageCacheDirectory = cacheDirectory,
+            PackageCacheDirectoryIsOperationLocal = request.PackageCacheDirectoryIsOperationLocal ||
+                                                    string.IsNullOrWhiteSpace(request.PackageCacheDirectory),
+            ExpectedPackageSha256 = null,
+            TrustPolicy = dependencyTrustPolicy,
+            Credential = request.Credential,
+            Force = false,
+            AllowClobber = request.AllowClobber,
+            AcceptLicense = request.AcceptLicense,
+            AuthenticodeCheck = request.AuthenticodeCheck,
+            DependencyConcurrency = request.DependencyConcurrency,
+            SkipDependencyCheck = false,
+            RepairInstalledManifestDependencies = request.RepairInstalledManifestDependencies
+        };
 
     private static bool TryCreateSatisfiedDependencyResult(
         ManagedModuleInstallRequest request,
@@ -272,7 +307,7 @@ public sealed partial class ManagedModuleInstallService
         if (installedVersion is null)
             return false;
 
-        var modulePath = Path.Combine(moduleRoot, dependencyName.Trim(), installedVersion);
+        var modulePath = ResolveInstalledModulePath(moduleRoot, dependencyName, installedVersion);
         result = CreateAlreadyInstalledResult(
             new ManagedModuleInstallRequest
             {
@@ -286,7 +321,8 @@ public sealed partial class ManagedModuleInstallService
                 Force = false,
                 AllowClobber = request.AllowClobber,
                 AcceptLicense = request.AcceptLicense,
-                AuthenticodeCheck = request.AuthenticodeCheck
+                AuthenticodeCheck = request.AuthenticodeCheck,
+                RepairInstalledManifestDependencies = request.RepairInstalledManifestDependencies
             },
             installedVersion,
             moduleRoot,
@@ -354,6 +390,10 @@ public sealed partial class ManagedModuleInstallService
         if (metadata is null)
             return result;
 
+        var repairRequest = request.RepairInstalledManifestDependencies
+            ? request
+            : CopyForInstalledManifestDependencyRepair(request);
+
         var dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
         var cacheDirectory = string.IsNullOrWhiteSpace(request.PackageCacheDirectory)
             ? Path.Combine(Path.GetTempPath(), "PFMM.C", NewShortId())
@@ -363,7 +403,7 @@ public sealed partial class ManagedModuleInstallService
         try
         {
             var dependencyResults = await InstallDependenciesAsync(
-                request,
+                repairRequest,
                 metadata,
                 cacheDirectory,
                 context,
@@ -385,6 +425,33 @@ public sealed partial class ManagedModuleInstallService
         }
     }
 
+    private static ManagedModuleInstallRequest CopyForInstalledManifestDependencyRepair(ManagedModuleInstallRequest request)
+        => new()
+        {
+            Repository = request.Repository,
+            Name = request.Name,
+            Version = request.Version,
+            MinimumVersion = request.MinimumVersion,
+            MaximumVersion = request.MaximumVersion,
+            VersionPolicy = request.VersionPolicy,
+            IncludePrerelease = request.IncludePrerelease,
+            Scope = request.Scope,
+            ShellEdition = request.ShellEdition,
+            ModuleRoot = request.ModuleRoot,
+            PackageCacheDirectory = request.PackageCacheDirectory,
+            PackageCacheDirectoryIsOperationLocal = request.PackageCacheDirectoryIsOperationLocal,
+            DependencyConcurrency = request.DependencyConcurrency,
+            ExpectedPackageSha256 = request.ExpectedPackageSha256,
+            TrustPolicy = request.TrustPolicy,
+            Credential = request.Credential,
+            Force = request.Force,
+            AllowClobber = request.AllowClobber,
+            AcceptLicense = request.AcceptLicense,
+            AuthenticodeCheck = request.AuthenticodeCheck,
+            SkipDependencyCheck = request.SkipDependencyCheck,
+            RepairInstalledManifestDependencies = true
+        };
+
     private static ManagedModulePackageMetadata? CreateInstalledManifestDependencyMetadata(
         string moduleName,
         string version,
@@ -398,8 +465,14 @@ public sealed partial class ManagedModuleInstallService
         if (requiredModules.Length == 0)
             return null;
 
+        var externalDependencies = ModuleManifestValueReader
+            .ReadPsDataStringOrArray(manifestPath!, "ExternalModuleDependencies")
+            .Where(static dependency => !string.IsNullOrWhiteSpace(dependency))
+            .Select(static dependency => dependency.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var dependencies = requiredModules
             .Where(static module => !string.IsNullOrWhiteSpace(module.ModuleName))
+            .Where(module => !externalDependencies.Contains(module.ModuleName!.Trim()))
             .Select(static module => new ManagedModuleDependencyInfo
             {
                 Id = module.ModuleName.Trim(),
@@ -416,8 +489,52 @@ public sealed partial class ManagedModuleInstallService
             Version = version,
             Dependencies = dependencies,
             ManifestDependencies = dependencies,
+            ManifestExternalModuleDependencies = externalDependencies.ToArray(),
             ModuleManifestPath = manifestPath
         };
+    }
+
+    private static bool WouldRepairInstalledManifestDependencies(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        string modulePath)
+    {
+        if (request.SkipDependencyCheck)
+            return false;
+
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return WouldRepairInstalledManifestDependenciesCore(request, request.Name, moduleRoot, modulePath, visited);
+    }
+
+    private static bool WouldRepairInstalledManifestDependenciesCore(
+        ManagedModuleInstallRequest request,
+        string moduleName,
+        string moduleRoot,
+        string modulePath,
+        ISet<string> visited)
+    {
+        if (!visited.Add(moduleName.Trim()))
+            return false;
+
+        var metadata = CreateInstalledManifestDependencyMetadata(moduleName, string.Empty, modulePath);
+        if (metadata is null)
+            return false;
+
+        foreach (var dependency in SelectDependencies(metadata))
+        {
+            var range = ManagedModuleVersionRange.Parse(dependency.VersionRange);
+            var installedVersion = GetInstalledVersions(moduleRoot, dependency.Id)
+                .Where(version => AllowsInstalledDependencyVersion(version, request, range))
+                .LastOrDefault();
+            if (installedVersion is null)
+                return true;
+
+            var dependencyPath = ResolveInstalledModulePath(moduleRoot, dependency.Id, installedVersion);
+            if (WouldRepairInstalledManifestDependenciesCore(request, dependency.Id, moduleRoot, dependencyPath, visited))
+                return true;
+        }
+
+        return false;
     }
 
     private static string? ResolveInstalledManifestPath(string moduleName, string modulePath)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -323,6 +323,139 @@ public sealed partial class ManagedModuleInstallService
         return range.IsSatisfiedBy(version);
     }
 
+    private async Task<ManagedModuleInstallResult> CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
+        ManagedModuleInstallRequest request,
+        string version,
+        string moduleRoot,
+        string modulePath,
+        TimeSpan elapsed,
+        TimeSpan versionResolutionElapsed,
+        long repositoryRequestCount,
+        TimeSpan installLockWaitElapsed,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken,
+        TimeSpan coalescedWaitElapsed = default)
+    {
+        var result = CreateAlreadyInstalledResult(
+            request,
+            version,
+            moduleRoot,
+            modulePath,
+            elapsed,
+            versionResolutionElapsed,
+            repositoryRequestCount,
+            installLockWaitElapsed,
+            coalescedWaitElapsed);
+
+        if (request.SkipDependencyCheck)
+            return result;
+
+        var metadata = CreateInstalledManifestDependencyMetadata(request.Name, version, modulePath);
+        if (metadata is null)
+            return result;
+
+        var dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var cacheDirectory = string.IsNullOrWhiteSpace(request.PackageCacheDirectory)
+            ? Path.Combine(Path.GetTempPath(), "PFMM.C", NewShortId())
+            : Path.GetFullPath(request.PackageCacheDirectory!.Trim().Trim('"'));
+        var ownsCache = string.IsNullOrWhiteSpace(request.PackageCacheDirectory);
+
+        try
+        {
+            var dependencyResults = await InstallDependenciesAsync(
+                request,
+                metadata,
+                cacheDirectory,
+                context,
+                cancellationToken).ConfigureAwait(false);
+            dependencyStopwatch.Stop();
+
+            result.DependencyElapsed = dependencyStopwatch.Elapsed;
+            result.DependencyResults = dependencyResults;
+            result.RepositoryRequestCount += SumRepositoryRequestCount(dependencyResults);
+            result.PackageRepositoryRequestCount += SumPackageRepositoryRequestCount(dependencyResults);
+            result.PackageRepositoryRedirectCount += SumPackageRepositoryRedirectCount(dependencyResults);
+            return result;
+        }
+        finally
+        {
+            dependencyStopwatch.Stop();
+            if (ownsCache)
+                ManagedModuleExtractedPackageCache.DeleteDirectoryQuietly(cacheDirectory);
+        }
+    }
+
+    private static ManagedModulePackageMetadata? CreateInstalledManifestDependencyMetadata(
+        string moduleName,
+        string version,
+        string modulePath)
+    {
+        var manifestPath = ResolveInstalledManifestPath(moduleName, modulePath);
+        if (string.IsNullOrWhiteSpace(manifestPath))
+            return null;
+
+        var requiredModules = ModuleManifestValueReader.ReadRequiredModules(manifestPath!);
+        if (requiredModules.Length == 0)
+            return null;
+
+        var dependencies = requiredModules
+            .Where(static module => !string.IsNullOrWhiteSpace(module.ModuleName))
+            .Select(static module => new ManagedModuleDependencyInfo
+            {
+                Id = module.ModuleName.Trim(),
+                VersionRange = ToManagedDependencyVersionRange(module),
+                TargetFramework = null
+            })
+            .ToArray();
+        if (dependencies.Length == 0)
+            return null;
+
+        return new ManagedModulePackageMetadata
+        {
+            Id = moduleName.Trim(),
+            Version = version,
+            Dependencies = dependencies,
+            ManifestDependencies = dependencies,
+            ModuleManifestPath = manifestPath
+        };
+    }
+
+    private static string? ResolveInstalledManifestPath(string moduleName, string modulePath)
+    {
+        if (!Directory.Exists(modulePath))
+            return null;
+
+        var expectedManifestPath = Path.Combine(modulePath, moduleName.Trim() + ".psd1");
+        if (File.Exists(expectedManifestPath))
+            return expectedManifestPath;
+
+        return Directory.EnumerateFiles(modulePath, "*.psd1", SearchOption.TopDirectoryOnly)
+            .FirstOrDefault();
+    }
+
+    private static string? ToManagedDependencyVersionRange(RequiredModuleReference module)
+    {
+        if (!string.IsNullOrWhiteSpace(module.RequiredVersion))
+            return "[" + module.RequiredVersion!.Trim() + "]";
+        if (!string.IsNullOrWhiteSpace(module.ModuleVersion) && !string.IsNullOrWhiteSpace(module.MaximumVersion))
+            return "[" + module.ModuleVersion!.Trim() + "," + module.MaximumVersion!.Trim() + "]";
+        if (!string.IsNullOrWhiteSpace(module.ModuleVersion))
+            return module.ModuleVersion!.Trim();
+        if (!string.IsNullOrWhiteSpace(module.MaximumVersion))
+            return "(," + module.MaximumVersion!.Trim() + "]";
+
+        return null;
+    }
+
+    private static long SumRepositoryRequestCount(IReadOnlyList<ManagedModuleInstallResult> dependencyResults)
+        => dependencyResults.Sum(static dependency => dependency.RepositoryRequestCount);
+
+    private static long SumPackageRepositoryRequestCount(IReadOnlyList<ManagedModuleInstallResult> dependencyResults)
+        => dependencyResults.Sum(static dependency => dependency.PackageRepositoryRequestCount);
+
+    private static long SumPackageRepositoryRedirectCount(IReadOnlyList<ManagedModuleInstallResult> dependencyResults)
+        => dependencyResults.Sum(static dependency => dependency.PackageRepositoryRedirectCount);
+
     private static IReadOnlyList<string> GetInstalledVersions(
         string moduleRoot,
         string moduleName,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -210,7 +210,12 @@ public sealed partial class ManagedModuleInstallService
         if (isSatisfied)
         {
             ManagedModuleInstallResult satisfiedInstallResult;
-            if (request.RepairInstalledManifestDependencies)
+            if (request.RepairInstalledManifestDependencies && context.IsActive(dependency.Id))
+            {
+                satisfiedInstallResult = satisfiedResult;
+                satisfiedInstallResult.Elapsed = satisfiedStopwatch.Elapsed;
+            }
+            else if (request.RepairInstalledManifestDependencies)
             {
                 satisfiedInstallResult = await InstallAsync(
                     CreateDependencyInstallRequest(

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -513,7 +513,7 @@ public sealed partial class ManagedModuleInstallService
         string modulePath,
         ISet<string> visited)
     {
-        if (!visited.Add(moduleName.Trim()))
+        if (!visited.Add(CreateManifestRepairVisitKey(moduleName, modulePath)))
             return false;
 
         var metadata = CreateInstalledManifestDependencyMetadata(moduleName, string.Empty, modulePath);
@@ -536,6 +536,12 @@ public sealed partial class ManagedModuleInstallService
 
         return false;
     }
+
+    private static string CreateManifestRepairVisitKey(string moduleName, string modulePath)
+        => string.Join("|", moduleName.Trim(), NormalizeManifestRepairPath(modulePath));
+
+    private static string NormalizeManifestRepairPath(string modulePath)
+        => Path.GetFullPath(modulePath.Trim().Trim('"')).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     private static string? ResolveInstalledManifestPath(string moduleName, string modulePath)
     {

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -60,17 +60,18 @@ public sealed partial class ManagedModuleInstallService
         var moduleRoot = ManagedModuleInstallRootResolver.Resolve(request.Scope, request.ShellEdition, request.ModuleRoot);
         if (TrySelectInstalledNoOpVersion(request, moduleRoot, context: null, out var installedVersion))
         {
-            var installedModulePath = Path.Combine(moduleRoot, request.Name.Trim(), installedVersion);
+            var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, installedVersion);
             return CreateInstallPlan(
                 request,
                 installedVersion,
                 moduleRoot,
                 installedModulePath,
-                exists: true);
+                exists: true,
+                wouldRepairDependencies: WouldRepairInstalledManifestDependencies(request, moduleRoot, installedModulePath));
         }
 
         var versionInfo = await ResolveSelectedVersionInfoAsync(request, cancellationToken, resolveExactMetadata: true).ConfigureAwait(false);
-        var modulePath = Path.Combine(moduleRoot, request.Name.Trim(), versionInfo.Version);
+        var modulePath = Path.Combine(moduleRoot, request.Name.Trim(), ResolveModuleDirectoryVersion(versionInfo.Version));
         return CreateInstallPlan(
             request,
             versionInfo.Version,
@@ -86,7 +87,8 @@ public sealed partial class ManagedModuleInstallService
         string moduleRoot,
         string modulePath,
         bool exists,
-        ManagedModuleVersionInfo? versionInfo = null)
+        ManagedModuleVersionInfo? versionInfo = null,
+        bool wouldRepairDependencies = false)
     {
         var requiresPackageDownloadBeforeNoOp = RequiresPackageDownloadBeforeNoOp(request);
         var action = exists
@@ -103,7 +105,7 @@ public sealed partial class ManagedModuleInstallService
             ModuleRoot = moduleRoot,
             ModulePath = modulePath,
             ExistingVersionFound = exists,
-            WouldWriteFiles = action != ManagedModuleInstallPlanAction.SkipExisting,
+            WouldWriteFiles = action != ManagedModuleInstallPlanAction.SkipExisting || wouldRepairDependencies,
             RequestedVersion = request.Version,
             MinimumVersion = request.MinimumVersion,
             MaximumVersion = request.MaximumVersion,
@@ -151,7 +153,7 @@ public sealed partial class ManagedModuleInstallService
 
         if (knownCoalescingKey is not null && context.TryGetCompletedInstall(knownCoalescingKey, out var completedInstall))
         {
-            var completedModulePath = Path.Combine(moduleRoot, request.Name.Trim(), completedInstall.Version);
+            var completedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, completedInstall.Version);
             _logger.Verbose($"Managed module install skipped operation-local completed target: {completedModulePath}");
             return CreateAlreadyInstalledResult(
                 request,
@@ -180,7 +182,7 @@ public sealed partial class ManagedModuleInstallService
                         }
 
                         coalescedWaitStopwatch.Stop();
-                        var completedModulePath = Path.Combine(moduleRoot, request.Name.Trim(), completed.Version);
+                        var completedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, completed.Version);
                         return CreateAlreadyInstalledResult(
                             request,
                             completed.Version,
@@ -208,7 +210,7 @@ public sealed partial class ManagedModuleInstallService
                 if (TrySelectInstalledNoOpVersion(request, moduleRoot, context, out var installedVersion))
                 {
                     installedNoOpVersion = installedVersion;
-                    installedNoOpModulePath = Path.Combine(moduleRoot, request.Name.Trim(), installedVersion);
+                    installedNoOpModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, installedVersion);
                 }
             }
 
@@ -862,6 +864,23 @@ public sealed partial class ManagedModuleInstallService
 
     private static string ResolveModuleDirectoryVersion(string version)
         => ManagedModulePackageIdentity.RequireSafeVersion(version, nameof(version));
+
+    private static string ResolveInstalledModulePath(string moduleRoot, string moduleName, string version)
+    {
+        var moduleFolder = Path.Combine(moduleRoot, moduleName.Trim());
+        var versionPath = Path.Combine(moduleFolder, ResolveModuleDirectoryVersion(version));
+        if (Directory.Exists(versionPath))
+            return versionPath;
+
+        var flatManifestPath = ResolveInstalledManifestPath(moduleName, moduleFolder);
+        if (!string.IsNullOrWhiteSpace(flatManifestPath) &&
+            IsInstalledModulePathSatisfied(moduleFolder, moduleName, version))
+        {
+            return moduleFolder;
+        }
+
+        return versionPath;
+    }
 
     private static bool IsInstalledModulePathSatisfied(string modulePath, string moduleName, string version)
     {

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -200,26 +200,34 @@ public sealed partial class ManagedModuleInstallService
                 }
             }
 
+            string? installedNoOpVersion = null;
+            string? installedNoOpModulePath = null;
             using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var initialLockWaitElapsed))
             {
                 installLockWaitElapsed += initialLockWaitElapsed;
                 if (TrySelectInstalledNoOpVersion(request, moduleRoot, context, out var installedVersion))
                 {
-                    var installedModulePath = Path.Combine(moduleRoot, request.Name.Trim(), installedVersion);
-                    _logger.Verbose($"Managed module install skipped existing satisfying version: {installedModulePath}");
-                    var result = CreateAlreadyInstalledResult(
-                        request,
-                        installedVersion,
-                        moduleRoot,
-                        installedModulePath,
-                        stopwatch.Elapsed,
-                        TimeSpan.Zero,
-                        repositoryRequestCount: 0,
-                        installLockWaitElapsed);
-
-                    context.RecordInstalledVersion(moduleRoot, request.Name, installedVersion);
-                    return CompletePreResolvedInstall(result);
+                    installedNoOpVersion = installedVersion;
+                    installedNoOpModulePath = Path.Combine(moduleRoot, request.Name.Trim(), installedVersion);
                 }
+            }
+
+            if (installedNoOpVersion is not null && installedNoOpModulePath is not null)
+            {
+                _logger.Verbose($"Managed module install skipped existing satisfying version: {installedNoOpModulePath}");
+                context.RecordInstalledVersion(moduleRoot, request.Name, installedNoOpVersion);
+                var result = await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
+                    request,
+                    installedNoOpVersion,
+                    moduleRoot,
+                    installedNoOpModulePath,
+                    stopwatch.Elapsed,
+                    TimeSpan.Zero,
+                    repositoryRequestCount: 0,
+                    installLockWaitElapsed,
+                    context,
+                    cancellationToken).ConfigureAwait(false);
+                return CompletePreResolvedInstall(result);
             }
 
             using var requestScope = _repositoryClient.BeginRequestScope();
@@ -409,7 +417,7 @@ public sealed partial class ManagedModuleInstallService
                 {
                     _logger.Verbose($"Managed module install skipped existing version: {modulePath}");
                     context.RecordInstalledVersion(moduleRoot, request.Name, version);
-                    return CreateAlreadyInstalledResult(
+                    return await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
                         request,
                         version,
                         moduleRoot,
@@ -417,7 +425,9 @@ public sealed partial class ManagedModuleInstallService
                         stopwatch.Elapsed,
                         versionResolutionElapsed,
                         requestScope.Count,
-                        installLockWaitElapsed);
+                        installLockWaitElapsed,
+                        context,
+                        cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -586,7 +596,7 @@ public sealed partial class ManagedModuleInstallService
                     {
                         _logger.Verbose($"Managed module install skipped concurrently installed version: {modulePath}");
                         context.RecordInstalledVersion(moduleRoot, request.Name, version);
-                        return CreateAlreadyInstalledResult(
+                        return await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
                             request,
                             version,
                             moduleRoot,
@@ -594,7 +604,9 @@ public sealed partial class ManagedModuleInstallService
                             stopwatch.Elapsed,
                             versionResolutionElapsed,
                             requestScope.Count,
-                            installLockWaitElapsed);
+                            installLockWaitElapsed,
+                            context,
+                            cancellationToken).ConfigureAwait(false);
                     }
 
                     if (directPayloadLease is not null && !Directory.Exists(modulePath))

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -872,6 +872,10 @@ public sealed partial class ManagedModuleInstallService
         if (Directory.Exists(versionPath))
             return versionPath;
 
+        var equivalentVersionPath = ResolveInstalledVersionDirectoryPath(moduleFolder, moduleName, version);
+        if (!string.IsNullOrWhiteSpace(equivalentVersionPath))
+            return equivalentVersionPath!;
+
         var flatManifestPath = ResolveInstalledManifestPath(moduleName, moduleFolder);
         if (!string.IsNullOrWhiteSpace(flatManifestPath) &&
             IsInstalledModulePathSatisfied(moduleFolder, moduleName, version))
@@ -880,6 +884,39 @@ public sealed partial class ManagedModuleInstallService
         }
 
         return versionPath;
+    }
+
+    private static string? ResolveInstalledVersionDirectoryPath(string moduleFolder, string moduleName, string version)
+    {
+        if (!Directory.Exists(moduleFolder))
+            return null;
+
+        try
+        {
+            foreach (var directoryPath in Directory.EnumerateDirectories(moduleFolder))
+            {
+                var directoryName = Path.GetFileName(directoryPath);
+                if (string.IsNullOrWhiteSpace(directoryName) ||
+                    ManagedModuleInstallContext.IsManagedStageDirectory(directoryName!) ||
+                    !IsInstalledVersionDirectoryName(directoryName))
+                {
+                    continue;
+                }
+
+                if (IsInstalledModulePathSatisfied(directoryPath, moduleName, version))
+                    return directoryPath;
+            }
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        return null;
     }
 
     private static bool IsInstalledModulePathSatisfied(string modulePath, string moduleName, string version)
@@ -908,6 +945,26 @@ public sealed partial class ManagedModuleInstallService
         {
             return true;
         }
+    }
+
+    private static bool IsInstalledVersionDirectoryName(string? directoryName)
+    {
+        if (string.IsNullOrWhiteSpace(directoryName))
+            return false;
+
+        var value = directoryName!.Trim();
+        var plusIndex = value.IndexOf('+');
+        if (plusIndex >= 0)
+            value = value.Substring(0, plusIndex);
+
+        var dashIndex = value.IndexOf('-');
+        var numeric = dashIndex >= 0 ? value.Substring(0, dashIndex) : value;
+        if (numeric.Length == 0)
+            return false;
+
+        var parts = numeric.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length > 0 &&
+               parts.All(static part => part.Length > 0 && part.All(static character => character >= '0' && character <= '9'));
     }
 
     private static ManagedModuleVersionInfo CreateRequestedVersionInfo(ManagedModuleInstallRequest request, string version)


### PR DESCRIPTION
## Summary
- Repair missing manifest-declared dependencies when a managed module's top-level version is already installed.
- Preserve the fast already-installed path for modules without manifest `RequiredModules`.
- Keep repair planning and install behavior aligned across external dependencies, flat installs, equivalent version directories, recursive installed dependencies, multi-version dependency graphs, and already-satisfied cycles.

## Validation
- Focused managed-module/plan/fanout/latest tests passed on the current head: 34/34.
- Broader `FullyQualifiedName~ManagedModule` test slice passed on the current head: 427/427.
- `git diff --check` passed.
- Earlier validation included module build with `-NoInteractive -NoExitCode -NoSign`, full `PowerForge.Tests`, and Windows PowerShell 5.1 / PowerShell 7 live Graph repair smoke.
