### PR TITLE
fix(msi): preserve script-owned service lifecycle

### DIFF
--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -332,11 +332,28 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.SetUninstallService" &&
             (string?)e.Attribute("Before") == "ServiceComponent.UninstallService" &&
-            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\""));
+            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\" AND NOT UPGRADINGPRODUCTCODE"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.UninstallService" &&
             (string?)e.Attribute("Before") == "RemoveFiles" &&
-            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\""));
+            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\" AND NOT UPGRADINGPRODUCTCODE"));
+    }
+
+    [Fact]
+    public void EmitSource_SuppressServiceControlRequiresScriptUninstallCommand()
+    {
+        var definition = CreateMonitoringInstaller();
+        var service = definition.Components.OfType<PowerForgeInstallerServiceComponent>().Single();
+        service.ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+        {
+            Command = "\"[INSTALLFOLDER]Monitoring.exe\" --install --name \"TestimoX.Monitoring\"",
+            SuppressServiceControl = true
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+
+        Assert.Contains("SuppressServiceControl requires ScriptInstall.UninstallCommand", exception.Message);
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -357,6 +357,23 @@ public sealed class PowerForgeInstallerAuthoringTests
     }
 
     [Fact]
+    public void EmitSource_ScriptUninstallCommandRequiresSuppressingServiceControl()
+    {
+        var definition = CreateMonitoringInstaller();
+        var service = definition.Components.OfType<PowerForgeInstallerServiceComponent>().Single();
+        service.ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+        {
+            Command = "\"[INSTALLFOLDER]Monitoring.exe\" --install --name \"TestimoX.Monitoring\"",
+            UninstallCommand = "\"[INSTALLFOLDER]Monitoring.exe\" --uninstall --name \"TestimoX.Monitoring\""
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new PowerForgeWixInstallerSourceEmitter().EmitSource(definition));
+
+        Assert.Contains("UninstallCommand requires ScriptInstall.SuppressServiceControl", exception.Message);
+    }
+
+    [Fact]
     public void EmitSource_ModelsLicenseAgreement()
     {
         var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -163,10 +163,12 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Id") == "ServiceComponent.SetBackupCommand" &&
             (string?)e.Attribute("Property") == "WixQuietExecCmdLine" &&
             ((string?)e.Attribute("Value"))?.Contains("powershell.exe -NoLogo -NoProfile", StringComparison.Ordinal) == true &&
-            ((string?)e.Attribute("Value"))?.Contains(@"Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("PF_SERVICE=TestimoX.Monitoring", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("PF_BACKUP=[TempFolder]tmx-svc.txt", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains(@"Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("ImagePath", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("WriteAllText", StringComparison.Ordinal) == true &&
-            ((string?)e.Attribute("Value"))?.Contains("[TempFolder]tmx-svc.txt", StringComparison.Ordinal) == true));
+            ((string?)e.Attribute("Value"))?.Contains("WriteAllText($backup", StringComparison.Ordinal) == true));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ServiceComponent.SetStopService" &&
             ((string?)e.Attribute("Value"))?.Contains("exit /b 0", StringComparison.Ordinal) == true));
@@ -325,6 +327,15 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ServiceComponent.SetUninstallService" &&
             ((string?)e.Attribute("Value"))?.Contains("--uninstall --name", StringComparison.Ordinal) == true));
+        var serviceExistsProperty = doc.Descendants(Wix + "Property").SingleOrDefault(e =>
+            (string?)e.Attribute("Secure") == "yes" &&
+            e.Descendants(Wix + "RegistrySearch").Any(search =>
+                (string?)search.Attribute("Root") == "HKLM" &&
+                (string?)search.Attribute("Key") == @"SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring" &&
+                (string?)search.Attribute("Name") == "ImagePath" &&
+                (string?)search.Attribute("Type") == "raw"));
+        Assert.NotNull(serviceExistsProperty);
+        var serviceExistsPropertyId = (string)serviceExistsProperty!.Attribute("Id")!;
 
         var sequenceRows = doc.Descendants(Wix + "InstallExecuteSequence")
             .Descendants(Wix + "Custom")
@@ -332,11 +343,13 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.SetUninstallService" &&
             (string?)e.Attribute("Before") == "ServiceComponent.UninstallService" &&
-            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\" AND NOT UPGRADINGPRODUCTCODE"));
+            ((string?)e.Attribute("Condition"))?.Contains("REMOVE=\"ALL\" AND NOT UPGRADINGPRODUCTCODE", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Condition"))?.Contains(serviceExistsPropertyId, StringComparison.Ordinal) == true));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.UninstallService" &&
             (string?)e.Attribute("Before") == "RemoveFiles" &&
-            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\" AND NOT UPGRADINGPRODUCTCODE"));
+            ((string?)e.Attribute("Condition"))?.Contains("REMOVE=\"ALL\" AND NOT UPGRADINGPRODUCTCODE", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Condition"))?.Contains(serviceExistsPropertyId, StringComparison.Ordinal) == true));
     }
 
     [Fact]
