### PR TITLE
Use the canonical async lifecycle for Task-backed cmdlets

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,8 @@
 
 ## Unreleased
 ### What's Changed
+- Hardened the canonical `AsyncPSCmdlet` lifecycle with request-specific prompt and `ShouldProcess` replies while preserving PowerShell-thread execution until the first await.
+- Converted Task-backed App Store Connect and managed catalog cmdlets from sync-over-async blocking to cancellable asynchronous lifecycle hooks.
 - Added `Import-IsolatedModule` with a built-in `ExchangeOnlineManagement` profile that loads EXO binary assemblies through a module-scoped AssemblyLoadContext, allowing EXO's OData 7.22 dependency line to coexist with Az.Storage's OData 7.6 line in the same PowerShell 7 process.
 - Added a built-in `MicrosoftTeams` profile for `Import-IsolatedModule` that loads the Teams connect, Teams cmdlet, policy administration, and ConfigAPI binary surfaces through `MicrosoftTeams.ALC`.
 - Added `Import-IsolatedModule -PreferIsolatedModulePath` so downstream modules that import a profiled module by name can opt into resolving the generated isolated copy first for the current PowerShell process.

--- a/PSPublishModule/Cmdlets/AddAppStoreConnectBetaTesterToGroupCommand.cs
+++ b/PSPublishModule/Cmdlets/AddAppStoreConnectBetaTesterToGroupCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -7,7 +8,7 @@ namespace PSPublishModule;
 /// Adds App Store Connect beta testers to a TestFlight beta group.
 /// </summary>
 [Cmdlet(VerbsCommon.Add, "AppStoreConnectBetaTesterToGroup", SupportsShouldProcess = true)]
-public sealed class AddAppStoreConnectBetaTesterToGroupCommand : PSCmdlet
+public sealed class AddAppStoreConnectBetaTesterToGroupCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -31,7 +32,7 @@ public sealed class AddAppStoreConnectBetaTesterToGroupCommand : PSCmdlet
     [Parameter(Mandatory = true)] public string[] BetaTesterId { get; set; } = System.Array.Empty<string>();
 
     /// <summary>Adds beta testers to a TestFlight beta group.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         if (!ShouldProcess(BetaGroupId, "Add App Store Connect beta tester(s) to beta group"))
             return;
@@ -39,6 +40,6 @@ public sealed class AddAppStoreConnectBetaTesterToGroupCommand : PSCmdlet
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        client.AddBetaTestersToBetaGroupAsync(BetaGroupId, BetaTesterId).GetAwaiter().GetResult();
+        await client.AddBetaTestersToBetaGroupAsync(BetaGroupId, BetaTesterId, CancelToken);
     }
 }

--- a/PSPublishModule/Cmdlets/AddAppStoreConnectBuildToBetaGroupCommand.cs
+++ b/PSPublishModule/Cmdlets/AddAppStoreConnectBuildToBetaGroupCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -7,7 +8,7 @@ namespace PSPublishModule;
 /// Adds App Store Connect builds to a TestFlight beta group.
 /// </summary>
 [Cmdlet(VerbsCommon.Add, "AppStoreConnectBuildToBetaGroup", SupportsShouldProcess = true)]
-public sealed class AddAppStoreConnectBuildToBetaGroupCommand : PSCmdlet
+public sealed class AddAppStoreConnectBuildToBetaGroupCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -31,7 +32,7 @@ public sealed class AddAppStoreConnectBuildToBetaGroupCommand : PSCmdlet
     [Parameter(Mandatory = true)] public string[] BuildId { get; set; } = System.Array.Empty<string>();
 
     /// <summary>Adds builds to a TestFlight beta group.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         if (!ShouldProcess(BetaGroupId, "Add App Store Connect build(s) to beta group"))
             return;
@@ -39,6 +40,6 @@ public sealed class AddAppStoreConnectBuildToBetaGroupCommand : PSCmdlet
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        client.AddBuildsToBetaGroupAsync(BetaGroupId, BuildId).GetAwaiter().GetResult();
+        await client.AddBuildsToBetaGroupAsync(BetaGroupId, BuildId, CancelToken);
     }
 }

--- a/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
+++ b/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
@@ -12,13 +12,20 @@ namespace PSPublishModule;
 /// </summary>
 /// <remarks>
 /// Invoke asynchronous hooks on the PowerShell pipeline thread until their first incomplete await.
-/// The base temporarily suppresses the host synchronization context while invoking each hook so
-/// continuations cannot be posted back to the pipeline thread while it is pumping output.
+/// The base temporarily replaces the host synchronization context with an internal thread-pool
+/// context while invoking each hook. This prevents continuations from capturing either the host
+/// context or a custom task scheduler that may be running the PowerShell pipeline thread.
 /// Keep hook implementations asynchronous all the way through and pass <see cref="CancelToken"/> to
 /// cancellable engine operations. Do not block with Task.Wait, Task.Result, or Task.WaitAll.
 /// </remarks>
 public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
 {
+    private sealed class AsyncHookSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback callback, object? state)
+            => ThreadPool.QueueUserWorkItem(_ => callback(state));
+    }
+
     private enum PipelineType
     {
         Output,
@@ -50,6 +57,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
     }
 
     private readonly CancellationTokenSource _cancelSource = new();
+    private static readonly SynchronizationContext HookSynchronizationContext = new AsyncHookSynchronizationContext();
     private BlockingCollection<PipelineItem>? _currentOutPipe;
     private int _pipelineThreadId;
 
@@ -288,7 +296,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
         var synchronizationContext = SynchronizationContext.Current;
         try
         {
-            SynchronizationContext.SetSynchronizationContext(null);
+            SynchronizationContext.SetSynchronizationContext(HookSynchronizationContext);
             blockTask = task();
         }
         catch

--- a/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
+++ b/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
@@ -10,6 +10,11 @@ namespace PSPublishModule;
 /// Base class for cmdlets that await asynchronous engine work while routing PowerShell pipeline writes
 /// back through the synchronous cmdlet pipeline thread.
 /// </summary>
+/// <remarks>
+/// Invoke asynchronous hooks on the PowerShell pipeline thread until their first incomplete await.
+/// Keep hook implementations asynchronous all the way through and pass <see cref="CancelToken"/> to
+/// cancellable engine operations. Do not block with Task.Wait, Task.Result, or Task.WaitAll.
+/// </remarks>
 public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
 {
     private enum PipelineType
@@ -26,9 +31,24 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
         PromptForCredential
     }
 
+    private sealed class PipelineItem
+    {
+        public PipelineItem(object? value, PipelineType type, BlockingCollection<object?>? replyPipe = null)
+        {
+            Value = value;
+            Type = type;
+            ReplyPipe = replyPipe;
+        }
+
+        public object? Value { get; }
+
+        public PipelineType Type { get; }
+
+        public BlockingCollection<object?>? ReplyPipe { get; }
+    }
+
     private readonly CancellationTokenSource _cancelSource = new();
