### PR TITLE
Add PSResourceGet operator spellings

### DIFF
--- a/Docs/PSPublishModule.ManagedModules.Compatibility.md
+++ b/Docs/PSPublishModule.ManagedModules.Compatibility.md
@@ -163,6 +163,8 @@ Repair-ManagedModule -Inventory $inventory -Latest -Repository PSGallery -ShowSu
 
 Compatibility aliases are exposed only when the old name maps to the same managed behavior. `-RequiredVersion`, `-AllowPrerelease`, `-Source`, `-RepositoryUri`, `-Path`, `-DestinationPath`, `-SkipDependenciesCheck`, `-ModulePath`, and `-NuGetApiKey` are safe aliases because they do not change the safety model.
 
+PSResourceGet operator spellings are accepted where they map to the same managed behavior without changing automation output. `Install-ManagedModule -Reinstall` is equivalent to the managed reinstall behavior behind `-Force` for the selected version. `Install-ManagedModule -NoClobber` is accepted as an explicit spelling for the managed default that rejects command export conflicts. `Install-ManagedModule`, `Save-ManagedModule`, and `Update-ManagedModule` accept `-Quiet` to suppress optional host summaries and progress-style output without suppressing pipeline result objects.
+
 `-TrustRepository` is not exposed as an alias. In PowerShellGet and PSResourceGet it is commonly used to skip an untrusted-repository prompt for that invocation. The managed engine does not prompt inside the reusable core; it uses repository profile trust evidence and the explicit `-RequireTrustedRepository` policy. A direct alias would invert the meaning and could make automation less safe.
 
 `Install-ManagedModule -RequiredResource` and `-RequiredResourceFile` accept the PSResourceGet per-resource keys `TrustRepository` and `Quiet` so existing resource maps do not fail validation. Repository trust still follows the managed safety model above, and quiet output remains controlled by the managed cmdlet/output path rather than by a per-resource option.

--- a/PSPublishModule/Cmdlets/InstallManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/InstallManagedModuleCommand.cs
@@ -168,9 +168,17 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
     [Parameter]
     public SwitchParameter Force { get; set; }
 
+    /// <summary>PSResourceGet-compatible spelling for reinstalling the selected module version when it already exists.</summary>
+    [Parameter]
+    public SwitchParameter Reinstall { get; set; }
+
     /// <summary>Allow command exports to overlap with other modules in the target root.</summary>
     [Parameter]
     public SwitchParameter AllowClobber { get; set; }
+
+    /// <summary>PSResourceGet-compatible spelling for the managed default that rejects command export conflicts.</summary>
+    [Parameter]
+    public SwitchParameter NoClobber { get; set; }
 
     /// <summary>Accept package licenses when packages declare license acceptance is required.</summary>
     [Parameter]
@@ -193,6 +201,10 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
     [Parameter]
     public SwitchParameter ShowSummary { get; set; }
 
+    /// <summary>Suppress optional host summaries and progress-style output without changing pipeline result objects.</summary>
+    [Parameter]
+    public SwitchParameter Quiet { get; set; }
+
     /// <summary>Installs the requested modules.</summary>
     protected override async Task ProcessRecordAsync()
     {
@@ -203,6 +215,8 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
         var logger = new CmdletLogger(this, MyInvocation.BoundParameters.ContainsKey("Verbose"));
         var repositoryClient = ManagedModuleCommandSupport.CreateRepositoryClient(this, logger, Proxy, ProxyCredential);
         var service = new ManagedModuleInstallService(logger, repositoryClient);
+        ManagedModuleCommandSupport.ValidateClobberSwitches(AllowClobber.IsPresent, NoClobber.IsPresent);
+        var writeSummary = ManagedModuleCommandSupport.ShouldWriteSummary(ShowSummary.IsPresent, Quiet.IsPresent);
         var targets = ResolveTargets().ToArray();
         ManagedModuleCommandSupport.ValidateSinglePackageHashTarget(ExpectedPackageSha256, targets.Select(static target => target.Name).ToArray());
         var defaultRepository = ManagedModuleCommandSupport.CreateRepository(
@@ -245,7 +259,7 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
             {
                 var plan = await service.PlanInstallAsync(request, CancelToken).ConfigureAwait(false);
                 WriteObject(plan);
-                if (ShowSummary.IsPresent)
+                if (writeSummary)
                     ManagedModuleSummaryWriter.Write(plan);
                 continue;
             }
@@ -256,7 +270,7 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
             var result = await service.InstallAsync(request, CancelToken).ConfigureAwait(false);
 
             WriteObject(result);
-            if (ShowSummary.IsPresent)
+            if (writeSummary)
                 ManagedModuleSummaryWriter.Write(result);
         }
     }
