### PR TITLE
Add nupkg save mode for managed modules

### DIFF
--- a/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
@@ -88,6 +88,10 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
     [ValidateNotNullOrEmpty]
     public string? PackageCacheDirectory { get; set; }
 
+    /// <summary>Save the selected packages as .nupkg files instead of unpacked module folders.</summary>
+    [Parameter]
+    public SwitchParameter AsNupkg { get; set; }
+
     /// <summary>Maximum number of dependency branches to save concurrently. Omit to use the managed engine default.</summary>
     [Parameter]
     [ValidateRange(1, 256)]
@@ -207,6 +211,7 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
                 Scope = ManagedModuleInstallScope.Custom,
                 ModuleRoot = moduleRoot,
                 PackageCacheDirectory = packageCacheDirectory,
+                SaveAsNupkg = AsNupkg.IsPresent,
                 DependencyConcurrency = DependencyConcurrency,
                 ExpectedPackageSha256 = ExpectedPackageSha256,
                 TrustPolicy = trustPolicy,

--- a/PowerForge.Tests/ManagedModuleBundleMetadataWriterTests.cs
+++ b/PowerForge.Tests/ManagedModuleBundleMetadataWriterTests.cs
@@ -72,4 +72,30 @@ public sealed class ManagedModuleBundleMetadataWriterTests
         Assert.Null(entry.PackagePath);
         Assert.Equal(new string('b', 64), entry.PackageSha256);
     }
