### PR TITLE
Add installed managed module resource filters

### DIFF
--- a/PSPublishModule/Cmdlets/GetManagedModuleCommand.cs
+++ b/PSPublishModule/Cmdlets/GetManagedModuleCommand.cs
@@ -45,7 +45,7 @@ public sealed class GetManagedModuleCommand : PSCmdlet
     [ValidateNotNullOrEmpty]
     public string[] Name { get; set; } = Array.Empty<string>();
 
-    /// <summary>Path to a previously written inventory JSON artifact.</summary>
+    /// <summary>Path to a module install root or previously written inventory JSON artifact.</summary>
     [Parameter(ParameterSetName = ParameterSetPath, Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string? Path { get; set; }
@@ -54,6 +54,18 @@ public sealed class GetManagedModuleCommand : PSCmdlet
     [Parameter(ParameterSetName = ParameterSetLocal)]
     [ValidateNotNullOrEmpty]
     public string[]? ModulePath { get; set; }
+
+    /// <summary>Exact module version or explicit version range to return.</summary>
+    [Parameter(ParameterSetName = ParameterSetLocal)]
+    [Parameter(ParameterSetName = ParameterSetPath)]
+    [ValidateNotNullOrEmpty]
+    public string? Version { get; set; }
+
+    /// <summary>Module installation scope to return.</summary>
+    [Parameter(ParameterSetName = ParameterSetLocal)]
+    [Parameter(ParameterSetName = ParameterSetPath)]
+    [ValidateSet("CurrentUser", "AllUsers")]
+    public string? Scope { get; set; }
 
     /// <summary>Include modules loaded in the current runspace as inventory evidence.</summary>
     [Parameter]
@@ -77,8 +89,6 @@ public sealed class GetManagedModuleCommand : PSCmdlet
         try
         {
             var inventory = ResolveInventory();
-            inventory.InstalledModules = FilterModules(inventory.InstalledModules ?? Array.Empty<ModuleStateInstalledModuleResult>());
-
             if (ShowSummary.IsPresent)
                 ModuleStateConsoleRenderer.WriteInventory(inventory);
 
@@ -110,33 +120,29 @@ public sealed class GetManagedModuleCommand : PSCmdlet
             : null;
 
         if (string.Equals(ParameterSetName, ParameterSetPath, StringComparison.OrdinalIgnoreCase))
-            return ModuleStateInventoryCommandSupport.CreateInventoryResultFromFile(ResolveFilePath(Path!, nameof(Path)), loadedModules);
+        {
+            var resolvedPath = ResolveExistingPath(Path!, nameof(Path));
+            if (File.Exists(resolvedPath))
+                return ModuleStateInventoryCommandSupport.CreateInventoryResultFromFile(resolvedPath, loadedModules, Name, Version, Scope);
+
+            return ModuleStateInventoryCommandSupport.CreateInventoryResultFromModulePaths(new[] { resolvedPath }, loadedModules, Name, Version, Scope);
+        }
 
         return ModuleStateInventoryCommandSupport.CreateInventoryResultFromModulePaths(
             ModulePath is { Length: > 0 }
                 ? ModulePath
                 : ModuleStateInventoryCommandSupport.ResolveEnvironmentModulePaths(),
-            loadedModules);
+            loadedModules,
+            Name,
+            Version,
+            Scope);
     }
 
-    private ModuleStateInstalledModuleResult[] FilterModules(ModuleStateInstalledModuleResult[] modules)
-    {
-        if (Name.Length == 0)
-            return modules;
-
-        var filters = Name
-            .Select(static name => new WildcardPattern(name, WildcardOptions.IgnoreCase))
-            .ToArray();
-        return modules
-            .Where(module => filters.Any(filter => filter.IsMatch(module.Name)))
-            .ToArray();
-    }
-
-    private string ResolveFilePath(string path, string parameterName)
+    private string ResolveExistingPath(string path, string parameterName)
     {
         var resolved = SessionState.Path.GetUnresolvedProviderPathFromPSPath(path);
-        if (!File.Exists(resolved))
-            throw new FileNotFoundException($"The {parameterName} file was not found.", resolved);
+        if (!File.Exists(resolved) && !Directory.Exists(resolved))
+            throw new FileNotFoundException($"The {parameterName} path was not found.", resolved);
 
         return resolved;
     }

--- a/PSPublishModule/Services/ModuleStateInventoryCommandSupport.cs
+++ b/PSPublishModule/Services/ModuleStateInventoryCommandSupport.cs
@@ -12,10 +12,21 @@ internal static class ModuleStateInventoryCommandSupport
 {
     internal static ModuleStateInventoryResult CreateInventoryResultFromFile(
         string inventoryPath,
-        IEnumerable<ModuleStateLoadedModuleEvidence>? loadedModules = null)
+        IEnumerable<ModuleStateLoadedModuleEvidence>? loadedModules = null,
+        IEnumerable<string>? names = null,
+        string? version = null,
+        string? scope = null)
     {
         var inventory = new ModuleStateJsonService().LoadInventory(inventoryPath);
         inventory = IncludeLoadedModulesCore(inventory, loadedModules);
+        inventory = ModuleStateInventoryFilter.Apply(inventory, new ModuleStateInventoryRequest(
+            inventory.InstalledModules
+                .Select(static module => module.Path)
+                .Where(static path => !string.IsNullOrWhiteSpace(path))
+                .Select(static path => new ModuleStateModulePath(path!)),
+            names,
+            version,
+            scope));
         return ModuleStateInventoryResultMapper.ToCmdletResult(
             inventory,
             inventoryPath,
@@ -24,13 +35,19 @@ internal static class ModuleStateInventoryCommandSupport
 
     internal static ModuleStateInventoryResult CreateInventoryResultFromModulePaths(
         IEnumerable<string> modulePaths,
-        IEnumerable<ModuleStateLoadedModuleEvidence>? loadedModules = null)
+        IEnumerable<ModuleStateLoadedModuleEvidence>? loadedModules = null,
+        IEnumerable<string>? names = null,
+        string? version = null,
+        string? scope = null)
     {
         var paths = NormalizeModulePaths(modulePaths);
         var request = new ModuleStateInventoryRequest(paths.Select(static path => new ModuleStateModulePath(
             path,
             InferPowerShellEdition(path),
-            InferScope(path))));
+            InferScope(path))),
+            names,
+            version,
+            scope);
         var inventory = new ModuleStateInventoryService().Collect(request);
         inventory = IncludeLoadedModulesCore(inventory, loadedModules);
         return ModuleStateInventoryResultMapper.ToCmdletResult(inventory, "ModulePath", paths);