@@ -269,6 +283,8 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
         if (ParameterSetName == RequiredResourceFileParameterSet)
             return ParseRequiredResource(ImportRequiredResourceFile());
 
+        var force = ManagedModuleCommandSupport.ResolveForce(Force.IsPresent, Reinstall.IsPresent);
+        var allowClobber = AllowClobber.IsPresent && !NoClobber.IsPresent;
         return Name.Select(moduleName => new RequiredResourceTarget(
             moduleName,
             Version,
@@ -278,8 +294,8 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
             Prerelease.IsPresent,
             Scope,
             null,
-            Force.IsPresent,
-            AllowClobber.IsPresent,
+            force,
+            allowClobber,
             AcceptLicense.IsPresent,
             SkipDependencyCheck.IsPresent));
     }
@@ -346,7 +362,7 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
         var name = GetString(options, "Name") ?? fallbackName;
         var repository = GetString(options, "Repository");
         var prerelease = GetBool(options, "Prerelease") ?? Prerelease.IsPresent;
-        var reinstall = GetBool(options, "Reinstall") ?? Force.IsPresent;
+        var reinstall = GetBool(options, "Reinstall") ?? ManagedModuleCommandSupport.ResolveForce(Force.IsPresent, Reinstall.IsPresent);
         var noClobber = GetBool(options, "NoClobber") ?? false;
         var acceptLicense = GetBool(options, "AcceptLicense") ?? AcceptLicense.IsPresent;
         var skipDependencyCheck = GetBool(options, "SkipDependencyCheck") ?? SkipDependencyCheck.IsPresent;
@@ -363,7 +379,7 @@ public sealed class InstallManagedModuleCommand : AsyncPSCmdlet
             scope,
             repository,
             reinstall,
-            AllowClobber.IsPresent && !noClobber,
+            AllowClobber.IsPresent && !NoClobber.IsPresent && !noClobber,
             acceptLicense,
             skipDependencyCheck);
     }

--- a/PSPublishModule/Cmdlets/ManagedModuleCommandSupport.cs
+++ b/PSPublishModule/Cmdlets/ManagedModuleCommandSupport.cs
@@ -147,6 +147,18 @@ internal static class ManagedModuleCommandSupport
         throw new InvalidOperationException("ExpectedPackageSha256 can only be used when exactly one module is targeted.");
     }
 
+    internal static bool ResolveForce(bool force, bool reinstall)
+        => force || reinstall;
+
+    internal static void ValidateClobberSwitches(bool allowClobber, bool noClobber)
+    {
+        if (allowClobber && noClobber)
+            throw new InvalidOperationException("Specify either AllowClobber or NoClobber, not both.");
+    }
+
+    internal static bool ShouldWriteSummary(bool showSummary, bool quiet)
+        => showSummary && !quiet;
+
     internal static string ResolveRepositorySource(PSCmdlet cmdlet, string repository)
         => ResolveRepositorySource(cmdlet, repository, out _);
 

--- a/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/SaveManagedModuleCommand.cs
@@ -175,6 +175,10 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
     [Parameter]
     public SwitchParameter ShowSummary { get; set; }
 
