### PR TITLE
Add managed find search parity filters

### DIFF
--- a/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
@@ -123,18 +123,24 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         var logger = new CmdletLogger(this, MyInvocation.BoundParameters.ContainsKey("Verbose"));
         var client = ManagedModuleCommandSupport.CreateRepositoryClient(this, logger, Proxy, ProxyCredential);
 
+        var roots = new List<ManagedModuleVersionInfo>();
         foreach (var moduleName in Name)
         {
             var output = ManagedModuleCommandSupport.HasWildcard(moduleName)
                 ? FindWildcardPackageVersions(client, repository, moduleName, credential)
                 : FindExactPackageVersions(client, repository, moduleName, credential);
+            output = HydrateVersionsForFindAsync(client, repository, output, credential)
+                .GetAwaiter()
+                .GetResult();
             output = ApplyFindFilters(output, moduleName);
-            if (IncludeDependencies.IsPresent && output.Count > 0)
-                output = IncludeDependencyVersions(client, repository, output, credential);
-
-            foreach (var version in output)
-                WriteObject(version);
+            roots.AddRange(output);
         }
+
+        var results = IncludeDependencies.IsPresent && roots.Count > 0
+            ? IncludeDependencyVersions(client, repository, roots, credential)
+            : roots;
+        foreach (var version in results)
+            WriteObject(version);
     }
 
     private IReadOnlyList<ManagedModuleVersionInfo> FindExactPackageVersions(
@@ -143,13 +149,6 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         string moduleName,
         RepositoryCredential? credential)
     {
-        if (HasTagFilters() && !AllVersions.IsPresent)
-        {
-            return client.SearchPackagesAsync(repository, ResolveSearchQuery(moduleName), Prerelease.IsPresent, credential, First)
-                .GetAwaiter()
-                .GetResult();
-        }
-
         if (AllVersions.IsPresent)
         {
             return client.GetVersionsAsync(repository, moduleName, Prerelease.IsPresent, credential)
@@ -170,7 +169,8 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         RepositoryCredential? credential)
     {
         var searchQuery = ResolveSearchQuery(moduleName);
-        var matches = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, First)
+        var searchTake = HasTagFilters() ? 1000 : First;
+        var matches = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, searchTake)
             .GetAwaiter()
             .GetResult();
         if (!AllVersions.IsPresent || matches.Count == 0)
@@ -194,19 +194,19 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         IReadOnlyList<ManagedModuleVersionInfo> output,
         string moduleName)
     {
-        var filtered = output
-            .Where(version => ManagedModuleSearchMatcher.IsMatch(moduleName, version.Name));
+        var hasWildcard = ManagedModuleCommandSupport.HasWildcard(moduleName);
+        var filtered = output.Where(version => MatchesRequestedName(moduleName, version.Name, hasWildcard));
 
-        var tagFilters = Tag?
-            .Where(static tag => !string.IsNullOrWhiteSpace(tag))
-            .Select(static tag => tag.Trim())
-            .ToArray();
+        var tagFilters = GetTagFilters();
         if (tagFilters is { Length: > 0 })
         {
             filtered = filtered.Where(version =>
                 version.Tags.Count > 0 &&
-                tagFilters.Any(tag => version.Tags.Any(packageTag => ManagedModuleSearchMatcher.IsMatch(tag, packageTag))));
+                tagFilters.All(tag => version.Tags.Any(packageTag => ManagedModuleSearchMatcher.IsMatch(tag, packageTag))));
         }
+
+        if (hasWildcard)
+            filtered = filtered.Take(First);
 
         return filtered.ToArray();
     }
@@ -216,8 +216,7 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         if (!IsBroadWildcard(moduleName))
             return moduleName;
 
-        var firstTag = Tag?.FirstOrDefault(static tag => !string.IsNullOrWhiteSpace(tag));
-        return string.IsNullOrWhiteSpace(firstTag) ? moduleName : firstTag!.Trim();
+        return moduleName;
     }
 
     private IReadOnlyList<ManagedModuleVersionInfo> IncludeDependencyVersions(
@@ -249,8 +248,14 @@ public sealed class FindManagedModuleCommand : PSCmdlet
                         credential)
                     .GetAwaiter()
                     .GetResult();
-                if (dependencyVersion is not null && !seen.Contains(CreateResultKey(dependencyVersion)))
-                    queue.Enqueue(dependencyVersion);
+                if (dependencyVersion is not null)
+                {
+                    var hydratedDependency = HydrateVersionForFindAsync(client, repository, dependencyVersion, credential)
+                        .GetAwaiter()
+                        .GetResult();
+                    if (!seen.Contains(CreateResultKey(hydratedDependency)))
+                        queue.Enqueue(hydratedDependency);
+                }
             }
         }
 
@@ -265,6 +270,79 @@ public sealed class FindManagedModuleCommand : PSCmdlet
 
     private bool HasTagFilters()
         => Tag?.Any(static tag => !string.IsNullOrWhiteSpace(tag)) == true;
+
+    private string[] GetTagFilters()
+        => Tag?
+            .Where(static tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(static tag => tag.Trim())
+            .ToArray() ?? Array.Empty<string>();
+
+    private bool RequiresMetadataHydration(ManagedModuleVersionInfo version)
+    {
+        if (HasTagFilters() && version.Tags.Count == 0)
+            return true;
+
+        return IncludeDependencies.IsPresent && version.Dependencies.Count == 0;
+    }
+
+    private async System.Threading.Tasks.Task<IReadOnlyList<ManagedModuleVersionInfo>> HydrateVersionsForFindAsync(
+        ManagedModuleRepositoryClient client,
+        ManagedModuleRepository repository,
+        IReadOnlyList<ManagedModuleVersionInfo> versions,
+        RepositoryCredential? credential)
+    {
+        if (!HasTagFilters() && !IncludeDependencies.IsPresent)
+            return versions;
+
+        var hydrated = new List<ManagedModuleVersionInfo>(versions.Count);
+        foreach (var version in versions)
+            hydrated.Add(await HydrateVersionForFindAsync(client, repository, version, credential).ConfigureAwait(false));
+
+        return hydrated;
+    }
+
+    private async System.Threading.Tasks.Task<ManagedModuleVersionInfo> HydrateVersionForFindAsync(
+        ManagedModuleRepositoryClient client,
+        ManagedModuleRepository repository,
+        ManagedModuleVersionInfo version,
+        RepositoryCredential? credential)
+    {
+        if (!RequiresMetadataHydration(version))
+            return version;
+
+        var metadata = await client.GetPackageMetadataAsync(
+                repository,
+                version.Name,
+                version.Version,
+                credential,
+                System.Threading.CancellationToken.None)
+            .ConfigureAwait(false);
+        return metadata is null ? version : CopyVersionInfoWithPackageMetadata(version, metadata);
+    }
+
+    private static ManagedModuleVersionInfo CopyVersionInfoWithPackageMetadata(
+        ManagedModuleVersionInfo version,
+        ManagedModulePackageMetadata metadata)
+        => new()
+        {
+            Name = version.Name,
+            Version = version.Version,
+            RepositoryName = version.RepositoryName,
+            RepositorySource = version.RepositorySource,
+            PackageSource = version.PackageSource,
+            IsPrerelease = version.IsPrerelease,
+            Listed = version.Listed,
+            License = metadata.License,
+            RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
+            Dependencies = metadata.Dependencies,
+            Tags = metadata.Tags,
+            ResourceType = version.ResourceType
+        };
+
+    private static bool MatchesRequestedName(string requestedName, string packageName, bool hasWildcard)
+        => hasWildcard
+            ? ManagedModuleSearchMatcher.IsMatch(requestedName, packageName)
+            : packageName.Equals(requestedName.Trim(), StringComparison.OrdinalIgnoreCase);
 
     private static bool IsBroadWildcard(string value)
     {

--- a/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
@@ -201,9 +201,10 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         const int pageSize = 1000;
         var searchQuery = ResolveSearchQuery(moduleName);
         var results = new List<ManagedModuleVersionInfo>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenVersions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        for (var skip = 0; results.Count < First; skip += pageSize)
+        for (var skip = 0; !HasEnoughTagPagedMatches(results, seenPackages); skip += pageSize)
         {
             var page = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, pageSize, skip)
                 .GetAwaiter()
@@ -220,24 +221,34 @@ public sealed class FindManagedModuleCommand : PSCmdlet
             candidates = ApplyFindFilters(candidates, moduleName, applyFirst: false);
             foreach (var candidate in candidates)
             {
-                if (!seen.Add(CreateResultKey(candidate)))
+                if (AllVersions.IsPresent &&
+                    !seenPackages.Contains(candidate.Name) &&
+                    seenPackages.Count >= First)
+                {
+                    break;
+                }
+
+                if (!seenVersions.Add(CreateResultKey(candidate)))
                     continue;
 
+                seenPackages.Add(candidate.Name);
                 results.Add(candidate);
-                if (results.Count >= First)
+                if (HasEnoughTagPagedMatches(results, seenPackages))
                     break;
             }
-
-            if (page.Count < pageSize)
-                break;
         }
 
-        return results
+        var ordered = results
             .OrderBy(static version => version.Name, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static version => version.Version, ManagedModuleVersionComparer.Instance)
-            .Take(First)
             .ToArray();
+        return AllVersions.IsPresent ? ordered : ordered.Take(First).ToArray();
     }
+
+    private bool HasEnoughTagPagedMatches(
+        IReadOnlyCollection<ManagedModuleVersionInfo> results,
+        IReadOnlyCollection<string> packageNames)
+        => AllVersions.IsPresent ? packageNames.Count >= First : results.Count >= First;
 
     private IReadOnlyList<ManagedModuleVersionInfo> ExpandAllVersions(
         ManagedModuleRepositoryClient client,
@@ -275,7 +286,7 @@ public sealed class FindManagedModuleCommand : PSCmdlet
                 tagFilters.All(tag => version.Tags.Any(packageTag => TagsMatch(tag, packageTag))));
         }
 