-    private BlockingCollection<(object? Value, PipelineType Type)>? _currentOutPipe;
-    private BlockingCollection<object?>? _currentReplyPipe;
+    private BlockingCollection<PipelineItem>? _currentOutPipe;
     private int _pipelineThreadId;
 
     /// <summary>Cancellation token triggered when PowerShell stops the cmdlet.</summary>
@@ -66,22 +86,24 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
     public new bool ShouldProcess(string? target, string action)
     {
         ThrowIfStopped();
-        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread)
+        if (_currentOutPipe is null || IsPipelineThread)
             return base.ShouldProcess(target ?? string.Empty, action);
 
-        _currentOutPipe.Add(((target ?? string.Empty, action), PipelineType.ShouldProcess), CancelToken);
-        return (bool)_currentReplyPipe.Take(CancelToken)!;
+        using var replyPipe = new BlockingCollection<object?>(boundedCapacity: 1);
+        _currentOutPipe.Add(new PipelineItem((target ?? string.Empty, action), PipelineType.ShouldProcess, replyPipe), CancelToken);
+        return (bool)replyPipe.Take(CancelToken)!;
     }
 
     /// <summary>Thread-safe credential prompt bridge for asynchronous cmdlet code.</summary>
     public PSCredential? PromptForCredential(string caption, string message, string userName, string targetName)
     {
         ThrowIfStopped();
-        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread)
+        if (_currentOutPipe is null || IsPipelineThread)
             return Host.UI.PromptForCredential(caption, message, userName, targetName);
 
-        _currentOutPipe.Add(((caption, message, userName, targetName), PipelineType.PromptForCredential), CancelToken);
-        return (PSCredential?)_currentReplyPipe.Take(CancelToken);
+        using var replyPipe = new BlockingCollection<object?>(boundedCapacity: 1);
+        _currentOutPipe.Add(new PipelineItem((caption, message, userName, targetName), PipelineType.PromptForCredential, replyPipe), CancelToken);
+        return (PSCredential?)replyPipe.Take(CancelToken);
     }
 
     /// <summary>Thread-safe output bridge for asynchronous cmdlet code.</summary>
@@ -98,7 +120,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
         }
 
-        _currentOutPipe.Add((sendToPipeline, enumerateCollection ? PipelineType.OutputEnumerate : PipelineType.Output), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(sendToPipeline, enumerateCollection ? PipelineType.OutputEnumerate : PipelineType.Output), CancelToken);
     }
 
     /// <summary>Thread-safe error bridge for asynchronous cmdlet code.</summary>
@@ -111,7 +133,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
         }
 
-        _currentOutPipe.Add((errorRecord, PipelineType.Error), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(errorRecord, PipelineType.Error), CancelToken);
     }
 
     /// <summary>Thread-safe warning bridge for asynchronous cmdlet code.</summary>
@@ -124,7 +146,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
         }
 
-        _currentOutPipe.Add((text, PipelineType.Warning), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(text, PipelineType.Warning), CancelToken);
     }
 
     /// <summary>Thread-safe verbose bridge for asynchronous cmdlet code.</summary>
@@ -137,7 +159,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
         }
 
-        _currentOutPipe.Add((text, PipelineType.Verbose), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(text, PipelineType.Verbose), CancelToken);
     }
 
     /// <summary>Thread-safe debug bridge for asynchronous cmdlet code.</summary>
@@ -150,7 +172,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
         }
 
-        _currentOutPipe.Add((text, PipelineType.Debug), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(text, PipelineType.Debug), CancelToken);
     }
 
     /// <summary>Thread-safe information bridge for asynchronous cmdlet code.</summary>
@@ -163,7 +185,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
         }
 
-        _currentOutPipe.Add((informationRecord, PipelineType.Information), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(informationRecord, PipelineType.Information), CancelToken);
     }
 
     /// <summary>Thread-safe progress bridge for asynchronous cmdlet code.</summary>
@@ -176,7 +198,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
         }
 
-        _currentOutPipe.Add((progressRecord, PipelineType.Progress), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(progressRecord, PipelineType.Progress), CancelToken);
     }
 
     /// <summary>Throws when PowerShell has requested cancellation.</summary>
@@ -195,17 +217,14 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
 
     private void RunBlockInAsync(Func<Task> task)
     {
-        using var outPipe = new BlockingCollection<(object? Value, PipelineType Type)>();
-        using var replyPipe = new BlockingCollection<object?>();
+        using var outPipe = new BlockingCollection<PipelineItem>();
         Task blockTask;
 
         void ClearPipes()
         {
             _currentOutPipe = null;
-            _currentReplyPipe = null;
             _pipelineThreadId = 0;
             CompleteAddingIfNeeded(outPipe);
-            CompleteAddingIfNeeded(replyPipe);
         }
 
         static void CompleteAddingIfNeeded<T>(BlockingCollection<T> pipe)
@@ -214,7 +233,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
                 pipe.CompleteAdding();
         }
 