@@ -552,6 +565,72 @@ public sealed class PowerForgeInstallerAuthoringTests
             command.Contains("[TempFolder]powerforge-ServiceOne-service-binpath.txt", StringComparison.Ordinal));
         Assert.Contains(backupCommands, command =>
             command.Contains("[TempFolder]powerforge-ServiceTwo-service-binpath.txt", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EmitSource_ScriptServiceBackupUsesEnvironmentForRuntimeExpandedPath()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Clear();
+        definition.Components.Add(new PowerForgeInstallerServiceComponent
+        {
+            Id = "ServiceComponent",
+            FileId = "ServiceExe",
+            Source = "$(var.PayloadDir)\\Service.exe",
+            ServiceName = "Contoso.Service",
+            DisplayName = "Contoso Service",
+            ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+            {
+                Command = "\"powershell.exe\" -NoP -EP Bypass -File \"[INSTALLFOLDER]Install-Service.ps1\"",
+                BackupExistingImagePath = true,
+                BackupPath = "[TempFolder]O'Connor\\service.txt"
+            }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        string command = doc.Descendants(Wix + "CustomAction")
+            .Where(e => (string?)e.Attribute("Id") == "ServiceComponent.SetBackupCommand")
+            .Select(e => (string?)e.Attribute("Value"))
+            .Single(value => !string.IsNullOrWhiteSpace(value))!;
+        Assert.Contains("set \"PF_BACKUP=[TempFolder]O'Connor\\service.txt\"", command, StringComparison.Ordinal);
+        Assert.Contains("[System.IO.File]::WriteAllText($backup", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("WriteAllText('[TempFolder]O''Connor", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmitSource_DoesNotUseExistingServiceUpgradeSignalWhenServiceControlRemovesOnInstall()
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Components.Clear();
+        definition.Components.Add(new PowerForgeInstallerServiceComponent
+        {
+            Id = "ServiceComponent",
+            FileId = "ServiceExe",
+            Source = "$(var.PayloadDir)\\Service.exe",
+            ServiceName = "Contoso.Service",
+            DisplayName = "Contoso Service",
+            ControlRemove = "both",
+            ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+            {
+                Command = "\"[INSTALLFOLDER]Service.exe\" --install",
+                UpgradeCommand = "\"[INSTALLFOLDER]Service.exe\" --install --preserve-existing-service-binpath"
+            }
+        });
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        var sequenceRows = doc.Descendants(Wix + "InstallExecuteSequence")
+            .Descendants(Wix + "Custom")
+            .ToArray();
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.SetInstallServiceUpgrade" &&
+            (string?)e.Attribute("Condition") == "(NOT REMOVE=\"ALL\") AND (WIX_UPGRADE_DETECTED)"));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.SetInstallService" &&
+            (string?)e.Attribute("Condition") == "(NOT REMOVE=\"ALL\") AND (NOT (WIX_UPGRADE_DETECTED))"));
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -162,10 +162,10 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ServiceComponent.SetBackupCommand" &&
             (string?)e.Attribute("Property") == "WixQuietExecCmdLine" &&
-            ((string?)e.Attribute("Value"))?.Contains(@"HKLM\SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("powershell.exe -NoLogo -NoProfile", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains(@"Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("ImagePath", StringComparison.Ordinal) == true &&
-            ((string?)e.Attribute("Value"))?.Contains("tokens=2,*", StringComparison.Ordinal) == true &&
-            ((string?)e.Attribute("Value"))?.Contains("do @echo %B", StringComparison.Ordinal) == true &&
+            ((string?)e.Attribute("Value"))?.Contains("WriteAllText", StringComparison.Ordinal) == true &&
             ((string?)e.Attribute("Value"))?.Contains("[TempFolder]tmx-svc.txt", StringComparison.Ordinal) == true));
         Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
             (string?)e.Attribute("Id") == "ServiceComponent.SetStopService" &&

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -142,6 +142,15 @@ public sealed class PowerForgeInstallerAuthoringTests
 
         var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
         var doc = XDocument.Parse(xml);
+        var serviceExistsProperty = doc.Descendants(Wix + "Property").SingleOrDefault(e =>
+            (string?)e.Attribute("Secure") == "yes" &&
+            e.Descendants(Wix + "RegistrySearch").Any(search =>
+                (string?)search.Attribute("Root") == "HKLM" &&
+                (string?)search.Attribute("Key") == @"SYSTEM\CurrentControlSet\Services\TestimoX.Monitoring" &&
+                (string?)search.Attribute("Name") == "ImagePath" &&
+                (string?)search.Attribute("Type") == "raw"));
+        Assert.NotNull(serviceExistsProperty);
+        var serviceExistsPropertyId = (string)serviceExistsProperty!.Attribute("Id")!;
 
         Assert.Null(doc.Descendants(Wix + "ServiceInstall").SingleOrDefault(e =>
             (string?)e.Attribute("Name") == "TestimoX.Monitoring"));
@@ -181,6 +190,12 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.Contains("ServiceComponent.StopService", sequenceActions);
         Assert.Contains("ServiceComponent.SetInstallServiceUpgrade", sequenceActions);
         Assert.Contains("ServiceComponent.InstallService", sequenceActions);
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.SetInstallServiceUpgrade" &&
+            ((string?)e.Attribute("Condition"))?.Contains("WIX_UPGRADE_DETECTED OR " + serviceExistsPropertyId, StringComparison.Ordinal) == true));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.SetInstallService" &&
+            ((string?)e.Attribute("Condition"))?.Contains("NOT (WIX_UPGRADE_DETECTED OR " + serviceExistsPropertyId + ")", StringComparison.Ordinal) == true));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.SetBackupCommand" &&
             (string?)e.Attribute("Before") == "RemoveExistingProducts"));
