### PR TITLE
Fix generated website accessibility contracts

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed class WebApiDocsGeneratorAccessibilityTests
+{
+    [Fact]
+    public void Generate_AssignsUniqueIdsToCaseDistinctNamespaces()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-namespace-ids-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "test.xml");
+            File.WriteAllText(xmlPath,
+                """
+                <doc>
+                  <assembly><name>Test</name></assembly>
+                  <members>
+                    <member name="T:Sample.QR.Upper"><summary>Upper namespace.</summary></member>
+                    <member name="T:Sample.Qr.Mixed"><summary>Mixed namespace.</summary></member>
+                  </members>
+                </doc>
+                """);
+
+            var outputPath = Path.Combine(root, "api");
+            var result = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                XmlPath = xmlPath,
+                OutputPath = outputPath,
+                Format = "html",
+                Template = "docs",
+                BaseUrl = "/api"
+            });
+
+            Assert.Equal(2, result.TypeCount);
+            var html = File.ReadAllText(Path.Combine(outputPath, "index.html"));
+            Assert.Single(Regex.Matches(html, "id=\"namespace-sample-qr\"", RegexOptions.IgnoreCase).Cast<Match>());
+            Assert.Single(Regex.Matches(html, "id=\"namespace-sample-qr-2\"", RegexOptions.IgnoreCase).Cast<Match>());
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
@@ -21,6 +21,7 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
                   <members>
                     <member name="T:Sample.QR.Upper"><summary>Upper namespace.</summary></member>
                     <member name="T:Sample.Qr.Mixed"><summary>Mixed namespace.</summary></member>