+
+    [Fact]
+    public void Create_uses_package_parent_as_root_for_nupkg_saves()
+    {
+        var result = new ManagedModuleInstallResult
+        {
+            Name = "Company.Tools",
+            Version = "2.0.0",
+            Status = ManagedModuleInstallStatus.Installed,
+            RepositoryName = "Local",
+            RepositorySource = "C:\\Feed",
+            ModulePath = Path.Combine("C:\\Bundle", "Company.Tools.2.0.0.nupkg"),
+            SavedAsNupkg = true,
+            Download = new ManagedModuleDownloadResult
+            {
+                PackagePath = Path.Combine("C:\\Bundle", "Company.Tools.2.0.0.nupkg"),
+                PackageSha256 = new string('b', 64)
+            }
+        };
+
+        var metadata = new ManagedModuleBundleMetadataWriter().Create(new[] { result });
+
+        Assert.Equal("C:\\Bundle", metadata.ModuleRoot);
+        var entry = Assert.Single(metadata.Modules);
+        Assert.Equal(Path.Combine("C:\\Bundle", "Company.Tools.2.0.0.nupkg"), entry.ModulePath);
+    }
 }

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -437,6 +437,41 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_plan_resolves_latest_when_existing_package_is_older()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.2.0.0.nupkg"),
+            "Company.Tools",
+            "2.0.0",
+            files: CreateToolFiles("2.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.False(plan.ExistingVersionFound);
+        Assert.Equal("2.0.0", plan.Version);
+        Assert.Equal(ManagedModuleInstallPlanAction.Install, plan.Action);
+        Assert.Equal(Path.Combine(destination.Path, "Company.Tools.2.0.0.nupkg"), plan.ModulePath);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_does_not_treat_longer_package_id_as_existing_version()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -497,6 +497,40 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_plan_does_not_reuse_prefix_package_as_dependency()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Core.Extensions.1.0.0.nupkg"),
+            "Company.Core.Extensions",
+            "1.0.0");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(feed.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
     public void SaveManagedModule_reuses_package_cache_when_exact_version_is_requested()
     {
         using var feed = new TemporaryDirectory();
@@ -553,6 +587,100 @@ public sealed class SaveManagedModuleCommandTests
         Assert.Equal(expectedSha256.ToLowerInvariant(), result.ExpectedPackageSha256);
         Assert.Equal(expectedSha256.ToLowerInvariant(), result.Download?.PackageSha256);
         Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Tools", "1.0.0", "Company.Tools.psd1")));
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_reuses_existing_package_with_expected_sha256_offline()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        TestPackageFactory.Create(
+            packagePath,
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+        var expectedSha256 = TestHash.ComputeSha256(packagePath).ToUpperInvariant();
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(feed.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("ExpectedPackageSha256", "sha256:" + expectedSha256);
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.True(result.SavedAsNupkg);
+        Assert.Equal(packagePath, result.ModulePath);
+        Assert.Equal(expectedSha256.ToLowerInvariant(), result.Download?.PackageSha256);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_reuses_existing_package_with_expected_sha256_offline()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        TestPackageFactory.Create(
+            packagePath,
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+        var expectedSha256 = TestHash.ComputeSha256(packagePath).ToUpperInvariant();
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(feed.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("ExpectedPackageSha256", "sha256:" + expectedSha256)
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.False(plan.WouldWriteFiles);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.Equal(expectedSha256.ToLowerInvariant(), plan.ExpectedPackageSha256);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_reuses_existing_package_with_allowed_author_offline()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        TestPackageFactory.Create(
+            packagePath,
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            authors: "Evotec");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(feed.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AllowedAuthor", new[] { "Evotec" });
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.True(result.SavedAsNupkg);
+        Assert.Equal(packagePath, result.ModulePath);
     }
 
     [Fact]

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -376,6 +376,96 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_plan_detects_existing_package_case_insensitively()
+    {
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "company.tools.1.0.0.nupkg");
+        TestPackageFactory.Create(
+            packagePath,
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(destination.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.Equal(packagePath, plan.ModulePath);
+        Assert.False(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_detects_existing_package_for_version_range()
+    {
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.2.0.nupkg");
+        TestPackageFactory.Create(
+            packagePath,
+            "Company.Tools",
+            "1.2.0",
+            files: CreateToolFiles("1.2.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(destination.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("MinimumVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal("1.2.0", plan.Version);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.Equal(packagePath, plan.ModulePath);
+        Assert.False(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_reports_license_required_for_existing_package()
+    {
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            requireLicenseAcceptance: true);
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(destination.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.True(plan.LicenseAcceptanceRequired);
+        Assert.False(plan.LicenseAccepted);
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_plan_marks_existing_package_with_missing_dependencies_as_writing()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -439,7 +439,7 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
-    public void SaveManagedModule_as_nupkg_plan_detects_existing_package_for_version_range()
+    public void SaveManagedModule_as_nupkg_plan_detects_existing_package_for_bounded_version_range()
     {
         using var destination = new TemporaryDirectory();
         var packagePath = Path.Combine(destination.Path, "Company.Tools.1.2.0.nupkg");
@@ -456,6 +456,7 @@ public sealed class SaveManagedModuleCommandTests
             .AddParameter("RepositoryName", "Local")
             .AddParameter("Path", destination.Path)
             .AddParameter("MinimumVersion", "1.0.0")
+            .AddParameter("MaximumVersion", "1.9.9")
             .AddParameter("AsNupkg")
             .AddParameter("Plan");
         var results = ps.Invoke();
@@ -570,6 +571,30 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_surfaces_existing_license_requirement_offline()
+    {
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            requireLicenseAcceptance: true);
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(destination.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg");
+
+        var ex = Assert.Throws<CmdletInvocationException>(() => ps.Invoke());
+        Assert.Contains("requires license acceptance", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_plan_marks_existing_package_with_missing_dependencies_as_writing()
     {
         using var feed = new TemporaryDirectory();
@@ -598,6 +623,39 @@ public sealed class SaveManagedModuleCommandTests
         Assert.True(plan.ExistingVersionFound);
         Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
         Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_minimum_version_resolves_latest_before_skip()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.2.0.0.nupkg"),
+            "Company.Tools",
+            "2.0.0",
+            files: CreateToolFiles("2.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("MinimumVersion", "1.0.0")
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.Equal("2.0.0", result.Version);
+        Assert.Equal(Path.Combine(destination.Path, "Company.Tools.2.0.0.nupkg"), result.ModulePath);
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Tools.2.0.0.nupkg")));
     }
 
     [Fact]

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -437,6 +437,42 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_does_not_treat_longer_package_id_as_existing_version()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.2024.1.0.0.nupkg"),
+            "Company.2024",
+            "1.0.0");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.1.0.0.nupkg"),
+            "Company",
+            "1.0.0",
+            files: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Company.psd1"] = "@{ ModuleVersion = '1.0.0' }"
+            });
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.Equal("Company", result.Name);
+        Assert.Equal("1.0.0", result.Version);
+        Assert.Equal(Path.Combine(destination.Path, "Company.1.0.0.nupkg"), result.ModulePath);
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.2024.1.0.0.nupkg")));
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.1.0.0.nupkg")));
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_plan_reports_license_required_for_existing_package()
     {
         using var destination = new TemporaryDirectory();
@@ -493,6 +529,39 @@ public sealed class SaveManagedModuleCommandTests
         Assert.True(plan.SaveAsNupkg);
         Assert.True(plan.ExistingVersionFound);
         Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_force_plan_does_not_read_corrupt_existing_package()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        File.WriteAllText(packagePath, "not a package");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Force")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.SaveAsNupkg);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.Reinstall, plan.Action);
         Assert.True(plan.WouldWriteFiles);
     }
 

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -603,6 +603,8 @@ public sealed class SaveManagedModuleCommandTests
         AssertNoPowerShellErrors(ps);
         var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
         Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.False(plan.WouldWriteFiles);
         Assert.True(plan.LicenseAcceptanceRequired);
         Assert.False(plan.LicenseAccepted);
     }
@@ -659,6 +661,37 @@ public sealed class SaveManagedModuleCommandTests
         var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
         Assert.NotNull(result.AuthenticodeVerification);
         Assert.Equal(0, result.AuthenticodeVerification.CheckedFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_does_not_skip_existing_package_when_authenticode_check_is_requested()
+    {
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(destination.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AuthenticodeCheck")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.SaveAsNupkg);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.Reinstall, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
+        Assert.True(plan.AuthenticodeCheck);
     }
 
     [Fact]

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -215,6 +215,52 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_recurses_existing_dependency_package_metadata()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Feature.1.0.0.nupkg"),
+            "Company.Feature",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateFeatureFiles("Company.Feature", "1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Feature", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+        File.Copy(
+            Path.Combine(feed.Path, "Company.Feature.1.0.0.nupkg"),
+            Path.Combine(destination.Path, "Company.Feature.1.0.0.nupkg"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        var flattened = Flatten(result).ToArray();
+        Assert.Contains(flattened, item => item.Name == "Company.Feature" && item.SavedAsNupkg);
+        Assert.Contains(flattened, item => item.Name == "Company.Core" && item.SavedAsNupkg);
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg")));
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Feature.1.0.0.nupkg")));
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg")));
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_skip_dependency_check_saves_only_requested_package()
     {
         using var feed = new TemporaryDirectory();
@@ -283,6 +329,37 @@ public sealed class SaveManagedModuleCommandTests
         Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
         Assert.Equal(Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"), plan.ModulePath);
         Assert.False(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_marks_existing_package_with_missing_dependencies_as_writing()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(feed.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.SaveAsNupkg);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
     }
 
     [Fact]

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.IO.Compression;
 using System.Management.Automation;
 using PowerForge;
 using PSPublishModule;
@@ -661,6 +662,37 @@ public sealed class SaveManagedModuleCommandTests
         Assert.True(plan.ExistingVersionFound);
         Assert.Equal(ManagedModuleInstallPlanAction.Reinstall, plan.Action);
         Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_replaces_corrupt_existing_package()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        File.WriteAllText(packagePath, "not a package");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.True(result.SavedAsNupkg);
+        Assert.Equal(packagePath, result.ModulePath);
+        using var archive = ZipFile.OpenRead(packagePath);
+        Assert.Contains(archive.Entries, entry => entry.FullName.EndsWith("Company.Tools.psd1", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -758,6 +758,44 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_policy_refresh_reuses_matched_package_path()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var matchedPackagePath = Path.Combine(destination.Path, "company.tools.1.0.0.nupkg");
+        TestPackageFactory.Create(
+            matchedPackagePath,
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            authors: "Contoso");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            authors: "Evotec");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AllowedAuthor", new[] { "Evotec" });
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.True(result.SavedAsNupkg);
+        Assert.Equal(matchedPackagePath, result.ModulePath);
+        Assert.Equal("Evotec", result.Download?.Metadata?.Authors);
+        Assert.Single(Directory.EnumerateFiles(destination.Path, "*.nupkg", SearchOption.TopDirectoryOnly));
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_plan_detects_saved_dependency_author_policy_failure()
     {
         using var destination = new TemporaryDirectory();

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -406,6 +406,38 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_reuses_case_matched_package_after_latest_resolution()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.2.0.0.nupkg"),
+            "Company.Tools",
+            "2.0.0",
+            files: CreateToolFiles("2.0.0"));
+        var matchedPackagePath = Path.Combine(destination.Path, "company.tools.2.0.0.nupkg");
+        TestPackageFactory.Create(
+            matchedPackagePath,
+            "Company.Tools",
+            "2.0.0",
+            files: CreateToolFiles("2.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.Equal(matchedPackagePath, result.ModulePath);
+        Assert.Single(Directory.EnumerateFiles(destination.Path, "*.nupkg", SearchOption.TopDirectoryOnly));
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_plan_detects_existing_package_for_version_range()
     {
         using var destination = new TemporaryDirectory();
@@ -595,6 +627,37 @@ public sealed class SaveManagedModuleCommandTests
         AssertNoPowerShellErrors(ps);
         var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
         Assert.True(plan.SaveAsNupkg);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.Reinstall, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_rejects_corrupt_existing_package_before_skip()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        File.WriteAllText(packagePath, "not a package");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
         Assert.True(plan.ExistingVersionFound);
         Assert.Equal(ManagedModuleInstallPlanAction.Reinstall, plan.Action);
         Assert.True(plan.WouldWriteFiles);
@@ -825,6 +888,48 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_resolves_dependency_range_when_saved_dependency_fails_policy()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            authors: "Contoso");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.1.0.nupkg"),
+            "Company.Core",
+            "1.1.0",
+            authors: "Evotec");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0, )", null) },
+            files: CreateToolFiles("1.0.0"),
+            authors: "Evotec");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AllowedAuthor", new[] { "Evotec" });
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal("1.1.0", dependency.Version);
+        Assert.Equal(Path.Combine(destination.Path, "Company.Core.1.1.0.nupkg"), dependency.ModulePath);
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_refreshes_existing_package_when_author_policy_fails()
     {
         using var feed = new TemporaryDirectory();
@@ -930,6 +1035,36 @@ public sealed class SaveManagedModuleCommandTests
 
         AssertNoPowerShellErrors(ps);
         var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_does_not_skip_same_path_local_feed_policy_failure()
+    {
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            authors: "Contoso");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", destination.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AllowedAuthor", new[] { "Evotec" })
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.Reinstall, plan.Action);
         Assert.True(plan.WouldWriteFiles);
     }
 

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -261,6 +261,50 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_matches_existing_dependency_package_id_case_insensitively()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "company.core.1.0.0.nupkg"),
+            "company.core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        var dependency = Assert.Single(result.DependencyResults);
+        var dependencyPackagePath = Path.Combine(destination.Path, "company.core.1.0.0.nupkg");
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.True(File.Exists(dependency.ModulePath));
+        Assert.True(File.Exists(dependency.Download?.PackagePath));
+        if (Path.DirectorySeparatorChar != '\\')
+        {
+            Assert.Equal(dependencyPackagePath, dependency.ModulePath);
+            Assert.Equal(dependencyPackagePath, dependency.Download?.PackagePath);
+        }
+
+        Assert.True(File.Exists(dependencyPackagePath));
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg")));
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_skip_dependency_check_saves_only_requested_package()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.IO.Compression;
 using System.Management.Automation;
+using System.Runtime.InteropServices;
 using PowerForge;
 using PSPublishModule;
 
@@ -592,6 +593,36 @@ public sealed class SaveManagedModuleCommandTests
 
         var ex = Assert.Throws<CmdletInvocationException>(() => ps.Invoke());
         Assert.Contains("requires license acceptance", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_verifies_existing_package_authenticode_check()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(destination.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AuthenticodeCheck");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.NotNull(result.AuthenticodeVerification);
+        Assert.Equal(0, result.AuthenticodeVerification.CheckedFiles);
     }
 
     [Fact]

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -118,6 +118,103 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_does_not_treat_unpacked_dependency_as_saved_package()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+        var unpackedDependencyPath = Path.Combine(destination.Path, "Company.Core", "1.0.0");
+        Directory.CreateDirectory(unpackedDependencyPath);
+        File.WriteAllText(Path.Combine(unpackedDependencyPath, "Company.Core.psd1"), "@{ ModuleVersion = '1.0.0' }");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        var dependency = Assert.Single(result.DependencyResults);
+        var dependencyPackagePath = Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg");
+        Assert.True(dependency.SavedAsNupkg);
+        Assert.Equal(dependencyPackagePath, dependency.ModulePath);
+        Assert.Equal(dependencyPackagePath, dependency.Download?.PackagePath);
+        Assert.True(File.Exists(dependencyPackagePath));
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_reports_package_paths_for_shared_transitive_dependencies()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.FeatureA.1.0.0.nupkg"),
+            "Company.FeatureA",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateFeatureFiles("Company.FeatureA", "1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.FeatureB.1.0.0.nupkg"),
+            "Company.FeatureB",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateFeatureFiles("Company.FeatureB", "1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[]
+            {
+                new TestDependency("Company.FeatureA", "[1.0.0]", null),
+                new TestDependency("Company.FeatureB", "[1.0.0]", null)
+            },
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("DependencyConcurrency", 2);
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        var flattened = Flatten(result).ToArray();
+        var coreResults = flattened.Where(item => item.Name == "Company.Core").ToArray();
+        Assert.NotEmpty(coreResults);
+        Assert.All(coreResults, item =>
+        {
+            Assert.True(item.SavedAsNupkg);
+            Assert.Equal(Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg"), item.ModulePath);
+            Assert.Equal(item.ModulePath, item.Download?.PackagePath);
+        });
+    }
+
+    [Fact]
     public void SaveManagedModule_as_nupkg_skip_dependency_check_saves_only_requested_package()
     {
         using var feed = new TemporaryDirectory();
@@ -343,6 +440,51 @@ public sealed class SaveManagedModuleCommandTests
         Assert.All(metadata.Modules, entry => Assert.Equal(64, entry.PackageSha256?.Length));
     }
 
+    [Fact]
+    public void SaveManagedModule_as_nupkg_writes_offline_bundle_metadata_with_package_root()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+        var metadataPath = Path.Combine(destination.Path, "bundle.metadata.json");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("BundleMetadataPath", metadataPath);
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Single(results);
+        var metadata = JsonSerializer.Deserialize<ManagedModuleBundleMetadata>(File.ReadAllText(metadataPath));
+        Assert.NotNull(metadata);
+        Assert.Equal(destination.Path, metadata.ModuleRoot);
+        Assert.Contains(metadata.Modules, entry =>
+            entry.Name == "Company.Tools" &&
+            entry.ModulePath == Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg") &&
+            entry.PackagePath == entry.ModulePath);
+        Assert.Contains(metadata.Modules, entry =>
+            entry.Name == "Company.Core" &&
+            entry.DependencyOf == "Company.Tools" &&
+            entry.ModulePath == Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg") &&
+            entry.PackagePath == entry.ModulePath);
+    }
+
     private static PowerShell CreatePowerShellWithModuleImported()
     {
         var ps = PowerShell.Create();
@@ -366,6 +508,22 @@ public sealed class SaveManagedModuleCommandTests
         {
             ["Company.Core.psd1"] = "@{ ModuleVersion = '" + version + "' }"
         };
+
+    private static IReadOnlyDictionary<string, string> CreateFeatureFiles(string name, string version)
+        => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [name + ".psd1"] = "@{ ModuleVersion = '" + version + "' }"
+        };
+
+    private static IEnumerable<ManagedModuleInstallResult> Flatten(ManagedModuleInstallResult result)
+    {
+        yield return result;
+        foreach (var dependency in result.DependencyResults)
+        {
+            foreach (var child in Flatten(dependency))
+                yield return child;
+        }
+    }
 
     private static void AssertNoPowerShellErrors(PowerShell ps)
     {

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -77,6 +77,118 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_saves_dependency_closure_to_destination()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.True(result.SavedAsNupkg);
+        Assert.True(dependency.SavedAsNupkg);
+        Assert.Equal(Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"), result.ModulePath);
+        Assert.Equal(result.ModulePath, result.Download?.PackagePath);
+        Assert.Null(result.ReceiptPath);
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg")));
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg")));
+        Assert.False(Directory.Exists(Path.Combine(destination.Path, "Company.Tools")));
+        Assert.False(Directory.Exists(Path.Combine(destination.Path, "Company.Core")));
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_skip_dependency_check_saves_only_requested_package()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            files: CreateCoreFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("SkipDependencyCheck");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.True(result.SavedAsNupkg);
+        Assert.Empty(result.DependencyResults);
+        Assert.True(File.Exists(Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg")));
+        Assert.False(File.Exists(Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg")));
+        Assert.False(Directory.Exists(Path.Combine(destination.Path, "Company.Tools")));
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_detects_existing_package()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+        File.Copy(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.SaveAsNupkg);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.Equal(Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"), plan.ModulePath);
+        Assert.False(plan.WouldWriteFiles);
+    }
+
+    [Fact]
     public void SaveManagedModule_reuses_package_cache_when_exact_version_is_requested()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -440,7 +440,7 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
-    public void SaveManagedModule_as_nupkg_plan_detects_existing_package_for_bounded_version_range()
+    public void SaveManagedModule_as_nupkg_plan_detects_existing_package_for_exact_version_offline()
     {
         using var destination = new TemporaryDirectory();
         var packagePath = Path.Combine(destination.Path, "Company.Tools.1.2.0.nupkg");
@@ -456,8 +456,7 @@ public sealed class SaveManagedModuleCommandTests
             .AddParameter("Repository", Path.Combine(destination.Path, "Unavailable"))
             .AddParameter("RepositoryName", "Local")
             .AddParameter("Path", destination.Path)
-            .AddParameter("MinimumVersion", "1.0.0")
-            .AddParameter("MaximumVersion", "1.9.9")
+            .AddParameter("RequiredVersion", "1.2.0")
             .AddParameter("AsNupkg")
             .AddParameter("Plan");
         var results = ps.Invoke();
@@ -469,6 +468,43 @@ public sealed class SaveManagedModuleCommandTests
         Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
         Assert.Equal(packagePath, plan.ModulePath);
         Assert.False(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_resolves_bounded_range_latest_before_skip()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"));
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.5.0.nupkg"),
+            "Company.Tools",
+            "1.5.0",
+            files: CreateToolFiles("1.5.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("MinimumVersion", "1.0.0")
+            .AddParameter("MaximumVersion", "2.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.False(plan.ExistingVersionFound);
+        Assert.Equal("1.5.0", plan.Version);
+        Assert.Equal(ManagedModuleInstallPlanAction.Install, plan.Action);
+        Assert.Equal(Path.Combine(destination.Path, "Company.Tools.1.5.0.nupkg"), plan.ModulePath);
+        Assert.True(plan.WouldWriteFiles);
     }
 
     [Fact]
@@ -654,6 +690,41 @@ public sealed class SaveManagedModuleCommandTests
         Assert.True(plan.ExistingVersionFound);
         Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
         Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_marks_policy_validated_existing_package_with_missing_dependencies_as_writing()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        TestPackageFactory.Create(
+            packagePath,
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"));
+        var expectedSha256 = TestHash.ComputeSha256(packagePath).ToUpperInvariant();
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(feed.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("ExpectedPackageSha256", "sha256:" + expectedSha256)
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.SaveAsNupkg);
+        Assert.True(plan.ExistingVersionFound);
+        Assert.Equal(ManagedModuleInstallPlanAction.SkipExisting, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
+        Assert.Equal(expectedSha256.ToLowerInvariant(), plan.ExpectedPackageSha256);
     }
 
     [Fact]

--- a/PowerForge.Tests/SaveManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/SaveManagedModuleCommandTests.cs
@@ -684,6 +684,114 @@ public sealed class SaveManagedModuleCommandTests
     }
 
     [Fact]
+    public void SaveManagedModule_as_nupkg_reuses_existing_dependency_with_allowed_author_offline()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Core.1.2.0.nupkg"),
+            "Company.Core",
+            "1.2.0",
+            authors: "Evotec");
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0, )", null) },
+            files: CreateToolFiles("1.0.0"),
+            authors: "Evotec");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", Path.Combine(feed.Path, "Unavailable"))
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AllowedAuthor", new[] { "Evotec" });
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        var dependency = Assert.Single(result.DependencyResults);
+        Assert.Equal("Company.Core", dependency.Name);
+        Assert.Equal("1.2.0", dependency.Version);
+        Assert.Equal(Path.Combine(destination.Path, "Company.Core.1.2.0.nupkg"), dependency.ModulePath);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_refreshes_existing_package_when_author_policy_fails()
+    {
+        using var feed = new TemporaryDirectory();
+        using var destination = new TemporaryDirectory();
+        var packagePath = Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg");
+        TestPackageFactory.Create(
+            packagePath,
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            authors: "Contoso");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateToolFiles("1.0.0"),
+            authors: "Evotec");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AllowedAuthor", new[] { "Evotec" });
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var result = Assert.IsType<ManagedModuleInstallResult>(Assert.Single(results).BaseObject);
+        Assert.True(result.SavedAsNupkg);
+        Assert.Equal(packagePath, result.ModulePath);
+        Assert.Equal("Evotec", result.Download?.Metadata?.Authors);
+    }
+
+    [Fact]
+    public void SaveManagedModule_as_nupkg_plan_detects_saved_dependency_author_policy_failure()
+    {
+        using var destination = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Core.1.0.0.nupkg"),
+            "Company.Core",
+            "1.0.0",
+            authors: "Contoso");
+        TestPackageFactory.Create(
+            Path.Combine(destination.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[1.0.0]", null) },
+            files: CreateToolFiles("1.0.0"),
+            authors: "Evotec");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Save-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", destination.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", destination.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("AsNupkg")
+            .AddParameter("AllowedAuthor", new[] { "Evotec" })
+            .AddParameter("Plan");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.True(plan.WouldWriteFiles);
+    }
+
+    [Fact]
     public void SaveManagedModule_accept_license_saves_license_required_package()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge/Models/ManagedModules/ManagedModuleInstallPlan.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleInstallPlan.cs
@@ -41,6 +41,11 @@ public sealed class ManagedModuleInstallPlan
     public string ModulePath { get; set; } = string.Empty;
 
     /// <summary>
+    /// True when the operation would save a .nupkg file instead of materializing an unpacked module directory.
+    /// </summary>
+    public bool SaveAsNupkg { get; set; }
+
+    /// <summary>
     /// True when the target module version already exists.
     /// </summary>
     public bool ExistingVersionFound { get; set; }

--- a/PowerForge/Models/ManagedModules/ManagedModuleInstallRequest.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleInstallRequest.cs
@@ -63,6 +63,11 @@ public sealed class ManagedModuleInstallRequest
     internal bool PackageCacheDirectoryIsOperationLocal { get; set; }
 
     /// <summary>
+    /// Save the selected packages as .nupkg files instead of unpacking them into module folders.
+    /// </summary>
+    public bool SaveAsNupkg { get; set; }
+
+    /// <summary>
     /// Maximum number of dependency branches to install concurrently. A value of 0 uses the engine default.
     /// </summary>
     public int DependencyConcurrency { get; set; }

--- a/PowerForge/Models/ManagedModules/ManagedModuleInstallResult.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleInstallResult.cs
@@ -81,6 +81,11 @@ public sealed class ManagedModuleInstallResult
     public string ModulePath { get; set; } = string.Empty;
 
     /// <summary>
+    /// True when the operation saved a .nupkg file instead of materializing an unpacked module directory.
+    /// </summary>
+    public bool SavedAsNupkg { get; set; }
+
+    /// <summary>
     /// Elapsed time spent by this install operation.
     /// </summary>
     public TimeSpan Elapsed { get; set; }

--- a/PowerForge/Services/ManagedModules/ManagedModuleBundleMetadataWriter.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleBundleMetadataWriter.cs
@@ -29,7 +29,7 @@ public sealed class ManagedModuleBundleMetadataWriter
         return new ManagedModuleBundleMetadata
         {
             CreatedUtc = DateTimeOffset.UtcNow,
-            ModuleRoot = entries.Select(static entry => Path.GetDirectoryName(Path.GetDirectoryName(entry.ModulePath) ?? string.Empty))
+            ModuleRoot = entries.Select(static entry => ResolveModuleRoot(entry.ModulePath))
                 .FirstOrDefault(static root => !string.IsNullOrWhiteSpace(root)) ?? string.Empty,
             Modules = entries
         };
@@ -85,4 +85,15 @@ public sealed class ManagedModuleBundleMetadataWriter
         => !string.IsNullOrWhiteSpace(packagePath) && File.Exists(packagePath)
             ? packagePath
             : null;
+
+    private static string? ResolveModuleRoot(string modulePath)
+    {
+        if (string.IsNullOrWhiteSpace(modulePath))
+            return null;
+
+        if (modulePath.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+            return Path.GetDirectoryName(modulePath);
+
+        return Path.GetDirectoryName(Path.GetDirectoryName(modulePath) ?? string.Empty);
+    }
 }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Coalescing.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Coalescing.cs
@@ -22,6 +22,7 @@ public sealed partial class ManagedModuleInstallService
             request.AllowClobber ? "clobber" : "no-clobber",
             request.AcceptLicense ? "license" : "no-license",
             request.AuthenticodeCheck ? "authenticode" : "no-authenticode",
+            request.SaveAsNupkg ? "nupkg" : "unpacked",
             NormalizeCoalescingValue(request.ExpectedPackageSha256),
             FingerprintTrustPolicy(request.TrustPolicy),
             request.SkipDependencyCheck ? "skip-deps" : "deps");

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -206,7 +206,13 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleInstallResult satisfiedResult = null!;
         var canUseSatisfiedDependency = request.SaveAsNupkg || dependencyTrustPolicy is null;
         var isSatisfied = canUseSatisfiedDependency &&
-                          TryCreateSatisfiedDependencyResult(request, dependency.Id, range, context, out satisfiedResult);
+                          TryCreateSatisfiedDependencyResult(
+                              request,
+                              dependency.Id,
+                              range,
+                              dependencyTrustPolicy,
+                              context,
+                              out satisfiedResult);
         satisfiedStopwatch.Stop();
         if (isSatisfied)
         {
@@ -313,10 +319,11 @@ public sealed partial class ManagedModuleInstallService
             RepairInstalledManifestDependencies = request.RepairInstalledManifestDependencies
         };
 
-    private static bool TryCreateSatisfiedDependencyResult(
+    private bool TryCreateSatisfiedDependencyResult(
         ManagedModuleInstallRequest request,
         string dependencyName,
         ManagedModuleVersionRange range,
+        ManagedModuleTrustPolicy? dependencyTrustPolicy,
         ManagedModuleInstallContext context,
         out ManagedModuleInstallResult result)
     {
@@ -324,6 +331,7 @@ public sealed partial class ManagedModuleInstallService
         var moduleRoot = ManagedModuleInstallRootResolver.Resolve(request.Scope, request.ShellEdition, request.ModuleRoot);
         var installedVersion = GetSatisfiedDependencyVersions(request, moduleRoot, dependencyName, context)
             .Where(version => AllowsInstalledDependencyVersion(version, request, range))
+            .Where(version => SavedDependencyPackageSatisfiesTrustPolicy(request, dependencyName, version, moduleRoot, dependencyTrustPolicy))
             .LastOrDefault();
         if (installedVersion is null)
             return false;
@@ -364,6 +372,28 @@ public sealed partial class ManagedModuleInstallService
 
         context.RecordInstalledVersion(moduleRoot, dependencyName, installedVersion);
         return true;
+    }
+
+    private bool SavedDependencyPackageSatisfiesTrustPolicy(
+        ManagedModuleInstallRequest request,
+        string dependencyName,
+        string version,
+        string moduleRoot,
+        ManagedModuleTrustPolicy? dependencyTrustPolicy)
+    {
+        if (!request.SaveAsNupkg)
+            return true;
+
+        var packagePath = ResolveExistingSavedPackagePath(moduleRoot, dependencyName, version);
+        if (string.IsNullOrWhiteSpace(packagePath))
+            return false;
+
+        return SavedDependencyPackageSatisfiesPlanPolicy(
+            request,
+            dependencyName,
+            version,
+            packagePath!,
+            dependencyTrustPolicy);
     }
 
     private static bool HasSatisfiedDependency(
@@ -781,7 +811,12 @@ public sealed partial class ManagedModuleInstallService
             if (string.IsNullOrWhiteSpace(dependencyPath))
                 return true;
 
-            if (!SavedDependencyPackageSatisfiesPlanPolicy(request, dependency.Id, savedVersion, dependencyPath!))
+            if (!SavedDependencyPackageSatisfiesPlanPolicy(
+                    request,
+                    dependency.Id,
+                    savedVersion,
+                    dependencyPath!,
+                    ResolveDependencyTrustPolicy(request.TrustPolicy)))
                 return true;
 
             if (WouldSavePackageDependenciesCore(request, dependency.Id, savedVersion, moduleRoot, dependencyPath!, visited))
@@ -795,12 +830,12 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleInstallRequest request,
         string dependencyId,
         string version,
-        string packagePath)
+        string packagePath,
+        ManagedModuleTrustPolicy? dependencyTrustPolicy)
     {
         try
         {
             var metadata = ReadSavedPackageMetadata(dependencyId, version, packagePath);
-            var dependencyTrustPolicy = ResolveDependencyTrustPolicy(request.TrustPolicy);
             ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, dependencyTrustPolicy);
             ThrowIfLicenseAcceptanceRequired(metadata, request);
             return true;

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -416,18 +416,14 @@ public sealed partial class ManagedModuleInstallService
             return Array.Empty<string>();
 
         var safePackageId = ManagedModulePackageIdentity.RequireSafeId(packageId, nameof(packageId));
-        var prefix = safePackageId + ".";
         var suffix = ".nupkg";
         try
         {
             return Directory.EnumerateFiles(root, "*" + suffix, SearchOption.TopDirectoryOnly)
                 .Select(path => Path.GetFileName(path))
-                .Where(fileName => !string.IsNullOrWhiteSpace(fileName) &&
-                                   fileName!.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-                                   fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
-                .Select(fileName => fileName!.Substring(prefix.Length, fileName.Length - prefix.Length - suffix.Length))
+                .Select(fileName => TryReadSavedPackageVersion(fileName, safePackageId, out var savedVersion) ? savedVersion : null)
                 .Where(static version => !string.IsNullOrWhiteSpace(version))
-                .Where(static version => IsInstalledVersionDirectoryName(version))
+                .Select(static version => version!)
                 .ToArray();
         }
         catch (IOException)
@@ -447,8 +443,6 @@ public sealed partial class ManagedModuleInstallService
 
         var safePackageId = ManagedModulePackageIdentity.RequireSafeId(packageId, nameof(packageId));
         var safeVersion = ManagedModulePackageIdentity.RequireSafeVersion(version, nameof(version));
-        var prefix = safePackageId + ".";
-        var suffix = "." + safeVersion + ".nupkg";
         if (Directory.Exists(root))
         {
             try
@@ -457,9 +451,8 @@ public sealed partial class ManagedModuleInstallService
                     .FirstOrDefault(path =>
                     {
                         var fileName = Path.GetFileName(path);
-                        return !string.IsNullOrWhiteSpace(fileName) &&
-                               fileName!.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
-                               fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
+                        return TryReadSavedPackageVersion(fileName, safePackageId, out var savedVersion) &&
+                               ManagedModuleVersionComparer.Instance.Compare(savedVersion, safeVersion) == 0;
                     });
                 if (!string.IsNullOrWhiteSpace(matchedPath))
                     return matchedPath;
@@ -475,6 +468,31 @@ public sealed partial class ManagedModuleInstallService
         }
 
         return File.Exists(expectedPath) ? expectedPath : null;
+    }
+
+    private static bool TryReadSavedPackageVersion(
+        string? fileName,
+        string safePackageId,
+        out string version)
+    {
+        version = string.Empty;
+        if (string.IsNullOrWhiteSpace(fileName))
+            return false;
+
+        var prefix = safePackageId + ".";
+        const string suffix = ".nupkg";
+        if (!fileName!.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+            !fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var candidate = fileName.Substring(prefix.Length, fileName.Length - prefix.Length - suffix.Length);
+        if (string.IsNullOrWhiteSpace(candidate) || !IsInstalledVersionDirectoryName(candidate))
+            return false;
+
+        version = candidate;
+        return true;
     }
 
     private static bool AllowsInstalledDependencyVersion(

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -391,7 +391,7 @@ public sealed partial class ManagedModuleInstallService
         string dependencyName,
         string version)
         => request.SaveAsNupkg
-            ? ResolveSavedPackagePath(moduleRoot, dependencyName, version)
+            ? ResolveExistingSavedPackagePath(moduleRoot, dependencyName, version) ?? ResolveSavedPackagePath(moduleRoot, dependencyName, version)
             : ResolveInstalledModulePath(moduleRoot, dependencyName, version);
 
     private static IReadOnlyList<string> GetSavedPackageVersions(
@@ -401,7 +401,7 @@ public sealed partial class ManagedModuleInstallService
     {
         var versions = GetInstalledVersions(moduleRoot, packageId, context)
             .Concat(EnumerateSavedPackageVersions(moduleRoot, packageId))
-            .Where(version => File.Exists(ResolveSavedPackagePath(moduleRoot, packageId, version)))
+            .Where(version => ResolveExistingSavedPackagePath(moduleRoot, packageId, version) is not null)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(static version => version, ManagedModuleVersionComparer.Instance)
             .ToArray();
@@ -420,7 +420,7 @@ public sealed partial class ManagedModuleInstallService
         var suffix = ".nupkg";
         try
         {
-            return Directory.EnumerateFiles(root, prefix + "*" + suffix, SearchOption.TopDirectoryOnly)
+            return Directory.EnumerateFiles(root, "*" + suffix, SearchOption.TopDirectoryOnly)
                 .Select(path => Path.GetFileName(path))
                 .Where(fileName => !string.IsNullOrWhiteSpace(fileName) &&
                                    fileName!.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
@@ -438,6 +438,43 @@ public sealed partial class ManagedModuleInstallService
         {
             return Array.Empty<string>();
         }
+    }
+
+    private static string? ResolveExistingSavedPackagePath(string moduleRoot, string packageId, string version)
+    {
+        var root = Path.GetFullPath(moduleRoot.Trim().Trim('"'));
+        var expectedPath = ResolveSavedPackagePath(moduleRoot, packageId, version);
+
+        var safePackageId = ManagedModulePackageIdentity.RequireSafeId(packageId, nameof(packageId));
+        var safeVersion = ManagedModulePackageIdentity.RequireSafeVersion(version, nameof(version));
+        var prefix = safePackageId + ".";
+        var suffix = "." + safeVersion + ".nupkg";
+        if (Directory.Exists(root))
+        {
+            try
+            {
+                var matchedPath = Directory.EnumerateFiles(root, "*.nupkg", SearchOption.TopDirectoryOnly)
+                    .FirstOrDefault(path =>
+                    {
+                        var fileName = Path.GetFileName(path);
+                        return !string.IsNullOrWhiteSpace(fileName) &&
+                               fileName!.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+                               fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
+                    });
+                if (!string.IsNullOrWhiteSpace(matchedPath))
+                    return matchedPath;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+
+        return File.Exists(expectedPath) ? expectedPath : null;
     }
 
     private static bool AllowsInstalledDependencyVersion(
@@ -694,11 +731,11 @@ public sealed partial class ManagedModuleInstallService
             if (savedVersion is null)
                 return true;
 
-            var dependencyPath = ResolveSavedPackagePath(moduleRoot, dependency.Id, savedVersion);
-            if (!File.Exists(dependencyPath))
+            var dependencyPath = ResolveExistingSavedPackagePath(moduleRoot, dependency.Id, savedVersion);
+            if (string.IsNullOrWhiteSpace(dependencyPath))
                 return true;
 
-            if (WouldSavePackageDependenciesCore(request, dependency.Id, savedVersion, moduleRoot, dependencyPath, visited))
+            if (WouldSavePackageDependenciesCore(request, dependency.Id, savedVersion, moduleRoot, dependencyPath!, visited))
                 return true;
         }
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -210,10 +210,24 @@ public sealed partial class ManagedModuleInstallService
         if (isSatisfied)
         {
             ManagedModuleInstallResult satisfiedInstallResult;
-            if (request.RepairInstalledManifestDependencies && context.IsActive(dependency.Id))
+            if ((request.SaveAsNupkg || request.RepairInstalledManifestDependencies) &&
+                context.IsActive(dependency.Id))
             {
                 satisfiedInstallResult = satisfiedResult;
                 satisfiedInstallResult.Elapsed = satisfiedStopwatch.Elapsed;
+            }
+            else if (request.SaveAsNupkg)
+            {
+                satisfiedInstallResult = await InstallAsync(
+                    CreateDependencyInstallRequest(
+                        request,
+                        dependency.Id,
+                        satisfiedResult.Version,
+                        cacheDirectory,
+                        dependencyTrustPolicy,
+                        range),
+                    context,
+                    cancellationToken).ConfigureAwait(false);
             }
             else if (request.RepairInstalledManifestDependencies)
             {
@@ -383,7 +397,7 @@ public sealed partial class ManagedModuleInstallService
     private static IReadOnlyList<string> GetSavedPackageVersions(
         string moduleRoot,
         string packageId,
-        ManagedModuleInstallContext context)
+        ManagedModuleInstallContext? context = null)
     {
         var versions = GetInstalledVersions(moduleRoot, packageId, context)
             .Concat(EnumerateSavedPackageVersions(moduleRoot, packageId))
@@ -636,6 +650,66 @@ public sealed partial class ManagedModuleInstallService
 
         return false;
     }
+
+    private bool WouldWriteExistingTargetDependencies(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        string version,
+        string modulePath)
+        => request.SaveAsNupkg
+            ? WouldSavePackageDependencies(request, moduleRoot, version, modulePath)
+            : WouldRepairInstalledManifestDependencies(request, moduleRoot, modulePath);
+
+    private bool WouldSavePackageDependencies(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        string version,
+        string packagePath)
+    {
+        if (request.SkipDependencyCheck)
+            return false;
+
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return WouldSavePackageDependenciesCore(request, request.Name, version, moduleRoot, packagePath, visited);
+    }
+
+    private bool WouldSavePackageDependenciesCore(
+        ManagedModuleInstallRequest request,
+        string packageId,
+        string version,
+        string moduleRoot,
+        string packagePath,
+        ISet<string> visited)
+    {
+        if (!visited.Add(CreateSavedPackageRepairVisitKey(packageId, packagePath)))
+            return false;
+
+        var metadata = ReadSavedPackageMetadata(packageId, version, packagePath);
+        foreach (var dependency in SelectDependencies(metadata))
+        {
+            var range = ManagedModuleVersionRange.Parse(dependency.VersionRange);
+            var savedVersion = GetSavedPackageVersions(moduleRoot, dependency.Id)
+                .Where(candidate => AllowsInstalledDependencyVersion(candidate, request, range))
+                .LastOrDefault();
+            if (savedVersion is null)
+                return true;
+
+            var dependencyPath = ResolveSavedPackagePath(moduleRoot, dependency.Id, savedVersion);
+            if (!File.Exists(dependencyPath))
+                return true;
+
+            if (WouldSavePackageDependenciesCore(request, dependency.Id, savedVersion, moduleRoot, dependencyPath, visited))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string CreateSavedPackageRepairVisitKey(string packageId, string packagePath)
+        => string.Join("|", packageId.Trim(), NormalizeSavedPackageRepairPath(packagePath));
+
+    private static string NormalizeSavedPackageRepairPath(string packagePath)
+        => Path.GetFullPath(packagePath.Trim().Trim('"')).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     private static string CreateManifestRepairVisitKey(string moduleName, string modulePath)
         => string.Join("|", moduleName.Trim(), NormalizeManifestRepairPath(modulePath));

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -204,7 +204,8 @@ public sealed partial class ManagedModuleInstallService
         var dependencyTrustPolicy = ResolveDependencyTrustPolicy(request.TrustPolicy);
         var satisfiedStopwatch = System.Diagnostics.Stopwatch.StartNew();
         ManagedModuleInstallResult satisfiedResult = null!;
-        var isSatisfied = dependencyTrustPolicy is null &&
+        var canUseSatisfiedDependency = request.SaveAsNupkg || dependencyTrustPolicy is null;
+        var isSatisfied = canUseSatisfiedDependency &&
                           TryCreateSatisfiedDependencyResult(request, dependency.Id, range, context, out satisfiedResult);
         satisfiedStopwatch.Stop();
         if (isSatisfied)
@@ -753,11 +754,46 @@ public sealed partial class ManagedModuleInstallService
             if (string.IsNullOrWhiteSpace(dependencyPath))
                 return true;
 
+            if (!SavedDependencyPackageSatisfiesPlanPolicy(request, dependency.Id, savedVersion, dependencyPath!))
+                return true;
+
             if (WouldSavePackageDependenciesCore(request, dependency.Id, savedVersion, moduleRoot, dependencyPath!, visited))
                 return true;
         }
 
         return false;
+    }
+
+    private bool SavedDependencyPackageSatisfiesPlanPolicy(
+        ManagedModuleInstallRequest request,
+        string dependencyId,
+        string version,
+        string packagePath)
+    {
+        try
+        {
+            var metadata = ReadSavedPackageMetadata(dependencyId, version, packagePath);
+            var dependencyTrustPolicy = ResolveDependencyTrustPolicy(request.TrustPolicy);
+            ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, dependencyTrustPolicy);
+            ThrowIfLicenseAcceptanceRequired(metadata, request);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (InvalidDataException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     private static string CreateSavedPackageRepairVisitKey(string packageId, string packagePath)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -285,6 +285,7 @@ public sealed partial class ManagedModuleInstallService
             PackageCacheDirectory = cacheDirectory,
             PackageCacheDirectoryIsOperationLocal = request.PackageCacheDirectoryIsOperationLocal ||
                                                     string.IsNullOrWhiteSpace(request.PackageCacheDirectory),
+            SaveAsNupkg = request.SaveAsNupkg,
             ExpectedPackageSha256 = null,
             TrustPolicy = dependencyTrustPolicy,
             Credential = request.Credential,
@@ -327,6 +328,7 @@ public sealed partial class ManagedModuleInstallService
                 AllowClobber = request.AllowClobber,
                 AcceptLicense = request.AcceptLicense,
                 AuthenticodeCheck = request.AuthenticodeCheck,
+                SaveAsNupkg = request.SaveAsNupkg,
                 RepairInstalledManifestDependencies = request.RepairInstalledManifestDependencies
             },
             installedVersion,
@@ -451,6 +453,7 @@ public sealed partial class ManagedModuleInstallService
             ModuleRoot = request.ModuleRoot,
             PackageCacheDirectory = request.PackageCacheDirectory,
             PackageCacheDirectoryIsOperationLocal = request.PackageCacheDirectoryIsOperationLocal,
+            SaveAsNupkg = request.SaveAsNupkg,
             DependencyConcurrency = request.DependencyConcurrency,
             ExpectedPackageSha256 = request.ExpectedPackageSha256,
             TrustPolicy = request.TrustPolicy,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -307,13 +307,16 @@ public sealed partial class ManagedModuleInstallService
     {
         result = null!;
         var moduleRoot = ManagedModuleInstallRootResolver.Resolve(request.Scope, request.ShellEdition, request.ModuleRoot);
-        var installedVersion = GetInstalledVersions(moduleRoot, dependencyName, context)
+        var installedVersion = GetSatisfiedDependencyVersions(request, moduleRoot, dependencyName, context)
             .Where(version => AllowsInstalledDependencyVersion(version, request, range))
             .LastOrDefault();
         if (installedVersion is null)
             return false;
 
-        var modulePath = ResolveInstalledModulePath(moduleRoot, dependencyName, installedVersion);
+        var modulePath = ResolveSatisfiedDependencyPath(request, moduleRoot, dependencyName, installedVersion);
+        if (!TargetExists(request, modulePath))
+            return false;
+
         result = CreateAlreadyInstalledResult(
             new ManagedModuleInstallRequest
             {
@@ -338,6 +341,12 @@ public sealed partial class ManagedModuleInstallService
             TimeSpan.Zero,
             repositoryRequestCount: 0,
             installLockWaitElapsed: TimeSpan.Zero);
+        if (request.SaveAsNupkg)
+        {
+            result.Download = CreateDownloadForSatisfiedSavedPackage(request, dependencyName, installedVersion, modulePath);
+            result.FileCount = 1;
+        }
+
         context.RecordInstalledVersion(moduleRoot, dependencyName, installedVersion);
         return true;
     }
@@ -349,8 +358,72 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleInstallContext context)
     {
         var moduleRoot = ManagedModuleInstallRootResolver.Resolve(request.Scope, request.ShellEdition, request.ModuleRoot);
-        return GetInstalledVersions(moduleRoot, dependencyName, context)
+        return GetSatisfiedDependencyVersions(request, moduleRoot, dependencyName, context)
             .Any(version => AllowsInstalledDependencyVersion(version, request, range));
+    }
+
+    private static IReadOnlyList<string> GetSatisfiedDependencyVersions(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        string dependencyName,
+        ManagedModuleInstallContext context)
+        => request.SaveAsNupkg
+            ? GetSavedPackageVersions(moduleRoot, dependencyName, context)
+            : GetInstalledVersions(moduleRoot, dependencyName, context);
+
+    private static string ResolveSatisfiedDependencyPath(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        string dependencyName,
+        string version)
+        => request.SaveAsNupkg
+            ? ResolveSavedPackagePath(moduleRoot, dependencyName, version)
+            : ResolveInstalledModulePath(moduleRoot, dependencyName, version);
+
+    private static IReadOnlyList<string> GetSavedPackageVersions(
+        string moduleRoot,
+        string packageId,
+        ManagedModuleInstallContext context)
+    {
+        var versions = GetInstalledVersions(moduleRoot, packageId, context)
+            .Concat(EnumerateSavedPackageVersions(moduleRoot, packageId))
+            .Where(version => File.Exists(ResolveSavedPackagePath(moduleRoot, packageId, version)))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static version => version, ManagedModuleVersionComparer.Instance)
+            .ToArray();
+
+        return versions;
+    }
+
+    private static IEnumerable<string> EnumerateSavedPackageVersions(string moduleRoot, string packageId)
+    {
+        var root = Path.GetFullPath(moduleRoot.Trim().Trim('"'));
+        if (!Directory.Exists(root))
+            return Array.Empty<string>();
+
+        var safePackageId = ManagedModulePackageIdentity.RequireSafeId(packageId, nameof(packageId));
+        var prefix = safePackageId + ".";
+        var suffix = ".nupkg";
+        try
+        {
+            return Directory.EnumerateFiles(root, prefix + "*" + suffix, SearchOption.TopDirectoryOnly)
+                .Select(path => Path.GetFileName(path))
+                .Where(fileName => !string.IsNullOrWhiteSpace(fileName) &&
+                                   fileName!.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) &&
+                                   fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                .Select(fileName => fileName!.Substring(prefix.Length, fileName.Length - prefix.Length - suffix.Length))
+                .Where(static version => !string.IsNullOrWhiteSpace(version))
+                .Where(static version => IsInstalledVersionDirectoryName(version))
+                .ToArray();
+        }
+        catch (IOException)
+        {
+            return Array.Empty<string>();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Array.Empty<string>();
+        }
     }
 
     private static bool AllowsInstalledDependencyVersion(
@@ -786,6 +859,23 @@ public sealed partial class ManagedModuleInstallService
 
         return trimmed.TrimEnd('/', '\\');
     }
+
+    private static ManagedModuleDownloadResult CreateDownloadForSatisfiedSavedPackage(
+        ManagedModuleInstallRequest request,
+        string packageId,
+        string version,
+        string packagePath)
+        => new()
+        {
+            Name = packageId.Trim(),
+            Version = version,
+            RepositoryName = request.Repository.Name,
+            Source = packagePath,
+            PackagePath = packagePath,
+            BytesWritten = 0,
+            FromCache = true,
+            PackageSha256 = ComputePackageSha256(packagePath)
+        };
 
     private static IEnumerable<ManagedModuleDependencyInfo> SelectDependencies(ManagedModulePackageMetadata? metadata)
     {

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.Dependencies.cs
@@ -421,8 +421,7 @@ public sealed partial class ManagedModuleInstallService
         try
         {
             return Directory.EnumerateFiles(root, "*" + suffix, SearchOption.TopDirectoryOnly)
-                .Select(path => Path.GetFileName(path))
-                .Select(fileName => TryReadSavedPackageVersion(fileName, safePackageId, out var savedVersion) ? savedVersion : null)
+                .Select(path => TryReadSavedPackageIdentityVersion(path, safePackageId, out var savedVersion) ? savedVersion : null)
                 .Where(static version => !string.IsNullOrWhiteSpace(version))
                 .Select(static version => version!)
                 .ToArray();
@@ -434,6 +433,34 @@ public sealed partial class ManagedModuleInstallService
         catch (UnauthorizedAccessException)
         {
             return Array.Empty<string>();
+        }
+    }
+
+    private static bool TryReadSavedPackageIdentityVersion(
+        string packagePath,
+        string safePackageId,
+        out string version)
+    {
+        version = string.Empty;
+        var fileName = Path.GetFileName(packagePath);
+        if (!TryReadSavedPackageVersion(fileName, safePackageId, out var fileVersion))
+            return false;
+
+        try
+        {
+            var metadata = new ManagedModulePackageReader().ReadMetadata(packagePath);
+            if (!metadata.Id.Equals(safePackageId, StringComparison.OrdinalIgnoreCase) ||
+                ManagedModuleVersionComparer.Instance.Compare(metadata.Version, fileVersion) != 0)
+            {
+                return false;
+            }
+
+            version = metadata.Version;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or InvalidDataException or InvalidOperationException or UnauthorizedAccessException)
+        {
+            return false;
         }
     }
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.PackagePrefetch.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.PackagePrefetch.cs
@@ -89,6 +89,7 @@ public sealed partial class ManagedModuleInstallService
 
     private static bool ShouldUseDependencyPackagePrefetch(ManagedModuleInstallRequest request)
         => !request.SkipDependencyCheck &&
+           !request.SaveAsNupkg &&
            !request.AuthenticodeCheck &&
            request.Credential is null &&
            (string.IsNullOrWhiteSpace(request.PackageCacheDirectory) || request.PackageCacheDirectoryIsOperationLocal) &&

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -235,6 +235,12 @@ public sealed partial class ManagedModuleInstallService
             request.ExpectedPackageSha256);
         ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, request.TrustPolicy);
         ThrowIfLicenseAcceptanceRequired(metadata, request);
+        var authenticode = VerifySavedPackageAuthenticodeIfRequested(
+            request,
+            version,
+            packagePath,
+            metadata,
+            cacheDirectory);
 
         var result = CreateAlreadyInstalledResult(
             request,
@@ -246,6 +252,7 @@ public sealed partial class ManagedModuleInstallService
             repositoryRequestCount,
             installLockWaitElapsed);
         result.Download = CreateDownloadForExistingSavedPackage(request, version, packagePath, metadata);
+        result.AuthenticodeVerification = authenticode;
         result.FileCount = 1;
 
         if (request.SkipDependencyCheck)
@@ -266,6 +273,29 @@ public sealed partial class ManagedModuleInstallService
         result.PackageRepositoryRequestCount += SumPackageRepositoryRequestCount(dependencyResults);
         result.PackageRepositoryRedirectCount += SumPackageRepositoryRedirectCount(dependencyResults);
         return result;
+    }
+
+    private ManagedModuleAuthenticodeVerificationResult? VerifySavedPackageAuthenticodeIfRequested(
+        ManagedModuleInstallRequest request,
+        string version,
+        string packagePath,
+        ManagedModulePackageMetadata metadata,
+        string cacheDirectory)
+    {
+        if (!request.AuthenticodeCheck)
+            return null;
+
+        var validationRoot = Path.Combine(cacheDirectory, "authenticode-" + NewShortId());
+        try
+        {
+            var validationModulePath = CreateStageModulePath(validationRoot, request.Name, version);
+            _ = _extractor.ExtractPackage(packagePath, validationModulePath, metadata.Id);
+            return _authenticodeVerifier.VerifyDirectory(validationModulePath);
+        }
+        finally
+        {
+            ManagedModuleExtractedPackageCache.DeleteDirectoryQuietly(validationRoot);
+        }
     }
 
     private async Task<ManagedModuleInstallResult> CreateAlreadySavedPackageNoOpResultAsync(

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -146,9 +146,31 @@ public sealed partial class ManagedModuleInstallService
 
                     promotionHadExistingTarget = File.Exists(packagePath);
                     var promotionMoveStopwatch = System.Diagnostics.Stopwatch.StartNew();
-                    CopyPackageToSavedPath(download.PackagePath, packagePath, overwrite: request.Force || RequiresPackageDownloadBeforeNoOp(request));
+                    var copiedPackage = CopyPackageToSavedPath(download.PackagePath, packagePath, overwrite: request.Force || RequiresPackageDownloadBeforeNoOp(request));
                     promotionMoveStopwatch.Stop();
                     promotionMoveElapsed = promotionMoveStopwatch.Elapsed;
+                    if (!copiedPackage)
+                    {
+                        _logger.Verbose($"Managed module save reused concurrently saved package: {packagePath}");
+                        var existing = await CreateAlreadySavedPackageResultAsync(
+                            request,
+                            version,
+                            moduleRoot,
+                            packagePath,
+                            stopwatch.Elapsed,
+                            versionResolutionElapsed,
+                            requestScope.Count,
+                            installLockWaitElapsed,
+                            cacheDirectory,
+                            context,
+                            cancellationToken).ConfigureAwait(false);
+                        existing.DependencyResults = dependencyResults;
+                        existing.DependencyElapsed = dependencyStopwatch.Elapsed;
+                        existing.RepositoryRequestCount += SumRepositoryRequestCount(dependencyResults);
+                        existing.PackageRepositoryRequestCount += SumPackageRepositoryRequestCount(dependencyResults);
+                        existing.PackageRepositoryRedirectCount += SumPackageRepositoryRedirectCount(dependencyResults);
+                        return existing;
+                    }
                 }
             }
 
@@ -385,7 +407,7 @@ public sealed partial class ManagedModuleInstallService
             Metadata = download.Metadata
         };
 
-    private static void CopyPackageToSavedPath(string sourcePath, string destinationPath, bool overwrite)
+    private static bool CopyPackageToSavedPath(string sourcePath, string destinationPath, bool overwrite)
     {
         var fullDestinationPath = Path.GetFullPath(destinationPath);
         var directory = Path.GetDirectoryName(fullDestinationPath);
@@ -400,13 +422,14 @@ public sealed partial class ManagedModuleInstallService
             if (File.Exists(fullDestinationPath))
             {
                 if (!overwrite)
-                    return;
+                    return false;
 
                 File.Replace(tempPath, fullDestinationPath, backupPath, ignoreMetadataErrors: true);
-                return;
+                return true;
             }
 
             File.Move(tempPath, fullDestinationPath);
+            return true;
         }
         catch
         {

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -254,19 +254,64 @@ public sealed partial class ManagedModuleInstallService
         return result;
     }
 
+    private async Task<ManagedModuleInstallResult> CreateAlreadySavedPackageNoOpResultAsync(
+        ManagedModuleInstallRequest request,
+        string version,
+        string moduleRoot,
+        string packagePath,
+        TimeSpan elapsed,
+        TimeSpan versionResolutionElapsed,
+        long repositoryRequestCount,
+        TimeSpan installLockWaitElapsed,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken)
+    {
+        var ownsCache = string.IsNullOrWhiteSpace(request.PackageCacheDirectory);
+        var cacheDirectory = ownsCache
+            ? Path.Combine(Path.GetTempPath(), "PFMM.C", NewShortId())
+            : Path.GetFullPath(request.PackageCacheDirectory!.Trim().Trim('"'));
+
+        try
+        {
+            return await CreateAlreadySavedPackageResultAsync(
+                request,
+                version,
+                moduleRoot,
+                packagePath,
+                elapsed,
+                versionResolutionElapsed,
+                repositoryRequestCount,
+                installLockWaitElapsed,
+                cacheDirectory,
+                context,
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (ownsCache)
+                ManagedModuleExtractedPackageCache.DeleteDirectoryQuietly(cacheDirectory);
+        }
+    }
+
     private ManagedModulePackageMetadata ReadSavedPackageMetadata(
         ManagedModuleInstallRequest request,
+        string version,
+        string packagePath)
+        => ReadSavedPackageMetadata(request.Name, version, packagePath);
+
+    private ManagedModulePackageMetadata ReadSavedPackageMetadata(
+        string packageId,
         string version,
         string packagePath)
     {
         try
         {
             var metadata = _repositoryClient.ReadPackageMetadata(packagePath);
-            if (!metadata.Id.Equals(request.Name.Trim(), StringComparison.OrdinalIgnoreCase) ||
+            if (!metadata.Id.Equals(packageId.Trim(), StringComparison.OrdinalIgnoreCase) ||
                 ManagedModuleVersionComparer.Instance.Compare(metadata.Version, version) != 0)
             {
                 throw new InvalidOperationException(
-                    $"Existing saved package '{packagePath}' does not match '{request.Name}' version '{version}'. Use Force to replace it.");
+                    $"Existing saved package '{packagePath}' does not match '{packageId}' version '{version}'. Use Force to replace it.");
             }
 
             return metadata;
@@ -274,7 +319,7 @@ public sealed partial class ManagedModuleInstallService
         catch (Exception ex) when (ex is not InvalidOperationException)
         {
             throw new InvalidOperationException(
-                $"Existing saved package '{packagePath}' could not be read as '{request.Name}' version '{version}'. Use Force to replace it.",
+                $"Existing saved package '{packagePath}' could not be read as '{packageId}' version '{version}'. Use Force to replace it.",
                 ex);
         }
     }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -323,18 +323,20 @@ public sealed partial class ManagedModuleInstallService
         if (!string.IsNullOrWhiteSpace(directory))
             Directory.CreateDirectory(directory!);
 
-        if (File.Exists(fullDestinationPath))
-        {
-            if (!overwrite)
-                return;
-
-            File.Delete(fullDestinationPath);
-        }
-
         var tempPath = fullDestinationPath + ".tmp-" + NewShortId();
+        var backupPath = fullDestinationPath + ".bak-" + NewShortId();
         try
         {
             File.Copy(sourcePath, tempPath, overwrite: true);
+            if (File.Exists(fullDestinationPath))
+            {
+                if (!overwrite)
+                    return;
+
+                File.Replace(tempPath, fullDestinationPath, backupPath, ignoreMetadataErrors: true);
+                return;
+            }
+
             File.Move(tempPath, fullDestinationPath);
         }
         catch
@@ -349,6 +351,19 @@ public sealed partial class ManagedModuleInstallService
             }
 
             throw;
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+                if (File.Exists(backupPath))
+                    File.Delete(backupPath);
+            }
+            catch
+            {
+            }
         }
     }
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -119,9 +119,11 @@ public sealed partial class ManagedModuleInstallService
                     promotionLockWaitElapsed += resolvedPromotionLockWaitElapsed;
                     installLockWaitElapsed += resolvedPromotionLockWaitElapsed;
 
-                    if (File.Exists(packagePath) &&
-                        !request.Force &&
-                        SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, version))
+                    var hasExistingPackage = File.Exists(packagePath);
+                    var canReuseExistingPackage = hasExistingPackage &&
+                                                  !request.Force &&
+                                                  SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, version);
+                    if (canReuseExistingPackage)
                     {
                         _logger.Verbose($"Managed module save skipped concurrently saved package: {packagePath}");
                         var existing = await CreateAlreadySavedPackageResultAsync(
@@ -144,9 +146,9 @@ public sealed partial class ManagedModuleInstallService
                         return existing;
                     }
 
-                    promotionHadExistingTarget = File.Exists(packagePath);
+                    promotionHadExistingTarget = hasExistingPackage;
                     var promotionMoveStopwatch = System.Diagnostics.Stopwatch.StartNew();
-                    var copiedPackage = CopyPackageToSavedPath(download.PackagePath, packagePath, overwrite: request.Force || RequiresPackageDownloadBeforeNoOp(request));
+                    var copiedPackage = CopyPackageToSavedPath(download.PackagePath, packagePath, overwrite: request.Force || !canReuseExistingPackage);
                     promotionMoveStopwatch.Stop();
                     promotionMoveElapsed = promotionMoveStopwatch.Elapsed;
                     if (!copiedPackage)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -305,6 +305,9 @@ public sealed partial class ManagedModuleInstallService
         string packagePath)
     {
         var metadata = ReadSavedPackageMetadata(request, version, packagePath);
+        var download = CreateDownloadForExistingSavedPackage(request, version, packagePath, metadata);
+        ManagedModulePackageIntegrity.VerifyDownload(download, request.ExpectedPackageSha256);
+        ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, request.TrustPolicy);
         return new ManagedModuleVersionInfo
         {
             Name = metadata.Id,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -27,7 +27,7 @@ public sealed partial class ManagedModuleInstallService
                 installLockWaitElapsed += initialLockWaitElapsed;
                 if (File.Exists(packagePath) &&
                     !request.Force &&
-                    !RequiresPackageDownloadBeforeNoOp(request))
+                    SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, version))
                 {
                     _logger.Verbose($"Managed module save skipped existing package: {packagePath}");
                     return await CreateAlreadySavedPackageResultAsync(
@@ -121,7 +121,7 @@ public sealed partial class ManagedModuleInstallService
 
                     if (File.Exists(packagePath) &&
                         !request.Force &&
-                        !RequiresPackageDownloadBeforeNoOp(request))
+                        SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, version))
                     {
                         _logger.Verbose($"Managed module save skipped concurrently saved package: {packagePath}");
                         var existing = await CreateAlreadySavedPackageResultAsync(

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -299,6 +299,27 @@ public sealed partial class ManagedModuleInstallService
         string packagePath)
         => ReadSavedPackageMetadata(request.Name, version, packagePath);
 
+    private ManagedModuleVersionInfo CreateSavedPackageVersionInfo(
+        ManagedModuleInstallRequest request,
+        string version,
+        string packagePath)
+    {
+        var metadata = ReadSavedPackageMetadata(request, version, packagePath);
+        return new ManagedModuleVersionInfo
+        {
+            Name = metadata.Id,
+            Version = metadata.Version,
+            RepositoryName = request.Repository.Name,
+            RepositorySource = request.Repository.Source,
+            PackageSource = packagePath,
+            IsPrerelease = ManagedModuleVersionComparer.IsPrerelease(metadata.Version),
+            Listed = true,
+            License = metadata.License,
+            RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
+            Dependencies = metadata.Dependencies
+        };
+    }
+
     private ManagedModulePackageMetadata ReadSavedPackageMetadata(
         string packageId,
         string version,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -138,11 +138,6 @@ public sealed partial class ManagedModuleInstallService
                             cacheDirectory,
                             context,
                             cancellationToken).ConfigureAwait(false);
-                        existing.DependencyResults = dependencyResults;
-                        existing.DependencyElapsed = dependencyStopwatch.Elapsed;
-                        existing.RepositoryRequestCount += SumRepositoryRequestCount(dependencyResults);
-                        existing.PackageRepositoryRequestCount += SumPackageRepositoryRequestCount(dependencyResults);
-                        existing.PackageRepositoryRedirectCount += SumPackageRepositoryRedirectCount(dependencyResults);
                         return existing;
                     }
 
@@ -166,11 +161,6 @@ public sealed partial class ManagedModuleInstallService
                             cacheDirectory,
                             context,
                             cancellationToken).ConfigureAwait(false);
-                        existing.DependencyResults = dependencyResults;
-                        existing.DependencyElapsed = dependencyStopwatch.Elapsed;
-                        existing.RepositoryRequestCount += SumRepositoryRequestCount(dependencyResults);
-                        existing.PackageRepositoryRequestCount += SumPackageRepositoryRequestCount(dependencyResults);
-                        existing.PackageRepositoryRedirectCount += SumPackageRepositoryRedirectCount(dependencyResults);
                         return existing;
                     }
                 }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.SavePackage.cs
@@ -1,0 +1,361 @@
+using System.Security.Cryptography;
+
+namespace PowerForge;
+
+public sealed partial class ManagedModuleInstallService
+{
+    private async Task<ManagedModuleInstallResult> SaveResolvedPackageAsync(
+        ManagedModuleInstallRequest request,
+        ManagedModuleVersionInfo versionInfo,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken,
+        System.Diagnostics.Stopwatch stopwatch,
+        ManagedModuleRepositoryClient.RepositoryRequestScope requestScope,
+        TimeSpan versionResolutionElapsed,
+        TimeSpan installLockWaitElapsed,
+        string version,
+        string moduleRoot,
+        string packagePath,
+        string cacheDirectory,
+        bool ownsCache)
+    {
+        var stageRoot = CreateStageRoot(moduleRoot, request.Name);
+        try
+        {
+            using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var initialLockWaitElapsed))
+            {
+                installLockWaitElapsed += initialLockWaitElapsed;
+                if (File.Exists(packagePath) &&
+                    !request.Force &&
+                    !RequiresPackageDownloadBeforeNoOp(request))
+                {
+                    _logger.Verbose($"Managed module save skipped existing package: {packagePath}");
+                    return await CreateAlreadySavedPackageResultAsync(
+                        request,
+                        version,
+                        moduleRoot,
+                        packagePath,
+                        stopwatch.Elapsed,
+                        versionResolutionElapsed,
+                        requestScope.Count,
+                        installLockWaitElapsed,
+                        cacheDirectory,
+                        context,
+                        cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            var repositoryDependencyHintMetadata = CreateRepositoryDependencyHintMetadata(versionInfo);
+            StartDependencyVersionSelectionPrewarm(
+                request,
+                repositoryDependencyHintMetadata,
+                context,
+                cancellationToken);
+            StartDependencyPackagePrefetch(
+                request,
+                repositoryDependencyHintMetadata,
+                context,
+                cancellationToken);
+
+            var downloadStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            ManagedModuleDownloadResult download;
+            long packageRepositoryRequestCount;
+            long packageRepositoryRedirectCount;
+            using (var packageRequestScope = _repositoryClient.BeginRequestScope())
+            {
+                download = await _repositoryClient.DownloadPackageAsync(
+                    request.Repository,
+                    request.Name,
+                    version,
+                    cacheDirectory,
+                    request.Credential,
+                    cancellationToken).ConfigureAwait(false);
+                packageRepositoryRequestCount = packageRequestScope.Count;
+                packageRepositoryRedirectCount = packageRequestScope.RedirectCount;
+            }
+
+            downloadStopwatch.Stop();
+            ManagedModulePackageIntegrity.VerifyDownload(download, request.ExpectedPackageSha256);
+            ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, download.Metadata, request.TrustPolicy);
+            ThrowIfLicenseAcceptanceRequired(download.Metadata, request);
+            StartDependencyVersionSelectionPrewarm(request, download.Metadata, context, cancellationToken);
+            StartDependencyPackagePrefetch(request, download.Metadata, context, cancellationToken);
+
+            ManagedModuleAuthenticodeVerificationResult? authenticode = null;
+            ManagedModuleArchiveExtractionResult? extraction = null;
+            if (request.AuthenticodeCheck)
+            {
+                var validationModulePath = CreateStageModulePath(stageRoot, request.Name, version);
+                extraction = _extractor.ExtractPackage(download.PackagePath, validationModulePath, download.Metadata?.Id);
+                authenticode = _authenticodeVerifier.VerifyDirectory(validationModulePath);
+            }
+
+            System.Diagnostics.Stopwatch dependencyStopwatch;
+            IReadOnlyList<ManagedModuleInstallResult> dependencyResults;
+            if (request.SkipDependencyCheck)
+            {
+                dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                dependencyResults = Array.Empty<ManagedModuleInstallResult>();
+            }
+            else
+            {
+                dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                dependencyResults = await InstallDependenciesAsync(request, download.Metadata, cacheDirectory, context, cancellationToken).ConfigureAwait(false);
+            }
+
+            dependencyStopwatch.Stop();
+
+            var promotionStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var promotionLockWaitElapsed = TimeSpan.Zero;
+            var promotionMoveElapsed = TimeSpan.Zero;
+            var promotionHadExistingTarget = false;
+            using (AcquirePromotionLock(moduleRoot, cancellationToken, out var promotionGateWaitElapsed))
+            {
+                promotionLockWaitElapsed += promotionGateWaitElapsed;
+                installLockWaitElapsed += promotionGateWaitElapsed;
+
+                using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var resolvedPromotionLockWaitElapsed))
+                {
+                    promotionLockWaitElapsed += resolvedPromotionLockWaitElapsed;
+                    installLockWaitElapsed += resolvedPromotionLockWaitElapsed;
+
+                    if (File.Exists(packagePath) &&
+                        !request.Force &&
+                        !RequiresPackageDownloadBeforeNoOp(request))
+                    {
+                        _logger.Verbose($"Managed module save skipped concurrently saved package: {packagePath}");
+                        var existing = await CreateAlreadySavedPackageResultAsync(
+                            request,
+                            version,
+                            moduleRoot,
+                            packagePath,
+                            stopwatch.Elapsed,
+                            versionResolutionElapsed,
+                            requestScope.Count,
+                            installLockWaitElapsed,
+                            cacheDirectory,
+                            context,
+                            cancellationToken).ConfigureAwait(false);
+                        existing.DependencyResults = dependencyResults;
+                        existing.DependencyElapsed = dependencyStopwatch.Elapsed;
+                        existing.RepositoryRequestCount += SumRepositoryRequestCount(dependencyResults);
+                        existing.PackageRepositoryRequestCount += SumPackageRepositoryRequestCount(dependencyResults);
+                        existing.PackageRepositoryRedirectCount += SumPackageRepositoryRedirectCount(dependencyResults);
+                        return existing;
+                    }
+
+                    promotionHadExistingTarget = File.Exists(packagePath);
+                    var promotionMoveStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                    CopyPackageToSavedPath(download.PackagePath, packagePath, overwrite: request.Force || RequiresPackageDownloadBeforeNoOp(request));
+                    promotionMoveStopwatch.Stop();
+                    promotionMoveElapsed = promotionMoveStopwatch.Elapsed;
+                }
+            }
+
+            promotionStopwatch.Stop();
+            var savedDownload = CopyDownloadForSavedPackage(download, packagePath, new FileInfo(packagePath).Length);
+            var result = new ManagedModuleInstallResult
+            {
+                Name = request.Name.Trim(),
+                Version = version,
+                Status = ManagedModuleInstallStatus.Installed,
+                RepositoryName = request.Repository.Name,
+                RepositorySource = request.Repository.Source,
+                RequestedVersion = request.Version,
+                MinimumVersion = request.MinimumVersion,
+                MaximumVersion = request.MaximumVersion,
+                VersionPolicy = request.VersionPolicy,
+                ExpectedPackageSha256 = ManagedModulePackageIntegrity.NormalizeSha256(request.ExpectedPackageSha256),
+                RequireTrustedRepository = request.TrustPolicy?.RequireTrustedRepository == true,
+                AllowedAuthors = ManagedModuleTrustEvaluator.NormalizeAuthors(request.TrustPolicy?.AllowedAuthors),
+                ModuleRoot = moduleRoot,
+                ModulePath = packagePath,
+                SavedAsNupkg = true,
+                Elapsed = stopwatch.Elapsed,
+                VersionResolutionElapsed = versionResolutionElapsed,
+                InstallLockWaitElapsed = installLockWaitElapsed,
+                Download = savedDownload,
+                AuthenticodeVerification = authenticode,
+                DownloadElapsed = downloadStopwatch.Elapsed,
+                FileCount = 1,
+                ExtractedBytes = 0,
+                ExtractionElapsed = extraction?.Elapsed ?? TimeSpan.Zero,
+                ExtractionFromCache = false,
+                ExtractionCacheLockWaitElapsed = TimeSpan.Zero,
+                DependencyElapsed = dependencyStopwatch.Elapsed,
+                PromotionElapsed = promotionStopwatch.Elapsed,
+                PromotionLockWaitElapsed = promotionLockWaitElapsed,
+                PromotionMoveElapsed = promotionMoveElapsed,
+                PromotionHadExistingTarget = promotionHadExistingTarget,
+                RepositoryRequestCount = Math.Max(requestScope.Count, packageRepositoryRequestCount) + SumRepositoryRequestCount(dependencyResults),
+                PackageRepositoryRequestCount = packageRepositoryRequestCount + SumPackageRepositoryRequestCount(dependencyResults),
+                PackageRepositoryRedirectCount = packageRepositoryRedirectCount + SumPackageRepositoryRedirectCount(dependencyResults),
+                DependencyResults = dependencyResults
+            };
+            return result;
+        }
+        finally
+        {
+            ManagedModuleExtractedPackageCache.DeleteDirectoryQuietly(stageRoot);
+            if (ownsCache)
+                ManagedModuleExtractedPackageCache.DeleteDirectoryQuietly(cacheDirectory);
+        }
+    }
+
+    private async Task<ManagedModuleInstallResult> CreateAlreadySavedPackageResultAsync(
+        ManagedModuleInstallRequest request,
+        string version,
+        string moduleRoot,
+        string packagePath,
+        TimeSpan elapsed,
+        TimeSpan versionResolutionElapsed,
+        long repositoryRequestCount,
+        TimeSpan installLockWaitElapsed,
+        string cacheDirectory,
+        ManagedModuleInstallContext context,
+        CancellationToken cancellationToken)
+    {
+        var metadata = ReadSavedPackageMetadata(request, version, packagePath);
+        ManagedModulePackageIntegrity.VerifyDownload(
+            CreateDownloadForExistingSavedPackage(request, version, packagePath, metadata),
+            request.ExpectedPackageSha256);
+        ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, request.TrustPolicy);
+        ThrowIfLicenseAcceptanceRequired(metadata, request);
+
+        var result = CreateAlreadyInstalledResult(
+            request,
+            version,
+            moduleRoot,
+            packagePath,
+            elapsed,
+            versionResolutionElapsed,
+            repositoryRequestCount,
+            installLockWaitElapsed);
+        result.Download = CreateDownloadForExistingSavedPackage(request, version, packagePath, metadata);
+        result.FileCount = 1;
+
+        if (request.SkipDependencyCheck)
+            return result;
+
+        var dependencyStopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var dependencyResults = await InstallDependenciesAsync(
+            request,
+            metadata,
+            cacheDirectory,
+            context,
+            cancellationToken).ConfigureAwait(false);
+        dependencyStopwatch.Stop();
+
+        result.DependencyElapsed = dependencyStopwatch.Elapsed;
+        result.DependencyResults = dependencyResults;
+        result.RepositoryRequestCount += SumRepositoryRequestCount(dependencyResults);
+        result.PackageRepositoryRequestCount += SumPackageRepositoryRequestCount(dependencyResults);
+        result.PackageRepositoryRedirectCount += SumPackageRepositoryRedirectCount(dependencyResults);
+        return result;
+    }
+
+    private ManagedModulePackageMetadata ReadSavedPackageMetadata(
+        ManagedModuleInstallRequest request,
+        string version,
+        string packagePath)
+    {
+        try
+        {
+            var metadata = _repositoryClient.ReadPackageMetadata(packagePath);
+            if (!metadata.Id.Equals(request.Name.Trim(), StringComparison.OrdinalIgnoreCase) ||
+                ManagedModuleVersionComparer.Instance.Compare(metadata.Version, version) != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Existing saved package '{packagePath}' does not match '{request.Name}' version '{version}'. Use Force to replace it.");
+            }
+
+            return metadata;
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                $"Existing saved package '{packagePath}' could not be read as '{request.Name}' version '{version}'. Use Force to replace it.",
+                ex);
+        }
+    }
+
+    private ManagedModuleDownloadResult CreateDownloadForExistingSavedPackage(
+        ManagedModuleInstallRequest request,
+        string version,
+        string packagePath,
+        ManagedModulePackageMetadata metadata)
+        => new()
+        {
+            Name = request.Name.Trim(),
+            Version = version,
+            RepositoryName = request.Repository.Name,
+            Source = packagePath,
+            PackagePath = packagePath,
+            BytesWritten = 0,
+            FromCache = true,
+            PackageSha256 = ComputePackageSha256(packagePath),
+            Metadata = metadata
+        };
+
+    private static ManagedModuleDownloadResult CopyDownloadForSavedPackage(
+        ManagedModuleDownloadResult download,
+        string packagePath,
+        long bytesWritten)
+        => new()
+        {
+            Name = download.Name,
+            Version = download.Version,
+            RepositoryName = download.RepositoryName,
+            Source = download.Source,
+            PackagePath = packagePath,
+            BytesWritten = bytesWritten,
+            RequestCount = download.RequestCount,
+            RedirectCount = download.RedirectCount,
+            FromCache = download.FromCache,
+            PackageSha256 = download.PackageSha256,
+            Metadata = download.Metadata
+        };
+
+    private static void CopyPackageToSavedPath(string sourcePath, string destinationPath, bool overwrite)
+    {
+        var fullDestinationPath = Path.GetFullPath(destinationPath);
+        var directory = Path.GetDirectoryName(fullDestinationPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory!);
+
+        if (File.Exists(fullDestinationPath))
+        {
+            if (!overwrite)
+                return;
+
+            File.Delete(fullDestinationPath);
+        }
+
+        var tempPath = fullDestinationPath + ".tmp-" + NewShortId();
+        try
+        {
+            File.Copy(sourcePath, tempPath, overwrite: true);
+            File.Move(tempPath, fullDestinationPath);
+        }
+        catch
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+            catch
+            {
+            }
+
+            throw;
+        }
+    }
+
+    private static string ComputePackageSha256(string path)
+    {
+        using var sha256 = SHA256.Create();
+        using var stream = File.OpenRead(path);
+        return string.Concat(sha256.ComputeHash(stream).Select(static value => value.ToString("x2")));
+    }
+}

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -72,7 +72,8 @@ public sealed partial class ManagedModuleInstallService
         }
 
         var versionInfo = await ResolveSelectedVersionInfoAsync(request, cancellationToken, resolveExactMetadata: true).ConfigureAwait(false);
-        if (TrySelectInstalledNoOpVersionAtLeast(request, moduleRoot, context: null, versionInfo.Version, out var satisfyingInstalledVersion))
+        if (!request.SaveAsNupkg &&
+            TrySelectInstalledNoOpVersionAtLeast(request, moduleRoot, context: null, versionInfo.Version, out var satisfyingInstalledVersion))
         {
             var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, satisfyingInstalledVersion);
             var installedVersionInfo = ManagedModuleVersionComparer.Instance.Compare(satisfyingInstalledVersion, versionInfo.Version) == 0
@@ -88,8 +89,10 @@ public sealed partial class ManagedModuleInstallService
                 wouldRepairDependencies: WouldRepairInstalledManifestDependencies(request, moduleRoot, installedModulePath));
         }
 
-        var modulePath = ResolveInstalledModulePath(moduleRoot, request.Name, versionInfo.Version);
-        var exists = IsInstalledModulePathSatisfied(modulePath, request.Name, versionInfo.Version);
+        var modulePath = ResolveTargetPath(request, moduleRoot, request.Name, versionInfo.Version);
+        var exists = request.SaveAsNupkg
+            ? File.Exists(modulePath)
+            : IsInstalledModulePathSatisfied(modulePath, request.Name, versionInfo.Version);
         return CreateInstallPlan(
             request,
             versionInfo.Version,
@@ -97,7 +100,7 @@ public sealed partial class ManagedModuleInstallService
             modulePath,
             exists,
             versionInfo,
-            exists && WouldRepairInstalledManifestDependencies(request, moduleRoot, modulePath));
+            !request.SaveAsNupkg && exists && WouldRepairInstalledManifestDependencies(request, moduleRoot, modulePath));
     }
 
     private static ManagedModuleInstallPlan CreateInstallPlan(
@@ -123,6 +126,7 @@ public sealed partial class ManagedModuleInstallService
             RepositorySource = request.Repository.Source,
             ModuleRoot = moduleRoot,
             ModulePath = modulePath,
+            SaveAsNupkg = request.SaveAsNupkg,
             ExistingVersionFound = exists,
             WouldWriteFiles = action != ManagedModuleInstallPlanAction.SkipExisting || wouldRepairDependencies,
             RequestedVersion = request.Version,
@@ -259,30 +263,33 @@ public sealed partial class ManagedModuleInstallService
             var version = versionInfo.Version;
             versionResolutionStopwatch.Stop();
 
-            using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var postResolutionLockWaitElapsed))
+            if (!request.SaveAsNupkg)
             {
-                installLockWaitElapsed += postResolutionLockWaitElapsed;
-                if (TrySelectInstalledNoOpVersionAtLeast(request, moduleRoot, context, version, out var satisfyingInstalledVersion))
+                using (AcquireInstallLock(moduleRoot, request.Name, cancellationToken, out var postResolutionLockWaitElapsed))
                 {
-                    var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, satisfyingInstalledVersion);
-                    _logger.Verbose($"Managed module install skipped existing satisfying version: {installedModulePath}");
-                    context.RecordInstalledVersion(moduleRoot, request.Name, satisfyingInstalledVersion);
-                    var result = await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
-                        request,
-                        satisfyingInstalledVersion,
-                        moduleRoot,
-                        installedModulePath,
-                        stopwatch.Elapsed,
-                        versionResolutionStopwatch.Elapsed,
-                        requestScope.Count,
-                        installLockWaitElapsed,
-                        context,
-                        cancellationToken).ConfigureAwait(false);
-                    return CompletePreResolvedInstall(result);
+                    installLockWaitElapsed += postResolutionLockWaitElapsed;
+                    if (TrySelectInstalledNoOpVersionAtLeast(request, moduleRoot, context, version, out var satisfyingInstalledVersion))
+                    {
+                        var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, satisfyingInstalledVersion);
+                        _logger.Verbose($"Managed module install skipped existing satisfying version: {installedModulePath}");
+                        context.RecordInstalledVersion(moduleRoot, request.Name, satisfyingInstalledVersion);
+                        var result = await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
+                            request,
+                            satisfyingInstalledVersion,
+                            moduleRoot,
+                            installedModulePath,
+                            stopwatch.Elapsed,
+                            versionResolutionStopwatch.Elapsed,
+                            requestScope.Count,
+                            installLockWaitElapsed,
+                            context,
+                            cancellationToken).ConfigureAwait(false);
+                        return CompletePreResolvedInstall(result);
+                    }
                 }
             }
 
-            var modulePath = ResolveInstalledModulePath(moduleRoot, request.Name, version);
+            var modulePath = ResolveTargetPath(request, moduleRoot, request.Name, version);
 
             var coalescingKey = preResolvedCoalescingKey ?? TryCreateInstallCoalescingKey(request, version, moduleRoot);
             if (preResolvedPendingInstall is not null && coalescingKey is not null)
@@ -391,6 +398,8 @@ public sealed partial class ManagedModuleInstallService
         out string version)
     {
         version = string.Empty;
+        if (request.SaveAsNupkg)
+            return false;
         if (request.Force)
             return false;
         if (RequiresPackageDownloadBeforeNoOp(request))
@@ -481,6 +490,24 @@ public sealed partial class ManagedModuleInstallService
             ? Path.Combine(Path.GetTempPath(), "PFMM.C", NewShortId())
             : Path.GetFullPath(request.PackageCacheDirectory!.Trim().Trim('"'));
         var moduleName = request.Name.Trim();
+        if (request.SaveAsNupkg)
+        {
+            return await SaveResolvedPackageAsync(
+                request,
+                versionInfo,
+                context,
+                cancellationToken,
+                stopwatch,
+                requestScope,
+                versionResolutionElapsed,
+                installLockWaitElapsed,
+                version,
+                moduleRoot,
+                modulePath,
+                cacheDirectory,
+                ownsCache).ConfigureAwait(false);
+        }
+
         var stageRoot = CreateStageRoot(moduleRoot, moduleName);
         var stageModulePath = CreateStageModulePath(stageRoot, moduleName, version);
         ManagedModuleExtractedPackageLease? directPayloadLease = null;
@@ -945,6 +972,21 @@ public sealed partial class ManagedModuleInstallService
     private static string ResolveModuleDirectoryVersion(string version)
         => ManagedModulePackageIdentity.RequireSafeVersion(version, nameof(version));
 
+    private static string ResolveTargetPath(ManagedModuleInstallRequest request, string moduleRoot, string moduleName, string version)
+        => request.SaveAsNupkg
+            ? ResolveSavedPackagePath(moduleRoot, moduleName, version)
+            : ResolveInstalledModulePath(moduleRoot, moduleName, version);
+
+    private static string ResolveSavedPackagePath(string moduleRoot, string packageId, string version)
+    {
+        var safePackageId = ManagedModulePackageIdentity.RequireSafeId(packageId, nameof(packageId));
+        var safeVersion = ManagedModulePackageIdentity.RequireSafeVersion(version, nameof(version));
+        return Path.Combine(moduleRoot, $"{safePackageId}.{safeVersion}.nupkg");
+    }
+
+    private static bool TargetExists(ManagedModuleInstallRequest request, string path)
+        => request.SaveAsNupkg ? File.Exists(path) : Directory.Exists(path);
+
     private static string ResolveInstalledModulePath(string moduleRoot, string moduleName, string version)
     {
         var moduleFolder = Path.Combine(moduleRoot, moduleName.Trim());
@@ -1102,6 +1144,7 @@ public sealed partial class ManagedModuleInstallService
             AllowedAuthors = ManagedModuleTrustEvaluator.NormalizeAuthors(request.TrustPolicy?.AllowedAuthors),
             ModuleRoot = moduleRoot,
             ModulePath = modulePath,
+            SavedAsNupkg = request.SaveAsNupkg,
             Elapsed = elapsed,
             VersionResolutionElapsed = versionResolutionElapsed,
             CoalescedWaitElapsed = coalescedWaitElapsed,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -459,6 +459,9 @@ public sealed partial class ManagedModuleInstallService
 
     private static bool CanSelectInstalledNoOpBeforeRepositoryResolution(ManagedModuleInstallRequest request)
     {
+        if (request.SaveAsNupkg)
+            return true;
+
         if (!string.IsNullOrWhiteSpace(request.Version))
             return true;
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -241,7 +241,7 @@ public sealed partial class ManagedModuleInstallService
             {
                 installLockWaitElapsed += initialLockWaitElapsed;
                 if (CanSelectInstalledNoOpBeforeRepositoryResolution(request) &&
-                    TrySelectInstalledNoOpVersion(request, moduleRoot, context, out var installedVersion))
+                    TrySelectInstalledNoOpVersion(request, moduleRoot, context, out var installedVersion, allowLicenseOnlySavedPackagePlan: request.SaveAsNupkg))
                 {
                     installedNoOpVersion = installedVersion;
                     installedNoOpModulePath = ResolveNoOpTargetPath(request, moduleRoot, request.Name, installedVersion);
@@ -471,7 +471,7 @@ public sealed partial class ManagedModuleInstallService
 
         var range = ResolveVersionRange(request.VersionPolicy, request.MinimumVersion, request.MaximumVersion);
         if (request.SaveAsNupkg)
-            return !range.IsUnbounded;
+            return range.ExactVersion is not null || range.MaximumVersion is not null;
 
         return range.ExactVersion is not null;
     }

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -176,13 +176,11 @@ public sealed partial class ManagedModuleInstallService
 
         if (knownCoalescingKey is not null && context.TryGetCompletedInstall(knownCoalescingKey, out var completedInstall))
         {
-            var completedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, completedInstall.Version);
-            _logger.Verbose($"Managed module install skipped operation-local completed target: {completedModulePath}");
-            return CreateAlreadyInstalledResult(
+            _logger.Verbose($"Managed module install skipped operation-local completed target: {completedInstall.ModulePath}");
+            return CreateCoalescedCompletedResult(
                 request,
-                completedInstall.Version,
+                completedInstall,
                 moduleRoot,
-                completedModulePath,
                 stopwatch.Elapsed,
                 TimeSpan.Zero,
                 repositoryRequestCount: 0,
@@ -205,12 +203,10 @@ public sealed partial class ManagedModuleInstallService
                         }
 
                         coalescedWaitStopwatch.Stop();
-                        var completedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, completed.Version);
-                        return CreateAlreadyInstalledResult(
+                        return CreateCoalescedCompletedResult(
                             request,
-                            completed.Version,
+                            completed,
                             moduleRoot,
-                            completedModulePath,
                             stopwatch.Elapsed,
                             TimeSpan.Zero,
                             repositoryRequestCount: 0,
@@ -323,11 +319,10 @@ public sealed partial class ManagedModuleInstallService
                         }
 
                         coalescedWaitStopwatch.Stop();
-                        return CreateAlreadyInstalledResult(
+                        return CreateCoalescedCompletedResult(
                             request,
-                            completed.Version,
+                            completed,
                             moduleRoot,
-                            modulePath,
                             stopwatch.Elapsed,
                             versionResolutionStopwatch.Elapsed,
                             requestScope.Count,
@@ -1150,6 +1145,47 @@ public sealed partial class ManagedModuleInstallService
             CoalescedWaitElapsed = coalescedWaitElapsed,
             InstallLockWaitElapsed = installLockWaitElapsed,
             RepositoryRequestCount = repositoryRequestCount
+        };
+
+    private static ManagedModuleInstallResult CreateCoalescedCompletedResult(
+        ManagedModuleInstallRequest request,
+        ManagedModuleInstallResult completed,
+        string moduleRoot,
+        TimeSpan elapsed,
+        TimeSpan versionResolutionElapsed,
+        long repositoryRequestCount,
+        TimeSpan installLockWaitElapsed,
+        TimeSpan coalescedWaitElapsed = default)
+        => new()
+        {
+            Name = request.Name.Trim(),
+            Version = completed.Version,
+            Status = ManagedModuleInstallStatus.AlreadyInstalled,
+            RepositoryName = request.Repository.Name,
+            RepositorySource = request.Repository.Source,
+            RequestedVersion = request.Version,
+            MinimumVersion = request.MinimumVersion,
+            MaximumVersion = request.MaximumVersion,
+            VersionPolicy = request.VersionPolicy,
+            ExpectedPackageSha256 = ManagedModulePackageIntegrity.NormalizeSha256(request.ExpectedPackageSha256),
+            RequireTrustedRepository = request.TrustPolicy?.RequireTrustedRepository == true,
+            AllowedAuthors = ManagedModuleTrustEvaluator.NormalizeAuthors(request.TrustPolicy?.AllowedAuthors),
+            ModuleRoot = moduleRoot,
+            ModulePath = completed.ModulePath,
+            SavedAsNupkg = completed.SavedAsNupkg,
+            Elapsed = elapsed,
+            VersionResolutionElapsed = versionResolutionElapsed,
+            CoalescedWaitElapsed = coalescedWaitElapsed,
+            InstallLockWaitElapsed = installLockWaitElapsed,
+            Download = completed.Download,
+            AuthenticodeVerification = completed.AuthenticodeVerification,
+            FileCount = completed.FileCount,
+            ExtractedBytes = completed.ExtractedBytes,
+            ExtractionFromCache = completed.ExtractionFromCache,
+            PackageRepositoryRequestCount = completed.PackageRepositoryRequestCount,
+            PackageRepositoryRedirectCount = completed.PackageRepositoryRedirectCount,
+            RepositoryRequestCount = repositoryRequestCount,
+            DependencyResults = completed.DependencyResults
         };
 
     private static ManagedModuleInstallLock AcquireInstallLock(

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -471,7 +471,7 @@ public sealed partial class ManagedModuleInstallService
 
         var range = ResolveVersionRange(request.VersionPolicy, request.MinimumVersion, request.MaximumVersion);
         if (request.SaveAsNupkg)
-            return range.ExactVersion is not null || range.MaximumVersion is not null;
+            return range.ExactVersion is not null;
 
         return range.ExactVersion is not null;
     }
@@ -565,7 +565,7 @@ public sealed partial class ManagedModuleInstallService
         => RequiresVerifiedPackage(request) || ManagedModuleTrustEvaluator.HasAllowedAuthorPolicy(request.TrustPolicy);
 
     private static bool ShouldProbeExistingTargetDependenciesForPlan(ManagedModuleInstallRequest request)
-        => !request.Force && !RequiresPackageDownloadBeforeNoOp(request);
+        => !request.Force && (request.SaveAsNupkg || !RequiresPackageDownloadBeforeNoOp(request));
 
     private async Task<ManagedModuleInstallResult> InstallResolvedAsync(
         ManagedModuleInstallRequest request,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -93,7 +93,7 @@ public sealed partial class ManagedModuleInstallService
                 wouldRepairDependencies: WouldRepairInstalledManifestDependencies(request, moduleRoot, installedModulePath));
         }
 
-        var modulePath = ResolveTargetPath(request, moduleRoot, request.Name, versionInfo.Version);
+        var modulePath = ResolveWriteTargetPath(request, moduleRoot, request.Name, versionInfo.Version);
         var exists = request.SaveAsNupkg
             ? File.Exists(modulePath)
             : IsInstalledModulePathSatisfied(modulePath, request.Name, versionInfo.Version);
@@ -109,7 +109,7 @@ public sealed partial class ManagedModuleInstallService
                                       WouldWriteExistingTargetDependencies(request, moduleRoot, versionInfo.Version, modulePath));
     }
 
-    private static ManagedModuleInstallPlan CreateInstallPlan(
+    private ManagedModuleInstallPlan CreateInstallPlan(
         ManagedModuleInstallRequest request,
         string version,
         string moduleRoot,
@@ -118,9 +118,12 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleVersionInfo? versionInfo = null,
         bool wouldRepairDependencies = false)
     {
-        var requiresPackageDownloadBeforeNoOp = RequiresPackageDownloadBeforeNoOp(request) &&
-                                                (!request.SaveAsNupkg ||
-                                                 !string.Equals(versionInfo?.PackageSource, modulePath, StringComparison.OrdinalIgnoreCase));
+        var canSkipExistingSavedPackage = !request.SaveAsNupkg ||
+                                          !exists ||
+                                          (!request.Force && SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, version));
+        var requiresPackageDownloadBeforeNoOp = request.SaveAsNupkg
+            ? !canSkipExistingSavedPackage
+            : RequiresPackageDownloadBeforeNoOp(request);
         var action = exists
             ? request.Force || requiresPackageDownloadBeforeNoOp ? ManagedModuleInstallPlanAction.Reinstall : ManagedModuleInstallPlanAction.SkipExisting
             : ManagedModuleInstallPlanAction.Install;
@@ -494,9 +497,6 @@ public sealed partial class ManagedModuleInstallService
         string moduleRoot,
         string version)
     {
-        if (!RequiresPackageDownloadBeforeNoOp(request))
-            return true;
-
         var packagePath = ResolveExistingSavedPackagePath(moduleRoot, request.Name, version);
         if (string.IsNullOrWhiteSpace(packagePath))
             return false;
@@ -507,6 +507,7 @@ public sealed partial class ManagedModuleInstallService
             var download = CreateDownloadForExistingSavedPackage(request, version, packagePath!, metadata);
             ManagedModulePackageIntegrity.VerifyDownload(download, request.ExpectedPackageSha256);
             ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, request.TrustPolicy);
+            ThrowIfLicenseAcceptanceRequired(metadata, request);
             return true;
         }
         catch (IOException)
@@ -1066,7 +1067,7 @@ public sealed partial class ManagedModuleInstallService
             : ResolveInstalledModulePath(moduleRoot, moduleName, version);
 
     private static string ResolveWriteTargetPath(ManagedModuleInstallRequest request, string moduleRoot, string moduleName, string version)
-        => request.SaveAsNupkg && (request.Force || RequiresPackageDownloadBeforeNoOp(request))
+        => request.SaveAsNupkg
             ? ResolveExistingSavedPackagePath(moduleRoot, moduleName, version) ?? ResolveTargetPath(request, moduleRoot, moduleName, version)
             : ResolveTargetPath(request, moduleRoot, moduleName, version);
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -1059,7 +1059,7 @@ public sealed partial class ManagedModuleInstallService
             : ResolveInstalledModulePath(moduleRoot, moduleName, version);
 
     private static string ResolveWriteTargetPath(ManagedModuleInstallRequest request, string moduleRoot, string moduleName, string version)
-        => request.SaveAsNupkg && request.Force
+        => request.SaveAsNupkg && (request.Force || RequiresPackageDownloadBeforeNoOp(request))
             ? ResolveExistingSavedPackagePath(moduleRoot, moduleName, version) ?? ResolveTargetPath(request, moduleRoot, moduleName, version)
             : ResolveTargetPath(request, moduleRoot, moduleName, version);
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -61,14 +61,14 @@ public sealed partial class ManagedModuleInstallService
         if (CanSelectInstalledNoOpBeforeRepositoryResolution(request) &&
             TrySelectInstalledNoOpVersion(request, moduleRoot, context: null, out var installedVersion))
         {
-            var installedModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, installedVersion);
+            var installedModulePath = ResolveNoOpTargetPath(request, moduleRoot, request.Name, installedVersion);
             return CreateInstallPlan(
                 request,
                 installedVersion,
                 moduleRoot,
                 installedModulePath,
                 exists: true,
-                wouldRepairDependencies: WouldRepairInstalledManifestDependencies(request, moduleRoot, installedModulePath));
+                wouldRepairDependencies: WouldWriteExistingTargetDependencies(request, moduleRoot, installedVersion, installedModulePath));
         }
 
         var versionInfo = await ResolveSelectedVersionInfoAsync(request, cancellationToken, resolveExactMetadata: true).ConfigureAwait(false);
@@ -100,7 +100,8 @@ public sealed partial class ManagedModuleInstallService
             modulePath,
             exists,
             versionInfo,
-            !request.SaveAsNupkg && exists && WouldRepairInstalledManifestDependencies(request, moduleRoot, modulePath));
+            wouldRepairDependencies: exists &&
+                                      WouldWriteExistingTargetDependencies(request, moduleRoot, versionInfo.Version, modulePath));
     }
 
     private static ManagedModuleInstallPlan CreateInstallPlan(
@@ -230,7 +231,7 @@ public sealed partial class ManagedModuleInstallService
                     TrySelectInstalledNoOpVersion(request, moduleRoot, context, out var installedVersion))
                 {
                     installedNoOpVersion = installedVersion;
-                    installedNoOpModulePath = ResolveInstalledModulePath(moduleRoot, request.Name, installedVersion);
+                    installedNoOpModulePath = ResolveNoOpTargetPath(request, moduleRoot, request.Name, installedVersion);
                 }
             }
 