-        if (applyFirst && hasWildcard)
+        if (applyFirst && hasWildcard && !AllVersions.IsPresent)
             filtered = filtered.Take(First);
 
         return filtered.ToArray();

--- a/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
@@ -123,7 +123,9 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         var logger = new CmdletLogger(this, MyInvocation.BoundParameters.ContainsKey("Verbose"));
         var client = ManagedModuleCommandSupport.CreateRepositoryClient(this, logger, Proxy, ProxyCredential);
 
-        var roots = new List<ManagedModuleVersionInfo>();
+        var roots = IncludeDependencies.IsPresent
+            ? new List<ManagedModuleVersionInfo>()
+            : null;
         foreach (var moduleName in Name)
         {
             var output = ManagedModuleCommandSupport.HasWildcard(moduleName)
@@ -133,10 +135,20 @@ public sealed class FindManagedModuleCommand : PSCmdlet
                 .GetAwaiter()
                 .GetResult();
             output = ApplyFindFilters(output, moduleName);
-            roots.AddRange(output);
+            if (roots is not null)
+            {
+                roots.AddRange(output);
+                continue;
+            }
+
+            foreach (var version in output)
+                WriteObject(version);
         }
 
-        var results = IncludeDependencies.IsPresent && roots.Count > 0
+        if (roots is null)
+            return;
+
+        var results = roots.Count > 0
             ? IncludeDependencyVersions(client, repository, roots, credential)
             : roots;
         foreach (var version in results)
@@ -204,13 +216,15 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         var seenVersions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var seenPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        for (var skip = 0; !HasEnoughTagPagedMatches(results, seenPackages); skip += pageSize)
+        for (var skip = 0; !HasEnoughTagPagedMatches(results, seenPackages);)
         {
             var page = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, pageSize, skip)
                 .GetAwaiter()
                 .GetResult();
             if (page.Count == 0)
                 break;
+
+            skip += page.Count;
 
             var candidates = AllVersions.IsPresent
                 ? ExpandAllVersions(client, repository, page, credential)
@@ -401,7 +415,7 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         return metadata is null ? version : CopyVersionInfoWithPackageMetadata(version, metadata);
     }
 
-    private static ManagedModuleVersionInfo CopyVersionInfoWithPackageMetadata(
+    internal static ManagedModuleVersionInfo CopyVersionInfoWithPackageMetadata(
         ManagedModuleVersionInfo version,
         ManagedModulePackageMetadata metadata)
         => new()
@@ -413,7 +427,7 @@ public sealed class FindManagedModuleCommand : PSCmdlet
             PackageSource = version.PackageSource,
             IsPrerelease = version.IsPrerelease,
             Listed = version.Listed,
-            License = metadata.License,
+            License = metadata.License ?? version.License,
             RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
             Dependencies = metadata.Dependencies,
             Tags = metadata.Tags,

--- a/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
@@ -168,9 +168,11 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         string moduleName,
         RepositoryCredential? credential)
     {
+        if (HasTagFilters())
+            return FindWildcardPackageVersionsWithTagPaging(client, repository, moduleName, credential);
+
         var searchQuery = ResolveSearchQuery(moduleName);
-        var searchTake = HasTagFilters() ? 1000 : First;
-        var matches = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, searchTake)
+        var matches = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, First)
             .GetAwaiter()
             .GetResult();
         if (!AllVersions.IsPresent || matches.Count == 0)
@@ -190,9 +192,77 @@ public sealed class FindManagedModuleCommand : PSCmdlet
             .ToArray();
     }
 
+    private IReadOnlyList<ManagedModuleVersionInfo> FindWildcardPackageVersionsWithTagPaging(
+        ManagedModuleRepositoryClient client,
+        ManagedModuleRepository repository,
+        string moduleName,
+        RepositoryCredential? credential)
+    {
+        const int pageSize = 1000;
+        var searchQuery = ResolveSearchQuery(moduleName);
+        var results = new List<ManagedModuleVersionInfo>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var skip = 0; results.Count < First; skip += pageSize)
+        {
+            var page = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, pageSize, skip)
+                .GetAwaiter()
+                .GetResult();
+            if (page.Count == 0)
+                break;
+
+            var candidates = AllVersions.IsPresent
+                ? ExpandAllVersions(client, repository, page, credential)
+                : page;
+            candidates = HydrateVersionsForFindAsync(client, repository, candidates, credential)
+                .GetAwaiter()
+                .GetResult();
+            candidates = ApplyFindFilters(candidates, moduleName, applyFirst: false);
+            foreach (var candidate in candidates)
+            {
+                if (!seen.Add(CreateResultKey(candidate)))
+                    continue;
+
+                results.Add(candidate);
+                if (results.Count >= First)
+                    break;
+            }
+
+            if (page.Count < pageSize)
+                break;
+        }
+
+        return results
+            .OrderBy(static version => version.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static version => version.Version, ManagedModuleVersionComparer.Instance)
+            .Take(First)
+            .ToArray();
+    }
+
+    private IReadOnlyList<ManagedModuleVersionInfo> ExpandAllVersions(
+        ManagedModuleRepositoryClient client,
+        ManagedModuleRepository repository,
+        IReadOnlyList<ManagedModuleVersionInfo> matches,
+        RepositoryCredential? credential)
+    {
+        var versions = new List<ManagedModuleVersionInfo>();
+        foreach (var match in matches)
+        {
+            versions.AddRange(client.GetVersionsAsync(repository, match.Name, Prerelease.IsPresent, credential)
+                .GetAwaiter()
+                .GetResult());
+        }
+
+        return versions
+            .OrderBy(static version => version.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static version => version.Version, ManagedModuleVersionComparer.Instance)
+            .ToArray();
+    }
+
     private IReadOnlyList<ManagedModuleVersionInfo> ApplyFindFilters(
         IReadOnlyList<ManagedModuleVersionInfo> output,
-        string moduleName)
+        string moduleName,
+        bool applyFirst = true)
     {
         var hasWildcard = ManagedModuleCommandSupport.HasWildcard(moduleName);
         var filtered = output.Where(version => MatchesRequestedName(moduleName, version.Name, hasWildcard));
@@ -202,10 +272,10 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         {
             filtered = filtered.Where(version =>
                 version.Tags.Count > 0 &&
-                tagFilters.All(tag => version.Tags.Any(packageTag => ManagedModuleSearchMatcher.IsMatch(tag, packageTag))));
+                tagFilters.All(tag => version.Tags.Any(packageTag => TagsMatch(tag, packageTag))));
         }
 
-        if (hasWildcard)
+        if (applyFirst && hasWildcard)
             filtered = filtered.Take(First);
 
         return filtered.ToArray();
@@ -343,6 +413,9 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         => hasWildcard
             ? ManagedModuleSearchMatcher.IsMatch(requestedName, packageName)
             : packageName.Equals(requestedName.Trim(), StringComparison.OrdinalIgnoreCase);
+
+    private static bool TagsMatch(string requestedTag, string packageTag)
+        => packageTag.Equals(requestedTag.Trim(), StringComparison.OrdinalIgnoreCase);
 
     private static bool IsBroadWildcard(string value)
     {

--- a/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
@@ -235,9 +235,8 @@ public sealed class FindManagedModuleCommand : PSCmdlet
             candidates = ApplyFindFilters(candidates, moduleName, applyFirst: false);
             foreach (var candidate in candidates)
             {
-                if (AllVersions.IsPresent &&
-                    !seenPackages.Contains(candidate.Name) &&
-                    seenPackages.Count >= First)
+                var isNewPackage = !seenPackages.Contains(candidate.Name);
+                if (AllVersions.IsPresent && isNewPackage && seenPackages.Count >= First)
                 {
                     break;
                 }
@@ -247,7 +246,7 @@ public sealed class FindManagedModuleCommand : PSCmdlet
 
                 seenPackages.Add(candidate.Name);
                 results.Add(candidate);
-                if (HasEnoughTagPagedMatches(results, seenPackages))
+                if (!AllVersions.IsPresent && HasEnoughTagPagedMatches(results, seenPackages))
                     break;
             }
         }

--- a/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/FindManagedModuleCommand.cs
@@ -61,6 +61,22 @@ public sealed class FindManagedModuleCommand : PSCmdlet
     [ValidateRange(1, 1000)]
     public int First { get; set; } = 100;
 
+    /// <summary>Filter results by package tag metadata.</summary>
+    [Parameter]
+    [Alias("Tags")]
+    [ValidateNotNullOrEmpty]
+    public string[]? Tag { get; set; }
+
+    /// <summary>Resource kind to find. Find-ManagedModule currently returns module resources.</summary>
+    [Parameter]
+    [Alias("Type")]
+    [ValidateSet("Module")]
+    public string[]? ResourceType { get; set; }
+
+    /// <summary>Include dependency resources exposed by repository metadata.</summary>
+    [Parameter]
+    public SwitchParameter IncludeDependencies { get; set; }
+
     /// <summary>Include prerelease versions.</summary>
     [Parameter]
     [Alias("AllowPrerelease")]
@@ -112,6 +128,9 @@ public sealed class FindManagedModuleCommand : PSCmdlet
             var output = ManagedModuleCommandSupport.HasWildcard(moduleName)
                 ? FindWildcardPackageVersions(client, repository, moduleName, credential)
                 : FindExactPackageVersions(client, repository, moduleName, credential);
+            output = ApplyFindFilters(output, moduleName);
+            if (IncludeDependencies.IsPresent && output.Count > 0)
+                output = IncludeDependencyVersions(client, repository, output, credential);
 
             foreach (var version in output)
                 WriteObject(version);