@@ -278,6 +293,50 @@ public sealed class PowerForgeInstallerAuthoringTests
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "InstallMonitoringLicense" &&
             (string?)e.Attribute("Before") == "InstallServices"));
+    }
+
+    [Fact]
+    public void EmitSource_ScriptInstallCanOwnServiceUninstallWithoutServiceControl()
+    {
+        var definition = CreateMonitoringInstaller();
+        var service = definition.Components.OfType<PowerForgeInstallerServiceComponent>().Single();
+        service.ScriptInstall = new PowerForgeInstallerServiceScriptInstall
+        {
+            Command = "\"[INSTALLFOLDER]Monitoring.exe\" --install --name \"TestimoX.Monitoring\"",
+            UpgradeCommand = "\"[INSTALLFOLDER]Monitoring.exe\" --install --name \"TestimoX.Monitoring\" --preserve-existing-service-binpath",
+            UninstallCommand = "\"[INSTALLFOLDER]Monitoring.exe\" --uninstall --name \"TestimoX.Monitoring\"",
+            SuppressServiceControl = true,
+            BackupExistingImagePath = true,
+            StopServiceForUpgrade = true
+        };
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.Null(doc.Descendants(Wix + "ServiceInstall").SingleOrDefault(e =>
+            (string?)e.Attribute("Name") == "TestimoX.Monitoring"));
+        Assert.Null(doc.Descendants(Wix + "ServiceControl").SingleOrDefault(e =>
+            (string?)e.Attribute("Name") == "TestimoX.Monitoring"));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponent.UninstallService" &&
+            (string?)e.Attribute("DllEntry") == "WixQuietExec" &&
+            (string?)e.Attribute("Execute") == "deferred" &&
+            (string?)e.Attribute("Impersonate") == "no"));
+        Assert.NotNull(doc.Descendants(Wix + "CustomAction").SingleOrDefault(e =>
+            (string?)e.Attribute("Id") == "ServiceComponent.SetUninstallService" &&
+            ((string?)e.Attribute("Value"))?.Contains("--uninstall --name", StringComparison.Ordinal) == true));
+
+        var sequenceRows = doc.Descendants(Wix + "InstallExecuteSequence")
+            .Descendants(Wix + "Custom")
+            .ToArray();
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.SetUninstallService" &&
+            (string?)e.Attribute("Before") == "ServiceComponent.UninstallService" &&
+            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\""));
+        Assert.NotNull(sequenceRows.SingleOrDefault(e =>
+            (string?)e.Attribute("Action") == "ServiceComponent.UninstallService" &&
+            (string?)e.Attribute("Before") == "RemoveFiles" &&
+            (string?)e.Attribute("Condition") == "REMOVE=\"ALL\""));
     }
 
     [Fact]
@@ -543,6 +602,33 @@ public sealed class PowerForgeInstallerAuthoringTests
             (string?)e.Attribute("Id") == "Message" &&
             (string?)e.Attribute("Text") == "Fill the required field before continuing: License key."));
         Assert.Equal(2, dialog.Descendants(Wix + "RadioButton").Count());