@@ -238,17 +239,29 @@ public sealed partial class ManagedModuleInstallService
             {
                 _logger.Verbose($"Managed module install skipped existing satisfying version: {installedNoOpModulePath}");
                 context.RecordInstalledVersion(moduleRoot, request.Name, installedNoOpVersion);
-                var result = await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
-                    request,
-                    installedNoOpVersion,
-                    moduleRoot,
-                    installedNoOpModulePath,
-                    stopwatch.Elapsed,
-                    TimeSpan.Zero,
-                    repositoryRequestCount: 0,
-                    installLockWaitElapsed,
-                    context,
-                    cancellationToken).ConfigureAwait(false);
+                var result = request.SaveAsNupkg
+                    ? await CreateAlreadySavedPackageNoOpResultAsync(
+                        request,
+                        installedNoOpVersion,
+                        moduleRoot,
+                        installedNoOpModulePath,
+                        stopwatch.Elapsed,
+                        TimeSpan.Zero,
+                        repositoryRequestCount: 0,
+                        installLockWaitElapsed,
+                        context,
+                        cancellationToken).ConfigureAwait(false)
+                    : await CreateAlreadyInstalledResultWithManifestDependencyRepairAsync(
+                        request,
+                        installedNoOpVersion,
+                        moduleRoot,
+                        installedNoOpModulePath,
+                        stopwatch.Elapsed,
+                        TimeSpan.Zero,
+                        repositoryRequestCount: 0,
+                        installLockWaitElapsed,
+                        context,
+                        cancellationToken).ConfigureAwait(false);
                 return CompletePreResolvedInstall(result);
             }
 