@@ -124,6 +143,13 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         string moduleName,
         RepositoryCredential? credential)
     {
+        if (HasTagFilters() && !AllVersions.IsPresent)
+        {
+            return client.SearchPackagesAsync(repository, ResolveSearchQuery(moduleName), Prerelease.IsPresent, credential, First)
+                .GetAwaiter()
+                .GetResult();
+        }
+
         if (AllVersions.IsPresent)
         {
             return client.GetVersionsAsync(repository, moduleName, Prerelease.IsPresent, credential)
@@ -143,7 +169,8 @@ public sealed class FindManagedModuleCommand : PSCmdlet
         string moduleName,
         RepositoryCredential? credential)
     {
-        var matches = client.SearchPackagesAsync(repository, moduleName, Prerelease.IsPresent, credential, First)
+        var searchQuery = ResolveSearchQuery(moduleName);
+        var matches = client.SearchPackagesAsync(repository, searchQuery, Prerelease.IsPresent, credential, First)
             .GetAwaiter()
             .GetResult();
         if (!AllVersions.IsPresent || matches.Count == 0)
@@ -163,4 +190,87 @@ public sealed class FindManagedModuleCommand : PSCmdlet
             .ToArray();
     }
 
+    private IReadOnlyList<ManagedModuleVersionInfo> ApplyFindFilters(
+        IReadOnlyList<ManagedModuleVersionInfo> output,
+        string moduleName)
+    {
+        var filtered = output
+            .Where(version => ManagedModuleSearchMatcher.IsMatch(moduleName, version.Name));
+
+        var tagFilters = Tag?
+            .Where(static tag => !string.IsNullOrWhiteSpace(tag))
+            .Select(static tag => tag.Trim())
+            .ToArray();
+        if (tagFilters is { Length: > 0 })
+        {
+            filtered = filtered.Where(version =>
+                version.Tags.Count > 0 &&
+                tagFilters.Any(tag => version.Tags.Any(packageTag => ManagedModuleSearchMatcher.IsMatch(tag, packageTag))));
+        }
+
+        return filtered.ToArray();
+    }
+
+    private string ResolveSearchQuery(string moduleName)
+    {
+        if (!IsBroadWildcard(moduleName))
+            return moduleName;
+
+        var firstTag = Tag?.FirstOrDefault(static tag => !string.IsNullOrWhiteSpace(tag));
+        return string.IsNullOrWhiteSpace(firstTag) ? moduleName : firstTag!.Trim();
+    }
+
+    private IReadOnlyList<ManagedModuleVersionInfo> IncludeDependencyVersions(
+        ManagedModuleRepositoryClient client,
+        ManagedModuleRepository repository,
+        IReadOnlyList<ManagedModuleVersionInfo> roots,
+        RepositoryCredential? credential)
+    {
+        var results = new List<ManagedModuleVersionInfo>();
+        var queue = new Queue<ManagedModuleVersionInfo>(roots);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!seen.Add(CreateResultKey(current)))
+                continue;
+
+            results.Add(current);
+            foreach (var dependency in current.Dependencies)
+            {
+                if (string.IsNullOrWhiteSpace(dependency.Id))
+                    continue;
+
+                var dependencyVersion = client.GetLatestDependencyVersionAsync(
+                        repository,
+                        dependency,
+                        Prerelease.IsPresent,
+                        credential)
+                    .GetAwaiter()
+                    .GetResult();
+                if (dependencyVersion is not null && !seen.Contains(CreateResultKey(dependencyVersion)))
+                    queue.Enqueue(dependencyVersion);
+            }
+        }
+
+        return results
+            .OrderBy(static version => version.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static version => version.Version, ManagedModuleVersionComparer.Instance)
+            .ToArray();
+    }
+
+    private static string CreateResultKey(ManagedModuleVersionInfo version)
+        => string.Join("|", version.ResourceType, version.Name, version.Version);
+
+    private bool HasTagFilters()
+        => Tag?.Any(static tag => !string.IsNullOrWhiteSpace(tag)) == true;
+
+    private static bool IsBroadWildcard(string value)
+    {
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ||
+               trimmed.Equals("*", StringComparison.Ordinal) ||
+               trimmed.Equals("?", StringComparison.Ordinal);
+    }
 }

--- a/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
@@ -317,6 +317,139 @@ public sealed class ManagedModuleAliasCommandTests
     }
 
     [Fact]
+    public void FindManagedModule_exact_name_with_tag_does_not_return_prefix_matches()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            tags: "automation");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.Extras.1.0.0.nupkg"),
+            "Company.Tools.Extras",
+            "1.0.0",
+            tags: "automation");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("Tag", "automation");
+
+        var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Tools", result.Name);
+    }
+
+    [Fact]
+    public void FindManagedModule_broad_wildcard_tag_search_does_not_use_tag_as_name_query()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            tags: "automation");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("Tag", "automation");
+
+        var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Tools", result.Name);
+    }
+
+    [Fact]
+    public void FindManagedModule_requires_all_tag_filters_to_match()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            tags: "automation reporting");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Data.1.0.0.nupkg"),
+            "Company.Data",
+            "1.0.0",
+            tags: "automation database");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("Tag", new[] { "automation", "reporting" });
+
+        var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Tools", result.Name);
+    }
+
+    [Fact]
+    public void FindManagedModule_applies_first_after_tag_filtering()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Audit.1.0.0.nupkg"),
+            "Company.Audit",
+            "1.0.0",
+            tags: "audit");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Reporting.1.0.0.nupkg"),
+            "Company.Reporting",
+            "1.0.0",
+            tags: "reporting");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("Tag", "reporting")
+            .AddParameter("First", 1);
+
+        var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Reporting", result.Name);
+    }
+
+    [Fact]
+    public void FindManagedModule_all_versions_preserves_tags_before_filtering()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            tags: "automation");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.1.0.nupkg"),
+            "Company.Tools",
+            "1.1.0",
+            tags: "reporting");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("AllVersions")
+            .AddParameter("Tag", "automation");
+
+        var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("1.0.0", result.Version);
+        Assert.Contains("automation", result.Tags);
+    }
+
+    [Fact]
     public void FindManagedModule_include_dependencies_returns_satisfying_dependency_resources()
     {
         using var feed = new TemporaryDirectory();
@@ -342,6 +475,39 @@ public sealed class ManagedModuleAliasCommandTests
         AssertNoPowerShellErrors(ps);
         Assert.Equal(new[] { "Company.Core:2.1.0", "Company.Tools:1.0.0" },
             result.Select(static item => item.Name + ":" + item.Version));
+    }
+
+    [Fact]
+    public void FindManagedModule_include_dependencies_deduplicates_across_requested_names()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[2.0.0, )", null) });
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Reporting.1.0.0.nupkg"),
+            "Company.Reporting",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[2.0.0, )", null) });
+        TestPackageFactory.Create(Path.Combine(feed.Path, "Company.Core.2.1.0.nupkg"), "Company.Core", "2.1.0");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", new[] { "Company.Tools", "Company.Reporting" })
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("IncludeDependencies");
+
+        var result = ps.Invoke()
+            .Select(static item => Assert.IsType<ManagedModuleVersionInfo>(item.BaseObject))
+            .OrderBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal(new[] { "Company.Core:2.1.0", "Company.Reporting:1.0.0", "Company.Tools:1.0.0" },
+            result.Select(static item => item.Name + ":" + item.Version));
+        Assert.Equal(1, result.Count(static item => item.Name == "Company.Core"));
     }
 
     [Fact]

--- a/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
@@ -605,6 +605,29 @@ public sealed class ManagedModuleAliasCommandTests
     }
 
     [Fact]
+    public void FindManagedModule_hydration_preserves_existing_license_metadata()
+    {
+        var version = new ManagedModuleVersionInfo
+        {
+            Name = "Company.Tools",
+            Version = "1.0.0",
+            License = "https://licenses.example.test/company-tools",
+            Tags = new[] { "automation" }
+        };
+        var metadata = new ManagedModulePackageMetadata
+        {
+            Id = "Company.Tools",
+            Version = "1.0.0",
+            Tags = new[] { "automation" }
+        };
+
+        var hydrated = FindManagedModuleCommand.CopyVersionInfoWithPackageMetadata(version, metadata);
+
+        Assert.Equal("https://licenses.example.test/company-tools", hydrated.License);
+        Assert.Contains("automation", hydrated.Tags);
+    }
+
+    [Fact]
     public void InstallManagedModule_requires_trusted_repository_profile_when_requested()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
@@ -505,6 +505,45 @@ public sealed class ManagedModuleAliasCommandTests
     }
 
     [Fact]
+    public void FindManagedModule_all_versions_tag_search_caps_package_ids_not_version_rows()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Alpha.1.0.0.nupkg"),
+            "Company.Alpha",
+            "1.0.0",
+            tags: "reporting");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Alpha.1.1.0.nupkg"),
+            "Company.Alpha",
+            "1.1.0",
+            tags: "reporting");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Beta.2.0.0.nupkg"),
+            "Company.Beta",
+            "2.0.0",
+            tags: "reporting");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("AllVersions")
+            .AddParameter("Tag", "reporting")
+            .AddParameter("First", 2);
+
+        var results = ps.Invoke()
+            .Select(static item => Assert.IsType<ManagedModuleVersionInfo>(item.BaseObject))
+            .OrderBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static item => item.Version, ManagedModuleVersionComparer.Instance)
+            .ToArray();
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal(new[] { "Company.Alpha:1.0.0", "Company.Alpha:1.1.0", "Company.Beta:2.0.0" },
+            results.Select(static item => item.Name + ":" + item.Version));
+    }
+
+    [Fact]
     public void FindManagedModule_include_dependencies_returns_satisfying_dependency_resources()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
@@ -305,7 +305,7 @@ public sealed class ManagedModuleAliasCommandTests
         ps.AddCommand("Find-ManagedModule")
             .AddParameter("Name", "Company.*")
             .AddParameter("Repository", feed.Path)
-            .AddParameter("Tag", new[] { "auto*" })
+            .AddParameter("Tag", new[] { "automation" })
             .AddParameter("Type", "Module");
 
         var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
