### PR TITLE
Summarize all publish channels and prefer managed module publishing

### DIFF
--- a/PSPublishModule/PSPublishModule.csproj
+++ b/PSPublishModule/PSPublishModule.csproj
@@ -58,6 +58,7 @@
 
   <ItemGroup>
     <Compile Include="..\PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\PipelinePublishSummary.cs" Link="PowerForge.ConsoleShared\PipelinePublishSummary.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
   </ItemGroup>

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <Compile Include="..\PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\PipelinePublishSummary.cs" Link="PowerForge.ConsoleShared\PipelinePublishSummary.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
   </ItemGroup>

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -417,8 +417,10 @@ internal static partial class Program
             if (publishSummary.Rows.Count > 0)
             {
                 logger.Info($"Publish: {publishSummary.Rows.Count} result(s) across {publishSummary.ChannelCount} channel(s)");
+                foreach (var channel in publishSummary.Channels)
+                    logger.Info($" - {channel.Channel}: {channel.Label}");
                 foreach (var row in publishSummary.Rows)
-                    logger.Info($" - {row.Channel} | {row.Target} | {row.Result} | {row.Method} | {row.Reference}");
+                    logger.Info($"   * {row.Channel} | {row.Target} | {row.Result} | {row.Method} | {row.Reference}");
             }
             else
             {

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -413,6 +413,18 @@ internal static partial class Program
                     logger.Info($" - {a.Type}{(string.IsNullOrWhiteSpace(a.Id) ? string.Empty : $" ({a.Id})")}: {a.OutputPath}");
             }
 
+            var publishSummary = PowerForge.ConsoleShared.PipelinePublishSummaryBuilder.Build(res);
+            if (publishSummary.Rows.Count > 0)
+            {
+                logger.Info($"Publish: {publishSummary.Rows.Count} result(s) across {publishSummary.ChannelCount} channel(s)");
+                foreach (var row in publishSummary.Rows)
+                    logger.Info($" - {row.Channel} | {row.Target} | {row.Result} | {row.Method} | {row.Reference}");
+            }
+            else
+            {
+                logger.Info("Publish: disabled");
+            }
+
             if (res.DiagnosticsBaseline is not null)
             {
                 var baseline = res.DiagnosticsBaseline;

--- a/PowerForge.ConsoleShared/PipelinePublishSummary.cs
+++ b/PowerForge.ConsoleShared/PipelinePublishSummary.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PowerForge;
+
+namespace PowerForge.ConsoleShared;
+
+internal sealed class PipelinePublishSummary
+{
+    internal PipelinePublishSummary(IReadOnlyList<PipelinePublishSummaryRow> rows)
+    {
+        Rows = rows ?? Array.Empty<PipelinePublishSummaryRow>();
+        ChannelCount = Rows
+            .Select(static row => row.Channel)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+    }
+
+    internal IReadOnlyList<PipelinePublishSummaryRow> Rows { get; }
+
+    internal int ChannelCount { get; }
+}
+
+internal sealed class PipelinePublishSummaryRow
+{
+    internal PipelinePublishSummaryRow(
+        string channel,
+        string target,
+        string result,
+        string method,
+        string reference)
+    {
+        Channel = channel ?? string.Empty;
+        Target = target ?? string.Empty;
+        Result = result ?? string.Empty;
+        Method = method ?? string.Empty;
+        Reference = reference ?? string.Empty;
+    }
+
+    internal string Channel { get; }
+
+    internal string Target { get; }
+
+    internal string Result { get; }
+
+    internal string Method { get; }
+
+    internal string Reference { get; }
+}
+
+internal static class PipelinePublishSummaryBuilder
+{
+    internal static PipelinePublishSummary Build(ModulePipelineResult result)
+    {
+        if (result is null)
+            throw new ArgumentNullException(nameof(result));
+
+        return Build(result.Plan.ModuleName, result.PublishResults, result.ProjectBuildResults);
+    }
+
+    internal static PipelinePublishSummary Build(
+        string moduleName,
+        IReadOnlyList<ModulePublishResult>? modulePublishes,
+        IReadOnlyList<ProjectBuildHostExecutionResult>? projectBuilds)
+    {
+        var rows = new List<PipelinePublishSummaryRow>();
+        AddProjectBuildRows(rows, projectBuilds);
+        AddModulePublishRows(rows, moduleName, modulePublishes);
+
+        var ordered = rows
+            .OrderBy(static row => GetChannelOrder(row.Channel))
+            .ToArray();
+        return new PipelinePublishSummary(ordered);
+    }
+
+    private static void AddProjectBuildRows(
+        ICollection<PipelinePublishSummaryRow> rows,
+        IReadOnlyList<ProjectBuildHostExecutionResult>? projectBuilds)
+    {
+        foreach (var build in projectBuilds ?? Array.Empty<ProjectBuildHostExecutionResult>())
+        {
+            var buildResult = build?.Result;
+            var release = buildResult?.Release;
+            if (release is null)
+                continue;
+
+            AddNuGetRows(rows, release, release.PublishedPackages, "Published");
+            AddNuGetRows(rows, release, release.SkippedDuplicatePackages, "Already existed");
+            AddNuGetRows(rows, release, release.FailedPackages, "Failed");
+            AddProjectGitHubRows(rows, buildResult!.GitHub, release);
+        }
+    }
+
+    private static void AddNuGetRows(
+        ICollection<PipelinePublishSummaryRow> rows,
+        DotNetRepositoryReleaseResult release,
+        IEnumerable<string>? packages,
+        string outcome)
+    {
+        foreach (var package in (packages ?? Array.Empty<string>())
+                     .Where(static path => !string.IsNullOrWhiteSpace(path))
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var project = FindProject(release, package);
+            var packageId = FirstNonEmpty(project?.PackageId, project?.ProjectName, Path.GetFileNameWithoutExtension(package));
+            var version = ResolveProjectVersion(release, project);
+            var identity = string.IsNullOrWhiteSpace(version)
+                ? packageId
+                : $"{packageId} {version}";
+            var reference = BuildNuGetReference(release.PublishSource, packageId, version);
+
+            rows.Add(new PipelinePublishSummaryRow(
+                channel: "NuGet",
+                target: BuildNuGetTarget(release.PublishSource),
+                result: $"{outcome} {identity}".Trim(),
+                method: "NuGet API",
+                reference: reference));
+        }
+    }
+
+    private static void AddProjectGitHubRows(
+        ICollection<PipelinePublishSummaryRow> rows,
+        IReadOnlyList<ProjectBuildGitHubResult>? publishes,
+        DotNetRepositoryReleaseResult release)
+    {
+        var assetCount = release.Projects
+            .Select(static project => project.ReleaseZipPath)
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+
+        foreach (var group in (publishes ?? Array.Empty<ProjectBuildGitHubResult>())
+                     .Where(static publish => publish is not null)
+                     .GroupBy(
+                         static publish => $"{publish.TagName}\n{publish.ReleaseUrl}\n{publish.Success}",
+                         StringComparer.OrdinalIgnoreCase))
+        {
+            var publish = group.First();
+            var tag = string.IsNullOrWhiteSpace(publish.TagName) ? "(tag unavailable)" : publish.TagName!;
+            var result = publish.Success
+                ? assetCount > 0 ? $"Published {tag} ({assetCount} assets)" : $"Published {tag}"
+                : $"Failed {tag}";
+
+            rows.Add(new PipelinePublishSummaryRow(
+                channel: "GitHub",
+                target: BuildGitHubTarget(publish.ReleaseUrl),
+                result: result,
+                method: "GitHub API",
+                reference: publish.Success ? publish.ReleaseUrl ?? string.Empty : publish.ErrorMessage ?? string.Empty));
+        }
+    }
+
+    private static void AddModulePublishRows(
+        ICollection<PipelinePublishSummaryRow> rows,
+        string moduleName,
+        IReadOnlyList<ModulePublishResult>? publishes)
+    {
+        foreach (var publish in publishes ?? Array.Empty<ModulePublishResult>())
+        {
+            if (publish is null)
+                continue;
+
+            if (publish.Destination == PublishDestination.GitHub)
+            {
+                var tag = string.IsNullOrWhiteSpace(publish.TagName) ? "(tag unavailable)" : publish.TagName!;
+                var assetCount = publish.AssetPaths?.Length ?? 0;
+                var result = publish.Succeeded
+                    ? assetCount > 0 ? $"Published {tag} ({assetCount} assets)" : $"Published {tag}"
+                    : $"Failed {tag}";
+                rows.Add(new PipelinePublishSummaryRow(
+                    channel: "GitHub",
+                    target: BuildGitHubTarget(publish.ReleaseUrl, publish.UserName, publish.RepositoryName),
+                    result: result,
+                    method: "GitHub API",
+                    reference: publish.Succeeded ? publish.ReleaseUrl ?? string.Empty : publish.ErrorMessage ?? string.Empty));
+                continue;
+            }
+
+            var version = string.IsNullOrWhiteSpace(publish.VersionText) ? "(version unavailable)" : publish.VersionText;
+            var identity = $"{moduleName} {version}".Trim();
+            rows.Add(new PipelinePublishSummaryRow(
+                channel: "PowerShellGallery",
+                target: string.IsNullOrWhiteSpace(publish.RepositoryName) ? "(repository unavailable)" : publish.RepositoryName!,
+                result: publish.Succeeded ? $"Published {identity}" : $"Failed {identity}",
+                method: publish.Tool?.ToString() ?? "Repository API",
+                reference: publish.Succeeded
+                    ? BuildPowerShellGalleryReference(moduleName, publish)
+                    : publish.ErrorMessage ?? string.Empty));
+        }
+    }
+
+    private static DotNetRepositoryProjectResult? FindProject(DotNetRepositoryReleaseResult release, string package)
+        => release.Projects.FirstOrDefault(project =>
+            project.Packages.Any(candidate => PathsEqual(candidate, package)));
+
+    private static string ResolveProjectVersion(
+        DotNetRepositoryReleaseResult release,
+        DotNetRepositoryProjectResult? project)
+    {
+        if (project is null)
+            return release.ResolvedVersion ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(project.NewVersion))
+            return project.NewVersion!;
+        if (release.ResolvedVersionsByProject.TryGetValue(project.ProjectName, out var resolved))
+            return resolved;
+        return project.OldVersion ?? release.ResolvedVersion ?? string.Empty;
+    }
+
+    private static string BuildNuGetTarget(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return "(NuGet feed)";
+        return IsNuGetOrg(source!) ? "nuget.org" : source!.Trim();
+    }
+
+    private static string BuildNuGetReference(string? source, string packageId, string version)
+    {
+        if (IsNuGetOrg(source) && !string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(version))
+            return $"https://www.nuget.org/packages/{Uri.EscapeDataString(packageId)}/{Uri.EscapeDataString(version)}";
+        return source?.Trim() ?? string.Empty;
+    }
+
+    private static string BuildPowerShellGalleryReference(string moduleName, ModulePublishResult publish)
+    {
+        if (string.Equals(publish.RepositoryName, "PSGallery", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(moduleName) &&
+            !string.IsNullOrWhiteSpace(publish.VersionText))
+        {
+            return $"https://www.powershellgallery.com/packages/{Uri.EscapeDataString(moduleName)}/{Uri.EscapeDataString(publish.VersionText)}";
+        }
+
+        return publish.ReleaseUrl ?? string.Empty;
+    }
+
+    private static string BuildGitHubTarget(string? releaseUrl, string? owner = null, string? repository = null)
+    {
+        if (!string.IsNullOrWhiteSpace(owner) || !string.IsNullOrWhiteSpace(repository))
+            return $"{FirstNonEmpty(owner, "(owner unavailable)")}/{FirstNonEmpty(repository, "(repository unavailable)")}";
+
+        if (Uri.TryCreate(releaseUrl, UriKind.Absolute, out var uri) &&
+            uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
+        {
+            var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length >= 2)
+                return $"{segments[0]}/{segments[1]}";
+        }
+
+        return "(GitHub release)";
+    }
+
+    private static bool IsNuGetOrg(string? source)
+        => !string.IsNullOrWhiteSpace(source) &&
+           source!.IndexOf("nuget.org", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    private static bool PathsEqual(string? left, string? right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            return false;
+
+        try
+        {
+            return string.Equals(Path.GetFullPath(left!), Path.GetFullPath(right!), StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return string.Equals(left!.Trim(), right!.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string FirstNonEmpty(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
+
+    private static int GetChannelOrder(string channel)
+        => channel switch
+        {
+            "NuGet" => 0,
+            "PowerShellGallery" => 1,
+            "GitHub" => 2,
+            _ => 3
+        };
+}

--- a/PowerForge.ConsoleShared/PipelinePublishSummary.cs
+++ b/PowerForge.ConsoleShared/PipelinePublishSummary.cs
@@ -11,15 +11,81 @@ internal sealed class PipelinePublishSummary
     internal PipelinePublishSummary(IReadOnlyList<PipelinePublishSummaryRow> rows)
     {
         Rows = rows ?? Array.Empty<PipelinePublishSummaryRow>();
-        ChannelCount = Rows
-            .Select(static row => row.Channel)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Count();
+        Channels = Rows
+            .GroupBy(static row => row.Channel, StringComparer.OrdinalIgnoreCase)
+            .Select(BuildChannelSummary)
+            .ToArray();
     }
 
     internal IReadOnlyList<PipelinePublishSummaryRow> Rows { get; }
 
-    internal int ChannelCount { get; }
+    internal IReadOnlyList<PipelinePublishChannelSummary> Channels { get; }
+
+    internal int ChannelCount => Channels.Count;
+
+    private static PipelinePublishChannelSummary BuildChannelSummary(
+        IGrouping<string, PipelinePublishSummaryRow> channel)
+    {
+        var rows = channel.ToArray();
+        var itemName = channel.Key switch
+        {
+            "NuGet" => rows.Length == 1 ? "package" : "packages",
+            "PowerShell Gallery" => rows.Length == 1 ? "module" : "modules",
+            "GitHub" => rows.Length == 1 ? "release" : "releases",
+            _ => rows.Length == 1 ? "result" : "results"
+        };
+        var parts = new List<string> { $"{rows.Length} {itemName}" };
+
+        AddOutcome(parts, rows, PipelinePublishOutcome.Published, "published");
+        AddOutcome(parts, rows, PipelinePublishOutcome.AlreadyExisted, "already existed");
+        AddOutcome(parts, rows, PipelinePublishOutcome.Failed, "failed");
+
+        var targets = rows
+            .Select(static row => row.Target)
+            .Where(static target => !string.IsNullOrWhiteSpace(target))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (targets.Length == 1)
+            parts.Add(targets[0]);
+        else if (targets.Length > 1)
+            parts.Add($"{targets.Length} targets");
+
+        var methods = rows
+            .Select(static row => row.Method)
+            .Where(static method => !string.IsNullOrWhiteSpace(method))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (methods.Length == 1)
+            parts.Add($"via {methods[0]}");
+        else if (methods.Length > 1)
+            parts.Add($"via {methods.Length} methods");
+
+        return new PipelinePublishChannelSummary(channel.Key, string.Join(", ", parts));
+    }
+
+    private static void AddOutcome(
+        ICollection<string> parts,
+        IEnumerable<PipelinePublishSummaryRow> rows,
+        PipelinePublishOutcome outcome,
+        string label)
+    {
+        var count = rows.Count(row => row.Outcome == outcome);
+        if (count > 0)
+            parts.Add($"{count} {label}");
+    }
+}
+
+internal sealed class PipelinePublishChannelSummary
+{
+    internal PipelinePublishChannelSummary(string channel, string label)
+    {
+        Channel = channel ?? string.Empty;
+        Label = label ?? string.Empty;
+    }
+
+    internal string Channel { get; }
+
+    internal string Label { get; }
 }
 
 internal sealed class PipelinePublishSummaryRow
@@ -29,13 +95,15 @@ internal sealed class PipelinePublishSummaryRow
         string target,
         string result,
         string method,
-        string reference)
+        string reference,
+        PipelinePublishOutcome outcome)
     {
         Channel = channel ?? string.Empty;
         Target = target ?? string.Empty;
         Result = result ?? string.Empty;
         Method = method ?? string.Empty;
         Reference = reference ?? string.Empty;
+        Outcome = outcome;
     }
 
     internal string Channel { get; }
@@ -47,6 +115,15 @@ internal sealed class PipelinePublishSummaryRow
     internal string Method { get; }
 
     internal string Reference { get; }
+
+    internal PipelinePublishOutcome Outcome { get; }
+}
+
+internal enum PipelinePublishOutcome
+{
+    Published,
+    AlreadyExisted,
+    Failed
 }
 
 internal static class PipelinePublishSummaryBuilder
@@ -85,9 +162,9 @@ internal static class PipelinePublishSummaryBuilder
             if (release is null)
                 continue;
 
-            AddNuGetRows(rows, release, release.PublishedPackages, "Published");
-            AddNuGetRows(rows, release, release.SkippedDuplicatePackages, "Already existed");
-            AddNuGetRows(rows, release, release.FailedPackages, "Failed");
+            AddNuGetRows(rows, release, release.PublishedPackages, PipelinePublishOutcome.Published);
+            AddNuGetRows(rows, release, release.SkippedDuplicatePackages, PipelinePublishOutcome.AlreadyExisted);
+            AddNuGetRows(rows, release, release.FailedPackages, PipelinePublishOutcome.Failed);
             AddProjectGitHubRows(rows, buildResult!.GitHub, release);
         }
     }
@@ -96,7 +173,7 @@ internal static class PipelinePublishSummaryBuilder
         ICollection<PipelinePublishSummaryRow> rows,
         DotNetRepositoryReleaseResult release,
         IEnumerable<string>? packages,
-        string outcome)
+        PipelinePublishOutcome outcome)
     {
         foreach (var package in (packages ?? Array.Empty<string>())
                      .Where(static path => !string.IsNullOrWhiteSpace(path))
@@ -113,9 +190,10 @@ internal static class PipelinePublishSummaryBuilder
             rows.Add(new PipelinePublishSummaryRow(
                 channel: "NuGet",
                 target: BuildNuGetTarget(release.PublishSource),
-                result: $"{outcome} {identity}".Trim(),
-                method: "NuGet API",
-                reference: reference));
+                result: $"{FormatOutcome(outcome)} {identity}".Trim(),
+                method: "dotnet nuget push",
+                reference: reference,
+                outcome: outcome));
         }
     }
 