-        void PumpItem((object? Value, PipelineType Type) item)
+        void PumpItem(PipelineItem item)
         {
             switch (item.Type)
             {
@@ -244,11 +263,11 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
                     break;
                 case PipelineType.ShouldProcess:
                     var should = ((string Target, string Action))item.Value!;
-                    replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
+                    item.ReplyPipe!.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
                     break;
                 case PipelineType.PromptForCredential:
                     var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
-                    replyPipe.Add(
+                    item.ReplyPipe!.Add(
                         Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
                         CancelToken);
                     break;
@@ -263,7 +282,6 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
 
         _pipelineThreadId = Environment.CurrentManagedThreadId;
         _currentOutPipe = outPipe;
-        _currentReplyPipe = replyPipe;
 
         try
         {
@@ -278,8 +296,15 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
         if (blockTask.IsCompleted)
         {
             CompleteAddingIfNeeded(outPipe);
-            PumpQueuedItems();
-            ClearPipes();
+            try
+            {
+                PumpQueuedItems();
+            }
+            finally
+            {
+                ClearPipes();
+            }
+
             blockTask.GetAwaiter().GetResult();
             return;
         }

--- a/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
+++ b/PSPublishModule/Cmdlets/AsyncPSCmdlet.cs
@@ -12,6 +12,8 @@ namespace PSPublishModule;
 /// </summary>
 /// <remarks>
 /// Invoke asynchronous hooks on the PowerShell pipeline thread until their first incomplete await.
+/// The base temporarily suppresses the host synchronization context while invoking each hook so
+/// continuations cannot be posted back to the pipeline thread while it is pumping output.
 /// Keep hook implementations asynchronous all the way through and pass <see cref="CancelToken"/> to
 /// cancellable engine operations. Do not block with Task.Wait, Task.Result, or Task.WaitAll.
 /// </remarks>
@@ -283,14 +285,20 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable
         _pipelineThreadId = Environment.CurrentManagedThreadId;
         _currentOutPipe = outPipe;
 
+        var synchronizationContext = SynchronizationContext.Current;
         try
         {
+            SynchronizationContext.SetSynchronizationContext(null);
             blockTask = task();
         }
         catch
         {
             ClearPipes();
             throw;
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
         }
 
         if (blockTask.IsCompleted)

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectAppCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectAppCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectApp")]
 [OutputType(typeof(AppStoreConnectAppInfo))]
-public sealed class GetAppStoreConnectAppCommand : PSCmdlet
+public sealed class GetAppStoreConnectAppCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -41,7 +42,7 @@ public sealed class GetAppStoreConnectAppCommand : PSCmdlet
     [Parameter(ParameterSetName = "Find")] public int Limit { get; set; } = 20;
 
     /// <summary>Reads app information from App Store Connect.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
@@ -49,12 +50,12 @@ public sealed class GetAppStoreConnectAppCommand : PSCmdlet
 
         if (ParameterSetName == "ById")
         {
-            var app = client.GetAppAsync(AppId!).GetAwaiter().GetResult();
+            var app = await client.GetAppAsync(AppId!, CancelToken);
             if (app is not null) WriteObject(app);
             return;
         }
 
-        var apps = client.FindAppsAsync(BundleId, Name, Platform, Limit).GetAwaiter().GetResult();
+        var apps = await client.FindAppsAsync(BundleId, Name, Platform, Limit, CancelToken);
         WriteObject(apps, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectBetaGroupCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectBetaGroupCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectBetaGroup")]
 [OutputType(typeof(AppStoreConnectBetaGroupInfo))]
-public sealed class GetAppStoreConnectBetaGroupCommand : PSCmdlet
+public sealed class GetAppStoreConnectBetaGroupCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -35,12 +36,12 @@ public sealed class GetAppStoreConnectBetaGroupCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 200;
 
     /// <summary>Reads TestFlight beta groups.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var groups = client.GetBetaGroupsAsync(AppId, Name, Limit).GetAwaiter().GetResult();
+        var groups = await client.GetBetaGroupsAsync(AppId, Name, Limit, CancelToken);
         WriteObject(groups, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectBetaTesterCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectBetaTesterCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectBetaTester")]
 [OutputType(typeof(AppStoreConnectBetaTesterInfo))]
-public sealed class GetAppStoreConnectBetaTesterCommand : PSCmdlet
+public sealed class GetAppStoreConnectBetaTesterCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -32,12 +33,12 @@ public sealed class GetAppStoreConnectBetaTesterCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 200;
 
     /// <summary>Reads TestFlight beta testers.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var testers = client.GetBetaTestersAsync(Email, Limit).GetAwaiter().GetResult();
+        var testers = await client.GetBetaTestersAsync(Email, Limit, CancelToken);
         WriteObject(testers, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectBuildCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectBuild")]
 [OutputType(typeof(AppStoreConnectBuildInfo))]
-public sealed class GetAppStoreConnectBuildCommand : PSCmdlet
+public sealed class GetAppStoreConnectBuildCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -41,17 +42,18 @@ public sealed class GetAppStoreConnectBuildCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 20;
 
     /// <summary>Reads build information from App Store Connect.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var builds = client.GetBuildsAsync(
+        var builds = await client.GetBuildsAsync(
             AppId,
             BuildNumber,
             Limit,
             MarketingVersion,
-            Platform).GetAwaiter().GetResult();
+            Platform,
+            CancelToken);
         WriteObject(builds, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectReleaseStateCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectReleaseStateCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -9,7 +10,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectReleaseState")]
 [OutputType(typeof(AppStoreConnectReleaseStateResult))]
-public sealed class GetAppStoreConnectReleaseStateCommand : PSCmdlet
+public sealed class GetAppStoreConnectReleaseStateCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -48,13 +49,13 @@ public sealed class GetAppStoreConnectReleaseStateCommand : PSCmdlet
     [Parameter] public SwitchParameter IncludeAllBetaGroups { get; set; }
 
     /// <summary>Reads App Store Connect release state.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectReleaseStateService(client);
-        var result = service.GetAsync(new AppStoreConnectReleaseStateRequest
+        var result = await service.GetAsync(new AppStoreConnectReleaseStateRequest
         {
             Credential = credential,
             AppId = AppId,
@@ -64,7 +65,7 @@ public sealed class GetAppStoreConnectReleaseStateCommand : PSCmdlet
             BetaGroupIds = BetaGroupId,
             BetaGroupNames = BetaGroupName,
             IncludeAllBetaGroups = IncludeAllBetaGroups.IsPresent
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectScreenshotCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectScreenshotCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectScreenshot")]
 [OutputType(typeof(AppStoreConnectScreenshotInfo))]
-public sealed class GetAppStoreConnectScreenshotCommand : PSCmdlet
+public sealed class GetAppStoreConnectScreenshotCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -34,12 +35,12 @@ public sealed class GetAppStoreConnectScreenshotCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 200;
 
     /// <summary>Reads screenshots in an App Store Connect screenshot set.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var screenshots = client.GetScreenshotsAsync(ScreenshotSetId, Limit).GetAwaiter().GetResult();
+        var screenshots = await client.GetScreenshotsAsync(ScreenshotSetId, Limit, CancelToken);
         WriteObject(screenshots, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectScreenshotSetCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectScreenshotSetCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectScreenshotSet")]
 [OutputType(typeof(AppStoreConnectScreenshotSetInfo))]
-public sealed class GetAppStoreConnectScreenshotSetCommand : PSCmdlet
+public sealed class GetAppStoreConnectScreenshotSetCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -34,12 +35,12 @@ public sealed class GetAppStoreConnectScreenshotSetCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 20;
 
     /// <summary>Reads screenshot sets.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var sets = client.GetScreenshotSetsAsync(VersionLocalizationId, Limit).GetAwaiter().GetResult();
+        var sets = await client.GetScreenshotSetsAsync(VersionLocalizationId, Limit, CancelToken);
         WriteObject(sets, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectSubscriptionCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectSubscriptionCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -10,7 +11,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectSubscription")]
 [OutputType(typeof(AppStoreConnectSubscriptionInfo))]
-public sealed class GetAppStoreConnectSubscriptionCommand : PSCmdlet
+public sealed class GetAppStoreConnectSubscriptionCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -39,12 +40,12 @@ public sealed class GetAppStoreConnectSubscriptionCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 200;
 
     /// <summary>Reads auto-renewable subscription products.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var subscriptions = client.GetSubscriptionsForAppAsync(AppId, Limit).GetAwaiter().GetResult();
+        var subscriptions = await client.GetSubscriptionsForAppAsync(AppId, Limit, CancelToken);
 
         var productIds = ProductId
             .Where(value => !string.IsNullOrWhiteSpace(value))

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectSubscriptionIntroductoryOfferCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectSubscriptionIntroductoryOfferCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectSubscriptionIntroductoryOffer")]
 [OutputType(typeof(AppStoreConnectSubscriptionIntroductoryOfferInfo))]
-public sealed class GetAppStoreConnectSubscriptionIntroductoryOfferCommand : PSCmdlet
+public sealed class GetAppStoreConnectSubscriptionIntroductoryOfferCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -34,12 +35,12 @@ public sealed class GetAppStoreConnectSubscriptionIntroductoryOfferCommand : PSC
     [Parameter] public int Limit { get; set; } = 200;
 
     /// <summary>Reads subscription introductory offers.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var offers = client.GetSubscriptionIntroductoryOffersAsync(SubscriptionId, Limit).GetAwaiter().GetResult();
+        var offers = await client.GetSubscriptionIntroductoryOffersAsync(SubscriptionId, Limit, CancelToken);
         WriteObject(offers, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectSubscriptionPricePointCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectSubscriptionPricePointCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectSubscriptionPricePoint")]
 [OutputType(typeof(AppStoreConnectSubscriptionPricePointInfo))]
-public sealed class GetAppStoreConnectSubscriptionPricePointCommand : PSCmdlet
+public sealed class GetAppStoreConnectSubscriptionPricePointCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -39,12 +40,12 @@ public sealed class GetAppStoreConnectSubscriptionPricePointCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 200;
 
     /// <summary>Reads available subscription price points.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var pricePoints = client.GetSubscriptionPricePointsAsync(SubscriptionId, TerritoryId, Limit).GetAwaiter().GetResult();
+        var pricePoints = await client.GetSubscriptionPricePointsAsync(SubscriptionId, TerritoryId, Limit, CancelToken);
         WriteObject(pricePoints, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectVersionCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectVersionCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectVersion")]
 [OutputType(typeof(AppStoreConnectVersionInfo))]
-public sealed class GetAppStoreConnectVersionCommand : PSCmdlet
+public sealed class GetAppStoreConnectVersionCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -38,12 +39,12 @@ public sealed class GetAppStoreConnectVersionCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 20;
 
     /// <summary>Reads App Store version information from App Store Connect.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var versions = client.GetVersionsAsync(AppId, VersionString, Platform, Limit).GetAwaiter().GetResult();
+        var versions = await client.GetVersionsAsync(AppId, VersionString, Platform, Limit, CancelToken);
         WriteObject(versions, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/GetAppStoreConnectVersionLocalizationCommand.cs
+++ b/PSPublishModule/Cmdlets/GetAppStoreConnectVersionLocalizationCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "AppStoreConnectVersionLocalization")]
 [OutputType(typeof(AppStoreConnectVersionLocalizationInfo))]
-public sealed class GetAppStoreConnectVersionLocalizationCommand : PSCmdlet
+public sealed class GetAppStoreConnectVersionLocalizationCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -37,12 +38,12 @@ public sealed class GetAppStoreConnectVersionLocalizationCommand : PSCmdlet
     [Parameter] public int Limit { get; set; } = 20;
 
     /// <summary>Reads App Store version localizations.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var localizations = client.GetVersionLocalizationsAsync(VersionId, Locale, Limit).GetAwaiter().GetResult();
+        var localizations = await client.GetVersionLocalizationsAsync(VersionId, Locale, Limit, CancelToken);
         WriteObject(localizations, enumerateCollection: true);
     }
 }

--- a/PSPublishModule/Cmdlets/NewAppStoreConnectBetaTesterCommand.cs
+++ b/PSPublishModule/Cmdlets/NewAppStoreConnectBetaTesterCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.New, "AppStoreConnectBetaTester", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectBetaTesterInfo))]
-public sealed class NewAppStoreConnectBetaTesterCommand : PSCmdlet
+public sealed class NewAppStoreConnectBetaTesterCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -38,7 +39,7 @@ public sealed class NewAppStoreConnectBetaTesterCommand : PSCmdlet
     [Parameter] public string[] BetaGroupId { get; set; } = System.Array.Empty<string>();
 
     /// <summary>Creates a TestFlight beta tester.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         if (!ShouldProcess(Email, "Create App Store Connect beta tester"))
             return;
@@ -46,7 +47,7 @@ public sealed class NewAppStoreConnectBetaTesterCommand : PSCmdlet
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var tester = client.CreateBetaTesterAsync(Email, FirstName, LastName, BetaGroupId).GetAwaiter().GetResult();
+        var tester = await client.CreateBetaTesterAsync(Email, FirstName, LastName, BetaGroupId, CancelToken);
         WriteObject(tester);
     }
 }

--- a/PSPublishModule/Cmdlets/NewAppStoreConnectScreenshotSetCommand.cs
+++ b/PSPublishModule/Cmdlets/NewAppStoreConnectScreenshotSetCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.New, "AppStoreConnectScreenshotSet", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectScreenshotSetInfo))]
-public sealed class NewAppStoreConnectScreenshotSetCommand : PSCmdlet
+public sealed class NewAppStoreConnectScreenshotSetCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -36,7 +37,7 @@ public sealed class NewAppStoreConnectScreenshotSetCommand : PSCmdlet
     public string ScreenshotDisplayType { get; set; } = string.Empty;
 
     /// <summary>Creates the screenshot set.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         if (!ShouldProcess(VersionLocalizationId, $"Create App Store Connect screenshot set '{ScreenshotDisplayType}'"))
             return;
@@ -44,7 +45,7 @@ public sealed class NewAppStoreConnectScreenshotSetCommand : PSCmdlet
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var set = client.CreateScreenshotSetAsync(VersionLocalizationId, ScreenshotDisplayType).GetAwaiter().GetResult();
+        var set = await client.CreateScreenshotSetAsync(VersionLocalizationId, ScreenshotDisplayType, CancelToken);
         WriteObject(set);
     }
 }

--- a/PSPublishModule/Cmdlets/NewAppStoreConnectSubscriptionIntroductoryOfferCommand.cs
+++ b/PSPublishModule/Cmdlets/NewAppStoreConnectSubscriptionIntroductoryOfferCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -10,7 +11,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.New, "AppStoreConnectSubscriptionIntroductoryOffer", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
 [OutputType(typeof(AppStoreConnectSubscriptionIntroductoryOfferInfo))]
-public sealed class NewAppStoreConnectSubscriptionIntroductoryOfferCommand : PSCmdlet
+public sealed class NewAppStoreConnectSubscriptionIntroductoryOfferCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -63,7 +64,7 @@ public sealed class NewAppStoreConnectSubscriptionIntroductoryOfferCommand : PSC
     public string[] TerritoryId { get; set; } = Array.Empty<string>();
 
     /// <summary>Creates a subscription introductory offer.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var territoryIds = TerritoryId
             .Where(static territoryId => !string.IsNullOrWhiteSpace(territoryId))
@@ -97,7 +98,7 @@ public sealed class NewAppStoreConnectSubscriptionIntroductoryOfferCommand : PSC
         using var client = new AppStoreConnectClient(credential);
         foreach (var territoryId in territoryIds)
         {
-            var offer = client.CreateSubscriptionIntroductoryOfferAsync(
+            var offer = await client.CreateSubscriptionIntroductoryOfferAsync(
                 SubscriptionId,
                 Duration,
                 OfferMode,
@@ -105,7 +106,8 @@ public sealed class NewAppStoreConnectSubscriptionIntroductoryOfferCommand : PSC
                 NumberOfPeriods,
                 StartDate,
                 EndDate,
-                SubscriptionPricePointId).GetAwaiter().GetResult();
+                SubscriptionPricePointId,
+                CancelToken);
             WriteObject(offer);
         }
     }

