### PR TITLE
Prevent stale RID packages and report build failures

### DIFF
--- a/PSPublishModule/Cmdlets/InvokeModuleBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeModuleBuildCommand.cs
@@ -494,6 +494,8 @@ public sealed partial class InvokeModuleBuildCommand : PSCmdlet
                 try { SpectrePipelineConsoleUi.WriteFailureSummary(workflow.Plan, ex); }
                 catch { /* best effort */ }
             }
+            if (outcome.ShouldWriteFailureMessage)
+                logger.Error(outcome.FailureMessage);
         }
 
         if (outcome.Succeeded)

--- a/PowerForge.ConsoleShared/SpectrePipelineSummaryWriter.cs
+++ b/PowerForge.ConsoleShared/SpectrePipelineSummaryWriter.cs
@@ -1098,6 +1098,7 @@ internal static class SpectrePipelineSummaryWriter
 
         var preferredPrefixes = new[]
         {
+            "Project build failed:",
             "Import-Module failed",
             "Cause:",
             "Detail:",

--- a/PowerForge.PowerShell/Models/ModuleBuildCompletionOutcome.cs
+++ b/PowerForge.PowerShell/Models/ModuleBuildCompletionOutcome.cs
@@ -9,5 +9,7 @@ internal sealed class ModuleBuildCompletionOutcome
     public string ErrorRecordId { get; set; } = string.Empty;
     public bool ShouldReplayBufferedLogs { get; set; }
     public bool ShouldWriteInteractiveFailureSummary { get; set; }
+    public bool ShouldWriteFailureMessage { get; set; }
+    public string FailureMessage { get; set; } = string.Empty;
     public string CompletionMessage { get; set; } = string.Empty;
 }

--- a/PowerForge.PowerShell/Services/ModuleBuildOutcomeService.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildOutcomeService.cs
@@ -20,6 +20,7 @@ internal sealed class ModuleBuildOutcomeService
     {
         var succeeded = workflow?.Succeeded ?? false;
         var duration = _logSupport.FormatDuration(elapsed);
+        var failureMessage = workflow?.Error?.Message?.Trim() ?? string.Empty;
 
         return new ModuleBuildCompletionOutcome
         {
@@ -36,6 +37,11 @@ internal sealed class ModuleBuildOutcomeService
                                                 workflow?.UsedInteractiveView == true &&
                                                 workflow?.Plan is not null &&
                                                 !workflow.WrotePolicySummary,
+            ShouldWriteFailureMessage = !succeeded &&
+                                        exitCodeMode &&
+                                        workflow?.UsedInteractiveView != true &&
+                                        failureMessage.Length > 0,
+            FailureMessage = failureMessage,
             CompletionMessage = succeeded
                 ? (jsonOnly
                     ? $"Pipeline config generated in {duration}"

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -208,6 +208,7 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
                     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+                    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
                   </PropertyGroup>
                 </Project>
                 """);
@@ -272,6 +273,7 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
                     <TargetFramework>net8.0</TargetFramework>
+                    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
                   </PropertyGroup>
                   <Import Project="build/outputs.props" />
                 </Project>

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -182,6 +182,134 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
         }
     }
 
+    [Fact]
+    public void FreshnessCleanup_EvaluatesConfiguredMetadataForEveryTargetFramework()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                    <AssemblyName>Sample.Net8</AssemblyName>
+                    <OutputPath>$(MSBuildThisFileDirectory)artifacts/bin/Release/net8.0/</OutputPath>
+                    <IntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts/obj/Release/net8.0/</IntermediateOutputPath>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+                    <AssemblyName>Sample.Net10</AssemblyName>
+                    <OutputPath>$(MSBuildThisFileDirectory)artifacts/bin/Release/net10.0/</OutputPath>
+                    <IntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts/obj/Release/net10.0/</IntermediateOutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.MultiTarget"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.MultiTarget.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var stalePaths = new[]
+            {
+                Path.Combine(root.FullName, "artifacts", "bin", "Release", "net8.0", "Sample.Net8.dll"),
+                Path.Combine(root.FullName, "artifacts", "bin", "Release", "net8.0", "old-rid", "Sample.Net8.dll"),
+                Path.Combine(root.FullName, "artifacts", "obj", "Release", "net8.0", "Sample.Net8.dll"),
+                Path.Combine(root.FullName, "artifacts", "bin", "Release", "net10.0", "Sample.Net10.dll"),
+                Path.Combine(root.FullName, "artifacts", "obj", "Release", "net10.0", "Sample.Net10.dll")
+            };
+            foreach (var path in stalePaths)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.MultiTarget",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(stalePaths.Length, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.All(stalePaths, path => Assert.False(File.Exists(path)));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FreshnessCleanup_EvaluatesMetadataFromExplicitProjectImport()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Imported"));
+            var importDirectory = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "build"));
+            File.WriteAllText(Path.Combine(importDirectory.FullName, "outputs.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <AssemblyName>Imported.Primary</AssemblyName>
+                    <OutputPath>$(MSBuildThisFileDirectory)../imported/bin/Release/net8.0/</OutputPath>
+                    <IntermediateOutputPath>$(MSBuildThisFileDirectory)../imported/obj/Release/net8.0/</IntermediateOutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Imported.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <Import Project="build/outputs.props" />
+                </Project>
+                """);
+
+            var output = Path.Combine(projectDirectory.FullName, "imported", "bin", "Release", "net8.0", "Imported.Primary.dll");
+            var intermediate = Path.Combine(projectDirectory.FullName, "imported", "obj", "Release", "net8.0", "Imported.Primary.dll");
+            foreach (var path in new[] { output, intermediate })
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.Imported",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(2, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.False(File.Exists(output));
+            Assert.False(File.Exists(intermediate));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
     [InlineData(DotNetRepositoryPackStrategy.PerProject, false, false, false)]
     [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, false, false)]

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -8,12 +8,72 @@ namespace PowerForge.Tests;
 
 public sealed class DotNetRepositoryReleaseFreshBuildTests
 {
+    [Fact]
+    public void FreshnessCleanup_RemovesOnlyPrimaryAssembliesFromSelectedConfigurationOutputs()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Package"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Package.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <AssemblyName>Sample.Primary</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var releaseFramework = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0"));
+            var releaseRid = Directory.CreateDirectory(Path.Combine(releaseFramework.FullName, "win-x64"));
+            var debugFramework = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "bin", "Debug", "net8.0"));
+            var intermediate = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "obj", "Release", "net8.0"));
+
+            var staleFramework = Path.Combine(releaseFramework.FullName, "Sample.Primary.dll");
+            var staleRid = Path.Combine(releaseRid.FullName, "Sample.Primary.dll");
+            var staleProjectName = Path.Combine(releaseFramework.FullName, "Sample.Package.exe");
+            var dependency = Path.Combine(releaseFramework.FullName, "Dependency.dll");
+            var debugOutput = Path.Combine(debugFramework.FullName, "Sample.Primary.dll");
+            var intermediateOutput = Path.Combine(intermediate.FullName, "Sample.Primary.dll");
+            var intermediateCache = Path.Combine(intermediate.FullName, "project.assets.cache");
+            foreach (var path in new[] { staleFramework, staleRid, staleProjectName, dependency, debugOutput, intermediateOutput, intermediateCache })
+                File.WriteAllText(path, path);
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.Package",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(4, removedFileCount);
+            Assert.False(File.Exists(staleFramework));
+            Assert.False(File.Exists(staleRid));
+            Assert.False(File.Exists(staleProjectName));
+            Assert.True(File.Exists(dependency));
+            Assert.True(File.Exists(debugOutput));
+            Assert.False(File.Exists(intermediateOutput));
+            Assert.True(File.Exists(intermediateCache));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
     [InlineData(DotNetRepositoryPackStrategy.PerProject, false)]
     [InlineData(DotNetRepositoryPackStrategy.MSBuild, false)]
     [InlineData(DotNetRepositoryPackStrategy.PerProject, true)]
     [InlineData(DotNetRepositoryPackStrategy.MSBuild, true)]
-    public void Execute_RebuildsStaleOutputBeforePacking(
+    public void Execute_RecompilesStaleOutputBeforePacking(
         DotNetRepositoryPackStrategy packStrategy,
         bool targetFrameworkFromImport)
     {

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -310,6 +310,127 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
         }
     }
 
+    [Fact]
+    public void FreshnessCleanup_RemovesAllReleaseArtifactPivotSiblings()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <UseArtifactsOutput>true</UseArtifactsOutput>
+                    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts/</ArtifactsPath>
+                    <BaseIntermediateOutputPath>$(ArtifactsPath)obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Artifacts"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Artifacts.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectBinRoot = Path.Combine(root.FullName, "artifacts", "bin", "Sample.Artifacts");
+            var projectObjRoot = Path.Combine(root.FullName, "artifacts", "obj", "Sample.Artifacts");
+            var releasePaths = new[]
+            {
+                Path.Combine(projectBinRoot, "release_net8.0", "Sample.Artifacts.dll"),
+                Path.Combine(projectBinRoot, "release_net8.0_win-x64", "Sample.Artifacts.dll"),
+                Path.Combine(projectObjRoot, "release_net8.0", "Sample.Artifacts.dll"),
+                Path.Combine(projectObjRoot, "release_net8.0_win-x64", "Sample.Artifacts.dll")
+            };
+            var debugOutput = Path.Combine(projectBinRoot, "debug_net8.0", "Sample.Artifacts.dll");
+            foreach (var path in releasePaths.Append(debugOutput))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.Artifacts",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(releasePaths.Length, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.All(releasePaths, path => Assert.False(File.Exists(path)));
+            Assert.True(File.Exists(debugOutput));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FreshnessCleanup_IncludesActualOutDirAndRidChildren()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.OutDir"));
+            var finalOutputRoot = Path.Combine(root.FullName, "final", "Release");
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.OutDir.csproj");
+            File.WriteAllText(projectPath, $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <OutDir>{finalOutputRoot}{Path.DirectorySeparatorChar}</OutDir>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var stalePaths = new[]
+            {
+                Path.Combine(finalOutputRoot, "Sample.OutDir.dll"),
+                Path.Combine(finalOutputRoot, "win-x64", "Sample.OutDir.dll"),
+                Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0", "Sample.OutDir.dll"),
+                Path.Combine(projectDirectory.FullName, "obj", "Release", "net8.0", "Sample.OutDir.dll")
+            };
+            foreach (var path in stalePaths)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.OutDir",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(stalePaths.Length, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.All(stalePaths, path => Assert.False(File.Exists(path)));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
     [InlineData(DotNetRepositoryPackStrategy.PerProject, false, false, false)]
     [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, false, false)]

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -49,11 +49,13 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
                 "Release",
                 new NullLogger(),
                 out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
                 out _,
                 out var error);
 
             Assert.True(success, error);
             Assert.Equal(4, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
             Assert.False(File.Exists(staleFramework));
             Assert.False(File.Exists(staleRid));
             Assert.False(File.Exists(staleProjectName));
@@ -68,14 +70,74 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
         }
     }
 
+    [Fact]
+    public void FreshnessCleanup_DoesNotTreatAbandonedConventionalObjAsConfiguredIntermediateProof()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <BaseOutputPath>$(MSBuildThisFileDirectory)artifacts/bin/</BaseOutputPath>
+                    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts/obj/</BaseIntermediateOutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Configured"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Configured.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <AssemblyName>Sample.Configured</AssemblyName>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var configuredOutput = Path.Combine(root.FullName, "artifacts", "bin", "Release", "net8.0", "Sample.Configured.dll");
+            var abandonedIntermediate = Path.Combine(projectDirectory.FullName, "obj", "Release", "net8.0", "Sample.Configured.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(configuredOutput)!);
+            Directory.CreateDirectory(Path.GetDirectoryName(abandonedIntermediate)!);
+            File.WriteAllText(configuredOutput, "configured-output");
+            File.WriteAllText(abandonedIntermediate, "abandoned-intermediate");
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.Configured",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(1, removedFileCount);
+            Assert.False(removedIntermediatePrimaryOutput);
+            Assert.False(File.Exists(configuredOutput));
+            Assert.True(File.Exists(abandonedIntermediate));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
-    [InlineData(DotNetRepositoryPackStrategy.PerProject, false)]
-    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false)]
-    [InlineData(DotNetRepositoryPackStrategy.PerProject, true)]
-    [InlineData(DotNetRepositoryPackStrategy.MSBuild, true)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, true, false)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, true, false)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, true)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, true)]
     public void Execute_RecompilesStaleOutputBeforePacking(
         DotNetRepositoryPackStrategy packStrategy,
-        bool targetFrameworkFromImport)
+        bool targetFrameworkFromImport,
+        bool centralOutputPaths)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -83,15 +145,25 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
             var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Stale"));
             var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Stale.csproj");
             var sourcePath = Path.Combine(projectDirectory.FullName, "Contract.cs");