@@ -394,7 +407,7 @@ public sealed partial class ManagedModuleInstallService
     {
         version = string.Empty;
         if (request.SaveAsNupkg)
-            return false;
+            return TrySelectSavedPackageNoOpVersion(request, moduleRoot, out version);
         if (request.Force)
             return false;
         if (RequiresPackageDownloadBeforeNoOp(request))
@@ -445,6 +458,37 @@ public sealed partial class ManagedModuleInstallService
         var range = ResolveVersionRange(request.VersionPolicy, request.MinimumVersion, request.MaximumVersion);
         return range.ExactVersion is not null;
     }
+
+    private static bool TrySelectSavedPackageNoOpVersion(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        out string version)
+    {
+        version = string.Empty;
+        if (request.Force)
+            return false;
+        if (RequiresPackageDownloadBeforeNoOp(request))
+            return false;
+        if (string.IsNullOrWhiteSpace(request.Version))
+            return false;
+
+        var requestedVersion = request.Version!.Trim();
+        var packagePath = ResolveSavedPackagePath(moduleRoot, request.Name, requestedVersion);
+        if (!File.Exists(packagePath))
+            return false;
+
+        version = requestedVersion;
+        return true;
+    }
+
+    private static string ResolveNoOpTargetPath(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        string name,
+        string version)
+        => request.SaveAsNupkg
+            ? ResolveTargetPath(request, moduleRoot, name, version)
+            : ResolveInstalledModulePath(moduleRoot, name, version);
 
     private static bool AllowsInstalledNoOpVersion(string version, ManagedModuleInstallRequest request)
     {

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -459,13 +459,13 @@ public sealed partial class ManagedModuleInstallService
 
     private static bool CanSelectInstalledNoOpBeforeRepositoryResolution(ManagedModuleInstallRequest request)
     {
-        if (request.SaveAsNupkg)
-            return true;
-
         if (!string.IsNullOrWhiteSpace(request.Version))
             return true;
 
         var range = ResolveVersionRange(request.VersionPolicy, request.MinimumVersion, request.MaximumVersion);
+        if (request.SaveAsNupkg)
+            return !range.IsUnbounded;
+
         return range.ExactVersion is not null;
     }
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -117,7 +117,7 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleVersionInfo? versionInfo = null,
         bool wouldRepairDependencies = false)
     {
-        var requiresPackageDownloadBeforeNoOp = RequiresPackageDownloadBeforeNoOp(request);
+        var requiresPackageDownloadBeforeNoOp = !request.SaveAsNupkg && RequiresPackageDownloadBeforeNoOp(request);
         var action = exists
             ? request.Force || requiresPackageDownloadBeforeNoOp ? ManagedModuleInstallPlanAction.Reinstall : ManagedModuleInstallPlanAction.SkipExisting
             : ManagedModuleInstallPlanAction.Install;
@@ -470,8 +470,6 @@ public sealed partial class ManagedModuleInstallService
     {
         version = string.Empty;
         if (request.Force)
-            return false;
-        if (RequiresPackageDownloadBeforeNoOp(request))
             return false;
 
         var savedVersion = GetSavedPackageVersions(moduleRoot, request.Name)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -62,12 +62,16 @@ public sealed partial class ManagedModuleInstallService
             TrySelectInstalledNoOpVersion(request, moduleRoot, context: null, out var installedVersion))
         {
             var installedModulePath = ResolveNoOpTargetPath(request, moduleRoot, request.Name, installedVersion);
+            var installedVersionInfo = request.SaveAsNupkg
+                ? CreateSavedPackageVersionInfo(request, installedVersion, installedModulePath)
+                : null;
             return CreateInstallPlan(
                 request,
                 installedVersion,
                 moduleRoot,
                 installedModulePath,
                 exists: true,
+                installedVersionInfo,
                 wouldRepairDependencies: WouldWriteExistingTargetDependencies(request, moduleRoot, installedVersion, installedModulePath));
         }
 
@@ -469,15 +473,14 @@ public sealed partial class ManagedModuleInstallService
             return false;
         if (RequiresPackageDownloadBeforeNoOp(request))
             return false;
-        if (string.IsNullOrWhiteSpace(request.Version))
+
+        var savedVersion = GetSavedPackageVersions(moduleRoot, request.Name)
+            .Where(candidate => AllowsInstalledNoOpVersion(candidate, request))
+            .LastOrDefault();
+        if (savedVersion is null)
             return false;
 
-        var requestedVersion = request.Version!.Trim();
-        var packagePath = ResolveSavedPackagePath(moduleRoot, request.Name, requestedVersion);
-        if (!File.Exists(packagePath))
-            return false;
-
-        version = requestedVersion;
+        version = savedVersion;
         return true;
     }
 