+    }
+
+    [Fact]
+    public void EmitSource_DoesNotInitializeUncheckedCheckboxProperties()
+    {
+        var definition = CreateMonitoringInstaller();
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.Null(doc.Descendants(Wix + "Property")
+            .SingleOrDefault(e => (string?)e.Attribute("Id") == "REMOVE_DATA"));
+    }
+
+    [Fact]
+    public void EmitSource_InitializesCheckedCheckboxProperties()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.Inputs.Single(input => input.Id == "RemoveData").DefaultValue = "true";
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+
+        Assert.NotNull(doc.Descendants(Wix + "Property")
+            .SingleOrDefault(e =>
+                (string?)e.Attribute("Id") == "REMOVE_DATA" &&
+                (string?)e.Attribute("Value") == "1"));
     }
 
     [Fact]

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -691,7 +691,7 @@ public sealed class PowerForgeInstallerServiceScriptInstall
     /// <summary>
     /// Condition used for the deferred uninstall action.
     /// </summary>
-    public string UninstallCondition { get; set; } = "REMOVE=\"ALL\"";
+    public string UninstallCondition { get; set; } = "REMOVE=\"ALL\" AND NOT UPGRADINGPRODUCTCODE";
 
     /// <summary>
     /// Suppresses WiX ServiceControl emission when script actions fully own service lifecycle.

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -683,6 +683,22 @@ public sealed class PowerForgeInstallerServiceScriptInstall
     public string? UpgradeCommand { get; set; }
 
     /// <summary>
