### PR TITLE
Fix quoted NuGet push response-file arguments

### DIFF
--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -31,12 +31,61 @@ public sealed class DotNetNuGetClientTests
             Assert.Single(captured.Arguments);
             Assert.StartsWith("@", captured.Arguments[0], StringComparison.Ordinal);
             Assert.NotNull(responseFileContent);
-            Assert.Contains("nuget", responseFileContent!, StringComparison.Ordinal);
-            Assert.Contains("push", responseFileContent!, StringComparison.Ordinal);
-            Assert.Contains("--skip-duplicate", responseFileContent!, StringComparison.Ordinal);
+            Assert.Equal(
+                string.Join(Environment.NewLine,
+                [
+                    "nuget",
+                    "push",
+                    @"C:\repo\Artifacts\Test.1.0.0.nupkg",
+                    "--api-key",
+                    "secret",
+                    "--source",
+                    "https://api.nuget.org/v3/index.json",
+                    "--skip-duplicate"
+                ]),
+                responseFileContent);
             Assert.True(result.Succeeded);
             Assert.NotNull(responseFilePath);
             Assert.False(File.Exists(responseFilePath!));
+        }
+        finally
+        {
+            try { Directory.Delete(runtimeDirectory, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task PushPackageAsync_WritesValuesWithSpacesAsSingleResponseFileLines()
+    {
+        string? responseFileContent = null;
+        var processRunner = new StubProcessRunner(request => {
+            responseFileContent = File.ReadAllText(request.Arguments.Single()[1..]);
+            return new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+        });
+        var runtimeDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var client = new DotNetNuGetClient(processRunner, runtimeDirectoryRoot: runtimeDirectory);
+
+        try
+        {
+            var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
+                packagePath: @"C:\repo with spaces\Artifacts\Test.1.0.0.nupkg",
+                apiKey: "secret value",
+                source: @"C:\local feed with spaces"));
+
+            Assert.Equal(
+                string.Join(Environment.NewLine,
+                [
+                    "nuget",
+                    "push",
+                    @"C:\repo with spaces\Artifacts\Test.1.0.0.nupkg",
+                    "--api-key",
+                    "secret value",
+                    "--source",
+                    @"C:\local feed with spaces",
+                    "--skip-duplicate"
+                ]),
+                responseFileContent);
+            Assert.True(result.Succeeded);
         }
         finally
         {

--- a/PowerForge/Services/DotNetNuGetClient.cs
+++ b/PowerForge/Services/DotNetNuGetClient.cs
@@ -141,14 +141,16 @@ public sealed class DotNetNuGetClient
 
     private static string BuildPushResponseFileContent(DotNetNuGetPushRequest request)
     {
+        // dotnet response files treat each line as one argument and preserve quote characters.
+        // Writing shell-style quotes here therefore passes the quotes into options such as --source.
         var lines = new List<string> {
             "nuget",
             "push",
-            QuoteResponseFileValue(request.PackagePath),
+            request.PackagePath,
             "--api-key",
-            QuoteResponseFileValue(request.ApiKey),
+            request.ApiKey,
             "--source",
-            QuoteResponseFileValue(request.Source)
+            request.Source
         };
 
         if (request.SkipDuplicate)
@@ -168,9 +170,6 @@ public sealed class DotNetNuGetClient
 
         return Environment.CurrentDirectory;
     }
-
-    private static string QuoteResponseFileValue(string value)
-        => "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
 
     private static void TryDeleteFile(string path)
     {


### PR DESCRIPTION
## Summary
- write `dotnet nuget push` response-file values as one raw argument per line
- prevent quote characters from becoming part of `--source`, package paths, and API keys
- cover the exact response-file content, including values containing spaces

## Why
DbaClientX package publishing currently reaches `dotnet nuget push` with a valid NuGet.org URL, but PowerForge wraps the response-file value in quotes. The .NET CLI preserves those quote characters and rejects the source as `"https://api.nuget.org/v3/index.json"`.

## Validation
- focused `DotNetNuGetClientTests`: 4 passed
- PowerForge builds: net472, net8.0, net10.0