### PR TITLE
fix(pack): resolve RID-specific package provenance outputs

### DIFF
--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -974,6 +974,61 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
+    public void ResolveBuildOutputDirectories_ProbesRidSpecificTargetDirInsteadOfFrameworkParent()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            var csprojPath = Path.Combine(projectDir.FullName, "Sample.Package.csproj");
+            File.WriteAllText(csprojPath, string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net472</TargetFramework>",
+                "    <RuntimeIdentifier>win-x64</RuntimeIdentifier>",
+                "    <AssemblyName>Sample.Package</AssemblyName>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            var frameworkDirectory = Directory.CreateDirectory(
+                Path.Combine(projectDir.FullName, "bin", "Release", "net472"));
+            var ridTargetDirectory = Directory.CreateDirectory(Path.Combine(frameworkDirectory.FullName, "win-x64"));
+            File.WriteAllText(Path.Combine(ridTargetDirectory.FullName, "Sample.Package.dll"), "rid-output");
+
+            var method = typeof(DotNetRepositoryReleaseService).GetMethod(
+                "ResolveBuildOutputDirectories",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(method);
+            var directories = Assert.IsType<string[]>(method!.Invoke(null, new object?[]
+            {
+                csprojPath,
+                projectDir.FullName,
+                "Release",
+                "Sample.Package",
+                new NullLogger(),
+                new[] { "Sample.Package.dll" }
+            }));
+
+            string expected = Path.GetFullPath(ridTargetDirectory.FullName)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            Assert.Contains(directories, path => string.Equals(
+                path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                expected,
+                StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(directories, path => string.Equals(
+                path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                Path.GetFullPath(frameworkDirectory.FullName).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_WithAssemblySigning_PreflightsBeforeEditingProjectVersion()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -650,7 +650,7 @@ public sealed partial class DotNetRepositoryReleaseService
             if (string.IsNullOrWhiteSpace(includePattern))
                 continue;
 
-            if (Directory.EnumerateFiles(directory, includePattern, SearchOption.AllDirectories).Any())
+            if (Directory.EnumerateFiles(directory, includePattern, SearchOption.TopDirectoryOnly).Any())
                 return true;
         }
 


### PR DESCRIPTION
## Summary

Fix package payload provenance validation for projects whose build output is nested beneath a runtime identifier, such as `bin/Release/net472/win-x64`.

PowerForge now treats a conventional target-framework directory as a valid fresh-output directory only when the expected primary assembly exists directly in that directory. Otherwise it evaluates MSBuild `TargetDir`, allowing RID-specific outputs to participate in package hash verification without admitting stale nested `publish` copies.

## Consumer impact

This unblocks DbaClientX SQLite package validation: its net472 output is RID-specific, and the packaged DLL can now be matched to the freshly rebuilt `win-x64` assembly.

## Validation

- 41 focused repository release and package provenance tests passed
- the DbaClientX six-package build passed payload provenance with this PowerForge build and advanced to the expected local certificate-signing gate