@@ -147,7 +225,8 @@ internal static class PipelinePublishSummaryBuilder
                 target: BuildGitHubTarget(publish.ReleaseUrl),
                 result: result,
                 method: "GitHub API",
-                reference: publish.Success ? publish.ReleaseUrl ?? string.Empty : publish.ErrorMessage ?? string.Empty));
+                reference: publish.Success ? publish.ReleaseUrl ?? string.Empty : publish.ErrorMessage ?? string.Empty,
+                outcome: publish.Success ? PipelinePublishOutcome.Published : PipelinePublishOutcome.Failed));
         }
     }
 
@@ -173,20 +252,22 @@ internal static class PipelinePublishSummaryBuilder
                     target: BuildGitHubTarget(publish.ReleaseUrl, publish.UserName, publish.RepositoryName),
                     result: result,
                     method: "GitHub API",
-                    reference: publish.Succeeded ? publish.ReleaseUrl ?? string.Empty : publish.ErrorMessage ?? string.Empty));
+                    reference: publish.Succeeded ? publish.ReleaseUrl ?? string.Empty : publish.ErrorMessage ?? string.Empty,
+                    outcome: publish.Succeeded ? PipelinePublishOutcome.Published : PipelinePublishOutcome.Failed));
                 continue;
             }
 
             var version = string.IsNullOrWhiteSpace(publish.VersionText) ? "(version unavailable)" : publish.VersionText;
             var identity = $"{moduleName} {version}".Trim();
             rows.Add(new PipelinePublishSummaryRow(
-                channel: "PowerShellGallery",
+                channel: "PowerShell Gallery",
                 target: string.IsNullOrWhiteSpace(publish.RepositoryName) ? "(repository unavailable)" : publish.RepositoryName!,
                 result: publish.Succeeded ? $"Published {identity}" : $"Failed {identity}",
                 method: publish.Tool?.ToString() ?? "Repository API",
                 reference: publish.Succeeded
                     ? BuildPowerShellGalleryReference(moduleName, publish)
-                    : publish.ErrorMessage ?? string.Empty));
+                    : publish.ErrorMessage ?? string.Empty,
+                outcome: publish.Succeeded ? PipelinePublishOutcome.Published : PipelinePublishOutcome.Failed));
         }
     }
 
@@ -271,11 +352,20 @@ internal static class PipelinePublishSummaryBuilder
     private static string FirstNonEmpty(params string?[] values)
         => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
 
+    private static string FormatOutcome(PipelinePublishOutcome outcome)
+        => outcome switch
+        {
+            PipelinePublishOutcome.Published => "Published",
+            PipelinePublishOutcome.AlreadyExisted => "Already existed",
+            PipelinePublishOutcome.Failed => "Failed",
+            _ => outcome.ToString()
+        };
+
     private static int GetChannelOrder(string channel)
         => channel switch
         {
             "NuGet" => 0,
-            "PowerShellGallery" => 1,
+            "PowerShell Gallery" => 1,
             "GitHub" => 2,
             _ => 3
         };

