### PR TITLE
Align managed install with latest-first repair semantics

### DIFF
--- a/Docs/PSPublishModule.ManagedModules.Compatibility.md
+++ b/Docs/PSPublishModule.ManagedModules.Compatibility.md
@@ -65,6 +65,10 @@ Install-ManagedModule -Name Company.Tools -Scope CurrentUser -Repository PSGalle
 Install-ManagedModule -Name Company.Tools -RequiredVersion 1.2.0 -ProfileName CompanyModules -AcceptLicense
 ```
 
+Default install is latest-first for broad requests. When the caller does not pin an exact version, `Install-ManagedModule` resolves the repository-selected version first, then compares that selected version with the target module root. If the repository has a newer version than the locally installed copy, the newer version is installed side-by-side. If the selected version is already installed, the command performs a cheap installed-manifest dependency health check. Missing or unsatisfied manifest `RequiredModules` are repaired automatically without forcing a healthy root-module reinstall.
+
+Exact-version installs keep the fast local no-op path. `-Version`, `-RequiredVersion`, or an exact `-VersionPolicy` can skip repository work when the selected installed version is already healthy. Use `-Force` only when the selected root module version itself should be replaced.
+
 ### Update
 
 ```powershell
@@ -80,6 +84,8 @@ Repair-ManagedModule -Latest -Repository PSGallery -Plan -ShowSummary
 Repair-ManagedModule -Family Graph -Repository PSGallery -Plan -ShowSummary
 Repair-ManagedModule -MaintenanceReceiptPath .\module-maintenance.json -Repository CompanyModules -Plan
 ```
+
+Repair plans include manifest dependency health. An installed module whose own version is otherwise fine can still receive an install-repair action when its manifest `RequiredModules` are missing or outside the declared version policy. External runtime dependencies declared through `PrivateData.PSData.ExternalModuleDependencies` are not treated as managed install dependencies.
 
 ### Installed Inventory
 
@@ -165,6 +171,8 @@ Those scenarios should continue through native provider commands until they have
 This checklist is the guardrail for replacing common PowerShellGet and PSResourceGet usage without surprises. Matching a parameter name is not enough; each item needs behavior proof, tests, and benchmark evidence when it can affect speed.
 
 - [x] `Install-ManagedModule` supports common `Install-Module` flows: `-Name`, `-Repository`, `-RequiredVersion`, `-MinimumVersion`, `-MaximumVersion`, `-Scope`, `-Force`, `-AllowClobber`, `-AcceptLicense`, `-Credential`, `-WhatIf`, and `-Confirm`.
+- [x] `Install-ManagedModule` resolves repository-selected latest versions for broad requests before treating a local install as satisfying the operation, matching PSResourceGet-style latest-first expectations without giving up exact-version no-op speed.
+- [x] `Install-ManagedModule` repairs missing or unsatisfied manifest dependencies when the selected installed version is already present and broken, without requiring `-Force`.
 - [x] `Update-ManagedModule` supports named updates and no-name estate updates from selected module roots, matching the common `Update-Module` operator habit.
 - [x] `Save-ManagedModule` supports dependency closure, explicit path, version policies, license acceptance, forced replacement, and import-validation benchmark proof.
 - [x] `Find-ManagedModule` supports repository/profile lookup, wildcard module names, all versions, prerelease inclusion, and fast latest-version lookup.
@@ -217,6 +225,8 @@ Cmdlets should map parameters into these models and write result objects. They s
 - Credentials are resolved before managed repository access. The core engine receives credential values or no credential; it does not call external credential helpers.
 - Retries, timeouts, cancellation, proxy behavior, endpoint selection, and HTTP error messages belong in the managed repository client. The public PowerShell Gallery default resolves read operations through its NuGet v2 endpoint to avoid slow or blocked v3 service-index probes.
 - Side-by-side versions are valid when version policies ask for exact or compatible copies. Forced replacement stages first and rolls back on promotion failure.
+- Broad install requests select from the repository first, then decide whether the selected version is already installed. This means `Install-ManagedModule -Name Microsoft.Graph` can install `2.38.0` side-by-side when `2.37.0` is present and `2.38.0` is the repository-selected version.
+- When the selected installed version is already present, install checks the installed manifest dependency graph and repairs missing or unsatisfied managed dependencies unless dependency checks are explicitly skipped.
 - Downgrades require a dedicated explicit downgrade policy; `-Force` alone is not a downgrade request.
 - Loaded modules can block unsafe updates unless the caller explicitly allows that risk.
 - Cross-scope repairs must target the requested scope and must not treat a satisfying copy in another scope as equivalent.
@@ -228,9 +238,11 @@ Cmdlets should map parameters into these models and write result objects. They s
 
 - `Install-ManagedModule -Force` and `Save-ManagedModule -Force` replace the exact selected module version when that version already exists in the target root.
 - Without `-Force`, installing or saving an exact version that already exists is a no-op plan and does not write files.
+- `-Force` is not required for dependency repair. If the repository-selected installed version is present but its managed manifest dependencies are missing or unsatisfied, install repairs those dependencies while leaving the healthy root module in place.
 - `Update-ManagedModule -Force` reinstalls the selected target version when the selected target is already the installed version.
 - `Update-ManagedModule -Force` does not silently downgrade a newer installed version to an older selected version. Downgrade behavior needs a separate explicit policy so stale-version repair and operator mistakes do not collapse into the same switch.
 - `Repair-ManagedModule -Force` marks prepared managed/private install, update, and save delivery commands as forced. In `-Plan` mode this is visible on the prepared command object and command arguments, but no mutation occurs.
+- `Repair-ManagedModule` can plan a non-forced install repair for an installed module whose manifest dependency graph is broken. The repair action targets the installed root module version so the managed installer can restore the dependency closure without replacing the healthy root module unless `-Force` is supplied.
 - `-Force` does not imply destructive old-version cleanup. Cleanup remains a separate maintenance/repair decision.
 - `Publish-ManagedModule -Force` bypasses managed preflight duplicate/version guards where the target repository supports replacement or accepts the pushed package. It does not guarantee that a remote feed will overwrite an existing package.
 

--- a/Docs/PSPublishModule.ManagedModules.Roadmap.md
+++ b/Docs/PSPublishModule.ManagedModules.Roadmap.md
@@ -22,6 +22,8 @@ The public PowerShell surface should stay thin. Reusable behavior belongs in Pow
 - [x] Managed find, save, install, update, publish, and repair cmdlets exist as thin PowerShell surfaces over the reusable C# engine.
 - [x] The core managed path avoids PowerShellGet, PSResourceGet, PackageManagement, external executables, and embedded PowerShell scripts for supported module lifecycle operations.
 - [x] `Repair-ManagedModule` is the operator-facing maintenance surface for stale versions, source drift, scope drift, family coherence, loaded-module safety, and old-version cleanup planning.
+- [x] `Install-ManagedModule` uses latest-first repository selection for broad requests while preserving exact-version fast no-op behavior.
+- [x] Installed selected versions are checked for broken managed manifest dependencies and repaired automatically without requiring `-Force`.
 - [x] Benchmarks live outside the shipped module under `Benchmarks/ManagedModules`, with named gates for install, save, update, publish, repair, security, and host drift.
 - [x] Current local Graph and Az evidence shows managed install/save ahead of the measured compatible providers on PowerShell 7 and Windows PowerShell 5.1 for the recorded gates.
 - [ ] Final release claims still need a fresh repeated benchmark pass from the release candidate build, including retained command lines, suite metadata, gate results, and compact evidence paths.
@@ -91,6 +93,8 @@ The public PowerShell surface should stay thin. Reusable behavior belongs in Pow
 - [x] Support `Update-ManagedModule` without `-Name` so the command updates installed modules from the selected roots like `Update-Module`.
 - [x] Finish exact `-Force`, `-TrustRepository`, and `-SkipPublisherCheck` semantics so compatibility choices are explicit and unsurprising.
 - [x] Define exact install/save/update semantics for `-Force`, `-AllowClobber`, and `-AcceptLicense` so the common managed delivery path is explicit and unsurprising.
+- [x] Define exact broad-install behavior: resolve the repository-selected version first, install a newer selected version side-by-side, and only no-op when the selected installed version is present and healthy.
+- [x] Define exact repair behavior for broken installed manifest dependency graphs: restore missing or unsatisfied managed `RequiredModules` without forcing a healthy root-module replacement.
 - [ ] Complete managed Authenticode/catalog validation compatible with PowerShellGet/PSResourceGet expectations, including explicit catalog policy evidence, timestamped signatures, and short-lived certificate behavior.
 - [x] Add initial Windows managed `-AuthenticodeCheck` support for install/save/update by validating extracted signable files before promotion.
 
@@ -99,6 +103,7 @@ The public PowerShell surface should stay thin. Reusable behavior belongs in Pow
 - [x] `Get-ManagedModule` inventories installed modules and returns module rows by default.
 - [x] `Update-ManagedModule` updates named modules or, when no name is supplied, all discovered modules in the selected scope/root.
 - [x] `Repair-ManagedModule` plans and applies estate maintenance through the ModuleState engine with managed delivery as the default transport.
+- [x] `Repair-ManagedModule` detects broken installed manifest dependency graphs and plans managed install repair actions for the affected installed root version.
 - [x] Finish `Repair-ManagedModule` proof for loaded-module safety and old-version cleanup.
 - [ ] `-Plan` remains the non-mutating inspection switch across install, update, and repair flows.
 - [ ] `-WhatIf` remains the operator safety gate for mutations.

--- a/PSPublishModule/Services/ModuleStateManagedDeliveryService.cs
+++ b/PSPublishModule/Services/ModuleStateManagedDeliveryService.cs
@@ -70,7 +70,7 @@ internal sealed class ModuleStateManagedDeliveryService
         return new ModuleStateDeliveryExecutionResult
         {
             Operation = "Install",
-            OperationPerformed = result.Status == ManagedModuleInstallStatus.Installed,
+            OperationPerformed = InstallWroteFiles(result),
             RepositoryName = repository.Name,
             RequestedTransport = ModuleStateDeliveryTransport.ManagedModule,
             EffectiveTransport = ModuleStateDeliveryTransport.ManagedModule,
@@ -301,6 +301,10 @@ internal sealed class ModuleStateManagedDeliveryService
                 }
             }
         };
+
+    private static bool InstallWroteFiles(ManagedModuleInstallResult result)
+        => result.Status == ManagedModuleInstallStatus.Installed ||
+           result.DependencyResults.Any(InstallWroteFiles);
 
     private static string? FirstNonEmpty(params string?[] values)
         => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));

--- a/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleDependencyInstallServiceTests.cs
@@ -73,6 +73,42 @@ public sealed class ManagedModuleDependencyInstallServiceTests
     }
 
     [Fact]
+    public async Task InstallAsync_repairs_manifest_dependency_when_repository_latest_is_already_installed()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        WriteInstalledRootWithRequiredModule(moduleRoot.Path, "Company.Tools", "1.0.0", "Company.Core", "1.0.0");
+        File.WriteAllText(Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0", "marker.txt"), "keep-root");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, result.Status);
+        Assert.Equal("1.0.0", result.Version);
+        Assert.Equal("keep-root", File.ReadAllText(Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0", "marker.txt")));
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal(ManagedModuleInstallStatus.Installed, dependency.Status);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Core", "1.0.0", "Company.Core.psd1")));
+    }
+
+    [Fact]
     public async Task InstallAsync_does_not_repair_manifest_dependencies_marked_external()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModuleInstallLatestVersionTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallLatestVersionTests.cs
@@ -6,7 +6,7 @@ namespace PowerForge.Tests;
 public sealed class ManagedModuleInstallLatestVersionTests
 {
     [Fact]
-    public async Task PlanInstallAsync_skips_installed_unbounded_version_without_repository_lookup()
+    public async Task PlanInstallAsync_keeps_higher_installed_unbounded_version_after_repository_lookup()
     {
         var requests = new List<RecordedRequest>();
         using var client = new HttpClient(new LatestPackageHandler(requests));
@@ -27,11 +27,11 @@ public sealed class ManagedModuleInstallLatestVersionTests
         Assert.Equal("1.2.0", plan.Version);
         Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
         Assert.True(plan.ExistingVersionFound);
-        Assert.Empty(requests);
+        Assert.Contains(requests, request => request.Url == LatestPackageHandler.LatestStableUrl);
     }
 
     [Fact]
-    public async Task InstallAsync_skips_installed_unbounded_version_without_repository_lookup()
+    public async Task InstallAsync_keeps_higher_installed_unbounded_version_after_repository_lookup()
     {
         var requests = new List<RecordedRequest>();
         using var client = new HttpClient(new LatestPackageHandler(requests));
@@ -51,18 +51,24 @@ public sealed class ManagedModuleInstallLatestVersionTests
 
         Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, result.Status);
         Assert.Equal("1.2.0", result.Version);
-        Assert.Equal(TimeSpan.Zero, result.VersionResolutionElapsed);
-        Assert.Equal(0, result.RepositoryRequestCount);
-        Assert.Empty(requests);
+        Assert.True(result.VersionResolutionElapsed > TimeSpan.Zero);
+        Assert.True(result.RepositoryRequestCount > 0);
+        Assert.Contains(requests, request => request.Url == LatestPackageHandler.LatestStableUrl);
     }
 
     [Fact]
-    public async Task InstallAsync_skips_highest_installed_version_within_requested_bounds_without_repository_lookup()
+    public async Task InstallAsync_keeps_higher_installed_version_within_requested_bounds_after_repository_lookup()
     {
-        var requests = new List<RecordedRequest>();
-        using var client = new HttpClient(new LatestPackageHandler(requests));
-        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
-        var service = new ManagedModuleInstallService(new NullLogger(), repositoryClient);
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.1.0.nupkg"),
+            "Company.Tools",
+            "1.1.0",
+            files: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Company.Tools.psd1"] = "@{ ModuleVersion = '1.1.0' }"
+            });
+        var service = new ManagedModuleInstallService(new NullLogger());
         using var moduleRoot = new TemporaryDirectory();
         Directory.CreateDirectory(Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0"));
         Directory.CreateDirectory(Path.Combine(moduleRoot.Path, "Company.Tools", "1.2.0"));
@@ -70,7 +76,7 @@ public sealed class ManagedModuleInstallLatestVersionTests
 
         var result = await service.InstallAsync(new ManagedModuleInstallRequest
         {
-            Repository = new ManagedModuleRepository("Gallery", "https://example.test/api/v2"),
+            Repository = new ManagedModuleRepository("Gallery", feed.Path),
             Name = "Company.Tools",
             MinimumVersion = "1.1.0",
             MaximumVersion = "1.3.0",
@@ -80,8 +86,8 @@ public sealed class ManagedModuleInstallLatestVersionTests
 
         Assert.Equal(ManagedModuleInstallStatus.AlreadyInstalled, result.Status);
         Assert.Equal("1.2.0", result.Version);
-        Assert.Equal(0, result.RepositoryRequestCount);
-        Assert.Empty(requests);
+        Assert.Equal(0, result.PackageRepositoryRequestCount);
+        Assert.False(File.Exists(Path.Combine(moduleRoot.Path, "Company.Tools", "1.1.0", "Company.Tools.psd1")));
     }
 
     [Fact]

--- a/PowerForge.Tests/ManagedModuleInstallServiceTests.cs
+++ b/PowerForge.Tests/ManagedModuleInstallServiceTests.cs
@@ -133,6 +133,75 @@ public sealed partial class ManagedModuleInstallServiceTests
     }
 
     [Fact]
+    public async Task InstallAsync_installs_repository_latest_when_older_satisfying_version_is_installed()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        var existingPath = Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0");
+        Directory.CreateDirectory(existingPath);
+        File.WriteAllText(Path.Combine(existingPath, "Company.Tools.psd1"), "@{ ModuleVersion = '1.0.0' }");
+        File.WriteAllText(Path.Combine(existingPath, "marker.txt"), "keep-old");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateModuleFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.1.0.nupkg"),
+            "Company.Tools",
+            "1.1.0",
+            files: CreateModuleFiles("1.1.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var result = await service.InstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal(ManagedModuleInstallStatus.Installed, result.Status);
+        Assert.Equal("1.1.0", result.Version);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Tools", "1.1.0", "Company.Tools.psd1")));
+        Assert.Equal("keep-old", File.ReadAllText(Path.Combine(existingPath, "marker.txt")));
+    }
+
+    [Fact]
+    public async Task PlanInstallAsync_reports_install_when_repository_latest_is_newer_than_installed_version()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        var existingPath = Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0");
+        Directory.CreateDirectory(existingPath);
+        File.WriteAllText(Path.Combine(existingPath, "Company.Tools.psd1"), "@{ ModuleVersion = '1.0.0' }");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateModuleFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.1.0.nupkg"),
+            "Company.Tools",
+            "1.1.0",
+            files: CreateModuleFiles("1.1.0"));
+        var service = new ManagedModuleInstallService(new NullLogger());
+
+        var plan = await service.PlanInstallAsync(new ManagedModuleInstallRequest
+        {
+            Repository = new ManagedModuleRepository("Local", feed.Path),
+            Name = "Company.Tools",
+            Scope = ManagedModuleInstallScope.Custom,
+            ModuleRoot = moduleRoot.Path
+        });
+
+        Assert.Equal("1.1.0", plan.Version);
+        Assert.Equal(ManagedModuleInstallPlanAction.Install, plan.Action);
+        Assert.False(plan.ExistingVersionFound);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
     public async Task InstallAsync_does_not_skip_author_policy_for_existing_version()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ModuleStateRepairPlannerTests.cs
+++ b/PowerForge.Tests/ModuleStateRepairPlannerTests.cs
@@ -458,4 +458,105 @@ public sealed class ModuleStateRepairPlannerTests
         Assert.Equal("=2.38.0", action.VersionPolicy);
         Assert.True(action.IsRepair);
     }
+
+    [Fact]
+    public void CreateRepairActions_PlansInstallRepairForBrokenManifestDependencyGraph()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var modulePath = WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Tools",
+            "1.0.0",
+            ("Company.Core", "1.0.0"));
+        var inventory = new ModuleStateInventory(new[]
+        {
+            new ModuleStateInstalledModule(
+                "Company.Tools",
+                "1.0.0",
+                scope: "CurrentUser",
+                path: modulePath,
+                isEffectiveImportCandidate: true)
+        });
+        var existingActions = new[]
+        {
+            new ModuleStatePlanAction(
+                ModuleStatePlanActionKind.NoAction,
+                "Company.Tools",
+                "1.0.0",
+                "=1.0.0",
+                "Installed module version satisfies desired policy.",
+                targetScope: "CurrentUser",
+                targetRepository: "Local")
+        };
+
+        var action = Assert.Single(new ModuleStateRepairPlanner().CreateRepairActions(
+            inventory,
+            Array.Empty<ModuleStateMaintenanceReceipt>(),
+            existingActions));
+
+        Assert.Equal(ModuleStatePlanActionKind.Install, action.Kind);
+        Assert.Equal("Company.Tools", action.ModuleName);
+        Assert.Equal("1.0.0", action.InstalledVersion);
+        Assert.Equal("=1.0.0", action.VersionPolicy);
+        Assert.Equal("CurrentUser", action.TargetScope);
+        Assert.Equal(moduleRoot.Path, action.TargetPath);
+        Assert.Equal("Local", action.TargetRepository);
+        Assert.True(action.IsRepair);
+        Assert.False(action.Force);
+    }
+
+    [Fact]
+    public void CreateRepairActions_DoesNotPlanManifestRepairForExternalDependency()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var modulePath = WriteInstalledModuleManifest(
+            moduleRoot.Path,
+            "Company.Tools",
+            "1.0.0",
+            ("External.Tools", "9.0.0"));
+        File.WriteAllText(
+            Path.Combine(modulePath, "Company.Tools.psd1"),
+            "@{ ModuleVersion = '1.0.0'; RequiredModules = @(@{ ModuleName = 'External.Tools'; RequiredVersion = '9.0.0'; }); PrivateData = @{ PSData = @{ ExternalModuleDependencies = @('External.Tools') } } }");
+        var inventory = new ModuleStateInventory(new[]
+        {
+            new ModuleStateInstalledModule("Company.Tools", "1.0.0", path: modulePath)
+        });
+        var existingActions = new[]
+        {
+            new ModuleStatePlanAction(
+                ModuleStatePlanActionKind.NoAction,
+                "Company.Tools",
+                "1.0.0",
+                "=1.0.0",
+                "Installed module version satisfies desired policy.")
+        };
+
+        var action = Assert.Single(new ModuleStateRepairPlanner().CreateRepairActions(
+            inventory,
+            Array.Empty<ModuleStateMaintenanceReceipt>(),
+            existingActions));
+
+        Assert.Equal(ModuleStatePlanActionKind.NoAction, action.Kind);
+        Assert.False(action.IsRepair);
+    }
+
+    private static string WriteInstalledModuleManifest(
+        string moduleRoot,
+        string moduleName,
+        string version,
+        params (string Name, string Version)[] dependencies)
+    {
+        var modulePath = Path.Combine(moduleRoot, moduleName, version);
+        Directory.CreateDirectory(modulePath);
+        var requiredModules = dependencies.Length == 0
+            ? string.Empty
+            : "; RequiredModules = @(" + string.Join(
+                ", ",
+                dependencies.Select(static dependency =>
+                    "@{ ModuleName = '" + dependency.Name + "'; RequiredVersion = '" + dependency.Version + "'; }")) + ")";
+        File.WriteAllText(
+            Path.Combine(modulePath, moduleName + ".psd1"),
+            "@{ ModuleVersion = '" + version + "'" + requiredModules + " }");
+        return modulePath;
+    }
 }

--- a/PowerForge.Tests/RepairManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/RepairManagedModuleCommandTests.cs
@@ -533,6 +533,39 @@ public sealed class RepairManagedModuleCommandTests
     }
 
     [Fact]
+    public void RepairManagedModule_AppliesManifestDependencyRepairToInstalledModule()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        CreateInstalledModuleWithRequiredModule(moduleRoot.Path, "Company.Tools", "1.0.0", "Company.Core", "1.0.0");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateModuleFiles("Company.Core", "1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Repair-ManagedModule")
+            .AddParameter("ModulePath", new[] { moduleRoot.Path })
+            .AddParameter("Name", new[] { "Company.Tools" })
+            .AddParameter("Repository", feed.Path);
+
+        var result = Assert.IsType<ModuleStateWorkflowResult>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        var action = Assert.Single(result.Plan.Actions, static action =>
+            string.Equals(action.ModuleName, "Company.Tools", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("Install", action.Kind);
+        Assert.True(action.IsRepair);
+        Assert.Equal("=1.0.0", action.VersionPolicy);
+        Assert.True(result.Apply.ExecutionRequested);
+        var execution = Assert.Single(result.Apply.ExecutionResults);
+        Assert.Equal("Install", execution.Operation);
+        Assert.True(execution.OperationPerformed);
+        Assert.True(File.Exists(Path.Combine(moduleRoot.Path, "Company.Core", "1.0.0", "Company.Core.psd1")));
+    }
+
+    [Fact]
     public void RepairManagedModule_ForceDoesNotApproveExplicitDowngradePolicy()
     {
         using var moduleRoot = new TemporaryDirectory();
@@ -566,6 +599,22 @@ public sealed class RepairManagedModuleCommandTests
         File.WriteAllText(
             Path.Combine(modulePath, name + ".psd1"),
             "@{ RootModule = '" + name + ".psm1'; ModuleVersion = '" + version + "' }");
+        File.WriteAllText(Path.Combine(modulePath, name + ".psm1"), string.Empty);
+        return modulePath;
+    }
+
+    private static string CreateInstalledModuleWithRequiredModule(
+        string moduleRoot,
+        string name,
+        string version,
+        string dependencyName,
+        string dependencyVersion)
+    {
+        var modulePath = Path.Combine(moduleRoot, name, version);
+        Directory.CreateDirectory(modulePath);
+        File.WriteAllText(
+            Path.Combine(modulePath, name + ".psd1"),
+            "@{ RootModule = '" + name + ".psm1'; ModuleVersion = '" + version + "'; RequiredModules = @(@{ ModuleName = '" + dependencyName + "'; RequiredVersion = '" + dependencyVersion + "'; }) }");
         File.WriteAllText(Path.Combine(modulePath, name + ".psm1"), string.Empty);
         return modulePath;
     }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -355,9 +355,15 @@ public sealed partial class ManagedModuleInstallService
         string version,
         ManagedModuleInstallRequest request,
         ManagedModuleVersionRange range)
+        => AllowsInstalledDependencyVersion(version, request.IncludePrerelease, range);
+
+    private static bool AllowsInstalledDependencyVersion(
+        string version,
+        bool includePrerelease,
+        ManagedModuleVersionRange range)
     {
         if (ManagedModuleVersionComparer.IsPrerelease(version) &&
-            !request.IncludePrerelease &&
+            !includePrerelease &&
             !range.AllowsPrerelease)
             return false;
 
@@ -503,19 +509,32 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleInstallRequest request,
         string moduleRoot,
         string modulePath)
-    {
-        if (request.SkipDependencyCheck)
-            return false;
+        => WouldRepairInstalledManifestDependencies(
+            request.Name,
+            moduleRoot,
+            modulePath,
+            request.IncludePrerelease,
+            request.SkipDependencyCheck);
 
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        return WouldRepairInstalledManifestDependenciesCore(request, request.Name, moduleRoot, modulePath, visited);
-    }
-
-    private static bool WouldRepairInstalledManifestDependenciesCore(
-        ManagedModuleInstallRequest request,
+    internal static bool WouldRepairInstalledManifestDependencies(
         string moduleName,
         string moduleRoot,
         string modulePath,
+        bool includePrerelease = false,
+        bool skipDependencyCheck = false)
+    {
+        if (skipDependencyCheck)
+            return false;
+
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return WouldRepairInstalledManifestDependenciesCore(moduleName, moduleRoot, modulePath, includePrerelease, visited);
+    }
+
+    private static bool WouldRepairInstalledManifestDependenciesCore(
+        string moduleName,
+        string moduleRoot,
+        string modulePath,
+        bool includePrerelease,
         ISet<string> visited)
     {
         if (!visited.Add(CreateManifestRepairVisitKey(moduleName, modulePath)))
@@ -529,13 +548,13 @@ public sealed partial class ManagedModuleInstallService
         {
             var range = ManagedModuleVersionRange.Parse(dependency.VersionRange);
             var installedVersion = GetInstalledVersions(moduleRoot, dependency.Id)
-                .Where(version => AllowsInstalledDependencyVersion(version, request, range))
+                .Where(version => AllowsInstalledDependencyVersion(version, includePrerelease, range))
                 .LastOrDefault();
             if (installedVersion is null)
                 return true;
 
             var dependencyPath = ResolveInstalledModulePath(moduleRoot, dependency.Id, installedVersion);
-            if (WouldRepairInstalledManifestDependenciesCore(request, dependency.Id, moduleRoot, dependencyPath, visited))
+            if (WouldRepairInstalledManifestDependenciesCore(dependency.Id, moduleRoot, dependencyPath, includePrerelease, visited))
                 return true;
         }
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -58,7 +58,8 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleTrustEvaluator.ThrowIfRepositoryRejected(request.Repository, request.TrustPolicy);
 
         var moduleRoot = ManagedModuleInstallRootResolver.Resolve(request.Scope, request.ShellEdition, request.ModuleRoot);
-        if (TrySelectInstalledNoOpVersion(request, moduleRoot, context: null, out var installedVersion))
+        if (CanSelectInstalledNoOpBeforeRepositoryResolution(request) &&
+            TrySelectInstalledNoOpVersion(request, moduleRoot, context: null, out var installedVersion))
         {
             var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, installedVersion);
             return CreateInstallPlan(
@@ -71,14 +72,32 @@ public sealed partial class ManagedModuleInstallService
         }
 
         var versionInfo = await ResolveSelectedVersionInfoAsync(request, cancellationToken, resolveExactMetadata: true).ConfigureAwait(false);
-        var modulePath = Path.Combine(moduleRoot, request.Name.Trim(), ResolveModuleDirectoryVersion(versionInfo.Version));
+        if (TrySelectInstalledNoOpVersionAtLeast(request, moduleRoot, context: null, versionInfo.Version, out var satisfyingInstalledVersion))
+        {
+            var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, satisfyingInstalledVersion);
+            var installedVersionInfo = ManagedModuleVersionComparer.Instance.Compare(satisfyingInstalledVersion, versionInfo.Version) == 0
+                ? versionInfo
+                : null;
+            return CreateInstallPlan(
+                request,
+                satisfyingInstalledVersion,
+                moduleRoot,
+                installedModulePath,
+                exists: true,
+                installedVersionInfo,
+                wouldRepairDependencies: WouldRepairInstalledManifestDependencies(request, moduleRoot, installedModulePath));
+        }
+
+        var modulePath = ResolveInstalledModulePath(moduleRoot, request.Name, versionInfo.Version);
+        var exists = IsInstalledModulePathSatisfied(modulePath, request.Name, versionInfo.Version);
         return CreateInstallPlan(
             request,
             versionInfo.Version,
             moduleRoot,
             modulePath,
-            Directory.Exists(modulePath),
-            versionInfo);
+            exists,
+            versionInfo,
+            exists && WouldRepairInstalledManifestDependencies(request, moduleRoot, modulePath));
     }
 
     private static ManagedModuleInstallPlan CreateInstallPlan(
@@ -207,7 +226,8 @@ public sealed partial class ManagedModuleInstallService
             using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var initialLockWaitElapsed))
             {
                 installLockWaitElapsed += initialLockWaitElapsed;
-                if (TrySelectInstalledNoOpVersion(request, moduleRoot, context, out var installedVersion))
+                if (CanSelectInstalledNoOpBeforeRepositoryResolution(request) &&
+                    TrySelectInstalledNoOpVersion(request, moduleRoot, context, out var installedVersion))
                 {
                     installedNoOpVersion = installedVersion;
                     installedNoOpModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, installedVersion);
@@ -238,7 +258,31 @@ public sealed partial class ManagedModuleInstallService
             var versionInfo = await ResolveSelectedVersionInfoAsync(request, cancellationToken).ConfigureAwait(false);
             var version = versionInfo.Version;
             versionResolutionStopwatch.Stop();
-            var modulePath = Path.Combine(moduleRoot, request.Name.Trim(), ResolveModuleDirectoryVersion(version));
+
+            using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var postResolutionLockWaitElapsed))
+            {
+                installLockWaitElapsed += postResolutionLockWaitElapsed;
+                if (TrySelectInstalledNoOpVersionAtLeast(request, moduleRoot, context, version, out var satisfyingInstalledVersion))
+                {
+                    var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, satisfyingInstalledVersion);
+                    _logger.Verbose($"Managed module install skipped existing satisfying version: {installedModulePath}");
+                    context.RecordInstalledVersion(moduleRoot, request.Name, satisfyingInstalledVersion);
+                    var result = await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
+                        request,
+                        satisfyingInstalledVersion,
+                        moduleRoot,
+                        installedModulePath,
+                        stopwatch.Elapsed,
+                        versionResolutionStopwatch.Elapsed,
+                        requestScope.Count,
+                        installLockWaitElapsed,
+                        context,
+                        cancellationToken).ConfigureAwait(false);
+                    return CompletePreResolvedInstall(result);
+                }
+            }
+
+            var modulePath = ResolveInstalledModulePath(moduleRoot, request.Name, version);
 
             var coalescingKey = preResolvedCoalescingKey ?? TryCreateInstallCoalescingKey(request, version, moduleRoot);
             if (preResolvedPendingInstall is not null && coalescingKey is not null)
@@ -360,6 +404,42 @@ public sealed partial class ManagedModuleInstallService
 
         version = installedVersion;
         return true;
+    }
+
+    private static bool TrySelectInstalledNoOpVersionAtLeast(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        ManagedModuleInstallContext? context,
+        string selectedVersion,
+        out string version)
+    {
+        version = string.Empty;
+
+        if (CanSelectInstalledNoOpBeforeRepositoryResolution(request) ||
+            request.Force ||
+            RequiresPackageDownloadBeforeNoOp(request))
+        {
+            return false;
+        }
+
+        var installedVersion = GetInstalledVersions(moduleRoot, request.Name, context)
+            .Where(candidate => AllowsInstalledNoOpVersion(candidate, request))
+            .Where(candidate => ManagedModuleVersionComparer.Instance.Compare(candidate, selectedVersion) >= 0)
+            .LastOrDefault();
+        if (installedVersion is null)
+            return false;
+
+        version = installedVersion;
+        return true;
+    }
+
+    private static bool CanSelectInstalledNoOpBeforeRepositoryResolution(ManagedModuleInstallRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.Version))
+            return true;
+
+        var range = ResolveVersionRange(request.VersionPolicy, request.MinimumVersion, request.MaximumVersion);
+        return range.ExactVersion is not null;
     }
 
     private static bool AllowsInstalledNoOpVersion(string version, ManagedModuleInstallRequest request)
@@ -928,13 +1008,13 @@ public sealed partial class ManagedModuleInstallService
         if (!File.Exists(manifestPath))
             manifestPath = Directory.EnumerateFiles(modulePath, "*.psd1", SearchOption.TopDirectoryOnly).FirstOrDefault() ?? string.Empty;
         if (string.IsNullOrWhiteSpace(manifestPath))
-            return true;
+            return IsInstalledPathVersionNameSatisfied(modulePath, version);
 
         try
         {
             var manifest = new ModuleManifestMetadataReader().Read(manifestPath);
             if (string.IsNullOrWhiteSpace(manifest.ModuleVersion))
-                return true;
+                return IsInstalledPathVersionNameSatisfied(modulePath, version);
 
             var manifestVersion = string.IsNullOrWhiteSpace(manifest.PreRelease)
                 ? manifest.ModuleVersion.Trim()
@@ -943,7 +1023,26 @@ public sealed partial class ManagedModuleInstallService
         }
         catch
         {
-            return true;
+            return IsInstalledPathVersionNameSatisfied(modulePath, version);
+        }
+    }
+
+    private static bool IsInstalledPathVersionNameSatisfied(string modulePath, string version)
+    {
+        var directoryName = Path.GetFileName(modulePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (string.IsNullOrWhiteSpace(directoryName) ||
+            !IsInstalledVersionDirectoryName(directoryName))
+        {
+            return false;
+        }
+
+        try
+        {
+            return ManagedModuleVersionComparer.Instance.Compare(directoryName!, version) == 0;
+        }
+        catch
+        {
+            return string.Equals(directoryName, ResolveModuleDirectoryVersion(version), StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/PowerForge/Services/ModuleState/ModuleStateRepairPlanner.cs
+++ b/PowerForge/Services/ModuleState/ModuleStateRepairPlanner.cs
@@ -39,6 +39,12 @@ internal sealed class ModuleStateRepairPlanner
             actionsByModule[CreateActionKey(repairAction)] = repairAction;
         }
 
+        foreach (var repairAction in CreateManifestDependencyRepairActions(inventory, actionsByModule.Values.ToArray()))
+        {
+            RemoveActionKeysForModuleScope(actionsByModule, repairAction);
+            actionsByModule[CreateActionKey(repairAction)] = repairAction;
+        }
+
         return actionsByModule.Values
             .OrderBy(static action => action.ModuleName, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static action => action.TargetScope, StringComparer.OrdinalIgnoreCase)
@@ -140,6 +146,45 @@ internal sealed class ModuleStateRepairPlanner
         }
     }
 
+    private static IEnumerable<ModuleStatePlanAction> CreateManifestDependencyRepairActions(
+        ModuleStateInventory inventory,
+        IEnumerable<ModuleStatePlanAction> existingActions)
+    {
+        foreach (var action in existingActions ?? Array.Empty<ModuleStatePlanAction>())
+        {
+            if (action.Kind != ModuleStatePlanActionKind.NoAction)
+                continue;
+
+            var installedModule = FindInstalledModuleForAction(inventory, action);
+            if (installedModule is null ||
+                string.IsNullOrWhiteSpace(installedModule.Path))
+            {
+                continue;
+            }
+
+            var moduleRoot = ResolveModuleRoot(installedModule);
+            if (string.IsNullOrWhiteSpace(moduleRoot) ||
+                !ManagedModuleInstallService.WouldRepairInstalledManifestDependencies(
+                    installedModule.Name,
+                    moduleRoot!,
+                    installedModule.Path!))
+            {
+                continue;
+            }
+
+            yield return new ModuleStatePlanAction(
+                ModuleStatePlanActionKind.Install,
+                installedModule.Name,
+                installedModule.Version,
+                "=" + ModuleStateVersion.NormalizeOrOriginal(installedModule.Version),
+                "Manifest dependency repair: installed module has missing or unsatisfied manifest RequiredModules.",
+                isRepair: true,
+                targetScope: installedModule.Scope,
+                targetPath: moduleRoot,
+                targetRepository: action.TargetRepository);
+        }
+    }
+
     private static ModuleStatePlanAction? FindCoveredAction(
         IEnumerable<ModuleStatePlanAction> existingActions,
         string moduleName,
@@ -157,6 +202,56 @@ internal sealed class ModuleStateRepairPlanner
             string.Equals(action.ModuleName, moduleName, StringComparison.OrdinalIgnoreCase) &&
             (string.IsNullOrWhiteSpace(action.TargetScope) ||
              string.Equals(action.TargetScope, targetScope, StringComparison.OrdinalIgnoreCase)));
+
+    private static ModuleStateInstalledModule? FindInstalledModuleForAction(
+        ModuleStateInventory inventory,
+        ModuleStatePlanAction action)
+    {
+        var candidates = inventory.InstalledModules
+            .Where(module => string.Equals(module.Name, action.ModuleName, StringComparison.OrdinalIgnoreCase))
+            .Where(module => string.IsNullOrWhiteSpace(action.InstalledVersion) ||
+                             VersionsEqual(module.Version, action.InstalledVersion!))
+            .Where(module => string.IsNullOrWhiteSpace(action.TargetScope) ||
+                             string.Equals(module.Scope, action.TargetScope, StringComparison.OrdinalIgnoreCase))
+            .Where(module => string.IsNullOrWhiteSpace(action.TargetPath) ||
+                             IsUnderTargetPath(module.Path, action.TargetPath!))
+            .ToArray();
+
+        return SelectInstalledModule(candidates);
+    }
+
+    private static string? ResolveModuleRoot(ModuleStateInstalledModule module)
+    {
+        if (string.IsNullOrWhiteSpace(module.Path))
+            return null;
+
+        var moduleDirectory = new System.IO.DirectoryInfo(module.Path!);
+        if (string.Equals(moduleDirectory.Name, module.Name, StringComparison.OrdinalIgnoreCase))
+            return moduleDirectory.Parent?.FullName;
+
+        var parent = moduleDirectory.Parent;
+        return parent is not null &&
+               string.Equals(parent.Name, module.Name, StringComparison.OrdinalIgnoreCase)
+            ? parent.Parent?.FullName
+            : null;
+    }
+
+    private static bool IsUnderTargetPath(string? modulePath, string targetPath)
+    {
+        if (string.IsNullOrWhiteSpace(modulePath))
+            return false;
+
+        var normalizedModulePath = NormalizePath(modulePath!);
+        var normalizedTargetPath = NormalizePath(targetPath);
+        var comparison = FrameworkCompatibility.GetPathStringComparison(targetPath);
+        return string.Equals(normalizedModulePath, normalizedTargetPath, comparison) ||
+               normalizedModulePath.StartsWith(normalizedTargetPath + "/", comparison);
+    }
+
+    private static string NormalizePath(string path)
+        => path.Trim()
+            .TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar)
+            .Replace('\\', '/');
 
     private static ModuleStatePlanAction? CreateRepairAction(
         ModuleStateInventory inventory,


### PR DESCRIPTION
## Summary
- make broad `Install-ManagedModule` requests resolve the repository-selected version before deciding local state is already satisfying
- keep exact-version installs on the fast local no-op path, and keep a higher already-installed satisfying version instead of downgrading by side effect
- repair missing or unsatisfied installed manifest `RequiredModules` when the selected version is already installed, and teach `Repair-ManagedModule` to plan/apply that repair
- document the Force-vs-repair semantics and add focused install/update/repair contract coverage

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ManagedModule"`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release`
- `.\Module\Build\Build-Module.ps1 -NoInteractive -NoExitCode -NoSign`
- local temp-feed smoke in PowerShell 7.6.3 and Windows PowerShell 5.1.26100.8655
- `git diff --check`
