### PR TITLE
Improve project build signing and publish timing

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
@@ -111,6 +111,10 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
     [Parameter]
     public SwitchParameter SkipAssemblySigning { get; set; }
 
+    /// <summary>Also sign copied dependency assemblies from build output folders.</summary>
+    [Parameter]
+    public SwitchParameter SignDependencyAssemblies { get; set; }
+
     /// <summary>Skip signing generated NuGet packages.</summary>
     [Parameter]
     public SwitchParameter SkipPackageSigning { get; set; }
@@ -193,6 +197,7 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
                 : PowerForge.CertificateStoreLocation.CurrentUser,
             TimeStampServer = TimeStampServer,
             SignAssemblies = SkipAssemblySigning.IsPresent ? false : null,
+            SignDependencyAssemblies = SignDependencyAssemblies.IsPresent,
             SignPackages = SkipPackageSigning.IsPresent ? false : null,
             SkipPack = SkipPack.IsPresent,
             Publish = Publish.IsPresent,

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -67,6 +67,10 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
     [Parameter]
     public SwitchParameter SignAssemblies { get; set; }
 
+    /// <summary>Whether copied dependency assemblies should also be signed, overriding the referenced JSON when set.</summary>
+    [Parameter]
+    public SwitchParameter SignDependencyAssemblies { get; set; }
+
     /// <summary>Whether generated NuGet packages should be signed, overriding the referenced JSON when set.</summary>
     [Parameter]
     public SwitchParameter SignPackages { get; set; }
@@ -94,6 +98,7 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
                 PublishGitHub = BoundSwitch(nameof(PublishGitHub), PublishGitHub),
                 CreateReleaseZip = BoundSwitch(nameof(CreateReleaseZip), CreateReleaseZip),
                 SignAssemblies = BoundSwitch(nameof(SignAssemblies), SignAssemblies),
+                SignDependencyAssemblies = BoundSwitch(nameof(SignDependencyAssemblies), SignDependencyAssemblies),
                 SignPackages = BoundSwitch(nameof(SignPackages), SignPackages),
                 Options = PackageBuildConfiguration.ToObjectDictionary(Options)
             }
@@ -246,6 +251,9 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
     /// <summary>Whether assemblies should be signed before packages are created.</summary>
     [Parameter] public SwitchParameter SignAssemblies { get; set; }
 
+    /// <summary>Whether copied dependency assemblies should also be signed.</summary>
+    [Parameter] public SwitchParameter SignDependencyAssemblies { get; set; }
+
     /// <summary>Whether generated NuGet packages should be signed.</summary>
     [Parameter] public SwitchParameter SignPackages { get; set; }
 
@@ -354,6 +362,7 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
                 CertificateStore = Normalize(CertificateStore),
                 TimeStampServer = Normalize(TimeStampServer),
                 SignAssemblies = BoundSwitch(nameof(SignAssemblies), SignAssemblies),
+                SignDependencyAssemblies = BoundSwitch(nameof(SignDependencyAssemblies), SignDependencyAssemblies),
                 SignPackages = BoundSwitch(nameof(SignPackages), SignPackages),
                 NugetCredentialUserName = Normalize(NugetCredentialUserName),
                 NugetCredentialSecret = NugetCredentialSecret,

--- a/PowerForge.PowerShell/Services/AuthenticodeSigningService.cs
+++ b/PowerForge.PowerShell/Services/AuthenticodeSigningService.cs
@@ -185,66 +185,66 @@ public sealed class AuthenticodeSigningService
 
     private IReadOnlyList<PSObject> SignWithWindowsAuthenticode(string[] files, AuthenticodeSignRequest request)
     {
-        var outputs = new List<PSObject>();
+        var unsignedFiles = GetUnsignedFiles("Get-AuthenticodeSignature", files);
+        if (unsignedFiles.Length == 0)
+            return Array.Empty<PSObject>();
 
-        foreach (var file in files)
-        {
-            var signature = InvokeSingle("Get-AuthenticodeSignature", ps =>
-            {
-                ps.AddParameter("FilePath", file);
-            });
-
-            var status = signature?.Properties["Status"]?.Value?.ToString();
-            if (!string.Equals(status, "NotSigned", StringComparison.OrdinalIgnoreCase))
-                continue;
-
+        foreach (var file in unsignedFiles)
             _logger.Verbose($"Signing file: {file}");
-            var signed = InvokeSingle("Set-AuthenticodeSignature", ps =>
-            {
-                ps.AddParameter("FilePath", file);
-                ps.AddParameter("Certificate", request.Certificate);
-                ps.AddParameter("TimestampServer", request.TimeStampServer);
-                ps.AddParameter("IncludeChain", request.WindowsIncludeChain);
-                ps.AddParameter("HashAlgorithm", request.HashAlgorithm);
-            });
 
-            if (signed is not null)
-                outputs.Add(signed);
-        }
-
-        return outputs;
+        return InvokeMany("Set-AuthenticodeSignature", ps =>
+        {
+            ps.AddParameter("FilePath", unsignedFiles);
+            ps.AddParameter("Certificate", request.Certificate);
+            ps.AddParameter("TimestampServer", request.TimeStampServer);
+            ps.AddParameter("IncludeChain", request.WindowsIncludeChain);
+            ps.AddParameter("HashAlgorithm", request.HashAlgorithm);
+        });
     }
 
     private IReadOnlyList<PSObject> SignWithOpenAuthenticode(string[] files, AuthenticodeSignRequest request)
     {
-        var outputs = new List<PSObject>();
+        var unsignedFiles = GetUnsignedFiles("Get-OpenAuthenticodeSignature", files);
+        if (unsignedFiles.Length == 0)
+            return Array.Empty<PSObject>();
 
-        foreach (var file in files)
+        foreach (var file in unsignedFiles)
+            _logger.Verbose($"Signing file: {file}");
+
+        return InvokeMany("Set-OpenAuthenticodeSignature", ps =>
         {
-            var signature = InvokeSingle("Get-OpenAuthenticodeSignature", ps =>
-            {
-                ps.AddParameter("FilePath", file);
-            });
+            ps.AddParameter("FilePath", unsignedFiles);
+            ps.AddParameter("Certificate", request.Certificate);
+            ps.AddParameter("TimeStampServer", request.TimeStampServer);
+            ps.AddParameter("IncludeChain", request.NonWindowsIncludeChain);
+            ps.AddParameter("HashAlgorithm", request.HashAlgorithm);
+        });
+    }
 
-            var status = signature?.Properties["Status"]?.Value?.ToString();
+    private string[] GetUnsignedFiles(string commandName, string[] files)
+    {
+        var signatures = InvokeMany(commandName, ps => ps.AddParameter("FilePath", files));
+        var unsigned = new List<string>();
+
+        for (var i = 0; i < signatures.Count; i++)
+        {
+            var signature = signatures[i];
+            var status = signature.Properties["Status"]?.Value?.ToString();
             if (!string.Equals(status, "NotSigned", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            _logger.Verbose($"Signing file: {file}");
-            var signed = InvokeSingle("Set-OpenAuthenticodeSignature", ps =>
-            {
-                ps.AddParameter("FilePath", file);
-                ps.AddParameter("Certificate", request.Certificate);
-                ps.AddParameter("TimeStampServer", request.TimeStampServer);
-                ps.AddParameter("IncludeChain", request.NonWindowsIncludeChain);
-                ps.AddParameter("HashAlgorithm", request.HashAlgorithm);
-            });
-
-            if (signed is not null)
-                outputs.Add(signed);
+            var path = signature.Properties["Path"]?.Value?.ToString();
+            if (!string.IsNullOrWhiteSpace(path))
+                unsigned.Add(path!);
+            else if (i < files.Length)
+                unsigned.Add(files[i]);
         }
 
-        return outputs;
+        return unsigned
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private void EnsureCommandAvailable(string name)
@@ -260,10 +260,15 @@ public sealed class AuthenticodeSigningService
 
     private PSObject? InvokeSingle(string commandName, Action<PowerShell> configure)
     {
+        var result = InvokeMany(commandName, configure);
+        return result.FirstOrDefault();
+    }
+
+    private IReadOnlyList<PSObject> InvokeMany(string commandName, Action<PowerShell> configure)
+    {
         using var ps = CreatePowerShell();
         ps.AddCommand(commandName);
         configure(ps);
-
         var result = ps.Invoke();
         if (ps.HadErrors)
         {
@@ -271,7 +276,7 @@ public sealed class AuthenticodeSigningService
             throw error?.Exception ?? new InvalidOperationException($"PowerShell command '{commandName}' failed.");
         }
 
-        return result.FirstOrDefault();
+        return result.ToArray();
     }
 
     private static PowerShell CreatePowerShell()

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -185,13 +185,25 @@ public sealed partial class ModulePipelineRunner
     {
         return destination switch
         {
-            PackageBuildPublishDestination.NuGet => release.Projects
+            PackageBuildPublishDestination.NuGet => HasAllArtifacts(release.Projects
                 .SelectMany(project => project.Packages)
-                .Any(package => !string.IsNullOrWhiteSpace(package) && File.Exists(package)),
-            PackageBuildPublishDestination.GitHub => release.Projects
-                .Any(project => !string.IsNullOrWhiteSpace(project.ReleaseZipPath) && File.Exists(project.ReleaseZipPath)),
+                .Where(package => !string.IsNullOrWhiteSpace(package))),
+            PackageBuildPublishDestination.GitHub => HasAllArtifacts(release.Projects
+                .Select(project => project.ReleaseZipPath)
+                .Where(path => !string.IsNullOrWhiteSpace(path))),
             _ => false
         };
+    }
+
+    private static bool HasAllArtifacts(IEnumerable<string?> artifactPaths)
+    {
+        var paths = artifactPaths
+            .Select(path => path?.Trim())
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return paths.Length > 0 && paths.All(path => File.Exists(path!));
     }
 
     private void PublishExistingPackageBuildResult(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -71,6 +71,9 @@ public sealed partial class ModulePipelineRunner
             if (segment?.Configuration is null || !ShouldExecuteProjectBuildPublish(plan, segment, destination))
                 continue;
 
+            if (TryExecuteExistingProjectBuildPublish(plan, session, state, segment, destination))
+                continue;
+
             ExecuteProjectBuildSegment(plan, session, state, segment, mode);
         }
 
@@ -79,8 +82,228 @@ public sealed partial class ModulePipelineRunner
             if (segment?.Configuration is null || !ShouldExecutePackageBuildPublish(plan, segment, destination))
                 continue;
 
+            if (TryExecuteExistingPackageBuildPublish(plan, session, state, segment, destination))
+                continue;
+
             ExecutePackageBuildSegment(plan, session, state, segment, mode);
         }
+    }
+
+    private bool TryExecuteExistingProjectBuildPublish(
+        ModulePipelinePlan plan,
+        ModulePipelineExecutionSession session,
+        ModulePipelineRunState state,
+        ConfigurationProjectBuildSegment segment,
+        PackageBuildPublishDestination destination)
+    {
+        if (!state.PackageBuildResultsBySegment.TryGetValue(segment, out var existing))
+            return false;
+        if (existing.Result.Release is null)
+            return false;
+
+        var cfg = segment.Configuration ?? throw new InvalidOperationException("ProjectBuild configuration is missing.");
+        var configPath = ResolvePackageBuildPath(plan.ProjectRoot, cfg.ConfigPath);
+        var configuration = LoadProjectBuildConfiguration(configPath, cfg);
+        if (!CanPublishExistingPackageBuildResult(configuration, configPath, destination))
+            return false;
+        if (!HasReusablePackageBuildArtifacts(existing.Result.Release, destination))
+            return false;
+
+        var step = session.GetProjectBuildStep(segment);
+        session.Start(step);
+        try
+        {
+            PublishExistingPackageBuildResult(existing, configuration, configPath, destination);
+            session.Done(step);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            session.Fail(step, ex);
+            throw;
+        }
+    }
+
+    private bool TryExecuteExistingPackageBuildPublish(
+        ModulePipelinePlan plan,
+        ModulePipelineExecutionSession session,
+        ModulePipelineRunState state,
+        ConfigurationPackageBuildSegment segment,
+        PackageBuildPublishDestination destination)
+    {
+        if (!state.PackageBuildResultsBySegment.TryGetValue(segment, out var existing))
+            return false;
+        if (existing.Result.Release is null)
+            return false;
+
+        var configuration = MapPackageBuildConfiguration(segment.Configuration, plan.ProjectRoot);
+        var configPath = Path.Combine(plan.ProjectRoot, "module.packagebuild.inline.json");
+        if (!CanPublishExistingPackageBuildResult(configuration, configPath, destination))
+            return false;
+        if (!HasReusablePackageBuildArtifacts(existing.Result.Release, destination))
+            return false;
+
+        var step = session.GetPackageBuildStep(segment);
+        session.Start(step);
+        try
+        {
+            PublishExistingPackageBuildResult(existing, configuration, configPath, destination);
+            session.Done(step);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            session.Fail(step, ex);
+            throw;
+        }
+    }
+
+    private static bool CanPublishExistingPackageBuildResult(
+        ProjectBuildConfiguration configuration,
+        string configPath,
+        PackageBuildPublishDestination destination)
+    {
+        var configDirectory = Path.GetDirectoryName(configPath);
+        if (string.IsNullOrWhiteSpace(configDirectory))
+            return false;
+
+        var feed = ProjectBuildPackageFeedResolver.Resolve(configuration, configDirectory);
+        return destination switch
+        {
+            PackageBuildPublishDestination.NuGet => !string.IsNullOrWhiteSpace(feed.PublishApiKey),
+            PackageBuildPublishDestination.GitHub =>
+                !string.IsNullOrWhiteSpace(feed.GitHubToken) &&
+                !string.IsNullOrWhiteSpace(configuration.GitHubUsername) &&
+                !string.IsNullOrWhiteSpace(configuration.GitHubRepositoryName),
+            _ => false
+        };
+    }
+
+    private static bool HasReusablePackageBuildArtifacts(
+        DotNetRepositoryReleaseResult release,
+        PackageBuildPublishDestination destination)
+    {
+        return destination switch
+        {
+            PackageBuildPublishDestination.NuGet => release.Projects
+                .SelectMany(project => project.Packages)
+                .Any(package => !string.IsNullOrWhiteSpace(package) && File.Exists(package)),
+            PackageBuildPublishDestination.GitHub => release.Projects
+                .Any(project => !string.IsNullOrWhiteSpace(project.ReleaseZipPath) && File.Exists(project.ReleaseZipPath)),
+            _ => false
+        };
+    }
+
+    private void PublishExistingPackageBuildResult(
+        ProjectBuildHostExecutionResult existing,
+        ProjectBuildConfiguration configuration,
+        string configPath,
+        PackageBuildPublishDestination destination)
+    {
+        var release = existing.Result.Release
+            ?? throw new InvalidOperationException($"Cannot reuse package build result for {destination}; the earlier package build did not include a release result.");
+
+        if (!release.Success)
+            throw new InvalidOperationException(release.ErrorMessage ?? $"Cannot reuse failed package build result for {destination}.");
+
+        switch (destination)
+        {
+            case PackageBuildPublishDestination.NuGet:
+                PublishExistingNuGetPackages(release, configuration, configPath);
+                break;
+            case PackageBuildPublishDestination.GitHub:
+                PublishExistingGitHubRelease(existing, release, configuration, configPath);
+                break;
+        }
+    }
+
+    private void PublishExistingNuGetPackages(
+        DotNetRepositoryReleaseResult release,
+        ProjectBuildConfiguration configuration,
+        string configPath)
+    {
+        var configDirectory = Path.GetDirectoryName(configPath);
+        if (string.IsNullOrWhiteSpace(configDirectory))
+            throw new InvalidOperationException($"Unable to resolve the configuration directory for '{configPath}'.");
+
+        var feed = ProjectBuildPackageFeedResolver.Resolve(configuration, configDirectory);
+        var apiKey = feed.PublishApiKey;
+        if (string.IsNullOrWhiteSpace(apiKey))
+            throw new InvalidOperationException("PublishApiKey is required when package NuGet publishing is enabled.");
+
+        var source = string.IsNullOrWhiteSpace(feed.PublishSource)
+            ? ProjectBuildPackageFeedResolver.GetDefaultPublishSource()
+            : feed.PublishSource!.Trim();
+        var packages = release.Projects
+            .SelectMany(project => project.Packages)
+            .Where(package => !string.IsNullOrWhiteSpace(package))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        _logger.Info($"Publishing {packages.Length} existing package(s) from earlier package build.");
+        var publish = new NuGetPackagePublishService(_logger).ExecutePackages(
+            packages,
+            apiKey!,
+            source,
+            configuration.SkipDuplicate ?? true,
+            configuration.PublishFailFast ?? true);
+
+        release.PublishedPackages.AddRange(publish.PublishedItems);
+        release.FailedPackages.AddRange(publish.FailedItems);
+        if (!publish.Success)
+        {
+            release.Success = false;
+            release.ErrorMessage = publish.ErrorMessage ?? "One or more packages failed to publish.";
+            throw new InvalidOperationException(release.ErrorMessage);
+        }
+    }
+
+    private void PublishExistingGitHubRelease(
+        ProjectBuildHostExecutionResult existing,
+        DotNetRepositoryReleaseResult release,
+        ProjectBuildConfiguration configuration,
+        string configPath)
+    {
+        var configDirectory = Path.GetDirectoryName(configPath);
+        if (string.IsNullOrWhiteSpace(configDirectory))
+            throw new InvalidOperationException($"Unable to resolve the configuration directory for '{configPath}'.");
+
+        var feed = ProjectBuildPackageFeedResolver.Resolve(configuration, configDirectory);
+        var token = feed.GitHubToken;
+        if (string.IsNullOrWhiteSpace(token))
+            throw new InvalidOperationException("GitHub access token is required for package GitHub publishing.");
+        if (string.IsNullOrWhiteSpace(configuration.GitHubUsername) || string.IsNullOrWhiteSpace(configuration.GitHubRepositoryName))
+            throw new InvalidOperationException("GitHubUsername and GitHubRepositoryName are required for package GitHub publishing.");
+
+        var preflightError = new ProjectBuildGitHubPreflightService(_logger).Validate(configuration, release, token!);
+        if (!string.IsNullOrWhiteSpace(preflightError))
+            throw new InvalidOperationException(preflightError);
+
+        _logger.Info("Publishing GitHub release from existing package build result.");
+        var summary = new ProjectBuildPublishHostService(_logger).PublishGitHub(
+            new ProjectBuildPublishHostConfiguration
+            {
+                GitHubUsername = configuration.GitHubUsername!.Trim(),
+                GitHubRepositoryName = configuration.GitHubRepositoryName!.Trim(),
+                GitHubToken = token,
+                GitHubReleaseMode = string.IsNullOrWhiteSpace(configuration.GitHubReleaseMode) ? "Single" : configuration.GitHubReleaseMode!.Trim(),
+                GitHubIncludeProjectNameInTag = configuration.GitHubIncludeProjectNameInTag,
+                GitHubIsPreRelease = configuration.GitHubIsPreRelease,
+                GitHubGenerateReleaseNotes = configuration.GitHubGenerateReleaseNotes,
+                GitHubReleaseName = NormalizeOptional(configuration.GitHubReleaseName),
+                GitHubTagName = NormalizeOptional(configuration.GitHubTagName),
+                GitHubTagTemplate = NormalizeOptional(configuration.GitHubTagTemplate),
+                GitHubPrimaryProject = NormalizeOptional(configuration.GitHubPrimaryProject),
+                GitHubTagConflictPolicy = NormalizeOptional(configuration.GitHubTagConflictPolicy),
+                PublishFailFast = configuration.PublishFailFast ?? true
+            },
+            release);
+
+        existing.Result.GitHub.AddRange(summary.Results);
+        existing.Result.Success = summary.Success;
+        existing.Result.ErrorMessage = summary.ErrorMessage;
+        if (!summary.Success)
+            throw new InvalidOperationException(summary.ErrorMessage ?? "Package GitHub publishing failed.");
     }
 
     private void ExecuteProjectBuildSegment(
@@ -103,6 +326,7 @@ public sealed partial class ModulePipelineRunner
                 segment.Configuration.Name ?? result.ConfigPath,
                 segment.Configuration.UseAsReleaseVersionSource,
                 segment.Configuration.ProvideLocalNuGetFeed,
+                segment,
                 mode,
                 "Project build");
 
@@ -135,6 +359,7 @@ public sealed partial class ModulePipelineRunner
                 segment.Configuration.Name ?? result.ConfigPath,
                 segment.Configuration.UseAsReleaseVersionSource,
                 segment.Configuration.ProvideLocalNuGetFeed,
+                segment,
                 mode,
                 "Package build");
 