@@ -314,6 +314,28 @@ public sealed class ManagedModuleAliasCommandTests
         Assert.Equal("Company.Tools", result.Name);
         Assert.Equal("Module", result.ResourceType);
         Assert.Contains("automation", result.Tags);
+    }
+
+    [Fact]
+    public void FindManagedModule_tag_filter_matches_literal_tags()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            tags: "automation reporting");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("Tag", "auto*");
+
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Empty(results);
     }
 
     [Fact]
@@ -401,6 +423,39 @@ public sealed class ManagedModuleAliasCommandTests
             "Company.Audit",
             "1.0.0",
             tags: "audit");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Reporting.1.0.0.nupkg"),
+            "Company.Reporting",
+            "1.0.0",
+            tags: "reporting");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("Tag", "reporting")
+            .AddParameter("First", 1);
+
+        var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Reporting", result.Name);
+    }
+
+    [Fact]
+    public void FindManagedModule_pages_tag_filtered_wildcard_searches_before_capping()
+    {
+        using var feed = new TemporaryDirectory();
+        for (var i = 0; i < 1005; i++)
+        {
+            var name = "Company.Noise" + i.ToString("0000", System.Globalization.CultureInfo.InvariantCulture);
+            TestPackageFactory.Create(
+                Path.Combine(feed.Path, name + ".1.0.0.nupkg"),
+                name,
+                "1.0.0",
+                tags: "noise");
+        }
+
         TestPackageFactory.Create(
             Path.Combine(feed.Path, "Company.Reporting.1.0.0.nupkg"),
             "Company.Reporting",

--- a/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
@@ -109,6 +109,23 @@ public sealed class ManagedModuleAliasCommandTests
         Assert.True(command.Parameters.ContainsKey("ProxyCredential"));
     }
 
+    [Fact]
+    public void FindManagedModule_exposes_psresourceget_search_parameters()
+    {
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Get-Command")
+            .AddArgument("Find-ManagedModule");
+
+        var command = Assert.IsType<CmdletInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.True(command.Parameters.ContainsKey("Tag"));
+        Assert.True(command.Parameters.ContainsKey("ResourceType"));
+        Assert.True(command.Parameters.ContainsKey("IncludeDependencies"));
+        Assert.Contains("Tags", command.Parameters["Tag"].Aliases);
+        Assert.Contains("Type", command.Parameters["ResourceType"].Aliases);
+    }
+
     [Theory]
     [InlineData("Find-ManagedModule", "Name", "ModuleName")]
     [InlineData("Find-ManagedModule", "Repository", "Source")]
@@ -266,6 +283,64 @@ public sealed class ManagedModuleAliasCommandTests
 
         AssertNoPowerShellErrors(ps);
         Assert.Equal(new[] { "Company.Core:2.0.0", "Company.Tools:1.0.0", "Company.Tools:1.1.0" },
+            result.Select(static item => item.Name + ":" + item.Version));
+    }
+
+    [Fact]
+    public void FindManagedModule_filters_local_feed_by_tag()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            tags: "automation reporting");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Data.1.0.0.nupkg"),
+            "Company.Data",
+            "1.0.0",
+            tags: "database storage");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("Tag", new[] { "auto*" })
+            .AddParameter("Type", "Module");
+
+        var result = Assert.IsType<ManagedModuleVersionInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Tools", result.Name);
+        Assert.Equal("Module", result.ResourceType);
+        Assert.Contains("automation", result.Tags);
+    }
+
+    [Fact]
+    public void FindManagedModule_include_dependencies_returns_satisfying_dependency_resources()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            dependencies: new[] { new TestDependency("Company.Core", "[2.0.0, )", null) });
+        TestPackageFactory.Create(Path.Combine(feed.Path, "Company.Core.1.0.0.nupkg"), "Company.Core", "1.0.0");
+        TestPackageFactory.Create(Path.Combine(feed.Path, "Company.Core.2.1.0.nupkg"), "Company.Core", "2.1.0");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("IncludeDependencies");
+
+        var result = ps.Invoke()
+            .Select(static item => Assert.IsType<ManagedModuleVersionInfo>(item.BaseObject))
+            .OrderBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal(new[] { "Company.Core:2.1.0", "Company.Tools:1.0.0" },
             result.Select(static item => item.Name + ":" + item.Version));
     }
 

--- a/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
@@ -544,6 +544,45 @@ public sealed class ManagedModuleAliasCommandTests
     }
 
     [Fact]
+    public void FindManagedModule_all_versions_tag_search_returns_all_versions_for_boundary_package()
+    {
+        using var feed = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Alpha.1.0.0.nupkg"),
+            "Company.Alpha",
+            "1.0.0",
+            tags: "reporting");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Alpha.1.1.0.nupkg"),
+            "Company.Alpha",
+            "1.1.0",
+            tags: "reporting");
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Beta.2.0.0.nupkg"),
+            "Company.Beta",
+            "2.0.0",
+            tags: "reporting");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Find-ManagedModule")
+            .AddParameter("Name", "Company.*")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("AllVersions")
+            .AddParameter("Tag", "reporting")
+            .AddParameter("First", 1);
+
+        var results = ps.Invoke()
+            .Select(static item => Assert.IsType<ManagedModuleVersionInfo>(item.BaseObject))
+            .OrderBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static item => item.Version, ManagedModuleVersionComparer.Instance)
+            .ToArray();
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal(new[] { "Company.Alpha:1.0.0", "Company.Alpha:1.1.0" },
+            results.Select(static item => item.Name + ":" + item.Version));
+    }
+
+    [Fact]
     public void FindManagedModule_include_dependencies_returns_satisfying_dependency_resources()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -1080,6 +1080,26 @@ public sealed class ManagedModuleRepositoryClientTests
     }
 
     [Fact]
+    public async Task SearchPackagesAsync_preserves_positional_cancellation_token_overload()
+    {
+        var requests = new List<RecordedRequest>();
+        using var client = new HttpClient(new ManagedModuleHandler(requests));
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+
+        var results = await repositoryClient.SearchPackagesAsync(
+            repository,
+            "Company.*",
+            false,
+            null,
+            100,
+            CancellationToken.None);
+
+        Assert.Equal(new[] { "Company.Core", "Company.Tools" }, results.Select(result => result.Name));
+        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Company.&prerelease=false&take=100&skip=0&semVerLevel=2.0.0");
+    }
+
+    [Fact]
     public async Task SearchPackagesAsync_rejects_flat_container_source_for_wildcards()
     {
         var requests = new List<RecordedRequest>();

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -1119,6 +1119,22 @@ public sealed class ManagedModuleRepositoryClientTests
     }
 
     [Fact]
+    public async Task SearchPackagesAsync_keeps_paging_when_nuget_v3_caps_search_page_size()
+    {
+        var requests = new List<RecordedRequest>();
+        using var client = new HttpClient(new ManagedModuleHandler(requests));
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+
+        var results = await repositoryClient.SearchPackagesAsync(repository, "Company.*", includePrerelease: false, take: 1000);
+
+        Assert.Contains(results, result => result.Name == "Company.Reporting");
+        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Company.&prerelease=false&take=1000&skip=0&semVerLevel=2.0.0");
+        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Company.&prerelease=false&take=1000&skip=1&semVerLevel=2.0.0");
+        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Company.&prerelease=false&take=1000&skip=2&semVerLevel=2.0.0");
+    }
+
+    [Fact]
     public async Task SearchPackagesAsync_preserves_positional_cancellation_token_overload()
     {
         var requests = new List<RecordedRequest>();
@@ -1558,6 +1574,15 @@ public sealed class ManagedModuleRepositoryClientTests
                             "{\"id\":\"Company.Core\",\"version\":\"2.0.0\",\"listed\":true}," +
                             "{\"id\":\"Other.Module\",\"version\":\"9.0.0\",\"listed\":true}" +
                             "]}");
+
+            if (uri.AbsoluteUri == "https://example.test/search?q=Company.&prerelease=false&take=1000&skip=0&semVerLevel=2.0.0")
+                return Json("{\"totalHits\":3,\"data\":[{\"id\":\"Company.Noise\",\"version\":\"1.0.0\",\"listed\":true}]}");
+
+            if (uri.AbsoluteUri == "https://example.test/search?q=Company.&prerelease=false&take=1000&skip=1&semVerLevel=2.0.0")
+                return Json("{\"totalHits\":3,\"data\":[{\"id\":\"Company.Reporting\",\"version\":\"1.0.0\",\"listed\":true}]}");
+
+            if (uri.AbsoluteUri == "https://example.test/search?q=Company.&prerelease=false&take=1000&skip=2&semVerLevel=2.0.0")
+                return Json("{\"totalHits\":3,\"data\":[{\"id\":\"Company.Final\",\"version\":\"1.0.0\",\"listed\":true}]}");
 
             if (uri.AbsoluteUri == "https://example.test/search?q=Company.Tools&prerelease=false&take=20&skip=0&semVerLevel=2.0.0")
                 return Json("{\"data\":[{\"id\":\"Company.Tools\",\"version\":\"1.1.0\",\"listed\":true}]}");

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -200,6 +200,29 @@ public sealed class ManagedModuleRepositoryClientTests
     }
 
     [Fact]
+    public async Task GetLatestDependencyVersionAsync_allows_unlisted_exact_dependency_version()
+    {
+        var requests = new List<RecordedRequest>();
+        using var client = new HttpClient(new ManagedModuleHandler(requests, includeRegistrationBase: true));
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+
+        var version = await repositoryClient.GetLatestDependencyVersionAsync(
+            repository,
+            new ManagedModuleDependencyInfo
+            {
+                Id = "Company.Core",
+                VersionRange = "[2.0.0]"
+            });
+
+        Assert.NotNull(version);
+        Assert.Equal("Company.Core", version!.Name);
+        Assert.Equal("2.0.0", version.Version);
+        Assert.False(version.Listed);
+        Assert.Contains(requests, request => request.Url == "https://example.test/registration/company.core/index.json");
+    }
+
+    [Fact]
     public async Task GetLatestVersionAsync_uses_nuget_v2_packages_latest_filter()
     {
         var requests = new List<RecordedRequest>();
@@ -1080,6 +1103,22 @@ public sealed class ManagedModuleRepositoryClientTests
     }
 
     [Fact]