+    /// <summary>Suppress optional host summaries and progress-style output without changing pipeline result objects.</summary>
+    [Parameter]
+    public SwitchParameter Quiet { get; set; }
+
     /// <summary>Saves requested modules.</summary>
     protected override async Task ProcessRecordAsync()
     {
@@ -192,6 +196,7 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
         var repositoryClient = ManagedModuleCommandSupport.CreateRepositoryClient(this, logger, Proxy, ProxyCredential);
         var service = new ManagedModuleInstallService(logger, repositoryClient);
         ManagedModuleCommandSupport.ValidateSinglePackageHashTarget(ExpectedPackageSha256, Name);
+        var writeSummary = ManagedModuleCommandSupport.ShouldWriteSummary(ShowSummary.IsPresent, Quiet.IsPresent);
 
         foreach (var moduleName in Name)
         {
@@ -222,7 +227,7 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
             {
                 var plan = await service.PlanInstallAsync(request, CancelToken).ConfigureAwait(false);
                 WriteObject(plan);
-                if (ShowSummary.IsPresent)
+                if (writeSummary)
                     ManagedModuleSummaryWriter.Write(plan);
                 continue;
             }
@@ -234,7 +239,7 @@ public sealed class SaveManagedModuleCommand : AsyncPSCmdlet
             _results.Add(result);
 
             WriteObject(result);
-            if (ShowSummary.IsPresent)
+            if (writeSummary)
                 ManagedModuleSummaryWriter.Write(result);
         }
     }

--- a/PSPublishModule/Cmdlets/UpdateManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/UpdateManagedModuleCommand.cs
@@ -212,6 +212,10 @@ public sealed class UpdateManagedModuleCommand : AsyncPSCmdlet
     [Parameter]
     public SwitchParameter ShowSummary { get; set; }
 
+    /// <summary>Suppress optional host summaries and progress-style output without changing pipeline result objects.</summary>
+    [Parameter]
+    public SwitchParameter Quiet { get; set; }
+
     /// <summary>Updates requested modules.</summary>
     protected override async Task ProcessRecordAsync()
     {
@@ -232,6 +236,7 @@ public sealed class UpdateManagedModuleCommand : AsyncPSCmdlet
         var targetModuleRoot = ManagedModuleInstallRootResolver.Resolve(targetScope, ShellEdition, moduleRoot);
         var moduleNames = ResolveModuleNames(targetModuleRoot).ToArray();
         var updateAllInstalled = Name.Length == 0;
+        var writeSummary = ManagedModuleCommandSupport.ShouldWriteSummary(ShowSummary.IsPresent, Quiet.IsPresent);
         if (moduleNames.Length == 0)
         {
             WriteVerbose($"No installed modules were found under '{targetModuleRoot}'.");
@@ -275,7 +280,7 @@ public sealed class UpdateManagedModuleCommand : AsyncPSCmdlet
                 {
                     var plan = await service.PlanUpdateAsync(request, CancelToken).ConfigureAwait(false);
                     WriteObject(plan);
-                    if (ShowSummary.IsPresent)
+                    if (writeSummary)
                         ManagedModuleSummaryWriter.Write(plan);
                     continue;
                 }
@@ -286,7 +291,7 @@ public sealed class UpdateManagedModuleCommand : AsyncPSCmdlet
                 var result = await service.UpdateAsync(request, CancelToken).ConfigureAwait(false);
 
                 WriteObject(result);
-                if (ShowSummary.IsPresent)
+                if (writeSummary)
                     ManagedModuleSummaryWriter.Write(result);
             }
             catch (Exception ex) when (updateAllInstalled)

--- a/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleAliasCommandTests.cs
@@ -142,6 +142,24 @@ public sealed class ManagedModuleAliasCommandTests
     }
 
     [Theory]
+    [InlineData("Install-ManagedModule", "Quiet")]
+    [InlineData("Install-ManagedModule", "Reinstall")]
+    [InlineData("Install-ManagedModule", "NoClobber")]
+    [InlineData("Save-ManagedModule", "Quiet")]
+    [InlineData("Update-ManagedModule", "Quiet")]
+    public void Managed_module_commands_expose_psresourceget_operator_spelling(string commandName, string parameterName)
+    {
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Get-Command")
+            .AddArgument(commandName);
+
+        var command = Assert.IsType<CmdletInfo>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.True(command.Parameters.ContainsKey(parameterName), $"{commandName} should expose PSResourceGet-compatible parameter '{parameterName}'.");
+    }
+
+    [Theory]
     [InlineData("Find-ManagedModule", "Name", "ModuleName")]
     [InlineData("Find-ManagedModule", "Repository", "Source")]
     [InlineData("Find-ManagedModule", "Repository", "RepositoryUri")]