@@ -155,6 +380,7 @@ public sealed partial class ModulePipelineRunner
         string laneLabel,
         bool useAsReleaseVersionSource,
         bool provideLocalNuGetFeed,
+        object segment,
         PackageBuildExecutionMode mode,
         string failurePrefix)
     {
@@ -168,6 +394,7 @@ public sealed partial class ModulePipelineRunner
         }
 
         state.ProjectBuildResults.Add(result);
+        state.PackageBuildResultsBySegment[segment] = result;
 
         if (provideLocalNuGetFeed)
             RegisterLocalNuGetFeeds(plan, result, laneLabel);
@@ -266,6 +493,8 @@ public sealed partial class ModulePipelineRunner
             target.CreateReleaseZip = reference.CreateReleaseZip;
         if (reference.SignAssemblies is not null)
             target.SignAssemblies = reference.SignAssemblies;
+        if (reference.SignDependencyAssemblies is not null)
+            target.SignDependencyAssemblies = reference.SignDependencyAssemblies;
         if (reference.SignPackages is not null)
             target.SignPackages = reference.SignPackages;
     }
@@ -474,6 +703,9 @@ public sealed partial class ModulePipelineRunner
         return false;
     }
 
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
+
     private static string DescribePackageBuildMode(PackageBuildExecutionMode mode)
         => mode switch
         {
@@ -524,6 +756,7 @@ public sealed partial class ModulePipelineRunner
             CertificateStore = source.CertificateStore,
             TimeStampServer = source.TimeStampServer,
             SignAssemblies = source.SignAssemblies,
+            SignDependencyAssemblies = source.SignDependencyAssemblies,
             SignPackages = source.SignPackages,
             NugetCredentialUserName = source.NugetCredentialUserName,
             NugetCredentialSecret = source.NugetCredentialSecret,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.State.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Run.State.cs
@@ -36,6 +36,7 @@ public sealed partial class ModulePipelineRunner
         public List<ArtefactBuildResult> ArtefactResults { get; } = new();
         public List<ModulePublishResult> PublishResults { get; } = new();
         public List<ProjectBuildHostExecutionResult> ProjectBuildResults { get; } = new();
+        public Dictionary<object, ProjectBuildHostExecutionResult> PackageBuildResultsBySegment { get; } = new();
         public List<ExternalAssetPreparationResult> ExternalAssetResults { get; } = new();
         public List<ReleaseVersionCandidate> ReleaseVersionCandidates { get; } = new();
         public ModuleReleaseCoordinationResult? ReleaseCoordinationResult { get; set; }

--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -80,6 +80,47 @@ public sealed class DotNetNuGetClientTests
         Assert.True(result.Succeeded);
     }
 