+    /// Optional uninstall command used when script-based service registration owns service removal.
+    /// Supports WiX formatted properties.
+    /// </summary>
+    public string? UninstallCommand { get; set; }
+
+    /// <summary>
+    /// Condition used for the deferred uninstall action.
+    /// </summary>
+    public string UninstallCondition { get; set; } = "REMOVE=\"ALL\"";
+
+    /// <summary>
+    /// Suppresses WiX ServiceControl emission when script actions fully own service lifecycle.
+    /// </summary>
+    public bool SuppressServiceControl { get; set; }
+
+    /// <summary>
     /// Condition used for the deferred install action.
     /// </summary>
     public string Condition { get; set; } = "NOT REMOVE=\"ALL\"";

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -1127,6 +1127,9 @@ public sealed partial class DotNetPublishPipelineRunner
         {
             Command = script.Command,
             UpgradeCommand = script.UpgradeCommand,
+            UninstallCommand = script.UninstallCommand,
+            UninstallCondition = script.UninstallCondition,
+            SuppressServiceControl = script.SuppressServiceControl,
             Condition = script.Condition,
             BackupExistingImagePath = script.BackupExistingImagePath,
             BackupPath = script.BackupPath,

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -307,6 +307,8 @@ internal static class PowerForgeInstallerDefinitionValidator
 
         Require(script.Command, $"service component '{service.Id}' ScriptInstall.Command");
         Require(script.Condition, $"service component '{service.Id}' ScriptInstall.Condition");
+        if (!string.IsNullOrWhiteSpace(script.UninstallCommand))
+            Require(script.UninstallCondition, $"service component '{service.Id}' ScriptInstall.UninstallCondition");
         if (script.BackupExistingImagePath)
             Require(script.BackupPath, $"service component '{service.Id}' ScriptInstall.BackupPath");
         if (script.StopDelaySeconds < 0)

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -309,6 +309,12 @@ internal static class PowerForgeInstallerDefinitionValidator
         Require(script.Condition, $"service component '{service.Id}' ScriptInstall.Condition");
         if (!string.IsNullOrWhiteSpace(script.UninstallCommand))
             Require(script.UninstallCondition, $"service component '{service.Id}' ScriptInstall.UninstallCondition");
+        else if (script.SuppressServiceControl)
+        {
+            throw new InvalidOperationException(
+                $"Service component '{service.Id}' ScriptInstall.SuppressServiceControl requires ScriptInstall.UninstallCommand.");
+        }
+
         if (script.BackupExistingImagePath)
             Require(script.BackupPath, $"service component '{service.Id}' ScriptInstall.BackupPath");
         if (script.StopDelaySeconds < 0)

--- a/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
+++ b/PowerForge/Services/Installers/PowerForgeInstallerDefinitionValidator.cs
@@ -308,7 +308,14 @@ internal static class PowerForgeInstallerDefinitionValidator
         Require(script.Command, $"service component '{service.Id}' ScriptInstall.Command");
         Require(script.Condition, $"service component '{service.Id}' ScriptInstall.Condition");
         if (!string.IsNullOrWhiteSpace(script.UninstallCommand))
+        {
             Require(script.UninstallCondition, $"service component '{service.Id}' ScriptInstall.UninstallCondition");
+            if (!script.SuppressServiceControl)
+            {
+                throw new InvalidOperationException(
+                    $"Service component '{service.Id}' ScriptInstall.UninstallCommand requires ScriptInstall.SuppressServiceControl.");
+            }
+        }
         else if (script.SuppressServiceControl)
         {
             throw new InvalidOperationException(

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -236,12 +236,19 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         PowerForgeInstallerServiceComponent service,
         string backupPath)
     {
-        var serviceName = EscapeCommandDoubleQuoted(service.ServiceName);
-        var backup = EscapeCommandDoubleQuoted(backupPath);
-        return "\"[%ComSpec]\" /c (for /f \"tokens=2,*\" %A in ('reg query \"HKLM\\SYSTEM\\CurrentControlSet\\Services\\" +
-               serviceName +
-               "\" /v ImagePath 2^>nul ^| find \"ImagePath\"') do @echo %B)>\"" +
-               backup +
+        string serviceName = EscapePowerShellSingleQuoted(service.ServiceName);
+        string backup = EscapePowerShellSingleQuoted(backupPath);
+        string command = "$p=(Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\" +
+                         serviceName +
+                         "' -Name ImagePath -ErrorAction SilentlyContinue).ImagePath; if ($null -ne $p) { [System.IO.File]::WriteAllText('" +
+                         backup +
+                         "', [string]$p) } elseif (Test-Path -LiteralPath '" +
+                         backup +
+                         "') { Remove-Item -LiteralPath '" +
+                         backup +
+                         "' -Force }";
+        return "\"[%ComSpec]\" /c powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command \"" +
+               EscapeCommandDoubleQuoted(command) +
                "\"";
     }
 
@@ -297,6 +304,9 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
 
     private static string EscapeCommandDoubleQuoted(string value)
         => (value ?? string.Empty).Replace("\"", "\\\"");
+
+    private static string EscapePowerShellSingleQuoted(string value)
+        => (value ?? string.Empty).Replace("'", "''");
 
     private static string CombineConditions(params string[] conditions)
     {

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -50,6 +50,8 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         yield return ids.InstallServiceId;
         yield return ids.SetInstallStandardId;
         yield return ids.SetInstallUpgradeId;
+        yield return ids.UninstallServiceId;
+        yield return ids.SetUninstallServiceId;
     }
 
     private static string? EmitServiceActions(
@@ -61,10 +63,21 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         var script = service.ScriptInstall!;
         var ids = BuildIds(service.Id);
         var resolvedBackupPath = ResolveBackupPath(service, script);
-        var upgradeCondition = CombineConditions(script.Condition, "WIX_UPGRADE_DETECTED", "NOT REMOVE=\"ALL\"");
+        string? serviceExistsProperty = string.IsNullOrWhiteSpace(script.UpgradeCommand)
+            ? null
+            : ids.ServiceExistsPropertyId;
+        var upgradeSignal = string.IsNullOrWhiteSpace(serviceExistsProperty)
+            ? "WIX_UPGRADE_DETECTED"
+            : "WIX_UPGRADE_DETECTED OR " + serviceExistsProperty;
+        var upgradeCondition = CombineConditions(script.Condition, upgradeSignal, "NOT REMOVE=\"ALL\"");
         var standardCondition = string.IsNullOrWhiteSpace(script.UpgradeCommand)
             ? script.Condition
-            : CombineConditions(script.Condition, "NOT WIX_UPGRADE_DETECTED", "NOT REMOVE=\"ALL\"");
+            : CombineConditions(script.Condition, "NOT (" + upgradeSignal + ")", "NOT REMOVE=\"ALL\"");
+
+        if (!string.IsNullOrWhiteSpace(serviceExistsProperty))
+        {
+            actions.Add(CreateExistingServiceSearch(serviceExistsProperty!, service));
+        }
 
         if (script.BackupExistingImagePath)
         {
@@ -83,6 +96,12 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         if (!string.IsNullOrWhiteSpace(script.UpgradeCommand))
         {
             actions.Add(CreateSetInstallCommand(ids.SetInstallUpgradeId, ids.InstallServiceId, script.UpgradeCommand!));
+        }
+
+        if (!string.IsNullOrWhiteSpace(script.UninstallCommand))
+        {
+            actions.Add(CreateQuietExecAction(ids.UninstallServiceId, execute: "deferred", hideTarget: true));
+            actions.Add(CreateSetInstallCommand(ids.SetUninstallServiceId, ids.UninstallServiceId, script.UninstallCommand!));
         }
 
         actions.Add(CreateSetInstallCommand(ids.SetInstallStandardId, ids.InstallServiceId, script.Command));
@@ -127,6 +146,20 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
                 new XAttribute("Action", ids.SetInstallUpgradeId),
                 new XAttribute("Before", ids.InstallServiceId),
                 new XAttribute("Condition", upgradeCondition)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(script.UninstallCommand))
+        {
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.SetUninstallServiceId),
+                new XAttribute("Before", ids.UninstallServiceId),
+                new XAttribute("Condition", script.UninstallCondition)));
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", ids.UninstallServiceId),
+                new XAttribute("Before", "RemoveFiles"),
+                new XAttribute("Condition", script.UninstallCondition)));
         }
 
         sequence.Add(new XElement(
@@ -174,6 +207,19 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             element.Add(new XAttribute("HideTarget", "yes"));
         return element;
     }
+
+    private static XElement CreateExistingServiceSearch(string propertyId, PowerForgeInstallerServiceComponent service)
+        => new(
+            WixNamespace + "Property",
+            new XAttribute("Id", propertyId),
+            new XAttribute("Secure", "yes"),
+            new XElement(
+                WixNamespace + "RegistrySearch",
+                new XAttribute("Id", propertyId + "_SEARCH"),
+                new XAttribute("Root", "HKLM"),
+                new XAttribute("Key", "SYSTEM\\CurrentControlSet\\Services\\" + service.ServiceName),
+                new XAttribute("Name", "ImagePath"),
+                new XAttribute("Type", "raw")));
 
     private static XElement CreateSetInstallCommand(string id, string actionId, string command)
         => new(
@@ -225,7 +271,10 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             BuildActionId(prefix, "StopService"),
             BuildActionId(prefix, "InstallService"),
             BuildActionId(prefix, "SetInstallService"),
-            BuildActionId(prefix, "SetInstallServiceUpgrade"));
+            BuildActionId(prefix, "SetInstallServiceUpgrade"),
+            BuildActionId(prefix, "UninstallService"),
+            BuildActionId(prefix, "SetUninstallService"),
+            "PF_" + HashId(serviceComponentId).ToUpperInvariant() + "_SERVICE_EXISTS");
     }
 
     private static string BuildActionId(string prefix, string suffix)