+                    <member name="T:Sample.Qr._2.Suffixed"><summary>Suffix-like namespace.</summary></member>
                   </members>
                 </doc>
                 """);
@@ -35,10 +36,11 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
                 BaseUrl = "/api"
             });
 
-            Assert.Equal(2, result.TypeCount);
+            Assert.Equal(3, result.TypeCount);
             var html = File.ReadAllText(Path.Combine(outputPath, "index.html"));
             Assert.Single(Regex.Matches(html, "id=\"namespace-sample-qr\"", RegexOptions.IgnoreCase).Cast<Match>());
             Assert.Single(Regex.Matches(html, "id=\"namespace-sample-qr-2\"", RegexOptions.IgnoreCase).Cast<Match>());
+            Assert.Single(Regex.Matches(html, "id=\"namespace-sample-qr-2-2\"", RegexOptions.IgnoreCase).Cast<Match>());
         }
         finally
         {

--- a/PowerForge.Tests/WebReleaseHubRenderingTests.cs
+++ b/PowerForge.Tests/WebReleaseHubRenderingTests.cs
@@ -22,6 +22,8 @@ public class WebReleaseHubRenderingTests
         Assert.Contains("Download Chat", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("data-release-platform=\"windows\"", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Platform: Windows", html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<h3 class=\"pf-release-group-title\">Platform: Windows</h3>", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("<h4 class=\"pf-release-group-title\">", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Latest Stable", html, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Preview", html, StringComparison.OrdinalIgnoreCase);
     }

--- a/PowerForge.Web/Services/ReleaseHubRenderer.cs
+++ b/PowerForge.Web/Services/ReleaseHubRenderer.cs
@@ -165,9 +165,9 @@ internal static class ReleaseHubRenderer
                 sb.Append("<section class=\"pf-release-group\" data-release-group=\"")
                     .Append(Html(group.Key))
                     .Append("\">");
-                sb.Append("<h4 class=\"pf-release-group-title\">")
+                sb.Append("<h3 class=\"pf-release-group-title\">")
                     .Append(Html(FormatGroupingLabel(mode, group.Key)))
-                    .Append("</h4>");
+                    .Append("</h3>");
             }
 
             sb.Append("<div class=\"pf-release-buttons-list\">");

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
@@ -1445,15 +1445,20 @@ body.pf-api-docs .api-suite-search-filter{
     private static IReadOnlyDictionary<string, string> BuildUniqueNamespaceAnchorIds(IEnumerable<string> namespaceNames)
     {
         var anchors = new Dictionary<string, string>(StringComparer.Ordinal);
-        var occurrences = new Dictionary<string, int>(StringComparer.Ordinal);
+        var emitted = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var namespaceName in namespaceNames)
         {
             var baseAnchor = BuildNamespaceAnchorId(namespaceName);
-            occurrences.TryGetValue(baseAnchor, out var occurrence);
-            occurrence++;
-            occurrences[baseAnchor] = occurrence;
-            anchors[namespaceName] = occurrence == 1 ? baseAnchor : $"{baseAnchor}-{occurrence}";
+            var anchor = baseAnchor;
+            var suffix = 2;
+            while (!emitted.Add(anchor))
+            {
+                anchor = $"{baseAnchor}-{suffix}";
+                suffix++;
+            }
+
+            anchors[namespaceName] = anchor;
         }
 
         return anchors;

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
@@ -1047,6 +1047,7 @@ body.pf-api-docs .api-suite-search-filter{
         var namespaceGroups = types
             .GroupBy(static t => string.IsNullOrWhiteSpace(t.Namespace) ? "(global)" : t.Namespace)
             .OrderBy(static g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static g => g.Key, StringComparer.Ordinal)
             .ToList();
         var mainTypes = GetMainTypes(types, options);
         var mainTypeNames = new HashSet<string>(mainTypes.Select(static t => t.Name), StringComparer.OrdinalIgnoreCase);
@@ -1276,7 +1277,9 @@ body.pf-api-docs .api-suite-search-filter{
         var namespaceGroups = types
             .GroupBy(static t => string.IsNullOrWhiteSpace(t.Namespace) ? "(global)" : t.Namespace)
             .OrderBy(static g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(static g => g.Key, StringComparer.Ordinal)
             .ToList();
+        var namespaceAnchors = BuildUniqueNamespaceAnchorIds(namespaceGroups.Select(static group => group.Key));
         var primaryKindPluralLabel = ResolvePrimaryKindPluralLabel(types);
 
         html.Line("<div class=\"api-overview ev-page-body\">");
@@ -1344,7 +1347,7 @@ body.pf-api-docs .api-suite-search-filter{
                     html.Line($"<p class=\"section-desc\">Browse all {types.Count} {primaryKindPluralLabel} organized by namespace.</p>");
                     foreach (var group in namespaceGroups)
                     {
-                        AppendOverviewNamespaceGroup(html, group, baseUrl, typeDisplayNames);
+                        AppendOverviewNamespaceGroup(html, group, namespaceAnchors[group.Key], baseUrl, typeDisplayNames);
                     }
                 }
                 html.Line("</section>");
@@ -1358,6 +1361,7 @@ body.pf-api-docs .api-suite-search-filter{
     private static void AppendOverviewNamespaceGroup(
         HtmlFragmentBuilder html,
         IGrouping<string, ApiTypeModel> group,
+        string anchor,
         string baseUrl,
         IReadOnlyDictionary<string, string> typeDisplayNames)
     {
@@ -1366,7 +1370,6 @@ body.pf-api-docs .api-suite-search-filter{
 
         const int visibleLimit = 24;
         var namespaceName = group.Key;
-        var anchor = BuildNamespaceAnchorId(namespaceName);
         var ordered = group.OrderBy(static t => t.Name, StringComparer.OrdinalIgnoreCase).ToList();
         var total = ordered.Count;
         var hasOverflow = total > visibleLimit;
@@ -1437,6 +1440,23 @@ body.pf-api-docs .api-suite-search-filter{
         normalized = normalized.Replace("(global)", "global", StringComparison.OrdinalIgnoreCase);
         normalized = SlugDashRegex.Replace(SlugNonAlnumRegex.Replace(normalized, "-"), "-").Trim('-');
         return string.IsNullOrWhiteSpace(normalized) ? "namespace-global" : "namespace-" + normalized;
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildUniqueNamespaceAnchorIds(IEnumerable<string> namespaceNames)
+    {
+        var anchors = new Dictionary<string, string>(StringComparer.Ordinal);
+        var occurrences = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var namespaceName in namespaceNames)
+        {
+            var baseAnchor = BuildNamespaceAnchorId(namespaceName);
+            occurrences.TryGetValue(baseAnchor, out var occurrence);
+            occurrence++;
+            occurrences[baseAnchor] = occurrence;
+            anchors[namespaceName] = occurrence == 1 ? baseAnchor : $"{baseAnchor}-{occurrence}";
+        }
+
+        return anchors;
     }
 
     private static string RenderApiGlyphSpan(string containerClass, string glyphClass, string glyph)

--- a/PowerForge.Web/Services/WebSiteAuditor.AssetsAndRendered.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.AssetsAndRendered.cs
@@ -831,7 +831,6 @@ public static partial class WebSiteAuditor
     let merged = white;
     for (let i = layers.length - 1; i >= 0; i--) {
       merged = composite(layers[i], merged);
-      if (merged.a >= 0.999) break;
     }
 
     return merged;


### PR DESCRIPTION
## Summary

- generate deterministic, unique API namespace anchors when normalized names collide
- keep release-group headings in the correct document hierarchy
- composite translucent ancestor backgrounds correctly before reporting rendered contrast
- add regression coverage for namespace-anchor and release-heading contracts

## Why this matters

The CodeGlyphX API and release pages exposed all three defects: case-distinct namespaces produced duplicate IDs, grouped releases skipped a heading level, and the rendered audit could stop at the first opaque intermediate result instead of evaluating the complete background stack. Fixing these in PowerForge keeps generated sites thin and consistent.

## Validation

- focused PowerForge generator/auditor tests pass (12/12)
- the complete CodeGlyphX website pipeline builds current API docs and finishes its rendered doctor audit with zero errors and zero warnings using this branch