### PR TITLE
Publish portable symbol packages from project builds

### DIFF
--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -283,6 +283,7 @@ Example configuration
   "UpdateVersions": true,
   "Build": true,
   "PackStrategy": "MSBuild",
+  "IncludeSymbols": true,
   "PublishNuget": true,
   "PublishGitHub": true,
   "CreateReleaseZip": true,
@@ -332,9 +333,11 @@ Staging and outputs
   planned `.nupkg` names, and release zip names. Otherwise it falls back to the csproj file name.
 - `CleanStaging`: if true, deletes the staging directory before a run. It does not clean project `bin`/`obj` directories; package correctness comes from the release rebuild and package-payload provenance check.
 - `PlanOutputPath`: optional file path for a JSON plan output.
+- `IncludeSymbols`: when true, produces portable `.snupkg` files for every packable project. Plan output includes their expected paths, and build output discovery rejects stale symbol packages just as it does stale primary packages.
 
 NuGet publishing
 - `PublishNuget`: enable `dotnet nuget push`.
+- Portable `.snupkg` files produced by the same build are published immediately after their primary `.nupkg` and are included in unified staged release assets and manifests.
 - `PublishApiKey` / `PublishApiKeyFilePath` / `PublishApiKeyEnvName`: API key sources.
 - `PublishFailFast`: stop on first publish/signing error.
 - `SkipDuplicate`: pass `--skip-duplicate` to `dotnet nuget push`.

--- a/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
@@ -123,6 +123,10 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
     [Parameter]
     public SwitchParameter SkipPack { get; set; }
 
+    /// <summary>Create portable <c>.snupkg</c> symbol packages alongside primary packages.</summary>
+    [Parameter]
+    public SwitchParameter IncludeSymbols { get; set; }
+
     /// <summary>Publish packages to the feed.</summary>
     [Parameter]
     public SwitchParameter Publish { get; set; }
@@ -200,6 +204,7 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
             SignDependencyAssemblies = SignDependencyAssemblies.IsPresent,
             SignPackages = SkipPackageSigning.IsPresent ? false : null,
             SkipPack = SkipPack.IsPresent,
+            IncludeSymbols = IncludeSymbols.IsPresent,
             Publish = Publish.IsPresent,
             PublishSource = PublishSource,
             PublishApiKey = PublishApiKey,

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -51,6 +51,10 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
     [Parameter]
     public SwitchParameter Build { get; set; }
 
+    /// <summary>Whether portable symbol packages should be created, overriding the referenced JSON when set.</summary>
+    [Parameter]
+    public SwitchParameter IncludeSymbols { get; set; }
+
     /// <summary>Whether NuGet packages should be published, overriding the referenced JSON when set.</summary>
     [Parameter]
     public SwitchParameter PublishNuget { get; set; }
@@ -94,6 +98,7 @@ public sealed class NewConfigurationProjectBuildCommand : PSCmdlet
                 ProvideLocalNuGetFeed = ProvideLocalNuGetFeed.IsPresent,
                 UpdateVersions = BoundSwitch(nameof(UpdateVersions), UpdateVersions),
                 Build = BoundSwitch(nameof(Build), Build),
+                IncludeSymbols = BoundSwitch(nameof(IncludeSymbols), IncludeSymbols),
                 PublishNuget = BoundSwitch(nameof(PublishNuget), PublishNuget),
                 PublishGitHub = BoundSwitch(nameof(PublishGitHub), PublishGitHub),
                 CreateReleaseZip = BoundSwitch(nameof(CreateReleaseZip), CreateReleaseZip),
@@ -205,6 +210,9 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
 
     /// <summary>Pack strategy, for example PerProject or MSBuild.</summary>
     [Parameter] public string? PackStrategy { get; set; }
+
+    /// <summary>Whether portable <c>.snupkg</c> symbol packages should be created.</summary>
+    [Parameter] public SwitchParameter IncludeSymbols { get; set; }
 
     /// <summary>Whether NuGet packages should be published.</summary>
     [Parameter] public SwitchParameter PublishNuget { get; set; }
@@ -347,6 +355,7 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
                 UpdateVersions = BoundSwitch(nameof(UpdateVersions), UpdateVersions),
                 Build = BoundSwitch(nameof(Build), Build),
                 PackStrategy = Normalize(PackStrategy),
+                IncludeSymbols = BoundSwitch(nameof(IncludeSymbols), IncludeSymbols),
                 PublishNuget = BoundSwitch(nameof(PublishNuget), PublishNuget),
                 PublishGitHub = BoundSwitch(nameof(PublishGitHub), PublishGitHub),
                 CreateReleaseZip = BoundSwitch(nameof(CreateReleaseZip), CreateReleaseZip),

--- a/PSPublishModule/Cmdlets/PublishNugetPackageCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishNugetPackageCommand.cs
@@ -143,7 +143,8 @@ public sealed class PublishNugetPackageCommand : PSCmdlet
                 Roots = resolvedRoots,
                 ApiKey = apiKey,
                 Source = source,
-                SkipDuplicate = SkipDuplicate.IsPresent
+                SkipDuplicate = SkipDuplicate.IsPresent,
+                WorkingDirectory = SessionState.Path.GetUnresolvedProviderPathFromPSPath(".")
             }, package => ShouldProcess(package, $"Publish NuGet package to {source}"));
 
             WriteObject(ToCmdletResult(serviceResult, source, profileName, repositoryName));

--- a/PSPublishModule/packages.lock.json
+++ b/PSPublishModule/packages.lock.json
@@ -241,7 +241,8 @@
         "dependencies": {
           "System.Reflection.Metadata": "[8.0.0, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "System.Text.Json": "[10.0.7, )"
+          "System.Text.Json": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.powershell": {
@@ -252,6 +253,28 @@
           "System.Security.Cryptography.Xml": "[10.0.7, )",
           "System.Text.Json": "[10.0.7, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net10.0": {
@@ -904,7 +927,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.powershell": {
@@ -914,6 +938,28 @@
           "PowerForge": "[1.0.0, )",
           "System.Security.Cryptography.Xml": "[10.0.7, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net8.0": {
@@ -1591,7 +1637,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.powershell": {
@@ -1601,6 +1648,28 @@
           "PowerForge": "[1.0.0, )",
           "System.Security.Cryptography.Xml": "[10.0.7, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.Cli/packages.lock.json
+++ b/PowerForge.Cli/packages.lock.json
@@ -603,7 +603,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.powershell": {
@@ -613,6 +614,28 @@
           "PowerForge": "[1.0.0, )",
           "System.Security.Cryptography.Xml": "[10.0.7, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net8.0": {
@@ -1242,7 +1265,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.powershell": {
@@ -1252,6 +1276,28 @@
           "PowerForge": "[1.0.0, )",
           "System.Security.Cryptography.Xml": "[10.0.7, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.Net472SmokeTests/packages.lock.json
+++ b/PowerForge.Net472SmokeTests/packages.lock.json
@@ -231,7 +231,8 @@
         "dependencies": {
           "System.Reflection.Metadata": "[8.0.0, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "System.Text.Json": "[10.0.7, )"
+          "System.Text.Json": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.powershell": {
@@ -242,6 +243,28 @@
           "System.Security.Cryptography.Xml": "[10.0.7, )",
           "System.Text.Json": "[10.0.7, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -498,6 +498,8 @@ public sealed partial class ModulePipelineRunner
             target.UpdateVersions = reference.UpdateVersions;
         if (reference.Build is not null)
             target.Build = reference.Build;
+        if (reference.IncludeSymbols is not null)
+            target.IncludeSymbols = reference.IncludeSymbols;
         if (reference.PublishNuget is not null)
             target.PublishNuget = reference.PublishNuget;
         if (reference.PublishGitHub is not null)
@@ -764,6 +766,7 @@ public sealed partial class ModulePipelineRunner
             UpdateVersions = source.UpdateVersions,
             Build = source.Build,
             PackStrategy = source.PackStrategy,
+            IncludeSymbols = source.IncludeSymbols,
             PublishNuget = source.PublishNuget,
             PublishGitHub = source.PublishGitHub,
             CreateReleaseZip = source.CreateReleaseZip,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -221,7 +221,7 @@ public sealed partial class ModulePipelineRunner
         switch (destination)
         {
             case PackageBuildPublishDestination.NuGet:
-                PublishExistingNuGetPackages(release, configuration, configPath);
+                PublishExistingNuGetPackages(release, configuration, configPath, existing.RootPath);
                 break;
             case PackageBuildPublishDestination.GitHub:
                 PublishExistingGitHubRelease(existing, release, configuration, configPath);
@@ -232,7 +232,8 @@ public sealed partial class ModulePipelineRunner
     private void PublishExistingNuGetPackages(
         DotNetRepositoryReleaseResult release,
         ProjectBuildConfiguration configuration,
-        string configPath)
+        string configPath,
+        string repositoryRoot)
     {
         var configDirectory = Path.GetDirectoryName(configPath);
         if (string.IsNullOrWhiteSpace(configDirectory))
@@ -243,15 +244,18 @@ public sealed partial class ModulePipelineRunner
         if (string.IsNullOrWhiteSpace(apiKey))
             throw new InvalidOperationException("PublishApiKey is required when package NuGet publishing is enabled.");
 
-        var source = string.IsNullOrWhiteSpace(feed.PublishSource)
+        var configuredSource = string.IsNullOrWhiteSpace(feed.PublishSource)
             ? ProjectBuildPackageFeedResolver.GetDefaultPublishSource()
             : feed.PublishSource!.Trim();
+        var source = DotNetRepositoryReleaseService.ResolvePublishSource(
+            configuredSource,
+            string.IsNullOrWhiteSpace(repositoryRoot) ? configDirectory : repositoryRoot);
         release.PublishSource = source;
-        var packages = release.Projects
-            .SelectMany(project => project.Packages)
-            .Where(package => !string.IsNullOrWhiteSpace(package))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        var publishSymbolsSeparately = (configuration.IncludeSymbols ?? false) &&
+            DotNetRepositoryReleaseService.IsLocalPublishSource(source);
+        var packages = DotNetRepositoryReleaseService.GetPackagesForPublish(
+            release.Projects,
+            includeSymbolPackages: publishSymbolsSeparately);
 
         _logger.Info($"Publishing {packages.Length} existing package(s) from earlier package build.");
         var publish = new NuGetPackagePublishService(_logger).ExecutePackages(
@@ -260,10 +264,9 @@ public sealed partial class ModulePipelineRunner
             source,
             configuration.SkipDuplicate ?? true,
             configuration.PublishFailFast ?? true,
-            suppressCompanionSymbols: !(configuration.IncludeSymbols ?? false));
+            suppressCompanionSymbols: !(configuration.IncludeSymbols ?? false) || publishSymbolsSeparately);
 
-        ApplyPublishedNuGetArtifactOutcomes(release, publish);
-        release.FailedPackages.AddRange(publish.FailedItems);
+        ApplyPublishedNuGetArtifactOutcomes(release, publish, publishSymbolsSeparately);
         if (!publish.Success)
         {
             release.Success = false;
@@ -274,23 +277,39 @@ public sealed partial class ModulePipelineRunner
 
     internal static void ApplyPublishedNuGetArtifactOutcomes(
         DotNetRepositoryReleaseResult release,
-        NuGetPackagePublishResult publish)
+        NuGetPackagePublishResult publish,
+        bool publishSymbolsSeparately = false)
     {
+        var publishedPrimaryPackages = new HashSet<string>(publish.PublishedItems, StringComparer.OrdinalIgnoreCase);
         var skippedPrimaryPackages = new HashSet<string>(publish.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
+        var failedPrimaryPackages = new HashSet<string>(publish.FailedItems, StringComparer.OrdinalIgnoreCase);
         var publishedArtifacts = new HashSet<string>(release.PublishedPackages, StringComparer.OrdinalIgnoreCase);
         var skippedArtifacts = new HashSet<string>(release.SkippedDuplicatePackages, StringComparer.OrdinalIgnoreCase);
-        foreach (var package in publish.PublishedItems)
+        var failedArtifacts = new HashSet<string>(release.FailedPackages, StringComparer.OrdinalIgnoreCase);
+        var attemptedPackages = publish.PackagePushResults.Keys
+            .Concat(publish.PublishedItems)
+            .Concat(publish.FailedItems)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        foreach (var package in attemptedPackages)
         {
             var project = release.Projects.FirstOrDefault(candidate =>
-                candidate.Packages.Contains(package, StringComparer.OrdinalIgnoreCase));
-            var artifacts = DotNetRepositoryReleaseService.GetPublishedArtifacts(project, package);
+                candidate.Packages.Contains(package, StringComparer.OrdinalIgnoreCase) ||
+                candidate.SymbolPackages.Contains(package, StringComparer.OrdinalIgnoreCase));
+            var artifacts = DotNetRepositoryReleaseService.GetPublishedArtifacts(
+                project,
+                package,
+                includeCompanionSymbols: !publishSymbolsSeparately);
             if (!publish.PackagePushResults.TryGetValue(package, out var pushResult))
             {
                 pushResult = new DotNetRepositoryReleaseService.PackagePushResult
                 {
-                    Outcome = skippedPrimaryPackages.Contains(package)
-                        ? DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate
-                        : DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                    Outcome = failedPrimaryPackages.Contains(package)
+                        ? DotNetRepositoryReleaseService.PackagePushOutcome.Failed
+                        : skippedPrimaryPackages.Contains(package)
+                            ? DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate
+                            : publishedPrimaryPackages.Contains(package)
+                                ? DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                                : DotNetRepositoryReleaseService.PackagePushOutcome.Failed
                 };
             }
 
@@ -302,9 +321,14 @@ public sealed partial class ModulePipelineRunner
                     if (skippedArtifacts.Add(artifact))
                         release.SkippedDuplicatePackages.Add(artifact);
                 }
-                else if (publishedArtifacts.Add(artifact))
+                else if (outcomes[artifact] == DotNetRepositoryReleaseService.PackagePushOutcome.Published)
                 {
-                    release.PublishedPackages.Add(artifact);
+                    if (publishedArtifacts.Add(artifact))
+                        release.PublishedPackages.Add(artifact);
+                }
+                else if (failedArtifacts.Add(artifact))
+                {
+                    release.FailedPackages.Add(artifact);
                 }
             }
         }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -249,7 +249,8 @@ public sealed partial class ModulePipelineRunner
             : feed.PublishSource!.Trim();
         var source = DotNetRepositoryReleaseService.ResolvePublishSource(
             configuredSource,
-            string.IsNullOrWhiteSpace(repositoryRoot) ? configDirectory : repositoryRoot);
+            string.IsNullOrWhiteSpace(repositoryRoot) ? configDirectory : repositoryRoot,
+            nuGetConfigSearchRoot: configDirectory);
         release.PublishSource = source;
         var publishSymbolsSeparately = (configuration.IncludeSymbols ?? false) &&
             DotNetRepositoryReleaseService.IsLocalPublishSource(source);
@@ -258,7 +259,9 @@ public sealed partial class ModulePipelineRunner
             includeSymbolPackages: publishSymbolsSeparately);
 
         _logger.Info($"Publishing {packages.Length} existing package(s) from earlier package build.");
-        var publish = new NuGetPackagePublishService(_logger).ExecutePackages(
+        var publish = new NuGetPackagePublishService(
+            _logger,
+            workingDirectory: configDirectory).ExecutePackages(
             packages,
             apiKey!,
             source,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -266,7 +266,11 @@ public sealed partial class ModulePipelineRunner
             configuration.PublishFailFast ?? true,
             suppressCompanionSymbols: !(configuration.IncludeSymbols ?? false) || publishSymbolsSeparately);
 
-        ApplyPublishedNuGetArtifactOutcomes(release, publish, publishSymbolsSeparately);
+        ApplyPublishedNuGetArtifactOutcomes(
+            release,
+            publish,
+            publishSymbolsSeparately,
+            configuration.SkipDuplicate ?? true);
         if (!publish.Success)
         {
             release.Success = false;
@@ -278,7 +282,8 @@ public sealed partial class ModulePipelineRunner
     internal static void ApplyPublishedNuGetArtifactOutcomes(
         DotNetRepositoryReleaseResult release,
         NuGetPackagePublishResult publish,
-        bool publishSymbolsSeparately = false)
+        bool publishSymbolsSeparately = false,
+        bool skipDuplicate = true)
     {
         var publishedPrimaryPackages = new HashSet<string>(publish.PublishedItems, StringComparer.OrdinalIgnoreCase);
         var skippedPrimaryPackages = new HashSet<string>(publish.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
@@ -313,7 +318,10 @@ public sealed partial class ModulePipelineRunner
                 };
             }
 
-            var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(artifacts, pushResult);
+            var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(
+                artifacts,
+                pushResult,
+                skipDuplicate);
             foreach (var artifact in artifacts)
             {
                 if (outcomes[artifact] == DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -259,7 +259,8 @@ public sealed partial class ModulePipelineRunner
             apiKey!,
             source,
             configuration.SkipDuplicate ?? true,
-            configuration.PublishFailFast ?? true);
+            configuration.PublishFailFast ?? true,
+            suppressCompanionSymbols: !(configuration.IncludeSymbols ?? false));
 
         ApplyPublishedNuGetArtifactOutcomes(release, publish);
         release.FailedPackages.AddRange(publish.FailedItems);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -186,7 +186,7 @@ public sealed partial class ModulePipelineRunner
         return destination switch
         {
             PackageBuildPublishDestination.NuGet => HasAllArtifacts(release.Projects
-                .SelectMany(project => project.Packages)
+                .SelectMany(project => project.Packages.Concat(project.SymbolPackages))
                 .Where(package => !string.IsNullOrWhiteSpace(package))),
             PackageBuildPublishDestination.GitHub => HasAllArtifacts(release.Projects
                 .Select(project => project.ReleaseZipPath)
@@ -261,7 +261,11 @@ public sealed partial class ModulePipelineRunner
             configuration.SkipDuplicate ?? true,
             configuration.PublishFailFast ?? true);
 
-        release.PublishedPackages.AddRange(publish.PublishedItems);
+        var skippedPrimaryPackages = new HashSet<string>(publish.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
+        release.PublishedPackages.AddRange(ExpandPublishedNuGetArtifacts(
+            release,
+            publish.PublishedItems.Where(package => !skippedPrimaryPackages.Contains(package))));
+        release.SkippedDuplicatePackages.AddRange(ExpandPublishedNuGetArtifacts(release, publish.SkippedDuplicateItems));
         release.FailedPackages.AddRange(publish.FailedItems);
         if (!publish.Success)
         {
@@ -269,6 +273,21 @@ public sealed partial class ModulePipelineRunner
             release.ErrorMessage = publish.ErrorMessage ?? "One or more packages failed to publish.";
             throw new InvalidOperationException(release.ErrorMessage);
         }
+    }
+
+    private static string[] ExpandPublishedNuGetArtifacts(
+        DotNetRepositoryReleaseResult release,
+        IEnumerable<string> primaryPackages)
+    {
+        return primaryPackages
+            .SelectMany(package =>
+            {
+                var project = release.Projects.FirstOrDefault(candidate =>
+                    candidate.Packages.Contains(package, StringComparer.OrdinalIgnoreCase));
+                return DotNetRepositoryReleaseService.GetPublishedArtifacts(project, package);
+            })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private void PublishExistingGitHubRelease(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -261,11 +261,7 @@ public sealed partial class ModulePipelineRunner
             configuration.SkipDuplicate ?? true,
             configuration.PublishFailFast ?? true);
 
-        var skippedPrimaryPackages = new HashSet<string>(publish.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
-        release.PublishedPackages.AddRange(ExpandPublishedNuGetArtifacts(
-            release,
-            publish.PublishedItems.Where(package => !skippedPrimaryPackages.Contains(package))));
-        release.SkippedDuplicatePackages.AddRange(ExpandPublishedNuGetArtifacts(release, publish.SkippedDuplicateItems));
+        ApplyPublishedNuGetArtifactOutcomes(release, publish);
         release.FailedPackages.AddRange(publish.FailedItems);
         if (!publish.Success)
         {
@@ -275,19 +271,42 @@ public sealed partial class ModulePipelineRunner
         }
     }
 
-    private static string[] ExpandPublishedNuGetArtifacts(
+    internal static void ApplyPublishedNuGetArtifactOutcomes(
         DotNetRepositoryReleaseResult release,
-        IEnumerable<string> primaryPackages)
+        NuGetPackagePublishResult publish)
     {
-        return primaryPackages
-            .SelectMany(package =>
+        var skippedPrimaryPackages = new HashSet<string>(publish.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
+        var publishedArtifacts = new HashSet<string>(release.PublishedPackages, StringComparer.OrdinalIgnoreCase);
+        var skippedArtifacts = new HashSet<string>(release.SkippedDuplicatePackages, StringComparer.OrdinalIgnoreCase);
+        foreach (var package in publish.PublishedItems)
+        {
+            var project = release.Projects.FirstOrDefault(candidate =>
+                candidate.Packages.Contains(package, StringComparer.OrdinalIgnoreCase));
+            var artifacts = DotNetRepositoryReleaseService.GetPublishedArtifacts(project, package);
+            if (!publish.PackagePushResults.TryGetValue(package, out var pushResult))
             {
-                var project = release.Projects.FirstOrDefault(candidate =>
-                    candidate.Packages.Contains(package, StringComparer.OrdinalIgnoreCase));
-                return DotNetRepositoryReleaseService.GetPublishedArtifacts(project, package);
-            })
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+                pushResult = new DotNetRepositoryReleaseService.PackagePushResult
+                {
+                    Outcome = skippedPrimaryPackages.Contains(package)
+                        ? DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate
+                        : DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                };
+            }
+
+            var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(artifacts, pushResult);
+            foreach (var artifact in artifacts)
+            {
+                if (outcomes[artifact] == DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate)
+                {
+                    if (skippedArtifacts.Add(artifact))
+                        release.SkippedDuplicatePackages.Add(artifact);
+                }
+                else if (publishedArtifacts.Add(artifact))
+                {
+                    release.PublishedPackages.Add(artifact);
+                }
+            }
+        }
     }
 
     private void PublishExistingGitHubRelease(

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -496,7 +496,8 @@ public sealed partial class ModulePipelineRunner
         var assets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var result in projectBuildResults ?? Array.Empty<ProjectBuildHostExecutionResult>())
         {
-            foreach (var package in result.Result?.Release?.Projects.SelectMany(static project => project.Packages) ?? Array.Empty<string>())
+            foreach (var package in result.Result?.Release?.Projects.SelectMany(static project =>
+                         project.Packages.Concat(project.SymbolPackages)) ?? Array.Empty<string>())
                 TryAddReleasePackageAsset(assets, package);
         }
 

--- a/PowerForge.PowerShell/packages.lock.json
+++ b/PowerForge.PowerShell/packages.lock.json
@@ -160,8 +160,31 @@
         "dependencies": {
           "System.Reflection.Metadata": "[8.0.0, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "System.Text.Json": "[10.0.7, )"
+          "System.Text.Json": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net10.0": {
@@ -762,8 +785,31 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net8.0": {
@@ -1389,8 +1435,31 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -17,12 +17,13 @@ public sealed class DotNetNuGetClientTests
             return new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
         });
         var runtimeDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var packagePath = Path.Combine(runtimeDirectory, "Artifacts", "Test.1.0.0.nupkg");
         var client = new DotNetNuGetClient(processRunner, runtimeDirectoryRoot: runtimeDirectory);
 
         try
         {
             var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
-                packagePath: @"C:\repo\Artifacts\Test.1.0.0.nupkg",
+                packagePath,
                 apiKey: "secret",
                 source: "https://api.nuget.org/v3/index.json",
                 skipDuplicate: true,
@@ -40,7 +41,7 @@ public sealed class DotNetNuGetClientTests
                 [
                     "nuget",
                     "push",
-                    @"C:\repo\Artifacts\Test.1.0.0.nupkg",
+                    packagePath,
                     "--api-key",
                     "secret",
                     "--source",
@@ -169,7 +170,7 @@ public sealed class DotNetNuGetClientTests
         try
         {
             var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
-                packagePath,
+                Path.GetRelativePath(root.FullName, packagePath),
                 "key",
                 "./feed",
                 skipDuplicate: true,
@@ -190,7 +191,7 @@ public sealed class DotNetNuGetClientTests
     }
 
     [Fact]
-    public async Task PushPackageAsync_WritesValuesWithSpacesAsSingleResponseFileLines()
+    public async Task PushPackageAsync_PreservesResponseFileValuesWithSpacesWithoutLiteralQuotes()
     {
         string? responseFileContent = null;
         var processRunner = new StubProcessRunner(request => {
@@ -198,25 +199,27 @@ public sealed class DotNetNuGetClientTests
             return new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
         });
         var runtimeDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge Tests", Guid.NewGuid().ToString("N"))).FullName;
+        var packagePath = Path.Combine(runtimeDirectory, "repo with spaces", "Artifacts", "Test.1.0.0.nupkg");
+        var source = Path.Combine(runtimeDirectory, "local feed with spaces");
         var client = new DotNetNuGetClient(processRunner, runtimeDirectoryRoot: runtimeDirectory);
 
         try
         {
             var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
-                packagePath: @"C:\repo with spaces\Artifacts\Test.1.0.0.nupkg",
+                packagePath,
                 apiKey: "secret value",
-                source: @"C:\local feed with spaces"));
+                source));
 
             Assert.Equal(
                 string.Join(Environment.NewLine,
                 [
                     "nuget",
                     "push",
-                    @"C:\repo with spaces\Artifacts\Test.1.0.0.nupkg",
+                    packagePath,
                     "--api-key",
                     "secret value",
                     "--source",
-                    @"C:\local feed with spaces",
+                    source,
                     "--skip-duplicate"
                 ]),
                 responseFileContent);
@@ -225,6 +228,48 @@ public sealed class DotNetNuGetClientTests
         finally
         {
             try { Directory.Delete(runtimeDirectory, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task PushPackageAsync_PublishesRelativePathsWithSpacesUsingDotNetCli()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge NuGet Push",
+            Guid.NewGuid().ToString("N")));
+        var repositoryDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Repository With Spaces"));
+        var packageDirectory = Directory.CreateDirectory(Path.Combine(repositoryDirectory.FullName, "Artifacts With Spaces"));
+        var feedDirectory = Directory.CreateDirectory(Path.Combine(repositoryDirectory.FullName, "Feed With Spaces"));
+        var packageFileName = "Sample.Package.1.0.0.nupkg";
+        var packagePath = Path.Combine(packageDirectory.FullName, packageFileName);
+        TestPackageFactory.Create(packagePath, "Sample.Package", "1.0.0");
+        var client = new DotNetNuGetClient(
+            runtimeDirectoryRoot: Path.Combine(root.FullName, "Runtime With Spaces"));
+
+        try
+        {
+            var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
+                packagePath: Path.Combine("Artifacts With Spaces", packageFileName),
+                apiKey: "unused key",
+                source: Path.Combine(".", "Feed With Spaces"),
+                skipDuplicate: true,
+                workingDirectory: repositoryDirectory.FullName,
+                timeout: TimeSpan.FromMinutes(1),
+                suppressCompanionSymbols: true));
+
+            Assert.True(
+                result.Succeeded,
+                $"{result.ErrorMessage}{Environment.NewLine}{result.StdOut}{Environment.NewLine}{result.StdErr}");
+            Assert.Single(Directory.GetFiles(
+                feedDirectory.FullName,
+                packageFileName,
+                SearchOption.AllDirectories));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
         }
     }
 

--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -25,6 +25,9 @@ public sealed class DotNetNuGetClientTests
                 packagePath: @"C:\repo\Artifacts\Test.1.0.0.nupkg",
                 apiKey: "secret",
                 source: "https://api.nuget.org/v3/index.json",
+                skipDuplicate: true,
+                workingDirectory: null,
+                timeout: null,
                 suppressCompanionSymbols: true));
 
             Assert.NotNull(captured);
@@ -54,6 +57,32 @@ public sealed class DotNetNuGetClientTests
         {
             try { Directory.Delete(runtimeDirectory, recursive: true); } catch { }
         }
+    }
+
+    [Fact]
+    public void PushRequest_RetainsOriginalSixArgumentConstructor()
+    {
+        var constructor = typeof(DotNetNuGetPushRequest).GetConstructor(new[]
+        {
+            typeof(string),
+            typeof(string),
+            typeof(string),
+            typeof(bool),
+            typeof(string),
+            typeof(TimeSpan?)
+        });
+
+        Assert.NotNull(constructor);
+        var request = Assert.IsType<DotNetNuGetPushRequest>(constructor!.Invoke(new object?[]
+        {
+            "Sample.1.0.0.nupkg",
+            "key",
+            "https://api.nuget.org/v3/index.json",
+            true,
+            null,
+            null
+        }));
+        Assert.False(request.SuppressCompanionSymbols);
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -86,6 +86,102 @@ public sealed class DotNetNuGetClientTests
     }
 
     [Fact]
+    public async Task PushPackageAsync_StagesCompanionSymbolsUnderConfigurationDirectory()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var configurationDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "repository"));
+        var packageDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "artifacts"));
+        var packagePath = Path.Combine(packageDirectory.FullName, "Sample.1.0.0.nupkg");
+        var symbolPackagePath = Path.ChangeExtension(packagePath, ".snupkg");
+        File.WriteAllText(packagePath, "primary");
+        File.WriteAllText(symbolPackagePath, "symbols");
+
+        ProcessRunRequest? captured = null;
+        string? stagedPackagePath = null;
+        var processRunner = new StubProcessRunner(request =>
+        {
+            captured = request;
+            var responseFile = request.Arguments.Single()[1..];
+            stagedPackagePath = File.ReadAllLines(responseFile)[2];
+            Assert.True(File.Exists(stagedPackagePath));
+            Assert.True(File.Exists(Path.ChangeExtension(stagedPackagePath, ".snupkg")));
+            return new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+        });
+        var client = new DotNetNuGetClient(
+            processRunner,
+            runtimeDirectoryRoot: Path.Combine(root.FullName, "runtime"));
+
+        try
+        {
+            var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
+                packagePath,
+                "key",
+                "PrivateFeed",
+                skipDuplicate: true,
+                workingDirectory: configurationDirectory.FullName,
+                timeout: null,
+                suppressCompanionSymbols: false));
+
+            Assert.True(result.Succeeded);
+            Assert.NotNull(captured);
+            Assert.StartsWith(configurationDirectory.FullName, captured!.WorkingDirectory, StringComparison.OrdinalIgnoreCase);
+            Assert.NotEqual(configurationDirectory.FullName, captured.WorkingDirectory);
+            Assert.NotEqual(packagePath, stagedPackagePath);
+            Assert.False(Directory.Exists(captured.WorkingDirectory));
+            Assert.True(File.Exists(packagePath));
+            Assert.True(File.Exists(symbolPackagePath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task PushPackageAsync_UsesPackageDirectoryWithinConfigurationHierarchy()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        var packageDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "artifacts", "packages"));
+        var packagePath = Path.Combine(packageDirectory.FullName, "Sample.1.0.0.nupkg");
+        var symbolPackagePath = Path.ChangeExtension(packagePath, ".snupkg");
+        File.WriteAllText(packagePath, "primary");
+        File.WriteAllText(symbolPackagePath, "symbols");
+
+        ProcessRunRequest? captured = null;
+        string? pushedPackagePath = null;
+        var processRunner = new StubProcessRunner(request =>
+        {
+            captured = request;
+            pushedPackagePath = File.ReadAllLines(request.Arguments.Single()[1..])[2];
+            return new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+        });
+        var client = new DotNetNuGetClient(
+            processRunner,
+            runtimeDirectoryRoot: Path.Combine(root.FullName, "runtime"));
+
+        try
+        {
+            var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
+                packagePath,
+                "key",
+                "PrivateFeed",
+                skipDuplicate: true,
+                workingDirectory: root.FullName,
+                timeout: null,
+                suppressCompanionSymbols: false));
+
+            Assert.True(result.Succeeded);
+            Assert.NotNull(captured);
+            Assert.Equal(packageDirectory.FullName, captured!.WorkingDirectory);
+            Assert.Equal(packagePath, pushedPackagePath);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public async Task PushPackageAsync_WritesValuesWithSpacesAsSingleResponseFileLines()
     {
         string? responseFileContent = null;

--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -98,11 +98,14 @@ public sealed class DotNetNuGetClientTests
 
         ProcessRunRequest? captured = null;
         string? stagedPackagePath = null;
+        string? pushedSource = null;
         var processRunner = new StubProcessRunner(request =>
         {
             captured = request;
             var responseFile = request.Arguments.Single()[1..];
-            stagedPackagePath = File.ReadAllLines(responseFile)[2];
+            var responseFileLines = File.ReadAllLines(responseFile);
+            stagedPackagePath = responseFileLines[2];
+            pushedSource = responseFileLines[6];
             Assert.True(File.Exists(stagedPackagePath));
             Assert.True(File.Exists(Path.ChangeExtension(stagedPackagePath, ".snupkg")));
             return new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
@@ -116,7 +119,7 @@ public sealed class DotNetNuGetClientTests
             var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
                 packagePath,
                 "key",
-                "PrivateFeed",
+                "./feed",
                 skipDuplicate: true,
                 workingDirectory: configurationDirectory.FullName,
                 timeout: null,
@@ -127,6 +130,7 @@ public sealed class DotNetNuGetClientTests
             Assert.StartsWith(configurationDirectory.FullName, captured!.WorkingDirectory, StringComparison.OrdinalIgnoreCase);
             Assert.NotEqual(configurationDirectory.FullName, captured.WorkingDirectory);
             Assert.NotEqual(packagePath, stagedPackagePath);
+            Assert.Equal(Path.Combine(configurationDirectory.FullName, "feed"), pushedSource);
             Assert.False(Directory.Exists(captured.WorkingDirectory));
             Assert.True(File.Exists(packagePath));
             Assert.True(File.Exists(symbolPackagePath));
@@ -149,10 +153,13 @@ public sealed class DotNetNuGetClientTests
 
         ProcessRunRequest? captured = null;
         string? pushedPackagePath = null;
+        string? pushedSource = null;
         var processRunner = new StubProcessRunner(request =>
         {
             captured = request;
-            pushedPackagePath = File.ReadAllLines(request.Arguments.Single()[1..])[2];
+            var responseFileLines = File.ReadAllLines(request.Arguments.Single()[1..]);
+            pushedPackagePath = responseFileLines[2];
+            pushedSource = responseFileLines[6];
             return new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
         });
         var client = new DotNetNuGetClient(
@@ -164,7 +171,7 @@ public sealed class DotNetNuGetClientTests
             var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
                 packagePath,
                 "key",
-                "PrivateFeed",
+                "./feed",
                 skipDuplicate: true,
                 workingDirectory: root.FullName,
                 timeout: null,
@@ -174,6 +181,7 @@ public sealed class DotNetNuGetClientTests
             Assert.NotNull(captured);
             Assert.Equal(packageDirectory.FullName, captured!.WorkingDirectory);
             Assert.Equal(packagePath, pushedPackagePath);
+            Assert.Equal(Path.Combine(root.FullName, "feed"), pushedSource);
         }
         finally
         {

--- a/PowerForge.Tests/DotNetNuGetClientTests.cs
+++ b/PowerForge.Tests/DotNetNuGetClientTests.cs
@@ -24,7 +24,8 @@ public sealed class DotNetNuGetClientTests
             var result = await client.PushPackageAsync(new DotNetNuGetPushRequest(
                 packagePath: @"C:\repo\Artifacts\Test.1.0.0.nupkg",
                 apiKey: "secret",
-                source: "https://api.nuget.org/v3/index.json"));
+                source: "https://api.nuget.org/v3/index.json",
+                suppressCompanionSymbols: true));
 
             Assert.NotNull(captured);
             Assert.Equal("dotnet", captured!.FileName);
@@ -41,7 +42,8 @@ public sealed class DotNetNuGetClientTests
                     "secret",
                     "--source",
                     "https://api.nuget.org/v3/index.json",
-                    "--skip-duplicate"
+                    "--skip-duplicate",
+                    "--no-symbols"
                 ]),
                 responseFileContent);
             Assert.True(result.Succeeded);

--- a/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
@@ -33,6 +33,7 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
                 TimeStampServer = "http://timestamp.test",
                 SignAssemblies = false,
                 SignPackages = false,
+                IncludeSymbols = true,
                 Publish = true,
                 PublishFailFast = true,
                 SkipDuplicate = true
@@ -51,6 +52,7 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
             Assert.Equal(PowerForge.CertificateStoreLocation.LocalMachine, context.Spec.CertificateStore);
             Assert.False(context.Spec.SignAssemblies);
             Assert.False(context.Spec.SignPackages);
+            Assert.True(context.Spec.IncludeSymbols);
             Assert.Equal("Debug", context.Spec.Configuration);
             Assert.True(context.Spec.Publish);
             Assert.True(context.Spec.PublishFailFast);

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -207,7 +207,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
-    public void GetPackagesForPublish_OrdersEachSymbolPackageAfterItsPrimaryPackage()
+    public void GetPackagesForPublish_PushesOnlyPrimaryPackages()
     {
         var first = new DotNetRepositoryProjectResult { ProjectName = "First" };
         first.Packages.Add("First.1.0.0.nupkg");
@@ -221,10 +221,27 @@ public sealed class DotNetRepositoryReleaseServiceTests
         Assert.Equal(new[]
         {
             "First.1.0.0.nupkg",
-            "First.1.0.0.snupkg",
-            "Second.2.0.0.nupkg",
-            "Second.2.0.0.snupkg"
+            "Second.2.0.0.nupkg"
         }, packages);
+    }
+
+    [Fact]
+    public void GetPublishedArtifacts_ReportsSymbolUploadedWithPrimaryPackage()
+    {
+        var project = new DotNetRepositoryProjectResult { ProjectName = "Sample" };
+        project.Packages.Add("Sample.1.0.0.nupkg");
+        project.SymbolPackages.Add("Sample.1.0.0.snupkg");
+        project.SymbolPackages.Add("Other.1.0.0.snupkg");
+
+        var artifacts = DotNetRepositoryReleaseService.GetPublishedArtifacts(
+            project,
+            "Sample.1.0.0.nupkg");
+
+        Assert.Equal(new[]
+        {
+            "Sample.1.0.0.nupkg",
+            "Sample.1.0.0.snupkg"
+        }, artifacts);
     }
 
     [Theory]
@@ -559,6 +576,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 Configuration = "Release",
                 OutputPath = Path.Combine(root.FullName, "packages"),
                 Pack = true,
+                IncludeSymbols = true,
                 Publish = true,
                 PublishApiKey = "key",
                 PublishSource = localFeed.FullName,
@@ -577,7 +595,9 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 (_, _) => "ABCDEF").Execute(spec);
 
             Assert.False(result.Success);
-            Assert.Single(packagesSeenBySigner);
+            Assert.Equal(2, packagesSeenBySigner.Length);
+            Assert.Contains(packagesSeenBySigner, package => package.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(packagesSeenBySigner, package => package.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase));
             Assert.Empty(result.PublishedPackages);
             Assert.Empty(Directory.EnumerateFiles(localFeed.FullName, "*.nupkg", SearchOption.AllDirectories));
             var project = Assert.Single(result.Projects, item => item.IsPackable);

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -278,6 +278,63 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
+    public void ResolvePublishSource_ResolvesNamedLocalSourceFromNuGetConfig()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(root.FullName, "NuGet.config"),
+                "<configuration><packageSources><clear /><add key=\"LocalFeed\" value=\"Artifacts/Feed\" /></packageSources></configuration>");
+            var configSearchRoot = Directory.CreateDirectory(Path.Combine(root.FullName, "Build"));
+
+            var source = DotNetRepositoryReleaseService.ResolvePublishSource(
+                "LocalFeed",
+                Path.Combine(root.FullName, "Sources"),
+                nuGetConfigSearchRoot: configSearchRoot.FullName);
+
+            Assert.Equal(
+                Path.GetFullPath(Path.Combine(root.FullName, "Artifacts", "Feed")),
+                source);
+            Assert.True(DotNetRepositoryReleaseService.IsLocalPublishSource(source));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void ResolvePublishSource_PreservesNamedRemoteSourceFromNuGetConfig()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(root.FullName, "NuGet.config"),
+                "<configuration><packageSources><clear /><add key=\"PrivateFeed\" value=\"https://packages.example.test/v3/index.json\" /></packageSources></configuration>");
+
+            var source = DotNetRepositoryReleaseService.ResolvePublishSource(
+                "PrivateFeed",
+                Path.Combine(root.FullName, "artifacts"),
+                nuGetConfigSearchRoot: root.FullName);
+
+            Assert.Equal("PrivateFeed", source);
+            Assert.False(DotNetRepositoryReleaseService.IsLocalPublishSource(source));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void GetPackagesForPublish_PushesOnlyPrimaryPackages()
     {
         var first = new DotNetRepositoryProjectResult { ProjectName = "First" };

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -261,12 +261,14 @@ public sealed class DotNetRepositoryReleaseServiceTests
         Assert.Contains("--no-symbols", startInfo.ArgumentList);
     }
 
-    [Fact]
-    public void ResolvePublishSource_ResolvesRelativeLocalFeedFromRepositoryRoot()
+    [Theory]
+    [InlineData("Artefacts/Feed")]
+    [InlineData(@"Artefacts\Feed")]
+    public void ResolvePublishSource_ResolvesRelativeLocalFeedFromRepositoryRoot(string configuredSource)
     {
         var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
 
-        var source = DotNetRepositoryReleaseService.ResolvePublishSource("Artefacts/Feed", root);
+        var source = DotNetRepositoryReleaseService.ResolvePublishSource(configuredSource, root);
 
         Assert.Equal(Path.GetFullPath(Path.Combine(root, "Artefacts", "Feed")), source);
     }

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -47,6 +47,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 Configuration = "Release",
                 OutputPath = Path.Combine(root.FullName, "Artefacts", "packages"),
                 Pack = true,
+                IncludeSymbols = true,
                 Publish = true,
                 WhatIf = true,
                 PublishApiKey = "dummy",
@@ -62,8 +63,11 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.True(string.IsNullOrWhiteSpace(result.ErrorMessage), result.ErrorMessage);
             var project = Assert.Single(result.Projects, p => p.IsPackable);
             var pkg = Assert.Single(project.Packages);
+            var symbols = Assert.Single(project.SymbolPackages);
             Assert.False(File.Exists(pkg));
+            Assert.False(File.Exists(symbols));
             Assert.Contains(pkg, result.PublishedPackages, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(symbols, result.PublishedPackages, StringComparer.OrdinalIgnoreCase);
         }
         finally
         {
@@ -202,6 +206,27 @@ public sealed class DotNetRepositoryReleaseServiceTests
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, result.Outcome);
     }
 
+    [Fact]
+    public void GetPackagesForPublish_OrdersEachSymbolPackageAfterItsPrimaryPackage()
+    {
+        var first = new DotNetRepositoryProjectResult { ProjectName = "First" };
+        first.Packages.Add("First.1.0.0.nupkg");
+        first.SymbolPackages.Add("First.1.0.0.snupkg");
+        var second = new DotNetRepositoryProjectResult { ProjectName = "Second" };
+        second.Packages.Add("Second.2.0.0.nupkg");
+        second.SymbolPackages.Add("Second.2.0.0.snupkg");
+
+        var packages = DotNetRepositoryReleaseService.GetPackagesForPublish(new[] { first, second });
+
+        Assert.Equal(new[]
+        {
+            "First.1.0.0.nupkg",
+            "First.1.0.0.snupkg",
+            "Second.2.0.0.nupkg",
+            "Second.2.0.0.snupkg"
+        }, packages);
+    }
+
     [Theory]
     [InlineData(false, "Build")]
     [InlineData(true, "Rebuild")]
@@ -313,6 +338,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 OutputPath = outputPath,
                 Pack = true,
                 PackStrategy = DotNetRepositoryPackStrategy.MSBuild,
+                IncludeSymbols = true,
                 Publish = false,
                 UpdateVersions = false,
                 CreateReleaseZip = false
@@ -326,6 +352,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.All(result.Projects.Where(project => project.IsPackable), project =>
             {
                 Assert.Single(project.Packages);
+                Assert.Single(project.SymbolPackages);
                 Assert.True(string.IsNullOrWhiteSpace(project.ErrorMessage), project.ErrorMessage);
             });
         }
@@ -446,6 +473,7 @@ public sealed class DotNetRepositoryReleaseServiceTests
                 OutputPath = Path.Combine(root.FullName, "packages"),
                 ReleaseZipOutputPath = Path.Combine(root.FullName, "releases"),
                 Pack = true,
+                IncludeSymbols = true,
                 Publish = false,
                 UpdateVersions = false,
                 CreateReleaseZip = true,
@@ -481,7 +509,9 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.True(File.Exists(signedMarker));
             var project = Assert.Single(result.Projects, item => item.IsPackable);
             Assert.Single(project.Packages);
+            Assert.Single(project.SymbolPackages);
             Assert.True(File.Exists(project.Packages[0]));
+            Assert.True(File.Exists(project.SymbolPackages[0]));
             Assert.True(File.Exists(project.ReleaseZipPath));
         }
         finally
@@ -1173,13 +1203,16 @@ public sealed class DotNetRepositoryReleaseServiceTests
         try
         {
             var existing = Path.Combine(root.FullName, "Sample.Package.1.0.0.nupkg");
-            var symbols = Path.Combine(root.FullName, "Sample.Package.1.0.0.symbols.nupkg");
+            var legacySymbols = Path.Combine(root.FullName, "Sample.Package.1.0.0.symbols.nupkg");
+            var symbols = Path.Combine(root.FullName, "Sample.Package.1.0.0.snupkg");
             File.WriteAllText(existing, "old");
+            File.WriteAllText(legacySymbols, "legacy symbols");
             File.WriteAllText(symbols, "symbols");
 
             var snapshot = DotNetRepositoryReleaseService.SnapshotPackages(root.FullName);
 
             Assert.False(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, existing));
+            Assert.False(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, symbols));
 
             File.WriteAllText(existing, "changed package");
             var created = Path.Combine(root.FullName, "Sample.Package.1.0.1.nupkg");
@@ -1190,7 +1223,8 @@ public sealed class DotNetRepositoryReleaseServiceTests
 
             File.Delete(existing);
             Assert.False(DotNetRepositoryReleaseService.WasPackageCreatedOrChanged(snapshot, existing));
-            Assert.DoesNotContain(symbols, snapshot.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(symbols, snapshot.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.DoesNotContain(legacySymbols, snapshot.Keys, StringComparer.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -207,7 +207,32 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
-    public void CreateNuGetPushStartInfo_UsesPrimaryPackageDirectoryForSymbolDiscovery()
+    public void ClassifyPublishedArtifacts_PreservesMixedDuplicateAndPublishedOutcomes()
+    {
+        var primary = "Sample.1.0.0.nupkg";
+        var symbols = "Sample.1.0.0.snupkg";
+        var pushResult = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate,
+            Message = string.Join(Environment.NewLine, new[]
+            {
+                $"Pushing {primary}...",
+                $"Package '{primary}' already exists and cannot be modified. The server returned 409 (Conflict).",
+                $"Pushing {symbols}...",
+                "Your package was pushed."
+            })
+        };
+
+        var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(
+            new[] { primary, symbols },
+            pushResult);
+
+        Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate, outcomes[primary]);
+        Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, outcomes[symbols]);
+    }
+
+    [Fact]
+    public void CreateNuGetPushStartInfo_UsesPackageDirectory()
     {
         var packageDirectory = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
         var packagePath = Path.Combine(packageDirectory, "Sample.1.0.0.nupkg");
@@ -219,6 +244,31 @@ public sealed class DotNetRepositoryReleaseServiceTests
             skipDuplicate: true);
 
         Assert.Equal(Path.GetFullPath(packageDirectory), startInfo.WorkingDirectory);
+    }
+
+    [Fact]
+    public void CreateNuGetPushStartInfo_SuppressesImplicitCompanionSymbolsWhenRequested()
+    {
+        var packagePath = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.nupkg");
+
+        var startInfo = DotNetRepositoryReleaseService.CreateNuGetPushStartInfo(
+            packagePath,
+            "key",
+            "https://api.nuget.org/v3/index.json",
+            skipDuplicate: true,
+            suppressCompanionSymbols: true);
+
+        Assert.Contains("--no-symbols", startInfo.ArgumentList);
+    }
+
+    [Fact]
+    public void ResolvePublishSource_ResolvesRelativeLocalFeedFromRepositoryRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+
+        var source = DotNetRepositoryReleaseService.ResolvePublishSource("Artefacts/Feed", root);
+
+        Assert.Equal(Path.GetFullPath(Path.Combine(root, "Artefacts", "Feed")), source);
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -231,36 +231,6 @@ public sealed class DotNetRepositoryReleaseServiceTests
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, outcomes[symbols]);
     }
 
-    [Fact]
-    public void CreateNuGetPushStartInfo_UsesPackageDirectory()
-    {
-        var packageDirectory = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
-        var packagePath = Path.Combine(packageDirectory, "Sample.1.0.0.nupkg");
-
-        var startInfo = DotNetRepositoryReleaseService.CreateNuGetPushStartInfo(
-            packagePath,
-            "key",
-            "https://api.nuget.org/v3/index.json",
-            skipDuplicate: true);
-
-        Assert.Equal(Path.GetFullPath(packageDirectory), startInfo.WorkingDirectory);
-    }
-
-    [Fact]
-    public void CreateNuGetPushStartInfo_SuppressesImplicitCompanionSymbolsWhenRequested()
-    {
-        var packagePath = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.nupkg");
-
-        var startInfo = DotNetRepositoryReleaseService.CreateNuGetPushStartInfo(
-            packagePath,
-            "key",
-            "https://api.nuget.org/v3/index.json",
-            skipDuplicate: true,
-            suppressCompanionSymbols: true);
-
-        Assert.Contains("--no-symbols", startInfo.ArgumentList);
-    }
-
     [Theory]
     [InlineData("Artefacts/Feed")]
     [InlineData(@"Artefacts\Feed")]
@@ -271,6 +241,18 @@ public sealed class DotNetRepositoryReleaseServiceTests
         var source = DotNetRepositoryReleaseService.ResolvePublishSource(configuredSource, root);
 
         Assert.Equal(Path.GetFullPath(Path.Combine(root, "Artefacts", "Feed")), source);
+    }
+
+    [Fact]
+    public void ResolvePublishSource_ResolvesFileUriToLocalPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var feed = Path.Combine(root, "Artefacts", "Local Feed");
+        var fileUri = new Uri(feed).AbsoluteUri;
+
+        var source = DotNetRepositoryReleaseService.ResolvePublishSource(fileUri, root);
+
+        Assert.Equal(Path.GetFullPath(feed), source);
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -225,7 +225,8 @@ public sealed class DotNetRepositoryReleaseServiceTests
 
         var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(
             new[] { primary, symbols },
-            pushResult);
+            pushResult,
+            skipDuplicate: true);
 
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate, outcomes[primary]);
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, outcomes[symbols]);
@@ -253,6 +254,27 @@ public sealed class DotNetRepositoryReleaseServiceTests
         var source = DotNetRepositoryReleaseService.ResolvePublishSource(fileUri, root);
 
         Assert.Equal(Path.GetFullPath(feed), source);
+    }
+
+    [Fact]
+    public void ResolvePublishSource_PreservesNamedSourceWhenMatchingDirectoryExists()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Contoso"));
+
+            var source = DotNetRepositoryReleaseService.ResolvePublishSource("Contoso", root.FullName);
+
+            Assert.Equal("Contoso", source);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
     }
 
     [Fact]

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -207,6 +207,21 @@ public sealed class DotNetRepositoryReleaseServiceTests
     }
 
     [Fact]
+    public void CreateNuGetPushStartInfo_UsesPrimaryPackageDirectoryForSymbolDiscovery()
+    {
+        var packageDirectory = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var packagePath = Path.Combine(packageDirectory, "Sample.1.0.0.nupkg");
+
+        var startInfo = DotNetRepositoryReleaseService.CreateNuGetPushStartInfo(
+            packagePath,
+            "key",
+            "https://api.nuget.org/v3/index.json",
+            skipDuplicate: true);
+
+        Assert.Equal(Path.GetFullPath(packageDirectory), startInfo.WorkingDirectory);
+    }
+
+    [Fact]
     public void GetPackagesForPublish_PushesOnlyPrimaryPackages()
     {
         var first = new DotNetRepositoryProjectResult { ProjectName = "First" };

--- a/PowerForge.Tests/DotNetRepositoryReleaseSummaryServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSummaryServiceTests.cs
@@ -19,6 +19,7 @@ public sealed class DotNetRepositoryReleaseSummaryServiceTests
             NewVersion = "2.0.5"
         });
         result.Projects[0].Packages.Add("LibraryA.2.0.5.nupkg");
+        result.Projects[0].SymbolPackages.Add("LibraryA.2.0.5.snupkg");
         result.Projects.Add(new DotNetRepositoryProjectResult
         {
             ProjectName = "LibraryB",
@@ -40,6 +41,7 @@ public sealed class DotNetRepositoryReleaseSummaryServiceTests
         Assert.Equal("LibraryA", summary.Projects[0].ProjectName);
         Assert.Equal(DotNetRepositoryReleaseProjectStatus.Ok, summary.Projects[0].Status);
         Assert.Equal("2.0.4 -> 2.0.5", summary.Projects[0].VersionDisplay);
+        Assert.Equal(2, summary.Projects[0].PackageCount);
         Assert.Equal("LibraryB", summary.Projects[1].ProjectName);
         Assert.Equal(DotNetRepositoryReleaseProjectStatus.Skipped, summary.Projects[1].Status);
         Assert.Equal("LibraryC", summary.Projects[2].ProjectName);
@@ -49,7 +51,7 @@ public sealed class DotNetRepositoryReleaseSummaryServiceTests
         Assert.Equal(3, summary.Totals.ProjectCount);
         Assert.Equal(2, summary.Totals.PackableCount);
         Assert.Equal(1, summary.Totals.FailedProjectCount);
-        Assert.Equal(1, summary.Totals.PackageCount);
+        Assert.Equal(2, summary.Totals.PackageCount);
         Assert.Equal(1, summary.Totals.PublishedPackageCount);
         Assert.Equal(1, summary.Totals.SkippedDuplicatePackageCount);
         Assert.Equal(1, summary.Totals.FailedPublishCount);

--- a/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetRepositoryReleaseSymbolPackageReviewTests
+{
+    [Theory]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild)]
+    public void Execute_DoesNotCollectProjectConfiguredSymbolsWithoutPowerForgeOptIn(
+        DotNetRepositoryPackStrategy packStrategy)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.0.0</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "    <IncludeSymbols>true</IncludeSymbols>",
+                "    <SymbolPackageFormat>snupkg</SymbolPackageFormat>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(
+                Path.Combine(projectDirectory.FullName, "Sample.cs"),
+                "namespace Sample.Package; public static class Sample { public static int Value => 1; }");
+
+            var outputPath = Path.Combine(root.FullName, "packages");
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = outputPath,
+                Pack = true,
+                PackStrategy = packStrategy,
+                IncludeSymbols = false,
+                Publish = false,
+                UpdateVersions = false,
+                CreateReleaseZip = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var project = Assert.Single(result.Projects, item => item.IsPackable);
+            Assert.Single(project.Packages);
+            Assert.Empty(project.SymbolPackages);
+            Assert.Single(Directory.EnumerateFiles(outputPath, "*.snupkg", SearchOption.AllDirectories));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
@@ -63,6 +63,35 @@ public sealed class DotNetRepositoryReleaseSymbolPackageReviewTests
     }
 
     [Fact]
+    public void PushPackage_CopiesExplicitSymbolPackageIntoLocalFeed()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packageDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "packages"));
+            var localFeed = Directory.CreateDirectory(Path.Combine(root.FullName, "feed"));
+            var primary = Path.Combine(localFeed.FullName, "Sample.1.0.0.nupkg");
+            var symbols = Path.Combine(packageDirectory.FullName, "Sample.1.0.0.snupkg");
+            File.WriteAllText(primary, "primary");
+            File.WriteAllText(symbols, "symbols");
+
+            var result = DotNetRepositoryReleaseService.PushPackage(
+                symbols,
+                "unused-for-local-feed",
+                new Uri(localFeed.FullName).AbsoluteUri,
+                skipDuplicate: true,
+                suppressCompanionSymbols: true);
+
+            Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, result.Outcome);
+            Assert.True(File.Exists(Path.Combine(localFeed.FullName, Path.GetFileName(symbols))));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_WithSymbolsAndLocalFeed_PublishesBothArtifacts()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
@@ -7,6 +7,121 @@ namespace PowerForge.Tests;
 
 public sealed class DotNetRepositoryReleaseSymbolPackageReviewTests
 {
+    [Fact]
+    public void ClassifyNuGetPushOutcome_DoesNotTreatLocalSkipDuplicateWarningAsSkipped()
+    {
+        var result = DotNetRepositoryReleaseService.ClassifyNuGetPushOutcome(
+            exitCode: 0,
+            skipDuplicate: true,
+            stdErr: "The option to skip duplicates is not currently supported for this type of push.",
+            stdOut: "Your package was pushed.");
+
+        Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, result.Outcome);
+    }
+
+    [Fact]
+    public void ClassifyPublishedArtifacts_PreservesPublishedPrimaryWhenCompanionFails()
+    {
+        var primary = "Sample.1.0.0.nupkg";
+        var symbols = "Sample.1.0.0.snupkg";
+        var pushResult = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+            Message = string.Join(Environment.NewLine, new[]
+            {
+                $"Pushing {primary}...",
+                "Your package was pushed.",
+                $"Pushing {symbols}...",
+                "Response status code does not indicate success: 400 (The symbol package is invalid)."
+            })
+        };
+
+        var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(
+            new[] { primary, symbols },
+            pushResult);
+
+        Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, outcomes[primary]);
+        Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Failed, outcomes[symbols]);
+    }
+
+    [Fact]
+    public void GetPackagesForPublish_IncludesSymbolsWhenRequestedForLocalFeed()
+    {
+        var project = new DotNetRepositoryProjectResult { ProjectName = "Sample" };
+        project.Packages.Add("Sample.1.0.0.nupkg");
+        project.SymbolPackages.Add("Sample.1.0.0.snupkg");
+
+        var packages = DotNetRepositoryReleaseService.GetPackagesForPublish(
+            new[] { project },
+            includeSymbolPackages: true);
+
+        Assert.Equal(new[]
+        {
+            "Sample.1.0.0.nupkg",
+            "Sample.1.0.0.snupkg"
+        }, packages);
+    }
+
+    [Fact]
+    public void Execute_WithSymbolsAndLocalFeed_PublishesBothArtifacts()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDir = Directory.CreateDirectory(Path.Combine(root.FullName, "Src", "Sample.Package"));
+            File.WriteAllText(Path.Combine(projectDir.FullName, "Sample.Package.csproj"), string.Join(Environment.NewLine, new[]
+            {
+                "<Project Sdk=\"Microsoft.NET.Sdk\">",
+                "  <PropertyGroup>",
+                "    <TargetFramework>net8.0</TargetFramework>",
+                "    <PackageId>Sample.Package</PackageId>",
+                "    <VersionPrefix>1.2.3</VersionPrefix>",
+                "    <IsPackable>true</IsPackable>",
+                "  </PropertyGroup>",
+                "</Project>"
+            }));
+            File.WriteAllText(
+                Path.Combine(projectDir.FullName, "Class1.cs"),
+                "namespace Sample.Package; public static class Class1 { public static string Value => \"symbols\"; }");
+
+            var localFeed = Directory.CreateDirectory(Path.Combine(root.FullName, "feed"));
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                IncludeSymbols = true,
+                Publish = true,
+                PublishApiKey = "unused-for-local-feed",
+                PublishSource = localFeed.FullName,
+                SkipDuplicate = true,
+                UpdateVersions = false,
+                CreateReleaseZip = false
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var project = Assert.Single(result.Projects, item => item.IsPackable);
+            var primary = Assert.Single(project.Packages);
+            var symbols = Assert.Single(project.SymbolPackages);
+            Assert.True(
+                result.PublishedPackages.Contains(primary, StringComparer.OrdinalIgnoreCase),
+                $"Primary package was not reported as published. Expected: {primary}. Published: {string.Join(", ", result.PublishedPackages)}. Skipped: {string.Join(", ", result.SkippedDuplicatePackages)}. Failed: {string.Join(", ", result.FailedPackages)}");
+            Assert.True(
+                result.PublishedPackages.Contains(symbols, StringComparer.OrdinalIgnoreCase),
+                $"Symbol package was not reported as published. Expected: {symbols}. Actual: {string.Join(", ", result.PublishedPackages)}");
+            Assert.True(File.Exists(Path.Combine(localFeed.FullName, Path.GetFileName(primary))));
+            Assert.True(File.Exists(Path.Combine(localFeed.FullName, Path.GetFileName(symbols))));
+            Assert.Empty(result.FailedPackages);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Theory]
     [InlineData(DotNetRepositoryPackStrategy.PerProject)]
     [InlineData(DotNetRepositoryPackStrategy.MSBuild)]

--- a/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
@@ -38,7 +38,34 @@ public sealed class DotNetRepositoryReleaseSymbolPackageReviewTests
 
         var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(
             new[] { primary, symbols },
-            pushResult);
+            pushResult,
+            skipDuplicate: true);
+
+        Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, outcomes[primary]);
+        Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Failed, outcomes[symbols]);
+    }
+
+    [Fact]
+    public void ClassifyPublishedArtifacts_PreservesConflictFailureWhenSkipDuplicateIsDisabled()
+    {
+        var primary = "Sample.1.0.0.nupkg";
+        var symbols = "Sample.1.0.0.snupkg";
+        var pushResult = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+            Message = string.Join(Environment.NewLine, new[]
+            {
+                $"Pushing {primary}...",
+                "Your package was pushed.",
+                $"Pushing {symbols}...",
+                $"Package '{symbols}' already exists and cannot be modified. The server returned 409 (Conflict)."
+            })
+        };
+
+        var outcomes = DotNetRepositoryReleaseService.ClassifyPublishedArtifacts(
+            new[] { primary, symbols },
+            pushResult,
+            skipDuplicate: false);
 
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Published, outcomes[primary]);
         Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.Failed, outcomes[symbols]);

--- a/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSymbolPackageReviewTests.cs
@@ -119,7 +119,7 @@ public sealed class DotNetRepositoryReleaseSymbolPackageReviewTests
     }
 
     [Fact]
-    public void Execute_WithSymbolsAndLocalFeed_PublishesBothArtifacts()
+    public void Execute_WithSymbolsAndNamedLocalFeed_PublishesBothArtifacts()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         try
@@ -141,6 +141,9 @@ public sealed class DotNetRepositoryReleaseSymbolPackageReviewTests
                 "namespace Sample.Package; public static class Class1 { public static string Value => \"symbols\"; }");
 
             var localFeed = Directory.CreateDirectory(Path.Combine(root.FullName, "feed"));
+            File.WriteAllText(
+                Path.Combine(root.FullName, "NuGet.config"),
+                $"<configuration><packageSources><clear /><add key=\"LocalFeed\" value=\"{localFeed.FullName}\" /></packageSources></configuration>");
             var spec = new DotNetRepositoryReleaseSpec
             {
                 RootPath = root.FullName,
@@ -150,7 +153,7 @@ public sealed class DotNetRepositoryReleaseSymbolPackageReviewTests
                 IncludeSymbols = true,
                 Publish = true,
                 PublishApiKey = "unused-for-local-feed",
-                PublishSource = localFeed.FullName,
+                PublishSource = "LocalFeed",
                 SkipDuplicate = true,
                 UpdateVersions = false,
                 CreateReleaseZip = false

--- a/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
@@ -71,6 +71,41 @@ public sealed partial class ModulePipelinePackageBuildTests
     }
 
     [Fact]
+    public void ApplyPublishedNuGetArtifactOutcomes_HonorsDisabledSkipDuplicatePolicy()
+    {
+        var primary = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.nupkg");
+        var symbols = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.snupkg");
+        var release = new DotNetRepositoryReleaseResult();
+        release.Projects.Add(new DotNetRepositoryProjectResult
+        {
+            Packages = { primary },
+            SymbolPackages = { symbols }
+        });
+        var publish = new NuGetPackagePublishResult { Success = false };
+        publish.FailedItems.Add(primary);
+        publish.PackagePushResults[primary] = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+            Message = string.Join(Environment.NewLine, new[]
+            {
+                $"Pushing {Path.GetFileName(primary)}...",
+                "Your package was pushed.",
+                $"Pushing {Path.GetFileName(symbols)}...",
+                $"Package '{Path.GetFileName(symbols)}' already exists and cannot be modified. The server returned 409 (Conflict)."
+            })
+        };
+
+        ModulePipelineRunner.ApplyPublishedNuGetArtifactOutcomes(
+            release,
+            publish,
+            skipDuplicate: false);
+
+        Assert.Equal(new[] { primary }, release.PublishedPackages);
+        Assert.Equal(new[] { symbols }, release.FailedPackages);
+        Assert.Empty(release.SkippedDuplicatePackages);
+    }
+
+    [Fact]
     public void ApplyPublishedNuGetArtifactOutcomes_TreatsLocalSymbolsAsSeparatePushes()
     {
         var primary = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.nupkg");

--- a/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
@@ -8,6 +8,38 @@ namespace PowerForge.Tests;
 public sealed partial class ModulePipelinePackageBuildTests
 {
     [Fact]
+    public void ApplyPublishedNuGetArtifactOutcomes_PreservesMixedPrimaryAndSymbolResults()
+    {
+        var primary = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.nupkg");
+        var symbols = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.snupkg");
+        var release = new DotNetRepositoryReleaseResult();
+        release.Projects.Add(new DotNetRepositoryProjectResult
+        {
+            Packages = { primary },
+            SymbolPackages = { symbols }
+        });
+        var publish = new NuGetPackagePublishResult();
+        publish.PublishedItems.Add(primary);
+        publish.SkippedDuplicateItems.Add(primary);
+        publish.PackagePushResults[primary] = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate,
+            Message = string.Join(Environment.NewLine, new[]
+            {
+                $"Pushing {Path.GetFileName(primary)}...",
+                $"Package '{Path.GetFileName(primary)}' already exists and cannot be modified.",
+                $"Pushing {Path.GetFileName(symbols)}...",
+                "Your package was pushed."
+            })
+        };
+
+        ModulePipelineRunner.ApplyPublishedNuGetArtifactOutcomes(release, publish);
+
+        Assert.Equal(new[] { symbols }, release.PublishedPackages);
+        Assert.Equal(new[] { primary }, release.SkippedDuplicatePackages);
+    }
+
+    [Fact]
     public void Run_DoesNotPublishPackageLaneWithoutExplicitPublishIntent()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildReviewTests.cs
@@ -40,6 +40,69 @@ public sealed partial class ModulePipelinePackageBuildTests
     }
 
     [Fact]
+    public void ApplyPublishedNuGetArtifactOutcomes_RecordsRemoteCompanionFailure()
+    {
+        var primary = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.nupkg");
+        var symbols = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.snupkg");
+        var release = new DotNetRepositoryReleaseResult();
+        release.Projects.Add(new DotNetRepositoryProjectResult
+        {
+            Packages = { primary },
+            SymbolPackages = { symbols }
+        });
+        var publish = new NuGetPackagePublishResult { Success = false };
+        publish.FailedItems.Add(primary);
+        publish.PackagePushResults[primary] = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+            Message = string.Join(Environment.NewLine, new[]
+            {
+                $"Pushing {Path.GetFileName(primary)}...",
+                "Your package was pushed.",
+                $"Pushing {Path.GetFileName(symbols)}...",
+                "Response status code does not indicate success: 400 (The symbol package is invalid)."
+            })
+        };
+
+        ModulePipelineRunner.ApplyPublishedNuGetArtifactOutcomes(release, publish);
+
+        Assert.Equal(new[] { primary }, release.PublishedPackages);
+        Assert.Equal(new[] { symbols }, release.FailedPackages);
+    }
+
+    [Fact]
+    public void ApplyPublishedNuGetArtifactOutcomes_TreatsLocalSymbolsAsSeparatePushes()
+    {
+        var primary = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.nupkg");
+        var symbols = Path.Combine(Path.GetTempPath(), "Sample.1.0.0.snupkg");
+        var release = new DotNetRepositoryReleaseResult();
+        release.Projects.Add(new DotNetRepositoryProjectResult
+        {
+            Packages = { primary },
+            SymbolPackages = { symbols }
+        });
+        var publish = new NuGetPackagePublishResult();
+        publish.PublishedItems.Add(primary);
+        publish.PublishedItems.Add(symbols);
+        publish.PackagePushResults[primary] = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+        };
+        publish.PackagePushResults[symbols] = new DotNetRepositoryReleaseService.PackagePushResult
+        {
+            Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+        };
+
+        ModulePipelineRunner.ApplyPublishedNuGetArtifactOutcomes(
+            release,
+            publish,
+            publishSymbolsSeparately: true);
+
+        Assert.Equal(new[] { primary, symbols }, release.PublishedPackages);
+        Assert.Empty(release.FailedPackages);
+    }
+
+    [Fact]
     public void Run_DoesNotPublishPackageLaneWithoutExplicitPublishIntent()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
@@ -648,8 +648,10 @@ public sealed partial class ModulePipelinePackageBuildTests
         }
     }
 
-    [Fact]
-    public void Run_DoesNotReusePackageBuildWhenSomeNuGetArtifactsAreMissing()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Run_DoesNotReusePackageBuildWhenSomeNuGetArtifactsAreMissing(bool missingSymbolPackage)
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
         var stagingPath = Path.Combine(Path.GetTempPath(), "PowerForge.Tests.Staging", Guid.NewGuid().ToString("N"));
@@ -661,7 +663,12 @@ public sealed partial class ModulePipelinePackageBuildTests
             var packageOutput = Directory.CreateDirectory(Path.Combine(root.FullName, "Artifacts", "NuGet"));
             var existingPackage = Path.Combine(packageOutput.FullName, "Dependency.Z.1.0.0.nupkg");
             var missingPackage = Path.Combine(packageOutput.FullName, "Consumer.A.1.0.0.nupkg");
+            var missingSymbol = Path.Combine(packageOutput.FullName, "Consumer.A.1.0.0.snupkg");
             File.WriteAllText(existingPackage, "package");
+            if (missingSymbolPackage)
+            {
+                File.WriteAllText(missingPackage, "package");
+            }
 
             var calls = new List<PackageBuildCall>();
             var runner = new ModulePipelineRunner(
@@ -690,6 +697,10 @@ public sealed partial class ModulePipelinePackageBuildTests
                         IsPackable = true
                     });
                     release.Projects[1].Packages.Add(missingPackage);
+                    if (missingSymbolPackage)
+                    {
+                        release.Projects[1].SymbolPackages.Add(missingSymbol);
+                    }
 
                     return new ProjectBuildHostExecutionResult
                     {
@@ -725,6 +736,7 @@ public sealed partial class ModulePipelinePackageBuildTests
                             RootPath = "Sources",
                             BuildBeforeModule = true,
                             Build = true,
+                            IncludeSymbols = missingSymbolPackage,
                             PublishNuget = true,
                             PublishApiKey = "key"
                         }

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -21,6 +21,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
 
             var packageOutput = Path.Combine(root.FullName, "Artifacts", "NuGet");
             var packagePath = Path.Combine(packageOutput, "HtmlTinkerX.2.0.1-beta1.nupkg");
+            var symbolPackagePath = Path.Combine(packageOutput, "HtmlTinkerX.2.0.1-beta1.snupkg");
             GitHubReleasePublishRequest? gitHubRequest = null;
 
             var runner = new ModulePipelineRunner(
@@ -35,6 +36,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                 {
                     Directory.CreateDirectory(packageOutput);
                     File.WriteAllText(packagePath, "package");
+                    File.WriteAllText(symbolPackagePath, "symbols");
 
                     var release = new DotNetRepositoryReleaseResult { Success = true };
                     var project = new DotNetRepositoryProjectResult
@@ -45,6 +47,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                         NewVersion = "2.0.1-beta1+build.7"
                     };
                     project.Packages.Add(packagePath);
+                    project.SymbolPackages.Add(symbolPackagePath);
                     release.Projects.Add(project);
 
                     return new ProjectBuildHostExecutionResult
@@ -90,7 +93,8 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                         {
                             Name = "Packages",
                             RootPath = "Sources",
-                            BuildBeforeModule = true
+                            BuildBeforeModule = true,
+                            IncludeSymbols = true
                         }
                     },
                     new ConfigurationArtefactSegment
@@ -149,9 +153,10 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.Equal(Path.GetFullPath(resolvedStageRoot), result.ReleaseCoordinationResult!.StageRoot);
             Assert.Equal("1.2.3", result.ReleaseCoordinationResult.ModuleVersion);
             Assert.Equal("2.0.1-beta1+build.7", result.ReleaseCoordinationResult.ReleaseVersion);
-            Assert.Equal(4, gitHubRequest.AssetFilePaths.Count);
+            Assert.Equal(5, gitHubRequest.AssetFilePaths.Count);
             Assert.Contains(gitHubRequest.AssetFilePaths, path => path.StartsWith(Path.Combine(resolvedStageRoot, "modules"), StringComparison.OrdinalIgnoreCase));
             Assert.Contains(gitHubRequest.AssetFilePaths, path => string.Equals(path, Path.Combine(resolvedStageRoot, "nuget", Path.GetFileName(packagePath)), StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(gitHubRequest.AssetFilePaths, path => string.Equals(path, Path.Combine(resolvedStageRoot, "nuget", Path.GetFileName(symbolPackagePath)), StringComparison.OrdinalIgnoreCase));
             Assert.Contains(gitHubRequest.AssetFilePaths, path => string.Equals(path, Path.Combine(resolvedStageRoot, "metadata", "release-manifest.json"), StringComparison.OrdinalIgnoreCase));
             Assert.Contains(gitHubRequest.AssetFilePaths, path => string.Equals(path, Path.Combine(resolvedStageRoot, "metadata", "SHA256SUMS.txt"), StringComparison.OrdinalIgnoreCase));
             Assert.All(gitHubRequest.AssetFilePaths, path => Assert.True(File.Exists(path), path));
@@ -161,7 +166,9 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.Equal("1.2.3", releaseManifest.RootElement.GetProperty("moduleVersion").GetString());
             Assert.Equal("2.0.1-beta1+build.7", releaseManifest.RootElement.GetProperty("releaseVersion").GetString());
             Assert.Contains("HtmlTinkerX.2.0.1-beta1.nupkg", manifestJson, StringComparison.Ordinal);
+            Assert.Contains("HtmlTinkerX.2.0.1-beta1.snupkg", manifestJson, StringComparison.Ordinal);
             Assert.Contains("nuget/HtmlTinkerX.2.0.1-beta1.nupkg", File.ReadAllText(Path.Combine(resolvedStageRoot, "metadata", "SHA256SUMS.txt")), StringComparison.Ordinal);
+            Assert.Contains("nuget/HtmlTinkerX.2.0.1-beta1.snupkg", File.ReadAllText(Path.Combine(resolvedStageRoot, "metadata", "SHA256SUMS.txt")), StringComparison.Ordinal);
             Assert.Single(result.PublishResults);
             Assert.Equal(gitHubRequest.AssetFilePaths.OrderBy(static path => path, StringComparer.OrdinalIgnoreCase), result.PublishResults[0].AssetPaths.OrderBy(static path => path, StringComparer.OrdinalIgnoreCase));
         }

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -214,6 +214,9 @@ public sealed class NuGetPackagePublishServiceTests
             Assert.True(result.Success);
             Assert.Contains(packagePath, result.PublishedItems, StringComparer.OrdinalIgnoreCase);
             Assert.Contains(packagePath, result.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
+            var pushResult = Assert.Contains(packagePath, result.PackagePushResults);
+            Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate, pushResult.Outcome);
+            Assert.Equal("already exists", pushResult.Message);
             Assert.Empty(result.FailedItems);
         }
         finally

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -42,7 +42,7 @@ public sealed class NuGetPackagePublishServiceTests
 
             var service = new NuGetPackagePublishService(
                 new NullLogger { IsVerbose = true },
-                (_, _, _, _) => new DotNetRepositoryReleaseService.PackagePushResult
+                (_, _, _, _, _) => new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
                     Message = "push failed"
@@ -77,11 +77,13 @@ public sealed class NuGetPackagePublishServiceTests
             File.WriteAllText(oldPackagePath, "old");
 
             var pushed = new List<string>();
+            var suppressCompanionSymbols = new List<bool>();
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (package, _, _, _) =>
+                (package, _, _, _, suppressSymbols) =>
                 {
                     pushed.Add(package);
+                    suppressCompanionSymbols.Add(suppressSymbols);
                     return new DotNetRepositoryReleaseService.PackagePushResult
                     {
                         Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
@@ -92,10 +94,12 @@ public sealed class NuGetPackagePublishServiceTests
                 new[] { packagePath },
                 "key",
                 "https://api.nuget.org/v3/index.json",
-                skipDuplicate: true);
+                skipDuplicate: true,
+                suppressCompanionSymbols: true);
 
             Assert.True(result.Success);
             Assert.Equal(new[] { packagePath }, pushed);
+            Assert.Equal(new[] { true }, suppressCompanionSymbols);
             Assert.Contains(packagePath, result.PublishedItems, StringComparer.OrdinalIgnoreCase);
             Assert.DoesNotContain(oldPackagePath, result.PublishedItems, StringComparer.OrdinalIgnoreCase);
         }
@@ -119,7 +123,7 @@ public sealed class NuGetPackagePublishServiceTests
             var pushed = new List<string>();
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (package, _, _, _) =>
+                (package, _, _, _, _) =>
                 {
                     pushed.Add(package);
                     return new DotNetRepositoryReleaseService.PackagePushResult
@@ -161,7 +165,7 @@ public sealed class NuGetPackagePublishServiceTests
             var pushed = new List<string>();
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (package, _, _, _) =>
+                (package, _, _, _, _) =>
                 {
                     pushed.Add(package);
                     return new DotNetRepositoryReleaseService.PackagePushResult
@@ -197,7 +201,7 @@ public sealed class NuGetPackagePublishServiceTests
 
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (_, _, _, _) => new DotNetRepositoryReleaseService.PackagePushResult
+                (_, _, _, _, _) => new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate,
                     Message = "already exists"

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -66,6 +66,47 @@ public sealed class NuGetPackagePublishServiceTests
     }
 
     [Fact]
+    public void Execute_UsesCallerContextAndSuppressesImplicitSymbols()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-caller-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packagePath = Path.Combine(root.FullName, "Sample.1.0.0.nupkg");
+            File.WriteAllText(packagePath, "pkg");
+            File.WriteAllText(Path.ChangeExtension(packagePath, ".snupkg"), "symbols");
+
+            DotNetNuGetPushRequest? captured = null;
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                request =>
+                {
+                    captured = request;
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                    };
+                });
+
+            var result = service.Execute(new NuGetPackagePublishRequest
+            {
+                Roots = new[] { root.FullName },
+                ApiKey = "key",
+                Source = "PrivateFeed",
+                WorkingDirectory = root.FullName
+            });
+
+            Assert.True(result.Success);
+            Assert.NotNull(captured);
+            Assert.Equal(root.FullName, captured!.WorkingDirectory);
+            Assert.True(captured.SuppressCompanionSymbols);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void ExecutePackages_PublishesOnlyExplicitPackagePaths()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-explicit-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -42,7 +42,7 @@ public sealed class NuGetPackagePublishServiceTests
 
             var service = new NuGetPackagePublishService(
                 new NullLogger { IsVerbose = true },
-                (_, _, _, _, _) => new DotNetRepositoryReleaseService.PackagePushResult
+                _ => new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
                     Message = "push failed"
@@ -80,10 +80,10 @@ public sealed class NuGetPackagePublishServiceTests
             var suppressCompanionSymbols = new List<bool>();
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (package, _, _, _, suppressSymbols) =>
+                request =>
                 {
-                    pushed.Add(package);
-                    suppressCompanionSymbols.Add(suppressSymbols);
+                    pushed.Add(request.PackagePath);
+                    suppressCompanionSymbols.Add(request.SuppressCompanionSymbols);
                     return new DotNetRepositoryReleaseService.PackagePushResult
                     {
                         Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
@@ -123,9 +123,9 @@ public sealed class NuGetPackagePublishServiceTests
             var pushed = new List<string>();
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (package, _, _, _, _) =>
+                request =>
                 {
-                    pushed.Add(package);
+                    pushed.Add(request.PackagePath);
                     return new DotNetRepositoryReleaseService.PackagePushResult
                     {
                         Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
@@ -165,9 +165,9 @@ public sealed class NuGetPackagePublishServiceTests
             var pushed = new List<string>();
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (package, _, _, _, _) =>
+                request =>
                 {
-                    pushed.Add(package);
+                    pushed.Add(request.PackagePath);
                     return new DotNetRepositoryReleaseService.PackagePushResult
                     {
                         Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
@@ -201,7 +201,7 @@ public sealed class NuGetPackagePublishServiceTests
 
             var service = new NuGetPackagePublishService(
                 new NullLogger(),
-                (_, _, _, _, _) => new DotNetRepositoryReleaseService.PackagePushResult
+                _ => new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate,
                     Message = "already exists"
@@ -222,6 +222,136 @@ public sealed class NuGetPackagePublishServiceTests
             Assert.Equal(DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate, pushResult.Outcome);
             Assert.Equal("already exists", pushResult.Message);
             Assert.Empty(result.FailedItems);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExecutePackages_UsesRepositoryContextForNamedSource()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-context-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packagePath = Path.Combine(root.FullName, "Sample.1.0.0.nupkg");
+            File.WriteAllText(packagePath, "pkg");
+
+            DotNetNuGetPushRequest? captured = null;
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                request =>
+                {
+                    captured = request;
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                    };
+                },
+                workingDirectory: root.FullName);
+
+            var result = service.ExecutePackages(
+                new[] { packagePath },
+                "key",
+                "PrivateFeed",
+                skipDuplicate: true);
+
+            Assert.True(result.Success);
+            Assert.NotNull(captured);
+            Assert.Equal("PrivateFeed", captured!.Source);
+            Assert.Equal(root.FullName, captured.WorkingDirectory);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExecutePackages_DoesNotPushSymbolsAfterPrimaryFailure()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-symbol-gate-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var primary = Path.Combine(root.FullName, "Sample.1.0.0.nupkg");
+            var symbols = Path.Combine(root.FullName, "Sample.1.0.0.snupkg");
+            File.WriteAllText(primary, "primary");
+            File.WriteAllText(symbols, "symbols");
+
+            var pushed = new List<string>();
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                request =>
+                {
+                    pushed.Add(request.PackagePath);
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+                        Message = "primary failed"
+                    };
+                });
+
+            var result = service.ExecutePackages(
+                new[] { primary, symbols },
+                "key",
+                root.FullName,
+                skipDuplicate: false,
+                publishFailFast: false,
+                suppressCompanionSymbols: true);
+
+            Assert.False(result.Success);
+            Assert.Equal(new[] { primary }, pushed);
+            Assert.Equal(new[] { primary, symbols }, result.FailedItems);
+            Assert.Equal(
+                DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
+                result.PackagePushResults[symbols].Outcome);
+            Assert.Contains("primary package", result.PackagePushResults[symbols].Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("primary failed", result.ErrorMessage);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ExecutePackages_PushesSymbolsAfterPrimaryDuplicateIsAllowed()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-nuget-publish-symbol-duplicate-" + Guid.NewGuid().ToString("N")));
+        try
+        {
+            var primary = Path.Combine(root.FullName, "Sample.1.0.0.nupkg");
+            var symbols = Path.Combine(root.FullName, "Sample.1.0.0.snupkg");
+            File.WriteAllText(primary, "primary");
+            File.WriteAllText(symbols, "symbols");
+
+            var pushed = new List<string>();
+            var service = new NuGetPackagePublishService(
+                new NullLogger(),
+                request =>
+                {
+                    pushed.Add(request.PackagePath);
+                    return new DotNetRepositoryReleaseService.PackagePushResult
+                    {
+                        Outcome = request.PackagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase)
+                            ? DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                            : DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate
+                    };
+                });
+
+            var result = service.ExecutePackages(
+                new[] { primary, symbols },
+                "key",
+                root.FullName,
+                skipDuplicate: true,
+                publishFailFast: false,
+                suppressCompanionSymbols: true);
+
+            Assert.True(result.Success);
+            Assert.Equal(new[] { primary, symbols }, pushed);
+            Assert.Contains(primary, result.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(symbols, result.PublishedItems, StringComparer.OrdinalIgnoreCase);
         }
         finally
         {

--- a/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
+++ b/PowerForge.Tests/NuGetPackagePublishServiceTests.cs
@@ -213,6 +213,7 @@ public sealed class NuGetPackagePublishServiceTests
 
             Assert.True(result.Success);
             Assert.Contains(packagePath, result.PublishedItems, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(packagePath, result.SkippedDuplicateItems, StringComparer.OrdinalIgnoreCase);
             Assert.Empty(result.FailedItems);
         }
         finally

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -111,6 +111,7 @@ public sealed class PowerForgeProjectCmdletTests
             .AddParameter("UseAsReleaseVersionSource")
             .AddParameter("ProvideLocalNuGetFeed")
             .AddParameter("Build")
+            .AddParameter("IncludeSymbols")
             .AddParameter("PublishNuget", false)
             .AddParameter("PublishGitHub", false)
             .AddParameter("CreateReleaseZip", false)
@@ -127,6 +128,7 @@ public sealed class PowerForgeProjectCmdletTests
         Assert.True(segment.Configuration.ProvideLocalNuGetFeed);
         Assert.True(segment.Configuration.Enabled);
         Assert.True(segment.Configuration.Build);
+        Assert.True(segment.Configuration.IncludeSymbols);
         Assert.False(segment.Configuration.PublishNuget);
         Assert.False(segment.Configuration.PublishGitHub);
         Assert.False(segment.Configuration.CreateReleaseZip);
@@ -150,6 +152,7 @@ public sealed class PowerForgeProjectCmdletTests
                 }
             })
             .AddParameter("BuildBeforeModule")
+            .AddParameter("IncludeSymbols")
             .AddParameter("PublishNuget", false)
             .AddParameter("UseGitHubPackages")
             .AddParameter("GitHubPackagesOwner", "EvotecIT")
@@ -162,6 +165,7 @@ public sealed class PowerForgeProjectCmdletTests
         Assert.Equal(".\\Sources", segment.Configuration.RootPath);
         Assert.Equal("2.0.X", segment.Configuration.ExpectedVersionMap?["HtmlTinkerX"]);
         Assert.True(segment.Configuration.BuildBeforeModule);
+        Assert.True(segment.Configuration.IncludeSymbols);
         Assert.False(segment.Configuration.PublishNuget);
         Assert.True(segment.Configuration.UseGitHubPackages);
         Assert.Equal("EvotecIT", segment.Configuration.GitHubPackagesOwner);

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -4914,11 +4914,13 @@ public sealed class PowerForgeReleaseServiceTests
     {
         var root = CreateSandbox();
         var package = Path.Combine(root, "IntelligenceX.Tools.Common.0.1.0.nupkg");
+        var symbolPackage = Path.Combine(root, "IntelligenceX.Tools.Common.0.1.0.snupkg");
         var bundleZip = Path.Combine(root, "IntelligenceX.Chat-Portable-win-x64.zip");
         var msi = Path.Combine(root, "IntelligenceX.Chat.Installer.msi");
         var storeUpload = Path.Combine(root, "IntelligenceX.Chat.Store.msixupload");
         var dotNetManifest = Path.Combine(root, "dotnet-manifest.json");
         File.WriteAllText(package, "pkg", new UTF8Encoding(false));
+        File.WriteAllText(symbolPackage, "symbols", new UTF8Encoding(false));
         File.WriteAllText(bundleZip, "zip", new UTF8Encoding(false));
         File.WriteAllText(msi, "msi", new UTF8Encoding(false));
         File.WriteAllText(storeUpload, "upload", new UTF8Encoding(false));
@@ -4938,6 +4940,7 @@ public sealed class PowerForgeReleaseServiceTests
                         IsPackable = true
                     };
                     project.Packages.Add(package);
+                    project.SymbolPackages.Add(symbolPackage);
                     release.Projects.Add(project);
 
                     return new ProjectBuildHostExecutionResult
@@ -5054,11 +5057,13 @@ public sealed class PowerForgeReleaseServiceTests
             Assert.Equal(Path.Combine(stageRoot, "release-manifest.json"), result.ReleaseManifestPath);
             Assert.Equal(Path.Combine(stageRoot, "SHA256SUMS.txt"), result.ReleaseChecksumsPath);
             Assert.True(File.Exists(Path.Combine(stageRoot, "nuget", Path.GetFileName(package))));
+            Assert.True(File.Exists(Path.Combine(stageRoot, "nuget", Path.GetFileName(symbolPackage))));
             Assert.True(File.Exists(Path.Combine(stageRoot, "portable", Path.GetFileName(bundleZip))));
             Assert.True(File.Exists(Path.Combine(stageRoot, "installer", Path.GetFileName(msi))));
             Assert.True(File.Exists(Path.Combine(stageRoot, "store", Path.GetFileName(storeUpload))));
             Assert.True(File.Exists(Path.Combine(stageRoot, "metadata", Path.GetFileName(dotNetManifest))));
             Assert.Contains(Path.Combine(stageRoot, "nuget", Path.GetFileName(package)), result.ReleaseAssets, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains(Path.Combine(stageRoot, "nuget", Path.GetFileName(symbolPackage)), result.ReleaseAssets, StringComparer.OrdinalIgnoreCase);
             Assert.Contains(Path.Combine(stageRoot, "portable", Path.GetFileName(bundleZip)), result.ReleaseAssets, StringComparer.OrdinalIgnoreCase);
 
             var stagedPackage = Assert.Single(
@@ -5068,6 +5073,7 @@ public sealed class PowerForgeReleaseServiceTests
 
             var checksumText = File.ReadAllText(Path.Combine(stageRoot, "SHA256SUMS.txt"));
             Assert.Contains("nuget/" + Path.GetFileName(package), checksumText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("nuget/" + Path.GetFileName(symbolPackage), checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("portable/" + Path.GetFileName(bundleZip), checksumText, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(package.Replace('\\', '/'), checksumText, StringComparison.OrdinalIgnoreCase);
         }

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -90,6 +90,7 @@ public sealed class ProjectBuildPreparationServiceTests
                 CertificateStore = "LocalMachine",
                 Configuration = "Debug",
                 PackStrategy = "MSBuild",
+                IncludeSymbols = true,
                 PublishNuget = true,
                 PublishGitHub = true
             };
@@ -109,6 +110,7 @@ public sealed class ProjectBuildPreparationServiceTests
             Assert.Equal(CertificateStoreLocation.LocalMachine, context.Spec.CertificateStore);
             Assert.Equal("Debug", context.Spec.Configuration);
             Assert.Equal(DotNetRepositoryPackStrategy.MSBuild, context.Spec.PackStrategy);
+            Assert.True(context.Spec.IncludeSymbols);
         }
         finally
         {

--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -860,7 +860,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.powershell": {
@@ -905,6 +906,28 @@
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -163,7 +163,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.web": {
@@ -176,6 +177,28 @@
           "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net8.0": {
@@ -334,7 +357,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforge.web": {
@@ -347,6 +371,28 @@
           "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.Web/packages.lock.json
+++ b/PowerForge.Web/packages.lock.json
@@ -168,8 +168,31 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net8.0": {
@@ -333,8 +356,31 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -44,6 +44,9 @@ public sealed class ProjectBuildConfigurationReference
     /// <summary>Whether package projects should be built/packed, overriding the referenced JSON when set.</summary>
     public bool? Build { get; set; }
 
+    /// <summary>Whether portable symbol packages should be created, overriding the referenced JSON when set.</summary>
+    public bool? IncludeSymbols { get; set; }
+
     /// <summary>Whether NuGet packages should be published, overriding the referenced JSON when set.</summary>
     public bool? PublishNuget { get; set; }
 
@@ -160,6 +163,9 @@ public sealed class PackageBuildConfiguration
 
     /// <summary>Pack strategy, for example PerProject or MSBuild.</summary>
     public string? PackStrategy { get; set; }
+
+    /// <summary>Whether portable <c>.snupkg</c> symbol packages should be created.</summary>
+    public bool? IncludeSymbols { get; set; }
 
     /// <summary>Whether NuGet packages should be published.</summary>
     public bool? PublishNuget { get; set; }

--- a/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
+++ b/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
@@ -12,7 +12,7 @@ public sealed class DotNetNuGetPushRequest
     /// <param name="apiKey">API key passed to the feed.</param>
     /// <param name="source">Feed source URL or name.</param>
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
-    /// <param name="workingDirectory">Optional working directory override.</param>
+    /// <param name="workingDirectory">Optional NuGet configuration and process context.</param>
     /// <param name="timeout">Optional timeout override.</param>
     public DotNetNuGetPushRequest(
         string packagePath,
@@ -39,7 +39,7 @@ public sealed class DotNetNuGetPushRequest
     /// <param name="apiKey">API key passed to the feed.</param>
     /// <param name="source">Feed source URL or name.</param>
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
-    /// <param name="workingDirectory">Optional working directory override.</param>
+    /// <param name="workingDirectory">Optional NuGet configuration and process context.</param>
     /// <param name="timeout">Optional timeout override.</param>
     /// <param name="suppressCompanionSymbols">When true, passes <c>--no-symbols</c>.</param>
     public DotNetNuGetPushRequest(
@@ -81,7 +81,8 @@ public sealed class DotNetNuGetPushRequest
     public bool SkipDuplicate { get; }
 
     /// <summary>
-    /// Gets the optional working directory override.
+    /// Gets the optional NuGet configuration and process context. When implicit symbol publication is enabled,
+    /// the client may stage the primary and companion packages beneath this directory for one-command publication.
     /// </summary>
     public string? WorkingDirectory { get; }
 

--- a/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
+++ b/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
@@ -8,7 +8,7 @@ public sealed class DotNetNuGetPushRequest
     /// <summary>
     /// Initializes a new instance of the <see cref="DotNetNuGetPushRequest"/> class.
     /// </summary>
-    /// <param name="packagePath">Package path to push.</param>
+    /// <param name="packagePath">Package path to push. Relative paths are resolved from <paramref name="workingDirectory" /> when supplied, or from the current process directory otherwise.</param>
     /// <param name="apiKey">API key passed to the feed.</param>
     /// <param name="source">Feed source URL, name, or local path. Explicit relative paths are resolved from <paramref name="workingDirectory" />.</param>
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
@@ -35,7 +35,7 @@ public sealed class DotNetNuGetPushRequest
     /// <summary>
     /// Initializes a new instance of the <see cref="DotNetNuGetPushRequest"/> class.
     /// </summary>
-    /// <param name="packagePath">Package path to push.</param>
+    /// <param name="packagePath">Package path to push. Relative paths are resolved from <paramref name="workingDirectory" /> when supplied, or from the current process directory otherwise.</param>
     /// <param name="apiKey">API key passed to the feed.</param>
     /// <param name="source">Feed source URL, name, or local path. Explicit relative paths are resolved from <paramref name="workingDirectory" />.</param>
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
@@ -61,7 +61,8 @@ public sealed class DotNetNuGetPushRequest
     }
 
     /// <summary>
-    /// Gets the package path to push.
+    /// Gets the package path to push. Relative paths are resolved from <see cref="WorkingDirectory" /> when supplied,
+    /// or from the current process directory otherwise.
     /// </summary>
     public string PackagePath { get; }
 

--- a/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
+++ b/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
@@ -10,7 +10,7 @@ public sealed class DotNetNuGetPushRequest
     /// </summary>
     /// <param name="packagePath">Package path to push.</param>
     /// <param name="apiKey">API key passed to the feed.</param>
-    /// <param name="source">Feed source URL or name.</param>
+    /// <param name="source">Feed source URL, name, or local path. Explicit relative paths are resolved from <paramref name="workingDirectory" />.</param>
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
     /// <param name="workingDirectory">Optional NuGet configuration and process context.</param>
     /// <param name="timeout">Optional timeout override.</param>
@@ -37,7 +37,7 @@ public sealed class DotNetNuGetPushRequest
     /// </summary>
     /// <param name="packagePath">Package path to push.</param>
     /// <param name="apiKey">API key passed to the feed.</param>
-    /// <param name="source">Feed source URL or name.</param>
+    /// <param name="source">Feed source URL, name, or local path. Explicit relative paths are resolved from <paramref name="workingDirectory" />.</param>
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
     /// <param name="workingDirectory">Optional NuGet configuration and process context.</param>
     /// <param name="timeout">Optional timeout override.</param>
@@ -71,7 +71,7 @@ public sealed class DotNetNuGetPushRequest
     public string ApiKey { get; }
 
     /// <summary>
-    /// Gets the feed source URL or name.
+    /// Gets the feed source URL, name, or local path. Explicit relative paths are resolved from <see cref="WorkingDirectory" />.
     /// </summary>
     public string Source { get; }
 

--- a/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
+++ b/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
@@ -14,13 +14,15 @@ public sealed class DotNetNuGetPushRequest
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
     /// <param name="workingDirectory">Optional working directory override.</param>
     /// <param name="timeout">Optional timeout override.</param>
+    /// <param name="suppressCompanionSymbols">When true, passes <c>--no-symbols</c>.</param>
     public DotNetNuGetPushRequest(
         string packagePath,
         string apiKey,
         string source,
         bool skipDuplicate = true,
         string? workingDirectory = null,
-        TimeSpan? timeout = null)
+        TimeSpan? timeout = null,
+        bool suppressCompanionSymbols = false)
     {
         PackagePath = packagePath;
         ApiKey = apiKey;
@@ -28,6 +30,7 @@ public sealed class DotNetNuGetPushRequest
         SkipDuplicate = skipDuplicate;
         WorkingDirectory = workingDirectory;
         Timeout = timeout;
+        SuppressCompanionSymbols = suppressCompanionSymbols;
     }
 
     /// <summary>
@@ -59,4 +62,9 @@ public sealed class DotNetNuGetPushRequest
     /// Gets the optional timeout override.
     /// </summary>
     public TimeSpan? Timeout { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether implicit companion symbol publication should be suppressed.
+    /// </summary>
+    public bool SuppressCompanionSymbols { get; }
 }

--- a/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
+++ b/PowerForge/Models/DotNet/DotNetNuGetPushRequest.cs
@@ -14,15 +14,42 @@ public sealed class DotNetNuGetPushRequest
     /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
     /// <param name="workingDirectory">Optional working directory override.</param>
     /// <param name="timeout">Optional timeout override.</param>
-    /// <param name="suppressCompanionSymbols">When true, passes <c>--no-symbols</c>.</param>
     public DotNetNuGetPushRequest(
         string packagePath,
         string apiKey,
         string source,
         bool skipDuplicate = true,
         string? workingDirectory = null,
-        TimeSpan? timeout = null,
-        bool suppressCompanionSymbols = false)
+        TimeSpan? timeout = null)
+        : this(
+            packagePath,
+            apiKey,
+            source,
+            skipDuplicate,
+            workingDirectory,
+            timeout,
+            suppressCompanionSymbols: false)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DotNetNuGetPushRequest"/> class.
+    /// </summary>
+    /// <param name="packagePath">Package path to push.</param>
+    /// <param name="apiKey">API key passed to the feed.</param>
+    /// <param name="source">Feed source URL or name.</param>
+    /// <param name="skipDuplicate">When true, passes <c>--skip-duplicate</c>.</param>
+    /// <param name="workingDirectory">Optional working directory override.</param>
+    /// <param name="timeout">Optional timeout override.</param>
+    /// <param name="suppressCompanionSymbols">When true, passes <c>--no-symbols</c>.</param>
+    public DotNetNuGetPushRequest(
+        string packagePath,
+        string apiKey,
+        string source,
+        bool skipDuplicate,
+        string? workingDirectory,
+        TimeSpan? timeout,
+        bool suppressCompanionSymbols)
     {
         PackagePath = packagePath;
         ApiKey = apiKey;

--- a/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
+++ b/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
@@ -28,6 +28,7 @@ internal sealed class DotNetRepositoryReleasePreparationRequest
     public bool? SignDependencyAssemblies { get; set; }
     public bool? SignPackages { get; set; }
     public bool SkipPack { get; set; }
+    public bool IncludeSymbols { get; set; }
     public bool Publish { get; set; }
     public string? PublishSource { get; set; }
     public string? PublishApiKey { get; set; }

--- a/PowerForge/Models/DotNetRepositoryReleaseResult.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseResult.cs
@@ -61,6 +61,9 @@ public sealed class DotNetRepositoryProjectResult
     /// <summary>Packages produced for this project.</summary>
     public List<string> Packages { get; } = new();
 
+    /// <summary>Portable symbol packages produced for this project.</summary>
+    public List<string> SymbolPackages { get; } = new();
+
     /// <summary>Release zip path (if created).</summary>
     public string? ReleaseZipPath { get; set; }
 

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -62,6 +62,9 @@ public sealed class DotNetRepositoryReleaseSpec
     /// <summary>When true, runs dotnet pack.</summary>
     public bool Pack { get; set; } = true;
 
+    /// <summary>When true, creates portable <c>.snupkg</c> symbol packages alongside primary packages.</summary>
+    public bool IncludeSymbols { get; set; }
+
     /// <summary>Strategy used for packing selected projects.</summary>
     public DotNetRepositoryPackStrategy PackStrategy { get; set; } = DotNetRepositoryPackStrategy.PerProject;
 

--- a/PowerForge/Models/NuGetPackagePublishRequest.cs
+++ b/PowerForge/Models/NuGetPackagePublishRequest.cs
@@ -8,4 +8,5 @@ internal sealed class NuGetPackagePublishRequest
     public string ApiKey { get; set; } = string.Empty;
     public string Source { get; set; } = "https://api.nuget.org/v3/index.json";
     public bool SkipDuplicate { get; set; }
+    public string? WorkingDirectory { get; set; }
 }

--- a/PowerForge/Models/NuGetPackagePublishResult.cs
+++ b/PowerForge/Models/NuGetPackagePublishResult.cs
@@ -6,6 +6,7 @@ internal sealed class NuGetPackagePublishResult
 {
     public bool Success { get; set; } = true;
     public List<string> PublishedItems { get; } = new();
+    public List<string> SkippedDuplicateItems { get; } = new();
     public List<string> FailedItems { get; } = new();
     public string? ErrorMessage { get; set; }
 }

--- a/PowerForge/Models/NuGetPackagePublishResult.cs
+++ b/PowerForge/Models/NuGetPackagePublishResult.cs
@@ -8,5 +8,6 @@ internal sealed class NuGetPackagePublishResult
     public List<string> PublishedItems { get; } = new();
     public List<string> SkippedDuplicateItems { get; } = new();
     public List<string> FailedItems { get; } = new();
+    public Dictionary<string, DotNetRepositoryReleaseService.PackagePushResult> PackagePushResults { get; } = new(StringComparer.OrdinalIgnoreCase);
     public string? ErrorMessage { get; set; }
 }

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -28,6 +28,7 @@ internal sealed class ProjectBuildConfiguration
     public bool? UpdateVersions { get; set; }
     public bool? Build { get; set; }
     public string? PackStrategy { get; set; }
+    public bool? IncludeSymbols { get; set; }
     public bool? PublishNuget { get; set; }
     public bool? PublishGitHub { get; set; }
     public bool? CreateReleaseZip { get; set; }

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -40,6 +40,10 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.7" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NuGet.Configuration" Version="7.6.0" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />

--- a/PowerForge/Services/DotNetNuGetClient.cs
+++ b/PowerForge/Services/DotNetNuGetClient.cs
@@ -155,6 +155,8 @@ public sealed class DotNetNuGetClient
 
         if (request.SkipDuplicate)
             lines.Add("--skip-duplicate");
+        if (request.SuppressCompanionSymbols)
+            lines.Add("--no-symbols");
 
         return string.Join(Environment.NewLine, lines);
     }

--- a/PowerForge/Services/DotNetNuGetClient.cs
+++ b/PowerForge/Services/DotNetNuGetClient.cs
@@ -55,7 +55,10 @@ public sealed class DotNetNuGetClient
             pushContext = PreparePushExecutionContext(request);
             File.WriteAllText(
                 responseFilePath,
-                BuildPushResponseFileContent(request, pushContext.Value.PackagePath));
+                BuildPushResponseFileContent(
+                    request,
+                    pushContext.Value.PackagePath,
+                    pushContext.Value.Source));
 
             var processResult = await _processRunner.RunAsync(
                 new ProcessRunRequest(
@@ -147,7 +150,8 @@ public sealed class DotNetNuGetClient
 
     private static string BuildPushResponseFileContent(
         DotNetNuGetPushRequest request,
-        string packagePath)
+        string packagePath,
+        string source)
     {
         // dotnet response files treat each line as one argument and preserve quote characters.
         // Writing shell-style quotes here therefore passes the quotes into options such as --source.
@@ -158,7 +162,7 @@ public sealed class DotNetNuGetClient
             "--api-key",
             request.ApiKey,
             "--source",
-            request.Source
+            source
         };
 
         if (request.SkipDuplicate)
@@ -176,17 +180,18 @@ public sealed class DotNetNuGetClient
     private static PushExecutionContext PreparePushExecutionContext(DotNetNuGetPushRequest request)
     {
         var workingDirectory = ResolveWorkingDirectory(request.WorkingDirectory, request.PackagePath);
+        var source = ResolvePushSource(request.Source, workingDirectory);
         if (request.SuppressCompanionSymbols ||
             string.IsNullOrWhiteSpace(request.WorkingDirectory) ||
             request.PackagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase) ||
             !request.PackagePath.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
         {
-            return new PushExecutionContext(request.PackagePath, workingDirectory, stagingDirectory: null);
+            return new PushExecutionContext(request.PackagePath, source, workingDirectory, stagingDirectory: null);
         }
 
         var symbolPackagePath = Path.ChangeExtension(request.PackagePath, ".snupkg");
         if (!File.Exists(symbolPackagePath))
-            return new PushExecutionContext(request.PackagePath, workingDirectory, stagingDirectory: null);
+            return new PushExecutionContext(request.PackagePath, source, workingDirectory, stagingDirectory: null);
 
         var configurationDirectory = Path.GetFullPath(workingDirectory);
         if (!Directory.Exists(configurationDirectory))
@@ -196,7 +201,7 @@ public sealed class DotNetNuGetClient
         if (!string.IsNullOrWhiteSpace(packageDirectory) &&
             IsSameOrChildDirectory(packageDirectory!, configurationDirectory))
         {
-            return new PushExecutionContext(request.PackagePath, packageDirectory!, stagingDirectory: null);
+            return new PushExecutionContext(request.PackagePath, source, packageDirectory!, stagingDirectory: null);
         }
 
         var stagingDirectory = Path.Combine(
@@ -209,7 +214,7 @@ public sealed class DotNetNuGetClient
             var stagedSymbolPackagePath = Path.Combine(stagingDirectory, Path.GetFileName(symbolPackagePath));
             File.Copy(request.PackagePath, stagedPackagePath);
             File.Copy(symbolPackagePath, stagedSymbolPackagePath);
-            return new PushExecutionContext(stagedPackagePath, stagingDirectory, stagingDirectory);
+            return new PushExecutionContext(stagedPackagePath, source, stagingDirectory, stagingDirectory);
         }
         catch
         {
@@ -225,6 +230,27 @@ public sealed class DotNetNuGetClient
         var normalizedCandidate = candidate.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         return string.Equals(normalizedCandidate, normalizedRoot, comparison) ||
                normalizedCandidate.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
+    }
+
+    /// <summary>
+    /// Anchors explicit relative filesystem sources to the caller's NuGet configuration context before
+    /// companion-symbol handling moves the process into a package or staging directory. Bare NuGet.config
+    /// source names and absolute URIs retain their original meaning.
+    /// </summary>
+    private static string ResolvePushSource(string source, string workingDirectory)
+    {
+        var trimmed = source.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+            return trimmed;
+
+        var normalized = PathValueResolver.NormalizeSeparators(trimmed);
+        if (Path.IsPathRooted(normalized))
+            return Path.GetFullPath(normalized);
+
+        return normalized.StartsWith(".", StringComparison.Ordinal) ||
+               normalized.IndexOf(Path.DirectorySeparatorChar) >= 0
+            ? PathValueResolver.Resolve(workingDirectory, normalized)
+            : trimmed;
     }
 
     private static string ResolveWorkingDirectory(string? workingDirectory, string packagePath)
@@ -287,15 +313,18 @@ public sealed class DotNetNuGetClient
     {
         public PushExecutionContext(
             string packagePath,
+            string source,
             string workingDirectory,
             string? stagingDirectory)
         {
             PackagePath = packagePath;
+            Source = source;
             WorkingDirectory = workingDirectory;
             StagingDirectory = stagingDirectory;
         }
 
         public string PackagePath { get; }
+        public string Source { get; }
         public string WorkingDirectory { get; }
         public string? StagingDirectory { get; }
     }

--- a/PowerForge/Services/DotNetNuGetClient.cs
+++ b/PowerForge/Services/DotNetNuGetClient.cs
@@ -153,8 +153,8 @@ public sealed class DotNetNuGetClient
         string packagePath,
         string source)
     {
-        // dotnet response files treat each line as one argument and preserve quote characters.
-        // Writing shell-style quotes here therefore passes the quotes into options such as --source.
+        // The .NET CLI keeps quotes as literal characters when one response-file token is written per line.
+        // Keep whitespace-bearing values raw so paths and keys remain single tokens without embedded quotes.
         var lines = new List<string> {
             "nuget",
             "push",
@@ -179,29 +179,38 @@ public sealed class DotNetNuGetClient
     /// </summary>
     private static PushExecutionContext PreparePushExecutionContext(DotNetNuGetPushRequest request)
     {
-        var workingDirectory = ResolveWorkingDirectory(request.WorkingDirectory, request.PackagePath);
+        var configurationDirectory = string.IsNullOrWhiteSpace(request.WorkingDirectory)
+            ? Environment.CurrentDirectory
+            : PathValueResolver.Resolve(Environment.CurrentDirectory, request.WorkingDirectory!);
+        var packagePath = PathValueResolver.Resolve(
+            string.IsNullOrWhiteSpace(request.WorkingDirectory)
+                ? Environment.CurrentDirectory
+                : configurationDirectory,
+            request.PackagePath);
+        var workingDirectory = string.IsNullOrWhiteSpace(request.WorkingDirectory)
+            ? Path.GetDirectoryName(packagePath) ?? configurationDirectory
+            : configurationDirectory;
         var source = ResolvePushSource(request.Source, workingDirectory);
         if (request.SuppressCompanionSymbols ||
             string.IsNullOrWhiteSpace(request.WorkingDirectory) ||
-            request.PackagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase) ||
-            !request.PackagePath.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+            packagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase) ||
+            !packagePath.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
         {
-            return new PushExecutionContext(request.PackagePath, source, workingDirectory, stagingDirectory: null);
+            return new PushExecutionContext(packagePath, source, workingDirectory, stagingDirectory: null);
         }
 
-        var symbolPackagePath = Path.ChangeExtension(request.PackagePath, ".snupkg");
+        var symbolPackagePath = Path.ChangeExtension(packagePath, ".snupkg");
         if (!File.Exists(symbolPackagePath))
-            return new PushExecutionContext(request.PackagePath, source, workingDirectory, stagingDirectory: null);
+            return new PushExecutionContext(packagePath, source, workingDirectory, stagingDirectory: null);
 
-        var configurationDirectory = Path.GetFullPath(workingDirectory);
         if (!Directory.Exists(configurationDirectory))
             throw new DirectoryNotFoundException($"NuGet push working directory not found: {configurationDirectory}");
 
-        var packageDirectory = Path.GetDirectoryName(Path.GetFullPath(request.PackagePath));
+        var packageDirectory = Path.GetDirectoryName(packagePath);
         if (!string.IsNullOrWhiteSpace(packageDirectory) &&
             IsSameOrChildDirectory(packageDirectory!, configurationDirectory))
         {
-            return new PushExecutionContext(request.PackagePath, source, packageDirectory!, stagingDirectory: null);
+            return new PushExecutionContext(packagePath, source, packageDirectory!, stagingDirectory: null);
         }
 
         var stagingDirectory = Path.Combine(
@@ -210,9 +219,9 @@ public sealed class DotNetNuGetClient
         try
         {
             Directory.CreateDirectory(stagingDirectory);
-            var stagedPackagePath = Path.Combine(stagingDirectory, Path.GetFileName(request.PackagePath));
+            var stagedPackagePath = Path.Combine(stagingDirectory, Path.GetFileName(packagePath));
             var stagedSymbolPackagePath = Path.Combine(stagingDirectory, Path.GetFileName(symbolPackagePath));
-            File.Copy(request.PackagePath, stagedPackagePath);
+            File.Copy(packagePath, stagedPackagePath);
             File.Copy(symbolPackagePath, stagedSymbolPackagePath);
             return new PushExecutionContext(stagedPackagePath, source, stagingDirectory, stagingDirectory);
         }

--- a/PowerForge/Services/DotNetNuGetClient.cs
+++ b/PowerForge/Services/DotNetNuGetClient.cs
@@ -48,15 +48,19 @@ public sealed class DotNetNuGetClient
 
         Directory.CreateDirectory(_runtimeDirectoryRoot);
         var responseFilePath = Path.Combine(_runtimeDirectoryRoot, $"nuget-push-{Guid.NewGuid():N}.rsp");
+        PushExecutionContext? pushContext = null;
 
         try
         {
-            File.WriteAllText(responseFilePath, BuildPushResponseFileContent(request));
+            pushContext = PreparePushExecutionContext(request);
+            File.WriteAllText(
+                responseFilePath,
+                BuildPushResponseFileContent(request, pushContext.Value.PackagePath));
 
             var processResult = await _processRunner.RunAsync(
                 new ProcessRunRequest(
                     _dotNetExecutable,
-                    ResolveWorkingDirectory(request.WorkingDirectory, request.PackagePath),
+                    pushContext.Value.WorkingDirectory,
                     [$"@{responseFilePath}"],
                     request.Timeout ?? _defaultTimeout),
                 cancellationToken).ConfigureAwait(false);
@@ -75,6 +79,8 @@ public sealed class DotNetNuGetClient
         finally
         {
             TryDeleteFile(responseFilePath);
+            if (pushContext?.StagingDirectory is string stagingDirectory)
+                TryDeleteDirectory(stagingDirectory);
         }
     }
 
@@ -139,14 +145,16 @@ public sealed class DotNetNuGetClient
                 : FirstLine(processResult.StdErr) ?? FirstLine(processResult.StdOut) ?? $"dotnet nuget sign failed with exit code {processResult.ExitCode}.");
     }
 
-    private static string BuildPushResponseFileContent(DotNetNuGetPushRequest request)
+    private static string BuildPushResponseFileContent(
+        DotNetNuGetPushRequest request,
+        string packagePath)
     {
         // dotnet response files treat each line as one argument and preserve quote characters.
         // Writing shell-style quotes here therefore passes the quotes into options such as --source.
         var lines = new List<string> {
             "nuget",
             "push",
-            request.PackagePath,
+            packagePath,
             "--api-key",
             request.ApiKey,
             "--source",
@@ -159,6 +167,64 @@ public sealed class DotNetNuGetClient
             lines.Add("--no-symbols");
 
         return string.Join(Environment.NewLine, lines);
+    }
+
+    /// <summary>
+    /// Keeps the NuGet.config lookup context while placing an implicit companion symbol package beside
+    /// the primary package in the process working directory, as required by <c>dotnet nuget push</c>.
+    /// </summary>
+    private static PushExecutionContext PreparePushExecutionContext(DotNetNuGetPushRequest request)
+    {
+        var workingDirectory = ResolveWorkingDirectory(request.WorkingDirectory, request.PackagePath);
+        if (request.SuppressCompanionSymbols ||
+            string.IsNullOrWhiteSpace(request.WorkingDirectory) ||
+            request.PackagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase) ||
+            !request.PackagePath.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
+        {
+            return new PushExecutionContext(request.PackagePath, workingDirectory, stagingDirectory: null);
+        }
+
+        var symbolPackagePath = Path.ChangeExtension(request.PackagePath, ".snupkg");
+        if (!File.Exists(symbolPackagePath))
+            return new PushExecutionContext(request.PackagePath, workingDirectory, stagingDirectory: null);
+
+        var configurationDirectory = Path.GetFullPath(workingDirectory);
+        if (!Directory.Exists(configurationDirectory))
+            throw new DirectoryNotFoundException($"NuGet push working directory not found: {configurationDirectory}");
+
+        var packageDirectory = Path.GetDirectoryName(Path.GetFullPath(request.PackagePath));
+        if (!string.IsNullOrWhiteSpace(packageDirectory) &&
+            IsSameOrChildDirectory(packageDirectory!, configurationDirectory))
+        {
+            return new PushExecutionContext(request.PackagePath, packageDirectory!, stagingDirectory: null);
+        }
+
+        var stagingDirectory = Path.Combine(
+            configurationDirectory,
+            $".powerforge-nuget-push-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(stagingDirectory);
+            var stagedPackagePath = Path.Combine(stagingDirectory, Path.GetFileName(request.PackagePath));
+            var stagedSymbolPackagePath = Path.Combine(stagingDirectory, Path.GetFileName(symbolPackagePath));
+            File.Copy(request.PackagePath, stagedPackagePath);
+            File.Copy(symbolPackagePath, stagedSymbolPackagePath);
+            return new PushExecutionContext(stagedPackagePath, stagingDirectory, stagingDirectory);
+        }
+        catch
+        {
+            TryDeleteDirectory(stagingDirectory);
+            throw;
+        }
+    }
+
+    private static bool IsSameOrChildDirectory(string candidate, string root)
+    {
+        var comparison = FrameworkCompatibility.PathStringComparison();
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedCandidate = candidate.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return string.Equals(normalizedCandidate, normalizedRoot, comparison) ||
+               normalizedCandidate.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
     }
 
     private static string ResolveWorkingDirectory(string? workingDirectory, string packagePath)
@@ -186,6 +252,19 @@ public sealed class DotNetNuGetClient
         }
     }
 
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
+    }
+
     private static string? FirstLine(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -203,4 +282,21 @@ public sealed class DotNetNuGetClient
         => string.IsNullOrWhiteSpace(runtimeDirectoryRoot)
             ? Path.Combine(Path.GetTempPath(), "PowerForge", "runtime", "dotnet-nuget")
             : runtimeDirectoryRoot!;
+
+    private readonly struct PushExecutionContext
+    {
+        public PushExecutionContext(
+            string packagePath,
+            string workingDirectory,
+            string? stagingDirectory)
+        {
+            PackagePath = packagePath;
+            WorkingDirectory = workingDirectory;
+            StagingDirectory = stagingDirectory;
+        }
+
+        public string PackagePath { get; }
+        public string WorkingDirectory { get; }
+        public string? StagingDirectory { get; }
+    }
 }

--- a/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
@@ -64,6 +64,7 @@ internal sealed class DotNetRepositoryReleasePreparationService
                 SignDependencyAssemblies = request.SignDependencyAssemblies ?? false,
                 SignPackages = ResolveSigningEnabled(request.SignPackages, request.CertificateThumbprint),
                 Pack = !request.SkipPack,
+                IncludeSymbols = request.IncludeSymbols,
                 Publish = request.Publish,
                 PublishSource = request.PublishSource,
                 PublishApiKey = publishApiKey,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
@@ -142,10 +142,13 @@ public sealed partial class DotNetRepositoryReleaseService
                 .ToArray();
             result.Packages.AddRange(pkgs);
 
-            var symbolPackages = Directory.EnumerateFiles(outputPath, "*.snupkg", SearchOption.AllDirectories)
-                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
-                .ToArray();
-            result.SymbolPackages.AddRange(symbolPackages);
+            if (spec.IncludeSymbols)
+            {
+                var symbolPackages = Directory.EnumerateFiles(outputPath, "*.snupkg", SearchOption.AllDirectories)
+                    .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
+                    .ToArray();
+                result.SymbolPackages.AddRange(symbolPackages);
+            }
 
             if (!TryValidatePackagePayloads(projects, spec, result.Packages, logger, out var validationError))
             {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private static DotNetPackResult PackProjectsWithMsBuild(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies)
+    {
+        var result = new DotNetPackResult();
+        if (projects.Count == 0)
+        {
+            result.Success = true;
+            return result;
+        }
+
+        if (string.IsNullOrWhiteSpace(spec.OutputPath))
+        {
+            result.Success = false;
+            result.ErrorMessage = "MSBuild batch pack requires OutputPath.";
+            return result;
+        }
+
+        var outputPath = Path.IsPathRooted(spec.OutputPath!)
+            ? spec.OutputPath!
+            : Path.GetFullPath(Path.Combine(spec.RootPath, spec.OutputPath!));
+        Directory.CreateDirectory(outputPath);
+        var existingPackages = SnapshotPackages(outputPath);
+
+        var tempRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "project-build", $"pack-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        var traversalPath = Path.Combine(tempRoot, "pack.proj");
+        try
+        {
+            var forceBatchRebuild = false;
+            foreach (var project in projects)
+            {
+                if (!TryRemoveStalePrimaryPackageOutputs(
+                        project,
+                        string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim(),
+                        logger,
+                        out _,
+                        out var removedIntermediatePrimaryOutput,
+                        out var cleanupDuration,
+                        out var cleanupError))
+                {
+                    result.Duration += cleanupDuration;
+                    result.ErrorMessage = cleanupError;
+                    return result;
+                }
+
+                result.Duration += cleanupDuration;
+                forceBatchRebuild |= !removedIntermediatePrimaryOutput;
+            }
+
+            if (forceBatchRebuild)
+                logger.Info("MSBuild batch freshness could not prove every intermediate output was removed; using the Rebuild safety target.");
+
+            WritePackTraversalProject(traversalPath, projects, spec, outputPath, forceBatchRebuild);
+
+            var shouldSignAssemblies = signAssemblies is not null && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
+            int exitCode;
+            string stdErr;
+            string stdOut;
+            TimeSpan duration;
+
+            if (shouldSignAssemblies)
+            {
+                exitCode = RunDotnetMsBuildTarget(
+                    traversalPath,
+                    tempRoot,
+                    "BuildSelected",
+                    "build",
+                    "dotnet msbuild build",
+                    projects.Count,
+                    logger,
+                    out stdErr,
+                    out stdOut,
+                    out duration);
+                result.Duration += duration;
+
+                if (exitCode != 0)
+                {
+                    result.ErrorMessage = $"dotnet msbuild batch build failed (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
+                    return result;
+                }
+
+                var signing = SignBatchBuildOutputs(projects, spec, logger, signAssemblies!);
+                result.Duration += signing.Duration;
+                if (!signing.Success)
+                {
+                    result.ErrorMessage = signing.ErrorMessage;
+                    return result;
+                }
+
+                exitCode = RunDotnetMsBuildTarget(
+                    traversalPath,
+                    tempRoot,
+                    "PackOnlySelected",
+                    "pack",
+                    "dotnet msbuild pack",
+                    projects.Count,
+                    logger,
+                    out stdErr,
+                    out stdOut,
+                    out duration);
+                result.Duration += duration;
+            }
+            else
+            {
+                exitCode = RunDotnetMsBuildTarget(
+                    traversalPath,
+                    tempRoot,
+                    "PackSelected",
+                    "pack",
+                    "dotnet msbuild pack",
+                    projects.Count,
+                    logger,
+                    out stdErr,
+                    out stdOut,
+                    out duration);
+                result.Duration += duration;
+            }
+
+            if (exitCode != 0)
+            {
+                result.ErrorMessage = $"dotnet msbuild batch pack failed (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
+                return result;
+            }
+
+            var pkgs = Directory.EnumerateFiles(outputPath, "*.nupkg", SearchOption.AllDirectories)
+                .Where(p => !p.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
+                .ToArray();
+            result.Packages.AddRange(pkgs);
+
+            var symbolPackages = Directory.EnumerateFiles(outputPath, "*.snupkg", SearchOption.AllDirectories)
+                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
+                .ToArray();
+            result.SymbolPackages.AddRange(symbolPackages);
+
+            if (!TryValidatePackagePayloads(projects, spec, result.Packages, logger, out var validationError))
+            {
+                result.Success = false;
+                result.ErrorMessage = validationError;
+                return result;
+            }
+
+            result.Success = true;
+            return result;
+        }
+        finally
+        {
+            TryDeleteDirectory(tempRoot, logger);
+        }
+    }
+
+    internal static void WritePackTraversalProject(
+        string traversalPath,
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        string outputPath,
+        bool forceRebuild = false)
+    {
+        var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
+        var buildProperties = $"Configuration={EscapeMsBuildPropertyValue(configuration)}";
+        var packProperties = new List<string>
+        {
+            buildProperties,
+            $"PackageOutputPath={EscapeMsBuildPropertyValue(outputPath)}",
+            "NoBuild=true",
+            "BuildProjectReferences=false"
+        };
+        if (spec.IncludeSymbols)
+        {
+            packProperties.Add("IncludeSymbols=true");
+            packProperties.Add("SymbolPackageFormat=snupkg");
+        }
+        var joinedPackProperties = string.Join(";", packProperties);
+
+        // Keep this a classic MSBuild project: it only fans out to concrete SDK projects
+        // and does not require Microsoft.Build.Traversal to be installed.
+        var document = new XDocument(
+            new XElement("Project",
+                new XElement("ItemGroup",
+                    projects.Select(project => new XElement("PackProject",
+                        new XAttribute("Include", Path.GetFullPath(project.CsprojPath))))),
+                new XElement("Target",
+                    new XAttribute("Name", "RestoreSelected"),
+                    new XElement("MSBuild",
+                        new XAttribute("Projects", "@(PackProject)"),
+                        // Restore and build all selected projects first, then pack without walking project
+                        // references. Otherwise packable project references can be packed twice in parallel.
+                        new XAttribute("Targets", "Restore"),
+                        new XAttribute("BuildInParallel", "true"),
+                        new XAttribute("StopOnFirstFailure", "true"),
+                        new XAttribute("Properties", buildProperties))),
+                new XElement("Target",
+                    new XAttribute("Name", "BuildSelected"),
+                    new XAttribute("DependsOnTargets", "RestoreSelected"),
+                    new XElement("MSBuild",
+                        new XAttribute("Projects", "@(PackProject)"),
+                        // Freshness cleanup normally permits an incremental Build. Rebuild remains
+                        // the safety target when an intermediate compiler output was not removed.
+                        new XAttribute("Targets", forceRebuild ? "Rebuild" : "Build"),
+                        new XAttribute("BuildInParallel", "true"),
+                        new XAttribute("StopOnFirstFailure", "true"),
+                        new XAttribute("Properties", buildProperties))),
+                new XElement("Target",
+                    new XAttribute("Name", "PackOnlySelected"),
+                    new XElement("MSBuild",
+                        new XAttribute("Projects", "@(PackProject)"),
+                        new XAttribute("Targets", "Pack"),
+                        new XAttribute("BuildInParallel", "true"),
+                        new XAttribute("StopOnFirstFailure", "true"),
+                        new XAttribute("Properties", joinedPackProperties))),
+                new XElement("Target",
+                    new XAttribute("Name", "PackSelected"),
+                    new XAttribute("DependsOnTargets", "BuildSelected;PackOnlySelected"))));
+
+        document.Save(traversalPath);
+    }
+
+    private static DotNetPackResult SignBatchBuildOutputs(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest> signAssemblies)
+    {
+        var result = new DotNetPackResult();
+        var watch = Stopwatch.StartNew();
+
+        try
+        {
+            var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
+            var signedOutputCount = 0;
+            var files = new List<string>();
+
+            foreach (var project in projects)
+            {
+                var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
+                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
+                var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
+                var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
+                {
+                    var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
+                    if (!SamePatterns(includePatterns, evaluatedIncludePatterns))
+                    {
+                        includePatterns = evaluatedIncludePatterns;
+                        outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
+                        signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                    }
+                }
+                logger.Info($"{project.ProjectName}: assembly signing include pattern(s): {string.Join(", ", includePatterns)}.");
+                files.AddRange(signingPlan.Files);
+                signedOutputCount += signingPlan.OutputDirectoryCount;
+            }
+
+            var filePaths = files
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (filePaths.Length > 0)
+                signAssemblies(new DotNetReleaseBuildAssemblySigningRequest
+                {
+                    ReleasePath = spec.RootPath,
+                    LocalStore = spec.CertificateStore,
+                    CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
+                    TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
+                    IncludePatterns = Array.Empty<string>(),
+                    FilePaths = filePaths
+                });
+
+            watch.Stop();
+            result.Duration = watch.Elapsed;
+            result.Success = true;
+            logger.Success($"MSBuild batch assembly signing completed for {signedOutputCount} output directorie(s), {filePaths.Length} file(s), in {FormatDuration(watch.Elapsed)}.");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            watch.Stop();
+            result.Duration = watch.Elapsed;
+            result.ErrorMessage = $"MSBuild batch assembly signing failed. {ex.Message}";
+            return result;
+        }
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -569,13 +569,12 @@ public sealed partial class DotNetRepositoryReleaseService
 
                     _logger.Info($"Publishing {Path.GetFileName(pkg)}...");
                     var packagePublishWatch = Stopwatch.StartNew();
-                    PushPackage(
+                    var pushResult = PushPackage(
                         pkg,
                         spec.PublishApiKey!,
                         source,
                         spec.SkipDuplicate,
-                        suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately,
-                        out var pushResult);
+                        suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately);
                     packagePublishWatch.Stop();
                     var artifactOutcomes = ClassifyPublishedArtifacts(publishedArtifacts, pushResult);
                     foreach (var artifact in publishedArtifacts)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -567,6 +567,30 @@ public sealed partial class DotNetRepositoryReleaseService
                         continue;
                     }
 
+                    if (publishSymbolsSeparately &&
+                        !CanPublishSymbolPackage(
+                            pkg,
+                            (IEnumerable<string>?)project?.Packages ?? Array.Empty<string>(),
+                            primaryPackage =>
+                                result.PublishedPackages.Contains(primaryPackage, StringComparer.OrdinalIgnoreCase) ||
+                                result.SkippedDuplicatePackages.Contains(primaryPackage, StringComparer.OrdinalIgnoreCase),
+                            out var primaryPackage))
+                    {
+                        var blockedResult = CreateBlockedCompanionResult(pkg, primaryPackage);
+                        result.Success = false;
+                        result.FailedPackages.Add(pkg);
+                        _logger.Warn(blockedResult.Message!);
+                        if (project is not null && string.IsNullOrWhiteSpace(project.ErrorMessage))
+                            project.ErrorMessage = blockedResult.Message;
+                        if (spec.PublishFailFast)
+                        {
+                            result.ErrorMessage = blockedResult.Message;
+                            return result;
+                        }
+
+                        continue;
+                    }
+
                     _logger.Info($"Publishing {Path.GetFileName(pkg)}...");
                     var packagePublishWatch = Stopwatch.StartNew();
                     var pushResult = PushPackage(
@@ -574,7 +598,8 @@ public sealed partial class DotNetRepositoryReleaseService
                         spec.PublishApiKey!,
                         source,
                         spec.SkipDuplicate,
-                        suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately);
+                        suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately,
+                        workingDirectory: root);
                     packagePublishWatch.Stop();
                     var artifactOutcomes = ClassifyPublishedArtifacts(
                         publishedArtifacts,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -576,7 +576,10 @@ public sealed partial class DotNetRepositoryReleaseService
                         spec.SkipDuplicate,
                         suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately);
                     packagePublishWatch.Stop();
-                    var artifactOutcomes = ClassifyPublishedArtifacts(publishedArtifacts, pushResult);
+                    var artifactOutcomes = ClassifyPublishedArtifacts(
+                        publishedArtifacts,
+                        pushResult,
+                        spec.SkipDuplicate);
                     foreach (var artifact in publishedArtifacts)
                     {
                         switch (artifactOutcomes[artifact])

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -46,6 +46,8 @@ public sealed partial class DotNetRepositoryReleaseService
                 return result;
             }
             spec.RootPath = root;
+            if (!string.IsNullOrWhiteSpace(spec.PublishSource))
+                spec.PublishSource = ResolvePublishSource(spec.PublishSource!, root);
 
             var include = BuildNameSet(spec.IncludeProjects);
             var exclude = BuildNameSet(spec.ExcludeProjects);
@@ -560,19 +562,29 @@ public sealed partial class DotNetRepositoryReleaseService
 
                     _logger.Info($"Publishing {Path.GetFileName(pkg)}...");
                     var packagePublishWatch = Stopwatch.StartNew();
-                    var push = PushPackage(pkg, spec.PublishApiKey!, source, spec.SkipDuplicate, out var pushResult);
+                    var push = PushPackage(
+                        pkg,
+                        spec.PublishApiKey!,
+                        source,
+                        spec.SkipDuplicate,
+                        suppressCompanionSymbols: !spec.IncludeSymbols,
+                        out var pushResult);
                     packagePublishWatch.Stop();
                     if (push)
                     {
-                        if (pushResult.Outcome == PackagePushOutcome.SkippedDuplicate)
+                        var artifactOutcomes = ClassifyPublishedArtifacts(publishedArtifacts, pushResult);
+                        foreach (var artifact in publishedArtifacts)
                         {
-                            result.SkippedDuplicatePackages.AddRange(publishedArtifacts);
-                            _logger.Info($"Skipped duplicate {Path.GetFileName(pkg)} in {FormatDuration(packagePublishWatch.Elapsed)}; package already exists in the feed.");
-                        }
-                        else
-                        {
-                            result.PublishedPackages.AddRange(publishedArtifacts);
-                            _logger.Success($"Published {Path.GetFileName(pkg)} in {FormatDuration(packagePublishWatch.Elapsed)}.");
+                            if (artifactOutcomes[artifact] == PackagePushOutcome.SkippedDuplicate)
+                            {
+                                result.SkippedDuplicatePackages.Add(artifact);
+                                _logger.Info($"Skipped duplicate {Path.GetFileName(artifact)} in {FormatDuration(packagePublishWatch.Elapsed)}; package already exists in the feed.");
+                            }
+                            else
+                            {
+                                result.PublishedPackages.Add(artifact);
+                                _logger.Success($"Published {Path.GetFileName(artifact)} in {FormatDuration(packagePublishWatch.Elapsed)}.");
+                            }
                         }
                     }
                     else

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -542,10 +542,14 @@ public sealed partial class DotNetRepositoryReleaseService
                 result.PublishSource = source;
 
                 var orderedProjects = SortProjectsForPublish(packable);
-                var packages = GetPackagesForPublish(orderedProjects);
+                var publishSymbolsSeparately = spec.IncludeSymbols && IsLocalPublishSource(source);
+                var packages = GetPackagesForPublish(orderedProjects, publishSymbolsSeparately);
 
                 var packageLookup = orderedProjects
-                    .SelectMany(p => p.Packages.Select(pkg => new { Package = pkg, Project = p }))
+                    .SelectMany(p => (publishSymbolsSeparately
+                            ? p.Packages.Concat(p.SymbolPackages)
+                            : p.Packages)
+                        .Select(pkg => new { Package = pkg, Project = p }))
                     .GroupBy(x => x.Package, StringComparer.OrdinalIgnoreCase)
                     .ToDictionary(g => g.Key, g => g.First().Project, StringComparer.OrdinalIgnoreCase);
 
@@ -553,7 +557,10 @@ public sealed partial class DotNetRepositoryReleaseService
                 foreach (var pkg in packages)
                 {
                     packageLookup.TryGetValue(pkg, out var project);
-                    var publishedArtifacts = GetPublishedArtifacts(project, pkg);
+                    var publishedArtifacts = GetPublishedArtifacts(
+                        project,
+                        pkg,
+                        includeCompanionSymbols: !publishSymbolsSeparately);
                     if (spec.WhatIf)
                     {
                         result.PublishedPackages.AddRange(publishedArtifacts);
@@ -562,43 +569,47 @@ public sealed partial class DotNetRepositoryReleaseService
 
                     _logger.Info($"Publishing {Path.GetFileName(pkg)}...");
                     var packagePublishWatch = Stopwatch.StartNew();
-                    var push = PushPackage(
+                    PushPackage(
                         pkg,
                         spec.PublishApiKey!,
                         source,
                         spec.SkipDuplicate,
-                        suppressCompanionSymbols: !spec.IncludeSymbols,
+                        suppressCompanionSymbols: !spec.IncludeSymbols || publishSymbolsSeparately,
                         out var pushResult);
                     packagePublishWatch.Stop();
-                    if (push)
+                    var artifactOutcomes = ClassifyPublishedArtifacts(publishedArtifacts, pushResult);
+                    foreach (var artifact in publishedArtifacts)
                     {
-                        var artifactOutcomes = ClassifyPublishedArtifacts(publishedArtifacts, pushResult);
-                        foreach (var artifact in publishedArtifacts)
+                        switch (artifactOutcomes[artifact])
                         {
-                            if (artifactOutcomes[artifact] == PackagePushOutcome.SkippedDuplicate)
-                            {
+                            case PackagePushOutcome.SkippedDuplicate:
                                 result.SkippedDuplicatePackages.Add(artifact);
                                 _logger.Info($"Skipped duplicate {Path.GetFileName(artifact)} in {FormatDuration(packagePublishWatch.Elapsed)}; package already exists in the feed.");
-                            }
-                            else
-                            {
+                                break;
+                            case PackagePushOutcome.Published:
                                 result.PublishedPackages.Add(artifact);
                                 _logger.Success($"Published {Path.GetFileName(artifact)} in {FormatDuration(packagePublishWatch.Elapsed)}.");
-                            }
+                                break;
+                            default:
+                                result.FailedPackages.Add(artifact);
+                                _logger.Warn($"NuGet push failed for {artifact} after {FormatDuration(packagePublishWatch.Elapsed)}: {pushResult.Message}");
+                                break;
                         }
                     }
-                    else
+
+                    var failedArtifacts = publishedArtifacts
+                        .Where(artifact => artifactOutcomes[artifact] == PackagePushOutcome.Failed)
+                        .ToArray();
+                    if (failedArtifacts.Length > 0)
                     {
                         result.Success = false;
-                        result.FailedPackages.Add(pkg);
                         var error = pushResult.Message;
-                        _logger.Warn($"NuGet push failed for {pkg} after {FormatDuration(packagePublishWatch.Elapsed)}: {error}");
                         if (project is not null && string.IsNullOrWhiteSpace(project.ErrorMessage))
-                            project.ErrorMessage = $"Publish failed for {Path.GetFileName(pkg)}: {error}";
+                            project.ErrorMessage = $"Publish failed for {string.Join(", ", failedArtifacts.Select(Path.GetFileName))}: {error}";
                         if (spec.PublishFailFast)
                         {
                             if (string.IsNullOrWhiteSpace(result.ErrorMessage))
-                                result.ErrorMessage = $"Publish failed for {Path.GetFileName(pkg)}.";
+                                result.ErrorMessage = $"Publish failed for {string.Join(", ", failedArtifacts.Select(Path.GetFileName))}.";
                             return result;
                         }
                     }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -428,18 +428,21 @@ public sealed partial class DotNetRepositoryReleaseService
                     foreach (var pkg in filtered)
                         project.Packages.Add(pkg);
 
-                    var filteredSymbols = FilterPackages(packResult.SymbolPackages, project.PackageId, project.NewVersion!);
-                    foreach (var symbolPackage in filteredSymbols)
-                        project.SymbolPackages.Add(symbolPackage);
-
-                    if (spec.IncludeSymbols && filteredSymbols.Count == 0)
+                    if (spec.IncludeSymbols)
                     {
-                        project.ErrorMessage = $"No symbol package found for version {project.NewVersion}.";
-                        _logger.Warn($"{project.ProjectName}: {project.ErrorMessage}");
-                        result.Success = false;
-                        if (spec.PublishFailFast)
-                            return result;
-                        continue;
+                        var filteredSymbols = FilterPackages(packResult.SymbolPackages, project.PackageId, project.NewVersion!);
+                        foreach (var symbolPackage in filteredSymbols)
+                            project.SymbolPackages.Add(symbolPackage);
+
+                        if (filteredSymbols.Count == 0)
+                        {
+                            project.ErrorMessage = $"No symbol package found for version {project.NewVersion}.";
+                            _logger.Warn($"{project.ProjectName}: {project.ErrorMessage}");
+                            result.Success = false;
+                            if (spec.PublishFailFast)
+                                return result;
+                            continue;
+                        }
                     }
 
                     var ignored = packResult.Packages.Except(filtered, StringComparer.OrdinalIgnoreCase).ToArray();
@@ -452,7 +455,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         var packTiming = batchPackResult is null
                             ? $" in {FormatDuration(packResult.Duration)}"
                             : " from MSBuild batch";
-                        _logger.Success($"{project.ProjectName}: package workflow produced {filtered.Count} package(s) and {filteredSymbols.Count} symbol package(s){packTiming}.");
+                        _logger.Success($"{project.ProjectName}: package workflow produced {filtered.Count} package(s) and {project.SymbolPackages.Count} symbol package(s){packTiming}.");
                     }
 
                     if (spec.CreateReleaseZip && !string.IsNullOrWhiteSpace(project.NewVersion))
@@ -486,7 +489,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 {
                     var packagesToSign = packable
                         .Where(project => string.IsNullOrWhiteSpace(project.ErrorMessage))
-                        .SelectMany(project => project.Packages)
+                        .SelectMany(project => project.Packages.Concat(project.SymbolPackages))
                         .Where(package => !string.IsNullOrWhiteSpace(package))
                         .Distinct(StringComparer.OrdinalIgnoreCase)
                         .ToArray();
@@ -540,16 +543,18 @@ public sealed partial class DotNetRepositoryReleaseService
                 var packages = GetPackagesForPublish(orderedProjects);
 
                 var packageLookup = orderedProjects
-                    .SelectMany(p => p.Packages.Concat(p.SymbolPackages).Select(pkg => new { Package = pkg, Project = p }))
+                    .SelectMany(p => p.Packages.Select(pkg => new { Package = pkg, Project = p }))
                     .GroupBy(x => x.Package, StringComparer.OrdinalIgnoreCase)
                     .ToDictionary(g => g.Key, g => g.First().Project, StringComparer.OrdinalIgnoreCase);
 
                 var publishWatch = Stopwatch.StartNew();
                 foreach (var pkg in packages)
                 {
+                    packageLookup.TryGetValue(pkg, out var project);
+                    var publishedArtifacts = GetPublishedArtifacts(project, pkg);
                     if (spec.WhatIf)
                     {
-                        result.PublishedPackages.Add(pkg);
+                        result.PublishedPackages.AddRange(publishedArtifacts);
                         continue;
                     }
 
@@ -561,12 +566,12 @@ public sealed partial class DotNetRepositoryReleaseService
                     {
                         if (pushResult.Outcome == PackagePushOutcome.SkippedDuplicate)
                         {
-                            result.SkippedDuplicatePackages.Add(pkg);
+                            result.SkippedDuplicatePackages.AddRange(publishedArtifacts);
                             _logger.Info($"Skipped duplicate {Path.GetFileName(pkg)} in {FormatDuration(packagePublishWatch.Elapsed)}; package already exists in the feed.");
                         }
                         else
                         {
-                            result.PublishedPackages.Add(pkg);
+                            result.PublishedPackages.AddRange(publishedArtifacts);
                             _logger.Success($"Published {Path.GetFileName(pkg)} in {FormatDuration(packagePublishWatch.Elapsed)}.");
                         }
                     }
@@ -576,7 +581,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         result.FailedPackages.Add(pkg);
                         var error = pushResult.Message;
                         _logger.Warn($"NuGet push failed for {pkg} after {FormatDuration(packagePublishWatch.Elapsed)}: {error}");
-                        if (packageLookup.TryGetValue(pkg, out var project) && string.IsNullOrWhiteSpace(project.ErrorMessage))
+                        if (project is not null && string.IsNullOrWhiteSpace(project.ErrorMessage))
                             project.ErrorMessage = $"Publish failed for {Path.GetFileName(pkg)}: {error}";
                         if (spec.PublishFailFast)
                         {
@@ -639,7 +644,7 @@ public sealed partial class DotNetRepositoryReleaseService
             if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
                 continue;
 
-            if (project.Packages.Any(package => failedPackages.Contains(package)))
+            if (project.Packages.Concat(project.SymbolPackages).Any(package => failedPackages.Contains(package)))
                 project.ErrorMessage = message;
         }
     }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -362,7 +362,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         }
                         else
                         {
-                            _logger.Success($"MSBuild batch pack produced {batchPackResult.Packages.Count} package(s) in {FormatDuration(batchPackResult.Duration)}.");
+                            _logger.Success($"MSBuild batch pack produced {batchPackResult.Packages.Count} package(s) and {batchPackResult.SymbolPackages.Count} symbol package(s) in {FormatDuration(batchPackResult.Duration)}.");
                         }
                     }
                 }
@@ -388,6 +388,12 @@ public sealed partial class DotNetRepositoryReleaseService
                         var planned = ResolvePackagePath(spec, project, project.NewVersion!);
                         if (!string.IsNullOrWhiteSpace(planned))
                             project.Packages.Add(planned!);
+                        if (spec.IncludeSymbols)
+                        {
+                            var plannedSymbols = ResolveSymbolPackagePath(spec, project, project.NewVersion!);
+                            if (!string.IsNullOrWhiteSpace(plannedSymbols))
+                                project.SymbolPackages.Add(plannedSymbols!);
+                        }
                         continue;
                     }
 
@@ -422,6 +428,20 @@ public sealed partial class DotNetRepositoryReleaseService
                     foreach (var pkg in filtered)
                         project.Packages.Add(pkg);
 
+                    var filteredSymbols = FilterPackages(packResult.SymbolPackages, project.PackageId, project.NewVersion!);
+                    foreach (var symbolPackage in filteredSymbols)
+                        project.SymbolPackages.Add(symbolPackage);
+
+                    if (spec.IncludeSymbols && filteredSymbols.Count == 0)
+                    {
+                        project.ErrorMessage = $"No symbol package found for version {project.NewVersion}.";
+                        _logger.Warn($"{project.ProjectName}: {project.ErrorMessage}");
+                        result.Success = false;
+                        if (spec.PublishFailFast)
+                            return result;
+                        continue;
+                    }
+
                     var ignored = packResult.Packages.Except(filtered, StringComparer.OrdinalIgnoreCase).ToArray();
                     // In batch mode, ignored packages are normally packages for other batched projects.
                     if (ignored.Length > 0 && batchPackResult is null)
@@ -432,7 +452,7 @@ public sealed partial class DotNetRepositoryReleaseService
                         var packTiming = batchPackResult is null
                             ? $" in {FormatDuration(packResult.Duration)}"
                             : " from MSBuild batch";
-                        _logger.Success($"{project.ProjectName}: package workflow produced {filtered.Count} package(s){packTiming}.");
+                        _logger.Success($"{project.ProjectName}: package workflow produced {filtered.Count} package(s) and {filteredSymbols.Count} symbol package(s){packTiming}.");
                     }
 
                     if (spec.CreateReleaseZip && !string.IsNullOrWhiteSpace(project.NewVersion))
@@ -517,13 +537,10 @@ public sealed partial class DotNetRepositoryReleaseService
                 result.PublishSource = source;
 
                 var orderedProjects = SortProjectsForPublish(packable);
-                var packages = orderedProjects.SelectMany(p => p.Packages)
-                    .Where(p => !string.IsNullOrWhiteSpace(p))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToArray();
+                var packages = GetPackagesForPublish(orderedProjects);
 
                 var packageLookup = orderedProjects
-                    .SelectMany(p => p.Packages.Select(pkg => new { Package = pkg, Project = p }))
+                    .SelectMany(p => p.Packages.Concat(p.SymbolPackages).Select(pkg => new { Package = pkg, Project = p }))
                     .GroupBy(x => x.Package, StringComparer.OrdinalIgnoreCase)
                     .ToDictionary(g => g.Key, g => g.First().Project, StringComparer.OrdinalIgnoreCase);
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.NuGetSources.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.NuGetSources.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Configuration;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private static bool TryResolveNamedLocalPublishSource(
+        string sourceName,
+        string searchRoot,
+        out string resolvedSource)
+    {
+        resolvedSource = string.Empty;
+        if (string.IsNullOrWhiteSpace(sourceName) || string.IsNullOrWhiteSpace(searchRoot))
+            return false;
+
+        try
+        {
+            var settingsRoot = Path.GetFullPath(searchRoot);
+            if (!Directory.Exists(settingsRoot))
+                settingsRoot = Path.GetDirectoryName(settingsRoot) ?? settingsRoot;
+
+            var settings = Settings.LoadDefaultSettings(settingsRoot);
+            var configuredSource = new PackageSourceProvider(settings)
+                .LoadPackageSources()
+                .FirstOrDefault(source => string.Equals(
+                    source.Name,
+                    sourceName,
+                    StringComparison.OrdinalIgnoreCase))
+                ?.Source;
+            if (string.IsNullOrWhiteSpace(configuredSource))
+                return false;
+            var configuredSourceValue = configuredSource!;
+
+            if (Uri.TryCreate(configuredSourceValue, UriKind.Absolute, out var configuredUri))
+            {
+                if (!configuredUri.IsFile)
+                    return false;
+
+                resolvedSource = Path.GetFullPath(configuredUri.LocalPath);
+                return true;
+            }
+
+            var normalized = PathValueResolver.NormalizeSeparators(configuredSourceValue);
+            resolvedSource = Path.IsPathRooted(normalized)
+                ? Path.GetFullPath(normalized)
+                : PathValueResolver.Resolve(settingsRoot, normalized);
+            return true;
+        }
+        catch
+        {
+            // dotnet nuget push reports malformed or inaccessible configuration itself.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Finds the primary package paired with a symbol package in an attempted publish set.
+    /// </summary>
+    internal static string? FindPrimaryPackageForSymbol(
+        string packagePath,
+        IEnumerable<string> packageCandidates)
+    {
+        if (string.IsNullOrWhiteSpace(packagePath) ||
+            !packagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var packageName = Path.GetFileNameWithoutExtension(packagePath);
+        return packageCandidates.FirstOrDefault(candidate =>
+            candidate.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(
+                Path.GetFileNameWithoutExtension(candidate),
+                packageName,
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Determines whether a symbol package may be published after its matching primary package.
+    /// </summary>
+    internal static bool CanPublishSymbolPackage(
+        string packagePath,
+        IEnumerable<string> packageCandidates,
+        Func<string, bool> primarySucceeded,
+        out string? primaryPackagePath)
+    {
+        if (!packagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
+        {
+            primaryPackagePath = null;
+            return true;
+        }
+
+        primaryPackagePath = FindPrimaryPackageForSymbol(packagePath, packageCandidates);
+        return primaryPackagePath is not null && primarySucceeded(primaryPackagePath);
+    }
+
+    /// <summary>
+    /// Creates the failure used when a companion symbol cannot follow its primary package.
+    /// </summary>
+    internal static PackagePushResult CreateBlockedCompanionResult(string packagePath, string? primaryPackagePath)
+        => new()
+        {
+            Outcome = PackagePushOutcome.Failed,
+            Message = string.IsNullOrWhiteSpace(primaryPackagePath)
+                ? $"Symbol package '{Path.GetFileName(packagePath)}' has no matching primary package in the publish set."
+                : $"Symbol package '{Path.GetFileName(packagePath)}' was not published because primary package '{Path.GetFileName(primaryPackagePath)}' did not publish successfully."
+        };
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -53,9 +53,28 @@ public sealed partial class DotNetRepositoryReleaseService
     internal static string[] GetPackagesForPublish(IEnumerable<DotNetRepositoryProjectResult> projects)
         => projects
             .Where(static project => project is not null)
-            .SelectMany(static project => project.Packages.Concat(project.SymbolPackages))
+            .SelectMany(static project => project.Packages)
             .Where(static package => !string.IsNullOrWhiteSpace(package))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+
+    internal static string[] GetPublishedArtifacts(
+        DotNetRepositoryProjectResult? project,
+        string package)
+    {
+        if (project is null || string.IsNullOrWhiteSpace(package))
+            return string.IsNullOrWhiteSpace(package) ? Array.Empty<string>() : new[] { package };
+
+        var packageName = Path.GetFileNameWithoutExtension(package);
+        return new[] { package }
+            .Concat(project.SymbolPackages.Where(symbolPackage =>
+                string.Equals(
+                    Path.GetFileNameWithoutExtension(symbolPackage),
+                    packageName,
+                    StringComparison.OrdinalIgnoreCase)))
+            .Where(static artifact => !string.IsNullOrWhiteSpace(artifact))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
 
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -109,12 +109,17 @@ public sealed partial class DotNetRepositoryReleaseService
             return source;
 
         var trimmed = source.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var absoluteUri))
+        {
+            if (!absoluteUri.IsFile)
+                return trimmed;
+
+            return Path.GetFullPath(absoluteUri.LocalPath);
+        }
+
         var normalized = PathValueResolver.NormalizeSeparators(trimmed);
         if (Path.IsPathRooted(normalized))
             return Path.GetFullPath(normalized);
-
-        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var absoluteUri) && !absoluteUri.IsFile)
-            return trimmed;
 
         var localCandidate = Path.Combine(repositoryRoot, normalized);
         if (normalized.IndexOf(Path.DirectorySeparatorChar) >= 0 ||

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -77,4 +77,28 @@ public sealed partial class DotNetRepositoryReleaseService
             .ToArray();
     }
 
+    internal static string ResolvePublishSource(string source, string repositoryRoot)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return source;
+
+        var trimmed = source.Trim();
+        if (Path.IsPathRooted(trimmed))
+            return Path.GetFullPath(trimmed);
+
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var absoluteUri) && !absoluteUri.IsFile)
+            return trimmed;
+
+        var localCandidate = Path.Combine(repositoryRoot, trimmed);
+        if (trimmed.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+            trimmed.IndexOf(Path.AltDirectorySeparatorChar) >= 0 ||
+            trimmed.StartsWith(".", StringComparison.Ordinal) ||
+            Directory.Exists(localCandidate))
+        {
+            return Path.GetFullPath(localCandidate);
+        }
+
+        return trimmed;
+    }
+
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -50,20 +50,31 @@ public sealed partial class DotNetRepositoryReleaseService
         return list;
     }
 
-    internal static string[] GetPackagesForPublish(IEnumerable<DotNetRepositoryProjectResult> projects)
+    internal static string[] GetPackagesForPublish(
+        IEnumerable<DotNetRepositoryProjectResult> projects,
+        bool includeSymbolPackages = false)
         => projects
             .Where(static project => project is not null)
-            .SelectMany(static project => project.Packages)
+            .SelectMany(project => includeSymbolPackages
+                ? project.Packages.Concat(project.SymbolPackages)
+                : project.Packages)
             .Where(static package => !string.IsNullOrWhiteSpace(package))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
     internal static string[] GetPublishedArtifacts(
         DotNetRepositoryProjectResult? project,
-        string package)
+        string package,
+        bool includeCompanionSymbols = true)
     {
         if (project is null || string.IsNullOrWhiteSpace(package))
             return string.IsNullOrWhiteSpace(package) ? Array.Empty<string>() : new[] { package };
+
+        if (!includeCompanionSymbols ||
+            package.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
+        {
+            return new[] { package };
+        }
 
         var packageName = Path.GetFileNameWithoutExtension(package);
         return new[] { package }
@@ -75,6 +86,21 @@ public sealed partial class DotNetRepositoryReleaseService
             .Where(static artifact => !string.IsNullOrWhiteSpace(artifact))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    /// <summary>
+    /// Determines whether a resolved NuGet publish source is a filesystem feed rather than a named or HTTP source.
+    /// </summary>
+    internal static bool IsLocalPublishSource(string source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return false;
+
+        var trimmed = source.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+            return uri.IsFile;
+
+        return Path.IsPathRooted(PathValueResolver.NormalizeSeparators(trimmed));
     }
 
     internal static string ResolvePublishSource(string source, string repositoryRoot)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -50,4 +50,12 @@ public sealed partial class DotNetRepositoryReleaseService
         return list;
     }
 
+    internal static string[] GetPackagesForPublish(IEnumerable<DotNetRepositoryProjectResult> projects)
+        => projects
+            .Where(static project => project is not null)
+            .SelectMany(static project => project.Packages.Concat(project.SymbolPackages))
+            .Where(static package => !string.IsNullOrWhiteSpace(package))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -121,10 +121,9 @@ public sealed partial class DotNetRepositoryReleaseService
         if (Path.IsPathRooted(normalized))
             return Path.GetFullPath(normalized);
 
-        var localCandidate = Path.Combine(repositoryRoot, normalized);
+        // Bare values can be NuGet.config source keys, so only explicit path syntax is rooted here.
         if (normalized.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
-            normalized.StartsWith(".", StringComparison.Ordinal) ||
-            Directory.Exists(localCandidate))
+            normalized.StartsWith(".", StringComparison.Ordinal))
         {
             return PathValueResolver.Resolve(repositoryRoot, normalized);
         }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -103,7 +103,17 @@ public sealed partial class DotNetRepositoryReleaseService
         return Path.IsPathRooted(PathValueResolver.NormalizeSeparators(trimmed));
     }
 
-    internal static string ResolvePublishSource(string source, string repositoryRoot)
+    /// <summary>
+    /// Resolves explicit filesystem sources and named local sources while preserving named remote sources.
+    /// </summary>
+    /// <param name="source">Configured source URL, path, or NuGet.config key.</param>
+    /// <param name="repositoryRoot">Repository root used for explicit relative paths.</param>
+    /// <param name="nuGetConfigSearchRoot">Optional directory whose NuGet.config hierarchy should resolve named sources.</param>
+    /// <returns>A normalized local path, or the original URL/source key.</returns>
+    internal static string ResolvePublishSource(
+        string source,
+        string repositoryRoot,
+        string? nuGetConfigSearchRoot = null)
     {
         if (string.IsNullOrWhiteSpace(source))
             return source;
@@ -128,7 +138,12 @@ public sealed partial class DotNetRepositoryReleaseService
             return PathValueResolver.Resolve(repositoryRoot, normalized);
         }
 
-        return trimmed;
+        return TryResolveNamedLocalPublishSource(
+            trimmed,
+            string.IsNullOrWhiteSpace(nuGetConfigSearchRoot) ? repositoryRoot : nuGetConfigSearchRoot!,
+            out var namedLocalSource)
+            ? namedLocalSource
+            : trimmed;
     }
 
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PathsAndFilters.cs
@@ -83,19 +83,19 @@ public sealed partial class DotNetRepositoryReleaseService
             return source;
 
         var trimmed = source.Trim();
-        if (Path.IsPathRooted(trimmed))
-            return Path.GetFullPath(trimmed);
+        var normalized = PathValueResolver.NormalizeSeparators(trimmed);
+        if (Path.IsPathRooted(normalized))
+            return Path.GetFullPath(normalized);
 
         if (Uri.TryCreate(trimmed, UriKind.Absolute, out var absoluteUri) && !absoluteUri.IsFile)
             return trimmed;
 
-        var localCandidate = Path.Combine(repositoryRoot, trimmed);
-        if (trimmed.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
-            trimmed.IndexOf(Path.AltDirectorySeparatorChar) >= 0 ||
-            trimmed.StartsWith(".", StringComparison.Ordinal) ||
+        var localCandidate = Path.Combine(repositoryRoot, normalized);
+        if (normalized.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+            normalized.StartsWith(".", StringComparison.Ordinal) ||
             Directory.Exists(localCandidate))
         {
-            return Path.GetFullPath(localCandidate);
+            return PathValueResolver.Resolve(repositoryRoot, normalized);
         }
 
         return trimmed;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -216,9 +216,17 @@ public sealed partial class DotNetRepositoryReleaseService
         };
     }
 
+    /// <summary>
+    /// Classifies each artifact mentioned by a combined primary and symbol package push transcript.
+    /// </summary>
+    /// <param name="artifacts">Primary and companion artifacts attempted by the push.</param>
+    /// <param name="pushResult">Overall process outcome and transcript.</param>
+    /// <param name="skipDuplicate">Whether duplicate conflicts are permitted to become skipped outcomes.</param>
+    /// <returns>The outcome for each artifact.</returns>
     internal static IReadOnlyDictionary<string, PackagePushOutcome> ClassifyPublishedArtifacts(
         IReadOnlyList<string> artifacts,
-        PackagePushResult pushResult)
+        PackagePushResult pushResult,
+        bool skipDuplicate)
     {
         var outcomes = artifacts.ToDictionary(
             artifact => artifact,
@@ -244,7 +252,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 }
             }
 
-            if (currentArtifact is not null && LooksLikeSkippedDuplicate(line))
+            if (skipDuplicate && currentArtifact is not null && LooksLikeSkippedDuplicate(line))
                 outcomes[currentArtifact] = PackagePushOutcome.SkippedDuplicate;
             else if (currentArtifact is not null && LooksLikePublished(line))
                 outcomes[currentArtifact] = PackagePushOutcome.Published;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -253,41 +253,32 @@ public sealed partial class DotNetRepositoryReleaseService
         return outcomes;
     }
 
-    private static bool PushPackage(
+    internal static PackagePushResult PushPackage(
         string packagePath,
         string apiKey,
         string source,
         bool skipDuplicate,
-        bool suppressCompanionSymbols,
-        out PackagePushResult result)
+        bool suppressCompanionSymbols)
     {
         if (IsLocalPublishSource(source) &&
             packagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
         {
-            return CopySymbolPackageToLocalFeed(packagePath, source, skipDuplicate, out result);
+            CopySymbolPackageToLocalFeed(packagePath, source, skipDuplicate, out var localResult);
+            return localResult;
         }
 
-        result = new PackagePushResult();
-        var psi = CreateNuGetPushStartInfo(packagePath, apiKey, source, skipDuplicate, suppressCompanionSymbols);
-
-        using var p = Process.Start(psi);
-        if (p is null)
-        {
-            result = new PackagePushResult
-            {
-                Outcome = PackagePushOutcome.Failed,
-                Message = "Failed to start dotnet."
-            };
-            return false;
-        }
-        // Start both stream reads before waiting to avoid pipe-buffer deadlocks.
-        var stdoutTask = p.StandardOutput.ReadToEndAsync();
-        var stderrTask = p.StandardError.ReadToEndAsync();
-        p.WaitForExit();
-        var stdOut = stdoutTask.GetAwaiter().GetResult();
-        var stdErr = stderrTask.GetAwaiter().GetResult();
-        result = ClassifyNuGetPushOutcome(p.ExitCode, skipDuplicate, stdErr, stdOut);
-        return result.Outcome != PackagePushOutcome.Failed;
+        var push = new DotNetNuGetClient()
+            .PushPackageAsync(new DotNetNuGetPushRequest(
+                packagePath,
+                apiKey,
+                source,
+                skipDuplicate,
+                workingDirectory: null,
+                timeout: null,
+                suppressCompanionSymbols: suppressCompanionSymbols))
+            .GetAwaiter()
+            .GetResult();
+        return ClassifyNuGetPushOutcome(push.ExitCode, skipDuplicate, push.StdErr, push.StdOut);
     }
 
     /// <summary>
@@ -353,49 +344,6 @@ public sealed partial class DotNetRepositoryReleaseService
             };
             return false;
         }
-    }
-
-    internal static ProcessStartInfo CreateNuGetPushStartInfo(
-        string packagePath,
-        string apiKey,
-        string source,
-        bool skipDuplicate,
-        bool suppressCompanionSymbols = false)
-    {
-        var packageDirectory = Path.GetDirectoryName(Path.GetFullPath(packagePath));
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            WorkingDirectory = string.IsNullOrWhiteSpace(packageDirectory) ? Environment.CurrentDirectory : packageDirectory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-        ProcessStartInfoEncoding.TryApplyUtf8(psi);
-
-#if NET472
-        var args = new List<string>
-        {
-            "nuget", "push", packagePath,
-            "--api-key", apiKey,
-            "--source", source
-        };
-        if (skipDuplicate) args.Add("--skip-duplicate");
-        if (suppressCompanionSymbols) args.Add("--no-symbols");
-        psi.Arguments = BuildWindowsArgumentString(args);
-#else
-        psi.ArgumentList.Add("nuget");
-        psi.ArgumentList.Add("push");
-        psi.ArgumentList.Add(packagePath);
-        psi.ArgumentList.Add("--api-key");
-        psi.ArgumentList.Add(apiKey);
-        psi.ArgumentList.Add("--source");
-        psi.ArgumentList.Add(source);
-        if (skipDuplicate) psi.ArgumentList.Add("--skip-duplicate");
-        if (suppressCompanionSymbols) psi.ArgumentList.Add("--no-symbols");
-#endif
-        return psi;
     }
 
     private static void LogProcessOutput(ILogger logger, string projectName, string operation, string stdOut, string stdErr)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -219,10 +219,39 @@ public sealed partial class DotNetRepositoryReleaseService
     private static bool PushPackage(string packagePath, string apiKey, string source, bool skipDuplicate, out PackagePushResult result)
     {
         result = new PackagePushResult();
+        var psi = CreateNuGetPushStartInfo(packagePath, apiKey, source, skipDuplicate);
 
+        using var p = Process.Start(psi);
+        if (p is null)
+        {
+            result = new PackagePushResult
+            {
+                Outcome = PackagePushOutcome.Failed,
+                Message = "Failed to start dotnet."
+            };
+            return false;
+        }
+        // Start both stream reads before waiting to avoid pipe-buffer deadlocks.
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        p.WaitForExit();
+        var stdOut = stdoutTask.GetAwaiter().GetResult();
+        var stdErr = stderrTask.GetAwaiter().GetResult();
+        result = ClassifyNuGetPushOutcome(p.ExitCode, skipDuplicate, stdErr, stdOut);
+        return result.Outcome != PackagePushOutcome.Failed;
+    }
+
+    internal static ProcessStartInfo CreateNuGetPushStartInfo(
+        string packagePath,
+        string apiKey,
+        string source,
+        bool skipDuplicate)
+    {
+        var packageDirectory = Path.GetDirectoryName(Path.GetFullPath(packagePath));
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
+            WorkingDirectory = string.IsNullOrWhiteSpace(packageDirectory) ? Environment.CurrentDirectory : packageDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -249,25 +278,7 @@ public sealed partial class DotNetRepositoryReleaseService
         psi.ArgumentList.Add(source);
         if (skipDuplicate) psi.ArgumentList.Add("--skip-duplicate");
 #endif
-
-        using var p = Process.Start(psi);
-        if (p is null)
-        {
-            result = new PackagePushResult
-            {
-                Outcome = PackagePushOutcome.Failed,
-                Message = "Failed to start dotnet."
-            };
-            return false;
-        }
-        // Start both stream reads before waiting to avoid pipe-buffer deadlocks.
-        var stdoutTask = p.StandardOutput.ReadToEndAsync();
-        var stderrTask = p.StandardError.ReadToEndAsync();
-        p.WaitForExit();
-        var stdOut = stdoutTask.GetAwaiter().GetResult();
-        var stdErr = stderrTask.GetAwaiter().GetResult();
-        result = ClassifyNuGetPushOutcome(p.ExitCode, skipDuplicate, stdErr, stdOut);
-        return result.Outcome != PackagePushOutcome.Failed;
+        return psi;
     }
 
     private static void LogProcessOutput(ILogger logger, string projectName, string operation, string stdOut, string stdErr)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -220,15 +220,13 @@ public sealed partial class DotNetRepositoryReleaseService
         IReadOnlyList<string> artifacts,
         PackagePushResult pushResult)
     {
-        var outcomes = new Dictionary<string, PackagePushOutcome>(StringComparer.OrdinalIgnoreCase);
-        if (pushResult.Outcome != PackagePushOutcome.SkippedDuplicate)
-        {
-            foreach (var artifact in artifacts)
-                outcomes[artifact] = pushResult.Outcome;
+        var outcomes = artifacts.ToDictionary(
+            artifact => artifact,
+            _ => pushResult.Outcome,
+            StringComparer.OrdinalIgnoreCase);
+        if (pushResult.Outcome == PackagePushOutcome.Published || artifacts.Count <= 1)
             return outcomes;
-        }
 
-        var skippedArtifacts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         string? currentArtifact = null;
         var lines = (pushResult.Message ?? string.Empty)
             .Replace("\r\n", "\n")
@@ -247,21 +245,9 @@ public sealed partial class DotNetRepositoryReleaseService
             }
 
             if (currentArtifact is not null && LooksLikeSkippedDuplicate(line))
-                skippedArtifacts.Add(currentArtifact);
-        }
-
-        if (skippedArtifacts.Count == 0)
-        {
-            foreach (var artifact in artifacts)
-                outcomes[artifact] = PackagePushOutcome.SkippedDuplicate;
-            return outcomes;
-        }
-
-        foreach (var artifact in artifacts)
-        {
-            outcomes[artifact] = skippedArtifacts.Contains(artifact)
-                ? PackagePushOutcome.SkippedDuplicate
-                : PackagePushOutcome.Published;
+                outcomes[currentArtifact] = PackagePushOutcome.SkippedDuplicate;
+            else if (currentArtifact is not null && LooksLikePublished(line))
+                outcomes[currentArtifact] = PackagePushOutcome.Published;
         }
 
         return outcomes;
@@ -275,6 +261,12 @@ public sealed partial class DotNetRepositoryReleaseService
         bool suppressCompanionSymbols,
         out PackagePushResult result)
     {
+        if (IsLocalPublishSource(source) &&
+            packagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
+        {
+            return CopySymbolPackageToLocalFeed(packagePath, source, skipDuplicate, out result);
+        }
+
         result = new PackagePushResult();
         var psi = CreateNuGetPushStartInfo(packagePath, apiKey, source, skipDuplicate, suppressCompanionSymbols);
 
@@ -296,6 +288,71 @@ public sealed partial class DotNetRepositoryReleaseService
         var stdErr = stderrTask.GetAwaiter().GetResult();
         result = ClassifyNuGetPushOutcome(p.ExitCode, skipDuplicate, stdErr, stdOut);
         return result.Outcome != PackagePushOutcome.Failed;
+    }
+
+    /// <summary>
+    /// Copies a symbol package beside its primary package because dotnet nuget push can exit successfully
+    /// without copying a directly supplied .snupkg to a local or UNC source.
+    /// </summary>
+    private static bool CopySymbolPackageToLocalFeed(
+        string packagePath,
+        string source,
+        bool skipDuplicate,
+        out PackagePushResult result)
+    {
+        try
+        {
+            var localFeed = Uri.TryCreate(source, UriKind.Absolute, out var uri) && uri.IsFile
+                ? uri.LocalPath
+                : source;
+            localFeed = Path.GetFullPath(localFeed);
+            if (!Directory.Exists(localFeed))
+                throw new DirectoryNotFoundException($"Local NuGet feed not found: {localFeed}");
+
+            var symbolFileName = Path.GetFileName(packagePath);
+            var primaryFileName = Path.GetFileNameWithoutExtension(packagePath) + ".nupkg";
+            var primaryPath = Directory
+                .EnumerateFiles(localFeed, primaryFileName, SearchOption.AllDirectories)
+                .OrderBy(path => string.Equals(
+                    Path.GetDirectoryName(path),
+                    localFeed,
+                    StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .FirstOrDefault();
+            var destinationDirectory = primaryPath is null
+                ? localFeed
+                : Path.GetDirectoryName(primaryPath) ?? localFeed;
+            var destinationPath = Path.Combine(destinationDirectory, symbolFileName);
+
+            if (File.Exists(destinationPath))
+            {
+                if (!skipDuplicate)
+                    throw new IOException($"Symbol package already exists in the local feed: {destinationPath}");
+
+                result = new PackagePushResult
+                {
+                    Outcome = PackagePushOutcome.SkippedDuplicate,
+                    Message = $"Symbol package already exists in the local feed: {destinationPath}"
+                };
+                return true;
+            }
+
+            File.Copy(packagePath, destinationPath, overwrite: false);
+            result = new PackagePushResult
+            {
+                Outcome = PackagePushOutcome.Published,
+                Message = $"Copied symbol package to local feed: {destinationPath}"
+            };
+            return true;
+        }
+        catch (Exception ex)
+        {
+            result = new PackagePushResult
+            {
+                Outcome = PackagePushOutcome.Failed,
+                Message = ex.Message
+            };
+            return false;
+        }
     }
 
     internal static ProcessStartInfo CreateNuGetPushStartInfo(
@@ -501,8 +558,17 @@ public sealed partial class DotNetRepositoryReleaseService
 
         return text.IndexOf("already exists", StringComparison.OrdinalIgnoreCase) >= 0 ||
                text.IndexOf("409 (Conflict)", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               text.IndexOf("cannot be modified", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               text.IndexOf("skip duplicate", StringComparison.OrdinalIgnoreCase) >= 0;
+               text.IndexOf("cannot be modified", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static bool LooksLikePublished(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        return text.IndexOf("package was pushed", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("successfully pushed", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("successfully published", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     internal enum PackagePushOutcome

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -216,10 +216,67 @@ public sealed partial class DotNetRepositoryReleaseService
         };
     }
 
-    private static bool PushPackage(string packagePath, string apiKey, string source, bool skipDuplicate, out PackagePushResult result)
+    internal static IReadOnlyDictionary<string, PackagePushOutcome> ClassifyPublishedArtifacts(
+        IReadOnlyList<string> artifacts,
+        PackagePushResult pushResult)
+    {
+        var outcomes = new Dictionary<string, PackagePushOutcome>(StringComparer.OrdinalIgnoreCase);
+        if (pushResult.Outcome != PackagePushOutcome.SkippedDuplicate)
+        {
+            foreach (var artifact in artifacts)
+                outcomes[artifact] = pushResult.Outcome;
+            return outcomes;
+        }
+
+        var skippedArtifacts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string? currentArtifact = null;
+        var lines = (pushResult.Message ?? string.Empty)
+            .Replace("\r\n", "\n")
+            .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var line in lines)
+        {
+            foreach (var artifact in artifacts)
+            {
+                var fileName = Path.GetFileName(artifact);
+                if (!string.IsNullOrWhiteSpace(fileName) &&
+                    line.IndexOf(fileName, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    currentArtifact = artifact;
+                    break;
+                }
+            }
+
+            if (currentArtifact is not null && LooksLikeSkippedDuplicate(line))
+                skippedArtifacts.Add(currentArtifact);
+        }
+
+        if (skippedArtifacts.Count == 0)
+        {
+            foreach (var artifact in artifacts)
+                outcomes[artifact] = PackagePushOutcome.SkippedDuplicate;
+            return outcomes;
+        }
+
+        foreach (var artifact in artifacts)
+        {
+            outcomes[artifact] = skippedArtifacts.Contains(artifact)
+                ? PackagePushOutcome.SkippedDuplicate
+                : PackagePushOutcome.Published;
+        }
+
+        return outcomes;
+    }
+
+    private static bool PushPackage(
+        string packagePath,
+        string apiKey,
+        string source,
+        bool skipDuplicate,
+        bool suppressCompanionSymbols,
+        out PackagePushResult result)
     {
         result = new PackagePushResult();
-        var psi = CreateNuGetPushStartInfo(packagePath, apiKey, source, skipDuplicate);
+        var psi = CreateNuGetPushStartInfo(packagePath, apiKey, source, skipDuplicate, suppressCompanionSymbols);
 
         using var p = Process.Start(psi);
         if (p is null)
@@ -245,7 +302,8 @@ public sealed partial class DotNetRepositoryReleaseService
         string packagePath,
         string apiKey,
         string source,
-        bool skipDuplicate)
+        bool skipDuplicate,
+        bool suppressCompanionSymbols = false)
     {
         var packageDirectory = Path.GetDirectoryName(Path.GetFullPath(packagePath));
         var psi = new ProcessStartInfo
@@ -267,6 +325,7 @@ public sealed partial class DotNetRepositoryReleaseService
             "--source", source
         };
         if (skipDuplicate) args.Add("--skip-duplicate");
+        if (suppressCompanionSymbols) args.Add("--no-symbols");
         psi.Arguments = BuildWindowsArgumentString(args);
 #else
         psi.ArgumentList.Add("nuget");
@@ -277,6 +336,7 @@ public sealed partial class DotNetRepositoryReleaseService
         psi.ArgumentList.Add("--source");
         psi.ArgumentList.Add(source);
         if (skipDuplicate) psi.ArgumentList.Add("--skip-duplicate");
+        if (suppressCompanionSymbols) psi.ArgumentList.Add("--no-symbols");
 #endif
         return psi;
     }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -266,27 +266,38 @@ public sealed partial class DotNetRepositoryReleaseService
         string apiKey,
         string source,
         bool skipDuplicate,
-        bool suppressCompanionSymbols)
+        bool suppressCompanionSymbols,
+        string? workingDirectory = null)
+        => PushPackage(new DotNetNuGetPushRequest(
+            packagePath,
+            apiKey,
+            source,
+            skipDuplicate,
+            workingDirectory,
+            timeout: null,
+            suppressCompanionSymbols));
+
+    internal static PackagePushResult PushPackage(DotNetNuGetPushRequest request)
     {
-        if (IsLocalPublishSource(source) &&
-            packagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        if (IsLocalPublishSource(request.Source) &&
+            request.PackagePath.EndsWith(".snupkg", StringComparison.OrdinalIgnoreCase))
         {
-            CopySymbolPackageToLocalFeed(packagePath, source, skipDuplicate, out var localResult);
+            CopySymbolPackageToLocalFeed(
+                request.PackagePath,
+                request.Source,
+                request.SkipDuplicate,
+                out var localResult);
             return localResult;
         }
 
         var push = new DotNetNuGetClient()
-            .PushPackageAsync(new DotNetNuGetPushRequest(
-                packagePath,
-                apiKey,
-                source,
-                skipDuplicate,
-                workingDirectory: null,
-                timeout: null,
-                suppressCompanionSymbols: suppressCompanionSymbols))
+            .PushPackageAsync(request)
             .GetAwaiter()
             .GetResult();
-        return ClassifyNuGetPushOutcome(push.ExitCode, skipDuplicate, push.StdErr, push.StdOut);
+        return ClassifyNuGetPushOutcome(push.ExitCode, request.SkipDuplicate, push.StdErr, push.StdOut);
     }
 
     /// <summary>

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ProcessAndPublishing.cs
@@ -1,0 +1,449 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private static int RunDotnetMsBuildTarget(
+        string traversalProject,
+        string workingDirectory,
+        string targetName,
+        string heartbeatOperation,
+        string logOperation,
+        int projectCount,
+        ILogger logger,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        stdErr = string.Empty;
+        stdOut = string.Empty;
+        duration = TimeSpan.Zero;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+#if NET472
+        psi.Arguments = BuildWindowsArgumentString(new[]
+        {
+            "msbuild",
+            traversalProject,
+            $"/t:{targetName}",
+            "/m",
+            "/nr:false",
+            logger.IsVerbose ? "/v:n" : "/v:m"
+        });
+#else
+        psi.ArgumentList.Add("msbuild");
+        psi.ArgumentList.Add(traversalProject);
+        psi.ArgumentList.Add($"/t:{targetName}");
+        psi.ArgumentList.Add("/m");
+        psi.ArgumentList.Add("/nr:false");
+        psi.ArgumentList.Add(logger.IsVerbose ? "/v:n" : "/v:m");
+#endif
+
+        var exitCode = RunProcessWithHeartbeat(
+            psi,
+            logger,
+            elapsed => $"MSBuild batch {heartbeatOperation} still running ({projectCount} project(s), {FormatDuration(elapsed)} elapsed).",
+            out stdErr,
+            out stdOut,
+            out duration);
+        LogProcessOutput(logger, "MSBuild batch", logOperation, stdOut, stdErr);
+        return exitCode;
+    }
+
+    private static int RunDotnetMsBuildGetProperty(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        string propertyName,
+        string projectName,
+        ILogger logger,
+        out string? value,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+        => RunDotnetMsBuildGetProperty(
+            csproj,
+            workingDirectory,
+            configuration,
+            targetFramework,
+            runtimeIdentifier: null,
+            propertyName,
+            projectName,
+            logger,
+            out value,
+            out stdErr,
+            out stdOut,
+            out duration);
+
+    private static int RunDotnetMsBuildGetProperty(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string? targetFramework,
+        string? runtimeIdentifier,
+        string propertyName,
+        string projectName,
+        ILogger logger,
+        out string? value,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        value = null;
+        stdErr = string.Empty;
+        stdOut = string.Empty;
+        duration = TimeSpan.Zero;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+        var args = new List<string>
+        {
+            "msbuild",
+            csproj,
+            "-nologo",
+            $"-getProperty:{propertyName}",
+            $"-p:Configuration={configuration}"
+        };
+        if (!string.IsNullOrWhiteSpace(targetFramework))
+            args.Add($"-p:TargetFramework={targetFramework!.Trim()}");
+        if (!string.IsNullOrWhiteSpace(runtimeIdentifier))
+            args.Add($"-p:RuntimeIdentifier={runtimeIdentifier!.Trim()}");
+
+#if NET472
+        psi.Arguments = BuildWindowsArgumentString(args);
+#else
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+#endif
+
+        var exitCode = RunProcessWithHeartbeat(
+            psi,
+            logger,
+            elapsed => $"{projectName}: dotnet msbuild {propertyName} still running ({FormatDuration(elapsed)} elapsed).",
+            out stdErr,
+            out stdOut,
+            out duration);
+        LogProcessOutput(logger, projectName, $"dotnet msbuild {propertyName}", stdOut, stdErr);
+        value = ExtractMsBuildPropertyValue(stdOut, propertyName);
+        return exitCode;
+    }
+
+    private static string? ExtractMsBuildPropertyValue(string stdOut, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(stdOut))
+            return null;
+
+        var lines = stdOut.Replace("\r\n", "\n").Split('\n')
+            .Select(static line => line.Trim())
+            .Where(static line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+        if (lines.Length == 0)
+            return null;
+
+        var xmlStart = Array.FindIndex(lines, static line => line.StartsWith("<", StringComparison.Ordinal));
+        if (xmlStart >= 0)
+        {
+            try
+            {
+                var xml = string.Join(Environment.NewLine, lines.Skip(xmlStart));
+                var document = XDocument.Parse(xml);
+                return document.Descendants()
+                    .FirstOrDefault(element => string.Equals(element.Name.LocalName, propertyName, StringComparison.OrdinalIgnoreCase))
+                    ?.Value;
+            }
+            catch
+            {
+                // Fall back to the last non-empty line for older MSBuild output shapes.
+            }
+        }
+
+        return lines[lines.Length - 1];
+    }
+
+    internal static PackagePushResult ClassifyNuGetPushOutcome(int exitCode, bool skipDuplicate, string stdErr, string stdOut)
+    {
+        var combined = string.Join(Environment.NewLine, stdErr, stdOut).Trim();
+
+        if (exitCode != 0)
+        {
+            return new PackagePushResult
+            {
+                Outcome = PackagePushOutcome.Failed,
+                Message = combined
+            };
+        }
+
+        if (skipDuplicate && LooksLikeSkippedDuplicate(combined))
+        {
+            return new PackagePushResult
+            {
+                Outcome = PackagePushOutcome.SkippedDuplicate,
+                Message = combined
+            };
+        }
+
+        return new PackagePushResult
+        {
+            Outcome = PackagePushOutcome.Published,
+            Message = combined
+        };
+    }
+
+    private static bool PushPackage(string packagePath, string apiKey, string source, bool skipDuplicate, out PackagePushResult result)
+    {
+        result = new PackagePushResult();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        ProcessStartInfoEncoding.TryApplyUtf8(psi);
+
+#if NET472
+        var args = new List<string>
+        {
+            "nuget", "push", packagePath,
+            "--api-key", apiKey,
+            "--source", source
+        };
+        if (skipDuplicate) args.Add("--skip-duplicate");
+        psi.Arguments = BuildWindowsArgumentString(args);
+#else
+        psi.ArgumentList.Add("nuget");
+        psi.ArgumentList.Add("push");
+        psi.ArgumentList.Add(packagePath);
+        psi.ArgumentList.Add("--api-key");
+        psi.ArgumentList.Add(apiKey);
+        psi.ArgumentList.Add("--source");
+        psi.ArgumentList.Add(source);
+        if (skipDuplicate) psi.ArgumentList.Add("--skip-duplicate");
+#endif
+
+        using var p = Process.Start(psi);
+        if (p is null)
+        {
+            result = new PackagePushResult
+            {
+                Outcome = PackagePushOutcome.Failed,
+                Message = "Failed to start dotnet."
+            };
+            return false;
+        }
+        // Start both stream reads before waiting to avoid pipe-buffer deadlocks.
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        p.WaitForExit();
+        var stdOut = stdoutTask.GetAwaiter().GetResult();
+        var stdErr = stderrTask.GetAwaiter().GetResult();
+        result = ClassifyNuGetPushOutcome(p.ExitCode, skipDuplicate, stdErr, stdOut);
+        return result.Outcome != PackagePushOutcome.Failed;
+    }
+
+    private static void LogProcessOutput(ILogger logger, string projectName, string operation, string stdOut, string stdErr)
+    {
+        if (!logger.IsVerbose)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(stdOut))
+            logger.Verbose($"{projectName}: {operation} stdout:{Environment.NewLine}{stdOut.TrimEnd()}");
+        if (!string.IsNullOrWhiteSpace(stdErr))
+            logger.Verbose($"{projectName}: {operation} stderr:{Environment.NewLine}{stdErr.TrimEnd()}");
+    }
+
+    private static string SummarizeProcessFailureOutput(string stdErr, string stdOut)
+    {
+        var sections = new List<string>();
+        if (!string.IsNullOrWhiteSpace(stdErr))
+            sections.Add("stderr:" + Environment.NewLine + SummarizeProcessOutputLines(stdErr));
+        if (!string.IsNullOrWhiteSpace(stdOut))
+            sections.Add("stdout:" + Environment.NewLine + SummarizeProcessOutputLines(stdOut));
+
+        return sections.Count == 0
+            ? string.Empty
+            : string.Join(Environment.NewLine, sections);
+    }
+
+    internal static string SummarizeProcessOutputLines(string text)
+    {
+        var lines = text.Replace("\r\n", "\n").Split('\n')
+            .Select(line => line.TrimEnd())
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+
+        const int firstLines = 10;
+        const int lastLines = 40;
+        const int maxDiagnosticLines = 20;
+        if (lines.Length <= firstLines + lastLines)
+            return string.Join(Environment.NewLine, lines);
+
+        var middle = lines.Skip(firstLines).Take(lines.Length - firstLines - lastLines).ToArray();
+        var diagnostics = middle
+            .Where(IsDiagnosticOutputLine)
+            .Distinct(StringComparer.Ordinal)
+            .Take(maxDiagnosticLines)
+            .ToArray();
+
+        var summary = new List<string>();
+        summary.AddRange(lines.Take(firstLines));
+        summary.Add($"... omitted {middle.Length} line(s); diagnostic lines from that range are shown below when detected ...");
+        if (diagnostics.Length > 0)
+        {
+            summary.Add("diagnostic lines:");
+            summary.AddRange(diagnostics);
+        }
+
+        summary.Add($"last {lastLines} line(s):");
+        summary.AddRange(lines.Skip(lines.Length - lastLines));
+        return string.Join(Environment.NewLine, summary);
+    }
+
+    private static bool IsDiagnosticOutputLine(string line)
+    {
+        return line.Contains(": error", StringComparison.OrdinalIgnoreCase) ||
+               line.StartsWith("error", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains("exception", StringComparison.OrdinalIgnoreCase) ||
+               line.StartsWith("failed", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains(": failed", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains("unable to", StringComparison.OrdinalIgnoreCase) ||
+               line.Contains("not found", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int RunProcessWithHeartbeat(
+        ProcessStartInfo psi,
+        ILogger logger,
+        Func<TimeSpan, string> heartbeatMessage,
+        out string stdErr,
+        out string stdOut,
+        out TimeSpan duration)
+    {
+        stdErr = string.Empty;
+        stdOut = string.Empty;
+        duration = TimeSpan.Zero;
+
+        using var p = Process.Start(psi);
+        if (p is null) return 1;
+
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        var stopwatch = Stopwatch.StartNew();
+        var nextProgress = HeartbeatInterval;
+
+        while (!p.WaitForExit(1000))
+        {
+            if (stopwatch.Elapsed < nextProgress)
+                continue;
+
+            logger.Info(heartbeatMessage(stopwatch.Elapsed));
+            nextProgress += HeartbeatInterval;
+        }
+
+        // On .NET Framework, WaitForExit(int) returning true does not guarantee async
+        // output callbacks have completed; the no-arg overload does.
+        p.WaitForExit();
+        stdOut = stdoutTask.GetAwaiter().GetResult();
+        stdErr = stderrTask.GetAwaiter().GetResult();
+        stopwatch.Stop();
+        duration = stopwatch.Elapsed;
+        return p.ExitCode;
+    }
+
+    internal static Dictionary<string, (DateTime LastWriteUtc, long Length)> SnapshotPackages(string packageRoot)
+    {
+        var snapshot = new Dictionary<string, (DateTime LastWriteUtc, long Length)>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(packageRoot))
+            return snapshot;
+
+        foreach (var path in Directory.EnumerateFiles(packageRoot, "*.nupkg", SearchOption.AllDirectories))
+        {
+            if (path.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var info = new FileInfo(path);
+            snapshot[path] = (info.LastWriteTimeUtc, info.Length);
+        }
+
+        foreach (var path in Directory.EnumerateFiles(packageRoot, "*.snupkg", SearchOption.AllDirectories))
+        {
+            var info = new FileInfo(path);
+            snapshot[path] = (info.LastWriteTimeUtc, info.Length);
+        }
+
+        return snapshot;
+    }
+
+    internal static bool WasPackageCreatedOrChanged(
+        IReadOnlyDictionary<string, (DateTime LastWriteUtc, long Length)> existingPackages,
+        string path)
+    {
+        var info = new FileInfo(path);
+        if (!info.Exists)
+            return false;
+
+        if (!existingPackages.TryGetValue(path, out var existing))
+            return true;
+
+        return existing.LastWriteUtc != info.LastWriteTimeUtc || existing.Length != info.Length;
+    }
+
+    private static string EscapeMsBuildPropertyValue(string value)
+        => value.Replace("%", "%25")
+            .Replace(";", "%3B")
+            .Replace("=", "%3D")
+            .Replace("$", "%24")
+            .Replace("@", "%40");
+
+    private static bool LooksLikeSkippedDuplicate(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        return text.IndexOf("already exists", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("409 (Conflict)", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("cannot be modified", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               text.IndexOf("skip duplicate", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    internal enum PackagePushOutcome
+    {
+        Published,
+        SkippedDuplicate,
+        Failed
+    }
+
+    internal sealed class PackagePushResult
+    {
+        public PackagePushOutcome Outcome { get; set; }
+        public string? Message { get; set; }
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.TypesAndArgs.cs
@@ -21,6 +21,7 @@ public sealed partial class DotNetRepositoryReleaseService
         public string? ErrorMessage { get; set; }
         public TimeSpan Duration { get; set; }
         public List<string> Packages { get; } = new();
+        public List<string> SymbolPackages { get; } = new();
     }
 
     private sealed class AssemblySigningPlan

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
@@ -59,7 +59,7 @@ public sealed partial class DotNetRepositoryReleaseService
             if (project.Packages.Count == 0)
                 return (false, $"Publish preflight failed: {project.ProjectName} has no packages to publish.");
 
-            foreach (var pkg in project.Packages)
+            foreach (var pkg in project.Packages.Concat(project.SymbolPackages))
             {
                 if (!spec.WhatIf && !File.Exists(pkg))
                     return (false, $"Publish preflight failed: package not found: {pkg}");

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -130,7 +130,7 @@ public sealed partial class DotNetRepositoryReleaseService
             }
         }
 
-        var exitCode = RunDotnetPack(project.CsprojPath, csprojDir, configuration, outputPath, project.ProjectName, logger, noBuild: true, out var stdErr, out var stdOut, out var duration);
+        var exitCode = RunDotnetPack(project.CsprojPath, csprojDir, configuration, outputPath, project.ProjectName, logger, noBuild: true, includeSymbols: spec.IncludeSymbols, out var stdErr, out var stdOut, out var duration);
         result.Duration += duration;
         if (exitCode != 0)
         {
@@ -147,10 +147,15 @@ public sealed partial class DotNetRepositoryReleaseService
                 .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
                 .ToArray();
             result.Packages.AddRange(pkgs);
+
+            var symbolPackages = Directory.EnumerateFiles(packageRoot, "*.snupkg", SearchOption.AllDirectories)
+                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
+                .ToArray();
+            result.SymbolPackages.AddRange(symbolPackages);
         }
         packageDiscoveryWatch.Stop();
         result.Duration += packageDiscoveryWatch.Elapsed;
-        logger.Success($"{project.ProjectName}: package discovery found {result.Packages.Count} package(s) in {FormatDuration(packageDiscoveryWatch.Elapsed)}.");
+        logger.Success($"{project.ProjectName}: package discovery found {result.Packages.Count} package(s) and {result.SymbolPackages.Count} symbol package(s) in {FormatDuration(packageDiscoveryWatch.Elapsed)}.");
 
         if (!TryValidateProjectPackagePayloads(project, spec, result.Packages, logger, out var validationError))
         {
@@ -162,279 +167,7 @@ public sealed partial class DotNetRepositoryReleaseService
         return result;
     }
 
-    private static DotNetPackResult PackProjectsWithMsBuild(
-        IReadOnlyList<DotNetRepositoryProjectResult> projects,
-        DotNetRepositoryReleaseSpec spec,
-        ILogger logger,
-        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies)
-    {
-        var result = new DotNetPackResult();
-        if (projects.Count == 0)
-        {
-            result.Success = true;
-            return result;
-        }
-
-        if (string.IsNullOrWhiteSpace(spec.OutputPath))
-        {
-            result.Success = false;
-            result.ErrorMessage = "MSBuild batch pack requires OutputPath.";
-            return result;
-        }
-
-        var outputPath = Path.IsPathRooted(spec.OutputPath!)
-            ? spec.OutputPath!
-            : Path.GetFullPath(Path.Combine(spec.RootPath, spec.OutputPath!));
-        Directory.CreateDirectory(outputPath);
-        var existingPackages = SnapshotPackages(outputPath);
-
-        var tempRoot = Path.Combine(Path.GetTempPath(), "PowerForge", "project-build", $"pack-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempRoot);
-        var traversalPath = Path.Combine(tempRoot, "pack.proj");
-        try
-        {
-            var forceBatchRebuild = false;
-            foreach (var project in projects)
-            {
-                if (!TryRemoveStalePrimaryPackageOutputs(
-                        project,
-                        string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim(),
-                        logger,
-                        out _,
-                        out var removedIntermediatePrimaryOutput,
-                        out var cleanupDuration,
-                        out var cleanupError))
-                {
-                    result.Duration += cleanupDuration;
-                    result.ErrorMessage = cleanupError;
-                    return result;
-                }
-
-                result.Duration += cleanupDuration;
-                forceBatchRebuild |= !removedIntermediatePrimaryOutput;
-            }
-
-            if (forceBatchRebuild)
-                logger.Info("MSBuild batch freshness could not prove every intermediate output was removed; using the Rebuild safety target.");
-
-            WritePackTraversalProject(traversalPath, projects, spec, outputPath, forceBatchRebuild);
-
-            var shouldSignAssemblies = signAssemblies is not null && !string.IsNullOrWhiteSpace(spec.CertificateThumbprint);
-            int exitCode;
-            string stdErr;
-            string stdOut;
-            TimeSpan duration;
-
-            if (shouldSignAssemblies)
-            {
-                exitCode = RunDotnetMsBuildTarget(
-                    traversalPath,
-                    tempRoot,
-                    "BuildSelected",
-                    "build",
-                    "dotnet msbuild build",
-                    projects.Count,
-                    logger,
-                    out stdErr,
-                    out stdOut,
-                    out duration);
-                result.Duration += duration;
-
-                if (exitCode != 0)
-                {
-                    result.ErrorMessage = $"dotnet msbuild batch build failed (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
-                    return result;
-                }
-
-                var signing = SignBatchBuildOutputs(projects, spec, logger, signAssemblies!);
-                result.Duration += signing.Duration;
-                if (!signing.Success)
-                {
-                    result.ErrorMessage = signing.ErrorMessage;
-                    return result;
-                }
-
-                exitCode = RunDotnetMsBuildTarget(
-                    traversalPath,
-                    tempRoot,
-                    "PackOnlySelected",
-                    "pack",
-                    "dotnet msbuild pack",
-                    projects.Count,
-                    logger,
-                    out stdErr,
-                    out stdOut,
-                    out duration);
-                result.Duration += duration;
-            }
-            else
-            {
-                exitCode = RunDotnetMsBuildTarget(
-                    traversalPath,
-                    tempRoot,
-                    "PackSelected",
-                    "pack",
-                    "dotnet msbuild pack",
-                    projects.Count,
-                    logger,
-                    out stdErr,
-                    out stdOut,
-                    out duration);
-                result.Duration += duration;
-            }
-
-            if (exitCode != 0)
-            {
-                result.ErrorMessage = $"dotnet msbuild batch pack failed (exit {exitCode}). {SummarizeProcessFailureOutput(stdErr, stdOut)}".Trim();
-                return result;
-            }
-
-            var pkgs = Directory.EnumerateFiles(outputPath, "*.nupkg", SearchOption.AllDirectories)
-                .Where(p => !p.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
-                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
-                .ToArray();
-            result.Packages.AddRange(pkgs);
-
-            if (!TryValidatePackagePayloads(projects, spec, result.Packages, logger, out var validationError))
-            {
-                result.Success = false;
-                result.ErrorMessage = validationError;
-                return result;
-            }
-
-            result.Success = true;
-            return result;
-        }
-        finally
-        {
-            TryDeleteDirectory(tempRoot, logger);
-        }
-    }
-
-    internal static void WritePackTraversalProject(
-        string traversalPath,
-        IReadOnlyList<DotNetRepositoryProjectResult> projects,
-        DotNetRepositoryReleaseSpec spec,
-        string outputPath,
-        bool forceRebuild = false)
-    {
-        var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
-        var buildProperties = $"Configuration={EscapeMsBuildPropertyValue(configuration)}";
-        var packProperties = string.Join(";",
-            buildProperties,
-            $"PackageOutputPath={EscapeMsBuildPropertyValue(outputPath)}",
-            "NoBuild=true",
-            "BuildProjectReferences=false");
-
-        // Keep this a classic MSBuild project: it only fans out to concrete SDK projects
-        // and does not require Microsoft.Build.Traversal to be installed.
-        var document = new XDocument(
-            new XElement("Project",
-                new XElement("ItemGroup",
-                    projects.Select(project => new XElement("PackProject",
-                        new XAttribute("Include", Path.GetFullPath(project.CsprojPath))))),
-                new XElement("Target",
-                    new XAttribute("Name", "RestoreSelected"),
-                    new XElement("MSBuild",
-                        new XAttribute("Projects", "@(PackProject)"),
-                        // Restore and build all selected projects first, then pack without walking project
-                        // references. Otherwise packable project references can be packed twice in parallel.
-                        new XAttribute("Targets", "Restore"),
-                        new XAttribute("BuildInParallel", "true"),
-                        new XAttribute("StopOnFirstFailure", "true"),
-                        new XAttribute("Properties", buildProperties))),
-                new XElement("Target",
-                    new XAttribute("Name", "BuildSelected"),
-                    new XAttribute("DependsOnTargets", "RestoreSelected"),
-                    new XElement("MSBuild",
-                        new XAttribute("Projects", "@(PackProject)"),
-                        // Freshness cleanup normally permits an incremental Build. Rebuild remains
-                        // the safety target when an intermediate compiler output was not removed.
-                        new XAttribute("Targets", forceRebuild ? "Rebuild" : "Build"),
-                        new XAttribute("BuildInParallel", "true"),
-                        new XAttribute("StopOnFirstFailure", "true"),
-                        new XAttribute("Properties", buildProperties))),
-                new XElement("Target",
-                    new XAttribute("Name", "PackOnlySelected"),
-                    new XElement("MSBuild",
-                        new XAttribute("Projects", "@(PackProject)"),
-                        new XAttribute("Targets", "Pack"),
-                        new XAttribute("BuildInParallel", "true"),
-                        new XAttribute("StopOnFirstFailure", "true"),
-                        new XAttribute("Properties", packProperties))),
-                new XElement("Target",
-                    new XAttribute("Name", "PackSelected"),
-                    new XAttribute("DependsOnTargets", "BuildSelected;PackOnlySelected"))));
-
-        document.Save(traversalPath);
-    }
-
-    private static DotNetPackResult SignBatchBuildOutputs(
-        IReadOnlyList<DotNetRepositoryProjectResult> projects,
-        DotNetRepositoryReleaseSpec spec,
-        ILogger logger,
-        Action<DotNetReleaseBuildAssemblySigningRequest> signAssemblies)
-    {
-        var result = new DotNetPackResult();
-        var watch = Stopwatch.StartNew();
-
-        try
-        {
-            var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
-            var signedOutputCount = 0;
-            var files = new List<string>();
-
-            foreach (var project in projects)
-            {
-                var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
-                var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
-                var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
-                var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
-                if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
-                {
-                    var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
-                    if (!SamePatterns(includePatterns, evaluatedIncludePatterns))
-                    {
-                        includePatterns = evaluatedIncludePatterns;
-                        outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
-                        signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
-                    }
-                }
-                logger.Info($"{project.ProjectName}: assembly signing include pattern(s): {string.Join(", ", includePatterns)}.");
-                files.AddRange(signingPlan.Files);
-                signedOutputCount += signingPlan.OutputDirectoryCount;
-            }
-
-            var filePaths = files
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-            if (filePaths.Length > 0)
-                signAssemblies(new DotNetReleaseBuildAssemblySigningRequest
-                {
-                    ReleasePath = spec.RootPath,
-                    LocalStore = spec.CertificateStore,
-                    CertificateThumbprint = spec.CertificateThumbprint!.Trim(),
-                    TimeStampServer = string.IsNullOrWhiteSpace(spec.TimeStampServer) ? "http://timestamp.digicert.com" : spec.TimeStampServer!.Trim(),
-                    IncludePatterns = Array.Empty<string>(),
-                    FilePaths = filePaths
-                });
-
-            watch.Stop();
-            result.Duration = watch.Elapsed;
-            result.Success = true;
-            logger.Success($"MSBuild batch assembly signing completed for {signedOutputCount} output directorie(s), {filePaths.Length} file(s), in {FormatDuration(watch.Elapsed)}.");
-            return result;
-        }
-        catch (Exception ex)
-        {
-            watch.Stop();
-            result.Duration = watch.Elapsed;
-            result.ErrorMessage = $"MSBuild batch assembly signing failed. {ex.Message}";
-            return result;
-        }
-    }
-
-    private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotNetRepositoryProjectResult project, string version)
+private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotNetRepositoryProjectResult project, string version)
     {
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
         var outputPath = string.IsNullOrWhiteSpace(spec.OutputPath)
@@ -448,6 +181,14 @@ public sealed partial class DotNetRepositoryReleaseService
         return Path.Combine(outputPath, $"{packageId}.{version}.nupkg");
     }
 
+    private static string? ResolveSymbolPackagePath(DotNetRepositoryReleaseSpec spec, DotNetRepositoryProjectResult project, string version)
+    {
+        var packagePath = ResolvePackagePath(spec, project, version);
+        return string.IsNullOrWhiteSpace(packagePath)
+            ? null
+            : Path.ChangeExtension(packagePath, ".snupkg");
+    }
+
     private static int RunDotnetPack(
         string csproj,
         string workingDirectory,
@@ -456,6 +197,7 @@ public sealed partial class DotNetRepositoryReleaseService
         string projectName,
         ILogger logger,
         bool noBuild,
+        bool includeSymbols,
         out string stdErr,
         out string stdOut,
         out TimeSpan duration)
@@ -484,6 +226,11 @@ public sealed partial class DotNetRepositoryReleaseService
             args.Add("-o");
             args.Add(outputPath!);
         }
+        if (includeSymbols)
+        {
+            args.Add("-p:IncludeSymbols=true");
+            args.Add("-p:SymbolPackageFormat=snupkg");
+        }
         psi.Arguments = BuildWindowsArgumentString(args);
 #else
         psi.ArgumentList.Add("pack");
@@ -496,6 +243,11 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             psi.ArgumentList.Add("-o");
             psi.ArgumentList.Add(outputPath!);
+        }
+        if (includeSymbols)
+        {
+            psi.ArgumentList.Add("-p:IncludeSymbols=true");
+            psi.ArgumentList.Add("-p:SymbolPackageFormat=snupkg");
         }
 #endif
 
@@ -883,437 +635,6 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             return Array.Empty<string>();
         }
-    }
-
-    private static int RunDotnetMsBuildTarget(
-        string traversalProject,
-        string workingDirectory,
-        string targetName,
-        string heartbeatOperation,
-        string logOperation,
-        int projectCount,
-        ILogger logger,
-        out string stdErr,
-        out string stdOut,
-        out TimeSpan duration)
-    {
-        stdErr = string.Empty;
-        stdOut = string.Empty;
-        duration = TimeSpan.Zero;
-
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WorkingDirectory = workingDirectory
-        };
-        ProcessStartInfoEncoding.TryApplyUtf8(psi);
-
-#if NET472
-        psi.Arguments = BuildWindowsArgumentString(new[]
-        {
-            "msbuild",
-            traversalProject,
-            $"/t:{targetName}",
-            "/m",
-            "/nr:false",
-            logger.IsVerbose ? "/v:n" : "/v:m"
-        });
-#else
-        psi.ArgumentList.Add("msbuild");
-        psi.ArgumentList.Add(traversalProject);
-        psi.ArgumentList.Add($"/t:{targetName}");
-        psi.ArgumentList.Add("/m");
-        psi.ArgumentList.Add("/nr:false");
-        psi.ArgumentList.Add(logger.IsVerbose ? "/v:n" : "/v:m");
-#endif
-
-        var exitCode = RunProcessWithHeartbeat(
-            psi,
-            logger,
-            elapsed => $"MSBuild batch {heartbeatOperation} still running ({projectCount} project(s), {FormatDuration(elapsed)} elapsed).",
-            out stdErr,
-            out stdOut,
-            out duration);
-        LogProcessOutput(logger, "MSBuild batch", logOperation, stdOut, stdErr);
-        return exitCode;
-    }
-
-    private static int RunDotnetMsBuildGetProperty(
-        string csproj,
-        string workingDirectory,
-        string configuration,
-        string? targetFramework,
-        string propertyName,
-        string projectName,
-        ILogger logger,
-        out string? value,
-        out string stdErr,
-        out string stdOut,
-        out TimeSpan duration)
-        => RunDotnetMsBuildGetProperty(
-            csproj,
-            workingDirectory,
-            configuration,
-            targetFramework,
-            runtimeIdentifier: null,
-            propertyName,
-            projectName,
-            logger,
-            out value,
-            out stdErr,
-            out stdOut,
-            out duration);
-
-    private static int RunDotnetMsBuildGetProperty(
-        string csproj,
-        string workingDirectory,
-        string configuration,
-        string? targetFramework,
-        string? runtimeIdentifier,
-        string propertyName,
-        string projectName,
-        ILogger logger,
-        out string? value,
-        out string stdErr,
-        out string stdOut,
-        out TimeSpan duration)
-    {
-        value = null;
-        stdErr = string.Empty;
-        stdOut = string.Empty;
-        duration = TimeSpan.Zero;
-
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WorkingDirectory = workingDirectory
-        };
-        ProcessStartInfoEncoding.TryApplyUtf8(psi);
-
-        var args = new List<string>
-        {
-            "msbuild",
-            csproj,
-            "-nologo",
-            $"-getProperty:{propertyName}",
-            $"-p:Configuration={configuration}"
-        };
-        if (!string.IsNullOrWhiteSpace(targetFramework))
-            args.Add($"-p:TargetFramework={targetFramework!.Trim()}");
-        if (!string.IsNullOrWhiteSpace(runtimeIdentifier))
-            args.Add($"-p:RuntimeIdentifier={runtimeIdentifier!.Trim()}");
-
-#if NET472
-        psi.Arguments = BuildWindowsArgumentString(args);
-#else
-        foreach (var arg in args)
-            psi.ArgumentList.Add(arg);
-#endif
-
-        var exitCode = RunProcessWithHeartbeat(
-            psi,
-            logger,
-            elapsed => $"{projectName}: dotnet msbuild {propertyName} still running ({FormatDuration(elapsed)} elapsed).",
-            out stdErr,
-            out stdOut,
-            out duration);
-        LogProcessOutput(logger, projectName, $"dotnet msbuild {propertyName}", stdOut, stdErr);
-        value = ExtractMsBuildPropertyValue(stdOut, propertyName);
-        return exitCode;
-    }
-
-    private static string? ExtractMsBuildPropertyValue(string stdOut, string propertyName)
-    {
-        if (string.IsNullOrWhiteSpace(stdOut))
-            return null;
-
-        var lines = stdOut.Replace("\r\n", "\n").Split('\n')
-            .Select(static line => line.Trim())
-            .Where(static line => !string.IsNullOrWhiteSpace(line))
-            .ToArray();
-        if (lines.Length == 0)
-            return null;
-
-        var xmlStart = Array.FindIndex(lines, static line => line.StartsWith("<", StringComparison.Ordinal));
-        if (xmlStart >= 0)
-        {
-            try
-            {
-                var xml = string.Join(Environment.NewLine, lines.Skip(xmlStart));
-                var document = XDocument.Parse(xml);
-                return document.Descendants()
-                    .FirstOrDefault(element => string.Equals(element.Name.LocalName, propertyName, StringComparison.OrdinalIgnoreCase))
-                    ?.Value;
-            }
-            catch
-            {
-                // Fall back to the last non-empty line for older MSBuild output shapes.
-            }
-        }
-
-        return lines[lines.Length - 1];
-    }
-
-    internal static PackagePushResult ClassifyNuGetPushOutcome(int exitCode, bool skipDuplicate, string stdErr, string stdOut)
-    {
-        var combined = string.Join(Environment.NewLine, stdErr, stdOut).Trim();
-
-        if (exitCode != 0)
-        {
-            return new PackagePushResult
-            {
-                Outcome = PackagePushOutcome.Failed,
-                Message = combined
-            };
-        }
-
-        if (skipDuplicate && LooksLikeSkippedDuplicate(combined))
-        {
-            return new PackagePushResult
-            {
-                Outcome = PackagePushOutcome.SkippedDuplicate,
-                Message = combined
-            };
-        }
-
-        return new PackagePushResult
-        {
-            Outcome = PackagePushOutcome.Published,
-            Message = combined
-        };
-    }
-
-    private static bool PushPackage(string packagePath, string apiKey, string source, bool skipDuplicate, out PackagePushResult result)
-    {
-        result = new PackagePushResult();
-
-        var psi = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-        ProcessStartInfoEncoding.TryApplyUtf8(psi);
-
-#if NET472
-        var args = new List<string>
-        {
-            "nuget", "push", packagePath,
-            "--api-key", apiKey,
-            "--source", source
-        };
-        if (skipDuplicate) args.Add("--skip-duplicate");
-        psi.Arguments = BuildWindowsArgumentString(args);
-#else
-        psi.ArgumentList.Add("nuget");
-        psi.ArgumentList.Add("push");
-        psi.ArgumentList.Add(packagePath);
-        psi.ArgumentList.Add("--api-key");
-        psi.ArgumentList.Add(apiKey);
-        psi.ArgumentList.Add("--source");
-        psi.ArgumentList.Add(source);
-        if (skipDuplicate) psi.ArgumentList.Add("--skip-duplicate");
-#endif
-
-        using var p = Process.Start(psi);
-        if (p is null)
-        {
-            result = new PackagePushResult
-            {
-                Outcome = PackagePushOutcome.Failed,
-                Message = "Failed to start dotnet."
-            };
-            return false;
-        }
-        // Start both stream reads before waiting to avoid pipe-buffer deadlocks.
-        var stdoutTask = p.StandardOutput.ReadToEndAsync();
-        var stderrTask = p.StandardError.ReadToEndAsync();
-        p.WaitForExit();
-        var stdOut = stdoutTask.GetAwaiter().GetResult();
-        var stdErr = stderrTask.GetAwaiter().GetResult();
-        result = ClassifyNuGetPushOutcome(p.ExitCode, skipDuplicate, stdErr, stdOut);
-        return result.Outcome != PackagePushOutcome.Failed;
-    }
-
-    private static void LogProcessOutput(ILogger logger, string projectName, string operation, string stdOut, string stdErr)
-    {
-        if (!logger.IsVerbose)
-            return;
-
-        if (!string.IsNullOrWhiteSpace(stdOut))
-            logger.Verbose($"{projectName}: {operation} stdout:{Environment.NewLine}{stdOut.TrimEnd()}");
-        if (!string.IsNullOrWhiteSpace(stdErr))
-            logger.Verbose($"{projectName}: {operation} stderr:{Environment.NewLine}{stdErr.TrimEnd()}");
-    }
-
-    private static string SummarizeProcessFailureOutput(string stdErr, string stdOut)
-    {
-        var sections = new List<string>();
-        if (!string.IsNullOrWhiteSpace(stdErr))
-            sections.Add("stderr:" + Environment.NewLine + SummarizeProcessOutputLines(stdErr));
-        if (!string.IsNullOrWhiteSpace(stdOut))
-            sections.Add("stdout:" + Environment.NewLine + SummarizeProcessOutputLines(stdOut));
-
-        return sections.Count == 0
-            ? string.Empty
-            : string.Join(Environment.NewLine, sections);
-    }
-
-    internal static string SummarizeProcessOutputLines(string text)
-    {
-        var lines = text.Replace("\r\n", "\n").Split('\n')
-            .Select(line => line.TrimEnd())
-            .Where(line => !string.IsNullOrWhiteSpace(line))
-            .ToArray();
-
-        const int firstLines = 10;
-        const int lastLines = 40;
-        const int maxDiagnosticLines = 20;
-        if (lines.Length <= firstLines + lastLines)
-            return string.Join(Environment.NewLine, lines);
-
-        var middle = lines.Skip(firstLines).Take(lines.Length - firstLines - lastLines).ToArray();
-        var diagnostics = middle
-            .Where(IsDiagnosticOutputLine)
-            .Distinct(StringComparer.Ordinal)
-            .Take(maxDiagnosticLines)
-            .ToArray();
-
-        var summary = new List<string>();
-        summary.AddRange(lines.Take(firstLines));
-        summary.Add($"... omitted {middle.Length} line(s); diagnostic lines from that range are shown below when detected ...");
-        if (diagnostics.Length > 0)
-        {
-            summary.Add("diagnostic lines:");
-            summary.AddRange(diagnostics);
-        }
-
-        summary.Add($"last {lastLines} line(s):");
-        summary.AddRange(lines.Skip(lines.Length - lastLines));
-        return string.Join(Environment.NewLine, summary);
-    }
-
-    private static bool IsDiagnosticOutputLine(string line)
-    {
-        return line.Contains(": error", StringComparison.OrdinalIgnoreCase) ||
-               line.StartsWith("error", StringComparison.OrdinalIgnoreCase) ||
-               line.Contains("exception", StringComparison.OrdinalIgnoreCase) ||
-               line.StartsWith("failed", StringComparison.OrdinalIgnoreCase) ||
-               line.Contains(": failed", StringComparison.OrdinalIgnoreCase) ||
-               line.Contains("unable to", StringComparison.OrdinalIgnoreCase) ||
-               line.Contains("not found", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static int RunProcessWithHeartbeat(
-        ProcessStartInfo psi,
-        ILogger logger,
-        Func<TimeSpan, string> heartbeatMessage,
-        out string stdErr,
-        out string stdOut,
-        out TimeSpan duration)
-    {
-        stdErr = string.Empty;
-        stdOut = string.Empty;
-        duration = TimeSpan.Zero;
-
-        using var p = Process.Start(psi);
-        if (p is null) return 1;
-
-        var stdoutTask = p.StandardOutput.ReadToEndAsync();
-        var stderrTask = p.StandardError.ReadToEndAsync();
-        var stopwatch = Stopwatch.StartNew();
-        var nextProgress = HeartbeatInterval;
-
-        while (!p.WaitForExit(1000))
-        {
-            if (stopwatch.Elapsed < nextProgress)
-                continue;
-
-            logger.Info(heartbeatMessage(stopwatch.Elapsed));
-            nextProgress += HeartbeatInterval;
-        }
-
-        // On .NET Framework, WaitForExit(int) returning true does not guarantee async
-        // output callbacks have completed; the no-arg overload does.
-        p.WaitForExit();
-        stdOut = stdoutTask.GetAwaiter().GetResult();
-        stdErr = stderrTask.GetAwaiter().GetResult();
-        stopwatch.Stop();
-        duration = stopwatch.Elapsed;
-        return p.ExitCode;
-    }
-
-    internal static Dictionary<string, (DateTime LastWriteUtc, long Length)> SnapshotPackages(string packageRoot)
-    {
-        var snapshot = new Dictionary<string, (DateTime LastWriteUtc, long Length)>(StringComparer.OrdinalIgnoreCase);
-        if (!Directory.Exists(packageRoot))
-            return snapshot;
-
-        foreach (var path in Directory.EnumerateFiles(packageRoot, "*.nupkg", SearchOption.AllDirectories))
-        {
-            if (path.EndsWith(".symbols.nupkg", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            var info = new FileInfo(path);
-            snapshot[path] = (info.LastWriteTimeUtc, info.Length);
-        }
-
-        return snapshot;
-    }
-
-    internal static bool WasPackageCreatedOrChanged(
-        IReadOnlyDictionary<string, (DateTime LastWriteUtc, long Length)> existingPackages,
-        string path)
-    {
-        var info = new FileInfo(path);
-        if (!info.Exists)
-            return false;
-
-        if (!existingPackages.TryGetValue(path, out var existing))
-            return true;
-
-        return existing.LastWriteUtc != info.LastWriteTimeUtc || existing.Length != info.Length;
-    }
-
-    private static string EscapeMsBuildPropertyValue(string value)
-        => value.Replace("%", "%25")
-            .Replace(";", "%3B")
-            .Replace("=", "%3D")
-            .Replace("$", "%24")
-            .Replace("@", "%40");
-
-    private static bool LooksLikeSkippedDuplicate(string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return false;
-
-        return text.IndexOf("already exists", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               text.IndexOf("409 (Conflict)", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               text.IndexOf("cannot be modified", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               text.IndexOf("skip duplicate", StringComparison.OrdinalIgnoreCase) >= 0;
-    }
-
-    internal enum PackagePushOutcome
-    {
-        Published,
-        SkippedDuplicate,
-        Failed
-    }
-
-    internal sealed class PackagePushResult
-    {
-        public PackagePushOutcome Outcome { get; set; }
-        public string? Message { get; set; }
     }
 
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -148,10 +148,13 @@ public sealed partial class DotNetRepositoryReleaseService
                 .ToArray();
             result.Packages.AddRange(pkgs);
 
-            var symbolPackages = Directory.EnumerateFiles(packageRoot, "*.snupkg", SearchOption.AllDirectories)
-                .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
-                .ToArray();
-            result.SymbolPackages.AddRange(symbolPackages);
+            if (spec.IncludeSymbols)
+            {
+                var symbolPackages = Directory.EnumerateFiles(packageRoot, "*.snupkg", SearchOption.AllDirectories)
+                    .Where(p => WasPackageCreatedOrChanged(existingPackages, p))
+                    .ToArray();
+                result.SymbolPackages.AddRange(symbolPackages);
+            }
         }
         packageDiscoveryWatch.Stop();
         result.Duration += packageDiscoveryWatch.Elapsed;

--- a/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
@@ -24,7 +24,7 @@ public sealed class DotNetRepositoryReleaseSummaryService
                 ProjectName = project.ProjectName,
                 IsPackable = project.IsPackable,
                 VersionDisplay = BuildVersionDisplay(project),
-                PackageCount = project.Packages.Count,
+                PackageCount = project.Packages.Count + project.SymbolPackages.Count,
                 Status = ResolveStatus(project),
                 ErrorMessage = project.ErrorMessage?.Trim() ?? string.Empty,
                 ErrorPreview = TrimForSummary(project.ErrorMessage, maxErrorLength)
@@ -39,7 +39,7 @@ public sealed class DotNetRepositoryReleaseSummaryService
                 ProjectCount = result.Projects.Count,
                 PackableCount = result.Projects.Count(p => p.IsPackable),
                 FailedProjectCount = result.Projects.Count(p => !string.IsNullOrWhiteSpace(p.ErrorMessage)),
-                PackageCount = result.Projects.Sum(p => p.Packages.Count),
+                PackageCount = result.Projects.Sum(p => p.Packages.Count + p.SymbolPackages.Count),
                 PublishedPackageCount = result.PublishedPackages.Count,
                 SkippedDuplicatePackageCount = result.SkippedDuplicatePackages.Count,
                 FailedPublishCount = result.FailedPackages.Count,

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -6,11 +6,11 @@ namespace PowerForge;
 internal sealed class NuGetPackagePublishService
 {
     private readonly ILogger _logger;
-    private readonly Func<string, string, string, bool, DotNetRepositoryReleaseService.PackagePushResult> _pushPackage;
+    private readonly Func<string, string, string, bool, bool, DotNetRepositoryReleaseService.PackagePushResult> _pushPackage;
 
     public NuGetPackagePublishService(
         ILogger logger,
-        Func<string, string, string, bool, DotNetRepositoryReleaseService.PackagePushResult>? pushPackage = null)
+        Func<string, string, string, bool, bool, DotNetRepositoryReleaseService.PackagePushResult>? pushPackage = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _pushPackage = pushPackage ?? PushPackage;
@@ -70,7 +70,7 @@ internal sealed class NuGetPackagePublishService
                 continue;
             }
 
-            var pushResult = _pushPackage(package, request.ApiKey, request.Source, request.SkipDuplicate)
+            var pushResult = _pushPackage(package, request.ApiKey, request.Source, request.SkipDuplicate, false)
                 ?? new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
@@ -105,7 +105,8 @@ internal sealed class NuGetPackagePublishService
         string apiKey,
         string source,
         bool skipDuplicate,
-        bool publishFailFast = true)
+        bool publishFailFast = true,
+        bool suppressCompanionSymbols = false)
     {
         if (packages is null)
             throw new ArgumentNullException(nameof(packages));
@@ -137,7 +138,7 @@ internal sealed class NuGetPackagePublishService
                 continue;
             }
 
-            var pushResult = _pushPackage(package, apiKey, source, skipDuplicate)
+            var pushResult = _pushPackage(package, apiKey, source, skipDuplicate, suppressCompanionSymbols)
                 ?? new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
@@ -173,10 +174,20 @@ internal sealed class NuGetPackagePublishService
         return result;
     }
 
-    private static DotNetRepositoryReleaseService.PackagePushResult PushPackage(string packagePath, string apiKey, string source, bool skipDuplicate)
+    private static DotNetRepositoryReleaseService.PackagePushResult PushPackage(
+        string packagePath,
+        string apiKey,
+        string source,
+        bool skipDuplicate,
+        bool suppressCompanionSymbols)
     {
         var result = new DotNetNuGetClient()
-            .PushPackageAsync(new DotNetNuGetPushRequest(packagePath, apiKey, source, skipDuplicate))
+            .PushPackageAsync(new DotNetNuGetPushRequest(
+                packagePath,
+                apiKey,
+                source,
+                skipDuplicate,
+                suppressCompanionSymbols: suppressCompanionSymbols))
             .GetAwaiter()
             .GetResult();
 

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -63,6 +63,10 @@ internal sealed class NuGetPackagePublishService
             if (shouldPublishPackage is not null && !shouldPublishPackage(package))
             {
                 result.PublishedItems.Add(package);
+                result.PackagePushResults[package] = new DotNetRepositoryReleaseService.PackagePushResult
+                {
+                    Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Published
+                };
                 continue;
             }
 
@@ -72,6 +76,7 @@ internal sealed class NuGetPackagePublishService
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
                     Message = "Push handler returned no result."
                 };
+            result.PackagePushResults[package] = pushResult;
 
             switch (pushResult.Outcome)
             {
@@ -138,6 +143,7 @@ internal sealed class NuGetPackagePublishService
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
                     Message = "Push handler returned no result."
                 };
+            result.PackagePushResults[package] = pushResult;
 
             switch (pushResult.Outcome)
             {

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -6,14 +6,17 @@ namespace PowerForge;
 internal sealed class NuGetPackagePublishService
 {
     private readonly ILogger _logger;
-    private readonly Func<string, string, string, bool, bool, DotNetRepositoryReleaseService.PackagePushResult> _pushPackage;
+    private readonly Func<DotNetNuGetPushRequest, DotNetRepositoryReleaseService.PackagePushResult> _pushPackage;
+    private readonly string? _workingDirectory;
 
     public NuGetPackagePublishService(
         ILogger logger,
-        Func<string, string, string, bool, bool, DotNetRepositoryReleaseService.PackagePushResult>? pushPackage = null)
+        Func<DotNetNuGetPushRequest, DotNetRepositoryReleaseService.PackagePushResult>? pushPackage = null,
+        string? workingDirectory = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _pushPackage = pushPackage ?? PushPackage;
+        _workingDirectory = workingDirectory;
     }
 
     public NuGetPackagePublishResult Execute(NuGetPackagePublishRequest request, Func<string, bool>? shouldPublishPackage = null)
@@ -70,7 +73,14 @@ internal sealed class NuGetPackagePublishService
                 continue;
             }
 
-            var pushResult = _pushPackage(package, request.ApiKey, request.Source, request.SkipDuplicate, false)
+            var pushResult = _pushPackage(new DotNetNuGetPushRequest(
+                    package,
+                    request.ApiKey,
+                    request.Source,
+                    request.SkipDuplicate,
+                    _workingDirectory,
+                    timeout: null,
+                    suppressCompanionSymbols: false))
                 ?? new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
@@ -138,7 +148,36 @@ internal sealed class NuGetPackagePublishService
                 continue;
             }
 
-            var pushResult = _pushPackage(package, apiKey, source, skipDuplicate, suppressCompanionSymbols)
+            if (!DotNetRepositoryReleaseService.CanPublishSymbolPackage(
+                    package,
+                    packagePaths,
+                    primaryPackage =>
+                        result.PackagePushResults.TryGetValue(primaryPackage, out var primaryResult) &&
+                        (primaryResult.Outcome == DotNetRepositoryReleaseService.PackagePushOutcome.Published ||
+                         primaryResult.Outcome == DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate),
+                    out var primaryPackage))
+            {
+                var blockedResult = DotNetRepositoryReleaseService.CreateBlockedCompanionResult(
+                    package,
+                    primaryPackage);
+                result.Success = false;
+                result.FailedItems.Add(package);
+                result.PackagePushResults[package] = blockedResult;
+                if (string.IsNullOrWhiteSpace(result.ErrorMessage))
+                    result.ErrorMessage = blockedResult.Message;
+                if (publishFailFast)
+                    return result;
+                continue;
+            }
+
+            var pushResult = _pushPackage(new DotNetNuGetPushRequest(
+                    package,
+                    apiKey,
+                    source,
+                    skipDuplicate,
+                    _workingDirectory,
+                    timeout: null,
+                    suppressCompanionSymbols))
                 ?? new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,
@@ -160,13 +199,13 @@ internal sealed class NuGetPackagePublishService
                     result.FailedItems.Add(package);
                     _logger.Verbose($"dotnet nuget push failed for {package}.");
                     if (pushResult.Message is string message && message.Length > 0)
-                        _logger.Verbose(message);
-                    if (publishFailFast)
                     {
-                        if (string.IsNullOrWhiteSpace(result.ErrorMessage) && pushResult.Message is string failureMessage && failureMessage.Length > 0)
-                            result.ErrorMessage = failureMessage;
-                        return result;
+                        _logger.Verbose(message);
+                        if (string.IsNullOrWhiteSpace(result.ErrorMessage))
+                            result.ErrorMessage = message;
                     }
+                    if (publishFailFast)
+                        return result;
                     break;
             }
         }
@@ -174,16 +213,6 @@ internal sealed class NuGetPackagePublishService
         return result;
     }
 
-    private static DotNetRepositoryReleaseService.PackagePushResult PushPackage(
-        string packagePath,
-        string apiKey,
-        string source,
-        bool skipDuplicate,
-        bool suppressCompanionSymbols)
-        => DotNetRepositoryReleaseService.PushPackage(
-            packagePath,
-            apiKey,
-            source,
-            skipDuplicate,
-            suppressCompanionSymbols);
+    private static DotNetRepositoryReleaseService.PackagePushResult PushPackage(DotNetNuGetPushRequest request)
+        => DotNetRepositoryReleaseService.PushPackage(request);
 }

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -78,9 +78,9 @@ internal sealed class NuGetPackagePublishService
                     request.ApiKey,
                     request.Source,
                     request.SkipDuplicate,
-                    _workingDirectory,
+                    request.WorkingDirectory ?? _workingDirectory,
                     timeout: null,
-                    suppressCompanionSymbols: false))
+                    suppressCompanionSymbols: true))
                 ?? new DotNetRepositoryReleaseService.PackagePushResult
                 {
                     Outcome = DotNetRepositoryReleaseService.PackagePushOutcome.Failed,

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -76,8 +76,11 @@ internal sealed class NuGetPackagePublishService
             switch (pushResult.Outcome)
             {
                 case DotNetRepositoryReleaseService.PackagePushOutcome.Published:
+                    result.PublishedItems.Add(package);
+                    break;
                 case DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate:
                     result.PublishedItems.Add(package);
+                    result.SkippedDuplicateItems.Add(package);
                     break;
                 default:
                     result.Success = false;
@@ -139,8 +142,11 @@ internal sealed class NuGetPackagePublishService
             switch (pushResult.Outcome)
             {
                 case DotNetRepositoryReleaseService.PackagePushOutcome.Published:
+                    result.PublishedItems.Add(package);
+                    break;
                 case DotNetRepositoryReleaseService.PackagePushOutcome.SkippedDuplicate:
                     result.PublishedItems.Add(package);
+                    result.SkippedDuplicateItems.Add(package);
                     break;
                 default:
                     result.Success = false;

--- a/PowerForge/Services/NuGetPackagePublishService.cs
+++ b/PowerForge/Services/NuGetPackagePublishService.cs
@@ -180,17 +180,10 @@ internal sealed class NuGetPackagePublishService
         string source,
         bool skipDuplicate,
         bool suppressCompanionSymbols)
-    {
-        var result = new DotNetNuGetClient()
-            .PushPackageAsync(new DotNetNuGetPushRequest(
-                packagePath,
-                apiKey,
-                source,
-                skipDuplicate,
-                suppressCompanionSymbols: suppressCompanionSymbols))
-            .GetAwaiter()
-            .GetResult();
-
-        return DotNetRepositoryReleaseService.ClassifyNuGetPushOutcome(result.ExitCode, skipDuplicate, result.StdErr, result.StdOut);
-    }
+        => DotNetRepositoryReleaseService.PushPackage(
+            packagePath,
+            apiKey,
+            source,
+            skipDuplicate,
+            suppressCompanionSymbols);
 }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -2893,7 +2893,7 @@ internal sealed class PowerForgeReleaseService
 
     private static IEnumerable<PowerForgeReleaseAssetEntry> CreatePackageAssetEntries(DotNetRepositoryProjectResult project)
     {
-        foreach (var package in project.Packages.Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path)))
+        foreach (var package in project.Packages.Concat(project.SymbolPackages).Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path)))
         {
             yield return new PowerForgeReleaseAssetEntry
             {
@@ -3213,6 +3213,7 @@ internal sealed class PowerForgeReleaseService
                 project.PackageId,
                 project.NewVersion,
                 Packages = project.Packages.ToArray(),
+                SymbolPackages = project.SymbolPackages.ToArray(),
                 project.ReleaseZipPath
             }).ToArray()
         };

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -104,6 +104,7 @@ internal sealed class ProjectBuildPreparationService
             OutputPath = context.OutputPath,
             ReleaseZipOutputPath = context.ReleaseZipOutputPath,
             PackStrategy = packStrategy,
+            IncludeSymbols = config.IncludeSymbols ?? false,
             CertificateThumbprint = config.CertificateThumbprint,
             CertificateStore = ProjectBuildSupportService.ParseCertificateStore(config.CertificateStore),
             TimeStampServer = config.TimeStampServer,

--- a/PowerForge/packages.lock.json
+++ b/PowerForge/packages.lock.json
@@ -122,6 +122,29 @@
         "type": "Transitive",
         "resolved": "4.6.2",
         "contentHash": "yQgmjfFximrNm9LIV3mL6T5MzjeC+epeE5rl4hXxAlYmxby7RM1dPSkIKXk9HNkl6G54h2JHOmLD46+Pey+IRg=="
+      },
+      "NuGet.Configuration": {
+        "type": "Direct",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net10.0": {
@@ -142,6 +165,29 @@
         "requested": "[10.0.7, )",
         "resolved": "10.0.7",
         "contentHash": "eqKW9wyPUhZi6pxy9Y0fQO/bdHROcwj0tYdmoGEPCPCtCJLFdVVAlzuuYYEnJI64HxhoXPYGhtx891g/jwN4rg=="
+      },
+      "NuGet.Configuration": {
+        "type": "Direct",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net8.0": {
@@ -162,6 +208,29 @@
         "requested": "[10.0.7, )",
         "resolved": "10.0.7",
         "contentHash": "eqKW9wyPUhZi6pxy9Y0fQO/bdHROcwj0tYdmoGEPCPCtCJLFdVVAlzuuYYEnJI64HxhoXPYGhtx891g/jwN4rg=="
+      },
+      "NuGet.Configuration": {
+        "type": "Direct",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForgeStudio.Cli/packages.lock.json
+++ b/PowerForgeStudio.Cli/packages.lock.json
@@ -87,7 +87,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforgestudio.domain": {
@@ -102,6 +103,28 @@
           "PowerForge": "[1.0.0, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForgeStudio.Orchestrator/packages.lock.json
+++ b/PowerForgeStudio.Orchestrator/packages.lock.json
@@ -88,11 +88,34 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforgestudio.domain": {
         "type": "Project"
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForgeStudio.Tests/packages.lock.json
+++ b/PowerForgeStudio.Tests/packages.lock.json
@@ -184,7 +184,8 @@
         "dependencies": {
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforgestudio.domain": {
@@ -199,6 +200,28 @@
           "PowerForge": "[1.0.0, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForgeStudio.Wpf/packages.lock.json
+++ b/PowerForgeStudio.Wpf/packages.lock.json
@@ -125,7 +125,8 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
-          "System.Reflection.MetadataLoadContext": "[8.0.0, )"
+          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
+          "NuGet.Configuration": "[7.6.0, )"
         }
       },
       "powerforgestudio.domain": {
@@ -140,6 +141,27 @@
           "PowerForge": "[1.0.0, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0"
+        }
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -120,6 +120,10 @@
       ],
       "description": "Controls how selected projects are packed. PerProject runs a non-incremental build followed by dotnet pack --no-build for each project. MSBuild/Batch requires OutputPath or StagingPath, generates a temporary MSBuild traversal project, and rebuilds then packs selected projects in one invocation; when no package output path is available it falls back to PerProject. Both strategies verify primary managed assemblies under lib/<tfm>, runtimes/<rid>/lib/<tfm>, and tools/<tfm>/any against exact fresh build target directories before signing or publishing. Native runtime assets and metadata-only packages are not assembly-hash targets. The batch target runs Restore;Rebuild;Pack, requires private feed credentials to be available to dotnet/MSBuild restore, stops on the first project failure, and treats the whole failed batch as failed, so already-produced packages from that batch are not signed or published. Projects without a resolved version are reported as failed skipped projects."
     },
+    "IncludeSymbols": {
+      "type": "boolean",
+      "description": "When true, creates portable .snupkg symbol packages and includes them in publish and staged release outputs."
+    },
     "PublishNuget": {
       "type": "boolean"
     },


### PR DESCRIPTION
## Summary

- add declarative portable symbol-package support to repository project builds through `IncludeSymbols`
- emit `.snupkg` outputs for per-project and MSBuild batch packing while collecting them only when PowerForge explicitly opts in
- sign primary and symbol packages together when package signing is enabled
- publish each primary `.nupkg` once from a directory that also contains its companion `.snupkg`, allowing remote NuGet feeds to upload both in one command
- keep NuGet.config source resolution intact by using the real package directory inside the configuration hierarchy and temporary, automatically cleaned staging beneath that hierarchy for external output paths
- publish symbols explicitly for local, UNC, and `file://` feeds, including reused package builds and hierarchical feed layouts
- resolve relative package and feed paths from the caller's working/configuration context before package-directory or staging relocation; resolve named local feeds through the real NuGet.config hierarchy while preserving named remote sources and absolute URIs
- publish a symbol package only after its matching primary package was published or accepted under `SkipDuplicate`
- use the shared typed NuGet client for direct and reused publication, with `--no-symbols` whenever symbols are disabled
- keep generic `Publish-NugetPackage` scoped to explicit primary packages, preserve its caller directory for relative/named sources, and suppress implicit symbol uploads that bypass `ShouldProcess`
- classify primary and symbol outcomes per artifact, preserving mixed results and honoring whether duplicate conflicts are allowed to be skipped
- require symbol artifacts when reusing an earlier build and carry them through summaries, unified module-release staging, GitHub assets, checksums, and release manifests
- preserve the existing public `DotNetNuGetPushRequest` constructor while adding companion-symbol suppression
- expose the option through `project.build.json`, repository-release commands, and both module-build package DSL surfaces

PowerForge remains the shared owner of symbol generation, signing, staging, publication, NuGet source resolution, and result reporting. Consumer projects opt in through configuration instead of adding local packaging logic.

## Validation

- multi-target Release solution build succeeded with zero warnings or errors across net472, net8, and net10
- direct typed-client regressions passed 8/8 on Windows and Ubuntu; related publishing contracts passed 26/26
- all 3,997 logical PowerForge cases were covered across broad and isolated runs; unrelated parallel fixture/timing failures passed immediately in isolation
- a real disposable local-feed push passed on Windows and Ubuntu with spaces in the repository, package, source, API-key, and runtime paths
- locked restore passed for the affected PowerForge/PSPublishModule project graph
- local-feed, file-URI, named-source, staging-cleanup, and duplicate-policy behavior passed on Windows and Ubuntu WSL
- real per-project and MSBuild batch tests cover explicit opt-in and project-only symbol settings
- a disposable package pair was signed with `dotnet nuget sign`; both archives contained `.signature.p7s`
- net472 smoke tests passed 4/4; Studio tests passed 147 with one skipped smoke harness
- dependency audit reported no known vulnerable packages
- `project.build.schema.json` parses successfully