@@ -277,7 +326,10 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             string stopServiceId,
             string installServiceId,
             string setInstallStandardId,
-            string setInstallUpgradeId)
+            string setInstallUpgradeId,
+            string uninstallServiceId,
+            string setUninstallServiceId,
+            string serviceExistsPropertyId)
         {
             BackupImagePathId = backupImagePathId;
             SetBackupCommandId = setBackupCommandId;
@@ -286,6 +338,9 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             InstallServiceId = installServiceId;
             SetInstallStandardId = setInstallStandardId;
             SetInstallUpgradeId = setInstallUpgradeId;
+            UninstallServiceId = uninstallServiceId;
+            SetUninstallServiceId = setUninstallServiceId;
+            ServiceExistsPropertyId = serviceExistsPropertyId;
         }
 
         internal string BackupImagePathId { get; }
@@ -295,5 +350,8 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         internal string InstallServiceId { get; }
         internal string SetInstallStandardId { get; }
         internal string SetInstallUpgradeId { get; }
+        internal string UninstallServiceId { get; }
+        internal string SetUninstallServiceId { get; }
+        internal string ServiceExistsPropertyId { get; }
     }
 }

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -63,16 +63,24 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         var script = service.ScriptInstall!;
         var ids = BuildIds(service.Id);
         var resolvedBackupPath = ResolveBackupPath(service, script);
-        string? serviceExistsProperty = string.IsNullOrWhiteSpace(script.UpgradeCommand)
+        bool hasUninstallCommand = !string.IsNullOrWhiteSpace(script.UninstallCommand);
+        string? serviceExistsProperty = string.IsNullOrWhiteSpace(script.UpgradeCommand) && !hasUninstallCommand
             ? null
             : ids.ServiceExistsPropertyId;
-        var upgradeSignal = string.IsNullOrWhiteSpace(serviceExistsProperty)
+        var existingServiceUpgradeSignal = !string.IsNullOrWhiteSpace(serviceExistsProperty) &&
+                                           CanUseExistingServiceUpgradeSignal(service)
+            ? serviceExistsProperty
+            : null;
+        var upgradeSignal = string.IsNullOrWhiteSpace(existingServiceUpgradeSignal)
             ? "WIX_UPGRADE_DETECTED"
-            : "WIX_UPGRADE_DETECTED OR " + serviceExistsProperty;
+            : "WIX_UPGRADE_DETECTED OR " + existingServiceUpgradeSignal;
         var upgradeCondition = CombineConditions(script.Condition, upgradeSignal, "NOT REMOVE=\"ALL\"");
         var standardCondition = string.IsNullOrWhiteSpace(script.UpgradeCommand)
             ? script.Condition
             : CombineConditions(script.Condition, "NOT (" + upgradeSignal + ")", "NOT REMOVE=\"ALL\"");