@@ -487,7 +490,7 @@ public sealed partial class ManagedModuleInstallService
         string name,
         string version)
         => request.SaveAsNupkg
-            ? ResolveTargetPath(request, moduleRoot, name, version)
+            ? ResolveExistingSavedPackagePath(moduleRoot, name, version) ?? ResolveTargetPath(request, moduleRoot, name, version)
             : ResolveInstalledModulePath(moduleRoot, name, version);
 
     private static bool AllowsInstalledNoOpVersion(string version, ManagedModuleInstallRequest request)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -72,7 +72,8 @@ public sealed partial class ManagedModuleInstallService
                 installedModulePath,
                 exists: true,
                 installedVersionInfo,
-                wouldRepairDependencies: WouldWriteExistingTargetDependencies(request, moduleRoot, installedVersion, installedModulePath));
+                wouldRepairDependencies: WouldWriteExistingTargetDependencies(request, moduleRoot, installedVersion, installedModulePath),
+                allowLicenseOnlySavedPackagePlan: true);
         }
 
         var versionInfo = await ResolveSelectedVersionInfoAsync(request, cancellationToken, resolveExactMetadata: true).ConfigureAwait(false);
@@ -119,11 +120,18 @@ public sealed partial class ManagedModuleInstallService
         string modulePath,
         bool exists,
         ManagedModuleVersionInfo? versionInfo = null,