--- a/PSPublishModule/Services/ModuleStateInventoryCommandSupport.cs
+++ b/PSPublishModule/Services/ModuleStateInventoryCommandSupport.cs
@@ -50,6 +50,7 @@ internal static class ModuleStateInventoryCommandSupport
             scope);
         var inventory = new ModuleStateInventoryService().Collect(request);
         inventory = IncludeLoadedModulesCore(inventory, loadedModules);
+        inventory = ModuleStateInventoryFilter.Apply(inventory, request);
         return ModuleStateInventoryResultMapper.ToCmdletResult(inventory, "ModulePath", paths);
     }
 

--- a/PSPublishModule/Services/ModuleStateInventoryResult.cs
+++ b/PSPublishModule/Services/ModuleStateInventoryResult.cs
@@ -27,6 +27,11 @@ public sealed class ModuleStateInventoryResult
 public sealed class ModuleStateInstalledModuleResult
 {
     /// <summary>
+    /// Gets or sets the installed resource type.
+    /// </summary>
+    public string Type { get; set; } = "Module";
+
+    /// <summary>
     /// Gets or sets the module name.
     /// </summary>
     public string Name { get; set; } = string.Empty;
@@ -50,6 +55,15 @@ public sealed class ModuleStateInstalledModuleResult
     /// Gets or sets the discovered module path.
     /// </summary>
     public string? Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets the PSResourceGet-compatible installed location.
+    /// </summary>
+    public string? InstalledLocation
+    {
+        get => Path;
+        set => Path = value;
+    }
 
     /// <summary>
     /// Gets or sets the repository that supplied the installed module when known.

--- a/PowerForge.Tests/GetManagedModuleCommandTests.cs
+++ b/PowerForge.Tests/GetManagedModuleCommandTests.cs
@@ -23,6 +23,8 @@ public sealed class GetManagedModuleCommandTests
         Assert.Equal("Company.Tools", result.Name);
         Assert.Equal("1.2.0", result.Version);
         Assert.Equal(Path.Combine(moduleRoot.Path, "Company.Tools", "1.2.0"), result.Path);
+        Assert.Equal("Module", result.Type);
+        Assert.Equal(result.Path, result.InstalledLocation);
     }
 
     [Fact]
@@ -44,6 +46,87 @@ public sealed class GetManagedModuleCommandTests
         var result = Assert.Single(inventory.InstalledModules);
         Assert.Equal("Company.Tools", result.Name);
         Assert.Equal(moduleRoot.Path, Assert.Single(inventory.ModulePaths));
+    }
+
+    [Fact]
+    public void GetManagedModule_PathDirectoryScansInstalledModules()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        CreateInstalledModule(moduleRoot.Path, "Company.Tools", "1.2.0");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Get-ManagedModule")
+            .AddParameter("Path", moduleRoot.Path)
+            .AddParameter("Name", "Company.Tools");
+
+        var result = Assert.IsType<ModuleStateInstalledModuleResult>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Tools", result.Name);
+        Assert.Equal(Path.Combine(moduleRoot.Path, "Company.Tools", "1.2.0"), result.InstalledLocation);
+    }
+
+    [Fact]
+    public void GetManagedModule_PathFileStillReadsInventoryJson()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var inventoryPath = Path.Combine(moduleRoot.Path, "inventory.json");
+        File.WriteAllText(inventoryPath, """{ "installedModules": [ { "name": "Company.Json", "version": "1.0.0", "scope": "CurrentUser" } ] }""");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Get-ManagedModule")
+            .AddParameter("Path", inventoryPath);
+
+        var result = Assert.IsType<ModuleStateInstalledModuleResult>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("Company.Json", result.Name);
+    }
+
+    [Fact]
+    public void GetManagedModule_VersionUsesExactMatchForPlainVersion()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        CreateInstalledModule(moduleRoot.Path, "Company.Tools", "1.0.0");
+        CreateInstalledModule(moduleRoot.Path, "Company.Tools", "1.2.0");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Get-ManagedModule")
+            .AddParameter("ModulePath", new[] { moduleRoot.Path })
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Version", "1.0");
+
+        var result = Assert.IsType<ModuleStateInstalledModuleResult>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("1.0.0", result.Version);
+    }
+
+    [Fact]
+    public void GetManagedModule_ScopeFiltersInventoryRows()
+    {
+        using var moduleRoot = new TemporaryDirectory();
+        var inventoryPath = Path.Combine(moduleRoot.Path, "inventory.json");
+        File.WriteAllText(inventoryPath, """
+{
+  "installedModules": [
+    { "name": "Company.Tools", "version": "1.0.0", "scope": "CurrentUser" },
+    { "name": "Company.Tools", "version": "2.0.0", "scope": "AllUsers" }
+  ]
+}
+""");
+
+        using var ps = CreatePowerShellWithModuleImported();
+        ps.AddCommand("Get-ManagedModule")
+            .AddParameter("Path", inventoryPath)
+            .AddParameter("Name", "Company.Tools")
+            .AddParameter("Scope", "AllUsers");
+
+        var result = Assert.IsType<ModuleStateInstalledModuleResult>(Assert.Single(ps.Invoke()).BaseObject);
+
+        AssertNoPowerShellErrors(ps);
+        Assert.Equal("2.0.0", result.Version);
+        Assert.Equal("AllUsers", result.Scope);
     }
 
     private static void CreateInstalledModule(string moduleRoot, string name, string version)

--- a/PowerForge.Tests/ModuleStateInventoryCommandSupportTests.cs
+++ b/PowerForge.Tests/ModuleStateInventoryCommandSupportTests.cs
@@ -88,6 +88,31 @@ public sealed class ModuleStateInventoryCommandSupportTests
     }
 
     [Fact]
+    public void CreateInventoryResultFromModulePaths_AppliesNameFilterAfterLoadedMerge()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var result = ModuleStateInventoryCommandSupport.CreateInventoryResultFromModulePaths(
+                new[] { root.FullName },
+                new[]
+                {
+                    new ModuleStateLoadedModuleEvidence("Microsoft.Graph.Users", "2.38.0", Path.Combine(root.FullName, "Microsoft.Graph.Users.psm1")),
+                    new ModuleStateLoadedModuleEvidence("Company.Runtime", "1.0.0", Path.Combine(root.FullName, "Company.Runtime.psm1"))
+                },
+                new[] { "Microsoft.Graph.*" });
+
+            var module = Assert.Single(result.InstalledModules);
+            Assert.Equal("Microsoft.Graph.Users", module.Name);
+            Assert.True(module.IsLoaded);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void CreateInventoryResultFromFile_AddsLoadedOnlyModule()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Models/ModuleState/ModuleStateInventoryRequest.cs
+++ b/PowerForge/Models/ModuleState/ModuleStateInventoryRequest.cs
@@ -6,8 +6,33 @@ namespace PowerForge;
 
 internal sealed class ModuleStateInventoryRequest
 {
-    internal ModuleStateInventoryRequest(IEnumerable<ModuleStateModulePath>? modulePaths)
-        => ModulePaths = (modulePaths ?? Array.Empty<ModuleStateModulePath>()).Where(static path => path is not null).ToArray();
+    internal ModuleStateInventoryRequest(
+        IEnumerable<ModuleStateModulePath>? modulePaths,
+        IEnumerable<string>? names = null,
+        string? version = null,
+        string? scope = null)
+    {
+        ModulePaths = (modulePaths ?? Array.Empty<ModuleStateModulePath>()).Where(static path => path is not null).ToArray();
+        Names = NormalizeNames(names);
+        Version = NormalizeOptional(version);
+        Scope = NormalizeOptional(scope);
+    }
 
     internal ModuleStateModulePath[] ModulePaths { get; }
+
+    internal string[] Names { get; }
+
+    internal string? Version { get; }
+
+    internal string? Scope { get; }
+
+    private static string[] NormalizeNames(IEnumerable<string>? names)
+        => (names ?? Array.Empty<string>())
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
 }

--- a/PowerForge/Services/ModuleState/ModuleStateInventoryFilter.cs
+++ b/PowerForge/Services/ModuleState/ModuleStateInventoryFilter.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PowerForge;
+
+internal static class ModuleStateInventoryFilter
+{
+    internal static ModuleStateInventory Apply(ModuleStateInventory inventory, ModuleStateInventoryRequest request)
+    {
+        if (inventory is null)
+            throw new ArgumentNullException(nameof(inventory));
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        var modules = inventory.InstalledModules.AsEnumerable();
+        if (request.Names.Length > 0)
+        {
+            var filters = request.Names
+                .Select(static name => new Regex("^" + WildcardToRegex(name) + "$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                .ToArray();
+            modules = modules.Where(module => filters.Any(filter => filter.IsMatch(module.Name)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Version))
+            modules = modules.Where(module => VersionMatches(module.Version, request.Version!));
+
+        if (!string.IsNullOrWhiteSpace(request.Scope))
+            modules = modules.Where(module => string.Equals(module.Scope, request.Scope, StringComparison.OrdinalIgnoreCase));
+
+        return new ModuleStateInventory(modules);
+    }
+
+    private static bool VersionMatches(string installedVersion, string requestedVersion)
+    {
+        var trimmed = requestedVersion.Trim();
+        if (!LooksLikeRange(trimmed))
+        {
+            if (ModuleStateVersion.TryParse(installedVersion, out var installed) &&
+                ModuleStateVersion.TryParse(trimmed, out var requested))
+                return installed.CompareTo(requested) == 0;
+
+            return string.Equals(installedVersion, trimmed, StringComparison.OrdinalIgnoreCase);
+        }
+
+        var range = ManagedModuleVersionRange.Parse(trimmed);
+        return range.IsSatisfiedBy(installedVersion);
+    }
+
+    private static bool LooksLikeRange(string version)
+        => version.StartsWith("=", StringComparison.Ordinal) ||
+           version.StartsWith("<", StringComparison.Ordinal) ||
+           version.StartsWith(">", StringComparison.Ordinal) ||
+           version.StartsWith("[", StringComparison.Ordinal) ||
+           version.StartsWith("(", StringComparison.Ordinal) ||
+           version.EndsWith("]", StringComparison.Ordinal) ||
+           version.EndsWith(")", StringComparison.Ordinal) ||
+           version.Contains(",", StringComparison.Ordinal);
+
+    private static string WildcardToRegex(string wildcard)
+    {
+        var builder = new StringBuilder();
+        foreach (var character in wildcard)
+        {
+            if (character == '*')
+                builder.Append(".*");
+            else if (character == '?')
+                builder.Append('.');
+            else
+                builder.Append(Regex.Escape(character.ToString()));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/PowerForge/Services/ModuleState/ModuleStateInventoryService.cs
+++ b/PowerForge/Services/ModuleState/ModuleStateInventoryService.cs
@@ -54,11 +54,12 @@ internal sealed class ModuleStateInventoryService
                     .First()
                     .Module));
 
-        return new ModuleStateInventory(modules
+        var inventory = new ModuleStateInventory(modules
             .Select(module => MarkEffective(module.Module, effectiveModules.Contains(module.Module)))
             .OrderBy(static module => module.Name, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static module => module.Version, StringComparer.OrdinalIgnoreCase)
             .ThenBy(static module => module.Path, StringComparer.OrdinalIgnoreCase));
+        return ModuleStateInventoryFilter.Apply(inventory, request);
     }
 
     private static ModuleStateInstalledModule MarkEffective(ModuleStateInstalledModule module, bool isEffective)


### PR DESCRIPTION
## Summary
- extend `Get-ManagedModule` installed inventory with PSResourceGet-shaped `-Version`, `-Scope`, and directory `-Path` behavior
- keep existing inventory JSON `-Path` support by treating files as inventory artifacts and directories as module roots
- add PSResourceGet-friendly installed row properties: `Type` and `InstalledLocation`
- move installed-resource filtering into the reusable PowerForge inventory layer so cmdlets stay thin

## Validation
- focused installed inventory tests passed
- PSPublishModule built for Windows PowerShell 5.1 and PowerShell 7 targets
- live `Get-ManagedModule -Path ... -Version 1.0` smoke passed in Windows PowerShell 5.1 and PowerShell 7