+        string uninstallCondition = !hasUninstallCommand || string.IsNullOrWhiteSpace(serviceExistsProperty)
+            ? script.UninstallCondition
+            : CombineConditions(script.UninstallCondition, serviceExistsProperty!);
 
         if (!string.IsNullOrWhiteSpace(serviceExistsProperty))
         {
@@ -98,14 +106,14 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             actions.Add(CreateSetInstallCommand(ids.SetInstallUpgradeId, ids.InstallServiceId, script.UpgradeCommand!));
         }
 
-        if (!string.IsNullOrWhiteSpace(script.UninstallCommand))
+        if (hasUninstallCommand)
         {
             actions.Add(CreateQuietExecAction(ids.UninstallServiceId, execute: "deferred", hideTarget: true));
             actions.Add(CreateSetInstallCommand(ids.SetUninstallServiceId, ids.UninstallServiceId, script.UninstallCommand!));
         }
 
         actions.Add(CreateSetInstallCommand(ids.SetInstallStandardId, ids.InstallServiceId, script.Command));
-        return AddSequenceRows(sequence, ids, script, standardCondition, upgradeCondition, upgradeSequenceTail);
+        return AddSequenceRows(sequence, ids, script, standardCondition, upgradeCondition, uninstallCondition, upgradeSequenceTail);
     }
 
     private static string? AddSequenceRows(
@@ -114,6 +122,7 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         PowerForgeInstallerServiceScriptInstall script,
         string standardCondition,
         string upgradeCondition,
+        string uninstallCondition,
         string? upgradeSequenceTail)
     {
         string? tail = upgradeSequenceTail;
@@ -154,12 +163,12 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
                 WixNamespace + "Custom",
                 new XAttribute("Action", ids.SetUninstallServiceId),
                 new XAttribute("Before", ids.UninstallServiceId),
-                new XAttribute("Condition", script.UninstallCondition)));
+                new XAttribute("Condition", uninstallCondition)));
             sequence.Add(new XElement(
                 WixNamespace + "Custom",
                 new XAttribute("Action", ids.UninstallServiceId),
                 new XAttribute("Before", "RemoveFiles"),
-                new XAttribute("Condition", script.UninstallCondition)));
+                new XAttribute("Condition", uninstallCondition)));
         }
 
         sequence.Add(new XElement(
@@ -236,18 +245,14 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         PowerForgeInstallerServiceComponent service,
         string backupPath)
     {
-        string serviceName = EscapePowerShellSingleQuoted(service.ServiceName);
-        string backup = EscapePowerShellSingleQuoted(backupPath);
-        string command = "$p=(Get-ItemProperty -LiteralPath 'Registry::HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\" +
-                         serviceName +
-                         "' -Name ImagePath -ErrorAction SilentlyContinue).ImagePath; if ($null -ne $p) { [System.IO.File]::WriteAllText('" +
-                         backup +
-                         "', [string]$p) } elseif (Test-Path -LiteralPath '" +
-                         backup +
-                         "') { Remove-Item -LiteralPath '" +
-                         backup +
-                         "' -Force }";
-        return "\"[%ComSpec]\" /c powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command \"" +
+        string serviceName = EscapeCmdSetValue(service.ServiceName);
+        string backup = EscapeCmdSetValue(backupPath);
+        string command = "$svc=$env:PF_SERVICE; $backup=$env:PF_BACKUP; $key=Join-Path 'Registry::HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services' $svc; $p=(Get-ItemProperty -LiteralPath $key -Name ImagePath -ErrorAction SilentlyContinue).ImagePath; if ($null -ne $p) { [System.IO.File]::WriteAllText($backup, [string]$p) } elseif (Test-Path -LiteralPath $backup) { Remove-Item -LiteralPath $backup -Force }";
+        return "\"[%ComSpec]\" /c set \"PF_SERVICE=" +
+               serviceName +
+               "\" && set \"PF_BACKUP=" +
+               backup +
+               "\" && powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command \"" +
                EscapeCommandDoubleQuoted(command) +
                "\"";
     }
@@ -308,6 +313,9 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
     private static string EscapePowerShellSingleQuoted(string value)
         => (value ?? string.Empty).Replace("'", "''");
 
+    private static string EscapeCmdSetValue(string value)
+        => (value ?? string.Empty).Replace("\"", string.Empty);
+
     private static string CombineConditions(params string[] conditions)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -319,6 +327,14 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             .ToArray();
         return string.Join(" AND ", parts);
     }