-        bool wouldRepairDependencies = false)
+        bool wouldRepairDependencies = false,
+        bool allowLicenseOnlySavedPackagePlan = false)
     {
         var canSkipExistingSavedPackage = !request.SaveAsNupkg ||
                                           !exists ||
-                                          (!request.Force && SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, version));
+                                          (!request.Force &&
+                                           !request.AuthenticodeCheck &&
+                                           SavedPackageSatisfiesNoOpPolicy(
+                                               request,
+                                               moduleRoot,
+                                               version,
+                                               enforceLicenseAcceptance: !allowLicenseOnlySavedPackagePlan));
         var requiresPackageDownloadBeforeNoOp = request.SaveAsNupkg
             ? !canSkipExistingSavedPackage
             : RequiresPackageDownloadBeforeNoOp(request);

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -104,7 +104,8 @@ public sealed partial class ManagedModuleInstallService
             modulePath,
             exists,
             versionInfo,
-            wouldRepairDependencies: exists &&
+            wouldRepairDependencies: ShouldProbeExistingTargetDependenciesForPlan(request) &&
+                                      exists &&
                                       WouldWriteExistingTargetDependencies(request, moduleRoot, versionInfo.Version, modulePath));
     }
 
@@ -551,6 +552,9 @@ public sealed partial class ManagedModuleInstallService
 
     private static bool RequiresPackageDownloadBeforeNoOp(ManagedModuleInstallRequest request)
         => RequiresVerifiedPackage(request) || ManagedModuleTrustEvaluator.HasAllowedAuthorPolicy(request.TrustPolicy);