+    public async Task SearchPackagesAsync_keeps_paging_after_filtered_empty_nuget_v3_pages()
+    {
+        var requests = new List<RecordedRequest>();
+        using var client = new HttpClient(new ManagedModuleHandler(requests));
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+
+        var results = await repositoryClient.SearchPackagesAsync(repository, "*Tools", includePrerelease: false, take: 1);
+
+        var result = Assert.Single(results);
+        Assert.Equal("Company.Tools", result.Name);
+        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Tools&prerelease=false&take=1&skip=0&semVerLevel=2.0.0");
+        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Tools&prerelease=false&take=1&skip=1&semVerLevel=2.0.0");
+    }
+
+    [Fact]
     public async Task SearchPackagesAsync_preserves_positional_cancellation_token_overload()
     {
         var requests = new List<RecordedRequest>();
@@ -1522,6 +1561,12 @@ public sealed class ManagedModuleRepositoryClientTests
 
             if (uri.AbsoluteUri == "https://example.test/search?q=Company.Tools&prerelease=false&take=20&skip=0&semVerLevel=2.0.0")
                 return Json("{\"data\":[{\"id\":\"Company.Tools\",\"version\":\"1.1.0\",\"listed\":true}]}");
+
+            if (uri.AbsoluteUri == "https://example.test/search?q=Tools&prerelease=false&take=1&skip=0&semVerLevel=2.0.0")
+                return Json("{\"data\":[{\"id\":\"Tools.Extras\",\"version\":\"1.0.0\",\"listed\":true}]}");
+
+            if (uri.AbsoluteUri == "https://example.test/search?q=Tools&prerelease=false&take=1&skip=1&semVerLevel=2.0.0")
+                return Json("{\"data\":[{\"id\":\"Company.Tools\",\"version\":\"1.0.0\",\"listed\":true}]}");
 
             if (uri.AbsoluteUri == "https://example.test/search?q=Unlisted.Tools&prerelease=false&take=20&skip=0&semVerLevel=2.0.0")
                 return Json("{\"data\":[{\"id\":\"Unlisted.Tools\",\"version\":\"1.5.0\",\"listed\":true}]}");

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -1095,6 +1095,26 @@ public sealed class ManagedModuleRepositoryClientTests
     }
 
     [Fact]
+    public async Task GetLatestDependencyVersionAsync_skips_unlisted_versions()
+    {
+        var requests = new List<RecordedRequest>();
+        using var client = new HttpClient(new ManagedModuleHandler(requests, includeRegistrationBase: true));
+        var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
+        var repository = new ManagedModuleRepository("Gallery", "https://example.test/v3/index.json");
+        var dependency = new ManagedModuleDependencyInfo
+        {
+            Id = "Unlisted.Tools",
+            VersionRange = "[1.0.0, )"
+        };
+
+        var result = await repositoryClient.GetLatestDependencyVersionAsync(repository, dependency);
+
+        Assert.NotNull(result);
+        Assert.Equal("2.0.0", result.Version);
+        Assert.True(result.Listed);
+    }
+
+    [Fact]
     public async Task SearchPackagesAsync_uses_powershellgallery_v2_read_api_for_canonical_default()
     {
         var requests = new List<RecordedRequest>();

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -411,7 +411,7 @@ public sealed class ManagedModuleRepositoryClientTests
         });
         Assert.Contains(
             requests,
-            request => request.Url == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsLatestVersion&$top=10&semVerLevel=2.0.0");
+            request => request.Url == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsLatestVersion&$top=10&$skip=0&semVerLevel=2.0.0");
     }
 
     [Fact]
@@ -426,7 +426,7 @@ public sealed class ManagedModuleRepositoryClientTests
 
         Assert.Contains(
             requests,
-            request => request.Url == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsAbsoluteLatestVersion&$top=10&semVerLevel=2.0.0");
+            request => request.Url == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsAbsoluteLatestVersion&$top=10&$skip=0&semVerLevel=2.0.0");
     }
 
     [Fact]
@@ -1076,7 +1076,7 @@ public sealed class ManagedModuleRepositoryClientTests
         var results = await repositoryClient.SearchPackagesAsync(repository, "Company.*");
 
         Assert.Equal(new[] { "Company.Core", "Company.Tools" }, results.Select(result => result.Name));
-        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Company.&prerelease=false&take=100&semVerLevel=2.0.0");
+        Assert.Contains(requests, request => request.Url == "https://example.test/search?q=Company.&prerelease=false&take=100&skip=0&semVerLevel=2.0.0");
     }
 
     [Fact]
@@ -1136,7 +1136,7 @@ public sealed class ManagedModuleRepositoryClientTests
         Assert.DoesNotContain(requests, request => request.Url == "https://www.powershellgallery.com/api/v3/index.json");
         Assert.Contains(
             requests,
-            request => request.Url == "https://www.powershellgallery.com/api/v2/Packages()?$filter=substringof('Pester',Id)%20and%20IsLatestVersion&$top=100&semVerLevel=2.0.0");
+            request => request.Url == "https://www.powershellgallery.com/api/v2/Packages()?$filter=substringof('Pester',Id)%20and%20IsLatestVersion&$top=100&$skip=0&semVerLevel=2.0.0");
     }
 
     [Fact]
@@ -1380,7 +1380,7 @@ public sealed class ManagedModuleRepositoryClientTests
                     "<entry><content><m:properties xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><d:Version>2.38.0</d:Version></m:properties></content></entry>" +
                     "</feed>");
 
-            if (uri.AbsoluteUri == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsLatestVersion&$top=10&semVerLevel=2.0.0")
+            if (uri.AbsoluteUri == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsLatestVersion&$top=10&$skip=0&semVerLevel=2.0.0")
                 return Xml(
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                     "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\" xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">" +
@@ -1390,14 +1390,14 @@ public sealed class ManagedModuleRepositoryClientTests
                     "<entry><content><m:properties><d:Id>Other.Module</d:Id><d:Version>9.0.0</d:Version></m:properties></content></entry>" +
                     "</feed>");
 
-            if (uri.AbsoluteUri == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsAbsoluteLatestVersion&$top=10&semVerLevel=2.0.0")
+            if (uri.AbsoluteUri == "https://example.test/api/v2/Packages()?$filter=startswith(Id,'Company.')%20and%20IsAbsoluteLatestVersion&$top=10&$skip=0&semVerLevel=2.0.0")
                 return Xml(
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                     "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\" xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">" +
                     "<entry><content><m:properties><d:Id>Company.Tools</d:Id><d:Version>1.2.0-preview1</d:Version></m:properties></content></entry>" +
                     "</feed>");
 
-            if (uri.AbsoluteUri == "https://www.powershellgallery.com/api/v2/Packages()?$filter=substringof('Pester',Id)%20and%20IsLatestVersion&$top=100&semVerLevel=2.0.0")
+            if (uri.AbsoluteUri == "https://www.powershellgallery.com/api/v2/Packages()?$filter=substringof('Pester',Id)%20and%20IsLatestVersion&$top=100&$skip=0&semVerLevel=2.0.0")
                 return Xml(
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                     "<feed xmlns=\"http://www.w3.org/2005/Atom\" xmlns:d=\"http://schemas.microsoft.com/ado/2007/08/dataservices\" xmlns:m=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\">" +
@@ -1493,17 +1493,17 @@ public sealed class ManagedModuleRepositoryClientTests
                 });
             }
 
-            if (uri.AbsoluteUri == "https://example.test/search?q=Company.&prerelease=false&take=100&semVerLevel=2.0.0")
+            if (uri.AbsoluteUri == "https://example.test/search?q=Company.&prerelease=false&take=100&skip=0&semVerLevel=2.0.0")
                 return Json("{\"data\":[" +
                             "{\"id\":\"Company.Tools\",\"version\":\"1.1.0\",\"listed\":true}," +
                             "{\"id\":\"Company.Core\",\"version\":\"2.0.0\",\"listed\":true}," +
                             "{\"id\":\"Other.Module\",\"version\":\"9.0.0\",\"listed\":true}" +
                             "]}");
 
-            if (uri.AbsoluteUri == "https://example.test/search?q=Company.Tools&prerelease=false&take=20&semVerLevel=2.0.0")
+            if (uri.AbsoluteUri == "https://example.test/search?q=Company.Tools&prerelease=false&take=20&skip=0&semVerLevel=2.0.0")
                 return Json("{\"data\":[{\"id\":\"Company.Tools\",\"version\":\"1.1.0\",\"listed\":true}]}");
 
-            if (uri.AbsoluteUri == "https://example.test/search?q=Unlisted.Tools&prerelease=false&take=20&semVerLevel=2.0.0")
+            if (uri.AbsoluteUri == "https://example.test/search?q=Unlisted.Tools&prerelease=false&take=20&skip=0&semVerLevel=2.0.0")
                 return Json("{\"data\":[{\"id\":\"Unlisted.Tools\",\"version\":\"1.5.0\",\"listed\":true}]}");
 
             if (uri.AbsoluteUri == "https://example.test/publish/" && request.Method == HttpMethod.Put)

--- a/PowerForge.Tests/ManagedModuleTestSupport.cs
+++ b/PowerForge.Tests/ManagedModuleTestSupport.cs
@@ -45,14 +45,15 @@ internal static class TestPackageFactory
         IReadOnlyList<TestDependency>? dependencies = null,
         IReadOnlyDictionary<string, string>? files = null,
         bool requireLicenseAcceptance = false,
-        string authors = "Evotec")
+        string authors = "Evotec",
+        string tags = "powershell automation company")
     {
         Directory.CreateDirectory(System.IO.Path.GetDirectoryName(packagePath)!);
         using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
         var nuspec = archive.CreateEntry(id + ".nuspec");
         using (var writer = new StreamWriter(nuspec.Open()))
         {
-            writer.Write(CreateNuspec(id, version, dependencies, requireLicenseAcceptance, authors));
+            writer.Write(CreateNuspec(id, version, dependencies, requireLicenseAcceptance, authors, tags));
         }
 
         if (files is null)
@@ -71,7 +72,8 @@ internal static class TestPackageFactory
         string version,
         bool requireLicenseAcceptance = false,
         IReadOnlyDictionary<string, string>? files = null,
-        IReadOnlyList<TestDependency>? dependencies = null)
+        IReadOnlyList<TestDependency>? dependencies = null,
+        string tags = "powershell automation company")
     {
         using var stream = new MemoryStream();
         using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
@@ -79,7 +81,7 @@ internal static class TestPackageFactory
             var nuspec = archive.CreateEntry(id + ".nuspec");
             using (var writer = new StreamWriter(nuspec.Open()))
             {
-                writer.Write(CreateNuspec(id, version, dependencies, requireLicenseAcceptance));
+                writer.Write(CreateNuspec(id, version, dependencies, requireLicenseAcceptance, tags: tags));
             }
 
             if (files is not null)
@@ -101,7 +103,8 @@ internal static class TestPackageFactory
         string version,
         IReadOnlyList<TestDependency>? dependencies = null,
         bool requireLicenseAcceptance = false,
-        string authors = "Evotec")
+        string authors = "Evotec",
+        string tags = "powershell automation company")
     {
         var licenseAcceptanceXml = requireLicenseAcceptance
             ? "    <requireLicenseAcceptance>true</requireLicenseAcceptance>" + Environment.NewLine
@@ -117,7 +120,7 @@ internal static class TestPackageFactory
     <description>Test package.</description>
     <projectUrl>https://example.test/{id}</projectUrl>
     <license type="expression">MIT</license>
-{licenseAcceptanceXml}    <tags>powershell automation company</tags>
+{licenseAcceptanceXml}    <tags>{tags}</tags>
 {dependencyXml}
   </metadata>
 </package>

--- a/PowerForge/Models/ManagedModules/ManagedModuleVersionInfo.cs
+++ b/PowerForge/Models/ManagedModules/ManagedModuleVersionInfo.cs
@@ -54,4 +54,14 @@ public sealed class ManagedModuleVersionInfo
     /// Dependencies exposed by repository metadata when available.
     /// </summary>
     public IReadOnlyList<ManagedModuleDependencyInfo> Dependencies { get; set; } = Array.Empty<ManagedModuleDependencyInfo>();
+
+    /// <summary>
+    /// Package tags exposed by repository or package metadata when available.
+    /// </summary>
+    public IReadOnlyList<string> Tags { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Resource kind represented by this result.
+    /// </summary>
+    public string ResourceType { get; set; } = "Module";
 }

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Coalescing.cs
@@ -13,7 +13,7 @@ public sealed partial class ManagedModuleRepositoryClient
         CancellationToken cancellationToken,
         Func<CancellationToken, Task<IReadOnlyList<ManagedModuleVersionInfo>>> factory)
     {
-        var key = BuildCoalescedQueryKey("versions", repository, packageId, includePrerelease, take: null, credential, cancellationToken);
+        var key = BuildCoalescedQueryKey("versions", repository, packageId, includePrerelease, take: null, skip: null, credential, cancellationToken);
         return key is null
             ? factory(cancellationToken)
             : ExecuteCoalescedAsync(_versionQueryTasks, key, cancellationToken, factory);
@@ -27,7 +27,7 @@ public sealed partial class ManagedModuleRepositoryClient
         CancellationToken cancellationToken,
         Func<CancellationToken, Task<ManagedModuleVersionInfo?>> factory)
     {
-        var key = BuildCoalescedQueryKey("latest", repository, packageId, includePrerelease, take: null, credential, cancellationToken);
+        var key = BuildCoalescedQueryKey("latest", repository, packageId, includePrerelease, take: null, skip: null, credential, cancellationToken);
         return key is null
             ? factory(cancellationToken)
             : ExecuteCoalescedAsync(_latestVersionQueryTasks, key, cancellationToken, factory);
@@ -38,11 +38,12 @@ public sealed partial class ManagedModuleRepositoryClient
         string query,
         bool includePrerelease,
         int take,
+        int skip,
         RepositoryCredential? credential,
         CancellationToken cancellationToken,
         Func<CancellationToken, Task<IReadOnlyList<ManagedModuleVersionInfo>>> factory)
     {
-        var key = BuildCoalescedQueryKey("search", repository, query, includePrerelease, take, credential, cancellationToken);
+        var key = BuildCoalescedQueryKey("search", repository, query, includePrerelease, take, skip, credential, cancellationToken);
         return key is null
             ? factory(cancellationToken)
             : ExecuteCoalescedAsync(_searchQueryTasks, key, cancellationToken, factory);
@@ -94,6 +95,7 @@ public sealed partial class ManagedModuleRepositoryClient
         string value,
         bool includePrerelease,
         int? take,
+        int? skip,
         RepositoryCredential? credential,
         CancellationToken cancellationToken)
     {
@@ -107,7 +109,8 @@ public sealed partial class ManagedModuleRepositoryClient
             NormalizeCoalescedRepositorySource(repository.Source),
             value.Trim(),
             includePrerelease ? "pre" : "stable",
-            take?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
+            take?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+            skip?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
     }
 
     private static string NormalizeCoalescedRepositorySource(string source)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
@@ -49,11 +49,12 @@ public sealed partial class ManagedModuleRepositoryClient
         bool includePrerelease,
         RepositoryCredential? credential,
         int take,
+        int skip,
         CancellationToken cancellationToken)
     {
         var document = await ReadNuGetV2XmlAsync(
                 repository,
-                BuildNuGetV2SearchUri(repository.Source, query, includePrerelease, take),
+                BuildNuGetV2SearchUri(repository.Source, query, includePrerelease, take, skip),
                 credential,
                 "Search",
                 $"Unable to search for '{query}'.",
@@ -325,7 +326,7 @@ public sealed partial class ManagedModuleRepositoryClient
         return new Uri(new Uri(EnsureTrailingSlash(source)), $"FindPackagesById()?id='{escapedId}'&semVerLevel=2.0.0");
     }
 
-    private static Uri BuildNuGetV2SearchUri(string source, string pattern, bool includePrerelease, int take)
+    private static Uri BuildNuGetV2SearchUri(string source, string pattern, bool includePrerelease, int take, int skip)
     {
         var searchText = ManagedModuleSearchMatcher.ToSearchText(pattern);
         var escapedSearch = Uri.EscapeDataString(searchText.Trim().Replace("'", "''"));
@@ -338,7 +339,7 @@ public sealed partial class ManagedModuleRepositoryClient
 
         return new Uri(
             new Uri(EnsureTrailingSlash(source)),
-            $"Packages()?$filter={filter}&$top={Math.Max(1, take)}&semVerLevel=2.0.0");
+            $"Packages()?$filter={filter}&$top={Math.Max(1, take)}&$skip={Math.Max(0, skip)}&semVerLevel=2.0.0");
     }
 
     private static Uri BuildNuGetV2LatestPackageUri(string source, string packageId, bool includePrerelease)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
@@ -258,6 +258,7 @@ public sealed partial class ManagedModuleRepositoryClient
         var license = ReadNuGetV2String(entry, data, "LicenseExpression") ??
                       ReadNuGetV2String(entry, data, "LicenseUrl");
         var dependencies = ReadNuGetV2Dependencies(entry, data);
+        var tags = SplitTags(ReadNuGetV2String(entry, data, "Tags"));
         return new ManagedModuleVersionInfo
         {
             Name = trimmedId,
@@ -269,7 +270,8 @@ public sealed partial class ManagedModuleRepositoryClient
             Listed = ReadNuGetV2Listed(entry, data),
             License = license,
             RequireLicenseAcceptance = ReadNuGetV2Boolean(entry, data, "RequireLicenseAcceptance"),
-            Dependencies = dependencies
+            Dependencies = dependencies,
+            Tags = tags
         };
     }
 

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.NuGetV2.cs
@@ -52,28 +52,57 @@ public sealed partial class ManagedModuleRepositoryClient
         int skip,
         CancellationToken cancellationToken)
     {
-        var document = await ReadNuGetV2XmlAsync(
-                repository,
-                BuildNuGetV2SearchUri(repository.Source, query, includePrerelease, take, skip),
-                credential,
-                "Search",
-                $"Unable to search for '{query}'.",
-                $"Managed module NuGet v2 search for '{query}' returned malformed XML.",
-                cancellationToken)
-            .ConfigureAwait(false);
-
         XNamespace atom = "http://www.w3.org/2005/Atom";
         XNamespace data = "http://schemas.microsoft.com/ado/2007/08/dataservices";
-        return document
-            .Descendants(atom + "entry")
-            .Select(entry => ReadNuGetV2SearchResult(repository, entry, data))
-            .Where(version => version is not null && ManagedModuleSearchMatcher.IsMatch(query, version.Name))
-            .Select(static version => version!)
-            .GroupBy(version => version.Name, StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.OrderBy(version => version.Version, ManagedModuleVersionComparer.Instance).Last())
-            .OrderBy(version => version.Name, StringComparer.OrdinalIgnoreCase)
-            .Take(Math.Max(1, take))
-            .ToArray();
+        var pageSize = Math.Max(1, take);
+        var matchingSkip = Math.Max(0, skip);
+        var matches = new List<ManagedModuleVersionInfo>();
+        var serverSkip = 0;
+
+        while (matches.Count < pageSize)
+        {
+            var document = await ReadNuGetV2XmlAsync(
+                    repository,
+                    BuildNuGetV2SearchUri(repository.Source, query, includePrerelease, pageSize, serverSkip),
+                    credential,
+                    "Search",
+                    $"Unable to search for '{query}'.",
+                    $"Managed module NuGet v2 search for '{query}' returned malformed XML.",
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            var entries = document.Descendants(atom + "entry").ToArray();
+            if (entries.Length == 0)
+                break;
+
+            var pageMatches = entries
+                .Select(entry => ReadNuGetV2SearchResult(repository, entry, data))
+                .Where(version => version is not null && ManagedModuleSearchMatcher.IsMatch(query, version.Name))
+                .Select(static version => version!)
+                .GroupBy(version => version.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.OrderBy(version => version.Version, ManagedModuleVersionComparer.Instance).Last())
+                .OrderBy(version => version.Name, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var match in pageMatches)
+            {
+                if (matchingSkip > 0)
+                {
+                    matchingSkip--;
+                    continue;
+                }
+
+                matches.Add(match);
+                if (matches.Count >= pageSize)
+                    break;
+            }
+
+            if (entries.Length < pageSize)
+                break;
+
+            serverSkip += entries.Length;
+        }
+
+        return matches;
     }
 
     private async Task<ManagedModuleVersionInfo?> GetLatestNuGetV2VersionAsync(

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -216,6 +216,7 @@ public sealed partial class ManagedModuleRepositoryClient
             .ConfigureAwait(false);
 
         return versions
+            .Where(static version => version.Listed)
             .Where(version => range.IsSatisfiedBy(version.Version))
             .OrderBy(version => version.Version, ManagedModuleVersionComparer.Instance)
             .LastOrDefault();

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -145,6 +145,7 @@ public sealed partial class ManagedModuleRepositoryClient
     /// <param name="includePrerelease">Include prerelease versions.</param>
     /// <param name="credential">Optional repository credential.</param>
     /// <param name="take">Maximum number of results.</param>
+    /// <param name="skip">Number of matching results to skip before returning a page.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Latest selected package versions.</returns>
     public async Task<IReadOnlyList<ManagedModuleVersionInfo>> SearchPackagesAsync(
@@ -153,32 +154,37 @@ public sealed partial class ManagedModuleRepositoryClient
         bool includePrerelease = false,
         RepositoryCredential? credential = null,
         int take = 100,
+        int skip = 0,
         CancellationToken cancellationToken = default)
     {
         if (repository is null)
             throw new ArgumentNullException(nameof(repository));
         if (string.IsNullOrWhiteSpace(query))
             throw new ArgumentException("Search query is required.", nameof(query));
+        if (skip < 0)
+            throw new ArgumentOutOfRangeException(nameof(skip), "Skip must not be negative.");
 
         return repository.Kind switch
         {
-            ManagedModuleRepositoryKind.LocalFolder => SearchLocalPackages(repository, query, includePrerelease, take),
+            ManagedModuleRepositoryKind.LocalFolder => SearchLocalPackages(repository, query, includePrerelease, take, skip),
             ManagedModuleRepositoryKind.NuGetV3 => await ExecuteCoalescedSearchQueryAsync(
                 repository,
                 query,
                 includePrerelease,
                 take,
+                skip,
                 credential,
                 cancellationToken,
-                token => SearchNuGetPackagesWithPowerShellGalleryReadApiAsync(repository, query, includePrerelease, credential, take, token)).ConfigureAwait(false),
+                token => SearchNuGetPackagesWithPowerShellGalleryReadApiAsync(repository, query, includePrerelease, credential, take, skip, token)).ConfigureAwait(false),
             ManagedModuleRepositoryKind.NuGetV2 => await ExecuteCoalescedSearchQueryAsync(
                 repository,
                 query,
                 includePrerelease,
                 take,
+                skip,
                 credential,
                 cancellationToken,
-                token => SearchNuGetV2PackagesAsync(repository, query, includePrerelease, credential, take, token)).ConfigureAwait(false),
+                token => SearchNuGetV2PackagesAsync(repository, query, includePrerelease, credential, take, skip, token)).ConfigureAwait(false),
             _ => throw new NotSupportedException($"Repository kind '{repository.Kind}' is not supported.")
         };
     }
@@ -378,15 +384,16 @@ public sealed partial class ManagedModuleRepositoryClient
         bool includePrerelease,
         RepositoryCredential? credential,
         int take,
+        int skip,
         CancellationToken cancellationToken)
     {
         if (ShouldUsePowerShellGalleryV2ReadApi(repository))
         {
             var fallback = CreatePowerShellGalleryV2Fallback(repository);
-            return await SearchNuGetV2PackagesAsync(fallback, query, includePrerelease, credential, take, cancellationToken).ConfigureAwait(false);
+            return await SearchNuGetV2PackagesAsync(fallback, query, includePrerelease, credential, take, skip, cancellationToken).ConfigureAwait(false);
         }
 
-        return await SearchNuGetPackagesAsync(repository, query, includePrerelease, credential, take, cancellationToken).ConfigureAwait(false);
+        return await SearchNuGetPackagesAsync(repository, query, includePrerelease, credential, take, skip, cancellationToken).ConfigureAwait(false);
     }
 
     private ManagedModuleDownloadResult? TryUseCachedPackage(
@@ -537,7 +544,8 @@ public sealed partial class ManagedModuleRepositoryClient
         ManagedModuleRepository repository,
         string query,
         bool includePrerelease,
-        int take)
+        int take,
+        int skip)
     {
         var root = ResolveLocalFolder(repository.Source);
         if (!Directory.Exists(root))
@@ -548,6 +556,7 @@ public sealed partial class ManagedModuleRepositoryClient
             .GroupBy(version => version.Name, StringComparer.OrdinalIgnoreCase)
             .Select(group => group.OrderBy(version => version.Version, ManagedModuleVersionComparer.Instance).Last())
             .OrderBy(version => version.Name, StringComparer.OrdinalIgnoreCase)
+            .Skip(Math.Max(0, skip))
             .Take(Math.Max(1, take))
             .ToArray();
     }
@@ -558,13 +567,14 @@ public sealed partial class ManagedModuleRepositoryClient
         bool includePrerelease,
         RepositoryCredential? credential,
         int take,
+        int skip,
         CancellationToken cancellationToken)
     {
         var searchService = await ResolveSearchQueryServiceAsync(repository, credential, cancellationToken).ConfigureAwait(false);
         var searchText = ManagedModuleSearchMatcher.ToSearchText(query);
         var uri = BuildSearchQueryUri(
             searchService,
-            $"q={Uri.EscapeDataString(searchText)}&prerelease={includePrerelease.ToString().ToLowerInvariant()}&take={Math.Max(1, take)}&semVerLevel=2.0.0");
+            $"q={Uri.EscapeDataString(searchText)}&prerelease={includePrerelease.ToString().ToLowerInvariant()}&take={Math.Max(1, take)}&skip={Math.Max(0, skip)}&semVerLevel=2.0.0");
         using var response = await SendWithPolicyAsync(
             () => CreateRequest(HttpMethod.Get, uri, credential, "application/json"),
             cancellationToken).ConfigureAwait(false);

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -184,6 +184,44 @@ public sealed partial class ManagedModuleRepositoryClient
     }
 
     /// <summary>
+    /// Resolves the latest available package version satisfying dependency metadata.
+    /// </summary>
+    /// <param name="repository">Repository to query.</param>
+    /// <param name="dependency">Dependency metadata.</param>
+    /// <param name="includePrerelease">Include prerelease versions even when the dependency range does not require them.</param>
+    /// <param name="credential">Optional repository credential.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The latest satisfying dependency version, or <c>null</c> when none is available.</returns>
+    public async Task<ManagedModuleVersionInfo?> GetLatestDependencyVersionAsync(
+        ManagedModuleRepository repository,
+        ManagedModuleDependencyInfo dependency,
+        bool includePrerelease = false,
+        RepositoryCredential? credential = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (repository is null)
+            throw new ArgumentNullException(nameof(repository));
+        if (dependency is null)
+            throw new ArgumentNullException(nameof(dependency));
+        if (string.IsNullOrWhiteSpace(dependency.Id))
+            throw new ArgumentException("Dependency id is required.", nameof(dependency));
+
+        var range = ManagedModuleVersionRange.Parse(dependency.VersionRange);
+        var versions = await GetVersionsAsync(
+                repository,
+                dependency.Id,
+                includePrerelease || range.AllowsPrerelease,
+                credential,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return versions
+            .Where(version => range.IsSatisfiedBy(version.Version))
+            .OrderBy(version => version.Version, ManagedModuleVersionComparer.Instance)
+            .LastOrDefault();
+    }
+
+    /// <summary>
     /// Downloads or copies a package to a destination directory.
     /// </summary>
     /// <param name="repository">Repository to use.</param>
@@ -484,7 +522,8 @@ public sealed partial class ManagedModuleRepositoryClient
                 IsPrerelease = metadata.IsPrerelease,
                 License = metadata.License,
                 RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
-                Dependencies = metadata.Dependencies
+                Dependencies = metadata.Dependencies,
+                Tags = metadata.Tags
             });
         }
 
@@ -1084,8 +1123,32 @@ public sealed partial class ManagedModuleRepositoryClient
             License = ReadOptionalString(item, "licenseExpression") ??
                       ReadOptionalString(item, "licenseUrl"),
             RequireLicenseAcceptance = ReadOptionalBoolean(item, "requireLicenseAcceptance"),
-            Dependencies = ReadSearchDependencies(item)
+            Dependencies = ReadSearchDependencies(item),
+            Tags = ReadSearchTags(item)
         };