--- a/PowerForge.ConsoleShared/PipelinePublishSummary.cs
+++ b/PowerForge.ConsoleShared/PipelinePublishSummary.cs
@@ -290,16 +290,31 @@ internal static class PipelinePublishSummaryBuilder
 
     private static string BuildNuGetTarget(string? source)
     {
-        if (string.IsNullOrWhiteSpace(source))
+        var safeSource = SanitizeRepositorySource(source);
+        if (string.IsNullOrWhiteSpace(safeSource))
             return "(NuGet feed)";
-        return IsNuGetOrg(source!) ? "nuget.org" : source!.Trim();
+        return IsNuGetOrg(safeSource) ? "nuget.org" : safeSource;
     }
 
     private static string BuildNuGetReference(string? source, string packageId, string version)
     {
         if (IsNuGetOrg(source) && !string.IsNullOrWhiteSpace(packageId) && !string.IsNullOrWhiteSpace(version))
             return $"https://www.nuget.org/packages/{Uri.EscapeDataString(packageId)}/{Uri.EscapeDataString(version)}";
-        return source?.Trim() ?? string.Empty;
+        return SanitizeRepositorySource(source);
+    }
+
+    private static string SanitizeRepositorySource(string? source)
+    {
+        var value = source?.Trim() ?? string.Empty;
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) || string.IsNullOrWhiteSpace(uri.UserInfo))
+            return value;
+
+        var builder = new UriBuilder(uri)
+        {
+            UserName = string.Empty,
+            Password = string.Empty
+        };
+        return builder.Uri.AbsoluteUri;
     }
 
     private static string BuildPowerShellGalleryReference(string moduleName, ModulePublishResult publish)

--- a/PowerForge.ConsoleShared/SpectrePipelineSummaryWriter.cs
+++ b/PowerForge.ConsoleShared/SpectrePipelineSummaryWriter.cs
@@ -197,9 +197,19 @@ internal static class SpectrePipelineSummaryWriter
             table.AddRow($"{(unicode ? "📦" : "*")} Artefacts", "[grey]None[/]");
 
         if (publishSummary.Rows.Count > 0)
+        {
             table.AddRow(
                 $"{(unicode ? "🚀" : "*")} Publish",
                 $"[green]{publishSummary.Rows.Count}[/] result(s) across [green]{publishSummary.ChannelCount}[/] channel(s)");
+
+            foreach (var channel in publishSummary.Channels)
+            {
+                var icon = unicode
+                    ? channel.Channel == "GitHub" ? "🚀" : "📦"
+                    : "*";
+                table.AddRow($"{icon} {Esc(channel.Channel)}", Esc(channel.Label));
+            }
+        }
         else
             table.AddRow($"{(unicode ? "🚀" : "*")} Publish", "[grey]Disabled[/]");
 

--- a/PowerForge.ConsoleShared/SpectrePipelineSummaryWriter.cs
+++ b/PowerForge.ConsoleShared/SpectrePipelineSummaryWriter.cs
@@ -57,6 +57,7 @@ internal static class SpectrePipelineSummaryWriter
         var unicode = AnsiConsole.Profile.Capabilities.Unicode;
         var border = unicode ? TableBorder.Rounded : TableBorder.Simple;
         var versionText = BuildServices.FormatVersionWithPreRelease(res.Plan.ResolvedVersion, res.Plan.PreRelease);
+        var publishSummary = PipelinePublishSummaryBuilder.Build(res);
 
         AnsiConsole.Write(new Rule($"[green]{(unicode ? "✅" : "OK")} Summary[/]").LeftJustified());
 
@@ -195,8 +196,10 @@ internal static class SpectrePipelineSummaryWriter
         else
             table.AddRow($"{(unicode ? "📦" : "*")} Artefacts", "[grey]None[/]");
 
-        if (res.PublishResults is { Length: > 0 })
-            table.AddRow($"{(unicode ? "🚀" : "*")} Publish", $"[green]{res.PublishResults.Length}[/] destination(s)");
+        if (publishSummary.Rows.Count > 0)
+            table.AddRow(
+                $"{(unicode ? "🚀" : "*")} Publish",
+                $"[green]{publishSummary.Rows.Count}[/] result(s) across [green]{publishSummary.ChannelCount}[/] channel(s)");
         else
             table.AddRow($"{(unicode ? "🚀" : "*")} Publish", "[grey]Disabled[/]");
 
@@ -330,24 +333,20 @@ internal static class SpectrePipelineSummaryWriter
             AnsiConsole.Write(artefacts);
         }
 
-        if (res.PublishResults is { Length: > 0 })
+        if (publishSummary.Rows.Count > 0)
         {
             AnsiConsole.WriteLine();
 
             var publishes = new Table()
                 .Border(border)
-                .AddColumn(new TableColumn("Destination").NoWrap())
+                .AddColumn(new TableColumn("Channel").NoWrap())
                 .AddColumn(new TableColumn("Target").NoWrap())
-                .AddColumn(new TableColumn("Published").NoWrap())
+                .AddColumn(new TableColumn("Result").NoWrap())
+                .AddColumn(new TableColumn("Method").NoWrap())
                 .AddColumn(new TableColumn("Reference"));
 
-            foreach (var publish in res.PublishResults)
-            {
-                var target = BuildPublishTarget(publish);
-                var published = BuildPublishLabel(publish);
-                var reference = BuildPublishReference(res.Plan, publish);
-                publishes.AddRow(Esc(publish.Destination.ToString()), Esc(target), Esc(published), Esc(reference));
-            }
+            foreach (var row in publishSummary.Rows)
+                publishes.AddRow(Esc(row.Channel), Esc(row.Target), Esc(row.Result), Esc(row.Method), Esc(row.Reference));
 
             AnsiConsole.Write(publishes);
         }
@@ -400,45 +399,6 @@ internal static class SpectrePipelineSummaryWriter
 
         AnsiConsole.Write(table);
         WriteFailureDetails(message, border);
-    }
-
-    private static string BuildPublishTarget(ModulePublishResult publish)
-    {
-        if (publish.Destination == PublishDestination.GitHub)
-        {
-            var owner = string.IsNullOrWhiteSpace(publish.UserName) ? "(owner?)" : publish.UserName;
-            var repo = string.IsNullOrWhiteSpace(publish.RepositoryName) ? "(repo?)" : publish.RepositoryName;
-            return $"{owner}/{repo}";
-        }
-
-        return string.IsNullOrWhiteSpace(publish.RepositoryName) ? "(repository?)" : publish.RepositoryName!;
-    }
-
-    private static string BuildPublishLabel(ModulePublishResult publish)
-    {
-        var version = string.IsNullOrWhiteSpace(publish.VersionText) ? "(unknown)" : publish.VersionText;
-        if (publish.Destination != PublishDestination.GitHub)
-            return version;
-
-        var tag = string.IsNullOrWhiteSpace(publish.TagName) ? "(tag?)" : publish.TagName;
-        var assetCount = publish.AssetPaths?.Length ?? 0;
-        return assetCount > 0 ? $"{tag} ({version}, assets {assetCount})" : $"{tag} ({version})";
-    }
-
-    private static string BuildPublishReference(ModulePipelinePlan plan, ModulePublishResult publish)
-    {
-        if (!string.IsNullOrWhiteSpace(publish.ReleaseUrl))
-            return publish.ReleaseUrl!;
-
-        if (publish.Destination == PublishDestination.PowerShellGallery &&
-            string.Equals(publish.RepositoryName, "PSGallery", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrWhiteSpace(plan.ModuleName) &&
-            !string.IsNullOrWhiteSpace(publish.VersionText))
-        {
-            return $"https://www.powershellgallery.com/packages/{plan.ModuleName}/{publish.VersionText}";
-        }
-
-        return string.Empty;
     }
 
     private static void WriteFileConsistencyIssues(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Dependencies.cs
@@ -216,7 +216,8 @@ public sealed partial class ModulePipelineRunner
                 case PublishTool.ManagedModule:
                     break;
                 case PublishTool.Auto:
-                    AddRepositoryToolDependencyForAuto(dependencies);
+                    if (!ModulePublisher.ShouldUseManagedModuleForAuto(cfg))
+                        AddRepositoryToolDependencyForAuto(dependencies);
                     break;
             }
         }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -246,6 +246,7 @@ public sealed partial class ModulePipelineRunner
         var source = string.IsNullOrWhiteSpace(feed.PublishSource)
             ? ProjectBuildPackageFeedResolver.GetDefaultPublishSource()
             : feed.PublishSource!.Trim();
+        release.PublishSource = source;
         var packages = release.Projects
             .SelectMany(project => project.Packages)
             .Where(package => !string.IsNullOrWhiteSpace(package))

--- a/PowerForge.Tests/ManagedModuleProviderSupportEvaluatorTests.cs
+++ b/PowerForge.Tests/ManagedModuleProviderSupportEvaluatorTests.cs
@@ -27,6 +27,18 @@ public sealed class ManagedModuleProviderSupportEvaluatorTests
         Assert.Empty(support.Limitations);
     }
 
+    [Fact]
+    public void EvaluateRepository_ClassifiesAzureArtifactsEndpointAsPartial()
+    {
+        var support = ManagedModuleProviderSupportEvaluator.Evaluate(new ManagedModuleRepository(
+            "CompanyModules",
+            "https://pkgs.dev.azure.com/contoso/Platform/_packaging/CompanyModules/nuget/v3/index.json"));
+
+        Assert.Equal(ManagedModuleProviderSupportLevel.Partial, support.Level);
+        Assert.True(support.CompatibilityFallbackRecommended);
+        Assert.Contains(support.Limitations, limitation => limitation.Contains("credential-provider", StringComparison.OrdinalIgnoreCase));
+    }
+
     [Theory]
     [InlineData(PrivateGalleryProvider.AzureArtifacts, ManagedModuleProviderSupportLevel.Partial, "credential-provider")]
     [InlineData(PrivateGalleryProvider.JFrog, ManagedModuleProviderSupportLevel.Partial, "OIDC")]

--- a/PowerForge.Tests/ManagedModuleProviderSupportEvaluatorTests.cs
+++ b/PowerForge.Tests/ManagedModuleProviderSupportEvaluatorTests.cs
@@ -17,14 +17,14 @@ public sealed class ManagedModuleProviderSupportEvaluatorTests
     }
 
     [Fact]
-    public void EvaluateRepository_ClassifiesNuGetV2AsPartialBecauseManagedPublishNeedsV3OrLocal()
+    public void EvaluateRepository_ClassifiesNuGetV2AsSupported()
     {
         var support = ManagedModuleProviderSupportEvaluator.Evaluate(new ManagedModuleRepository("Legacy", "https://nuget.example.test/api/v2"));
 
-        Assert.Equal(ManagedModuleProviderSupportLevel.Partial, support.Level);
+        Assert.Equal(ManagedModuleProviderSupportLevel.Supported, support.Level);
         Assert.True(support.ManagedLifecycleSupported);
-        Assert.True(support.CompatibilityFallbackRecommended);
-        Assert.Contains(support.Limitations, limitation => limitation.Contains("publishing", StringComparison.OrdinalIgnoreCase));
+        Assert.False(support.CompatibilityFallbackRecommended);
+        Assert.Empty(support.Limitations);
     }
 
     [Theory]

--- a/PowerForge.Tests/ManagedModuleProviderSupportEvaluatorTests.cs
+++ b/PowerForge.Tests/ManagedModuleProviderSupportEvaluatorTests.cs
@@ -27,6 +27,19 @@ public sealed class ManagedModuleProviderSupportEvaluatorTests
         Assert.Empty(support.Limitations);
     }
 
+    [Theory]
+    [InlineData("https://packages.example.test/api/v2/items/psscript")]
+    [InlineData("https://www.powershellgallery.com/api/v2/items/psscript/")]
+    public void EvaluateRepository_RejectsPowerShellGetScriptEndpointsForModulePublishing(string source)
+    {
+        var support = ManagedModuleProviderSupportEvaluator.Evaluate(new ManagedModuleRepository("Scripts", source));
+
+        Assert.Equal(ManagedModuleProviderSupportLevel.Unsupported, support.Level);
+        Assert.False(support.ManagedLifecycleSupported);
+        Assert.True(support.CompatibilityFallbackRecommended);
+        Assert.Contains(support.Limitations, limitation => limitation.Contains("module publish", StringComparison.OrdinalIgnoreCase));
+    }
+
     [Fact]
     public void EvaluateRepository_ClassifiesAzureArtifactsEndpointAsPartial()
     {

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -131,7 +131,7 @@ public sealed class ManagedModuleRepositoryClientTests
         var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
         var repository = new ManagedModuleRepository(
             "PSGallery",
-            "https://www.powershellgallery.com/api/v3/index.json");
+            ManagedModuleCatalogDefaults.PowerShellGalleryV2);
 
         var versions = await repositoryClient.GetVersionsAsync(repository, "Pester", includePrerelease: false);
 
@@ -156,7 +156,7 @@ public sealed class ManagedModuleRepositoryClientTests
         var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
         var repository = new ManagedModuleRepository(
             "PSGallery",
-            "https://www.powershellgallery.com/api/v3/index.json");
+            ManagedModuleCatalogDefaults.PowerShellGalleryV2);
 
         var versions = await repositoryClient.GetVersionsAsync(repository, "Pester", includePrerelease: false);
 
@@ -954,7 +954,7 @@ public sealed class ManagedModuleRepositoryClientTests
         var repositoryClient = new ManagedModuleRepositoryClient(new NullLogger(), client);
         var repository = new ManagedModuleRepository(
             "PSGallery",
-            "https://www.powershellgallery.com/api/v3/index.json");
+            ManagedModuleCatalogDefaults.PowerShellGalleryV2);
 
         var result = await repositoryClient.PublishPackageAsync(
             repository,
@@ -963,9 +963,14 @@ public sealed class ManagedModuleRepositoryClientTests
 
         Assert.True(result.Published);
         Assert.Equal(201, result.StatusCode);
-        var publishRequest = Assert.Single(requests, request => request.Url == "https://psgallery.test/publish/");
+        var publishRequest = Assert.Single(requests, request => request.Url == "https://www.powershellgallery.com/api/v2/package");
         Assert.Equal(HttpMethod.Put, publishRequest.Method);
         Assert.Equal("gallery-key", publishRequest.ApiKey);
+        Assert.Equal("multipart/form-data", publishRequest.ContentType);
+        Assert.Equal(1, publishRequest.MultipartPartCount);
+        Assert.Equal("package", publishRequest.MultipartPartName);
+        Assert.Equal("Company.Tools.1.0.0.nupkg", publishRequest.MultipartFileName);
+        Assert.Equal("application/octet-stream", publishRequest.MultipartPartContentType);
     }
 
     [Fact]
@@ -1328,7 +1333,19 @@ public sealed class ManagedModuleRepositoryClientTests
             var apiKey = request.Headers.TryGetValues("X-NuGet-ApiKey", out var values)
                 ? values.FirstOrDefault()
                 : null;
-            _requests.Add(new RecordedRequest(uri.AbsoluteUri, request.Method, request.Headers.Authorization, apiKey, request.Headers.UserAgent.ToString()));
+            var multipart = request.Content as MultipartFormDataContent;
+            var firstPart = multipart?.FirstOrDefault();
+            _requests.Add(new RecordedRequest(
+                uri.AbsoluteUri,
+                request.Method,
+                request.Headers.Authorization,
+                apiKey,
+                request.Headers.UserAgent.ToString(),
+                request.Content?.Headers.ContentType?.MediaType,
+                multipart?.Count() ?? 0,
+                firstPart?.Headers.ContentDisposition?.Name?.Trim('"'),
+                firstPart?.Headers.ContentDisposition?.FileName?.Trim('"'),
+                firstPart?.Headers.ContentType?.MediaType));
 
             if (uri.AbsoluteUri == "https://example.test/v3/index.json")
             {
@@ -1643,6 +1660,9 @@ public sealed class ManagedModuleRepositoryClientTests
             if (uri.AbsoluteUri == "https://psgallery.test/publish/" && request.Method == HttpMethod.Put)
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
 
+            if (uri.AbsoluteUri == "https://www.powershellgallery.com/api/v2/package" && request.Method == HttpMethod.Put)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
+
             if (uri.AbsoluteUri == "https://push.example.test/api/v2/package" && request.Method == HttpMethod.Put)
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
 
@@ -1686,13 +1706,28 @@ public sealed class ManagedModuleRepositoryClientTests
 
     internal sealed class RecordedRequest
     {
-        public RecordedRequest(string url, HttpMethod method, AuthenticationHeaderValue? authorization, string? apiKey, string userAgent)
+        public RecordedRequest(
+            string url,
+            HttpMethod method,
+            AuthenticationHeaderValue? authorization,
+            string? apiKey,
+            string userAgent,
+            string? contentType,
+            int multipartPartCount,
+            string? multipartPartName,
+            string? multipartFileName,
+            string? multipartPartContentType)
         {
             Url = url;
             Method = method;
             Authorization = authorization;
             ApiKey = apiKey;
             UserAgent = userAgent;
+            ContentType = contentType;
+            MultipartPartCount = multipartPartCount;
+            MultipartPartName = multipartPartName;
+            MultipartFileName = multipartFileName;
+            MultipartPartContentType = multipartPartContentType;
         }
 
         public string Url { get; }
@@ -1704,5 +1739,15 @@ public sealed class ManagedModuleRepositoryClientTests
         public string? ApiKey { get; }
 
         public string UserAgent { get; }
+
+        public string? ContentType { get; }
+
+        public int MultipartPartCount { get; }
+
+        public string? MultipartPartName { get; }
+
+        public string? MultipartFileName { get; }
+
+        public string? MultipartPartContentType { get; }
     }
 }

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -918,6 +918,7 @@ public sealed class ManagedModuleRepositoryClientTests
         var publishRequest = Assert.Single(requests, request => request.Url == "https://example.test/publish/");
         Assert.Equal(HttpMethod.Put, publishRequest.Method);
         Assert.Equal("publish-key", publishRequest.ApiKey);
+        Assert.DoesNotContain(requests, request => request.Url == "https://example.test/symbol-publish/");
     }
 
     [Fact]
@@ -1361,6 +1362,7 @@ public sealed class ManagedModuleRepositoryClientTests
                 return Json("{\"resources\":[" +
                             "{\"@id\":\"https://example.test/packages/\",\"@type\":\"PackageBaseAddress/3.0.0\"}," +
                             "{\"@id\":\"https://example.test/search\",\"@type\":\"SearchQueryService/3.5.0\"}," +
+                            "{\"@id\":\"https://example.test/symbol-publish/\",\"@type\":\"SymbolPackagePublish/4.9.0\"}," +
                             "{\"@id\":\"https://example.test/publish/\",\"@type\":\"PackagePublish/2.0.0\"}" +
                             registration +
                             "]}");

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -987,7 +987,7 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
-    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForAutoRepositoryPublishWhenNoPublishToolExists()
+    public void EnsureBuildDependenciesInstalledIfNeeded_SkipsRepositoryToolForManagedAutoPublishWhenNoPublishToolExists()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -1006,9 +1006,8 @@ public sealed class ModulePipelineHostedOperationsTests
             var plan = runner.Plan(spec);
             var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
 
-            Assert.Single(result);
-            Assert.Equal(1, hostedOperations.DependencyInstallCalls);
-            Assert.Equal("Microsoft.PowerShell.PSResourceGet", Assert.Single(hostedOperations.LastDependencies).Name);
+            Assert.Empty(result);
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
         }
         finally
         {
@@ -1017,7 +1016,7 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
-    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsPSResourceGetForAutoRepositoryPublishWhenPowerShellGetIsTooOld()
+    public void EnsureBuildDependenciesInstalledIfNeeded_SkipsRepositoryToolForManagedAutoPublishWhenPowerShellGetIsTooOld()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -1034,6 +1033,44 @@ public sealed class ModulePipelineHostedOperationsTests
                 {
                     ["PowerShellGet"] = "1.0.0.1"
                 }),
+                hostedOperations);
+
+            var plan = runner.Plan(spec);
+            var result = InvokeEnsureBuildDependenciesInstalledIfNeeded(runner, plan);
+
+            Assert.Empty(result);
+            Assert.Equal(0, hostedOperations.DependencyInstallCalls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void EnsureBuildDependenciesInstalledIfNeeded_InstallsRepositoryToolForAutoPublishWithRuntimeCredentialProvider()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var repository = new PublishRepositoryConfiguration
+            {
+                Name = "JFrog",
+                Uri = "https://example.jfrog.io/artifactory/api/nuget/v3/feed",
+                CredentialProvider = new RepositoryCredentialProviderConfiguration
+                {
+                    Kind = RepositoryCredentialProviderKind.JFrogOidc
+                }
+            };
+            var spec = CreatePublishToolSpec(root.FullName, moduleName, PublishTool.Auto, repository: repository);
+            var hostedOperations = new FakeHostedOperations();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                new ThrowingPowerShellRunner(),
+                new FakeMetadataProvider(),
                 hostedOperations);
 
             var plan = runner.Plan(spec);
@@ -2329,7 +2366,8 @@ public sealed class ModulePipelineHostedOperationsTests
         string moduleName,
         PublishTool tool,
         ConfigurationGateMode? gateMode = null,
-        bool publishEnabled = true)
+        bool publishEnabled = true,
+        PublishRepositoryConfiguration? repository = null)
     {
         return new ModulePipelineSpec
         {
@@ -2358,7 +2396,9 @@ public sealed class ModulePipelineHostedOperationsTests
                         Enabled = publishEnabled,
                         Destination = PublishDestination.PowerShellGallery,
                         Tool = tool,
-                        ApiKey = "test-api-key"
+                        ApiKey = "test-api-key",
+                        RepositoryName = repository?.Name,
+                        Repository = repository
                     }
                 }
             }.Where(static segment => segment is not null).Cast<IConfigurationSegment>().ToArray()

--- a/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
+++ b/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
@@ -160,6 +160,19 @@ public sealed class ModulePublisherManagedModuleTests
                 Uri = "https://pkgs.dev.azure.com/contoso/Platform/_packaging/CompanyModules/nuget/v3/index.json"
             }
         };
+        var registeredRequiredModuleSource = new PublishConfiguration
+        {
+            Destination = PublishDestination.PowerShellGallery,
+            Tool = PublishTool.Auto,
+            RepositoryName = "CompanyModules",
+            PublishRequiredModules = true,
+            RequiredModuleSourceRepository = "RegisteredUpstream",
+            Repository = new PublishRepositoryConfiguration
+            {
+                Name = "CompanyModules",
+                Uri = "https://packages.example.test/v3/index.json"
+            }
+        };
 
         Assert.True(ModulePublisher.ShouldUseManagedModuleForAuto(psGallery));
         Assert.True(ModulePublisher.ShouldUseManagedModuleForAuto(psGalleryV3));
@@ -171,6 +184,27 @@ public sealed class ModulePublisherManagedModuleTests
             ModulePublisher.NormalizeManagedRepositorySource(ManagedModuleCatalogDefaults.PowerShellGalleryV3));
         Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(runtimeCredential));
         Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(azureArtifacts));
+        Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(registeredRequiredModuleSource));
+    }
+
+    [Fact]
+    public void ModulePublishResult_preserves_legacy_constructor_signature()
+    {
+        var constructor = typeof(ModulePublishResult).GetConstructor(new[]
+        {
+            typeof(PublishDestination),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(bool),
+            typeof(string[]),
+            typeof(string),
+            typeof(bool),
+            typeof(string)
+        });
+
+        Assert.NotNull(constructor);
     }
 
     [Fact]

--- a/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
+++ b/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
@@ -173,6 +173,17 @@ public sealed class ModulePublisherManagedModuleTests
                 Uri = "https://packages.example.test/v3/index.json"
             }
         };
+        var scriptEndpoint = new PublishConfiguration
+        {
+            Destination = PublishDestination.PowerShellGallery,
+            Tool = PublishTool.Auto,
+            RepositoryName = "CompanyScripts",
+            Repository = new PublishRepositoryConfiguration
+            {
+                Name = "CompanyScripts",
+                Uri = "https://packages.example.test/api/v2/items/psscript"
+            }
+        };
 
         Assert.True(ModulePublisher.ShouldUseManagedModuleForAuto(psGallery));
         Assert.True(ModulePublisher.ShouldUseManagedModuleForAuto(psGalleryV3));
@@ -185,6 +196,7 @@ public sealed class ModulePublisherManagedModuleTests
         Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(runtimeCredential));
         Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(azureArtifacts));
         Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(registeredRequiredModuleSource));
+        Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(scriptEndpoint));
     }
 
     [Fact]

--- a/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
+++ b/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
@@ -122,6 +122,17 @@ public sealed class ModulePublisherManagedModuleTests
             Tool = PublishTool.Auto,
             RepositoryName = "PSGallery"
         };
+        var psGalleryV3 = new PublishConfiguration
+        {
+            Destination = PublishDestination.PowerShellGallery,
+            Tool = PublishTool.Auto,
+            RepositoryName = "PSGallery",
+            Repository = new PublishRepositoryConfiguration
+            {
+                Name = "PSGallery",
+                Uri = ManagedModuleCatalogDefaults.PowerShellGalleryV3
+            }
+        };
         var runtimeCredential = new PublishConfiguration
         {
             Destination = PublishDestination.PowerShellGallery,
@@ -137,12 +148,29 @@ public sealed class ModulePublisherManagedModuleTests
                 }
             }
         };
+        var azureArtifacts = new PublishConfiguration
+        {
+            Destination = PublishDestination.PowerShellGallery,
+            Tool = PublishTool.Auto,
+            ApiKey = "AzureDevOps",
+            RepositoryName = "CompanyModules",
+            Repository = new PublishRepositoryConfiguration
+            {
+                Name = "CompanyModules",
+                Uri = "https://pkgs.dev.azure.com/contoso/Platform/_packaging/CompanyModules/nuget/v3/index.json"
+            }
+        };
 
         Assert.True(ModulePublisher.ShouldUseManagedModuleForAuto(psGallery));
+        Assert.True(ModulePublisher.ShouldUseManagedModuleForAuto(psGalleryV3));
         Assert.Equal(
             ManagedModuleCatalogDefaults.PowerShellGalleryV2,
             ModulePublisher.ResolveDefaultManagedRepositorySource("PSGallery"));
+        Assert.Equal(
+            ManagedModuleCatalogDefaults.PowerShellGalleryV2,
+            ModulePublisher.NormalizeManagedRepositorySource(ManagedModuleCatalogDefaults.PowerShellGalleryV3));
         Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(runtimeCredential));
+        Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(azureArtifacts));
     }
 
     [Fact]

--- a/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
+++ b/PowerForge.Tests/ModulePublisherManagedModuleTests.cs
@@ -56,6 +56,7 @@ public sealed class ModulePublisherManagedModuleTests
             Assert.True(result.Succeeded);
             Assert.Equal("Local", result.RepositoryName);
             Assert.Equal("3.0.13", result.VersionText);
+            Assert.Equal(PublishTool.ManagedModule, result.Tool);
             Assert.True(File.Exists(Path.Combine(feed.Path, "PSPublishModule.3.0.13.nupkg")));
         }
         finally
@@ -63,6 +64,85 @@ public sealed class ModulePublisherManagedModuleTests
             if (Directory.Exists(stagingRoot))
                 Directory.Delete(stagingRoot, recursive: true);
         }
+    }
+
+    [Fact]
+    public void Publish_Auto_UsesManagedEngineWithoutPowerShellRunner()
+    {
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N"));
+        using var feed = new TemporaryDirectory();
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            var manifestPath = Path.Combine(stagingRoot, "PSPublishModule.psd1");
+            File.WriteAllText(
+                manifestPath,
+                "@{ ModuleVersion = '3.0.14'; RootModule = 'PSPublishModule.psm1'; Author = 'Evotec'; Description = 'Managed auto publish test.' }");
+            File.WriteAllText(Path.Combine(stagingRoot, "PSPublishModule.psm1"), string.Empty);
+
+            var publisher = new ModulePublisher(
+                new NullLogger(),
+                new StubPowerShellRunner(_ => throw new InvalidOperationException("PowerShell runner should not be used by managed publish.")));
+            var publish = new PublishConfiguration
+            {
+                Destination = PublishDestination.PowerShellGallery,
+                Enabled = true,
+                Tool = PublishTool.Auto,
+                RepositoryName = "Local",
+                Repository = new PublishRepositoryConfiguration
+                {
+                    Name = "Local",
+                    Uri = feed.Path
+                }
+            };
+            var buildResult = new ModuleBuildResult(
+                stagingPath: stagingRoot,
+                manifestPath: manifestPath,
+                exports: new ExportSet(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>()));
+
+            var result = publisher.Publish(publish, CreatePlan(), buildResult, Array.Empty<ArtefactBuildResult>());
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(PublishTool.ManagedModule, result.Tool);
+            Assert.True(File.Exists(Path.Combine(feed.Path, "PSPublishModule.3.0.14.nupkg")));
+        }
+        finally
+        {
+            if (Directory.Exists(stagingRoot))
+                Directory.Delete(stagingRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AutoToolSelection_UsesManagedForPsGalleryAndRetainsCompatibilityForRuntimeCredentialProviders()
+    {
+        var psGallery = new PublishConfiguration
+        {
+            Destination = PublishDestination.PowerShellGallery,
+            Tool = PublishTool.Auto,
+            RepositoryName = "PSGallery"
+        };
+        var runtimeCredential = new PublishConfiguration
+        {
+            Destination = PublishDestination.PowerShellGallery,
+            Tool = PublishTool.Auto,
+            RepositoryName = "JFrog",
+            Repository = new PublishRepositoryConfiguration
+            {
+                Name = "JFrog",
+                Uri = "https://example.jfrog.io/artifactory/api/nuget/v3/feed",
+                CredentialProvider = new RepositoryCredentialProviderConfiguration
+                {
+                    Kind = RepositoryCredentialProviderKind.JFrogOidc
+                }
+            }
+        };
+
+        Assert.True(ModulePublisher.ShouldUseManagedModuleForAuto(psGallery));
+        Assert.Equal(
+            ManagedModuleCatalogDefaults.PowerShellGalleryV2,
+            ModulePublisher.ResolveDefaultManagedRepositorySource("PSGallery"));
+        Assert.False(ModulePublisher.ShouldUseManagedModuleForAuto(runtimeCredential));
     }
 
     [Fact]

--- a/PowerForge.Tests/PipelinePublishSummaryTests.cs
+++ b/PowerForge.Tests/PipelinePublishSummaryTests.cs
@@ -7,16 +7,28 @@ public sealed class PipelinePublishSummaryTests
     [Fact]
     public void Build_combines_nuget_package_github_psgallery_and_module_github_results()
     {
-        const string corePackage = @"C:\artifacts\DbaClientX.Core.0.12.0.nupkg";
-        const string sqlitePackage = @"C:\artifacts\DbaClientX.SQLite.0.11.0.nupkg";
+        const string corePackage = @"C:\artifacts\DBAClientX.Core.0.12.0.nupkg";
+        const string sqlServerPackage = @"C:\artifacts\DBAClientX.SqlServer.0.11.0.nupkg";
+        const string postgreSqlPackage = @"C:\artifacts\DBAClientX.PostgreSql.0.11.0.nupkg";
+        const string mySqlPackage = @"C:\artifacts\DBAClientX.MySql.0.11.0.nupkg";
+        const string sqlitePackage = @"C:\artifacts\DBAClientX.SQLite.0.11.0.nupkg";
+        const string oraclePackage = @"C:\artifacts\DBAClientX.Oracle.0.11.0.nupkg";
         var release = new DotNetRepositoryReleaseResult
         {
             Success = true,
             PublishSource = "https://api.nuget.org/v3/index.json"
         };
-        release.Projects.Add(CreateProject("DbaClientX.Core", "DbaClientX.Core", "0.12.0", corePackage, @"C:\artifacts\DbaClientX.Core.0.12.0.zip"));
-        release.Projects.Add(CreateProject("DbaClientX.SQLite", "DbaClientX.SQLite", "0.11.0", sqlitePackage, @"C:\artifacts\DbaClientX.SQLite.0.11.0.zip"));
+        release.Projects.Add(CreateProject("DbaClientX.Core", "DBAClientX.Core", "0.12.0", corePackage, @"C:\artifacts\DBAClientX.Core.0.12.0.zip"));
+        release.Projects.Add(CreateProject("DbaClientX.SqlServer", "DBAClientX.SqlServer", "0.11.0", sqlServerPackage, @"C:\artifacts\DBAClientX.SqlServer.0.11.0.zip"));
+        release.Projects.Add(CreateProject("DbaClientX.PostgreSql", "DBAClientX.PostgreSql", "0.11.0", postgreSqlPackage, @"C:\artifacts\DBAClientX.PostgreSql.0.11.0.zip"));
+        release.Projects.Add(CreateProject("DbaClientX.MySql", "DBAClientX.MySql", "0.11.0", mySqlPackage, @"C:\artifacts\DBAClientX.MySql.0.11.0.zip"));
+        release.Projects.Add(CreateProject("DbaClientX.SQLite", "DBAClientX.SQLite", "0.11.0", sqlitePackage, @"C:\artifacts\DBAClientX.SQLite.0.11.0.zip"));
+        release.Projects.Add(CreateProject("DbaClientX.Oracle", "DBAClientX.Oracle", "0.11.0", oraclePackage, @"C:\artifacts\DBAClientX.Oracle.0.11.0.zip"));
         release.PublishedPackages.Add(corePackage);
+        release.PublishedPackages.Add(sqlServerPackage);
+        release.PublishedPackages.Add(postgreSqlPackage);
+        release.PublishedPackages.Add(mySqlPackage);
+        release.PublishedPackages.Add(oraclePackage);
         release.SkippedDuplicatePackages.Add(sqlitePackage);
 
         var packageBuild = new ProjectBuildHostExecutionResult
@@ -29,7 +41,11 @@ public sealed class PipelinePublishSummaryTests
             }
         };
         packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.Core"));
+        packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.SqlServer"));
+        packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.PostgreSql"));
+        packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.MySql"));
         packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.SQLite"));
+        packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.Oracle"));
 
         var modulePublishes = new[]
         {
@@ -52,7 +68,16 @@ public sealed class PipelinePublishSummaryTests
                 "DbaClientX-PowerShellModule.v1.0.2",
                 "1.0.2",
                 false,
-                new[] { "module.zip", corePackage, sqlitePackage },
+                new[]
+                {
+                    "module.zip",
+                    corePackage,
+                    sqlServerPackage,
+                    postgreSqlPackage,
+                    mySqlPackage,
+                    sqlitePackage,
+                    oraclePackage
+                },
                 "https://github.com/EvotecIT/DbaClientX/releases/tag/DbaClientX-PowerShellModule.v1.0.2",
                 true,
                 null)
@@ -63,19 +88,23 @@ public sealed class PipelinePublishSummaryTests
             modulePublishes,
             new[] { packageBuild });
 