-            if (targetFrameworkFromImport)
+            if (targetFrameworkFromImport || centralOutputPaths)
             {
-                File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
-                    <Project>
-                      <PropertyGroup>
-                        <TargetFramework>net8.0</TargetFramework>
-                      </PropertyGroup>
-                    </Project>
-                    """);
+                var importedProperties = new List<string>();
+                if (targetFrameworkFromImport)
+                    importedProperties.Add("    <TargetFramework>net8.0</TargetFramework>");
+                if (centralOutputPaths)
+                {
+                    importedProperties.Add("    <BaseOutputPath>$(MSBuildThisFileDirectory)artifacts/bin/</BaseOutputPath>");
+                    importedProperties.Add("    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts/obj/</BaseIntermediateOutputPath>");
+                }
+
+                File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), string.Join(Environment.NewLine, new[]
+                {
+                    "<Project>",
+                    "  <PropertyGroup>",
+                    string.Join(Environment.NewLine, importedProperties),
+                    "  </PropertyGroup>",
+                    "</Project>"
+                }));
             }
 
             var projectLines = new List<string>
@@ -113,7 +185,9 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
             File.WriteAllText(sourcePath, "namespace Sample.Stale; public sealed class LegacyContract { }");
 
             RunDotNet(projectDirectory.FullName, "build", projectPath, "--configuration", "Release", "--nologo");
-            var assemblyPath = Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0", "Sample.Stale.dll");
+            var assemblyPath = centralOutputPaths
+                ? Path.Combine(root.FullName, "artifacts", "bin", "Release", "net8.0", "Sample.Stale.dll")
+                : Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0", "Sample.Stale.dll");
             Assert.True(File.Exists(assemblyPath));
             var staleAssembly = File.ReadAllBytes(assemblyPath);
 

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshBuildTests.cs
@@ -127,17 +127,75 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
         }
     }
 
+    [Fact]
+    public void FreshnessCleanup_DoesNotDeleteConditionalOutputFromAnotherConfiguration()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Conditional"));
+            var debugOutputRoot = Path.Combine(root.FullName, "debug-only");
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Conditional.csproj");
+            File.WriteAllText(projectPath, $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+                    <OutputPath>{debugOutputRoot}</OutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var releaseOutput = Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0", "Sample.Conditional.dll");
+            var releaseIntermediate = Path.Combine(projectDirectory.FullName, "obj", "Release", "net8.0", "Sample.Conditional.dll");
+            var debugOutput = Path.Combine(debugOutputRoot, "Sample.Conditional.dll");
+            foreach (var path in new[] { releaseOutput, releaseIntermediate, debugOutput })
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.Conditional",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(2, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.False(File.Exists(releaseOutput));
+            Assert.False(File.Exists(releaseIntermediate));
+            Assert.True(File.Exists(debugOutput));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
-    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, false)]
-    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, false)]
-    [InlineData(DotNetRepositoryPackStrategy.PerProject, true, false)]
-    [InlineData(DotNetRepositoryPackStrategy.MSBuild, true, false)]
-    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, true)]
-    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, true)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, true, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, true, false, false)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, true, false)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, true, false)]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject, false, false, true)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild, false, false, true)]
     public void Execute_RecompilesStaleOutputBeforePacking(
         DotNetRepositoryPackStrategy packStrategy,
         bool targetFrameworkFromImport,
-        bool centralOutputPaths)
+        bool centralOutputPaths,
+        bool centralAssemblyName)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -145,7 +203,7 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
             var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Stale"));
             var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Stale.csproj");
             var sourcePath = Path.Combine(projectDirectory.FullName, "Contract.cs");
-            if (targetFrameworkFromImport || centralOutputPaths)
+            if (targetFrameworkFromImport || centralOutputPaths || centralAssemblyName)
             {
                 var importedProperties = new List<string>();
                 if (targetFrameworkFromImport)
@@ -155,6 +213,8 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
                     importedProperties.Add("    <BaseOutputPath>$(MSBuildThisFileDirectory)artifacts/bin/</BaseOutputPath>");
                     importedProperties.Add("    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts/obj/</BaseIntermediateOutputPath>");
                 }
+                if (centralAssemblyName)
+                    importedProperties.Add("    <AssemblyName>Sample.Central</AssemblyName>");
 
                 File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), string.Join(Environment.NewLine, new[]
                 {
@@ -185,9 +245,10 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
             File.WriteAllText(sourcePath, "namespace Sample.Stale; public sealed class LegacyContract { }");
 
             RunDotNet(projectDirectory.FullName, "build", projectPath, "--configuration", "Release", "--nologo");
+            var assemblyFileName = centralAssemblyName ? "Sample.Central.dll" : "Sample.Stale.dll";
             var assemblyPath = centralOutputPaths
-                ? Path.Combine(root.FullName, "artifacts", "bin", "Release", "net8.0", "Sample.Stale.dll")
-                : Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0", "Sample.Stale.dll");
+                ? Path.Combine(root.FullName, "artifacts", "bin", "Release", "net8.0", assemblyFileName)
+                : Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0", assemblyFileName);
             Assert.True(File.Exists(assemblyPath));
             var staleAssembly = File.ReadAllBytes(assemblyPath);
 
@@ -211,7 +272,7 @@ public sealed class DotNetRepositoryReleaseFreshBuildTests
             Assert.True(result.Success, result.ErrorMessage);
             Assert.NotEqual(staleAssembly, File.ReadAllBytes(assemblyPath));
             var package = Assert.Single(Assert.Single(result.Projects, project => project.IsPackable).Packages);
-            var typeNames = ReadPackagedTypeNames(package, "Sample.Stale.dll");
+            var typeNames = ReadPackagedTypeNames(package, assemblyFileName);
             Assert.Contains("Sample.Stale.CurrentContract", typeNames);
             Assert.DoesNotContain("Sample.Stale.LegacyContract", typeNames);
         }

--- a/PowerForge.Tests/DotNetRepositoryReleaseFreshnessDimensionTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseFreshnessDimensionTests.cs
@@ -1,0 +1,202 @@
+namespace PowerForge.Tests;
+
+public sealed class DotNetRepositoryReleaseFreshnessDimensionTests
+{
+    [Fact]
+    public void FreshnessCleanup_DoesNotWidenTargetFrameworkPrefixedCustomRoots()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.CustomLayout"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.CustomLayout.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+                    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+                    <BaseOutputPath>$(MSBuildProjectDirectory)/artifacts/bin/</BaseOutputPath>
+                    <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/artifacts/obj/</BaseIntermediateOutputPath>
+                    <OutputPath>$(BaseOutputPath)$(TargetFramework)/$(Configuration)/</OutputPath>
+                    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(TargetFramework)/$(Configuration)/</IntermediateOutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var activePaths = new[]
+            {
+                Path.Combine(projectDirectory.FullName, "artifacts", "bin", "net8.0", "Release", "Sample.CustomLayout.dll"),
+                Path.Combine(projectDirectory.FullName, "artifacts", "obj", "net8.0", "Release", "Sample.CustomLayout.dll")
+            };
+            var unrelatedPaths = new[]
+            {
+                Path.Combine(projectDirectory.FullName, "artifacts", "bin", "net8.0", "Debug", "Sample.CustomLayout.dll"),
+                Path.Combine(projectDirectory.FullName, "artifacts", "bin", "net10.0", "Release", "Sample.CustomLayout.dll")
+            };
+            foreach (var path in activePaths.Concat(unrelatedPaths))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.CustomLayout",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(activePaths.Length, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.All(activePaths, path => Assert.False(File.Exists(path)));
+            Assert.All(unrelatedPaths, path => Assert.True(File.Exists(path)));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FreshnessCleanup_EvaluatesTargetFrameworksForActiveConfiguration()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.ConfigurationFramework"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.ConfigurationFramework.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+                    <TargetFramework>net10.0</TargetFramework>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                    <AssemblyName>Sample.DebugFramework</AssemblyName>
+                    <OutputPath>$(MSBuildProjectDirectory)/artifacts/bin/Debug/net8.0/</OutputPath>
+                    <IntermediateOutputPath>$(MSBuildProjectDirectory)/artifacts/obj/Debug/net8.0/</IntermediateOutputPath>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+                    <AssemblyName>Sample.ReleaseFramework</AssemblyName>
+                    <OutputPath>$(MSBuildProjectDirectory)/artifacts/bin/Release/net10.0/</OutputPath>
+                    <IntermediateOutputPath>$(MSBuildProjectDirectory)/artifacts/obj/Release/net10.0/</IntermediateOutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var releasePaths = new[]
+            {
+                Path.Combine(projectDirectory.FullName, "artifacts", "bin", "Release", "net10.0", "Sample.ReleaseFramework.dll"),
+                Path.Combine(projectDirectory.FullName, "artifacts", "obj", "Release", "net10.0", "Sample.ReleaseFramework.dll")
+            };
+            var debugOutput = Path.Combine(projectDirectory.FullName, "artifacts", "bin", "Debug", "net8.0", "Sample.DebugFramework.dll");
+            foreach (var path in releasePaths.Append(debugOutput))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.ConfigurationFramework",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(releasePaths.Length, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.All(releasePaths, path => Assert.False(File.Exists(path)));
+            Assert.True(File.Exists(debugOutput));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void FreshnessCleanup_EvaluatesConfiguredRuntimeIdentifierMetadata()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.RuntimeMetadata"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.RuntimeMetadata.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+                    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+                    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+                    <AssemblyName>Sample.Windows</AssemblyName>
+                    <OutputPath>$(MSBuildProjectDirectory)/custom/bin/win-x64/</OutputPath>
+                    <IntermediateOutputPath>$(MSBuildProjectDirectory)/custom/obj/win-x64/</IntermediateOutputPath>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+                    <AssemblyName>Sample.Linux</AssemblyName>
+                    <OutputPath>$(MSBuildProjectDirectory)/custom/bin/linux-x64/</OutputPath>
+                    <IntermediateOutputPath>$(MSBuildProjectDirectory)/custom/obj/linux-x64/</IntermediateOutputPath>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var stalePaths = new[]
+            {
+                Path.Combine(projectDirectory.FullName, "custom", "bin", "win-x64", "Sample.Windows.dll"),
+                Path.Combine(projectDirectory.FullName, "custom", "obj", "win-x64", "Sample.Windows.dll"),
+                Path.Combine(projectDirectory.FullName, "custom", "bin", "linux-x64", "Sample.Linux.dll"),
+                Path.Combine(projectDirectory.FullName, "custom", "obj", "linux-x64", "Sample.Linux.dll")
+            };
+            foreach (var path in stalePaths)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, path);
+            }
+
+            var success = DotNetRepositoryReleaseService.TryRemoveStalePrimaryPackageOutputs(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.RuntimeMetadata",
+                    CsprojPath = projectPath
+                },
+                "Release",
+                new NullLogger(),
+                out var removedFileCount,
+                out var removedIntermediatePrimaryOutput,
+                out _,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.Equal(stalePaths.Length, removedFileCount);
+            Assert.True(removedIntermediatePrimaryOutput);
+            Assert.All(stalePaths, path => Assert.False(File.Exists(path)));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -244,7 +244,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 Assert.Equal("true", msbuild.Attribute("StopOnFirstFailure")?.Value);
             });
             Assert.Equal("Restore", msbuildTasks[0].Attribute("Targets")?.Value);
-            Assert.Equal("Rebuild", msbuildTasks[1].Attribute("Targets")?.Value);
+            Assert.Equal("Build", msbuildTasks[1].Attribute("Targets")?.Value);
             Assert.Equal("Pack", msbuildTasks[2].Attribute("Targets")?.Value);
             Assert.Equal("Configuration=Release", msbuildTasks[0].Attribute("Properties")?.Value);
             Assert.Equal("Configuration=Release", msbuildTasks[1].Attribute("Properties")?.Value);

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -202,8 +202,10 @@ public sealed class DotNetRepositoryReleaseServiceTests
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, result.Outcome);
     }
 
-    [Fact]
-    public void WritePackTraversalProject_EmitsBatchPackProjectWithEscapedProperties()
+    [Theory]
+    [InlineData(false, "Build")]
+    [InlineData(true, "Rebuild")]
+    public void WritePackTraversalProject_EmitsBatchPackProjectWithEscapedProperties(bool forceRebuild, string expectedBuildTarget)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -229,7 +231,8 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 traversalPath,
                 new[] { project },
                 spec,
-                outputPath);
+                outputPath,
+                forceRebuild);
 
             var document = XDocument.Load(traversalPath);
             var packProject = Assert.Single(document.Descendants("PackProject"));
@@ -244,7 +247,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 Assert.Equal("true", msbuild.Attribute("StopOnFirstFailure")?.Value);
             });
             Assert.Equal("Restore", msbuildTasks[0].Attribute("Targets")?.Value);
-            Assert.Equal("Build", msbuildTasks[1].Attribute("Targets")?.Value);
+            Assert.Equal(expectedBuildTarget, msbuildTasks[1].Attribute("Targets")?.Value);
             Assert.Equal("Pack", msbuildTasks[2].Attribute("Targets")?.Value);
             Assert.Equal("Configuration=Release", msbuildTasks[0].Attribute("Properties")?.Value);
             Assert.Equal("Configuration=Release", msbuildTasks[1].Attribute("Properties")?.Value);

--- a/PowerForge.Tests/DotNetRepositoryReleaseSummaryServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSummaryServiceTests.cs
@@ -55,4 +55,40 @@ public sealed class DotNetRepositoryReleaseSummaryServiceTests
         Assert.Equal(1, summary.Totals.FailedPublishCount);
         Assert.Equal("2.0.5", summary.Totals.ResolvedVersion);
     }
+
+    [Fact]
+    public void CreateFailureReport_IncludesEveryFailureWithoutTruncation()
+    {
+        var longDetail = new string('x', 2500) + " END-OF-DETAIL";
+        var result = new DotNetRepositoryReleaseResult
+        {
+            Success = false,
+            ErrorMessage = "One or more projects failed: ProjectA: first failure; ProjectB: " + longDetail
+        };
+        result.Projects.Add(new DotNetRepositoryProjectResult
+        {
+            ProjectName = "ProjectA",
+            IsPackable = true,
+            ErrorMessage = "first failure"
+        });
+        result.Projects.Add(new DotNetRepositoryProjectResult
+        {
+            ProjectName = "ProjectB",
+            IsPackable = true,
+            ErrorMessage = "ProjectB: " + longDetail
+        });
+        result.FailedPackages.Add("ProjectA.1.0.0.nupkg");
+        result.FailedPackages.Add("ProjectB.1.0.0.nupkg");
+
+        var report = new DotNetRepositoryReleaseSummaryService().CreateFailureReport(result);
+
+        Assert.StartsWith("Project build failed: 2 of 2 project(s) failed.", report, StringComparison.Ordinal);
+        Assert.Contains("Detail: ProjectA: first failure", report, StringComparison.Ordinal);
+        Assert.Contains("Detail: ProjectB: ", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("Detail: ProjectB: ProjectB:", report, StringComparison.Ordinal);
+        Assert.Contains("END-OF-DETAIL", report, StringComparison.Ordinal);
+        Assert.Contains("Detail: Failed package publish: ProjectA.1.0.0.nupkg", report, StringComparison.Ordinal);
+        Assert.Contains("Detail: Failed package publish: ProjectB.1.0.0.nupkg", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("One or more projects failed:", report, StringComparison.Ordinal);
+    }
 }

--- a/PowerForge.Tests/ModuleBuildOutcomeServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildOutcomeServiceTests.cs
@@ -24,6 +24,8 @@ public sealed class ModuleBuildOutcomeServiceTests
         Assert.False(result.ShouldEmitErrorRecord);
         Assert.False(result.ShouldReplayBufferedLogs);
         Assert.False(result.ShouldWriteInteractiveFailureSummary);
+        Assert.False(result.ShouldWriteFailureMessage);
+        Assert.Equal(string.Empty, result.FailureMessage);
         Assert.Equal("Module build completed in 2s 500ms", result.CompletionMessage);
     }
 
@@ -50,6 +52,8 @@ public sealed class ModuleBuildOutcomeServiceTests
         Assert.Equal("InvokeModuleBuildDslFailed", result.ErrorRecordId);
         Assert.True(result.ShouldReplayBufferedLogs);
         Assert.False(result.ShouldWriteInteractiveFailureSummary);
+        Assert.False(result.ShouldWriteFailureMessage);
+        Assert.Equal("boom", result.FailureMessage);
         Assert.Equal("Pipeline config generation failed in 1m 0s", result.CompletionMessage);
     }
 
@@ -75,7 +79,33 @@ public sealed class ModuleBuildOutcomeServiceTests
         Assert.False(result.ShouldEmitErrorRecord);
         Assert.True(result.ShouldReplayBufferedLogs);
         Assert.True(result.ShouldWriteInteractiveFailureSummary);
+        Assert.False(result.ShouldWriteFailureMessage);
         Assert.Equal("Module build failed in 250ms", result.CompletionMessage);
+    }
+
+    [Fact]
+    public void Evaluate_PreservesFullFailureMessageForNonInteractiveExitCodeBuilds()
+    {
+        var failure = "Project build failed: 2 of 2 project(s) failed." + Environment.NewLine +
+                      "Detail: ProjectA: first failure" + Environment.NewLine +
+                      "Detail: ProjectB: " + new string('x', 2500) + " END-OF-DETAIL";
+        var workflow = new ModuleBuildWorkflowResult
+        {
+            Succeeded = false,
+            UsedInteractiveView = false,
+            Error = new InvalidOperationException(failure)
+        };
+
+        var result = new ModuleBuildOutcomeService().Evaluate(
+            workflow,
+            exitCodeMode: true,
+            jsonOnly: false,
+            useLegacy: false,
+            elapsed: TimeSpan.FromSeconds(1));
+
+        Assert.True(result.ShouldWriteFailureMessage);
+        Assert.Equal(failure, result.FailureMessage);
+        Assert.Contains("END-OF-DETAIL", result.FailureMessage, StringComparison.Ordinal);
     }
 
     private static ModulePipelinePlan CreateUninitializedPlan()

--- a/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildWorkflowServiceTests.cs
@@ -158,9 +158,57 @@ public sealed class ProjectBuildWorkflowServiceTests
         Assert.Contains(logger.SuccessMessages, message => message.Contains("GitHub publish completed in", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void Execute_reports_all_project_failures_and_uses_error_severity()
+    {
+        var callIndex = 0;
+        var logger = new RecordingLogger();
+        var service = new ProjectBuildWorkflowService(
+            logger,
+            executeRelease: _ =>
+            {
+                callIndex++;
+                if (callIndex == 1)
+                    return new DotNetRepositoryReleaseResult { Success = true };
+
+                var release = new DotNetRepositoryReleaseResult { Success = false };
+                release.Projects.Add(new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "ProjectA",
+                    IsPackable = true,
+                    ErrorMessage = "package provenance mismatch"
+                });
+                release.Projects.Add(new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "ProjectB",
+                    IsPackable = true,
+                    ErrorMessage = "signing failed"
+                });
+                return release;
+            });
+
+        var workflow = service.Execute(
+            new ProjectBuildConfiguration(),
+            Directory.GetCurrentDirectory(),
+            new ProjectBuildPreparedContext
+            {
+                RootPath = Directory.GetCurrentDirectory(),
+                Spec = new DotNetRepositoryReleaseSpec { RootPath = Directory.GetCurrentDirectory() }
+            },
+            executeBuild: true);
+
+        Assert.False(workflow.Result.Success);
+        Assert.Contains("2 of 2 project(s) failed", workflow.Result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("Detail: ProjectA: package provenance mismatch", workflow.Result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("Detail: ProjectB: signing failed", workflow.Result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains(logger.ErrorMessages, message =>
+            message.Contains("Project build release execution failed after", StringComparison.OrdinalIgnoreCase));
+    }
+
     private sealed class RecordingLogger : ILogger
     {
         public List<string> SuccessMessages { get; } = new();
+        public List<string> ErrorMessages { get; } = new();
 
         public bool IsVerbose => false;
 
@@ -170,7 +218,7 @@ public sealed class ProjectBuildWorkflowServiceTests
 
         public void Warn(string message) { }
 
-        public void Error(string message) { }
+        public void Error(string message) => ErrorMessages.Add(message);
 
         public void Verbose(string message) { }
     }

--- a/PowerForge.Tests/SpectrePipelineSummaryWriterTests.cs
+++ b/PowerForge.Tests/SpectrePipelineSummaryWriterTests.cs
@@ -66,6 +66,25 @@ public sealed class SpectrePipelineSummaryWriterTests
     }
 
     [Fact]
+    public void NormalizeFailureMessage_PreservesCompleteProjectBuildReport()
+    {
+        var detail = new string('x', 2500) + " END-OF-DETAIL";
+        var message = string.Join(Environment.NewLine, new[]
+        {
+            "Project build failed: 2 of 6 project(s) failed.",
+            "Detail: ProjectA: package provenance mismatch",
+            "Detail: ProjectB: " + detail
+        });
+
+        var normalized = SpectrePipelineSummaryWriter.NormalizeFailureMessage(new InvalidOperationException(message));
+
+        Assert.Contains("Project build failed: 2 of 6 project(s) failed.", normalized, StringComparison.Ordinal);
+        Assert.Contains("Detail: ProjectA: package provenance mismatch", normalized, StringComparison.Ordinal);
+        Assert.Contains("END-OF-DETAIL", normalized, StringComparison.Ordinal);
+        Assert.DoesNotContain("…", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NormalizeFailureMessage_PreservesStructuredContinuationLines()
     {
         var message = string.Join(Environment.NewLine, new[]

--- a/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
@@ -46,7 +46,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         logger,
                         out var evaluatedOutputRoots,
                         out var evaluatedIntermediateRoots,
-                        out var evaluatedAssemblyName,
+                        out var evaluatedAssemblyNames,
                         out _,
                         out error))
                 {
@@ -63,8 +63,11 @@ public sealed partial class DotNetRepositoryReleaseService
                 // compiler output was invalidated. An abandoned conventional obj tree must
                 // not accidentally enable the incremental fast path.
                 intermediateRoots = evaluatedIntermediateRoots;
-                primaryFileNames.Add(evaluatedAssemblyName + ".dll");
-                primaryFileNames.Add(evaluatedAssemblyName + ".exe");
+                foreach (var evaluatedAssemblyName in evaluatedAssemblyNames)
+                {
+                    primaryFileNames.Add(evaluatedAssemblyName + ".dll");
+                    primaryFileNames.Add(evaluatedAssemblyName + ".exe");
+                }
             }
 
             var searchRoots = outputRoots
@@ -166,6 +169,8 @@ public sealed partial class DotNetRepositoryReleaseService
             try
             {
                 var document = XDocument.Load(path);
+                if (document.Descendants().Any(element => string.Equals(element.Name.LocalName, "Import", StringComparison.OrdinalIgnoreCase)))
+                    return true;
                 if (document.Descendants().Any(element => outputProperties.Contains(element.Name.LocalName)))
                     return true;
 
@@ -192,64 +197,96 @@ public sealed partial class DotNetRepositoryReleaseService
         ILogger logger,
         out string[] outputRoots,
         out string[] intermediateRoots,
-        out string evaluatedAssemblyName,
+        out string[] evaluatedAssemblyNames,
         out TimeSpan duration,
         out string error)
     {
         const string propertyNames = "AssemblyName,BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir";
-        var exitCode = RunDotnetMsBuildGetProperty(
-            project.CsprojPath,
-            projectDirectory,
-            configuration,
-            null,
-            propertyNames,
-            project.ProjectName,
-            logger,
-            out _,
-            out var stdErr,
-            out var stdOut,
-            out duration);
-        if (exitCode != 0)
-        {
-            outputRoots = Array.Empty<string>();
-            intermediateRoots = Array.Empty<string>();
-            evaluatedAssemblyName = string.Empty;
-            error = $"Could not evaluate configured output paths for {project.ProjectName}. {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
-            return false;
-        }
+        var resolvedOutputRoots = new List<string>();
+        var resolvedIntermediateRoots = new List<string>();
+        var resolvedAssemblyNames = new List<string>();
+        duration = TimeSpan.Zero;
+        var targetFrameworks = ResolveConfiguredTargetFrameworks(
+                project.CsprojPath,
+                projectDirectory,
+                configuration,
+                project.ProjectName,
+                logger)
+            .Where(framework => string.IsNullOrWhiteSpace(framework) || framework!.IndexOf("$(", StringComparison.Ordinal) < 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (targetFrameworks.Length == 0)
+            targetFrameworks = new string?[] { null };
 
-        try
+        foreach (var targetFramework in targetFrameworks)
         {
-            var jsonStart = stdOut.IndexOf('{');
-            var jsonEnd = stdOut.LastIndexOf('}');
-            if (jsonStart < 0 || jsonEnd < jsonStart)
-                throw new InvalidDataException("MSBuild property output did not contain a JSON object.");
-
-            using var document = JsonDocument.Parse(stdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
-            var properties = document.RootElement.GetProperty("Properties");
-            outputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "OutputPath", "OutDir", "TargetDir", "BaseOutputPath");
-            intermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath", "BaseIntermediateOutputPath");
-            evaluatedAssemblyName = properties.TryGetProperty("AssemblyName", out var assemblyNameProperty)
-                ? assemblyNameProperty.GetString() ?? string.Empty
-                : string.Empty;
-            if (outputRoots.Length == 0 || intermediateRoots.Length == 0 || !IsUsableAssemblyName(evaluatedAssemblyName))
+            var exitCode = RunDotnetMsBuildGetProperty(
+                project.CsprojPath,
+                projectDirectory,
+                configuration,
+                targetFramework,
+                propertyNames,
+                project.ProjectName,
+                logger,
+                out _,
+                out var stdErr,
+                out var stdOut,
+                out var evaluationDuration);
+            duration += evaluationDuration;
+            if (exitCode != 0)
             {
-                error = $"Configured build metadata for {project.ProjectName} could not be resolved to output roots, intermediate roots, and an assembly name.";
+                outputRoots = Array.Empty<string>();
+                intermediateRoots = Array.Empty<string>();
+                evaluatedAssemblyNames = Array.Empty<string>();
+                error = $"Could not evaluate configured output paths for {project.ProjectName}{FormatTargetFrameworkContext(targetFramework)}. {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
                 return false;
             }
 
-            error = string.Empty;
-            logger.Verbose($"{project.ProjectName}: evaluated {outputRoots.Length} output and {intermediateRoots.Length} intermediate freshness root(s) in {FormatDuration(duration)}.");
-            return true;
+            try
+            {
+                var jsonStart = stdOut.IndexOf('{');
+                var jsonEnd = stdOut.LastIndexOf('}');
+                if (jsonStart < 0 || jsonEnd < jsonStart)
+                    throw new InvalidDataException("MSBuild property output did not contain a JSON object.");
+
+                using var document = JsonDocument.Parse(stdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
+                var properties = document.RootElement.GetProperty("Properties");
+                var frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "OutputPath", "OutDir", "TargetDir", "BaseOutputPath")
+                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework));
+                var frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath", "BaseIntermediateOutputPath")
+                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework));
+                var evaluatedAssemblyName = properties.TryGetProperty("AssemblyName", out var assemblyNameProperty)
+                    ? assemblyNameProperty.GetString() ?? string.Empty
+                    : string.Empty;
+                if (!frameworkOutputRoots.Any() || !frameworkIntermediateRoots.Any() || !IsUsableAssemblyName(evaluatedAssemblyName))
+                {
+                    outputRoots = Array.Empty<string>();
+                    intermediateRoots = Array.Empty<string>();
+                    evaluatedAssemblyNames = Array.Empty<string>();
+                    error = $"Configured build metadata for {project.ProjectName}{FormatTargetFrameworkContext(targetFramework)} could not be resolved to output roots, intermediate roots, and an assembly name.";
+                    return false;
+                }
+
+                resolvedOutputRoots.AddRange(frameworkOutputRoots);
+                resolvedIntermediateRoots.AddRange(frameworkIntermediateRoots);
+                resolvedAssemblyNames.Add(evaluatedAssemblyName.Trim());
+            }
+            catch (Exception ex)
+            {
+                outputRoots = Array.Empty<string>();
+                intermediateRoots = Array.Empty<string>();
+                evaluatedAssemblyNames = Array.Empty<string>();
+                error = $"Could not parse configured output paths for {project.ProjectName}{FormatTargetFrameworkContext(targetFramework)}. {ex.Message}";
+                return false;
+            }
         }
-        catch (Exception ex)
-        {
-            outputRoots = Array.Empty<string>();
-            intermediateRoots = Array.Empty<string>();
-            evaluatedAssemblyName = string.Empty;
-            error = $"Could not parse configured output paths for {project.ProjectName}. {ex.Message}";
-            return false;
-        }
+
+        outputRoots = resolvedOutputRoots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        intermediateRoots = resolvedIntermediateRoots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        evaluatedAssemblyNames = resolvedAssemblyNames.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        error = string.Empty;
+        logger.Verbose($"{project.ProjectName}: evaluated {outputRoots.Length} output, {intermediateRoots.Length} intermediate, and {evaluatedAssemblyNames.Length} assembly-name freshness value(s) across {targetFrameworks.Length} target framework(s) in {FormatDuration(duration)}.");
+        return true;
     }
 
     private static string[] ResolveEvaluatedRoots(
@@ -282,4 +319,26 @@ public sealed partial class DotNetRepositoryReleaseService
         var normalizedPath = Path.GetFullPath(path);
         return normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
     }
+
+    private static string ResolveConfigurationCleanupRoot(string root, string? targetFramework)
+    {
+        var resolved = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.IsNullOrWhiteSpace(targetFramework))
+            return resolved;
+
+        var normalized = resolved.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        var framework = targetFramework!.Trim();
+        var marker = Path.DirectorySeparatorChar + framework + Path.DirectorySeparatorChar;
+        var markerIndex = normalized.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (markerIndex >= 0)
+            return normalized.Substring(0, markerIndex);
+
+        var suffix = Path.DirectorySeparatorChar + framework;
+        return normalized.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            ? normalized.Substring(0, normalized.Length - suffix.Length)
+            : normalized;
+    }
+
+    private static string FormatTargetFrameworkContext(string? targetFramework)
+        => string.IsNullOrWhiteSpace(targetFramework) ? string.Empty : $" ({targetFramework})";
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    /// <summary>
+    /// Removes only primary project assemblies that could survive in an obsolete
+    /// framework/RID output or intermediate directory. Removing the intermediate
+    /// compiler output also forces a normal incremental build to recompile the
+    /// package producer before a later no-build pack.
+    /// </summary>
+    internal static bool TryRemoveStalePrimaryPackageOutputs(
+        DotNetRepositoryProjectResult project,
+        string configuration,
+        ILogger logger,
+        out int removedFileCount,
+        out TimeSpan duration,
+        out string error)
+    {
+        var watch = Stopwatch.StartNew();
+        removedFileCount = 0;
+        error = string.Empty;
+
+        try
+        {
+            var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
+            var primaryFileNames = ResolvePrimaryAssemblyFileNamesForCleanup(project)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var searchRoots = ResolvePrimaryOutputCleanupRoots(project.CsprojPath, projectDirectory, configuration);
+
+            foreach (var searchRoot in searchRoots)
+            {
+                if (!Directory.Exists(searchRoot))
+                    continue;
+
+                foreach (var path in Directory.EnumerateFiles(searchRoot, "*", SearchOption.AllDirectories))
+                {
+                    if (!primaryFileNames.Contains(Path.GetFileName(path)))
+                        continue;
+
+                    File.Delete(path);
+                    removedFileCount++;
+                }
+            }
+
+            watch.Stop();
+            duration = watch.Elapsed;
+            var message = $"{project.ProjectName}: freshness cleanup removed {removedFileCount} stale primary output(s) from {searchRoots.Length} scoped root(s) in {FormatDuration(duration)}.";
+            if (removedFileCount > 0)
+                logger.Success(message);
+            else
+                logger.Info(message);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            watch.Stop();
+            duration = watch.Elapsed;
+            error = $"Freshness cleanup failed for {project.ProjectName} after removing {removedFileCount} file(s). {ex.Message}";
+            logger.Error(error);
+            return false;
+        }
+    }
+
+    private static string[] ResolvePrimaryAssemblyFileNamesForCleanup(DotNetRepositoryProjectResult project)
+    {
+        var assemblyNames = new List<string> { project.ProjectName };
+        try
+        {
+            var document = XDocument.Load(project.CsprojPath);
+            assemblyNames.AddRange(document.Descendants()
+                .Where(static element => string.Equals(element.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase))
+                .Select(static element => element.Value)
+                .Where(IsUsableAssemblyName)
+                .Select(static value => value.Trim()));
+        }
+        catch
+        {
+            // The project filename remains the SDK default assembly name.
+        }
+
+        return assemblyNames
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .SelectMany(static value => new[] { value.Trim() + ".dll", value.Trim() + ".exe" })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string[] ResolvePrimaryOutputCleanupRoots(
+        string csproj,
+        string projectDirectory,
+        string configuration)
+    {
+        var roots = new List<string>
+        {
+            Path.Combine(projectDirectory, "bin", configuration),
+            Path.Combine(projectDirectory, "obj", configuration)
+        };
+
+        foreach (var configuredOutputPath in ReadOutputPaths(csproj))
+        {
+            if (configuredOutputPath.IndexOf("$(", StringComparison.Ordinal) >= 0)
+                continue;
+
+            roots.Add(Path.IsPathRooted(configuredOutputPath)
+                ? configuredOutputPath
+                : Path.Combine(projectDirectory, configuredOutputPath));
+        }
+
+        return roots
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
@@ -201,107 +201,107 @@ public sealed partial class DotNetRepositoryReleaseService
         out TimeSpan duration,
         out string error)
     {
-        const string propertyNames = "AssemblyName,ArtifactsPath,ArtifactsPivots,UseArtifactsOutput,BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir";
+        const string propertyNames = "AssemblyName,ArtifactsPath,ArtifactsPivots,UseArtifactsOutput,BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir,RuntimeIdentifier,RuntimeIdentifiers";
         var resolvedOutputRoots = new List<string>();
         var resolvedIntermediateRoots = new List<string>();
         var resolvedAssemblyNames = new List<string>();
         duration = TimeSpan.Zero;
-        var targetFrameworks = ResolveConfiguredTargetFrameworks(
-                project.CsprojPath,
+        if (!TryResolveActiveTargetFrameworks(
+                project,
                 projectDirectory,
                 configuration,
-                project.ProjectName,
-                logger)
-            .Where(framework => string.IsNullOrWhiteSpace(framework) || framework!.IndexOf("$(", StringComparison.Ordinal) < 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (targetFrameworks.Length == 0)
-            targetFrameworks = new string?[] { null };
+                logger,
+                out var targetFrameworks,
+                out var frameworkEvaluationDuration,
+                out error))
+        {
+            duration += frameworkEvaluationDuration;
+            outputRoots = Array.Empty<string>();
+            intermediateRoots = Array.Empty<string>();
+            evaluatedAssemblyNames = Array.Empty<string>();
+            return false;
+        }
+        duration += frameworkEvaluationDuration;
 
         foreach (var targetFramework in targetFrameworks)
         {
-            var exitCode = RunDotnetMsBuildGetProperty(
-                project.CsprojPath,
-                projectDirectory,
-                configuration,
-                targetFramework,
-                propertyNames,
-                project.ProjectName,
-                logger,
-                out _,
-                out var stdErr,
-                out var stdOut,
-                out var evaluationDuration);
+            if (!TryEvaluateCleanupProperties(
+                    project,
+                    projectDirectory,
+                    configuration,
+                    targetFramework,
+                    runtimeIdentifier: null,
+                    propertyNames,
+                    logger,
+                    out var properties,
+                    out var evaluationDuration,
+                    out error))
+            {
+                duration += evaluationDuration;
+                outputRoots = Array.Empty<string>();
+                intermediateRoots = Array.Empty<string>();
+                evaluatedAssemblyNames = Array.Empty<string>();
+                return false;
+            }
             duration += evaluationDuration;
-            if (exitCode != 0)
+
+            if (!TryAddEvaluatedCleanupMetadata(
+                    project,
+                    projectDirectory,
+                    configuration,
+                    targetFramework,
+                    runtimeIdentifier: null,
+                    properties,
+                    resolvedOutputRoots,
+                    resolvedIntermediateRoots,
+                    resolvedAssemblyNames,
+                    out error))
             {
                 outputRoots = Array.Empty<string>();
                 intermediateRoots = Array.Empty<string>();
                 evaluatedAssemblyNames = Array.Empty<string>();
-                error = $"Could not evaluate configured output paths for {project.ProjectName}{FormatTargetFrameworkContext(targetFramework)}. {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
                 return false;
             }
 
-            try
+            foreach (var runtimeIdentifier in ResolveConfiguredRuntimeIdentifiers(properties))
             {
-                var jsonStart = stdOut.IndexOf('{');
-                var jsonEnd = stdOut.LastIndexOf('}');
-                if (jsonStart < 0 || jsonEnd < jsonStart)
-                    throw new InvalidDataException("MSBuild property output did not contain a JSON object.");
-
-                using var document = JsonDocument.Parse(stdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
-                var properties = document.RootElement.GetProperty("Properties");
-                var frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "TargetDir", "OutDir", "OutputPath");
-                if (frameworkOutputRoots.Length == 0)
-                    frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "BaseOutputPath");
-                var frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath");
-                if (frameworkIntermediateRoots.Length == 0)
-                    frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "BaseIntermediateOutputPath");
-
-                frameworkOutputRoots = frameworkOutputRoots
-                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework))
-                    .ToArray();
-                frameworkIntermediateRoots = frameworkIntermediateRoots
-                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework))
-                    .ToArray();
-
-                var useArtifactsOutput = properties.TryGetProperty("UseArtifactsOutput", out var useArtifactsOutputProperty) &&
-                                         bool.TryParse(useArtifactsOutputProperty.GetString(), out var parsedUseArtifactsOutput) &&
-                                         parsedUseArtifactsOutput;
-                if (useArtifactsOutput)
+                if (!TryEvaluateCleanupProperties(
+                        project,
+                        projectDirectory,
+                        configuration,
+                        targetFramework,
+                        runtimeIdentifier,
+                        propertyNames,
+                        logger,
+                        out var runtimeProperties,
+                        out evaluationDuration,
+                        out error))
                 {
-                    frameworkOutputRoots = ExpandArtifactConfigurationRoots(
-                        frameworkOutputRoots,
-                        ResolveEvaluatedRoots(properties, projectDirectory, "BaseOutputPath"),
-                        configuration);
-                    frameworkIntermediateRoots = ExpandArtifactConfigurationRoots(
-                        frameworkIntermediateRoots,
-                        ResolveEvaluatedRoots(properties, projectDirectory, "BaseIntermediateOutputPath"),
-                        configuration);
+                    duration += evaluationDuration;
+                    outputRoots = Array.Empty<string>();
+                    intermediateRoots = Array.Empty<string>();
+                    evaluatedAssemblyNames = Array.Empty<string>();
+                    return false;
                 }
-                var evaluatedAssemblyName = properties.TryGetProperty("AssemblyName", out var assemblyNameProperty)
-                    ? assemblyNameProperty.GetString() ?? string.Empty
-                    : string.Empty;
-                if (!frameworkOutputRoots.Any() || !frameworkIntermediateRoots.Any() || !IsUsableAssemblyName(evaluatedAssemblyName))
+                duration += evaluationDuration;
+
+                if (!TryAddEvaluatedCleanupMetadata(
+                        project,
+                        projectDirectory,
+                        configuration,
+                        targetFramework,
+                        runtimeIdentifier,
+                        runtimeProperties,
+                        resolvedOutputRoots,
+                        resolvedIntermediateRoots,
+                        resolvedAssemblyNames,
+                        out error))
                 {
                     outputRoots = Array.Empty<string>();
                     intermediateRoots = Array.Empty<string>();
                     evaluatedAssemblyNames = Array.Empty<string>();
-                    error = $"Configured build metadata for {project.ProjectName}{FormatTargetFrameworkContext(targetFramework)} could not be resolved to output roots, intermediate roots, and an assembly name.";
                     return false;
                 }
-
-                resolvedOutputRoots.AddRange(frameworkOutputRoots);
-                resolvedIntermediateRoots.AddRange(frameworkIntermediateRoots);
-                resolvedAssemblyNames.Add(evaluatedAssemblyName.Trim());
-            }
-            catch (Exception ex)
-            {
-                outputRoots = Array.Empty<string>();
-                intermediateRoots = Array.Empty<string>();
-                evaluatedAssemblyNames = Array.Empty<string>();
-                error = $"Could not parse configured output paths for {project.ProjectName}{FormatTargetFrameworkContext(targetFramework)}. {ex.Message}";
-                return false;
             }
         }
 
@@ -313,18 +313,188 @@ public sealed partial class DotNetRepositoryReleaseService
         return true;
     }
 
+    private static bool TryResolveActiveTargetFrameworks(
+        DotNetRepositoryProjectResult project,
+        string projectDirectory,
+        string configuration,
+        ILogger logger,
+        out string?[] targetFrameworks,
+        out TimeSpan duration,
+        out string error)
+    {
+        const string propertyNames = "TargetFrameworks,TargetFramework";
+        if (!TryEvaluateCleanupProperties(
+                project,
+                projectDirectory,
+                configuration,
+                targetFramework: null,
+                runtimeIdentifier: null,
+                propertyNames,
+                logger,
+                out var properties,
+                out duration,
+                out error))
+        {
+            targetFrameworks = Array.Empty<string?>();
+            return false;
+        }
+
+        targetFrameworks = SplitEvaluatedList(properties, "TargetFrameworks")
+            .Concat(SplitEvaluatedList(properties, "TargetFramework"))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Cast<string?>()
+            .ToArray();
+        if (targetFrameworks.Length == 0)
+            targetFrameworks = new string?[] { null };
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryEvaluateCleanupProperties(
+        DotNetRepositoryProjectResult project,
+        string projectDirectory,
+        string configuration,
+        string? targetFramework,
+        string? runtimeIdentifier,
+        string propertyNames,
+        ILogger logger,
+        out Dictionary<string, string> properties,
+        out TimeSpan duration,
+        out string error)
+    {
+        var exitCode = RunDotnetMsBuildGetProperty(
+            project.CsprojPath,
+            projectDirectory,
+            configuration,
+            targetFramework,
+            runtimeIdentifier,
+            propertyNames,
+            project.ProjectName,
+            logger,
+            out _,
+            out var stdErr,
+            out var stdOut,
+            out duration);
+        if (exitCode != 0)
+        {
+            properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            error = $"Could not evaluate configured output paths for {project.ProjectName}{FormatBuildDimensionContext(targetFramework, runtimeIdentifier)}. {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
+            return false;
+        }
+
+        try
+        {
+            var jsonStart = stdOut.IndexOf('{');
+            var jsonEnd = stdOut.LastIndexOf('}');
+            if (jsonStart < 0 || jsonEnd < jsonStart)
+                throw new InvalidDataException("MSBuild property output did not contain a JSON object.");
+
+            using var document = JsonDocument.Parse(stdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
+            properties = document.RootElement.GetProperty("Properties")
+                .EnumerateObject()
+                .ToDictionary(
+                    static property => property.Name,
+                    static property => property.Value.GetString() ?? string.Empty,
+                    StringComparer.OrdinalIgnoreCase);
+            error = string.Empty;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            error = $"Could not parse configured output paths for {project.ProjectName}{FormatBuildDimensionContext(targetFramework, runtimeIdentifier)}. {ex.Message}";
+            return false;
+        }
+    }
+
+    private static bool TryAddEvaluatedCleanupMetadata(
+        DotNetRepositoryProjectResult project,
+        string projectDirectory,
+        string configuration,
+        string? targetFramework,
+        string? runtimeIdentifier,
+        IReadOnlyDictionary<string, string> properties,
+        ICollection<string> resolvedOutputRoots,
+        ICollection<string> resolvedIntermediateRoots,
+        ICollection<string> resolvedAssemblyNames,
+        out string error)
+    {
+        var frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "TargetDir", "OutDir", "OutputPath");
+        if (frameworkOutputRoots.Length == 0)
+            frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "BaseOutputPath");
+        var frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath");
+        if (frameworkIntermediateRoots.Length == 0)
+            frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "BaseIntermediateOutputPath");
+
+        frameworkOutputRoots = frameworkOutputRoots
+            .Select(root => ResolveConfigurationCleanupRoot(root, configuration, targetFramework))
+            .ToArray();
+        frameworkIntermediateRoots = frameworkIntermediateRoots
+            .Select(root => ResolveConfigurationCleanupRoot(root, configuration, targetFramework))
+            .ToArray();
+
+        var useArtifactsOutput = properties.TryGetValue("UseArtifactsOutput", out var useArtifactsOutputProperty) &&
+                                 bool.TryParse(useArtifactsOutputProperty, out var parsedUseArtifactsOutput) &&
+                                 parsedUseArtifactsOutput;
+        if (useArtifactsOutput)
+        {
+            frameworkOutputRoots = ExpandArtifactConfigurationRoots(
+                frameworkOutputRoots,
+                ResolveEvaluatedRoots(properties, projectDirectory, "BaseOutputPath"),
+                configuration);
+            frameworkIntermediateRoots = ExpandArtifactConfigurationRoots(
+                frameworkIntermediateRoots,
+                ResolveEvaluatedRoots(properties, projectDirectory, "BaseIntermediateOutputPath"),
+                configuration);
+        }
+
+        var evaluatedAssemblyName = properties.TryGetValue("AssemblyName", out var assemblyNameProperty)
+            ? assemblyNameProperty
+            : string.Empty;
+        if (!frameworkOutputRoots.Any() || !frameworkIntermediateRoots.Any() || !IsUsableAssemblyName(evaluatedAssemblyName))
+        {
+            error = $"Configured build metadata for {project.ProjectName}{FormatBuildDimensionContext(targetFramework, runtimeIdentifier)} could not be resolved to output roots, intermediate roots, and an assembly name.";
+            return false;
+        }
+
+        foreach (var root in frameworkOutputRoots)
+            resolvedOutputRoots.Add(root);
+        foreach (var root in frameworkIntermediateRoots)
+            resolvedIntermediateRoots.Add(root);
+        resolvedAssemblyNames.Add(evaluatedAssemblyName.Trim());
+        error = string.Empty;
+        return true;
+    }
+
+    private static string[] ResolveConfiguredRuntimeIdentifiers(IReadOnlyDictionary<string, string> properties)
+        => SplitEvaluatedList(properties, "RuntimeIdentifiers")
+            .Concat(SplitEvaluatedList(properties, "RuntimeIdentifier"))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static string[] SplitEvaluatedList(IReadOnlyDictionary<string, string> properties, string propertyName)
+    {
+        if (!properties.TryGetValue(propertyName, out var value) || string.IsNullOrWhiteSpace(value) || value.IndexOf("$(", StringComparison.Ordinal) >= 0)
+            return Array.Empty<string>();
+
+        return value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static item => item.Trim())
+            .Where(static item => item.Length > 0)
+            .ToArray();
+    }
+
     private static string[] ResolveEvaluatedRoots(
-        JsonElement properties,
+        IReadOnlyDictionary<string, string> properties,
         string projectDirectory,
         params string[] propertyNames)
     {
         var roots = new List<string>();
         foreach (var propertyName in propertyNames)
         {
-            if (!properties.TryGetProperty(propertyName, out var property))
+            if (!properties.TryGetValue(propertyName, out var value))
                 continue;
 
-            var value = property.GetString();
             if (string.IsNullOrWhiteSpace(value) || value!.IndexOf("$(", StringComparison.Ordinal) >= 0)
                 continue;
 
@@ -345,7 +515,7 @@ public sealed partial class DotNetRepositoryReleaseService
         return normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string ResolveConfigurationCleanupRoot(string root, string? targetFramework)
+    private static string ResolveConfigurationCleanupRoot(string root, string configuration, string? targetFramework)
     {
         var resolved = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         if (string.IsNullOrWhiteSpace(targetFramework))
@@ -353,19 +523,24 @@ public sealed partial class DotNetRepositoryReleaseService
 
         var normalized = resolved.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
         var framework = targetFramework!.Trim();
-        var marker = Path.DirectorySeparatorChar + framework + Path.DirectorySeparatorChar;
-        var markerIndex = normalized.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (markerIndex >= 0)
-            return normalized.Substring(0, markerIndex);
-
         var suffix = Path.DirectorySeparatorChar + framework;
-        return normalized.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
-            ? normalized.Substring(0, normalized.Length - suffix.Length)
+        if (!normalized.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            return normalized;
+
+        var parent = normalized.Substring(0, normalized.Length - suffix.Length);
+        return string.Equals(Path.GetFileName(parent), configuration, StringComparison.OrdinalIgnoreCase)
+            ? parent
             : normalized;
     }
 
-    private static string FormatTargetFrameworkContext(string? targetFramework)
-        => string.IsNullOrWhiteSpace(targetFramework) ? string.Empty : $" ({targetFramework})";
+    private static string FormatBuildDimensionContext(string? targetFramework, string? runtimeIdentifier)
+    {
+        var values = new[] { targetFramework, runtimeIdentifier }
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .ToArray();
+        return values.Length == 0 ? string.Empty : $" ({string.Join(", ", values)})";
+    }
 
     private static string[] ExpandArtifactConfigurationRoots(
         IEnumerable<string> evaluatedRoots,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
@@ -201,7 +201,7 @@ public sealed partial class DotNetRepositoryReleaseService
         out TimeSpan duration,
         out string error)
     {
-        const string propertyNames = "AssemblyName,BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir";
+        const string propertyNames = "AssemblyName,ArtifactsPath,ArtifactsPivots,UseArtifactsOutput,BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir";
         var resolvedOutputRoots = new List<string>();
         var resolvedIntermediateRoots = new List<string>();
         var resolvedAssemblyNames = new List<string>();
@@ -251,10 +251,34 @@ public sealed partial class DotNetRepositoryReleaseService
 
                 using var document = JsonDocument.Parse(stdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
                 var properties = document.RootElement.GetProperty("Properties");
-                var frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "OutputPath", "OutDir", "TargetDir", "BaseOutputPath")
-                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework));
-                var frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath", "BaseIntermediateOutputPath")
-                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework));
+                var frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "TargetDir", "OutDir", "OutputPath");
+                if (frameworkOutputRoots.Length == 0)
+                    frameworkOutputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "BaseOutputPath");
+                var frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath");
+                if (frameworkIntermediateRoots.Length == 0)
+                    frameworkIntermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "BaseIntermediateOutputPath");
+
+                frameworkOutputRoots = frameworkOutputRoots
+                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework))
+                    .ToArray();
+                frameworkIntermediateRoots = frameworkIntermediateRoots
+                    .Select(root => ResolveConfigurationCleanupRoot(root, targetFramework))
+                    .ToArray();
+
+                var useArtifactsOutput = properties.TryGetProperty("UseArtifactsOutput", out var useArtifactsOutputProperty) &&
+                                         bool.TryParse(useArtifactsOutputProperty.GetString(), out var parsedUseArtifactsOutput) &&
+                                         parsedUseArtifactsOutput;
+                if (useArtifactsOutput)
+                {
+                    frameworkOutputRoots = ExpandArtifactConfigurationRoots(
+                        frameworkOutputRoots,
+                        ResolveEvaluatedRoots(properties, projectDirectory, "BaseOutputPath"),
+                        configuration);
+                    frameworkIntermediateRoots = ExpandArtifactConfigurationRoots(
+                        frameworkIntermediateRoots,
+                        ResolveEvaluatedRoots(properties, projectDirectory, "BaseIntermediateOutputPath"),
+                        configuration);
+                }
                 var evaluatedAssemblyName = properties.TryGetProperty("AssemblyName", out var assemblyNameProperty)
                     ? assemblyNameProperty.GetString() ?? string.Empty
                     : string.Empty;
@@ -294,6 +318,7 @@ public sealed partial class DotNetRepositoryReleaseService
         string projectDirectory,
         params string[] propertyNames)
     {
+        var roots = new List<string>();
         foreach (var propertyName in propertyNames)
         {
             if (!properties.TryGetProperty(propertyName, out var property))
@@ -306,10 +331,10 @@ public sealed partial class DotNetRepositoryReleaseService
             var resolved = Path.IsPathRooted(value)
                 ? value
                 : Path.Combine(projectDirectory, value);
-            return new[] { Path.GetFullPath(resolved) };
+            roots.Add(Path.GetFullPath(resolved));
         }
 
-        return Array.Empty<string>();
+        return roots.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
     private static bool IsPathWithinRoot(string path, string root)
@@ -341,4 +366,28 @@ public sealed partial class DotNetRepositoryReleaseService
 
     private static string FormatTargetFrameworkContext(string? targetFramework)
         => string.IsNullOrWhiteSpace(targetFramework) ? string.Empty : $" ({targetFramework})";
+
+    private static string[] ExpandArtifactConfigurationRoots(
+        IEnumerable<string> evaluatedRoots,
+        IEnumerable<string> artifactBaseRoots,
+        string configuration)
+    {
+        var roots = new List<string>(evaluatedRoots);
+        var pivotPrefix = configuration.Trim() + "_";
+        foreach (var baseRoot in artifactBaseRoots.Where(Directory.Exists))
+        {
+            roots.AddRange(Directory.EnumerateDirectories(baseRoot, "*", SearchOption.TopDirectoryOnly)
+                .Where(path =>
+                {
+                    var name = Path.GetFileName(path);
+                    return string.Equals(name, configuration, StringComparison.OrdinalIgnoreCase) ||
+                           name.StartsWith(pivotPrefix, StringComparison.OrdinalIgnoreCase);
+                }));
+        }
+
+        return roots
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
@@ -35,9 +35,9 @@ public sealed partial class DotNetRepositoryReleaseService
             var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
             var primaryFileNames = ResolvePrimaryAssemblyFileNamesForCleanup(project)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var outputRoots = ResolvePrimaryOutputCleanupRoots(project.CsprojPath, projectDirectory, configuration);
+            var outputRoots = ResolvePrimaryOutputCleanupRoots(projectDirectory, configuration);
             var intermediateRoots = new[] { Path.GetFullPath(Path.Combine(projectDirectory, "obj", configuration)) };
-            if (HasConfiguredOutputPathProperties(project.CsprojPath, projectDirectory))
+            if (RequiresEvaluatedCleanupMetadata(project.CsprojPath, projectDirectory))
             {
                 if (!TryResolveEvaluatedCleanupRoots(
                         project,
@@ -46,6 +46,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         logger,
                         out var evaluatedOutputRoots,
                         out var evaluatedIntermediateRoots,
+                        out var evaluatedAssemblyName,
                         out _,
                         out error))
                 {
@@ -55,14 +56,15 @@ public sealed partial class DotNetRepositoryReleaseService
                     return false;
                 }
 
-                outputRoots = outputRoots
-                    .Concat(evaluatedOutputRoots)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
+                // Configured projects must use only roots evaluated for the active build.
+                // Raw conditional OutputPath values can point at another configuration.
+                outputRoots = evaluatedOutputRoots;
                 // Only an evaluated intermediate root proves that a centrally configured
                 // compiler output was invalidated. An abandoned conventional obj tree must
                 // not accidentally enable the incremental fast path.
                 intermediateRoots = evaluatedIntermediateRoots;
+                primaryFileNames.Add(evaluatedAssemblyName + ".dll");
+                primaryFileNames.Add(evaluatedAssemblyName + ".exe");
             }
 
             var searchRoots = outputRoots
@@ -131,33 +133,15 @@ public sealed partial class DotNetRepositoryReleaseService
             .ToArray();
     }
 
-    private static string[] ResolvePrimaryOutputCleanupRoots(
-        string csproj,
-        string projectDirectory,
-        string configuration)
+    private static string[] ResolvePrimaryOutputCleanupRoots(string projectDirectory, string configuration)
     {
-        var roots = new List<string>
+        return new[]
         {
-            Path.Combine(projectDirectory, "bin", configuration)
+            Path.GetFullPath(Path.Combine(projectDirectory, "bin", configuration))
         };
-
-        foreach (var configuredOutputPath in ReadOutputPaths(csproj))
-        {
-            if (configuredOutputPath.IndexOf("$(", StringComparison.Ordinal) >= 0)
-                continue;
-
-            roots.Add(Path.IsPathRooted(configuredOutputPath)
-                ? configuredOutputPath
-                : Path.Combine(projectDirectory, configuredOutputPath));
-        }
-
-        return roots
-            .Select(Path.GetFullPath)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
     }
 
-    private static bool HasConfiguredOutputPathProperties(string csproj, string projectDirectory)
+    private static bool RequiresEvaluatedCleanupMetadata(string csproj, string projectDirectory)
     {
         var paths = new List<string> { csproj };
         for (var directory = new DirectoryInfo(projectDirectory); directory is not null; directory = directory.Parent)
@@ -166,7 +150,7 @@ public sealed partial class DotNetRepositoryReleaseService
             paths.Add(Path.Combine(directory.FullName, "Directory.Build.targets"));
         }
 
-        var relevantProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        var outputProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "ArtifactsPath",
             "BaseIntermediateOutputPath",
@@ -182,7 +166,14 @@ public sealed partial class DotNetRepositoryReleaseService
             try
             {
                 var document = XDocument.Load(path);
-                if (document.Descendants().Any(element => relevantProperties.Contains(element.Name.LocalName)))
+                if (document.Descendants().Any(element => outputProperties.Contains(element.Name.LocalName)))
+                    return true;
+
+                var assemblyNames = document.Descendants()
+                    .Where(element => string.Equals(element.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase));
+                if (!string.Equals(path, csproj, StringComparison.OrdinalIgnoreCase) && assemblyNames.Any())
+                    return true;
+                if (assemblyNames.Any(element => element.Value.IndexOf("$(", StringComparison.Ordinal) >= 0))
                     return true;
             }
             catch
@@ -201,10 +192,11 @@ public sealed partial class DotNetRepositoryReleaseService
         ILogger logger,
         out string[] outputRoots,
         out string[] intermediateRoots,
+        out string evaluatedAssemblyName,
         out TimeSpan duration,
         out string error)
     {
-        const string propertyNames = "BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir";
+        const string propertyNames = "AssemblyName,BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir";
         var exitCode = RunDotnetMsBuildGetProperty(
             project.CsprojPath,
             projectDirectory,
@@ -221,6 +213,7 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             outputRoots = Array.Empty<string>();
             intermediateRoots = Array.Empty<string>();
+            evaluatedAssemblyName = string.Empty;
             error = $"Could not evaluate configured output paths for {project.ProjectName}. {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
             return false;
         }
@@ -236,9 +229,12 @@ public sealed partial class DotNetRepositoryReleaseService
             var properties = document.RootElement.GetProperty("Properties");
             outputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "OutputPath", "OutDir", "TargetDir", "BaseOutputPath");
             intermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath", "BaseIntermediateOutputPath");
-            if (outputRoots.Length == 0 || intermediateRoots.Length == 0)
+            evaluatedAssemblyName = properties.TryGetProperty("AssemblyName", out var assemblyNameProperty)
+                ? assemblyNameProperty.GetString() ?? string.Empty
+                : string.Empty;
+            if (outputRoots.Length == 0 || intermediateRoots.Length == 0 || !IsUsableAssemblyName(evaluatedAssemblyName))
             {
-                error = $"Configured output paths for {project.ProjectName} could not be resolved to both output and intermediate roots.";
+                error = $"Configured build metadata for {project.ProjectName} could not be resolved to output roots, intermediate roots, and an assembly name.";
                 return false;
             }
 
@@ -250,6 +246,7 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             outputRoots = Array.Empty<string>();
             intermediateRoots = Array.Empty<string>();
+            evaluatedAssemblyName = string.Empty;
             error = $"Could not parse configured output paths for {project.ProjectName}. {ex.Message}";
             return false;
         }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.FreshPackageOutputs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Xml.Linq;
 
 namespace PowerForge;
@@ -20,11 +21,13 @@ public sealed partial class DotNetRepositoryReleaseService
         string configuration,
         ILogger logger,
         out int removedFileCount,
+        out bool removedIntermediatePrimaryOutput,
         out TimeSpan duration,
         out string error)
     {
         var watch = Stopwatch.StartNew();
         removedFileCount = 0;
+        removedIntermediatePrimaryOutput = false;
         error = string.Empty;
 
         try
@@ -32,7 +35,41 @@ public sealed partial class DotNetRepositoryReleaseService
             var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
             var primaryFileNames = ResolvePrimaryAssemblyFileNamesForCleanup(project)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var searchRoots = ResolvePrimaryOutputCleanupRoots(project.CsprojPath, projectDirectory, configuration);
+            var outputRoots = ResolvePrimaryOutputCleanupRoots(project.CsprojPath, projectDirectory, configuration);
+            var intermediateRoots = new[] { Path.GetFullPath(Path.Combine(projectDirectory, "obj", configuration)) };
+            if (HasConfiguredOutputPathProperties(project.CsprojPath, projectDirectory))
+            {
+                if (!TryResolveEvaluatedCleanupRoots(
+                        project,
+                        projectDirectory,
+                        configuration,
+                        logger,
+                        out var evaluatedOutputRoots,
+                        out var evaluatedIntermediateRoots,
+                        out _,
+                        out error))
+                {
+                    watch.Stop();
+                    duration = watch.Elapsed;
+                    logger.Error(error);
+                    return false;
+                }
+
+                outputRoots = outputRoots
+                    .Concat(evaluatedOutputRoots)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                // Only an evaluated intermediate root proves that a centrally configured
+                // compiler output was invalidated. An abandoned conventional obj tree must
+                // not accidentally enable the incremental fast path.
+                intermediateRoots = evaluatedIntermediateRoots;
+            }
+
+            var searchRoots = outputRoots
+                .Concat(intermediateRoots)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            var intermediateRootSet = intermediateRoots.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             foreach (var searchRoot in searchRoots)
             {
@@ -46,6 +83,8 @@ public sealed partial class DotNetRepositoryReleaseService
 
                     File.Delete(path);
                     removedFileCount++;
+                    if (intermediateRootSet.Any(root => IsPathWithinRoot(path, root)))
+                        removedIntermediatePrimaryOutput = true;
                 }
             }
 
@@ -99,8 +138,7 @@ public sealed partial class DotNetRepositoryReleaseService
     {
         var roots = new List<string>
         {
-            Path.Combine(projectDirectory, "bin", configuration),
-            Path.Combine(projectDirectory, "obj", configuration)
+            Path.Combine(projectDirectory, "bin", configuration)
         };
 
         foreach (var configuredOutputPath in ReadOutputPaths(csproj))
@@ -117,5 +155,134 @@ public sealed partial class DotNetRepositoryReleaseService
             .Select(Path.GetFullPath)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private static bool HasConfiguredOutputPathProperties(string csproj, string projectDirectory)
+    {
+        var paths = new List<string> { csproj };
+        for (var directory = new DirectoryInfo(projectDirectory); directory is not null; directory = directory.Parent)
+        {
+            paths.Add(Path.Combine(directory.FullName, "Directory.Build.props"));
+            paths.Add(Path.Combine(directory.FullName, "Directory.Build.targets"));
+        }
+
+        var relevantProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "ArtifactsPath",
+            "BaseIntermediateOutputPath",
+            "BaseOutputPath",
+            "IntermediateOutputPath",
+            "OutDir",
+            "OutputPath",
+            "UseArtifactsOutput"
+        };
+
+        foreach (var path in paths.Where(File.Exists).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var document = XDocument.Load(path);
+                if (document.Descendants().Any(element => relevantProperties.Contains(element.Name.LocalName)))
+                    return true;
+            }
+            catch
+            {
+                // MSBuild evaluation below remains unnecessary when configuration metadata cannot be inspected.
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveEvaluatedCleanupRoots(
+        DotNetRepositoryProjectResult project,
+        string projectDirectory,
+        string configuration,
+        ILogger logger,
+        out string[] outputRoots,
+        out string[] intermediateRoots,
+        out TimeSpan duration,
+        out string error)
+    {
+        const string propertyNames = "BaseOutputPath,BaseIntermediateOutputPath,OutputPath,OutDir,IntermediateOutputPath,TargetDir";
+        var exitCode = RunDotnetMsBuildGetProperty(
+            project.CsprojPath,
+            projectDirectory,
+            configuration,
+            null,
+            propertyNames,
+            project.ProjectName,
+            logger,
+            out _,
+            out var stdErr,
+            out var stdOut,
+            out duration);
+        if (exitCode != 0)
+        {
+            outputRoots = Array.Empty<string>();
+            intermediateRoots = Array.Empty<string>();
+            error = $"Could not evaluate configured output paths for {project.ProjectName}. {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
+            return false;
+        }
+
+        try
+        {
+            var jsonStart = stdOut.IndexOf('{');
+            var jsonEnd = stdOut.LastIndexOf('}');
+            if (jsonStart < 0 || jsonEnd < jsonStart)
+                throw new InvalidDataException("MSBuild property output did not contain a JSON object.");
+
+            using var document = JsonDocument.Parse(stdOut.Substring(jsonStart, jsonEnd - jsonStart + 1));
+            var properties = document.RootElement.GetProperty("Properties");
+            outputRoots = ResolveEvaluatedRoots(properties, projectDirectory, "OutputPath", "OutDir", "TargetDir", "BaseOutputPath");
+            intermediateRoots = ResolveEvaluatedRoots(properties, projectDirectory, "IntermediateOutputPath", "BaseIntermediateOutputPath");
+            if (outputRoots.Length == 0 || intermediateRoots.Length == 0)
+            {
+                error = $"Configured output paths for {project.ProjectName} could not be resolved to both output and intermediate roots.";
+                return false;
+            }
+
+            error = string.Empty;
+            logger.Verbose($"{project.ProjectName}: evaluated {outputRoots.Length} output and {intermediateRoots.Length} intermediate freshness root(s) in {FormatDuration(duration)}.");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            outputRoots = Array.Empty<string>();
+            intermediateRoots = Array.Empty<string>();
+            error = $"Could not parse configured output paths for {project.ProjectName}. {ex.Message}";
+            return false;
+        }
+    }
+
+    private static string[] ResolveEvaluatedRoots(
+        JsonElement properties,
+        string projectDirectory,
+        params string[] propertyNames)
+    {
+        foreach (var propertyName in propertyNames)
+        {
+            if (!properties.TryGetProperty(propertyName, out var property))
+                continue;
+
+            var value = property.GetString();
+            if (string.IsNullOrWhiteSpace(value) || value!.IndexOf("$(", StringComparison.Ordinal) >= 0)
+                continue;
+
+            var resolved = Path.IsPathRooted(value)
+                ? value
+                : Path.Combine(projectDirectory, value);
+            return new[] { Path.GetFullPath(resolved) };
+        }
+
+        return Array.Empty<string>();
+    }
+
+    private static bool IsPathWithinRoot(string path, string root)
+    {
+        var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var normalizedPath = Path.GetFullPath(path);
+        return normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
@@ -13,7 +13,19 @@ public sealed partial class DotNetRepositoryReleaseService
         out string error)
     {
         var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
-        logger.Info($"{project.ProjectName}: rebuilding assemblies before no-build pack...");
+        if (!TryRemoveStalePrimaryPackageOutputs(
+                project,
+                configuration,
+                logger,
+                out _,
+                out var cleanupDuration,
+                out error))
+        {
+            duration = cleanupDuration;
+            return false;
+        }
+
+        logger.Info($"{project.ProjectName}: building fresh assemblies before no-build pack...");
         var exitCode = RunDotnetBuild(
             project.CsprojPath,
             projectDirectory,
@@ -23,13 +35,14 @@ public sealed partial class DotNetRepositoryReleaseService
             out var standardError,
             out var standardOutput,
             out duration);
+        duration += cleanupDuration;
         if (exitCode != 0)
         {
             error = $"dotnet build failed for {project.ProjectName} (exit {exitCode}). {SummarizeProcessFailureOutput(standardError, standardOutput)}".Trim();
             return false;
         }
 
-        logger.Success($"{project.ProjectName}: release rebuild completed in {FormatDuration(duration)}.");
+        logger.Success($"{project.ProjectName}: fresh release build completed in {FormatDuration(duration)}.");
         error = string.Empty;
         return true;
     }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
@@ -18,6 +18,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 configuration,
                 logger,
                 out _,
+                out var removedIntermediatePrimaryOutput,
                 out var cleanupDuration,
                 out error))
         {
@@ -26,12 +27,15 @@ public sealed partial class DotNetRepositoryReleaseService
         }
 
         logger.Info($"{project.ProjectName}: building fresh assemblies before no-build pack...");
+        if (!removedIntermediatePrimaryOutput)
+            logger.Info($"{project.ProjectName}: no primary intermediate output was removed; using a non-incremental safety build.");
         var exitCode = RunDotnetBuild(
             project.CsprojPath,
             projectDirectory,
             configuration,
             project.ProjectName,
             logger,
+            forceNonIncremental: !removedIntermediatePrimaryOutput,
             out var standardError,
             out var standardOutput,
             out duration);

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -193,6 +193,7 @@ public sealed partial class DotNetRepositoryReleaseService
         var traversalPath = Path.Combine(tempRoot, "pack.proj");
         try
         {
+            var forceBatchRebuild = false;
             foreach (var project in projects)
             {
                 if (!TryRemoveStalePrimaryPackageOutputs(
@@ -200,6 +201,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim(),
                         logger,
                         out _,
+                        out var removedIntermediatePrimaryOutput,
                         out var cleanupDuration,
                         out var cleanupError))
                 {
@@ -209,9 +211,13 @@ public sealed partial class DotNetRepositoryReleaseService
                 }
 
                 result.Duration += cleanupDuration;
+                forceBatchRebuild |= !removedIntermediatePrimaryOutput;
             }
 
-            WritePackTraversalProject(traversalPath, projects, spec, outputPath);
+            if (forceBatchRebuild)
+                logger.Info("MSBuild batch freshness could not prove every intermediate output was removed; using the Rebuild safety target.");
+
+            WritePackTraversalProject(traversalPath, projects, spec, outputPath, forceBatchRebuild);
 
             var shouldSignAssemblies = signAssemblies is not null && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
             int exitCode;
@@ -309,7 +315,8 @@ public sealed partial class DotNetRepositoryReleaseService
         string traversalPath,
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         DotNetRepositoryReleaseSpec spec,
-        string outputPath)
+        string outputPath,
+        bool forceRebuild = false)
     {
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
         var buildProperties = $"Configuration={EscapeMsBuildPropertyValue(configuration)}";
@@ -341,10 +348,9 @@ public sealed partial class DotNetRepositoryReleaseService
                     new XAttribute("DependsOnTargets", "RestoreSelected"),
                     new XElement("MSBuild",
                         new XAttribute("Projects", "@(PackProject)"),
-                        // Freshness cleanup removes each selected project's primary output first.
-                        // A normal Build therefore recompiles the package producer while preserving
-                        // incremental project-reference and intermediate-output caches.
-                        new XAttribute("Targets", "Build"),
+                        // Freshness cleanup normally permits an incremental Build. Rebuild remains
+                        // the safety target when an intermediate compiler output was not removed.
+                        new XAttribute("Targets", forceRebuild ? "Rebuild" : "Build"),
                         new XAttribute("BuildInParallel", "true"),
                         new XAttribute("StopOnFirstFailure", "true"),
                         new XAttribute("Properties", buildProperties))),
@@ -510,6 +516,7 @@ public sealed partial class DotNetRepositoryReleaseService
         string configuration,
         string projectName,
         ILogger logger,
+        bool forceNonIncremental,
         out string stdErr,
         out string stdOut,
         out TimeSpan duration)
@@ -530,12 +537,17 @@ public sealed partial class DotNetRepositoryReleaseService
         ProcessStartInfoEncoding.TryApplyUtf8(psi);
 
 #if NET472
-        psi.Arguments = BuildWindowsArgumentString(new[] { "build", csproj, "--configuration", configuration });
+        var args = new List<string> { "build", csproj, "--configuration", configuration };
+        if (forceNonIncremental)
+            args.Add("--no-incremental");
+        psi.Arguments = BuildWindowsArgumentString(args);
 #else
         psi.ArgumentList.Add("build");
         psi.ArgumentList.Add(csproj);
         psi.ArgumentList.Add("--configuration");
         psi.ArgumentList.Add(configuration);
+        if (forceNonIncremental)
+            psi.ArgumentList.Add("--no-incremental");
 #endif
 
         var exitCode = RunProcessWithHeartbeat(

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -954,6 +954,33 @@ public sealed partial class DotNetRepositoryReleaseService
         out string stdErr,
         out string stdOut,
         out TimeSpan duration)
+        => RunDotnetMsBuildGetProperty(
+            csproj,
+            workingDirectory,
+            configuration,
+            targetFramework,
+            runtimeIdentifier: null,
+            propertyName,
+            projectName,
+            logger,
+            out value,
+            out stdErr,
+            out stdOut,
+            out duration);
+
+    private static int RunDotnetMsBuildGetProperty(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        string? runtimeIdentifier,
+        string propertyName,
+        string projectName,
+        ILogger logger,
+        out string? value,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
     {
         value = null;
         stdErr = string.Empty;
@@ -981,6 +1008,8 @@ public sealed partial class DotNetRepositoryReleaseService
         };
         if (!string.IsNullOrWhiteSpace(targetFramework))
             args.Add($"-p:TargetFramework={targetFramework!.Trim()}");
+        if (!string.IsNullOrWhiteSpace(runtimeIdentifier))
+            args.Add($"-p:RuntimeIdentifier={runtimeIdentifier!.Trim()}");
 
 #if NET472
         psi.Arguments = BuildWindowsArgumentString(args);

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -193,6 +193,24 @@ public sealed partial class DotNetRepositoryReleaseService
         var traversalPath = Path.Combine(tempRoot, "pack.proj");
         try
         {
+            foreach (var project in projects)
+            {
+                if (!TryRemoveStalePrimaryPackageOutputs(
+                        project,
+                        string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim(),
+                        logger,
+                        out _,
+                        out var cleanupDuration,
+                        out var cleanupError))
+                {
+                    result.Duration += cleanupDuration;
+                    result.ErrorMessage = cleanupError;
+                    return result;
+                }
+
+                result.Duration += cleanupDuration;
+            }
+
             WritePackTraversalProject(traversalPath, projects, spec, outputPath);
 
             var shouldSignAssemblies = signAssemblies is not null && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
@@ -323,7 +341,10 @@ public sealed partial class DotNetRepositoryReleaseService
                     new XAttribute("DependsOnTargets", "RestoreSelected"),
                     new XElement("MSBuild",
                         new XAttribute("Projects", "@(PackProject)"),
-                        new XAttribute("Targets", "Rebuild"),
+                        // Freshness cleanup removes each selected project's primary output first.
+                        // A normal Build therefore recompiles the package producer while preserving
+                        // incremental project-reference and intermediate-output caches.
+                        new XAttribute("Targets", "Build"),
                         new XAttribute("BuildInParallel", "true"),
                         new XAttribute("StopOnFirstFailure", "true"),
                         new XAttribute("Properties", buildProperties))),
@@ -509,13 +530,12 @@ public sealed partial class DotNetRepositoryReleaseService
         ProcessStartInfoEncoding.TryApplyUtf8(psi);
 
 #if NET472
-        psi.Arguments = BuildWindowsArgumentString(new[] { "build", csproj, "--configuration", configuration, "--no-incremental" });
+        psi.Arguments = BuildWindowsArgumentString(new[] { "build", csproj, "--configuration", configuration });
 #else
         psi.ArgumentList.Add("build");
         psi.ArgumentList.Add(csproj);
         psi.ArgumentList.Add("--configuration");
         psi.ArgumentList.Add(configuration);
-        psi.ArgumentList.Add("--no-incremental");
 #endif
 
         var exitCode = RunProcessWithHeartbeat(

--- a/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
@@ -48,6 +48,52 @@ public sealed class DotNetRepositoryReleaseSummaryService
         };
     }
 
+    /// <summary>
+    /// Creates a complete, multiline failure report without truncating project or package details.
+    /// </summary>
+    /// <param name="result">Repository release result to report.</param>
+    /// <returns>A human-readable failure report, or an empty string when the result succeeded.</returns>
+    public string CreateFailureReport(DotNetRepositoryReleaseResult result)
+    {
+        if (result is null)
+            throw new ArgumentNullException(nameof(result));
+        if (result.Success)
+            return string.Empty;
+
+        var failedProjects = result.Projects
+            .Where(static project => !string.IsNullOrWhiteSpace(project.ErrorMessage))
+            .OrderBy(static project => project.ProjectName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var failedPackages = result.FailedPackages
+            .Where(static package => !string.IsNullOrWhiteSpace(package))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static package => package, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var headline = failedProjects.Length > 0
+            ? $"Project build failed: {failedProjects.Length} of {result.Projects.Count} project(s) failed."
+            : "Project build failed.";
+        var lines = new List<string> { headline };
+
+        var aggregateError = result.ErrorMessage?.Trim();
+        if (!string.IsNullOrWhiteSpace(aggregateError) &&
+            !IsGeneratedProjectAggregate(aggregateError!, failedProjects))
+        {
+            lines.Add($"Cause: {aggregateError}");
+        }
+
+        foreach (var project in failedProjects)
+            lines.Add($"Detail: {FormatProjectFailure(project)}");
+
+        foreach (var package in failedPackages)
+            lines.Add($"Detail: Failed package publish: {package}");
+
+        if (lines.Count == 1)
+            lines.Add("Cause: The release pipeline reported failure without a detailed cause.");
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
     private static string BuildVersionDisplay(DotNetRepositoryProjectResult project)
     {
         if (string.IsNullOrWhiteSpace(project.OldVersion) && string.IsNullOrWhiteSpace(project.NewVersion))
@@ -75,5 +121,29 @@ public sealed class DotNetRepositoryReleaseSummaryService
             return trimmed;
 
         return trimmed.Substring(0, maxLength - 3) + "...";
+    }
+
+    private static bool IsGeneratedProjectAggregate(
+        string aggregateError,
+        IReadOnlyCollection<DotNetRepositoryProjectResult> failedProjects)
+    {
+        if (failedProjects.Count == 0 ||
+            !aggregateError.StartsWith("One or more projects failed:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return failedProjects.All(project =>
+            aggregateError.IndexOf(project.ProjectName, StringComparison.OrdinalIgnoreCase) >= 0 &&
+            aggregateError.IndexOf(project.ErrorMessage!.Trim(), StringComparison.OrdinalIgnoreCase) >= 0);
+    }
+
+    private static string FormatProjectFailure(DotNetRepositoryProjectResult project)
+    {
+        var error = project.ErrorMessage!.Trim();
+        var projectPrefix = project.ProjectName + ":";
+        return error.StartsWith(projectPrefix, StringComparison.OrdinalIgnoreCase)
+            ? error
+            : $"{project.ProjectName}: {error}";
     }
 }

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -116,14 +116,16 @@ internal sealed class ProjectBuildWorkflowService
         if (release is not null && release.Success)
             _logger.Success($"Project build release execution completed in {DotNetRepositoryReleaseService.FormatDuration(releaseWatch.Elapsed)}.");
         else
-            _logger.Warn($"Project build release execution failed after {DotNetRepositoryReleaseService.FormatDuration(releaseWatch.Elapsed)}.");
+            _logger.Error($"Project build release execution failed after {DotNetRepositoryReleaseService.FormatDuration(releaseWatch.Elapsed)}.");
 
         var result = new ProjectBuildResult { Release = release };
 
         if (release is null || !release.Success)
         {
             result.Success = false;
-            result.ErrorMessage = release?.ErrorMessage ?? "Release pipeline failed.";
+            result.ErrorMessage = release is null
+                ? "Project build failed. Cause: The release pipeline returned no result."
+                : new DotNetRepositoryReleaseSummaryService().CreateFailureReport(release);
             return new ProjectBuildWorkflowResult { Result = result };
         }
 


### PR DESCRIPTION
## Summary

- prevent `dotnet pack --no-build` from consuming stale primary assemblies left in obsolete framework/RID output folders
- keep conventional package builds incremental by removing only the selected project's primary `.dll`/`.exe` files from active `bin`/`obj` configuration roots, preserving restore assets, generated files, dependency outputs, and unrelated projects
- evaluate active MSBuild final-output/intermediate roots and assembly names for central, imported, configuration-, target-framework-, runtime-identifier-, `OutDir`, and artifacts-pivot layouts
- report complete project-build failures instead of collapsing them to a generic module-build error
- preserve every failed project and failed publish artifact without truncating long details
- emit non-interactive `-ExitCode` failures and classify fatal release completion as an error

## Behavior

Before a package-producing project is built, PowerForge applies a scoped freshness boundary to that project. Conventional layouts take the fast incremental `Build` path without launching MSBuild property evaluation. Configured layouts evaluate the active configuration and target frameworks once, then expand only declared runtime identifiers when RID-conditioned metadata exists. Root normalization only collapses the standard `Configuration/TargetFramework` suffix, so custom `TargetFramework/Configuration` layouts are not widened into Debug or unrelated TFM trees.

If the real intermediate primary output cannot be invalidated, PowerForge uses `--no-incremental` or `Rebuild` for safety. Package payload provenance validation still verifies the resulting NuGet assemblies against the fresh build. Cleanup, evaluation, build, pack, and provenance failures retain their complete project/package causes before the module returns exit code 1.

## Performance

The conventional path remains a filesystem-only cleanup and measured 0-4 ms per selected project; the DbaClientX dirty-workspace reproduction removed stale SQLite framework/RID outputs in 3 ms. MSBuild property queries are limited to projects that actually configure or import output metadata, and RID expansion is limited to their evaluated active TFMs and declared RIDs.