--- a/PSPublishModule/Cmdlets/PublishAppStoreConnectApprovedVersionCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishAppStoreConnectApprovedVersionCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsData.Publish, "AppStoreConnectApprovedVersion", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectVersionReleaseResult))]
-public sealed class PublishAppStoreConnectApprovedVersionCommand : PSCmdlet
+public sealed class PublishAppStoreConnectApprovedVersionCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -38,7 +39,7 @@ public sealed class PublishAppStoreConnectApprovedVersionCommand : PSCmdlet
     [Parameter] public SwitchParameter AllowNonPendingDeveloperRelease { get; set; }
 
     /// <summary>Requests release of an approved App Store version.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()}";
         if (!ShouldProcess(target, "Publish approved App Store Connect version"))
@@ -48,13 +49,13 @@ public sealed class PublishAppStoreConnectApprovedVersionCommand : PSCmdlet
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectVersionReleaseService(client);
-        var result = service.ReleaseAsync(new AppStoreConnectVersionReleaseRequest
+        var result = await service.ReleaseAsync(new AppStoreConnectVersionReleaseRequest
         {
             AppId = AppId,
             VersionString = VersionString,
             Platform = Platform,
             RequirePendingDeveloperRelease = !AllowNonPendingDeveloperRelease.IsPresent
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/PublishAppStoreConnectScreenshotCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishAppStoreConnectScreenshotCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -9,7 +10,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsData.Publish, "AppStoreConnectScreenshot", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectScreenshotUploadResult))]
-public sealed class PublishAppStoreConnectScreenshotCommand : PSCmdlet
+public sealed class PublishAppStoreConnectScreenshotCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -38,7 +39,7 @@ public sealed class PublishAppStoreConnectScreenshotCommand : PSCmdlet
     public string Path { get; set; } = string.Empty;
 
     /// <summary>Uploads and commits the screenshot file.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path);
         if (!ShouldProcess(resolvedPath, $"Upload App Store Connect screenshot to set '{ScreenshotSetId}'"))