+
+    private static bool CanUseExistingServiceUpgradeSignal(PowerForgeInstallerServiceComponent service)
+        => service.ScriptInstall?.SuppressServiceControl == true ||
+           !RemovesServiceDuringInstall(service.ControlRemove);
+
+    private static bool RemovesServiceDuringInstall(string? controlRemove)
+        => string.Equals(controlRemove, "install", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(controlRemove, "both", StringComparison.OrdinalIgnoreCase);
 
     private static string HashId(string value)
     {

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -149,7 +149,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
         foreach (var input in definition.Inputs)
         {
-            if (string.IsNullOrWhiteSpace(input.DefaultValue) &&
+            string? defaultValue = NormalizeDefaultValue(input);
+            if (string.IsNullOrWhiteSpace(defaultValue) &&
                 !input.Secure &&
                 !input.Hidden &&
                 input.RegistrySearch is null)
@@ -161,8 +162,8 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 WixNamespace + "Property",
                 new XAttribute("Id", input.PropertyName));
 
-            if (!string.IsNullOrWhiteSpace(input.DefaultValue))
-                property.Add(new XAttribute("Value", input.DefaultValue!));
+            if (!string.IsNullOrWhiteSpace(defaultValue))
+                property.Add(new XAttribute("Value", defaultValue!));
             if (input.Secure)
                 property.Add(new XAttribute("Secure", "yes"));
             if (input.Hidden)
@@ -180,6 +181,26 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
         package.Add(property);
         }
+    }
+
+    private static string? NormalizeDefaultValue(PowerForgeInstallerInput input)
+    {
+        if (input.Kind != PowerForgeInstallerInputKind.Checkbox)
+            return input.DefaultValue;
+
+        string? defaultValue = input.DefaultValue;
+        if (string.IsNullOrWhiteSpace(defaultValue))
+            return null;
+
+        string value = defaultValue!.Trim();
+        if (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase))
+        {
+            return "1";
+        }
+
+        return null;
     }
 
     private static void EmitLaunchConditions(XElement package, PowerForgeInstallerDefinition definition)
@@ -894,14 +915,17 @@ public sealed class PowerForgeWixInstallerSourceEmitter
                 new XAttribute("Value", "1")));
         }
 
-        component.Add(new XElement(
-            WixNamespace + "ServiceControl",
-            new XAttribute("Id", service.Id + "Control"),
-            new XAttribute("Name", service.ServiceName),
-            new XAttribute("Start", service.ControlStart),
-            new XAttribute("Stop", service.ControlStop),
-            new XAttribute("Remove", service.ControlRemove),
-            new XAttribute("Wait", "yes")));
+        if (service.ScriptInstall?.SuppressServiceControl != true)
+        {
+            component.Add(new XElement(
+                WixNamespace + "ServiceControl",
+                new XAttribute("Id", service.Id + "Control"),
+                new XAttribute("Name", service.ServiceName),
+                new XAttribute("Start", service.ControlStart),
+                new XAttribute("Stop", service.ControlStop),
+                new XAttribute("Remove", service.ControlRemove),
+                new XAttribute("Wait", "yes")));
+        }
 
         return component;
     }

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -412,6 +412,9 @@
       "properties": {
         "Command": { "type": "string", "minLength": 1 },
         "UpgradeCommand": { "type": ["string", "null"], "minLength": 1 },
+        "UninstallCommand": { "type": ["string", "null"], "minLength": 1 },
+        "UninstallCondition": { "type": "string", "minLength": 1 },
+        "SuppressServiceControl": { "type": "boolean" },
         "Condition": { "type": "string", "minLength": 1 },
         "BackupExistingImagePath": { "type": "boolean" },
         "BackupPath": { "type": "string", "minLength": 1 },


### PR DESCRIPTION
## Summary
- avoid initializing unchecked checkbox inputs as checked in generated MSI UI
- detect existing script-installed services through AppSearch and use preserve/update commands when MSI will not remove the service before the script runs
- add script-owned uninstall support plus optional ServiceControl suppression for services where executable custom actions own registration/removal
- harden service ImagePath backup by reading the registry value through PowerShell and passing runtime-expanded backup paths safely through environment variables
- gate script-owned uninstall actions by actual service registration so optional services do not fail uninstall when they were never installed

## Why
TestimoX Monitoring upgrades exposed a risky path where WiX could delete or mark the service for deletion before the executable-based preservation/update action ran. This keeps script-owned service lifecycle under the script, gives uninstall a clean hook, and preserves custom service `--config` paths more reliably during major upgrades.

## Validation
- dotnet.exe build PowerForge\PowerForge.csproj -c Debug -f net472 --no-restore
- dotnet.exe test PowerForge.Tests\PowerForge.Tests.csproj -c Debug --filter "FullyQualifiedName~PowerForgeInstallerAuthoringTests" --no-restore
- git diff --check -- PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs