### PR TITLE
Keep generated ALC helpers private

### DIFF
--- a/PowerForge.Tests/ModuleBuilderManifestMutatorTests.cs
+++ b/PowerForge.Tests/ModuleBuilderManifestMutatorTests.cs
@@ -64,6 +64,48 @@ public sealed class ModuleBuilderManifestMutatorTests
         }
     }
 
+    [Fact]
+    public void BuildInPlace_DoesNotExportGeneratedDevelopmentBinaryHelper()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            const string moduleName = "TestModule";
+            File.WriteAllText(Path.Combine(root, $"{moduleName}.psd1"), "@{ ModuleVersion = '1.0.0'; RootModule = 'TestModule.psm1' }");
+            File.WriteAllText(Path.Combine(root, $"{moduleName}.psm1"), "function Import-TestModuleDevelopmentBinaryModule { } function Invoke-TestModule { }");
+
+            var mutator = new RecordingManifestMutator();
+            var scriptDetector = new RecordingScriptFunctionExportDetector(
+                "Import-TestModuleDevelopmentBinaryModule",
+                "Invoke-TestModule");
+            var builder = new ModuleBuilder(new NullLogger(), mutator, scriptDetector);
+
+            builder.BuildInPlace(new ModuleBuilder.Options
+            {
+                ProjectRoot = root,
+                ModuleName = moduleName,
+                ModuleVersion = "2.0.0"
+            });
+
+            var exportWrite = Assert.Single(mutator.TopLevelStringArrayWrites, static write => write.Key == "FunctionsToExport");
+            Assert.Equal(new[] { "Invoke-TestModule" }, exportWrite.Values);
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+
     private sealed class RecordingManifestMutator : IModuleManifestMutator
     {
         public List<(string FilePath, string NewVersion)> TopLevelVersionWrites { get; } = new();

--- a/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
+++ b/PowerForge.Tests/ModulePipelineExportAssemblyInferenceTests.cs
@@ -906,6 +906,52 @@ public sealed class ModulePipelineExportAssemblyInferenceTests
     }
 
     [Fact]
+    public void BuildToStaging_WithDesktopBinaryConflict_ReturnsAdvisoryWithoutFailingBuild()
+    {
+        var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "DemoModule";
+            var source = Path.Combine(tempRoot.FullName, "src");
+            var staging = Path.Combine(tempRoot.FullName, "staging");
+            var stagedAssembly = BuildLibrary(tempRoot.FullName, "SharedAuth", "2.0.0");
+            var installedAssembly = BuildLibrary(tempRoot.FullName, "SharedAuth", "1.0.0", projectFolderName: "SharedAuth_DesktopOther");
+
+            WriteMinimalBinaryModule(source, moduleName);
+            Directory.CreateDirectory(Path.Combine(source, "Lib", "Default"));
+            File.Copy(stagedAssembly, Path.Combine(source, "Lib", "Default", "SharedAuth.dll"), overwrite: true);
+
+            var moduleSearchRoot = Directory.CreateDirectory(Path.Combine(tempRoot.FullName, "PSModules"));
+            var installedModuleDir = Directory.CreateDirectory(Path.Combine(moduleSearchRoot.FullName, "OtherModule", "1.0.0", "bin"));
+            File.Copy(installedAssembly, Path.Combine(installedModuleDir.FullName, "SharedAuth.dll"), overwrite: true);
+
+            var pipeline = ModuleBuildPipelineFactory.Create(new NullLogger());
+            var result = pipeline.BuildToStaging(new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = source,
+                StagingPath = staging,
+                Version = "1.0.0",
+                Frameworks = new[] { "net472", "net8.0" },
+                ExportAssemblies = new[] { "SharedAuth.dll" },
+                DisableBinaryCmdletScan = true,
+                UseAssemblyLoadContext = true,
+                BinaryConflictSearchRoots = new[] { moduleSearchRoot.FullName }
+            });
+
+            Assert.True(Directory.Exists(result.StagingPath));
+            Assert.Contains(
+                result.BuildNotes,
+                note => note.Severity == ModuleOwnerNoteSeverity.Warning &&
+                        note.Title.Contains("Binary Conflicts (Desktop)", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { tempRoot.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void BuildToStaging_DirectBuildSpecExplicitNone_DoesNotEmitTypeAcceleratorBootstrapper()
     {
         var tempRoot = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -289,7 +289,12 @@ public sealed class ModuleBuilder
         }
 
         if (scripts.Length > 0)
-            functionsToSet = _scriptFunctionExportDetector.DetectScriptFunctions(scripts);
+        {
+            functionsToSet = _scriptFunctionExportDetector
+                .DetectScriptFunctions(scripts)
+                .Where(functionName => !IsGeneratedDevelopmentBinaryHelper(functionName, opts.ModuleName))
+                .ToArray();
+        }
 
         IEnumerable<string>? cmdletsToSet = null;
         IEnumerable<string>? aliasesToSet = null;
@@ -368,6 +373,16 @@ public sealed class ModuleBuilder
         if (aliases is not null)
             changed |= _manifestMutator.TrySetTopLevelStringArray(psd1Path, "AliasesToExport", aliases.ToArray());
         return changed;
+    }
+
+    private static bool IsGeneratedDevelopmentBinaryHelper(string? functionName, string moduleName)
+    {
+        if (string.IsNullOrWhiteSpace(functionName) || string.IsNullOrWhiteSpace(moduleName))
+            return false;
+
+        var trimmedFunctionName = functionName!.Trim();
+        var expected = $"Import-{moduleName}DevelopmentBinaryModule";
+        return string.Equals(trimmedFunctionName, expected, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsCore(string tfm)


### PR DESCRIPTION
## Summary
- keeps PowerForge-generated development binary loader helpers out of `FunctionsToExport`
- preserves real root-psm1 function export detection for modules that intentionally expose script functions
- adds regression coverage that Desktop binary conflict advisories do not fail staging builds by default

## Why
PSWriteOffice's packaged ALC conflict lane was failing after the OfficeIMO release because the generated `Import-<ModuleName>DevelopmentBinaryModule` helper was being detected as a public function export. Documentation parity then required command docs for that internal helper. Binary conflict scanning itself remains advisory-only: the Desktop advisory is shown, but the build continues.

## Validation
- `dotnet build .\PSPublishModule.sln --nologo`
- `dotnet test .\PowerForge.Tests\PowerForge.Tests.csproj --filter "FullyQualifiedName~ModuleBuilderManifestMutatorTests|FullyQualifiedName~ModulePipelineExportAssemblyInferenceTests" --no-build --nologo --verbosity normal`
- PSWriteOffice local build using this PSPublishModule DLL completed with documentation parity verified at 421 Markdown / 421 MAML commands
- PSWriteOffice packaged ALC conflict smoke test passed with a default-context DocumentFormat.OpenXml conflict assembly