### PR TITLE
fix(publish): escape MSBuild property values

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerHardeningTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using Xunit;
@@ -9,6 +10,21 @@ namespace PowerForge.Tests;
 
 public sealed class DotNetPublishPipelineRunnerHardeningTests
 {
+    [Fact]
+    public void BuildMsBuildPropertyArgs_EscapesListAndAssignmentSeparators()
+    {
+        var properties = new Dictionary<string, string>
+        {
+            ["MonitoringDbProviders"] = "Sqlite,SqlServer",
+            ["Composite"] = "one;two=three%$@"
+        };
+
+        string[] arguments = DotNetPublishPipelineRunner.BuildMsBuildPropertyArgs(properties).ToArray();
+
+        Assert.Contains("/p:MonitoringDbProviders=Sqlite%2CSqlServer", arguments);
+        Assert.Contains("/p:Composite=one%3Btwo%3Dthree%25%24%40", arguments);
+    }
+
     [Fact]
     public void Plan_DeniesOutputPathOutsideProjectRoot_ByDefault()
     {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -241,13 +241,22 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
-    private static IEnumerable<string> BuildMsBuildPropertyArgs(IReadOnlyDictionary<string, string> props)
+    internal static IEnumerable<string> BuildMsBuildPropertyArgs(IReadOnlyDictionary<string, string> props)
     {
         if (props is null || props.Count == 0) return Array.Empty<string>();
         return props
             .Where(kv => !string.IsNullOrWhiteSpace(kv.Key))
-            .Select(kv => $"/p:{kv.Key}={kv.Value}");
+            .Select(kv => $"/p:{kv.Key}={EscapeMsBuildPropertyValue(kv.Value)}");
     }
+
+    private static string EscapeMsBuildPropertyValue(string? value)
+        => (value ?? string.Empty)
+            .Replace("%", "%25")
+            .Replace(";", "%3B")
+            .Replace(",", "%2C")
+            .Replace("=", "%3D")
+            .Replace("$", "%24")
+            .Replace("@", "%40");
 
     internal static string ResolvePath(string baseDir, string path)
     {


### PR DESCRIPTION
## Summary

PowerForge now percent-escapes MSBuild property values before passing them as `/p:` command-line arguments. This allows list-valued properties such as `Sqlite,SqlServer` and values containing semicolons, assignments, percent signs, dollar signs, or at signs to reach MSBuild as one property value instead of being split into additional properties.

## Why

Publishing TestimoX.Monitoring with more than one database provider failed with `MSB1006` because the comma-delimited value was interpreted by MSBuild command-line parsing. The escaping belongs in the shared publish pipeline so every PowerForge consumer gets the same behavior.

## Validation

- Focused PowerForge hardening suite: 29 tests passed
- TestimoX.Monitoring multi-provider package completed successfully with `MonitoringDbProviders=Sqlite,SqlServer`