+    [Fact]
+    public async Task SignPackageAsync_AcceptsMultiplePackagesInOneProcess()
+    {
+        ProcessRunRequest? captured = null;
+        var processRunner = new StubProcessRunner(request => {
+            captured = request;
+            return new ProcessRunResult(0, string.Empty, string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+        });
+        var client = new DotNetNuGetClient(processRunner);
+
+        var result = await client.SignPackageAsync(new DotNetNuGetSignRequest(
+            packagePaths: new[]
+            {
+                @"C:\repo\Artifacts\One.1.0.0.nupkg",
+                @"C:\repo\Artifacts\Two.1.0.0.nupkg"
+            },
+            certificateFingerprint: "ABC123",
+            certificateStoreLocation: "CurrentUser",
+            timeStampServer: "http://timestamp.digicert.com"));
+
+        Assert.NotNull(captured);
+        Assert.Equal(
+            [
+                "nuget",
+                "sign",
+                @"C:\repo\Artifacts\One.1.0.0.nupkg",
+                @"C:\repo\Artifacts\Two.1.0.0.nupkg",
+                "--certificate-fingerprint",
+                "ABC123",
+                "--certificate-store-location",
+                "CurrentUser",
+                "--certificate-store-name",
+                "My",
+                "--timestamper",
+                "http://timestamp.digicert.com",
+                "--overwrite"
+            ],
+            captured!.Arguments);
+        Assert.True(result.Succeeded);
+    }
+
     private sealed class StubProcessRunner : IProcessRunner
     {
         private readonly Func<ProcessRunRequest, ProcessRunResult> _execute;

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -478,6 +479,76 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.Single(project.Packages);
             Assert.True(File.Exists(project.Packages[0]));
             Assert.True(File.Exists(project.ReleaseZipPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_WithPackageSigningFailure_DoesNotPublishUnsignedPackagesWhenFailFastIsDisabled()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"signed\"; }");
+
+            var localFeed = Directory.CreateDirectory(Path.Combine(root.FullName, "feed"));
+            var packagesSeenBySigner = Array.Empty<string>();
+            DotNetRepositoryReleaseService.PackageSigningHandler signPackages = (
+                IReadOnlyList<string> packages,
+                DotNetRepositoryReleaseSpec spec,
+                string sha256,
+                out string error) =>
+            {
+                packagesSeenBySigner = packages.ToArray();
+                error = "simulated signing failure";
+                return false;
+            };
+
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = true,
+                PublishApiKey = "key",
+                PublishSource = localFeed.FullName,
+                PublishFailFast = false,
+                SkipDuplicate = true,
+                UpdateVersions = false,
+                CreateReleaseZip = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = false,
+                SignPackages = true
+            };
+
+            var result = new DotNetRepositoryReleaseService(
+                new NullLogger(),
+                signPackages,
+                (_, _) => "ABCDEF").Execute(spec);
+
+            Assert.False(result.Success);
+            Assert.Single(packagesSeenBySigner);
+            Assert.Empty(result.PublishedPackages);
+            Assert.Empty(Directory.EnumerateFiles(localFeed.FullName, "*.nupkg", SearchOption.AllDirectories));
+            var project = Assert.Single(result.Projects, item => item.IsPackable);
+            Assert.Contains("Package signing failed", project.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Publish preflight failed", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -246,6 +246,13 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.Equal("Pack", msbuildTasks[2].Attribute("Targets")?.Value);
             Assert.Equal("Configuration=Release", msbuildTasks[0].Attribute("Properties")?.Value);
             Assert.Equal("Configuration=Release", msbuildTasks[1].Attribute("Properties")?.Value);
+            Assert.Equal("RestoreSelected", msbuildTasks[0].Parent?.Attribute("Name")?.Value);
+            Assert.Equal("BuildSelected", msbuildTasks[1].Parent?.Attribute("Name")?.Value);
+            Assert.Equal("PackOnlySelected", msbuildTasks[2].Parent?.Attribute("Name")?.Value);
+            Assert.Equal("RestoreSelected", msbuildTasks[1].Parent?.Attribute("DependsOnTargets")?.Value);
+            Assert.Equal("BuildSelected;PackOnlySelected", document.Descendants("Target")
+                .Single(target => string.Equals(target.Attribute("Name")?.Value, "PackSelected", StringComparison.Ordinal))
+                .Attribute("DependsOnTargets")?.Value);
             Assert.Equal(
                 $"Configuration=Release;PackageOutputPath={outputPath.Replace("%", "%25").Replace(";", "%3B").Replace("=", "%3D").Replace("$", "%24").Replace("@", "%40")};NoBuild=true;BuildProjectReferences=false",
                 msbuildTasks[2].Attribute("Properties")?.Value);
@@ -324,6 +331,88 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_MsBuildBatchPack_WithAssemblySigning_SignsBuildOutputsBeforeNoBuildPack()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var sharedDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Shared"));
+            File.WriteAllText(Path.Combine(sharedDir.FullName, "Shared.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Shared</PackageId>",
+                "    <VersionPrefix>1.0.0</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(sharedDir.FullName, "Greeter.cs"), "namespace Sample.Shared; public static class Greeter { public static string Hello() => \"hello\"; }");
+
+            var consumerDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Consumer"));
+            File.WriteAllText(Path.Combine(consumerDir.FullName, "Consumer.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Consumer</PackageId>",
+                "    <VersionPrefix>1.0.0</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "  <ItemGroup>",
+                "    <ProjectReference Include=\"..\\Shared\\Shared.csproj\" />",
+                "  </ItemGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(consumerDir.FullName, "Consumer.cs"), "namespace Sample.Consumer; public static class Consumer { public static string Hello() => Sample.Shared.Greeter.Hello(); }");
+
+            var signedAssemblies = 0;
+            var outputPath = Path.Combine(root.FullName, "packages");
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = outputPath,
+                Pack = true,
+                PackStrategy = DotNetRepositoryPackStrategy.MSBuild,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request =>
+                {
+                    Assert.Equal("ABC123", request.CertificateThumbprint);
+                    var filePaths = Assert.IsType<string[]>(request.FilePaths);
+                    signedAssemblies += filePaths.Count(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains(filePaths, path => path.EndsWith(Path.Combine("Shared", "bin", "Release", "net8.0", "Shared.dll"), StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains(filePaths, path => path.EndsWith(Path.Combine("Consumer", "bin", "Release", "net8.0", "Consumer.dll"), StringComparison.OrdinalIgnoreCase));
+                },
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(2, signedAssemblies);
+            Assert.True(File.Exists(Path.Combine(outputPath, "Sample.Shared.1.0.0.nupkg")));
+            Assert.True(File.Exists(Path.Combine(outputPath, "Sample.Consumer.1.0.0.nupkg")));
+            Assert.All(result.Projects.Where(project => project.IsPackable), project =>
+            {
+                Assert.Single(project.Packages);
+                Assert.True(string.IsNullOrWhiteSpace(project.ErrorMessage), project.ErrorMessage);
+            });
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_WithAssemblySigning_SignsBuildOutputsBeforePacking()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -367,8 +456,11 @@ public sealed class DotNetRepositoryReleaseServiceTests
                     signingCalls++;
                     Assert.Equal(CertificateStoreLocation.CurrentUser, request.LocalStore);
                     Assert.Equal("ABC123", request.CertificateThumbprint);
-                    var assembly = Directory.EnumerateFiles(request.ReleasePath, "Sample.Package.dll", SearchOption.AllDirectories)
-                        .SingleOrDefault();
+                    Assert.Contains("Sample.Package.dll", request.IncludePatterns);
+                    Assert.Contains("Sample.Package.exe", request.IncludePatterns);
+                    Assert.DoesNotContain("*.dll", request.IncludePatterns);
+                    var filePaths = Assert.IsType<string[]>(request.FilePaths);
+                    var assembly = filePaths.SingleOrDefault(path => path.EndsWith("Sample.Package.dll", StringComparison.OrdinalIgnoreCase));
                     Assert.False(string.IsNullOrWhiteSpace(assembly));
                     signedMarker = Path.Combine(Path.GetDirectoryName(assembly!)!, "signed.marker");
                     File.WriteAllText(signedMarker, "signed-before-pack");
@@ -386,6 +478,122 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.Single(project.Packages);
             Assert.True(File.Exists(project.Packages[0]));
             Assert.True(File.Exists(project.ReleaseZipPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_WithAssemblySigning_UsesEvaluatedAssemblyNameWhenImported()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project>",
+                "  <PropertyGroup>",
+                "    <AssemblyName>Signed.Sample</AssemblyName>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"signed\"; }");
+
+            var signedPath = string.Empty;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request =>
+                {
+                    Assert.Contains("Signed.Sample.dll", request.IncludePatterns);
+                    Assert.DoesNotContain("*.dll", request.IncludePatterns);
+                    var filePaths = Assert.IsType<string[]>(request.FilePaths);
+                    signedPath = filePaths.Single(path => path.EndsWith("Signed.Sample.dll", StringComparison.OrdinalIgnoreCase));
+                },
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.False(string.IsNullOrWhiteSpace(signedPath));
+            Assert.True(File.Exists(signedPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_WithAssemblySigningDependencyOptIn_UsesBroadIncludePatterns()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"signed\"; }");
+
+            string[]? includePatterns = null;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignDependencyAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request => includePatterns = request.IncludePatterns,
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.NotNull(includePatterns);
+            Assert.Contains("*.dll", includePatterns!);
+            Assert.Contains("*.exe", includePatterns!);
         }
         finally
         {
@@ -433,10 +641,10 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 spec,
                 request =>
                 {
-                    Assert.Contains("custom-output", request.ReleasePath, StringComparison.OrdinalIgnoreCase);
-                    var assembly = Directory.EnumerateFiles(request.ReleasePath, "Sample.Package.dll", SearchOption.AllDirectories)
-                        .SingleOrDefault();
+                    var filePaths = Assert.IsType<string[]>(request.FilePaths);
+                    var assembly = filePaths.SingleOrDefault(path => path.EndsWith("Sample.Package.dll", StringComparison.OrdinalIgnoreCase));
                     Assert.False(string.IsNullOrWhiteSpace(assembly));
+                    Assert.Contains("custom-output", assembly, StringComparison.OrdinalIgnoreCase);
                     signedPath = assembly!;
                 },
                 _ => { });

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -685,6 +685,127 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_WithAssemblySigning_IncludesOwnAssemblyUnderInternalsDirectory()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Internals", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"signed\"; }");
+
+            var signedPath = string.Empty;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request =>
+                {
+                    var filePaths = Assert.IsType<string[]>(request.FilePaths);
+                    signedPath = filePaths.Single(path => path.EndsWith("Sample.Package.dll", StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains($"{Path.DirectorySeparatorChar}Internals{Path.DirectorySeparatorChar}", signedPath, StringComparison.OrdinalIgnoreCase);
+                },
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.False(string.IsNullOrWhiteSpace(signedPath));
+            Assert.True(File.Exists(signedPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_WithAssemblySigning_IncludesEveryEvaluatedTargetFrameworkAssemblyName()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "  <PropertyGroup Condition=\"'$(TargetFramework)' == 'net8.0'\">",
+                "    <AssemblyName>Sample.Net8</AssemblyName>",
+                "  </PropertyGroup>",
+                "  <PropertyGroup Condition=\"'$(TargetFramework)' == 'net10.0'\">",
+                "    <AssemblyName>Sample.Net10</AssemblyName>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"signed\"; }");
+
+            string[]? includePatterns = null;
+            string[]? signedPaths = null;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request =>
+                {
+                    includePatterns = request.IncludePatterns;
+                    signedPaths = Assert.IsType<string[]>(request.FilePaths);
+                },
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.NotNull(includePatterns);
+            Assert.Contains("Sample.Net8.dll", includePatterns!);
+            Assert.Contains("Sample.Net10.dll", includePatterns!);
+            Assert.DoesNotContain("*.dll", includePatterns!);
+            Assert.NotNull(signedPaths);
+            Assert.Contains(signedPaths!, path => path.EndsWith("Sample.Net8.dll", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(signedPaths!, path => path.EndsWith("Sample.Net10.dll", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_WithAssemblySigningDependencyOptIn_UsesBroadIncludePatterns()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 using Xunit;
 
@@ -622,6 +623,68 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_WithAssemblySigning_UsesEvaluatedAssemblyNameWhenConditional()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "  <PropertyGroup Condition=\"'$(Configuration)' == 'Debug'\">",
+                "    <AssemblyName>Debug.Sample</AssemblyName>",
+                "  </PropertyGroup>",
+                "  <PropertyGroup Condition=\"'$(Configuration)' == 'Release'\">",
+                "    <AssemblyName>Release.Sample</AssemblyName>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Class1.cs"), "namespace Sample.Package; public static class Class1 { public static string Value => \"signed\"; }");
+
+            var signedPath = string.Empty;
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = false,
+                CertificateThumbprint = "ABC123",
+                SignAssemblies = true,
+                SignPackages = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                spec,
+                request =>
+                {
+                    Assert.Contains("Release.Sample.dll", request.IncludePatterns);
+                    Assert.DoesNotContain("Debug.Sample.dll", request.IncludePatterns);
+                    var filePaths = Assert.IsType<string[]>(request.FilePaths);
+                    signedPath = filePaths.Single(path => path.EndsWith("Release.Sample.dll", StringComparison.OrdinalIgnoreCase));
+                },
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.False(string.IsNullOrWhiteSpace(signedPath));
+            Assert.True(File.Exists(signedPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_WithAssemblySigningDependencyOptIn_UsesBroadIncludePatterns()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -724,6 +787,64 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.True(File.Exists(signedPath));
             var project = Assert.Single(result.Projects, item => item.IsPackable);
             Assert.Single(project.Packages);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ResolveBuildOutputDirectories_ProbesEvaluatedTargetDirForMissingTargetFrameworkOutputs()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            var customNet10Output = Path.Combine(root.FullName, "custom-net10");
+            var customNet10TargetDir = Path.Combine(customNet10Output, "net10.0");
+            var customNet10OutputPath = customNet10Output + Path.DirectorySeparatorChar;
+            var csprojPath = Path.Combine(projectDir.FullName, "Sample.Package.csproj");
+            File.WriteAllText(csprojPath, string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "  <PropertyGroup Condition=\"'$(TargetFramework)' == 'net10.0'\">",
+                $"    <OutputPath>{customNet10OutputPath}</OutputPath>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            var conventionalNet8Output = Directory.CreateDirectory(Path.Combine(projectDir.FullName, "bin", "Release", "net8.0"));
+            Directory.CreateDirectory(customNet10TargetDir);
+            File.WriteAllText(Path.Combine(conventionalNet8Output.FullName, "Sample.Package.dll"), "net8");
+            File.WriteAllText(Path.Combine(customNet10TargetDir, "Sample.Package.dll"), "net10");
+
+            var method = typeof(DotNetRepositoryReleaseService).GetMethod(
+                "ResolveBuildOutputDirectories",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(method);
+            var directories = Assert.IsType<string[]>(method!.Invoke(null, new object?[]
+            {
+                csprojPath,
+                projectDir.FullName,
+                "Release",
+                "Sample.Package",
+                new NullLogger(),
+                new[] { "Sample.Package.dll" }
+            }));
+
+            Assert.Contains(directories, path => path.EndsWith(Path.Combine("bin", "Release", "net8.0"), StringComparison.OrdinalIgnoreCase));
+            var expectedCustomOutput = Path.GetFullPath(customNet10TargetDir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            Assert.Contains(directories, path => string.Equals(
+                path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                expectedCustomOutput,
+                StringComparison.OrdinalIgnoreCase));
         }
         finally
         {

--- a/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
@@ -584,7 +584,13 @@ public sealed partial class ModulePipelinePackageBuildTests
                         Success = true,
                         ConfigPath = configPath ?? request.ConfigPath,
                         RootPath = root.FullName,
-                        Result = new ProjectBuildResult { Success = true }
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = request.Build == true
+                                ? new DotNetRepositoryReleaseResult { Success = true }
+                                : null
+                        }
                     };
                 });
 

--- a/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
@@ -649,6 +649,106 @@ public sealed partial class ModulePipelinePackageBuildTests
     }
 
     [Fact]
+    public void Run_DoesNotReusePackageBuildWhenSomeNuGetArtifactsAreMissing()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var packageOutput = Directory.CreateDirectory(Path.Combine(root.FullName, "Artifacts", "NuGet"));
+            var existingPackage = Path.Combine(packageOutput.FullName, "Dependency.Z.1.0.0.nupkg");
+            var missingPackage = Path.Combine(packageOutput.FullName, "Consumer.A.1.0.0.nupkg");
+            File.WriteAllText(existingPackage, "package");
+
+            var calls = new List<PackageBuildCall>();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: (request, configuration, configPath) =>
+                {
+                    calls.Add(new PackageBuildCall(request, configuration, configPath));
+                    var release = new DotNetRepositoryReleaseResult { Success = true };
+                    release.Projects.Add(new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Dependency.Z",
+                        PackageId = "Dependency.Z",
+                        IsPackable = true
+                    });
+                    release.Projects[0].Packages.Add(existingPackage);
+                    release.Projects.Add(new DotNetRepositoryProjectResult
+                    {
+                        ProjectName = "Consumer.A",
+                        PackageId = "Consumer.A",
+                        IsPackable = true
+                    });
+                    release.Projects[1].Packages.Add(missingPackage);
+
+                    return new ProjectBuildHostExecutionResult
+                    {
+                        Success = true,
+                        ConfigPath = configPath ?? request.ConfigPath,
+                        RootPath = root.FullName,
+                        OutputPath = packageOutput.FullName,
+                        Result = new ProjectBuildResult
+                        {
+                            Success = true,
+                            Release = release
+                        }
+                    };
+                });
+
+            var spec = new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.0",
+                    StagingPath = stagingPath
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationPackageBuildSegment
+                    {
+                        Configuration = new PackageBuildConfiguration
+                        {
+                            Name = "InlinePackages",
+                            RootPath = "Sources",
+                            BuildBeforeModule = true,
+                            Build = true,
+                            PublishNuget = true,
+                            PublishApiKey = "key"
+                        }
+                    }
+                }
+            };
+
+            var result = runner.Run(spec);
+
+            Assert.Equal(2, calls.Count);
+            Assert.Single(result.ProjectBuildResults);
+            Assert.True(calls[0].Request.Build);
+            Assert.False(calls[0].Request.PublishNuget);
+            Assert.False(calls[1].Request.Build);
+            Assert.True(calls[1].Request.PublishNuget);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+            try { if (Directory.Exists(stagingPath)) Directory.Delete(stagingPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Run_GateBuild_SuppressesPackagePublishActions()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -66,6 +66,88 @@ public sealed class NuGetPackagePublishServiceTests
     }
 
     [Fact]
+    public void ExecutePackages_PublishesOnlyExplicitPackagePaths()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-explicit-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packagePath = Path.Combine(root.FullName, "Sample.1.0.0.nupkg");
+            var oldPackagePath = Path.Combine(root.FullName, "Sample.0.9.0.nupkg");
+            File.WriteAllText(packagePath, "pkg");
+            File.WriteAllText(oldPackagePath, "old");
+
+            var pushed = new List<string>();
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                (package, _, _, _) =>
+                {
+                    pushed.Add(package);
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                    };
+                });
+
+            var result = service.ExecutePackages(
+                new[] { packagePath },
+                "key",
+                "https://api.nuget.org/v3/index.json",
+                skipDuplicate: true);
+
+            Assert.True(result.Success);
+            Assert.Equal(new[] { packagePath }, pushed);
+            Assert.Contains(packagePath, result.PublishedItems, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain(oldPackagePath, result.PublishedItems, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExecutePackages_StopsOnFirstFailureWhenPublishFailFast()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-explicit-failfast-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var firstPackagePath = Path.Combine(root.FullName, "Sample.One.1.0.0.nupkg");
+            var secondPackagePath = Path.Combine(root.FullName, "Sample.Two.1.0.0.nupkg");
+            File.WriteAllText(firstPackagePath, "pkg");
+            File.WriteAllText(secondPackagePath, "pkg");
+
+            var pushed = new List<string>();
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                (package, _, _, _) =>
+                {
+                    pushed.Add(package);
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+                        Message = "push failed"
+                    };
+                });
+
+            var result = service.ExecutePackages(
+                new[] { firstPackagePath, secondPackagePath },
+                "key",
+                "https://api.nuget.org/v3/index.json",
+                skipDuplicate: true,
+                publishFailFast: true);
+
+            Assert.False(result.Success);
+            Assert.Equal(new[] { firstPackagePath }, pushed);
+            Assert.Contains(firstPackagePath, result.FailedItems, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain(secondPackagePath, result.FailedItems, StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Execute_treats_skipped_duplicate_as_success()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-dup-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -148,6 +148,45 @@ public sealed class NuGetPackagePublishServiceTests
     }
 
     [Fact]
+    public void ExecutePackages_PreservesExplicitPackageOrder()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-explicit-order-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var dependencyPackagePath = Path.Combine(root.FullName, "Z.Dependency.1.0.0.nupkg");
+            var consumerPackagePath = Path.Combine(root.FullName, "A.Consumer.1.0.0.nupkg");
+            File.WriteAllText(dependencyPackagePath, "pkg");
+            File.WriteAllText(consumerPackagePath, "pkg");
+
+            var pushed = new List<string>();
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                (package, _, _, _) =>
+                {
+                    pushed.Add(package);
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                    };
+                });
+
+            var result = service.ExecutePackages(
+                new[] { dependencyPackagePath, consumerPackagePath, dependencyPackagePath },
+                "key",
+                "https://api.nuget.org/v3/index.json",
+                skipDuplicate: true);
+
+            Assert.True(result.Success);
+            Assert.Equal(new[] { dependencyPackagePath, consumerPackagePath }, pushed);
+            Assert.Equal(new[] { dependencyPackagePath, consumerPackagePath }, result.PublishedItems);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void Execute_treats_skipped_duplicate_as_success()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-dup-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ProjectBuildGitHubPreflightTests.cs
+++ b/PowerForge.Tests/ProjectBuildGitHubPreflightTests.cs
@@ -60,6 +60,48 @@ public sealed class ProjectBuildGitHubPreflightTests
         Assert.Null(advisory);
     }
 
+    [Fact]
+    public void Validate_SkipsReleaseProbe_WhenTagTemplateContainsTimestamp()
+    {
+        var probeCalls = 0;
+        var service = new ProjectBuildGitHubPreflightService(
+            new NullLogger(),
+            probeRelease: (_, _, _, _) =>
+            {
+                probeCalls++;
+                return new ProjectBuildGitHubPreflightService.GitHubReleaseProbeResult { Exists = true };
+            });
+
+        var plan = new DotNetRepositoryReleaseResult
+        {
+            Success = true,
+            Projects =
+            {
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "OfficeIMO.Word",
+                    IsPackable = true,
+                    NewVersion = "1.0.75",
+                    ReleaseZipPath = "OfficeIMO.Word.1.0.75.zip"
+                }
+            }
+        };
+
+        var result = service.Validate(
+            new ProjectBuildConfiguration
+            {
+                GitHubReleaseMode = "Single",
+                GitHubUsername = "EvotecIT",
+                GitHubRepositoryName = "OfficeIMO",
+                GitHubTagTemplate = "{Repo}-v{UtcTimestamp}"
+            },
+            plan,
+            "token");
+
+        Assert.Null(result);
+        Assert.Equal(0, probeCalls);
+    }
+
     private static List<DotNetRepositoryProjectResult> CreateProjects() =>
         new()
         {

--- a/PowerForge.Tests/ProjectBuildPublishHostServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPublishHostServiceTests.cs
@@ -24,6 +24,7 @@ public sealed class ProjectBuildPublishHostServiceTests
               "GitHubUsername": "EvotecIT",
               "GitHubRepositoryName": "PSPublishModule",
               "GitHubReleaseMode": "PerProject",
+              "PublishFailFast": false,
             }
             """);
 
@@ -42,6 +43,7 @@ public sealed class ProjectBuildPublishHostServiceTests
             Assert.Equal("EvotecIT", configuration.GitHubUsername);
             Assert.Equal("PSPublishModule", configuration.GitHubRepositoryName);
             Assert.Equal("PerProject", configuration.GitHubReleaseMode);
+            Assert.False(configuration.PublishFailFast);
         }
         finally
         {
@@ -110,7 +112,8 @@ public sealed class ProjectBuildPublishHostServiceTests
             GitHubTagName = "v1.2.3",
             GitHubTagTemplate = "{Project}-v{Version}",
             GitHubPrimaryProject = "PSPublishModule",
-            GitHubTagConflictPolicy = "AppendUtcTimestamp"
+            GitHubTagConflictPolicy = "AppendUtcTimestamp",
+            PublishFailFast = false
         };
 
         var release = new DotNetRepositoryReleaseResult {
@@ -142,6 +145,7 @@ public sealed class ProjectBuildPublishHostServiceTests
         Assert.Equal("{Project}-v{Version}", captured.TagTemplate);
         Assert.Equal("PSPublishModule", captured.PrimaryProject);
         Assert.Equal("AppendUtcTimestamp", captured.TagConflictPolicy);
+        Assert.False(captured.PublishFailFast);
     }
 
     private sealed class EnvironmentScope : IDisposable

--- a/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
@@ -73,18 +73,24 @@ public sealed class ProjectBuildWorkflowServiceTests
     public void Execute_runs_release_and_github_publish_when_requested()
     {
         var callIndex = 0;
+        var logger = new RecordingLogger();
         var service = new ProjectBuildWorkflowService(
-            new NullLogger(),
+            logger,
             executeRelease: spec =>
             {
                 callIndex++;
                 if (callIndex == 1)
                 {
                     Assert.True(spec.WhatIf);
-                    return new DotNetRepositoryReleaseResult { Success = true };
+                    var plan = new DotNetRepositoryReleaseResult { Success = true };
+                    plan.ResolvedVersionsByProject["ProjectA"] = "1.2.3";
+                    return plan;
                 }
 
                 Assert.False(spec.WhatIf);
+                Assert.Null(spec.ExpectedVersion);
+                Assert.NotNull(spec.ExpectedVersionsByProject);
+                Assert.Equal("1.2.3", spec.ExpectedVersionsByProject!["ProjectA"]);
                 return new DotNetRepositoryReleaseResult
                 {
                     Success = true,
@@ -147,5 +153,25 @@ public sealed class ProjectBuildWorkflowServiceTests
         Assert.Single(workflow.Result.GitHub);
         Assert.NotNull(workflow.GitHubPublishSummary);
         Assert.Equal("v1.2.3", workflow.GitHubPublishSummary!.SummaryTag);
+        Assert.Contains(logger.SuccessMessages, message => message.Contains("Project build plan prepared in", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(logger.SuccessMessages, message => message.Contains("Project build release execution completed in", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(logger.SuccessMessages, message => message.Contains("GitHub publish completed in", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> SuccessMessages { get; } = new();
+
+        public bool IsVerbose => false;
+
+        public void Info(string message) { }
+
+        public void Success(string message) => SuccessMessages.Add(message);
+
+        public void Warn(string message) { }
+
+        public void Error(string message) { }
+
+        public void Verbose(string message) { }
     }
 }

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -56,6 +56,9 @@ public sealed class ProjectBuildConfigurationReference
     /// <summary>Whether assemblies should be signed before packages are created, overriding the referenced JSON when set.</summary>
     public bool? SignAssemblies { get; set; }
 
+    /// <summary>Whether copied dependency assemblies should also be signed, overriding the referenced JSON when set.</summary>
+    public bool? SignDependencyAssemblies { get; set; }
+
     /// <summary>Whether generated NuGet packages should be signed, overriding the referenced JSON when set.</summary>
     public bool? SignPackages { get; set; }
 
@@ -202,6 +205,9 @@ public sealed class PackageBuildConfiguration
 
     /// <summary>Whether assemblies should be signed before packages are created.</summary>
     public bool? SignAssemblies { get; set; }
+
+    /// <summary>Whether copied dependency assemblies should also be signed.</summary>
+    public bool? SignDependencyAssemblies { get; set; }
 
     /// <summary>Whether generated NuGet packages should be signed.</summary>
     public bool? SignPackages { get; set; }

--- a/PowerForge/Models/DotNet/DotNetNuGetSignRequest.cs
+++ b/PowerForge/Models/DotNet/DotNetNuGetSignRequest.cs
@@ -25,8 +25,44 @@ public sealed class DotNetNuGetSignRequest
         bool overwrite = true,
         string? workingDirectory = null,
         TimeSpan? timeout = null)
+        : this(
+            new[] { packagePath },
+            certificateFingerprint,
+            certificateStoreLocation,
+            timeStampServer,
+            certificateStoreName,
+            overwrite,
+            workingDirectory,
+            timeout)
     {
-        PackagePath = packagePath;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DotNetNuGetSignRequest"/> class.
+    /// </summary>
+    /// <param name="packagePaths">Package paths to sign.</param>
+    /// <param name="certificateFingerprint">SHA256 certificate fingerprint.</param>
+    /// <param name="certificateStoreLocation">Certificate store location.</param>
+    /// <param name="timeStampServer">Timestamp server URL.</param>
+    /// <param name="certificateStoreName">Certificate store name. Defaults to <c>My</c>.</param>
+    /// <param name="overwrite">When true, passes <c>--overwrite</c>.</param>
+    /// <param name="workingDirectory">Optional working directory override.</param>
+    /// <param name="timeout">Optional timeout override.</param>
+    public DotNetNuGetSignRequest(
+        IEnumerable<string> packagePaths,
+        string certificateFingerprint,
+        string certificateStoreLocation,
+        string timeStampServer,
+        string certificateStoreName = "My",
+        bool overwrite = true,
+        string? workingDirectory = null,
+        TimeSpan? timeout = null)
+    {
+        PackagePaths = (packagePaths ?? Array.Empty<string>())
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
         CertificateFingerprint = certificateFingerprint;
         CertificateStoreLocation = certificateStoreLocation;
         CertificateStoreName = certificateStoreName;
@@ -39,7 +75,12 @@ public sealed class DotNetNuGetSignRequest
     /// <summary>
     /// Gets the package path to sign.
     /// </summary>
-    public string PackagePath { get; }
+    public string PackagePath => PackagePaths.FirstOrDefault() ?? string.Empty;
+
+    /// <summary>
+    /// Gets the package paths to sign.
+    /// </summary>
+    public string[] PackagePaths { get; }
 
     /// <summary>
     /// Gets the SHA256 certificate fingerprint.

--- a/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
+++ b/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
@@ -25,6 +25,7 @@ internal sealed class DotNetRepositoryReleasePreparationRequest
     public CertificateStoreLocation CertificateStore { get; set; } = CertificateStoreLocation.CurrentUser;
     public string? TimeStampServer { get; set; }
     public bool? SignAssemblies { get; set; }
+    public bool? SignDependencyAssemblies { get; set; }
     public bool? SignPackages { get; set; }
     public bool SkipPack { get; set; }
     public bool Publish { get; set; }

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -83,6 +83,9 @@ public sealed class DotNetRepositoryReleaseSpec
     /// <summary>When true and a certificate is configured, signs build outputs before packing.</summary>
     public bool SignAssemblies { get; set; } = true;
 
+    /// <summary>When true, assembly signing also signs copied dependency assemblies from build outputs.</summary>
+    public bool SignDependencyAssemblies { get; set; }
+
     /// <summary>When true and a certificate is configured, signs generated NuGet packages.</summary>
     public bool SignPackages { get; set; } = true;
 

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -43,6 +43,7 @@ internal sealed class ProjectBuildConfiguration
     public string? CertificateStore { get; set; }
     public string? TimeStampServer { get; set; }
     public bool? SignAssemblies { get; set; }
+    public bool? SignDependencyAssemblies { get; set; }
     public bool? SignPackages { get; set; }
     public string? NugetCredentialUserName { get; set; }
     public string? NugetCredentialSecret { get; set; }

--- a/PowerForge/Models/ProjectBuildPublishHostConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildPublishHostConfiguration.cs
@@ -55,4 +55,7 @@ public sealed class ProjectBuildPublishHostConfiguration
 
     /// <summary>Configured GitHub tag conflict policy.</summary>
     public string? GitHubTagConflictPolicy { get; set; }
+
+    /// <summary>Whether publishing failures should stop on first error.</summary>
+    public bool PublishFailFast { get; set; } = true;
 }

--- a/PowerForge/Services/DotNetNuGetClient.cs
+++ b/PowerForge/Services/DotNetNuGetClient.cs
@@ -88,8 +88,8 @@ public sealed class DotNetNuGetClient
     {
         if (request is null)
             throw new ArgumentNullException(nameof(request));
-        if (string.IsNullOrWhiteSpace(request.PackagePath))
-            throw new ArgumentException("PackagePath is required.", nameof(request));
+        if (request.PackagePaths.Length == 0)
+            throw new ArgumentException("At least one package path is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(request.CertificateFingerprint))
             throw new ArgumentException("CertificateFingerprint is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(request.CertificateStoreLocation))
@@ -101,8 +101,11 @@ public sealed class DotNetNuGetClient
 
         var arguments = new List<string> {
             "nuget",
-            "sign",
-            request.PackagePath,
+            "sign"
+        };
+        arguments.AddRange(request.PackagePaths);
+        arguments.AddRange(new[]
+        {
             "--certificate-fingerprint",
             request.CertificateFingerprint,
             "--certificate-store-location",
@@ -111,7 +114,7 @@ public sealed class DotNetNuGetClient
             request.CertificateStoreName,
             "--timestamper",
             request.TimeStampServer
-        };
+        });
 
         if (request.Overwrite)
             arguments.Add("--overwrite");

--- a/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
@@ -61,6 +61,7 @@ internal sealed class DotNetRepositoryReleasePreparationService
                 CertificateStore = mappedStore,
                 TimeStampServer = request.TimeStampServer,
                 SignAssemblies = ResolveSigningEnabled(request.SignAssemblies, request.CertificateThumbprint),
+                SignDependencyAssemblies = request.SignDependencyAssemblies ?? false,
                 SignPackages = ResolveSigningEnabled(request.SignPackages, request.CertificateThumbprint),
                 Pack = !request.SkipPack,
                 Publish = request.Publish,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -318,9 +318,7 @@ public sealed partial class DotNetRepositoryReleaseService
             {
                 DotNetPackResult? batchPackResult = null;
                 HashSet<DotNetRepositoryProjectResult>? batchCandidateSet = null;
-                var batchPackRequested = spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf && !signAssemblyOutputs;
-                if (spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf && signAssemblyOutputs)
-                    _logger.Info("Assembly signing enabled; using per-project pack so build outputs can be signed before packages are created.");
+                var batchPackRequested = spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf;
                 if (batchPackRequested)
                 {
                     var batchCandidates = packable
@@ -350,7 +348,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     else if (batchCandidates.Length > 0)
                     {
                         _logger.Info($"Packing {batchCandidates.Length} project(s) with MSBuild batch strategy...");
-                        batchPackResult = PackProjectsWithMsBuild(batchCandidates, spec, _logger);
+                        batchPackResult = PackProjectsWithMsBuild(batchCandidates, spec, _logger, signAssemblyOutputs ? signAssemblies : null);
                         if (!batchPackResult.Success)
                         {
                             var batchError = $"{batchPackResult.ErrorMessage ?? "MSBuild batch pack failed."} (MSBuild batch failed; enable verbose logging to see per-project MSBuild output.)";
@@ -434,37 +432,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         var packTiming = batchPackResult is null
                             ? $" in {FormatDuration(packResult.Duration)}"
                             : " from MSBuild batch";
-                        _logger.Success($"{project.ProjectName}: packed {filtered.Count} package(s){packTiming}.");
-                    }
-
-                    if (signNuGetPackages && signingSha256 is not null)
-                    {
-                        if (project.Packages.Count == 0)
-                        {
-                            project.ErrorMessage = "No packages to sign.";
-                            _logger.Warn($"{project.ProjectName}: {project.ErrorMessage}");
-                            result.Success = false;
-                            if (spec.PublishFailFast)
-                                return result;
-                            continue;
-                        }
-
-                        _logger.Info($"Signing {project.ProjectName} package(s)...");
-                        var signingWatch = Stopwatch.StartNew();
-                        if (!SignPackages(project.Packages, spec, signingSha256, out var signError))
-                        {
-                            signingWatch.Stop();
-                            project.ErrorMessage = signError;
-                            _logger.Warn($"{project.ProjectName}: {signError}");
-                            result.Success = false;
-                            if (spec.PublishFailFast)
-                                return result;
-                        }
-                        else
-                        {
-                            signingWatch.Stop();
-                            _logger.Success($"{project.ProjectName}: signed {project.Packages.Count} package(s) in {FormatDuration(signingWatch.Elapsed)}.");
-                        }
+                        _logger.Success($"{project.ProjectName}: package workflow produced {filtered.Count} package(s){packTiming}.");
                     }
 
                     if (spec.CreateReleaseZip && !string.IsNullOrWhiteSpace(project.NewVersion))
@@ -490,6 +458,36 @@ public sealed partial class DotNetRepositoryReleaseService
                                 var zipSize = File.Exists(zipPath) ? new FileInfo(zipPath).Length : 0;
                                 _logger.Success($"{project.ProjectName}: release zip created in {FormatDuration(zipWatch.Elapsed)} ({zippedFiles} file(s), {FormatBytes(zippedBytes)} input, {FormatBytes(zipSize)} zip).");
                             }
+                        }
+                    }
+                }
+
+                if (!spec.WhatIf && signNuGetPackages && signingSha256 is not null)
+                {
+                    var packagesToSign = packable
+                        .Where(project => string.IsNullOrWhiteSpace(project.ErrorMessage))
+                        .SelectMany(project => project.Packages)
+                        .Where(package => !string.IsNullOrWhiteSpace(package))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+
+                    if (packagesToSign.Length > 0)
+                    {
+                        _logger.Info($"Signing {packagesToSign.Length} NuGet package(s)...");
+                        var signingWatch = Stopwatch.StartNew();
+                        if (!SignPackages(packagesToSign, spec, signingSha256, out var signError))
+                        {
+                            signingWatch.Stop();
+                            result.ErrorMessage = signError;
+                            _logger.Warn(signError);
+                            result.Success = false;
+                            if (spec.PublishFailFast)
+                                return result;
+                        }
+                        else
+                        {
+                            signingWatch.Stop();
+                            _logger.Success($"Signed {packagesToSign.Length} NuGet package(s) in {FormatDuration(signingWatch.Elapsed)}.");
                         }
                     }
                 }
@@ -527,6 +525,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     .GroupBy(x => x.Package, StringComparer.OrdinalIgnoreCase)
                     .ToDictionary(g => g.Key, g => g.First().Project, StringComparer.OrdinalIgnoreCase);
 
+                var publishWatch = Stopwatch.StartNew();
                 foreach (var pkg in packages)
                 {
                     if (spec.WhatIf)
@@ -536,18 +535,20 @@ public sealed partial class DotNetRepositoryReleaseService
                     }
 
                     _logger.Info($"Publishing {Path.GetFileName(pkg)}...");
+                    var packagePublishWatch = Stopwatch.StartNew();
                     var push = PushPackage(pkg, spec.PublishApiKey!, source, spec.SkipDuplicate, out var pushResult);
+                    packagePublishWatch.Stop();
                     if (push)
                     {
                         if (pushResult.Outcome == PackagePushOutcome.SkippedDuplicate)
                         {
                             result.SkippedDuplicatePackages.Add(pkg);
-                            _logger.Info($"Skipped duplicate {Path.GetFileName(pkg)}; package already exists in the feed.");
+                            _logger.Info($"Skipped duplicate {Path.GetFileName(pkg)} in {FormatDuration(packagePublishWatch.Elapsed)}; package already exists in the feed.");
                         }
                         else
                         {
                             result.PublishedPackages.Add(pkg);
-                            _logger.Success($"Published {Path.GetFileName(pkg)}.");
+                            _logger.Success($"Published {Path.GetFileName(pkg)} in {FormatDuration(packagePublishWatch.Elapsed)}.");
                         }
                     }
                     else
@@ -555,7 +556,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         result.Success = false;
                         result.FailedPackages.Add(pkg);
                         var error = pushResult.Message;
-                        _logger.Warn($"NuGet push failed for {pkg}: {error}");
+                        _logger.Warn($"NuGet push failed for {pkg} after {FormatDuration(packagePublishWatch.Elapsed)}: {error}");
                         if (packageLookup.TryGetValue(pkg, out var project) && string.IsNullOrWhiteSpace(project.ErrorMessage))
                             project.ErrorMessage = $"Publish failed for {Path.GetFileName(pkg)}: {error}";
                         if (spec.PublishFailFast)
@@ -566,6 +567,12 @@ public sealed partial class DotNetRepositoryReleaseService
                         }
                     }
                 }
+                publishWatch.Stop();
+                var publishSummary = $"NuGet publish phase completed in {FormatDuration(publishWatch.Elapsed)} ({result.PublishedPackages.Count} published, {result.SkippedDuplicatePackages.Count} skipped duplicate, {result.FailedPackages.Count} failed).";
+                if (result.FailedPackages.Count == 0)
+                    _logger.Success(publishSummary);
+                else
+                    _logger.Warn(publishSummary);
             }
 
             if (result.ResolvedVersionsByProject.Count > 0)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -220,7 +220,7 @@ public sealed partial class DotNetRepositoryReleaseService
 
             if (signNuGetPackages)
             {
-                signingSha256 = GetCertificateSha256(spec.CertificateThumbprint!.Trim(), spec.CertificateStore);
+                signingSha256 = _getCertificateSha256(spec.CertificateThumbprint!.Trim(), spec.CertificateStore);
                 if (signingSha256 is null)
                 {
                     result.Success = false;
@@ -475,12 +475,13 @@ public sealed partial class DotNetRepositoryReleaseService
                     {
                         _logger.Info($"Signing {packagesToSign.Length} NuGet package(s)...");
                         var signingWatch = Stopwatch.StartNew();
-                        if (!SignPackages(packagesToSign, spec, signingSha256, out var signError))
+                        if (!_signPackages(packagesToSign, spec, signingSha256, out var signError))
                         {
                             signingWatch.Stop();
                             result.ErrorMessage = signError;
                             _logger.Warn(signError);
                             result.Success = false;
+                            MarkPackageSigningFailure(packable, packagesToSign, signError);
                             if (spec.PublishFailFast)
                                 return result;
                         }
@@ -596,6 +597,32 @@ public sealed partial class DotNetRepositoryReleaseService
             result.Success = false;
             result.ErrorMessage = ex.Message;
             return result;
+        }
+    }
+
+    private static void MarkPackageSigningFailure(
+        IEnumerable<DotNetRepositoryProjectResult> projects,
+        IReadOnlyList<string> packagesToSign,
+        string signError)
+    {
+        var failedPackages = new HashSet<string>(
+            packagesToSign.Where(package => !string.IsNullOrWhiteSpace(package)),
+            StringComparer.OrdinalIgnoreCase);
+
+        if (failedPackages.Count == 0)
+            return;
+
+        var message = string.IsNullOrWhiteSpace(signError)
+            ? "Package signing failed."
+            : $"Package signing failed: {signError}";
+
+        foreach (var project in projects)
+        {
+            if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
+                continue;
+
+            if (project.Packages.Any(package => failedPackages.Contains(package)))
+                project.ErrorMessage = message;
         }
     }
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Signing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Signing.cs
@@ -22,21 +22,22 @@ public sealed partial class DotNetRepositoryReleaseService
         var store = spec.CertificateStore == CertificateStoreLocation.LocalMachine ? "LocalMachine" : "CurrentUser";
         var timeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim();
 
-        foreach (var pkg in packages)
-        {
-            var exitCode = RunDotnetSign(pkg, sha256, store, timeStampServer, out var stdErr, out var stdOut);
-            if (exitCode == 0) continue;
+        var packagePaths = packages
+            .Where(package => !string.IsNullOrWhiteSpace(package))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (packagePaths.Length == 0) return true;
 
-            var msg = string.Join(Environment.NewLine, stdErr, stdOut).Trim();
-            error = $"Signing failed for {Path.GetFileName(pkg)}. {msg}".Trim();
-            return false;
-        }
+        var exitCode = RunDotnetSign(packagePaths, sha256, store, timeStampServer, out var stdErr, out var stdOut);
+        if (exitCode == 0) return true;
 
-        return true;
+        var msg = string.Join(Environment.NewLine, stdErr, stdOut).Trim();
+        error = $"Signing failed for {packagePaths.Length} package(s). {msg}".Trim();
+        return false;
     }
 
     private static int RunDotnetSign(
-        string packagePath,
+        IReadOnlyList<string> packagePaths,
         string sha256,
         string store,
         string timeStampServer,
@@ -45,7 +46,7 @@ public sealed partial class DotNetRepositoryReleaseService
     {
         var result = new DotNetNuGetClient()
             .SignPackageAsync(new DotNetNuGetSignRequest(
-                packagePath: packagePath,
+                packagePaths: packagePaths,
                 certificateFingerprint: sha256,
                 certificateStoreLocation: store,
                 timeStampServer: timeStampServer))

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -23,6 +23,13 @@ public sealed partial class DotNetRepositoryReleaseService
         public List<string> Packages { get; } = new();
     }
 
+    private sealed class AssemblySigningPlan
+    {
+        public string[] IncludePatterns { get; set; } = Array.Empty<string>();
+        public string[] Files { get; set; } = Array.Empty<string>();
+        public int OutputDirectoryCount { get; set; }
+    }
+
     internal static string FormatDuration(TimeSpan duration)
     {
         if (duration.TotalHours >= 1)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -78,6 +78,7 @@ public sealed partial class DotNetRepositoryReleaseService
         var shouldSignAssemblies = signAssemblies is not null && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
         if (shouldSignAssemblies)
         {
+            logger.Info($"{project.ProjectName}: building assemblies before pack signing...");
             var buildExitCode = RunDotnetBuild(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, out var buildStdErr, out var buildStdOut, out var buildDuration);
             result.Duration += buildDuration;
             if (buildExitCode != 0)
@@ -85,21 +86,45 @@ public sealed partial class DotNetRepositoryReleaseService
                 result.ErrorMessage = $"dotnet build failed for {project.ProjectName} (exit {buildExitCode}). {SummarizeProcessFailureOutput(buildStdErr, buildStdOut)}".Trim();
                 return result;
             }
+            logger.Success($"{project.ProjectName}: build before pack signing completed in {FormatDuration(buildDuration)}.");
 
             try
             {
-                var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger);
-                foreach (var outputDirectory in outputDirectories)
+                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec);
+                var resolveOutputWatch = Stopwatch.StartNew();
+                var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
+                var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
+                {
+                    var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
+                    if (!SamePatterns(includePatterns, evaluatedIncludePatterns))
+                    {
+                        includePatterns = evaluatedIncludePatterns;
+                        outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
+                        signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                    }
+                }
+                resolveOutputWatch.Stop();
+                result.Duration += resolveOutputWatch.Elapsed;
+                logger.Success($"{project.ProjectName}: resolved {outputDirectories.Length} signing output directorie(s) in {FormatDuration(resolveOutputWatch.Elapsed)}.");
+
+                var assemblySigningWatch = Stopwatch.StartNew();
+                logger.Info($"{project.ProjectName}: assembly signing include pattern(s): {string.Join(", ", includePatterns)}.");
+                if (signingPlan.Files.Length > 0)
                 {
                     signAssemblies!(new DotNetReleaseBuildAssemblySigningRequest
                     {
-                        ReleasePath = outputDirectory,
+                        ReleasePath = outputDirectories.Length == 1 ? outputDirectories[0] : csprojDir,
                         LocalStore = spec.CertificateStore,
                         CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
                         TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
-                        IncludePatterns = new[] { "*.dll", "*.exe" }
+                        IncludePatterns = includePatterns,
+                        FilePaths = signingPlan.Files
                     });
                 }
+                assemblySigningWatch.Stop();
+                result.Duration += assemblySigningWatch.Elapsed;
+                logger.Success($"{project.ProjectName}: assembly signing completed for {signingPlan.OutputDirectoryCount} output directorie(s), {signingPlan.Files.Length} file(s), in {FormatDuration(assemblySigningWatch.Elapsed)}.");
             }
             catch (Exception ex)
             {
@@ -115,7 +140,9 @@ public sealed partial class DotNetRepositoryReleaseService
             result.ErrorMessage = $"dotnet pack failed for {project.ProjectName} (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
             return result;
         }
+        logger.Success($"{project.ProjectName}: dotnet pack completed in {FormatDuration(duration)}.");
 
+        var packageDiscoveryWatch = Stopwatch.StartNew();
         if (Directory.Exists(packageRoot))
         {
             var pkgs = Directory.EnumerateFiles(packageRoot, "*.nupkg", SearchOption.AllDirectories)
@@ -124,6 +151,9 @@ public sealed partial class DotNetRepositoryReleaseService
                 .ToArray();
             result.Packages.AddRange(pkgs);
         }
+        packageDiscoveryWatch.Stop();
+        result.Duration += packageDiscoveryWatch.Elapsed;
+        logger.Success($"{project.ProjectName}: package discovery found {result.Packages.Count} package(s) in {FormatDuration(packageDiscoveryWatch.Elapsed)}.");
 
         result.Success = true;
         return result;
@@ -132,7 +162,8 @@ public sealed partial class DotNetRepositoryReleaseService
     private static DotNetPackResult PackProjectsWithMsBuild(
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         DotNetRepositoryReleaseSpec spec,
-        ILogger logger)
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies)
     {
         var result = new DotNetPackResult();
         if (projects.Count == 0)
@@ -161,15 +192,69 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             WritePackTraversalProject(traversalPath, projects, spec, outputPath);
 
-            var exitCode = RunDotnetMsBuildPack(
-                traversalPath,
-                tempRoot,
-                projects.Count,
-                logger,
-                out var stdErr,
-                out var stdOut,
-                out var duration);
-            result.Duration = duration;
+            var shouldSignAssemblies = signAssemblies is not null && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
+            int exitCode;
+            string stdErr;
+            string stdOut;
+            TimeSpan duration;
+
+            if (shouldSignAssemblies)
+            {
+                exitCode = RunDotnetMsBuildTarget(
+                    traversalPath,
+                    tempRoot,
+                    "BuildSelected",
+                    "build",
+                    "dotnet msbuild build",
+                    projects.Count,
+                    logger,
+                    out stdErr,
+                    out stdOut,
+                    out duration);
+                result.Duration += duration;
+
+                if (exitCode != 0)
+                {
+                    result.ErrorMessage = $"dotnet msbuild batch build failed (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
+                    return result;
+                }
+
+                var signing = SignBatchBuildOutputs(projects, spec, logger, signAssemblies!);
+                result.Duration += signing.Duration;
+                if (!signing.Success)
+                {
+                    result.ErrorMessage = signing.ErrorMessage;
+                    return result;
+                }
+
+                exitCode = RunDotnetMsBuildTarget(
+                    traversalPath,
+                    tempRoot,
+                    "PackOnlySelected",
+                    "pack",
+                    "dotnet msbuild pack",
+                    projects.Count,
+                    logger,
+                    out stdErr,
+                    out stdOut,
+                    out duration);
+                result.Duration += duration;
+            }
+            else
+            {
+                exitCode = RunDotnetMsBuildTarget(
+                    traversalPath,
+                    tempRoot,
+                    "PackSelected",
+                    "pack",
+                    "dotnet msbuild pack",
+                    projects.Count,
+                    logger,
+                    out stdErr,
+                    out stdOut,
+                    out duration);
+                result.Duration += duration;
+            }
 
             if (exitCode != 0)
             {
@@ -213,7 +298,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     projects.Select(project => new XElement("PackProject",
                         new XAttribute("Include", Path.GetFullPath(project.CsprojPath))))),
                 new XElement("Target",
-                    new XAttribute("Name", "PackSelected"),
+                    new XAttribute("Name", "RestoreSelected"),
                     new XElement("MSBuild",
                         new XAttribute("Projects", "@(PackProject)"),
                         // Restore and build all selected projects first, then pack without walking project
@@ -221,21 +306,94 @@ public sealed partial class DotNetRepositoryReleaseService
                         new XAttribute("Targets", "Restore"),
                         new XAttribute("BuildInParallel", "true"),
                         new XAttribute("StopOnFirstFailure", "true"),
-                        new XAttribute("Properties", buildProperties)),
+                        new XAttribute("Properties", buildProperties))),
+                new XElement("Target",
+                    new XAttribute("Name", "BuildSelected"),
+                    new XAttribute("DependsOnTargets", "RestoreSelected"),
                     new XElement("MSBuild",
                         new XAttribute("Projects", "@(PackProject)"),
                         new XAttribute("Targets", "Build"),
                         new XAttribute("BuildInParallel", "true"),
                         new XAttribute("StopOnFirstFailure", "true"),
-                        new XAttribute("Properties", buildProperties)),
+                        new XAttribute("Properties", buildProperties))),
+                new XElement("Target",
+                    new XAttribute("Name", "PackOnlySelected"),
                     new XElement("MSBuild",
                         new XAttribute("Projects", "@(PackProject)"),
                         new XAttribute("Targets", "Pack"),
                         new XAttribute("BuildInParallel", "true"),
                         new XAttribute("StopOnFirstFailure", "true"),
-                        new XAttribute("Properties", packProperties)))));
+                        new XAttribute("Properties", packProperties))),
+                new XElement("Target",
+                    new XAttribute("Name", "PackSelected"),
+                    new XAttribute("DependsOnTargets", "BuildSelected;PackOnlySelected"))));
 
         document.Save(traversalPath);
+    }
+
+    private static DotNetPackResult SignBatchBuildOutputs(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest> signAssemblies)
+    {
+        var result = new DotNetPackResult();
+        var watch = Stopwatch.StartNew();
+
+        try
+        {
+            var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
+            var signedOutputCount = 0;
+            var files = new List<string>();
+
+            foreach (var project in projects)
+            {
+                var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
+                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec);
+                var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
+                var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
+                {
+                    var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
+                    if (!SamePatterns(includePatterns, evaluatedIncludePatterns))
+                    {
+                        includePatterns = evaluatedIncludePatterns;
+                        outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
+                        signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                    }
+                }
+                logger.Info($"{project.ProjectName}: assembly signing include pattern(s): {string.Join(", ", includePatterns)}.");
+                files.AddRange(signingPlan.Files);
+                signedOutputCount += signingPlan.OutputDirectoryCount;
+            }
+
+            var filePaths = files
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (filePaths.Length > 0)
+                signAssemblies(new DotNetReleaseBuildAssemblySigningRequest
+                {
+                    ReleasePath = spec.RootPath,
+                    LocalStore = spec.CertificateStore,
+                    CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
+                    TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
+                    IncludePatterns = Array.Empty<string>(),
+                    FilePaths = filePaths
+                });
+
+            watch.Stop();
+            result.Duration = watch.Elapsed;
+            result.Success = true;
+            logger.Success($"MSBuild batch assembly signing completed for {signedOutputCount} output directorie(s), {filePaths.Length} file(s), in {FormatDuration(watch.Elapsed)}.");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            watch.Stop();
+            result.Duration = watch.Elapsed;
+            result.ErrorMessage = $"MSBuild batch assembly signing failed. {ex.Message}";
+            return result;
+        }
     }
 
     private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotNetRepositoryProjectResult project, string version)
@@ -364,9 +522,27 @@ public sealed partial class DotNetRepositoryReleaseService
         string workingDirectory,
         string configuration,
         string projectName,
-        ILogger logger)
+        ILogger logger,
+        IReadOnlyList<string>? includePatterns = null)
     {
         var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in ResolveConventionalBuildOutputDirectories(csproj, workingDirectory, configuration))
+        {
+            if (!Directory.Exists(directory))
+                continue;
+
+            if (includePatterns is { Count: > 0 } && !ContainsSignableFiles(directory, includePatterns))
+                continue;
+
+            directories.Add(Path.GetFullPath(directory));
+        }
+
+        if (directories.Count > 0)
+        {
+            logger.Verbose($"{projectName}: resolved {directories.Count} signing output directorie(s) from conventional build paths.");
+            return directories.ToArray();
+        }
+
         foreach (var targetFramework in ReadTargetFrameworks(csproj))
         {
             var exitCode = RunDotnetMsBuildGetProperty(
@@ -407,6 +583,196 @@ public sealed partial class DotNetRepositoryReleaseService
         return directories.ToArray();
     }
 
+    private static string[] ResolveConventionalBuildOutputDirectories(
+        string csproj,
+        string workingDirectory,
+        string configuration)
+    {
+        var directories = new List<string>();
+        var targetFrameworks = ReadTargetFrameworks(csproj)
+            .Where(static framework => !string.IsNullOrWhiteSpace(framework))
+            .Select(static framework => framework!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (var targetFramework in targetFrameworks)
+            directories.Add(Path.Combine(workingDirectory, "bin", configuration, targetFramework));
+
+        foreach (var outputPath in ReadOutputPaths(csproj))
+        {
+            var resolved = Path.IsPathRooted(outputPath)
+                ? outputPath
+                : Path.GetFullPath(Path.Combine(workingDirectory, outputPath));
+            directories.Add(resolved);
+
+            foreach (var targetFramework in targetFrameworks)
+                directories.Add(Path.Combine(resolved, targetFramework));
+        }
+
+        if (targetFrameworks.Length == 0)
+            directories.Add(Path.Combine(workingDirectory, "bin", configuration));
+
+        return directories
+            .Where(static directory => !string.IsNullOrWhiteSpace(directory))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static bool ContainsSignableFiles(string directory, IReadOnlyList<string> includePatterns)
+    {
+        foreach (var includePattern in includePatterns)
+        {
+            if (string.IsNullOrWhiteSpace(includePattern))
+                continue;
+
+            if (Directory.EnumerateFiles(directory, includePattern, SearchOption.AllDirectories)
+                    .Any(static file => !IsInternalsPath(file)))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string[] ResolveAssemblySigningIncludePatterns(
+        DotNetRepositoryProjectResult project,
+        DotNetRepositoryReleaseSpec spec,
+        string? workingDirectory = null,
+        string? configuration = null,
+        ILogger? logger = null)
+    {
+        if (spec.SignDependencyAssemblies)
+            return new[] { "*.dll", "*.exe" };
+
+        var assemblyNames = new[] { ResolveAssemblyName(project.CsprojPath, project.ProjectName, workingDirectory, configuration, logger), project.ProjectName }
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return assemblyNames
+            .SelectMany(static assemblyName => new[]
+            {
+                $"{assemblyName}.dll",
+                $"{assemblyName}.exe"
+            })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static AssemblySigningPlan BuildAssemblySigningPlan(
+        IReadOnlyList<string> outputDirectories,
+        IReadOnlyList<string> includePatterns)
+    {
+        var files = new List<string>();
+        var outputDirectoryCount = 0;
+
+        foreach (var outputDirectory in outputDirectories)
+        {
+            if (string.IsNullOrWhiteSpace(outputDirectory) || !Directory.Exists(outputDirectory))
+                continue;
+
+            outputDirectoryCount++;
+            foreach (var includePattern in includePatterns)
+            {
+                if (string.IsNullOrWhiteSpace(includePattern))
+                    continue;
+
+                files.AddRange(Directory.EnumerateFiles(outputDirectory, includePattern, SearchOption.AllDirectories)
+                    .Where(static file => !IsInternalsPath(file)));
+            }
+        }
+
+        return new AssemblySigningPlan
+        {
+            IncludePatterns = includePatterns.ToArray(),
+            Files = files
+                .Select(Path.GetFullPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            OutputDirectoryCount = outputDirectoryCount
+        };
+    }
+
+    private static bool SamePatterns(IReadOnlyList<string> left, IReadOnlyList<string> right)
+        => left.Count == right.Count && left
+            .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+            .SequenceEqual(right.OrderBy(static value => value, StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
+
+    private static bool IsInternalsPath(string filePath)
+    {
+        return filePath.IndexOf($"{Path.DirectorySeparatorChar}Internals{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               filePath.IndexOf("/Internals/", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               filePath.IndexOf("\\Internals\\", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string ResolveAssemblyName(
+        string csproj,
+        string projectName,
+        string? workingDirectory = null,
+        string? configuration = null,
+        ILogger? logger = null)
+    {
+        try
+        {
+            var document = XDocument.Load(csproj);
+            var assemblyName = document.Descendants()
+                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase))
+                ?.Value;
+            if (IsUsableAssemblyName(assemblyName))
+                return assemblyName!.Trim();
+        }
+        catch
+        {
+            // Project file metadata is best-effort here; the csproj name is the SDK default.
+        }
+
+        var evaluatedAssemblyName = ResolveEvaluatedAssemblyName(csproj, workingDirectory, configuration, projectName, logger);
+        if (IsUsableAssemblyName(evaluatedAssemblyName))
+            return evaluatedAssemblyName!.Trim();
+
+        return string.IsNullOrWhiteSpace(projectName)
+            ? Path.GetFileNameWithoutExtension(csproj) ?? "Project"
+            : projectName.Trim();
+    }
+
+    private static string? ResolveEvaluatedAssemblyName(
+        string csproj,
+        string? workingDirectory,
+        string? configuration,
+        string projectName,
+        ILogger? logger)
+    {
+        if (string.IsNullOrWhiteSpace(workingDirectory) || string.IsNullOrWhiteSpace(configuration) || logger is null)
+            return null;
+
+        foreach (var targetFramework in ReadTargetFrameworks(csproj))
+        {
+            var exitCode = RunDotnetMsBuildGetProperty(
+                csproj,
+                workingDirectory!,
+                configuration!,
+                targetFramework,
+                "AssemblyName",
+                projectName,
+                logger,
+                out var value,
+                out _,
+                out _,
+                out _);
+
+            if (exitCode == 0 && IsUsableAssemblyName(value))
+                return value!.Trim();
+        }
+
+        return null;
+    }
+
+    private static bool IsUsableAssemblyName(string? assemblyName)
+        => !string.IsNullOrWhiteSpace(assemblyName) &&
+           assemblyName!.IndexOf("$(", StringComparison.Ordinal) < 0 &&
+           assemblyName.IndexOf(';') < 0;
+
     private static string?[] ReadTargetFrameworks(string csproj)
     {
         try
@@ -439,9 +805,32 @@ public sealed partial class DotNetRepositoryReleaseService
         return new string?[] { null };
     }
 
-    private static int RunDotnetMsBuildPack(
+    private static string[] ReadOutputPaths(string csproj)
+    {
+        try
+        {
+            var document = XDocument.Load(csproj);
+            return document.Descendants()
+                .Where(element =>
+                    string.Equals(element.Name.LocalName, "OutputPath", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(element.Name.LocalName, "OutDir", StringComparison.OrdinalIgnoreCase))
+                .Select(static element => element.Value?.Trim())
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray()!;
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private static int RunDotnetMsBuildTarget(
         string traversalProject,
         string workingDirectory,
+        string targetName,
+        string heartbeatOperation,
+        string logOperation,
         int projectCount,
         ILogger logger,
         out string stdErr,
@@ -468,7 +857,7 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             "msbuild",
             traversalProject,
-            "/t:PackSelected",
+            $"/t:{targetName}",
             "/m",
             "/nr:false",
             logger.IsVerbose ? "/v:n" : "/v:m"
@@ -476,7 +865,7 @@ public sealed partial class DotNetRepositoryReleaseService
 #else
         psi.ArgumentList.Add("msbuild");
         psi.ArgumentList.Add(traversalProject);
-        psi.ArgumentList.Add("/t:PackSelected");
+        psi.ArgumentList.Add($"/t:{targetName}");
         psi.ArgumentList.Add("/m");
         psi.ArgumentList.Add("/nr:false");
         psi.ArgumentList.Add(logger.IsVerbose ? "/v:n" : "/v:m");
@@ -485,11 +874,11 @@ public sealed partial class DotNetRepositoryReleaseService
         var exitCode = RunProcessWithHeartbeat(
             psi,
             logger,
-            elapsed => $"MSBuild batch pack still running ({projectCount} project(s), {FormatDuration(elapsed)} elapsed).",
+            elapsed => $"MSBuild batch {heartbeatOperation} still running ({projectCount} project(s), {FormatDuration(elapsed)} elapsed).",
             out stdErr,
             out stdOut,
             out duration);
-        LogProcessOutput(logger, "MSBuild batch", "dotnet msbuild pack", stdOut, stdErr);
+        LogProcessOutput(logger, "MSBuild batch", logOperation, stdOut, stdErr);
         return exitCode;
     }
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -537,14 +537,11 @@ public sealed partial class DotNetRepositoryReleaseService
             directories.Add(Path.GetFullPath(directory));
         }
 
-        if (directories.Count > 0)
-        {
-            logger.Verbose($"{projectName}: resolved {directories.Count} signing output directorie(s) from conventional build paths.");
-            return directories.ToArray();
-        }
-
         foreach (var targetFramework in ReadTargetFrameworks(csproj))
         {
+            if (directories.Count > 0 && HasOutputDirectoryForTargetFramework(directories, targetFramework))
+                continue;
+
             var exitCode = RunDotnetMsBuildGetProperty(
                 csproj,
                 workingDirectory,
@@ -581,6 +578,19 @@ public sealed partial class DotNetRepositoryReleaseService
             throw new DirectoryNotFoundException($"No build output directory found for {projectName}.");
 
         return directories.ToArray();
+    }
+
+    private static bool HasOutputDirectoryForTargetFramework(IEnumerable<string> directories, string? targetFramework)
+    {
+        if (string.IsNullOrWhiteSpace(targetFramework))
+            return directories.Any();
+
+        var normalizedTargetFramework = targetFramework!.Trim();
+        return directories.Any(directory =>
+        {
+            var parts = directory.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+            return parts.Any(part => string.Equals(part, normalizedTargetFramework, StringComparison.OrdinalIgnoreCase));
+        });
     }
 
     private static string[] ResolveConventionalBuildOutputDirectories(
@@ -713,6 +723,10 @@ public sealed partial class DotNetRepositoryReleaseService
         string? configuration = null,
         ILogger? logger = null)
     {
+        var evaluatedAssemblyName = ResolveEvaluatedAssemblyName(csproj, workingDirectory, configuration, projectName, logger);
+        if (IsUsableAssemblyName(evaluatedAssemblyName))
+            return evaluatedAssemblyName!.Trim();
+
         try
         {
             var document = XDocument.Load(csproj);
@@ -726,10 +740,6 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             // Project file metadata is best-effort here; the csproj name is the SDK default.
         }
-
-        var evaluatedAssemblyName = ResolveEvaluatedAssemblyName(csproj, workingDirectory, configuration, projectName, logger);
-        if (IsUsableAssemblyName(evaluatedAssemblyName))
-            return evaluatedAssemblyName!.Trim();
 
         return string.IsNullOrWhiteSpace(projectName)
             ? Path.GetFileNameWithoutExtension(csproj) ?? "Project"

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -90,7 +90,7 @@ public sealed partial class DotNetRepositoryReleaseService
 
             try
             {
-                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec);
+                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
                 var resolveOutputWatch = Stopwatch.StartNew();
                 var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
                 var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
@@ -349,7 +349,7 @@ public sealed partial class DotNetRepositoryReleaseService
             foreach (var project in projects)
             {
                 var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
-                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec);
+                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
                 var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
                 var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
                 if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
@@ -636,8 +636,7 @@ public sealed partial class DotNetRepositoryReleaseService
             if (string.IsNullOrWhiteSpace(includePattern))
                 continue;
 
-            if (Directory.EnumerateFiles(directory, includePattern, SearchOption.AllDirectories)
-                    .Any(static file => !IsInternalsPath(file)))
+            if (Directory.EnumerateFiles(directory, includePattern, SearchOption.AllDirectories).Any())
                 return true;
         }
 
@@ -654,7 +653,8 @@ public sealed partial class DotNetRepositoryReleaseService
         if (spec.SignDependencyAssemblies)
             return new[] { "*.dll", "*.exe" };
 
-        var assemblyNames = new[] { ResolveAssemblyName(project.CsprojPath, project.ProjectName, workingDirectory, configuration, logger), project.ProjectName }
+        var assemblyNames = ResolveAssemblyNames(project.CsprojPath, project.ProjectName, workingDirectory, configuration, logger)
+            .Concat(new[] { project.ProjectName })
             .Where(static name => !string.IsNullOrWhiteSpace(name))
             .Select(static name => name!.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -688,8 +688,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 if (string.IsNullOrWhiteSpace(includePattern))
                     continue;
 
-                files.AddRange(Directory.EnumerateFiles(outputDirectory, includePattern, SearchOption.AllDirectories)
-                    .Where(static file => !IsInternalsPath(file)));
+                files.AddRange(Directory.EnumerateFiles(outputDirectory, includePattern, SearchOption.AllDirectories));
             }
         }
 
@@ -709,44 +708,46 @@ public sealed partial class DotNetRepositoryReleaseService
             .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
             .SequenceEqual(right.OrderBy(static value => value, StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
 
-    private static bool IsInternalsPath(string filePath)
-    {
-        return filePath.IndexOf($"{Path.DirectorySeparatorChar}Internals{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               filePath.IndexOf("/Internals/", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               filePath.IndexOf("\\Internals\\", StringComparison.OrdinalIgnoreCase) >= 0;
-    }
-
-    private static string ResolveAssemblyName(
+    private static string[] ResolveAssemblyNames(
         string csproj,
         string projectName,
         string? workingDirectory = null,
         string? configuration = null,
         ILogger? logger = null)
     {
-        var evaluatedAssemblyName = ResolveEvaluatedAssemblyName(csproj, workingDirectory, configuration, projectName, logger);
-        if (IsUsableAssemblyName(evaluatedAssemblyName))
-            return evaluatedAssemblyName!.Trim();
+        var assemblyNames = new List<string>();
+        var evaluatedAssemblyNames = ResolveEvaluatedAssemblyNames(csproj, workingDirectory, configuration, projectName, logger);
+        assemblyNames.AddRange(evaluatedAssemblyNames);
 
-        try
+        if (evaluatedAssemblyNames.Length == 0)
         {
-            var document = XDocument.Load(csproj);
-            var assemblyName = document.Descendants()
-                .FirstOrDefault(element => string.Equals(element.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase))
-                ?.Value;
-            if (IsUsableAssemblyName(assemblyName))
-                return assemblyName!.Trim();
-        }
-        catch
-        {
-            // Project file metadata is best-effort here; the csproj name is the SDK default.
+            try
+            {
+                var document = XDocument.Load(csproj);
+                assemblyNames.AddRange(document.Descendants()
+                    .Where(element => string.Equals(element.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase))
+                    .Select(static element => element.Value)
+                    .Where(IsUsableAssemblyName)
+                    .Select(static assemblyName => assemblyName!.Trim()));
+            }
+            catch
+            {
+                // Project file metadata is best-effort here; the csproj name is the SDK default.
+            }
         }
 
-        return string.IsNullOrWhiteSpace(projectName)
+        assemblyNames.Add(string.IsNullOrWhiteSpace(projectName)
             ? Path.GetFileNameWithoutExtension(csproj) ?? "Project"
-            : projectName.Trim();
+            : projectName.Trim());
+
+        return assemblyNames
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
-    private static string? ResolveEvaluatedAssemblyName(
+    private static string[] ResolveEvaluatedAssemblyNames(
         string csproj,
         string? workingDirectory,
         string? configuration,
@@ -754,8 +755,9 @@ public sealed partial class DotNetRepositoryReleaseService
         ILogger? logger)
     {
         if (string.IsNullOrWhiteSpace(workingDirectory) || string.IsNullOrWhiteSpace(configuration) || logger is null)
-            return null;
+            return Array.Empty<string>();
 
+        var assemblyNames = new List<string>();
         foreach (var targetFramework in ReadTargetFrameworks(csproj))
         {
             var exitCode = RunDotnetMsBuildGetProperty(
@@ -772,10 +774,12 @@ public sealed partial class DotNetRepositoryReleaseService
                 out _);
 
             if (exitCode == 0 && IsUsableAssemblyName(value))
-                return value!.Trim();
+                assemblyNames.Add(value!.Trim());
         }
 
-        return null;
+        return assemblyNames
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static bool IsUsableAssemblyName(string? assemblyName)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.cs
@@ -15,8 +15,16 @@ namespace PowerForge;
 /// </summary>
 public sealed partial class DotNetRepositoryReleaseService
 {
+    internal delegate bool PackageSigningHandler(
+        IReadOnlyList<string> packages,
+        DotNetRepositoryReleaseSpec spec,
+        string sha256,
+        out string error);
+
     private readonly ILogger _logger;
     private readonly NuGetPackageVersionResolver _resolver;
+    private readonly PackageSigningHandler _signPackages;
+    private readonly Func<string, CertificateStoreLocation, string?> _getCertificateSha256;
     private static readonly string[] DefaultExcludeDirectories =
     {
         ".git", ".vs", ".idea", "bin", "obj", "node_modules", "packages",
@@ -27,9 +35,19 @@ public sealed partial class DotNetRepositoryReleaseService
     /// Creates a new repository release service.
     /// </summary>
     public DotNetRepositoryReleaseService(ILogger logger)
+        : this(logger, SignPackages, GetCertificateSha256)
+    {
+    }
+
+    internal DotNetRepositoryReleaseService(
+        ILogger logger,
+        PackageSigningHandler? signPackages,
+        Func<string, CertificateStoreLocation, string?>? getCertificateSha256)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _resolver = new NuGetPackageVersionResolver(_logger);
+        _signPackages = signPackages ?? SignPackages;
+        _getCertificateSha256 = getCertificateSha256 ?? GetCertificateSha256;
     }
 
 }

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -63,6 +64,7 @@ public sealed class GitHubReleasePublisher
                 throw new FileNotFoundException($"GitHub asset not found: {assetPath}");
         }
 
+        var releaseWatch = Stopwatch.StartNew();
         var release = CreateRelease(
             owner,
             repo,
@@ -75,6 +77,8 @@ public sealed class GitHubReleasePublisher
             isDraft,
             isPreRelease,
             reuseExistingReleaseOnConflict);
+        releaseWatch.Stop();
+        _logger.Success($"GitHub release ready in {DotNetRepositoryReleaseService.FormatDuration(releaseWatch.Elapsed)}: {release.HtmlUrl}");
 
         var result = new GitHubReleasePublishResult
         {
@@ -89,6 +93,7 @@ public sealed class GitHubReleasePublisher
         if (assets.Length > 0)
         {
             var uploadUrl = RemoveUploadUrlTemplate(release.UploadUrl);
+            var assetUploadWatch = Stopwatch.StartNew();
             result.SkippedExistingAssets.AddRange(UploadAssets(
                 uploadUrl,
                 assets,
@@ -98,6 +103,9 @@ public sealed class GitHubReleasePublisher
                 release.Id,
                 replaceExistingAssets,
                 result.ReplacedExistingAssets));
+            assetUploadWatch.Stop();
+            var uploaded = assets.Length - result.SkippedExistingAssets.Count;
+            _logger.Success($"GitHub release asset upload phase completed in {DotNetRepositoryReleaseService.FormatDuration(assetUploadWatch.Elapsed)} ({uploaded} uploaded, {result.SkippedExistingAssets.Count} skipped).");
         }
 
         return result;
@@ -245,8 +253,10 @@ public sealed class GitHubReleasePublisher
                 replacedExistingAssets.Add(fileName);
             }
 
-            _logger.Info($"Uploading GitHub release asset: {fileName}");
+            var assetSize = new FileInfo(assetPath).Length;
+            _logger.Info($"Uploading GitHub release asset: {fileName} ({DotNetRepositoryReleaseService.FormatBytes(assetSize)})");
 
+            var assetWatch = Stopwatch.StartNew();
             var resp = UploadAsset(uploadUrl, assetPath, fileName, token);
             var respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             if (!resp.IsSuccessStatusCode && replaceExistingAssets &&
@@ -268,7 +278,8 @@ public sealed class GitHubReleasePublisher
                     // Idempotency: reruns can hit "asset already exists". Prefer to continue rather than failing the whole build.
                     if ((int)resp.StatusCode == 422 && IsAlreadyExistsValidationError(respText, fieldName: "name"))
                     {
-                        _logger.Info($"GitHub release asset '{fileName}' already exists; skipping upload.");
+                        assetWatch.Stop();
+                        _logger.Info($"GitHub release asset '{fileName}' already exists; skipping upload after {DotNetRepositoryReleaseService.FormatDuration(assetWatch.Elapsed)}.");
                         skippedAssets.Add(fileName);
                         continue;
                     }
@@ -276,6 +287,9 @@ public sealed class GitHubReleasePublisher
                     throw new InvalidOperationException($"GitHub asset upload failed for '{fileName}' ({(int)resp.StatusCode} {resp.ReasonPhrase}). {TrimForMessage(respText)}");
                 }
             }
+
+            assetWatch.Stop();
+            _logger.Success($"Uploaded GitHub release asset: {fileName} in {DotNetRepositoryReleaseService.FormatDuration(assetWatch.Elapsed)} ({DotNetRepositoryReleaseService.FormatBytes(assetSize)}).");
         }
 
         return skippedAssets;

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -92,6 +92,76 @@ internal sealed class NuGetPackagePublishService
         return result;
     }
 
+    public NuGetPackagePublishResult ExecutePackages(
+        IReadOnlyList<string> packages,
+        string apiKey,
+        string source,
+        bool skipDuplicate,
+        bool publishFailFast = true)
+    {
+        if (packages is null)
+            throw new ArgumentNullException(nameof(packages));
+
+        var result = new NuGetPackagePublishResult();
+        var unique = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var packagePaths = packages
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Where(path => unique.Add(path))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (packagePaths.Length == 0)
+        {
+            result.Success = false;
+            result.ErrorMessage = "No package paths were provided.";
+            return result;
+        }
+
+        foreach (var package in packagePaths)
+        {
+            if (!File.Exists(package))
+            {
+                result.Success = false;
+                result.FailedItems.Add(package);
+                if (string.IsNullOrWhiteSpace(result.ErrorMessage))
+                    result.ErrorMessage = $"Package '{package}' not found.";
+                if (publishFailFast)
+                    return result;
+                continue;
+            }
+
+            var pushResult = _pushPackage(package, apiKey, source, skipDuplicate)
+                ?? new DotNetRepositoryReleaseService.PackagePushResult
+                {
+                    Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+                    Message = "Push handler returned no result."
+                };
+
+            switch (pushResult.Outcome)
+            {
+                case DotNetRepositoryReleaseService.PackagePushOutcome.Published:
+                case DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate:
+                    result.PublishedItems.Add(package);
+                    break;
+                default:
+                    result.Success = false;
+                    result.FailedItems.Add(package);
+                    _logger.Verbose($"dotnet nuget push failed for {package}.");
+                    if (pushResult.Message is string message && message.Length > 0)
+                        _logger.Verbose(message);
+                    if (publishFailFast)
+                    {
+                        if (string.IsNullOrWhiteSpace(result.ErrorMessage) && pushResult.Message is string failureMessage && failureMessage.Length > 0)
+                            result.ErrorMessage = failureMessage;
+                        return result;
+                    }
+                    break;
+            }
+        }
+
+        return result;
+    }
+
     private static DotNetRepositoryReleaseService.PackagePushResult PushPackage(string packagePath, string apiKey, string source, bool skipDuplicate)
     {
         var result = new DotNetNuGetClient()

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -107,7 +107,6 @@ internal sealed class NuGetPackagePublishService
         var packagePaths = packages
             .Where(path => !string.IsNullOrWhiteSpace(path))
             .Where(path => unique.Add(path))
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
         if (packagePaths.Length == 0)

--- a/PowerForge/Services/ProjectBuildGitHubPreflightService.cs
+++ b/PowerForge/Services/ProjectBuildGitHubPreflightService.cs
@@ -36,6 +36,11 @@ internal sealed class ProjectBuildGitHubPreflightService
         var conflictPolicy = ProjectBuildSupportService.ParseGitHubTagConflictPolicy(config.GitHubTagConflictPolicy);
         if (!string.Equals(conflictPolicy, "Reuse", StringComparison.OrdinalIgnoreCase))
             return null;
+        if (string.IsNullOrWhiteSpace(config.GitHubTagName) && HasVolatileTagTemplate(config.GitHubTagTemplate))
+        {
+            _logger.Info("GitHub preflight: skipping release reuse probe because the tag template contains a timestamp token.");
+            return null;
+        }
 
         var plannedAssetNames = plan.Projects
             .Where(project => project.IsPackable && !string.IsNullOrWhiteSpace(project.ReleaseZipPath))
@@ -92,6 +97,17 @@ internal sealed class ProjectBuildGitHubPreflightService
 
         _logger.Info($"GitHub preflight: release tag '{tag}' already exists; validating asset set before publish.");
         return ProjectBuildGitHubPublisher.BuildSingleReleaseReuseAdvisory(tag, plan.Projects, plannedAssetNames, existingRelease.AssetNames);
+    }
+
+    private static bool HasVolatileTagTemplate(string? tagTemplate)
+    {
+        if (string.IsNullOrWhiteSpace(tagTemplate))
+            return false;
+
+        return tagTemplate!.IndexOf("{Timestamp}", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               tagTemplate.IndexOf("{UtcTimestamp}", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               tagTemplate.IndexOf("{DateTime}", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               tagTemplate.IndexOf("{UtcDateTime}", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private static GitHubReleaseProbeResult ProbeGitHubReleaseByTag(

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -108,6 +108,7 @@ internal sealed class ProjectBuildPreparationService
             CertificateStore = ProjectBuildSupportService.ParseCertificateStore(config.CertificateStore),
             TimeStampServer = config.TimeStampServer,
             SignAssemblies = ResolveSigningEnabled(config.SignAssemblies, config.CertificateThumbprint),
+            SignDependencyAssemblies = config.SignDependencyAssemblies ?? false,
             SignPackages = ResolveSigningEnabled(config.SignPackages, config.CertificateThumbprint),
             Pack = context.Build || context.PublishNuget || context.PublishGitHub,
             CreateReleaseZip = context.CreateReleaseZip,

--- a/PowerForge/Services/ProjectBuildPublishHostService.cs
+++ b/PowerForge/Services/ProjectBuildPublishHostService.cs
@@ -69,7 +69,8 @@ public sealed class ProjectBuildPublishHostService
             GitHubTagTemplate = TrimOrNull(config.GitHubTagTemplate),
             GitHubReleaseMode = releaseMode,
             GitHubPrimaryProject = TrimOrNull(config.GitHubPrimaryProject),
-            GitHubTagConflictPolicy = TrimOrNull(config.GitHubTagConflictPolicy)
+            GitHubTagConflictPolicy = TrimOrNull(config.GitHubTagConflictPolicy),
+            PublishFailFast = config.PublishFailFast ?? true
         };
     }
 
@@ -94,7 +95,8 @@ public sealed class ProjectBuildPublishHostService
             TagName = configuration.GitHubTagName,
             TagTemplate = configuration.GitHubTagTemplate,
             PrimaryProject = configuration.GitHubPrimaryProject,
-            TagConflictPolicy = configuration.GitHubTagConflictPolicy
+            TagConflictPolicy = configuration.GitHubTagConflictPolicy,
+            PublishFailFast = configuration.PublishFailFast
         };
 
         return (_publishGitHub ?? (publishRequest => new ProjectBuildGitHubPublisher(_logger).Publish(publishRequest)))(request);

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace PowerForge;
 
 internal sealed class ProjectBuildWorkflowService
@@ -45,10 +47,25 @@ internal sealed class ProjectBuildWorkflowService
 
         var spec = preparation.Spec ?? throw new ArgumentException("Prepared spec is required.", nameof(preparation));
         spec.WhatIf = true;
+        var planWatch = Stopwatch.StartNew();
         var plan = _executeRelease(spec, _signAssemblies, _validateAssemblySigning);
+        planWatch.Stop();
+        if (plan.Success)
+            _logger.Success($"Project build plan prepared in {DotNetRepositoryReleaseService.FormatDuration(planWatch.Elapsed)}.");
+        else
+            _logger.Warn($"Project build plan failed after {DotNetRepositoryReleaseService.FormatDuration(planWatch.Elapsed)}.");
+
         var preflightErrors = new List<string>();
         if (!plan.Success)
             preflightErrors.Add(plan.ErrorMessage ?? "Plan/preflight validation failed.");
+        else if (plan.ResolvedVersionsByProject.Count > 0)
+        {
+            spec.ExpectedVersion = null;
+            spec.ExpectedVersionsByProject = new Dictionary<string, string>(
+                plan.ResolvedVersionsByProject,
+                StringComparer.OrdinalIgnoreCase);
+            _logger.Info($"Reusing {plan.ResolvedVersionsByProject.Count} resolved project version(s) from the plan for release execution.");
+        }
 
         if (!executeBuild || preparation.PlanOnly)
         {
@@ -93,7 +110,14 @@ internal sealed class ProjectBuildWorkflowService
         _support.TryWritePlan(plan, preparation.PlanOutputPath);
 
         spec.WhatIf = false;
+        var releaseWatch = Stopwatch.StartNew();
         var release = _executeRelease(spec, _signAssemblies, _validateAssemblySigning);
+        releaseWatch.Stop();
+        if (release is not null && release.Success)
+            _logger.Success($"Project build release execution completed in {DotNetRepositoryReleaseService.FormatDuration(releaseWatch.Elapsed)}.");
+        else
+            _logger.Warn($"Project build release execution failed after {DotNetRepositoryReleaseService.FormatDuration(releaseWatch.Elapsed)}.");
+
         var result = new ProjectBuildResult { Release = release };
 
         if (release is null || !release.Success)
@@ -124,6 +148,7 @@ internal sealed class ProjectBuildWorkflowService
             return new ProjectBuildWorkflowResult { Result = result };
         }
 
+        var gitHubWatch = Stopwatch.StartNew();
         var publishSummary = _publishGitHub(new ProjectBuildGitHubPublishRequest
         {
             Owner = config.GitHubUsername!,
@@ -141,6 +166,11 @@ internal sealed class ProjectBuildWorkflowService
             PrimaryProject = config.GitHubPrimaryProject,
             TagConflictPolicy = config.GitHubTagConflictPolicy
         });
+        gitHubWatch.Stop();
+        if (publishSummary.Success)
+            _logger.Success($"GitHub publish completed in {DotNetRepositoryReleaseService.FormatDuration(gitHubWatch.Elapsed)}.");
+        else
+            _logger.Warn($"GitHub publish failed after {DotNetRepositoryReleaseService.FormatDuration(gitHubWatch.Elapsed)}.");
 
         result.GitHub.AddRange(publishSummary.Results);
         result.Success = publishSummary.Success;

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -162,6 +162,10 @@
       "type": "boolean",
       "description": "When true and CertificateThumbprint is configured, signs build outputs before NuGet packages and release ZIPs are created. Defaults to true when CertificateThumbprint is set."
     },
+    "SignDependencyAssemblies": {
+      "type": "boolean",
+      "description": "When true, assembly signing also signs copied dependency assemblies from build output folders. Defaults to false so only the current project's assemblies are signed."
+    },
     "SignPackages": {
       "type": "boolean",
       "description": "When true and CertificateThumbprint is configured, signs generated NuGet packages. Defaults to true when CertificateThumbprint is set."


### PR DESCRIPTION
## Summary
- make assembly signing default to first-party build outputs only, with explicit `SignDependencyAssemblies` opt-in for copied dependency assemblies
- include first-party assemblies even when a project lives under an `Internals` directory, instead of skipping by path name
- include every evaluated target-framework assembly name when signing multi-target projects with conditional `AssemblyName` metadata
- make package timing honest: project logs now report the package workflow, while phase logs measure build-before-sign, output resolution, assembly signing, pack, package signing, publish, and GitHub upload separately
- reduce repeated work by reusing a completed project package build for module publish instead of rebuilding/repacking/resigning/rezipping for NuGet and GitHub publish
- require all reused NuGet or GitHub package artifacts to still exist before publishing from a prior package build; partial artifact sets now fall back to the normal publish path
- guard reused publish lanes so empty earlier build results fall back to the normal publish path, and preserve configured `PublishFailFast` for reused NuGet/GitHub publishes
- prevent NuGet publish from continuing after required package signing fails, including non-fail-fast runs
- preserve explicit package order when publishing reused package outputs, so dependency-first order from the caller is not alphabetically reshuffled
- avoid repeated signing discovery by resolving conventional SDK output folders first and passing explicit file paths to the signing service
- probe evaluated `TargetDir` for target frameworks that do not have conventional output folders, so custom output paths are still included in assembly signing
- prefer evaluated `AssemblyName` when signing first-party assemblies, so conditional/imported project metadata signs the produced assembly instead of a raw XML fallback
- reduce signing process overhead by batching assembly signing requests and signing all produced NuGet packages with one `dotnet nuget sign` invocation
- keep `PackStrategy=MSBuild` as the build-once path: batch build selected projects, sign outputs, then pack with `NoBuild=true`
- skip stale GitHub release reuse preflight when timestamped tag templates are intentionally volatile

## Validation
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj -c Release --no-restore --filter "DotNetRepositoryReleaseServiceTests|DotNetNuGetClientTests|ProjectBuildPreparationServiceTests|NuGetPackagePublishServiceTests|ModulePipelinePackageBuildTests|ProjectBuildWorkflowServiceTests|ProjectBuildGitHubPreflightTests|PowerForgeProjectCmdletTests|ProjectBuildPublishHostServiceTests"` (110 passed)
- `dotnet build .\PowerForge.PowerShell\PowerForge.PowerShell.csproj -c Release -f net472 --no-restore --nologo`
- `git diff --check`

## OfficeIMO timing evidence
- full OfficeIMO no-publish release run on this branch: 653.933s for 43 package workflows and release zips
- phase totals from that run: build-before-pack 66.3s, output directory resolution 0.048s, assembly signing 391.2s, derived raw `dotnet pack` time 44.0s, release zip 27.0s, NuGet package signing 132.0s
- earlier full OfficeIMO publish run on the first PR version: 948.775s total, including 1.5m NuGet publish and 2.0m GitHub upload; release execution before GitHub upload was 13.6m
- output directory resolution was previously a visible 52.0s bucket; conventional path resolution removes that repeated MSBuild property probing for normal SDK outputs
- three-project OfficeIMO slice after fast output resolution: 49.119s, versus 58.833s for the earlier per-project slice

## Notes
- signing remains the largest release cost because timestamping is paid per signed file: about 391s for OfficeIMO assembly outputs and about 132s for 43 NuGet packages in the measured no-publish run
- parallel package signing was tested and rejected because concurrent timestamp requests made the DigiCert timestamp endpoint fail; this PR keeps the safer single-process batch signing path