--- a/PowerForge.Tests/ManagedModuleClobberCommandTests.cs
+++ b/PowerForge.Tests/ManagedModuleClobberCommandTests.cs
@@ -62,6 +62,23 @@ public sealed class ManagedModuleClobberCommandTests
     }
 
     [Fact]
+    public void InstallManagedModule_rejects_allow_clobber_with_no_clobber()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Install-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("ModuleRoot", moduleRoot.Path)
+            .AddParameter("AllowClobber")
+            .AddParameter("NoClobber");
+
+        var exception = Assert.Throws<CmdletInvocationException>(() => ps.Invoke());
+
+        Assert.Contains("AllowClobber", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("NoClobber", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void InstallManagedModule_rejects_wildcard_export_clobber_risk_by_default()
     {
         using var feed = new TemporaryDirectory();

--- a/PowerForge.Tests/ManagedModulePlanCommandTests.cs
+++ b/PowerForge.Tests/ManagedModulePlanCommandTests.cs
@@ -130,6 +130,36 @@ public sealed class ManagedModulePlanCommandTests
     }
 
     [Fact]
+    public void InstallManagedModule_plan_reinstalls_existing_exact_version_with_reinstall()
+    {
+        using var feed = new TemporaryDirectory();
+        using var moduleRoot = new TemporaryDirectory();
+        TestPackageFactory.Create(
+            Path.Combine(feed.Path, "Company.Tools.1.0.0.nupkg"),
+            "Company.Tools",
+            "1.0.0",
+            files: CreateModuleFiles("1.0.0"));
+        Directory.CreateDirectory(Path.Combine(moduleRoot.Path, "Company.Tools", "1.0.0"));
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Install-ManagedModule")
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Repository", feed.Path)
+            .AddParameter("RepositoryName", "Local")
+            .AddParameter("Path", moduleRoot.Path)
+            .AddParameter("RequiredVersion", "1.0.0")
+            .AddParameter("Plan")
+            .AddParameter("Reinstall");
+        var results = ps.Invoke();
+
+        AssertNoPowerShellErrors(ps);
+        var plan = Assert.IsType<ManagedModuleInstallPlan>(Assert.Single(results).BaseObject);
+        Assert.Equal(ManagedModuleInstallPlanAction.Reinstall, plan.Action);
+        Assert.True(plan.WouldWriteFiles);
+        Assert.True(plan.ExistingVersionFound);
+    }
+
+    [Fact]
     public void UpdateManagedModule_plan_reinstalls_selected_version_with_force_when_already_current()
     {
         using var feed = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- add PSResourceGet-compatible operator spellings for existing managed module workflows
- map `Install-ManagedModule -Reinstall` to the existing managed reinstall/force behavior for the selected version
- accept `Install-ManagedModule -NoClobber` as the explicit spelling for the managed default no-clobber policy, with a guard against combining it with `-AllowClobber`
- add `-Quiet` to install/save/update so callers can suppress optional host summaries without losing pipeline result objects

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~ManagedModuleAliasCommandTests|FullyQualifiedName~ManagedModulePlanCommandTests|FullyQualifiedName~ManagedModuleClobberCommandTests" -v:n` (87/87 passed)
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net472 --no-restore`
- `dotnet build .\PSPublishModule\PSPublishModule.csproj -c Release -f net10.0 --no-restore`
- Windows PowerShell 5.1 live import confirmed `Quiet`, `Reinstall`, and `NoClobber` parameter exposure
- PowerShell 7.6.3 live import confirmed `Quiet`, `Reinstall`, and `NoClobber` parameter exposure
- `git diff --check`