### PR TITLE
Stabilize module formatting and managed uploads

### DIFF
--- a/PowerForge.PowerShell/Services/ModuleBuildProfileFactory.cs
+++ b/PowerForge.PowerShell/Services/ModuleBuildProfileFactory.cs
@@ -38,7 +38,7 @@ internal sealed class ModuleBuildProfileFactory
             PlaceOpenBraceNewLineAfter = true,
             PlaceOpenBraceIgnoreOneLineBlock = false,
             PlaceCloseBraceEnable = true,
-            PlaceCloseBraceNewLineAfter = true,
+            PlaceCloseBraceNewLineAfter = false,
             PlaceCloseBraceIgnoreOneLineBlock = false,
             PlaceCloseBraceNoEmptyLineBefore = true,
             UseConsistentIndentationEnable = true,

--- a/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
+++ b/PowerForge.Tests/ManagedModuleRepositoryClientTests.cs
@@ -973,6 +973,7 @@ public sealed class ManagedModuleRepositoryClientTests
         Assert.Equal("package", publishRequest.MultipartPartName);
         Assert.Equal("Company.Tools.1.0.0.nupkg", publishRequest.MultipartFileName);
         Assert.Equal("application/octet-stream", publishRequest.MultipartPartContentType);
+        Assert.Equal(HttpVersion.Version11, publishRequest.Version);
     }
 
     [Fact]
@@ -1347,6 +1348,7 @@ public sealed class ManagedModuleRepositoryClientTests
                 apiKey,
                 nuGetClientVersion,
                 request.Headers.UserAgent.ToString(),
+                request.Version,
                 request.Content?.Headers.ContentType?.MediaType,
                 multipart?.Count() ?? 0,
                 firstPart?.Headers.ContentDisposition?.Name?.Trim('"'),
@@ -1720,6 +1722,7 @@ public sealed class ManagedModuleRepositoryClientTests
             string? apiKey,
             string? nuGetClientVersion,
             string userAgent,
+            Version version,
             string? contentType,
             int multipartPartCount,
             string? multipartPartName,
@@ -1732,6 +1735,7 @@ public sealed class ManagedModuleRepositoryClientTests
             ApiKey = apiKey;
             NuGetClientVersion = nuGetClientVersion;
             UserAgent = userAgent;
+            Version = version;
             ContentType = contentType;
             MultipartPartCount = multipartPartCount;
             MultipartPartName = multipartPartName;
@@ -1750,6 +1754,8 @@ public sealed class ManagedModuleRepositoryClientTests
         public string? NuGetClientVersion { get; }
 
         public string UserAgent { get; }
+
+        public Version Version { get; }
 
         public string? ContentType { get; }
 

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -286,6 +286,12 @@ public sealed class PowerForgeProjectCmdletTests
         Assert.Contains(segments, static segment => segment is ConfigurationBuildSegment);
         Assert.DoesNotContain(segments, static segment => segment is ConfigurationDocumentationSegment);
 
+        var mergedPsm1Formatting = segments
+            .OfType<ConfigurationFormattingSegment>()
+            .Select(static segment => segment.Options.Merge.FormatCodePSM1)
+            .Single(static formatting => formatting is not null);
+        Assert.False(mergedPsm1Formatting!.FormatterSettings!.Rules.PSPlaceCloseBrace!.NewLineAfter);
+
         var build = segments.OfType<ConfigurationBuildSegment>().Single().BuildModule;
         Assert.True(build.Enable);
         Assert.True(build.Merge);

--- a/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Publish.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleRepositoryClient.Publish.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -121,6 +122,11 @@ public sealed partial class ManagedModuleRepositoryClient
             () =>
             {
                 var request = CreateRequest(HttpMethod.Put, new Uri(publishAddress), credential, "application/json");
+                // NuGet-compatible endpoints and intermediaries can reset HTTP/2 multipart uploads.
+                request.Version = HttpVersion.Version11;
+#if !NET472
+                request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+#endif
                 request.Headers.TryAddWithoutValidation(NuGetClientVersionHeader, NuGetPublishProtocolClientVersion);
                 var packageContent = new StreamContent(File.OpenRead(package));
                 packageContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");


### PR DESCRIPTION
## Summary

- keep generated module bootstrappers stable when the staged module is formatted and synchronized
- publish managed-module package uploads over exact HTTP/1.1 while retaining HTTP/2 negotiation for repository reads and downloads
- add regression coverage for both contracts

## Validation

- affected test classes: 82 passed
- `dotnet build .\PSPublishModule.sln -c Release`: 0 warnings, 0 errors
- module Build gate completed successfully and left the generated bootstrapper unchanged