+
+    private static bool ShouldProbeExistingTargetDependenciesForPlan(ManagedModuleInstallRequest request)
+        => !request.Force && !RequiresPackageDownloadBeforeNoOp(request);
 
     private async Task<ManagedModuleInstallResult> InstallResolvedAsync(
         ManagedModuleInstallRequest request,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -59,7 +59,7 @@ public sealed partial class ManagedModuleInstallService
 
         var moduleRoot = ManagedModuleInstallRootResolver.Resolve(request.Scope, request.ShellEdition, request.ModuleRoot);
         if (CanSelectInstalledNoOpBeforeRepositoryResolution(request) &&
-            TrySelectInstalledNoOpVersion(request, moduleRoot, context: null, out var installedVersion))
+            TrySelectInstalledNoOpVersion(request, moduleRoot, context: null, out var installedVersion, allowLicenseOnlySavedPackagePlan: true))
         {
             var installedModulePath = ResolveNoOpTargetPath(request, moduleRoot, request.Name, installedVersion);
             var installedVersionInfo = request.SaveAsNupkg
@@ -97,6 +97,10 @@ public sealed partial class ManagedModuleInstallService
         var exists = request.SaveAsNupkg
             ? File.Exists(modulePath)
             : IsInstalledModulePathSatisfied(modulePath, request.Name, versionInfo.Version);
+        var canProbeExistingTargetDependencies = ShouldProbeExistingTargetDependenciesForPlan(request) &&
+                                                 exists &&
+                                                 (!request.SaveAsNupkg ||
+                                                  SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, versionInfo.Version, enforceLicenseAcceptance: false));
         return CreateInstallPlan(
             request,
             versionInfo.Version,
@@ -104,8 +108,7 @@ public sealed partial class ManagedModuleInstallService
             modulePath,
             exists,
             versionInfo,
-            wouldRepairDependencies: ShouldProbeExistingTargetDependenciesForPlan(request) &&
-                                      exists &&
+            wouldRepairDependencies: canProbeExistingTargetDependencies &&
                                       WouldWriteExistingTargetDependencies(request, moduleRoot, versionInfo.Version, modulePath));
     }
 