@@ -47,7 +48,7 @@ public sealed class PublishAppStoreConnectScreenshotCommand : PSCmdlet
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var result = client.UploadScreenshotAsync(ScreenshotSetId, resolvedPath).GetAwaiter().GetResult();
+        var result = await client.UploadScreenshotAsync(ScreenshotSetId, resolvedPath, CancelToken);
         WriteObject(result);
     }
 }

--- a/PSPublishModule/Cmdlets/PublishAppStoreConnectTestFlightBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/PublishAppStoreConnectTestFlightBuildCommand.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using System.Linq;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -9,7 +10,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsData.Publish, "AppStoreConnectTestFlightBuild", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectTestFlightDistributionResult))]
-public sealed class PublishAppStoreConnectTestFlightBuildCommand : PSCmdlet
+public sealed class PublishAppStoreConnectTestFlightBuildCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -54,7 +55,7 @@ public sealed class PublishAppStoreConnectTestFlightBuildCommand : PSCmdlet
     [Parameter] public SwitchParameter AllowUnprocessedBuild { get; set; }
 
     /// <summary>Distributes a processed build to TestFlight beta groups and optional testers.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
         if (!ShouldProcess(target, "Publish App Store Connect TestFlight build to beta groups"))
@@ -64,7 +65,7 @@ public sealed class PublishAppStoreConnectTestFlightBuildCommand : PSCmdlet
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectTestFlightDistributionService(client);
-        var result = service.DistributeAsync(new AppStoreConnectTestFlightDistributionRequest
+        var result = await service.DistributeAsync(new AppStoreConnectTestFlightDistributionRequest
         {
             AppId = AppId,
             VersionString = VersionString,
@@ -78,7 +79,7 @@ public sealed class PublishAppStoreConnectTestFlightBuildCommand : PSCmdlet
                 .ToArray(),
             CreateMissingTesters = !NoCreateMissingTesters.IsPresent,
             RequireValidBuild = !AllowUnprocessedBuild.IsPresent
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/SetAppStoreConnectVersionBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/SetAppStoreConnectVersionBuildCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Set, "AppStoreConnectVersionBuild", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectReleasePreparationResult))]
-public sealed class SetAppStoreConnectVersionBuildCommand : PSCmdlet
+public sealed class SetAppStoreConnectVersionBuildCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -47,7 +48,7 @@ public sealed class SetAppStoreConnectVersionBuildCommand : PSCmdlet
     [Parameter] public SwitchParameter AllowUnprocessedBuild { get; set; }
 
     /// <summary>Creates or finds an App Store version and selects a processed build for Distribution.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
         if (!ShouldProcess(target, "Prepare App Store Connect version build"))
@@ -57,7 +58,7 @@ public sealed class SetAppStoreConnectVersionBuildCommand : PSCmdlet
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectReleasePreparationService(client);
-        var result = service.PrepareAsync(new AppStoreConnectReleasePreparationRequest
+        var result = await service.PrepareAsync(new AppStoreConnectReleasePreparationRequest
         {
             AppId = AppId,
             VersionString = VersionString,
@@ -66,7 +67,7 @@ public sealed class SetAppStoreConnectVersionBuildCommand : PSCmdlet
             CreateVersion = !NoCreateVersion.IsPresent,
             SelectBuild = !NoSelectBuild.IsPresent,
             RequireValidBuild = !AllowUnprocessedBuild.IsPresent
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/SetAppStoreConnectVersionLocalizationCommand.cs
+++ b/PSPublishModule/Cmdlets/SetAppStoreConnectVersionLocalizationCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsCommon.Set, "AppStoreConnectVersionLocalization", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectVersionLocalizationInfo))]
-public sealed class SetAppStoreConnectVersionLocalizationCommand : PSCmdlet
+public sealed class SetAppStoreConnectVersionLocalizationCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -49,7 +50,7 @@ public sealed class SetAppStoreConnectVersionLocalizationCommand : PSCmdlet
     [Parameter] public string? WhatsNew { get; set; }
 
     /// <summary>Updates localized App Store metadata fields.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         if (!ShouldProcess(VersionLocalizationId, "Update App Store Connect version localization"))
             return;
@@ -57,7 +58,7 @@ public sealed class SetAppStoreConnectVersionLocalizationCommand : PSCmdlet
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
-        var result = client.UpdateVersionLocalizationAsync(VersionLocalizationId, new AppStoreConnectVersionLocalizationUpdate
+        var result = await client.UpdateVersionLocalizationAsync(VersionLocalizationId, new AppStoreConnectVersionLocalizationUpdate
         {
             Description = Description,
             Keywords = Keywords,
@@ -65,7 +66,7 @@ public sealed class SetAppStoreConnectVersionLocalizationCommand : PSCmdlet
             PromotionalText = PromotionalText,
             SupportUrl = SupportUrl,
             WhatsNew = WhatsNew
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/SubmitAppStoreConnectTestFlightBuildForReviewCommand.cs
+++ b/PSPublishModule/Cmdlets/SubmitAppStoreConnectTestFlightBuildForReviewCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsLifecycle.Submit, "AppStoreConnectTestFlightBuildForReview", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectBetaAppReviewSubmissionResult))]
-public sealed class SubmitAppStoreConnectTestFlightBuildForReviewCommand : PSCmdlet
+public sealed class SubmitAppStoreConnectTestFlightBuildForReviewCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -41,7 +42,7 @@ public sealed class SubmitAppStoreConnectTestFlightBuildForReviewCommand : PSCmd
     [Parameter] public SwitchParameter AllowUnprocessedBuild { get; set; }
 
     /// <summary>Submits a TestFlight build to Beta App Review for external testing.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
         if (!ShouldProcess(target, "Submit App Store Connect TestFlight build to Beta App Review"))
@@ -51,14 +52,14 @@ public sealed class SubmitAppStoreConnectTestFlightBuildForReviewCommand : PSCmd
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectBetaAppReviewSubmissionService(client);
-        var result = service.SubmitAsync(new AppStoreConnectBetaAppReviewSubmissionRequest
+        var result = await service.SubmitAsync(new AppStoreConnectBetaAppReviewSubmissionRequest
         {
             AppId = AppId,
             VersionString = VersionString,
             BuildNumber = BuildNumber,
             Platform = Platform,
             RequireValidBuild = !AllowUnprocessedBuild.IsPresent
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/SubmitAppStoreConnectVersionForReviewCommand.cs
+++ b/PSPublishModule/Cmdlets/SubmitAppStoreConnectVersionForReviewCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using System.Text.Json;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -11,7 +12,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsLifecycle.Submit, "AppStoreConnectVersionForReview", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectReviewSubmissionResult))]
-public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
+public sealed class SubmitAppStoreConnectVersionForReviewCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -65,7 +66,7 @@ public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
     [Parameter] public SwitchParameter AllowNotReady { get; set; }
 
     /// <summary>Submits the Distribution version to App Review.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var target = $"{AppId.Trim()} {Platform} {VersionString.Trim()} ({BuildNumber.Trim()})";
         if (!ShouldProcess(target, "Submit App Store Connect version to App Review"))
@@ -76,7 +77,7 @@ public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
         var screenshotSpec = ResolveScreenshotSpec();
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectReviewSubmissionService(client);
-        var result = service.SubmitAsync(new AppStoreConnectReviewSubmissionRequest
+        var result = await service.SubmitAsync(new AppStoreConnectReviewSubmissionRequest
         {
             AppId = AppId,
             VersionString = VersionString,
@@ -93,7 +94,7 @@ public sealed class SubmitAppStoreConnectVersionForReviewCommand : PSCmdlet
                 MinimumScreenshotsPerSet = MinimumScreenshotsPerSet,
                 ScreenshotSpec = screenshotSpec
             }
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/SyncAppStoreConnectScreenshotsCommand.cs
+++ b/PSPublishModule/Cmdlets/SyncAppStoreConnectScreenshotsCommand.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Management.Automation;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -12,7 +13,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsData.Sync, "AppStoreConnectScreenshots", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectScreenshotSyncResult))]
-public sealed class SyncAppStoreConnectScreenshotsCommand : PSCmdlet
+public sealed class SyncAppStoreConnectScreenshotsCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -39,7 +40,7 @@ public sealed class SyncAppStoreConnectScreenshotsCommand : PSCmdlet
     public SwitchParameter ReplaceExisting { get; set; }
 
     /// <summary>Syncs local screenshot folders to App Store Connect screenshot sets.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var resolvedConfigPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(ConfigPath);
         if (!ShouldProcess(resolvedConfigPath, "Sync App Store Connect screenshots"))
@@ -59,12 +60,12 @@ public sealed class SyncAppStoreConnectScreenshotsCommand : PSCmdlet
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectScreenshotSyncService(client);
-        var result = service.SyncAsync(new AppStoreConnectScreenshotSyncRequest
+        var result = await service.SyncAsync(new AppStoreConnectScreenshotSyncRequest
         {
             Spec = spec,
             ReplaceExisting = ReplaceExisting.IsPresent,
             BaseDirectory = Path.GetDirectoryName(resolvedConfigPath) ?? SessionState.Path.CurrentFileSystemLocation.Path
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/SyncAppStoreConnectVersionMetadataCommand.cs
+++ b/PSPublishModule/Cmdlets/SyncAppStoreConnectVersionMetadataCommand.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Management.Automation;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -12,7 +13,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsData.Sync, "AppStoreConnectVersionMetadata", SupportsShouldProcess = true)]
 [OutputType(typeof(AppStoreConnectVersionMetadataSyncResult))]
-public sealed class SyncAppStoreConnectVersionMetadataCommand : PSCmdlet
+public sealed class SyncAppStoreConnectVersionMetadataCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -35,7 +36,7 @@ public sealed class SyncAppStoreConnectVersionMetadataCommand : PSCmdlet
     public string ConfigPath { get; set; } = string.Empty;
 
     /// <summary>Syncs localized App Store version metadata.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var resolvedConfigPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(ConfigPath);
         if (!ShouldProcess(resolvedConfigPath, "Sync App Store Connect version metadata"))
@@ -52,10 +53,10 @@ public sealed class SyncAppStoreConnectVersionMetadataCommand : PSCmdlet
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectVersionMetadataSyncService(client);
-        var result = service.SyncAsync(new AppStoreConnectVersionMetadataSyncRequest
+        var result = await service.SyncAsync(new AppStoreConnectVersionMetadataSyncRequest
         {
             Spec = spec
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/TestAppStoreConnectReleaseReadinessCommand.cs
+++ b/PSPublishModule/Cmdlets/TestAppStoreConnectReleaseReadinessCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsDiagnostic.Test, "AppStoreConnectReleaseReadiness")]
 [OutputType(typeof(AppStoreConnectReleaseReadinessResult))]
-public sealed class TestAppStoreConnectReleaseReadinessCommand : PSCmdlet
+public sealed class TestAppStoreConnectReleaseReadinessCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -77,13 +78,13 @@ public sealed class TestAppStoreConnectReleaseReadinessCommand : PSCmdlet
     [Parameter] public SwitchParameter NoRequireCompleteScreenshots { get; set; }
 
     /// <summary>Checks App Store Connect release readiness.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
         var service = new AppStoreConnectReleaseReadinessService(client);
-        var result = service.CheckAsync(new AppStoreConnectReleaseReadinessRequest
+        var result = await service.CheckAsync(new AppStoreConnectReleaseReadinessRequest
         {
             AppId = AppId,
             VersionString = VersionString,
@@ -102,7 +103,7 @@ public sealed class TestAppStoreConnectReleaseReadinessCommand : PSCmdlet
             RequireWhatsNew = RequireWhatsNew.IsPresent,
             RequireScreenshots = !NoRequireScreenshots.IsPresent,
             RequireCompleteScreenshots = !NoRequireCompleteScreenshots.IsPresent
-        }).GetAwaiter().GetResult();
+        }, CancelToken);
 
         WriteObject(result);
     }

--- a/PSPublishModule/Cmdlets/TestAppleAppReleaseDriftCommand.cs
+++ b/PSPublishModule/Cmdlets/TestAppleAppReleaseDriftCommand.cs
@@ -1,4 +1,5 @@
 using System.Management.Automation;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -8,7 +9,7 @@ namespace PSPublishModule;
 /// </summary>
 [Cmdlet(VerbsDiagnostic.Test, "AppleAppReleaseDrift")]
 [OutputType(typeof(bool), typeof(AppleAppReleaseDriftReport))]
-public sealed class TestAppleAppReleaseDriftCommand : PSCmdlet
+public sealed class TestAppleAppReleaseDriftCommand : AsyncPSCmdlet
 {
     /// <summary>Issuer ID from App Store Connect API keys.</summary>
     [Parameter(Mandatory = true)] public string IssuerId { get; set; } = string.Empty;
@@ -47,14 +48,14 @@ public sealed class TestAppleAppReleaseDriftCommand : PSCmdlet
     [Parameter] public SwitchParameter Quiet { get; set; }
 
     /// <summary>Tests local Xcode project version values against App Store Connect.</summary>
-    protected override void ProcessRecord()
+    protected override async Task ProcessRecordAsync()
     {
         var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path);
         var privateKeyPath = AppStoreConnectCommandSupport.ResolvePrivateKeyPath(SessionState, PrivateKeyPath);
         var credential = AppStoreConnectCommandSupport.CreateCredential(IssuerId, KeyId, PrivateKey, privateKeyPath, TokenLifetimeMinutes);
         using var client = new AppStoreConnectClient(credential);
 
-        var report = client.TestReleaseDriftAsync(resolvedPath, AppId, BundleId, Platform).GetAwaiter().GetResult();
+        var report = await client.TestReleaseDriftAsync(resolvedPath, AppId, BundleId, Platform, CancelToken);
         if (!Quiet.IsPresent)
         {
             foreach (var message in report.Messages)

--- a/PSPublishModule/Cmdlets/UpdateManagedModuleCatalogCommand.cs
+++ b/PSPublishModule/Cmdlets/UpdateManagedModuleCatalogCommand.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
-using System.Threading;
+using System.Threading.Tasks;
 using PowerForge;
 
 namespace PSPublishModule;
@@ -17,7 +17,7 @@ namespace PSPublishModule;
 /// </example>
 [Cmdlet(VerbsData.Update, "ManagedModuleCatalog", SupportsShouldProcess = true)]
 [OutputType(typeof(ManagedModuleCatalogUpdateResult))]
-public sealed class UpdateManagedModuleCatalogCommand : PSCmdlet
+public sealed class UpdateManagedModuleCatalogCommand : AsyncPSCmdlet
 {
     /// <summary>Catalog name. Defaults to PSGallery.</summary>
     [Parameter(Position = 0)]
@@ -60,16 +60,17 @@ public sealed class UpdateManagedModuleCatalogCommand : PSCmdlet
     private readonly List<string> _packageNames = new();
 
     /// <summary>Collects package names from the pipeline.</summary>
-    protected override void ProcessRecord()
+    protected override Task ProcessRecordAsync()
     {
         if (PackageName is null)
-            return;
+            return Task.CompletedTask;
 
         _packageNames.AddRange(PackageName.Where(static name => !string.IsNullOrWhiteSpace(name)));
+        return Task.CompletedTask;
     }
 
     /// <summary>Refreshes the catalog.</summary>
-    protected override void EndProcessing()
+    protected override async Task EndProcessingAsync()
     {
         if (Scope == ModuleRepositoryProfileScope.All)
             throw new ArgumentException("Update-ManagedModuleCatalog requires User or Machine scope.", nameof(Scope));
@@ -79,13 +80,13 @@ public sealed class UpdateManagedModuleCatalogCommand : PSCmdlet
             return;
 
         var credential = ManagedModuleCommandSupport.ResolveCredential(this, Credential, CredentialUserName, CredentialSecret, CredentialSecretFilePath);
-        var result = store.UpdateCatalogAsync(new ManagedModuleCatalogUpdateRequest
+        var result = await store.UpdateCatalogAsync(new ManagedModuleCatalogUpdateRequest
         {
             Name = Name,
             PackageNames = _packageNames.ToArray(),
             IncludePrerelease = IncludePrerelease,
             Credential = credential
-        }, CancellationToken.None).GetAwaiter().GetResult();
+        }, CancelToken);
         WriteObject(result);
     }
 }

--- a/PowerForge.Tests/AsyncPSCmdletTests.cs
+++ b/PowerForge.Tests/AsyncPSCmdletTests.cs
@@ -51,6 +51,28 @@ public sealed class AsyncPSCmdletTests
         var item = Assert.Single(result);
         Assert.Equal("queued-output", item.BaseObject);
     }
+
+    [Fact]
+    public void AsyncPSCmdlet_does_not_capture_a_host_synchronization_context()
+    {
+        var sessionState = InitialSessionState.CreateDefault();
+        sessionState.Commands.Add(new SessionStateCmdletEntry(
+            "Test-AsyncSynchronizationContext",
+            typeof(TestAsyncSynchronizationContextCommand),
+            helpFileName: null));
+
+        using var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        using var powerShell = PowerShell.Create();
+        powerShell.Runspace = runspace;
+        powerShell.AddCommand("Test-AsyncSynchronizationContext");
+
+        var result = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
+        var item = Assert.Single(result);
+        Assert.Equal(0, item.BaseObject);
+    }
 }
 
 [Cmdlet(VerbsDiagnostic.Test, "AsyncThreadAffinity")]
@@ -100,5 +122,45 @@ public sealed class TestAsyncQueuedOutputCommand : AsyncPSCmdlet
             throw workerException;
 
         return Task.CompletedTask;
+    }
+}
+
+[Cmdlet(VerbsDiagnostic.Test, "AsyncSynchronizationContext")]
+public sealed class TestAsyncSynchronizationContextCommand : AsyncPSCmdlet
+{
+    private ForwardingSynchronizationContext? _context;
+
+    protected override void ProcessRecord()
+    {
+        var previousContext = SynchronizationContext.Current;
+        _context = new ForwardingSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(_context);
+        try
+        {
+            base.ProcessRecord();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+    }
+
+    protected override async Task ProcessRecordAsync()
+    {
+        await Task.Yield();
+        WriteObject(_context!.PostCount);
+    }
+}
+
+public sealed class ForwardingSynchronizationContext : SynchronizationContext
+{
+    private int _postCount;
+
+    public int PostCount => Volatile.Read(ref _postCount);
+
+    public override void Post(SendOrPostCallback callback, object? state)
+    {
+        Interlocked.Increment(ref _postCount);
+        ThreadPool.QueueUserWorkItem(_ => callback(state));
     }
 }

--- a/PowerForge.Tests/AsyncPSCmdletTests.cs
+++ b/PowerForge.Tests/AsyncPSCmdletTests.cs
@@ -9,6 +9,28 @@ namespace PowerForge.Tests;
 public sealed class AsyncPSCmdletTests
 {
     [Fact]
+    public void AsyncPSCmdlet_starts_hooks_on_the_pipeline_thread_and_pumps_after_await()
+    {
+        var sessionState = InitialSessionState.CreateDefault();
+        sessionState.Commands.Add(new SessionStateCmdletEntry(
+            "Test-AsyncThreadAffinity",
+            typeof(TestAsyncThreadAffinityCommand),
+            helpFileName: null));
+
+        using var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        using var powerShell = PowerShell.Create();
+        powerShell.Runspace = runspace;
+        powerShell.AddCommand("Test-AsyncThreadAffinity");
+
+        var result = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
+        var item = Assert.Single(result);
+        Assert.Equal("post-await-output", item.BaseObject);
+    }
+
+    [Fact]
     public void AsyncPSCmdlet_drains_worker_thread_writes_when_task_completes_synchronously()
     {
         var sessionState = InitialSessionState.CreateDefault();
@@ -28,6 +50,25 @@ public sealed class AsyncPSCmdletTests
         Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
         var item = Assert.Single(result);
         Assert.Equal("queued-output", item.BaseObject);
+    }
+}
+
+[Cmdlet(VerbsDiagnostic.Test, "AsyncThreadAffinity")]
+public sealed class TestAsyncThreadAffinityCommand : AsyncPSCmdlet
+{
+    private int _pipelineThreadId;
+
+    protected override void BeginProcessing()
+    {
+        _pipelineThreadId = Environment.CurrentManagedThreadId;
+        base.BeginProcessing();
+    }
+
+    protected override async Task ProcessRecordAsync()
+    {
+        Assert.Equal(_pipelineThreadId, Environment.CurrentManagedThreadId);
+        await Task.Yield();
+        WriteObject("post-await-output");
     }
 }
 

--- a/PowerForge.Tests/AsyncPSCmdletTests.cs
+++ b/PowerForge.Tests/AsyncPSCmdletTests.cs
@@ -73,6 +73,28 @@ public sealed class AsyncPSCmdletTests
         var item = Assert.Single(result);
         Assert.Equal(0, item.BaseObject);
     }
+
+    [Fact]
+    public void AsyncPSCmdlet_does_not_capture_a_custom_task_scheduler()
+    {
+        var sessionState = InitialSessionState.CreateDefault();
+        sessionState.Commands.Add(new SessionStateCmdletEntry(
+            "Test-AsyncTaskScheduler",
+            typeof(TestAsyncTaskSchedulerCommand),
+            helpFileName: null));
+
+        using var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        using var powerShell = PowerShell.Create();
+        powerShell.Runspace = runspace;
+        powerShell.AddCommand("Test-AsyncTaskScheduler");
+
+        var result = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
+        var item = Assert.Single(result);
+        Assert.Equal(0, item.BaseObject);
+    }
 }
 
 [Cmdlet(VerbsDiagnostic.Test, "AsyncThreadAffinity")]
@@ -150,6 +172,59 @@ public sealed class TestAsyncSynchronizationContextCommand : AsyncPSCmdlet
         await Task.Yield();
         WriteObject(_context!.PostCount);
     }
+}
+
+[Cmdlet(VerbsDiagnostic.Test, "AsyncTaskScheduler")]
+public sealed class TestAsyncTaskSchedulerCommand : AsyncPSCmdlet
+{
+    private readonly ForwardingTaskScheduler _scheduler = new();
+
+    protected override void ProcessRecord()
+        => _scheduler.Run(base.ProcessRecord);
+
+    protected override async Task ProcessRecordAsync()
+    {
+        Assert.Same(_scheduler, TaskScheduler.Current);
+        await Task.Yield();
+        WriteObject(_scheduler.QueuedTaskCount);
+    }
+}
+
+public sealed class ForwardingTaskScheduler : TaskScheduler
+{
+    private int _executeNextTaskInline;
+    private int _queuedTaskCount;
+
+    public int QueuedTaskCount => Volatile.Read(ref _queuedTaskCount);
+
+    public void Run(Action action)
+    {
+        Volatile.Write(ref _executeNextTaskInline, 1);
+        var task = Task.Factory.StartNew(
+            action,
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            this);
+        task.GetAwaiter().GetResult();
+    }
+
+    protected override IEnumerable<Task> GetScheduledTasks()
+        => Array.Empty<Task>();
+
+    protected override void QueueTask(Task task)
+    {
+        if (Interlocked.Exchange(ref _executeNextTaskInline, 0) == 1)
+        {
+            Assert.True(TryExecuteTask(task));
+            return;
+        }
+
+        Interlocked.Increment(ref _queuedTaskCount);
+        ThreadPool.QueueUserWorkItem(_ => TryExecuteTask(task));
+    }
+
+    protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        => false;
 }
 
 public sealed class ForwardingSynchronizationContext : SynchronizationContext


### PR DESCRIPTION
## Summary

- keep `AsyncPSCmdlet` as the canonical source implementation in PSPublishModule, without introducing a shared package or consumer dependency
- preserve PowerShell pipeline-thread execution until the first incomplete await, then route stream writes, confirmations, and prompts back through that thread
- route hook continuations through an internal thread-pool context so neither a host `SynchronizationContext` nor a custom `TaskScheduler` can deadlock the pipeline pump
- isolate reply-bearing pipeline requests so concurrent `ShouldProcess` or credential operations cannot consume each other's replies
- convert 29 Task-backed App Store Connect and managed catalog cmdlets from sync-over-async blocking to cancellable async lifecycle hooks

## Compatibility

The PowerShell command names and parameters are unchanged. Synchronous cmdlets remain on `PSCmdlet`; only commands that await Task-based engine work use `AsyncPSCmdlet`.

Other Evotec modules should copy this source implementation and adjust the namespace and repository formatting. They do not take a PSPublishModule package dependency.

## Validation

The lifecycle regression suite covers pipeline-thread startup, post-await output, synchronous queue draining, host synchronization contexts, and custom task schedulers. PSPublishModule builds cleanly for .NET Framework 4.7.2, .NET 8, and .NET 10, and the compiled commands import in PowerShell 7 and Windows PowerShell 5.1.