+    }
+
+    private static IReadOnlyList<string> ReadSearchTags(JsonElement item)
+    {
+        if (!item.TryGetProperty("tags", out var tags))
+            return Array.Empty<string>();
+
+        if (tags.ValueKind == JsonValueKind.Array)
+        {
+            var values = tags.EnumerateArray()
+                .Where(static tag => tag.ValueKind == JsonValueKind.String)
+                .Select(static tag => tag.GetString()?.Trim())
+                .Where(static tag => !string.IsNullOrWhiteSpace(tag))
+                .Select(static tag => tag!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return values.Length == 0 ? Array.Empty<string>() : values;
+        }
+
+        if (tags.ValueKind == JsonValueKind.String)
+            return SplitTags(tags.GetString());
+
+        return Array.Empty<string>();
     }
 
     private static IReadOnlyList<ManagedModuleDependencyInfo> ReadSearchDependencies(JsonElement item)
@@ -1167,9 +1230,25 @@ public sealed partial class ManagedModuleRepositoryClient
                 PackageSource = file,
                 IsPrerelease = metadata.IsPrerelease,
                 License = metadata.License,
-                RequireLicenseAcceptance = metadata.RequireLicenseAcceptance
+                RequireLicenseAcceptance = metadata.RequireLicenseAcceptance,
+                Dependencies = metadata.Dependencies,
+                Tags = metadata.Tags
             };
         }
+    }
+
+    private static IReadOnlyList<string> SplitTags(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return Array.Empty<string>();
+
+        var tags = value!
+            .Split(new[] { ' ', ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static tag => tag.Trim())
+            .Where(static tag => tag.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return tags.Length == 0 ? Array.Empty<string>() : tags;
     }
 
     private static string? ReadOptionalString(JsonElement item, string propertyName)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -145,7 +145,6 @@ public sealed partial class ManagedModuleRepositoryClient
     /// <param name="includePrerelease">Include prerelease versions.</param>
     /// <param name="credential">Optional repository credential.</param>
     /// <param name="take">Maximum number of results.</param>
-    /// <param name="skip">Number of matching results to skip before returning a page.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Latest selected package versions.</returns>
     public async Task<IReadOnlyList<ManagedModuleVersionInfo>> SearchPackagesAsync(
@@ -154,7 +153,27 @@ public sealed partial class ManagedModuleRepositoryClient
         bool includePrerelease = false,
         RepositoryCredential? credential = null,
         int take = 100,
-        int skip = 0,
+        CancellationToken cancellationToken = default)
+        => await SearchPackagesAsync(repository, query, includePrerelease, credential, take, skip: 0, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Searches package ids from the repository and returns a page of latest selected versions per match.
+    /// </summary>
+    /// <param name="repository">Repository to query.</param>
+    /// <param name="query">Package id text or wildcard pattern.</param>
+    /// <param name="includePrerelease">Include prerelease versions.</param>
+    /// <param name="credential">Optional repository credential.</param>
+    /// <param name="take">Maximum number of results.</param>
+    /// <param name="skip">Number of matching results to skip before returning a page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Latest selected package versions.</returns>
+    public async Task<IReadOnlyList<ManagedModuleVersionInfo>> SearchPackagesAsync(
+        ManagedModuleRepository repository,
+        string query,
+        bool includePrerelease,
+        RepositoryCredential? credential,
+        int take,
+        int skip,
         CancellationToken cancellationToken = default)
     {
         if (repository is null)

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -241,8 +241,8 @@ public sealed partial class ManagedModuleRepositoryClient
             .ConfigureAwait(false);
 
         return versions
-            .Where(static version => version.Listed)
             .Where(version => range.IsSatisfiedBy(version.Version))
+            .Where(version => range.ExactVersion is not null || version.Listed)
             .OrderBy(version => version.Version, ManagedModuleVersionComparer.Instance)
             .LastOrDefault();
     }
@@ -589,33 +589,63 @@ public sealed partial class ManagedModuleRepositoryClient
         int skip,
         CancellationToken cancellationToken)
     {
+        var pageSize = Math.Max(1, take);
+        var matchingSkip = Math.Max(0, skip);
+        var matches = new List<ManagedModuleVersionInfo>();
+        var serverSkip = 0;
         var searchService = await ResolveSearchQueryServiceAsync(repository, credential, cancellationToken).ConfigureAwait(false);
         var searchText = ManagedModuleSearchMatcher.ToSearchText(query);
-        var uri = BuildSearchQueryUri(
-            searchService,
-            $"q={Uri.EscapeDataString(searchText)}&prerelease={includePrerelease.ToString().ToLowerInvariant()}&take={Math.Max(1, take)}&skip={Math.Max(0, skip)}&semVerLevel=2.0.0");
-        using var response = await SendWithPolicyAsync(
-            () => CreateRequest(HttpMethod.Get, uri, credential, "application/json"),
-            cancellationToken).ConfigureAwait(false);
-        if (!response.IsSuccessStatusCode)
-            throw CreateRepositoryHttpException(repository, "Search", response.StatusCode, $"Unable to search for '{query}'.");
 
-        using var document = await ReadJsonDocumentAsync(
-            response.Content,
-            repository,
-            "Search",
-            $"Managed module search for '{query}' returned malformed JSON.",
-            cancellationToken).ConfigureAwait(false);
-        if (!document.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
-            throw CreateRepositoryContractException(repository, "Search", "Repository response did not include a search data array.");
+        while (matches.Count < pageSize)
+        {
+            var uri = BuildSearchQueryUri(
+                searchService,
+                $"q={Uri.EscapeDataString(searchText)}&prerelease={includePrerelease.ToString().ToLowerInvariant()}&take={pageSize}&skip={serverSkip}&semVerLevel=2.0.0");
+            using var response = await SendWithPolicyAsync(
+                () => CreateRequest(HttpMethod.Get, uri, credential, "application/json"),
+                cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+                throw CreateRepositoryHttpException(repository, "Search", response.StatusCode, $"Unable to search for '{query}'.");
 
-        return data.EnumerateArray()
-            .Select(item => ReadSearchResult(repository, item))
-            .Where(version => version is not null && ManagedModuleSearchMatcher.IsMatch(query, version.Name))
-            .Select(static version => version!)
-            .OrderBy(static version => version.Name, StringComparer.OrdinalIgnoreCase)
-            .Take(Math.Max(1, take))
-            .ToArray();
+            using var document = await ReadJsonDocumentAsync(
+                response.Content,
+                repository,
+                "Search",
+                $"Managed module search for '{query}' returned malformed JSON.",
+                cancellationToken).ConfigureAwait(false);
+            if (!document.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
+                throw CreateRepositoryContractException(repository, "Search", "Repository response did not include a search data array.");
+
+            var rawPage = data.EnumerateArray().ToArray();
+            if (rawPage.Length == 0)
+                break;
+
+            var pageMatches = rawPage
+                .Select(item => ReadSearchResult(repository, item))
+                .Where(version => version is not null && ManagedModuleSearchMatcher.IsMatch(query, version.Name))
+                .Select(static version => version!)
+                .OrderBy(static version => version.Name, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var match in pageMatches)
+            {
+                if (matchingSkip > 0)
+                {
+                    matchingSkip--;
+                    continue;
+                }
+
+                matches.Add(match);
+                if (matches.Count >= pageSize)
+                    break;
+            }
+
+            if (rawPage.Length < pageSize)
+                break;
+
+            serverSkip += rawPage.Length;
+        }
+
+        return matches;
     }
 
     private async Task<IReadOnlyDictionary<string, bool>> TryResolveVersionListingMapAsync(

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.cs
@@ -620,6 +620,7 @@ public sealed partial class ManagedModuleRepositoryClient
             if (rawPage.Length == 0)
                 break;
 
+            var totalHits = ReadSearchTotalHits(document.RootElement);
             var pageMatches = rawPage
                 .Select(item => ReadSearchResult(repository, item))
                 .Where(version => version is not null && ManagedModuleSearchMatcher.IsMatch(query, version.Name))
@@ -639,13 +640,30 @@ public sealed partial class ManagedModuleRepositoryClient
                     break;
             }
 
-            if (rawPage.Length < pageSize)
+            var nextServerSkip = serverSkip + rawPage.Length;
+            var serverHasMore = totalHits.HasValue
+                ? nextServerSkip < totalHits.Value
+                : rawPage.Length >= pageSize;
+            if (!serverHasMore)
                 break;
 
-            serverSkip += rawPage.Length;
+            serverSkip = nextServerSkip;
         }
 
         return matches;
+    }
+
+    private static int? ReadSearchTotalHits(JsonElement root)
+    {
+        if (!root.TryGetProperty("totalHits", out var totalHits))
+            return null;
+
+        return totalHits.ValueKind switch
+        {
+            JsonValueKind.Number when totalHits.TryGetInt32(out var value) => value,
+            JsonValueKind.String when int.TryParse(totalHits.GetString(), out var value) => value,
+            _ => null
+        };
     }
 
     private async Task<IReadOnlyDictionary<string, bool>> TryResolveVersionListingMapAsync(


### PR DESCRIPTION
## Summary
- add PSResourceGet-shaped search parameters to `Find-ManagedModule`: `-Tag`/`-Tags`, `-ResourceType`/`-Type` for module resources, and `-IncludeDependencies`
- preserve package tags on managed find results and expose `ResourceType = Module`
- resolve dependency resources from repository metadata without package downloads or script-resource work on the normal find path

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ManagedModuleAliasCommandTests|FullyQualifiedName~ManagedModuleRepositoryClientTests"` (133/133)
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ManagedModule"` (430/430)
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472`
- `git diff --check`
- `Build\Build-Module.ps1 -Framework auto -Configuration Release` (passed; existing desktop binary-conflict advisory and existing mixed-line-ending warning in PSPublishModule.Tests.ps1)
- live local-feed smoke on PowerShell 7.6.3 and Windows PowerShell 5.1.26100.8655 for `-Tag/-Type` and `-IncludeDependencies`

## Notes
This is the first M5 search-parity slice. Command-name and DSC-resource search still need package-content inspection and should stay separate so module-only find remains metadata-only and fast.