@@ -413,11 +416,12 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleInstallRequest request,
         string moduleRoot,
         ManagedModuleInstallContext? context,
-        out string version)
+        out string version,
+        bool allowLicenseOnlySavedPackagePlan = false)
     {
         version = string.Empty;
         if (request.SaveAsNupkg)
-            return TrySelectSavedPackageNoOpVersion(request, moduleRoot, out version);
+            return TrySelectSavedPackageNoOpVersion(request, moduleRoot, out version, allowLicenseOnlySavedPackagePlan);
         if (request.Force)
             return false;
         if (RequiresPackageDownloadBeforeNoOp(request))
@@ -475,7 +479,8 @@ public sealed partial class ManagedModuleInstallService
     private bool TrySelectSavedPackageNoOpVersion(
         ManagedModuleInstallRequest request,
         string moduleRoot,
-        out string version)
+        out string version,
+        bool allowLicenseOnlyPlan = false)
     {
         version = string.Empty;
         if (request.Force)
@@ -483,7 +488,7 @@ public sealed partial class ManagedModuleInstallService
 
         var savedVersion = GetSavedPackageVersions(moduleRoot, request.Name)
             .Where(candidate => AllowsInstalledNoOpVersion(candidate, request))
-            .Where(candidate => SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, candidate))
+            .Where(candidate => SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, candidate, enforceLicenseAcceptance: !allowLicenseOnlyPlan))
             .LastOrDefault();
         if (savedVersion is null)
             return false;
@@ -495,7 +500,8 @@ public sealed partial class ManagedModuleInstallService
     private bool SavedPackageSatisfiesNoOpPolicy(
         ManagedModuleInstallRequest request,
         string moduleRoot,
-        string version)
+        string version,
+        bool enforceLicenseAcceptance = true)
     {
         var packagePath = ResolveExistingSavedPackagePath(moduleRoot, request.Name, version);
         if (string.IsNullOrWhiteSpace(packagePath))
@@ -507,7 +513,8 @@ public sealed partial class ManagedModuleInstallService
             var download = CreateDownloadForExistingSavedPackage(request, version, packagePath!, metadata);
             ManagedModulePackageIntegrity.VerifyDownload(download, request.ExpectedPackageSha256);
             ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, request.TrustPolicy);
-            ThrowIfLicenseAcceptanceRequired(metadata, request);
+            if (enforceLicenseAcceptance)
+                ThrowIfLicenseAcceptanceRequired(metadata, request);
             return true;
         }
         catch (IOException)

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -117,7 +117,9 @@ public sealed partial class ManagedModuleInstallService
         ManagedModuleVersionInfo? versionInfo = null,
         bool wouldRepairDependencies = false)
     {
-        var requiresPackageDownloadBeforeNoOp = !request.SaveAsNupkg && RequiresPackageDownloadBeforeNoOp(request);
+        var requiresPackageDownloadBeforeNoOp = RequiresPackageDownloadBeforeNoOp(request) &&
+                                                (!request.SaveAsNupkg ||
+                                                 !string.Equals(versionInfo?.PackageSource, modulePath, StringComparison.OrdinalIgnoreCase));
         var action = exists
             ? request.Force || requiresPackageDownloadBeforeNoOp ? ManagedModuleInstallPlanAction.Reinstall : ManagedModuleInstallPlanAction.SkipExisting
             : ManagedModuleInstallPlanAction.Install;
@@ -302,7 +304,7 @@ public sealed partial class ManagedModuleInstallService
                 }
             }
 
-            var modulePath = ResolveTargetPath(request, moduleRoot, request.Name, version);
+            var modulePath = ResolveWriteTargetPath(request, moduleRoot, request.Name, version);
 
             var coalescingKey = preResolvedCoalescingKey ?? TryCreateInstallCoalescingKey(request, version, moduleRoot);
             if (preResolvedPendingInstall is not null && coalescingKey is not null)
@@ -403,7 +405,7 @@ public sealed partial class ManagedModuleInstallService
         }
     }
 
-    private static bool TrySelectInstalledNoOpVersion(
+    private bool TrySelectInstalledNoOpVersion(
         ManagedModuleInstallRequest request,
         string moduleRoot,
         ManagedModuleInstallContext? context,
@@ -463,7 +465,7 @@ public sealed partial class ManagedModuleInstallService
         return range.ExactVersion is not null;
     }
 
-    private static bool TrySelectSavedPackageNoOpVersion(
+    private bool TrySelectSavedPackageNoOpVersion(
         ManagedModuleInstallRequest request,
         string moduleRoot,
         out string version)
@@ -474,12 +476,51 @@ public sealed partial class ManagedModuleInstallService
 
         var savedVersion = GetSavedPackageVersions(moduleRoot, request.Name)
             .Where(candidate => AllowsInstalledNoOpVersion(candidate, request))
+            .Where(candidate => SavedPackageSatisfiesNoOpPolicy(request, moduleRoot, candidate))
             .LastOrDefault();
         if (savedVersion is null)
             return false;
 
         version = savedVersion;
         return true;
+    }
+
+    private bool SavedPackageSatisfiesNoOpPolicy(
+        ManagedModuleInstallRequest request,
+        string moduleRoot,
+        string version)
+    {
+        if (!RequiresPackageDownloadBeforeNoOp(request))
+            return true;
+
+        var packagePath = ResolveExistingSavedPackagePath(moduleRoot, request.Name, version);
+        if (string.IsNullOrWhiteSpace(packagePath))
+            return false;
+
+        try
+        {
+            var metadata = ReadSavedPackageMetadata(request, version, packagePath!);
+            var download = CreateDownloadForExistingSavedPackage(request, version, packagePath!, metadata);
+            ManagedModulePackageIntegrity.VerifyDownload(download, request.ExpectedPackageSha256);
+            ManagedModuleTrustEvaluator.ThrowIfPackageRejected(request.Repository, metadata, request.TrustPolicy);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (InvalidDataException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     private static string ResolveNoOpTargetPath(
@@ -1016,6 +1057,11 @@ public sealed partial class ManagedModuleInstallService
         => request.SaveAsNupkg
             ? ResolveSavedPackagePath(moduleRoot, moduleName, version)
             : ResolveInstalledModulePath(moduleRoot, moduleName, version);
+
+    private static string ResolveWriteTargetPath(ManagedModuleInstallRequest request, string moduleRoot, string moduleName, string version)
+        => request.SaveAsNupkg && request.Force
+            ? ResolveExistingSavedPackagePath(moduleRoot, moduleName, version) ?? ResolveTargetPath(request, moduleRoot, moduleName, version)
+            : ResolveTargetPath(request, moduleRoot, moduleName, version);
 
     private static string ResolveSavedPackagePath(string moduleRoot, string packageId, string version)
     {


### PR DESCRIPTION
## Summary
- add `Save-ManagedModule -AsNupkg` so managed saves can preserve `.nupkg` packages instead of unpacking module folders
- keep dependency closure behavior for package saves, while `-SkipDependencyCheck` saves only the requested package
- expose package-save state on managed install/save plans and results for callers and summaries
- repair review-hardened existing-package cases, including transitive package repair, plan accuracy for partial bundles, exact existing nupkg plans without repository access, and case-insensitive saved package ID matching

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~SaveManagedModuleCommandTests"` (16/16)
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ManagedModule"` (437/437)
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472`
- `git diff --check`
- earlier Windows PowerShell 5.1 and PowerShell 7 live smoke saving a local package with `Save-ManagedModule -AsNupkg`