-        Assert.Equal(5, summary.Rows.Count);
+        Assert.Equal(9, summary.Rows.Count);
         Assert.Equal(3, summary.ChannelCount);
         Assert.Equal(3, summary.Channels.Count);
-        Assert.Contains(summary.Channels, channel => channel.Channel == "NuGet" && channel.Label == "2 packages, 1 published, 1 already existed, nuget.org, via dotnet nuget push");
+        Assert.Contains(summary.Channels, channel => channel.Channel == "NuGet" && channel.Label == "6 packages, 5 published, 1 already existed, nuget.org, via dotnet nuget push");
         Assert.Contains(summary.Channels, channel => channel.Channel == "PowerShell Gallery" && channel.Label == "1 module, 1 published, PSGallery, via ManagedModule");
         Assert.Contains(summary.Channels, channel => channel.Channel == "GitHub" && channel.Label == "2 releases, 2 published, EvotecIT/DbaClientX, via GitHub API");
-        Assert.Equal(2, summary.Rows.Count(row => row.Channel == "NuGet"));
+        Assert.Equal(6, summary.Rows.Count(row => row.Channel == "NuGet"));
         Assert.Equal(2, summary.Rows.Count(row => row.Channel == "GitHub"));
-        Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX.Core 0.12.0" && row.Reference.EndsWith("/DbaClientX.Core/0.12.0", StringComparison.Ordinal));
-        Assert.Contains(summary.Rows, row => row.Result == "Already existed DbaClientX.SQLite 0.11.0" && row.Reference.EndsWith("/DbaClientX.SQLite/0.11.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Result == "Published DBAClientX.Core 0.12.0" && row.Reference.EndsWith("/DBAClientX.Core/0.12.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Result == "Published DBAClientX.SqlServer 0.11.0" && row.Reference.EndsWith("/DBAClientX.SqlServer/0.11.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Result == "Published DBAClientX.PostgreSql 0.11.0" && row.Reference.EndsWith("/DBAClientX.PostgreSql/0.11.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Result == "Published DBAClientX.MySql 0.11.0" && row.Reference.EndsWith("/DBAClientX.MySql/0.11.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Result == "Already existed DBAClientX.SQLite 0.11.0" && row.Reference.EndsWith("/DBAClientX.SQLite/0.11.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Result == "Published DBAClientX.Oracle 0.11.0" && row.Reference.EndsWith("/DBAClientX.Oracle/0.11.0", StringComparison.Ordinal));
         Assert.Contains(summary.Rows, row => row.Channel == "PowerShell Gallery" && row.Method == "ManagedModule" && row.Result == "Published DbaClientX 1.0.2");
-        Assert.Single(summary.Rows, row => row.Result == "Published DbaClientX-v20260712082246 (2 assets)");
-        Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX-PowerShellModule.v1.0.2 (3 assets)");
+        Assert.Single(summary.Rows, row => row.Result == "Published DbaClientX-v20260712082246 (6 assets)");
+        Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX-PowerShellModule.v1.0.2 (7 assets)");
     }
 
     [Fact]

--- a/PowerForge.Tests/PipelinePublishSummaryTests.cs
+++ b/PowerForge.Tests/PipelinePublishSummaryTests.cs
@@ -17,7 +17,7 @@ public sealed class PipelinePublishSummaryTests
         release.Projects.Add(CreateProject("DbaClientX.Core", "DbaClientX.Core", "0.12.0", corePackage, @"C:\artifacts\DbaClientX.Core.0.12.0.zip"));
         release.Projects.Add(CreateProject("DbaClientX.SQLite", "DbaClientX.SQLite", "0.11.0", sqlitePackage, @"C:\artifacts\DbaClientX.SQLite.0.11.0.zip"));
         release.PublishedPackages.Add(corePackage);
-        release.PublishedPackages.Add(sqlitePackage);
+        release.SkippedDuplicatePackages.Add(sqlitePackage);
 
         var packageBuild = new ProjectBuildHostExecutionResult
         {
@@ -65,10 +65,15 @@ public sealed class PipelinePublishSummaryTests
 
         Assert.Equal(5, summary.Rows.Count);
         Assert.Equal(3, summary.ChannelCount);
+        Assert.Equal(3, summary.Channels.Count);
+        Assert.Contains(summary.Channels, channel => channel.Channel == "NuGet" && channel.Label == "2 packages, 1 published, 1 already existed, nuget.org, via dotnet nuget push");
+        Assert.Contains(summary.Channels, channel => channel.Channel == "PowerShell Gallery" && channel.Label == "1 module, 1 published, PSGallery, via ManagedModule");
+        Assert.Contains(summary.Channels, channel => channel.Channel == "GitHub" && channel.Label == "2 releases, 2 published, EvotecIT/DbaClientX, via GitHub API");
         Assert.Equal(2, summary.Rows.Count(row => row.Channel == "NuGet"));
         Assert.Equal(2, summary.Rows.Count(row => row.Channel == "GitHub"));
         Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX.Core 0.12.0" && row.Reference.EndsWith("/DbaClientX.Core/0.12.0", StringComparison.Ordinal));
-        Assert.Contains(summary.Rows, row => row.Channel == "PowerShellGallery" && row.Method == "ManagedModule" && row.Result == "Published DbaClientX 1.0.2");
+        Assert.Contains(summary.Rows, row => row.Result == "Already existed DbaClientX.SQLite 0.11.0" && row.Reference.EndsWith("/DbaClientX.SQLite/0.11.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Channel == "PowerShell Gallery" && row.Method == "ManagedModule" && row.Result == "Published DbaClientX 1.0.2");
         Assert.Single(summary.Rows, row => row.Result == "Published DbaClientX-v20260712082246 (2 assets)");
         Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX-PowerShellModule.v1.0.2 (3 assets)");
     }

--- a/PowerForge.Tests/PipelinePublishSummaryTests.cs
+++ b/PowerForge.Tests/PipelinePublishSummaryTests.cs
@@ -78,6 +78,39 @@ public sealed class PipelinePublishSummaryTests
         Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX-PowerShellModule.v1.0.2 (3 assets)");
     }
 
+    [Fact]
+    public void Build_redacts_private_feed_credentials_from_targets_and_references()
+    {
+        const string package = @"C:\artifacts\Company.Tools.1.0.0.nupkg";
+        var release = new DotNetRepositoryReleaseResult
+        {
+            Success = true,
+            PublishSource = "https://user:token@feed.example/v3/index.json"
+        };
+        release.Projects.Add(CreateProject("Company.Tools", "Company.Tools", "1.0.0", package, @"C:\artifacts\Company.Tools.1.0.0.zip"));
+        release.PublishedPackages.Add(package);
+        var build = new ProjectBuildHostExecutionResult
+        {
+            Success = true,
+            Result = new ProjectBuildResult
+            {
+                Success = true,
+                Release = release
+            }
+        };
+
+        var summary = PipelinePublishSummaryBuilder.Build(
+            "Company.Tools",
+            Array.Empty<ModulePublishResult>(),
+            new[] { build });
+
+        var row = Assert.Single(summary.Rows);
+        Assert.Equal("https://feed.example/v3/index.json", row.Target);
+        Assert.Equal("https://feed.example/v3/index.json", row.Reference);
+        Assert.DoesNotContain("user", summary.Channels[0].Label, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("token", summary.Channels[0].Label, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static DotNetRepositoryProjectResult CreateProject(
         string projectName,
         string packageId,

--- a/PowerForge.Tests/PipelinePublishSummaryTests.cs
+++ b/PowerForge.Tests/PipelinePublishSummaryTests.cs
@@ -1,0 +1,103 @@
+using PowerForge.ConsoleShared;
+
+namespace PowerForge.Tests;
+
+public sealed class PipelinePublishSummaryTests
+{
+    [Fact]
+    public void Build_combines_nuget_package_github_psgallery_and_module_github_results()
+    {
+        const string corePackage = @"C:\artifacts\DbaClientX.Core.0.12.0.nupkg";
+        const string sqlitePackage = @"C:\artifacts\DbaClientX.SQLite.0.11.0.nupkg";
+        var release = new DotNetRepositoryReleaseResult
+        {
+            Success = true,
+            PublishSource = "https://api.nuget.org/v3/index.json"
+        };
+        release.Projects.Add(CreateProject("DbaClientX.Core", "DbaClientX.Core", "0.12.0", corePackage, @"C:\artifacts\DbaClientX.Core.0.12.0.zip"));
+        release.Projects.Add(CreateProject("DbaClientX.SQLite", "DbaClientX.SQLite", "0.11.0", sqlitePackage, @"C:\artifacts\DbaClientX.SQLite.0.11.0.zip"));
+        release.PublishedPackages.Add(corePackage);
+        release.PublishedPackages.Add(sqlitePackage);
+
+        var packageBuild = new ProjectBuildHostExecutionResult
+        {
+            Success = true,
+            Result = new ProjectBuildResult
+            {
+                Success = true,
+                Release = release
+            }
+        };
+        packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.Core"));
+        packageBuild.Result.GitHub.Add(CreateProjectGitHub("DbaClientX.SQLite"));
+
+        var modulePublishes = new[]
+        {
+            new ModulePublishResult(
+                PublishDestination.PowerShellGallery,
+                "PSGallery",
+                null,
+                null,
+                "1.0.2",
+                false,
+                Array.Empty<string>(),
+                null,
+                true,
+                null,
+                PublishTool.ManagedModule),
+            new ModulePublishResult(
+                PublishDestination.GitHub,
+                "DbaClientX",
+                "EvotecIT",
+                "DbaClientX-PowerShellModule.v1.0.2",
+                "1.0.2",
+                false,
+                new[] { "module.zip", corePackage, sqlitePackage },
+                "https://github.com/EvotecIT/DbaClientX/releases/tag/DbaClientX-PowerShellModule.v1.0.2",
+                true,
+                null)
+        };
+
+        var summary = PipelinePublishSummaryBuilder.Build(
+            "DbaClientX",
+            modulePublishes,
+            new[] { packageBuild });
+
+        Assert.Equal(5, summary.Rows.Count);
+        Assert.Equal(3, summary.ChannelCount);
+        Assert.Equal(2, summary.Rows.Count(row => row.Channel == "NuGet"));
+        Assert.Equal(2, summary.Rows.Count(row => row.Channel == "GitHub"));
+        Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX.Core 0.12.0" && row.Reference.EndsWith("/DbaClientX.Core/0.12.0", StringComparison.Ordinal));
+        Assert.Contains(summary.Rows, row => row.Channel == "PowerShellGallery" && row.Method == "ManagedModule" && row.Result == "Published DbaClientX 1.0.2");
+        Assert.Single(summary.Rows, row => row.Result == "Published DbaClientX-v20260712082246 (2 assets)");
+        Assert.Contains(summary.Rows, row => row.Result == "Published DbaClientX-PowerShellModule.v1.0.2 (3 assets)");
+    }
+
+    private static DotNetRepositoryProjectResult CreateProject(
+        string projectName,
+        string packageId,
+        string version,
+        string package,
+        string releaseZip)
+    {
+        var result = new DotNetRepositoryProjectResult
+        {
+            ProjectName = projectName,
+            PackageId = packageId,
+            IsPackable = true,
+            NewVersion = version,
+            ReleaseZipPath = releaseZip
+        };
+        result.Packages.Add(package);
+        return result;
+    }
+
+    private static ProjectBuildGitHubResult CreateProjectGitHub(string projectName)
+        => new()
+        {
+            ProjectName = projectName,
+            Success = true,
+            TagName = "DbaClientX-v20260712082246",
+            ReleaseUrl = "https://github.com/EvotecIT/DbaClientX/releases/tag/DbaClientX-v20260712082246"
+        };
+}

--- a/PowerForge/Models/Configuration/ConfigurationEnums.cs
+++ b/PowerForge/Models/Configuration/ConfigurationEnums.cs
@@ -17,7 +17,7 @@ public enum PublishDestination
 public enum PublishTool
 {
     /// <summary>
-    /// Choose the best available tool at runtime (prefer PSResourceGet, fall back to PowerShellGet).
+    /// Choose the best available tool at runtime (prefer the managed C# publisher and use compatibility tools only when required).
     /// </summary>
     Auto,
     /// <summary>Use Microsoft.PowerShell.PSResourceGet.</summary>

--- a/PowerForge/Models/DotNetRepositoryReleaseResult.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseResult.cs
@@ -30,6 +30,9 @@ public sealed class DotNetRepositoryReleaseResult
 
     /// <summary>Packages that failed to publish.</summary>
     public List<string> FailedPackages { get; } = new();
+
+    /// <summary>NuGet-compatible source used for package publishing, when publishing was executed.</summary>
+    public string? PublishSource { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/ModulePublishResult.cs
+++ b/PowerForge/Models/ModulePublishResult.cs
@@ -35,6 +35,9 @@ public sealed class ModulePublishResult
     /// <summary>Optional error message when <see cref="Succeeded"/> is false.</summary>
     public string? ErrorMessage { get; }
 
+    /// <summary>Repository publishing engine used for PowerShell repository destinations.</summary>
+    public PublishTool? Tool { get; }
+
     /// <summary>
     /// Creates a new result instance.
     /// </summary>
@@ -48,7 +51,8 @@ public sealed class ModulePublishResult
         string[] assetPaths,
         string? releaseUrl,
         bool succeeded,
-        string? errorMessage)
+        string? errorMessage,
+        PublishTool? tool = null)
     {
         Destination = destination;
         RepositoryName = repositoryName;
@@ -60,5 +64,6 @@ public sealed class ModulePublishResult
         ReleaseUrl = releaseUrl;
         Succeeded = succeeded;
         ErrorMessage = errorMessage;
+        Tool = tool;
     }
 }

--- a/PowerForge/Models/ModulePublishResult.cs
+++ b/PowerForge/Models/ModulePublishResult.cs
@@ -51,8 +51,37 @@ public sealed class ModulePublishResult
         string[] assetPaths,
         string? releaseUrl,
         bool succeeded,
+        string? errorMessage)
+        : this(
+            destination,
+            repositoryName,
+            userName,
+            tagName,
+            versionText,
+            isPreRelease,
+            assetPaths,
+            releaseUrl,
+            succeeded,
+            errorMessage,
+            tool: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new result instance and records the repository publishing engine.
+    /// </summary>
+    public ModulePublishResult(
+        PublishDestination destination,
+        string? repositoryName,
+        string? userName,
+        string? tagName,
+        string versionText,
+        bool isPreRelease,
+        string[] assetPaths,
+        string? releaseUrl,
+        bool succeeded,
         string? errorMessage,
-        PublishTool? tool = null)
+        PublishTool? tool)
     {
         Destination = destination;
         RepositoryName = repositoryName;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -514,6 +514,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 var source = string.IsNullOrWhiteSpace(spec.PublishSource)
                     ? "https://api.nuget.org/v3/index.json"
                     : spec.PublishSource!.Trim();
+                result.PublishSource = source;
 
                 var orderedProjects = SortProjectsForPublish(packable);
                 var packages = orderedProjects.SelectMany(p => p.Packages)

--- a/PowerForge/Services/ManagedModules/ManagedModuleProviderSupportEvaluator.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleProviderSupportEvaluator.cs
@@ -15,6 +15,13 @@ public static class ManagedModuleProviderSupportEvaluator
         if (repository is null)
             throw new ArgumentNullException(nameof(repository));
 
+        if (IsPowerShellScriptEndpoint(repository))
+        {
+            return Unsupported(
+                "PowerShellGet script feed",
+                "Script-source endpoints are not module publish endpoints; use the compatibility publishing tools or configure the module feed root.");
+        }
+
         if (IsPowerShellGallery(repository))
         {
             return Supported("PowerShell Gallery");
@@ -66,6 +73,14 @@ public static class ManagedModuleProviderSupportEvaluator
     private static bool IsPowerShellGallery(ManagedModuleRepository repository)
         => string.Equals(repository.Name, "PSGallery", StringComparison.OrdinalIgnoreCase) ||
            repository.Source.IndexOf("powershellgallery.com", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    private static bool IsPowerShellScriptEndpoint(ManagedModuleRepository repository)
+    {
+        if (!Uri.TryCreate(repository.Source, UriKind.Absolute, out var uri))
+            return false;
+
+        return uri.AbsolutePath.TrimEnd('/').EndsWith("/items/psscript", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static bool IsAzureArtifacts(ManagedModuleRepository repository)
     {

--- a/PowerForge/Services/ManagedModules/ManagedModuleProviderSupportEvaluator.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleProviderSupportEvaluator.cs
@@ -20,6 +20,11 @@ public static class ManagedModuleProviderSupportEvaluator
             return Supported("PowerShell Gallery");
         }
 
+        if (IsAzureArtifacts(repository))
+        {
+            return Evaluate(PrivateGalleryProvider.AzureArtifacts);
+        }
+
         return repository.Kind switch
         {
             ManagedModuleRepositoryKind.LocalFolder => Supported("Local folder feed"),
@@ -61,6 +66,15 @@ public static class ManagedModuleProviderSupportEvaluator
     private static bool IsPowerShellGallery(ManagedModuleRepository repository)
         => string.Equals(repository.Name, "PSGallery", StringComparison.OrdinalIgnoreCase) ||
            repository.Source.IndexOf("powershellgallery.com", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    private static bool IsAzureArtifacts(ManagedModuleRepository repository)
+    {
+        if (!Uri.TryCreate(repository.Source, UriKind.Absolute, out var uri))
+            return false;
+
+        return uri.Host.Equals("pkgs.dev.azure.com", StringComparison.OrdinalIgnoreCase) ||
+               uri.Host.EndsWith(".pkgs.visualstudio.com", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static ManagedModuleProviderSupport Supported(string provider)
         => new()

--- a/PowerForge/Services/ManagedModules/ManagedModuleProviderSupportEvaluator.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleProviderSupportEvaluator.cs
@@ -24,10 +24,7 @@ public static class ManagedModuleProviderSupportEvaluator
         {
             ManagedModuleRepositoryKind.LocalFolder => Supported("Local folder feed"),
             ManagedModuleRepositoryKind.NuGetV3 => Supported("Generic NuGet v3 feed"),
-            ManagedModuleRepositoryKind.NuGetV2 => Partial(
-                "NuGet v2 feed",
-                managedLifecycleSupported: true,
-                "NuGet v2 package lookup and download are supported, but managed publishing requires a local folder or NuGet v3 publish endpoint."),
+            ManagedModuleRepositoryKind.NuGetV2 => Supported("NuGet v2 feed"),
             _ => Unsupported(
                 repository.Kind.ToString(),
                 "Repository kind is not supported by the managed module engine.")

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Publish.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Publish.cs
@@ -118,8 +118,11 @@ public sealed partial class ManagedModuleRepositoryClient
             () =>
             {
                 var request = CreateRequest(HttpMethod.Put, new Uri(publishAddress), credential, "application/json");
-                request.Content = new StreamContent(File.OpenRead(package));
-                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                var packageContent = new StreamContent(File.OpenRead(package));
+                packageContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                var multipart = new MultipartFormDataContent();
+                multipart.Add(packageContent, "package", Path.GetFileName(package));
+                request.Content = multipart;
                 return request;
             },
             cancellationToken).ConfigureAwait(false);

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Publish.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Publish.cs
@@ -203,7 +203,12 @@ public sealed partial class ManagedModuleRepositoryClient
         if (string.IsNullOrWhiteSpace(type))
             return false;
 
-        return type!.IndexOf("PackagePublish", StringComparison.OrdinalIgnoreCase) >= 0;
+        var normalized = type!.Trim();
+        var versionSeparator = normalized.IndexOf('/');
+        if (versionSeparator >= 0)
+            normalized = normalized.Substring(0, versionSeparator);
+
+        return string.Equals(normalized, "PackagePublish", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ResolveNuGetV2PackagePublishAddress(string source)

--- a/PowerForge/Services/ManagedModules/ManagedRequiredModuleRepositoryValidator.cs
+++ b/PowerForge/Services/ManagedModules/ManagedRequiredModuleRepositoryValidator.cs
@@ -323,6 +323,17 @@ internal sealed class ManagedRequiredModuleRepositoryValidator
             $"Managed required-module mirroring could not resolve source repository '{source}'. Use PSGallery, a repository URL, a local feed path, or the target repository name.");
     }
 
+    internal static bool CanResolveSourceRepository(PublishConfiguration publish, string targetRepositoryName)
+    {
+        if (!publish.PublishRequiredModules || !string.IsNullOrWhiteSpace(publish.RequiredModuleSourceRepositoryUri))
+            return true;
+
+        var source = ResolveSourceRepositoryName(publish);
+        return string.Equals(source, "PSGallery", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(source, targetRepositoryName, StringComparison.OrdinalIgnoreCase) ||
+               LooksLikeRepositorySource(source);
+    }
+
     private static bool IsPowerShellGalleryRepository(ManagedModuleRepository repository)
     {
         if (string.Equals(repository.Name, "PSGallery", StringComparison.OrdinalIgnoreCase))

--- a/PowerForge/Services/ModulePublisher.ManagedModule.cs
+++ b/PowerForge/Services/ModulePublisher.ManagedModule.cs
@@ -5,6 +5,31 @@ namespace PowerForge;
 /// </content>
 public sealed partial class ModulePublisher
 {
+    internal static bool ShouldUseManagedModuleForAuto(PublishConfiguration publish)
+    {
+        if (publish is null)
+            throw new ArgumentNullException(nameof(publish));
+        if (publish.Tool == PublishTool.ManagedModule)
+            return true;
+        if (publish.Tool != PublishTool.Auto)
+            return false;
+        if (publish.Repository?.CredentialProvider is { Kind: not RepositoryCredentialProviderKind.None })
+            return false;
+
+        var (repositoryName, repository) = ResolveRepository(publish);
+        try
+        {
+            var support = ManagedModuleProviderSupportEvaluator.Evaluate(
+                CreateManagedPublishRepository(repositoryName, repository));
+            return support.Level == ManagedModuleProviderSupportLevel.Supported;
+        }
+        catch (InvalidOperationException)
+        {
+            // Named repositories without an explicit URI still require the compatibility registration path.
+            return false;
+        }
+    }
+
     private void PublishToRepositoryWithManagedModule(
         PublishConfiguration publish,
         ModulePipelinePlan plan,
@@ -69,10 +94,10 @@ public sealed partial class ModulePublisher
             repoConfig?.Trusted ?? true);
     }
 
-    private static string ResolveDefaultManagedRepositorySource(string repositoryName)
+    internal static string ResolveDefaultManagedRepositorySource(string repositoryName)
     {
         if (string.Equals(repositoryName, "PSGallery", StringComparison.OrdinalIgnoreCase))
-            return "https://www.powershellgallery.com/api/v3/index.json";
+            return ManagedModuleCatalogDefaults.PowerShellGalleryV2;
 
         throw new InvalidOperationException(
             $"Managed module publishing requires a repository Uri, SourceUri, or PublishUri for repository '{repositoryName}'.");

--- a/PowerForge/Services/ModulePublisher.ManagedModule.cs
+++ b/PowerForge/Services/ModulePublisher.ManagedModule.cs
@@ -17,6 +17,8 @@ public sealed partial class ModulePublisher
             return false;
 
         var (repositoryName, repository) = ResolveRepository(publish);
+        if (!ManagedRequiredModuleRepositoryValidator.CanResolveSourceRepository(publish, repositoryName))
+            return false;
         try
         {
             var support = ManagedModuleProviderSupportEvaluator.Evaluate(

--- a/PowerForge/Services/ModulePublisher.ManagedModule.cs
+++ b/PowerForge/Services/ModulePublisher.ManagedModule.cs
@@ -71,6 +71,8 @@ public sealed partial class ModulePublisher
         var source = FirstNonEmpty(repoConfig?.PublishUri, repoConfig?.Uri, repoConfig?.SourceUri);
         if (string.IsNullOrWhiteSpace(source))
             source = ResolveDefaultManagedRepositorySource(repositoryName);
+        else
+            source = NormalizeManagedRepositorySource(source!);
 
         return new ManagedModuleRepository(
             repositoryName,
@@ -86,6 +88,8 @@ public sealed partial class ModulePublisher
         var source = FirstNonEmpty(repoConfig?.Uri, repoConfig?.SourceUri, repoConfig?.PublishUri);
         if (string.IsNullOrWhiteSpace(source))
             source = ResolveDefaultManagedRepositorySource(repositoryName);
+        else
+            source = NormalizeManagedRepositorySource(source!);
 
         return new ManagedModuleRepository(
             repositoryName,
@@ -101,6 +105,14 @@ public sealed partial class ModulePublisher
 
         throw new InvalidOperationException(
             $"Managed module publishing requires a repository Uri, SourceUri, or PublishUri for repository '{repositoryName}'.");
+    }
+
+    internal static string NormalizeManagedRepositorySource(string source)
+    {
+        var normalized = source.Trim().TrimEnd('/');
+        return normalized.Equals(ManagedModuleCatalogDefaults.PowerShellGalleryV3, StringComparison.OrdinalIgnoreCase)
+            ? ManagedModuleCatalogDefaults.PowerShellGalleryV2
+            : normalized;
     }
 
     private static RepositoryCredential? ResolveManagedReadCredential(PublishRepositoryConfiguration? repoConfig)

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -181,7 +181,9 @@ public sealed partial class ModulePublisher
         if (isPsGallery && string.IsNullOrWhiteSpace(publish.ApiKey))
             throw new InvalidOperationException("Publish API key is required for repository publishing to PSGallery.");
 
-        var managedRepository = publish.Tool == PublishTool.ManagedModule
+        var useManagedModule = publish.Tool == PublishTool.ManagedModule ||
+                               publish.Tool == PublishTool.Auto && ShouldUseManagedModuleForAuto(publish);
+        var managedRepository = useManagedModule
             ? CreateManagedPublishRepository(repositoryName, repoConfig)
             : null;
         var managedLocalFolder = managedRepository?.Kind == ManagedModuleRepositoryKind.LocalFolder;
@@ -192,6 +194,18 @@ public sealed partial class ModulePublisher
         var tool = publish.Tool;
         if (tool == PublishTool.Auto)
         {
+            if (useManagedModule)
+            {
+                return PublishToRepositoryWithTool(
+                    PublishTool.ManagedModule,
+                    publish,
+                    plan,
+                    buildResult,
+                    repositoryName,
+                    repoConfig,
+                    includeScriptFolders);
+            }
+
             try
             {
                 return PublishToRepositoryWithTool(PublishTool.PSResourceGet, publish, plan, buildResult, repositoryName, repoConfig, includeScriptFolders);
@@ -294,7 +308,7 @@ public sealed partial class ModulePublisher
                     skipDependenciesCheck: true);
                 CleanupTemporaryPublishPath(temporaryPublishPath);
                 temporaryPublishPath = null;
-                return CreateRepositoryPublishResult(repositoryName, versionText);
+                return CreateRepositoryPublishResult(repositoryName, versionText, tool);
             }
 
             if (tool != PublishTool.PowerShellGet)
@@ -347,10 +361,10 @@ public sealed partial class ModulePublisher
                 CleanupTemporaryPublishPath(temporaryPackagePath);
         }
 
-        return CreateRepositoryPublishResult(repositoryName, versionText);
+        return CreateRepositoryPublishResult(repositoryName, versionText, tool);
     }
 
-    private static ModulePublishResult CreateRepositoryPublishResult(string repositoryName, string versionText)
+    private static ModulePublishResult CreateRepositoryPublishResult(string repositoryName, string versionText, PublishTool tool)
     {
         return new ModulePublishResult(
             destination: PublishDestination.PowerShellGallery,
@@ -362,7 +376,8 @@ public sealed partial class ModulePublisher
             assetPaths: Array.Empty<string>(),
             releaseUrl: null,
             succeeded: true,
-            errorMessage: null);
+            errorMessage: null,
+            tool: tool);
     }
 
     internal static string PrepareModulePackageForRepositoryPublish(


### PR DESCRIPTION
## Summary

- add headline totals and detailed outcome rows for NuGet, PowerShell Gallery, and GitHub publishing
- map every package reported by a project build; the DbaClientX contract now covers Core, SqlServer, PostgreSql, MySql, SQLite, and Oracle with package-specific versions and links
- make `PublishTool.Auto` use the managed C# publisher for PSGallery and supported static NuGet feeds, while retaining compatibility tools for runtime credential providers, script endpoints, and unresolved registered repositories
- publish to PSGallery through its NuGet v2 multipart endpoint and redact credentials from private-feed summary URLs

Mixed builds now show package counts and outcomes, destination, and publishing method in the main summary. Existing `PublishTool.Auto` consumers need no configuration change after the updated PSPublishModule/PowerForge package is released.

## Validation

- 137 focused publish, repository-protocol, dependency-preflight, and summary tests
- PSPublishModule builds for net472, net8.0, and net10.0
- PowerForge.Cli builds for net8.0 and net10.0