### PR TITLE
Improve PowerShell Gallery version resolution errors

### DIFF
--- a/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildPreparationServiceTests.cs
@@ -1835,7 +1835,7 @@ $packageOptions['PlanOutputPath'] = 'Build/package-options-plan.json'
                 {
                     Name = moduleName,
                     SourcePath = root.FullName,
-                    Version = "1.2.X"
+                    Version = "1.2.3"
                 },
                 Segments = new IConfigurationSegment[]
                 {

--- a/PowerForge.Tests/ModuleVersionStepperTests.cs
+++ b/PowerForge.Tests/ModuleVersionStepperTests.cs
@@ -70,6 +70,69 @@ public sealed class ModuleVersionStepperTests
         Assert.Equal("3.0.1", result.CurrentVersion);
     }
 
+    [Fact]
+    public void Step_ReportsBothGalleryFailuresWithoutScanningFromBaseVersion()
+    {
+        var handler = new ThrowingPowerShellGalleryHandler("Gallery socket unavailable.");
+        using var client = new HttpClient(handler);
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(1, string.Empty, "Find-PSResource socket unavailable.", "pwsh.exe")),
+            client);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            stepper.Step("3.0.X", moduleName: "PSPublishModule", localPsd1Path: null, repository: "PSGallery"));
+
+        Assert.Contains("both PowerShell Gallery lookup paths failed", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("No candidate version was selected", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Gallery socket unavailable", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Find-PSResource", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public void Step_RejectsCandidateWhenAvailabilityProbeFails()
+    {
+        using var client = new HttpClient(new AvailabilityFailureHandler());
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(0, VisibleRepositoryItem("PSPublishModule", "3.0.55"), string.Empty, "pwsh.exe")),
+            client);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            stepper.Step("3.0.X", moduleName: "PSPublishModule", localPsd1Path: null, repository: "PSGallery"));
+
+        Assert.Contains("Unable to verify whether PowerShell Gallery version '3.0.56' is available", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("No version was selected to avoid reusing an existing package version", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Exact-version socket unavailable", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Step_RejectsSuccessfulExactLookupWithMismatchedVersionMetadata()
+    {
+        using var client = new HttpClient(new MismatchedVersionHandler());
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(0, VisibleRepositoryItem("PSPublishModule", "3.0.55"), string.Empty, "pwsh.exe")),
+            client);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            stepper.Step("3.0.X", moduleName: "PSPublishModule", localPsd1Path: null, repository: "PSGallery"));
+
+        Assert.Contains("Unable to verify whether PowerShell Gallery version '3.0.56' is available", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("contained version '9.9.9'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VersionPatternStepper_RejectsPatternWhoseFixedPrefixIsBelowCurrentVersion()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            VersionPatternStepper.Step("1.2.X", new Version(2, 0, 0)));
+
+        Assert.Contains("cannot produce a version greater than current version '2.0.0'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("fixed prefix is lower", exception.Message, StringComparison.Ordinal);
+    }
+
     private static string VisibleRepositoryItem(string name, string version)
         => string.Join("::", new[]
         {
@@ -270,4 +333,83 @@ public sealed class ModuleVersionStepperTests
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
         }
     }
+
+    private sealed class ThrowingPowerShellGalleryHandler : HttpMessageHandler
+    {
+        private readonly string _message;
+
+        public ThrowingPowerShellGalleryHandler(string message)
+        {
+            _message = message;
+        }
+
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            throw new HttpRequestException(_message);
+        }
+    }
+
+    private sealed class AvailabilityFailureHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri?.ToString() ?? string.Empty;
+            if (uri.Contains("FindPackagesById", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(BuildVersionFeed("3.0.55"), Encoding.UTF8, "application/atom+xml")
+                });
+            }
+
+            throw new HttpRequestException("Exact-version socket unavailable.");
+        }
+    }
+
+    private sealed class MismatchedVersionHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri?.ToString() ?? string.Empty;
+            var body = uri.Contains("FindPackagesById", StringComparison.OrdinalIgnoreCase)
+                ? BuildVersionFeed("3.0.55")
+                : BuildVersionEntry("9.9.9");
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/atom+xml")
+            });
+        }
+    }
+
+    private static string BuildVersionFeed(string version)
+        => $$"""
+           <?xml version="1.0" encoding="utf-8"?>
+           <feed xmlns="http://www.w3.org/2005/Atom"
+                 xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                 xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+             <entry>
+               <m:properties>
+                 <d:Version>{{version}}</d:Version>
+                 <d:IsPrerelease>false</d:IsPrerelease>
+                 <d:Published m:type="Edm.DateTime">2026-03-10T10:00:00</d:Published>
+               </m:properties>
+             </entry>
+           </feed>
+           """;
+
+    private static string BuildVersionEntry(string version)
+        => $$"""
+           <?xml version="1.0" encoding="utf-8"?>
+           <entry xmlns="http://www.w3.org/2005/Atom"
+                  xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+                  xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+             <m:properties>
+               <d:Version>{{version}}</d:Version>
+             </m:properties>
+           </entry>
+           """;
 }

--- a/PowerForge.Tests/ModuleVersionStepperTests.cs
+++ b/PowerForge.Tests/ModuleVersionStepperTests.cs
@@ -71,6 +71,44 @@ public sealed class ModuleVersionStepperTests
     }
 
     [Fact]
+    public void Step_UsesGalleryBaselineWhenTheRawFeedConfirmsNoPublishedVersions()
+    {
+        using var client = new HttpClient(new FakeCandidateReservationHandler());
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(1, string.Empty, "Find-PSResource reported no matching package.", "pwsh.exe")),
+            client);
+
+        var result = stepper.Step("3.0.X", moduleName: "PSPublishModule", localPsd1Path: null, repository: "PSGallery");
+
+        Assert.Equal("3.0.0", result.Version);
+        Assert.Equal(ModuleVersionSource.Repository, result.CurrentVersionSource);
+        Assert.Null(result.CurrentVersion);
+    }
+
+    [Fact]
+    public void Step_LocalPsd1VersioningDoesNotQueryPowerShellGallery()
+    {
+        using var directory = new TemporaryDirectory();
+        var manifestPath = Path.Combine(directory.Path, "OfflineModule.psd1");
+        File.WriteAllText(manifestPath, "@{ ModuleVersion = '1.2.3' }");
+
+        var handler = new ThrowingPowerShellGalleryHandler("Gallery socket unavailable.");
+        using var client = new HttpClient(handler);
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(1, string.Empty, "Find-PSResource socket unavailable.", "pwsh.exe")),
+            client);
+
+        var result = stepper.Step("1.2.X", moduleName: "OfflineModule", localPsd1Path: manifestPath, repository: "PSGallery");
+
+        Assert.Equal("1.2.4", result.Version);
+        Assert.Equal(ModuleVersionSource.LocalPsd1, result.CurrentVersionSource);
+        Assert.Equal("1.2.3", result.CurrentVersion);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
     public void Step_ReportsBothGalleryFailuresWithoutScanningFromBaseVersion()
     {
         var handler = new ThrowingPowerShellGalleryHandler("Gallery socket unavailable.");

--- a/PowerForge.Tests/ModuleVersionStepperTests.cs
+++ b/PowerForge.Tests/ModuleVersionStepperTests.cs
@@ -109,6 +109,58 @@ public sealed class ModuleVersionStepperTests
     }
 
     [Fact]
+    public void Step_MissingLocalPsd1DoesNotUseAnUnverifiedBaselineCandidate()
+    {
+        using var directory = new TemporaryDirectory();
+        var manifestPath = Path.Combine(directory.Path, "MissingModule.psd1");
+        using var client = new HttpClient(new FakeCandidateReservationHandler("3.0.0"));
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(1, string.Empty, "Find-PSResource should not run.", "pwsh.exe")),
+            client);
+
+        var result = stepper.Step("3.0.X", moduleName: "PSPublishModule", localPsd1Path: manifestPath, repository: "PSGallery");
+
+        Assert.Equal("3.0.1", result.Version);
+        Assert.Equal(ModuleVersionSource.LocalPsd1, result.CurrentVersionSource);
+        Assert.Null(result.CurrentVersion);
+    }
+
+    [Fact]
+    public void Step_TreatsNuGetNormalizedExactMetadataAsAnExistingVersion()
+    {
+        using var client = new HttpClient(new NormalizedVersionHandler());
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(1, string.Empty, "Find-PSResource should not run.", "pwsh.exe")),
+            client);
+
+        var result = stepper.Step("1.2.3.X", moduleName: "PSPublishModule", localPsd1Path: null, repository: "PSGallery");
+
+        Assert.Equal("1.2.3.1", result.Version);
+        Assert.Equal(ModuleVersionSource.Repository, result.CurrentVersionSource);
+        Assert.Equal("1.2.3.0", result.CurrentVersion);
+    }
+
+    [Fact]
+    public void Step_UsesBaselineWhenPrivateRepositoryReportsPackageNotFound()
+    {
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(
+                1,
+                string.Empty,
+                "Package with name 'PrivateModule' could not be found in repository 'InternalRepo'.",
+                "pwsh.exe")));
+
+        var result = stepper.Step("1.0.X", moduleName: "PrivateModule", localPsd1Path: null, repository: "InternalRepo");
+
+        Assert.Equal("1.0.0", result.Version);
+        Assert.Equal(ModuleVersionSource.Repository, result.CurrentVersionSource);
+        Assert.Null(result.CurrentVersion);
+    }
+
+    [Fact]
     public void Step_ReportsBothGalleryFailuresWithoutScanningFromBaseVersion()
     {
         var handler = new ThrowingPowerShellGalleryHandler("Gallery socket unavailable.");
@@ -420,6 +472,31 @@ public sealed class ModuleVersionStepperTests
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/atom+xml")
             });
+        }
+    }
+
+    private sealed class NormalizedVersionHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri?.ToString() ?? string.Empty;
+            if (uri.Contains("FindPackagesById", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(BuildVersionFeed("1.2.2"), Encoding.UTF8, "application/atom+xml")
+                });
+            }
+
+            if (uri.Contains("1.2.3.0", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(BuildVersionEntry("1.2.3"), Encoding.UTF8, "application/atom+xml")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
         }
     }
 

--- a/PowerForge/Services/ModuleVersionStepper.cs
+++ b/PowerForge/Services/ModuleVersionStepper.cs
@@ -119,24 +119,39 @@ public sealed class ModuleVersionStepper
             }
         }
 
+        Exception? galleryLookupFailure = null;
         if (string.Equals(repository, "PSGallery", StringComparison.OrdinalIgnoreCase))
         {
+            Version? galleryVersion = null;
             try
             {
-                var galleryVersion = TryResolveCurrentVersionFromPowerShellGalleryFeed(moduleName!, prerelease);
-                var reservedVersion = TryResolveReservedPowerShellGalleryVersion(expectedVersion, moduleName!, galleryVersion, prerelease);
-                if (reservedVersion is not null && (galleryVersion is null || reservedVersion.CompareTo(galleryVersion) > 0))
-                {
-                    _logger.Verbose($"PowerShell Gallery reserved version for '{moduleName}' was resolved from the exact package metadata endpoint ({reservedVersion}).");
-                    return (reservedVersion, ModuleVersionSource.Repository);
-                }
-
-                if (galleryVersion is not null)
-                    return (galleryVersion, ModuleVersionSource.Repository);
+                galleryVersion = TryResolveCurrentVersionFromPowerShellGalleryFeed(moduleName!, prerelease);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (IsGalleryLookupFailure(ex))
             {
+                galleryLookupFailure = ex;
                 _logger.Warn($"Couldn't resolve current version from the raw PowerShell Gallery feed: {ex.Message}");
+            }
+
+            if (galleryLookupFailure is null)
+            {
+                try
+                {
+                    var reservedVersion = TryResolveReservedPowerShellGalleryVersion(expectedVersion, moduleName!, galleryVersion, prerelease);
+                    if (reservedVersion is not null && (galleryVersion is null || reservedVersion.CompareTo(galleryVersion) > 0))
+                    {
+                        _logger.Verbose($"PowerShell Gallery reserved version for '{moduleName}' was resolved from the exact package metadata endpoint ({reservedVersion}).");
+                        return (reservedVersion, ModuleVersionSource.Repository);
+                    }
+
+                    if (galleryVersion is not null)
+                        return (galleryVersion, ModuleVersionSource.Repository);
+                }
+                catch (Exception ex) when (IsGalleryLookupFailure(ex))
+                {
+                    galleryLookupFailure = ex;
+                    _logger.Warn($"Couldn't resolve reserved versions from the PowerShell Gallery exact-package endpoint: {ex.Message}");
+                }
             }
         }
 
@@ -161,7 +176,12 @@ public sealed class ModuleVersionStepper
         catch (Exception ex)
         {
             _logger.Warn($"Couldn't resolve current version from repository: {ex.Message}");
-            return (null, ModuleVersionSource.Repository);
+            throw CreateCurrentVersionResolutionException(
+                expectedVersion,
+                moduleName!,
+                repository,
+                galleryLookupFailure,
+                ex);
         }
     }
 
@@ -224,22 +244,78 @@ public sealed class ModuleVersionStepper
         }
 
         var candidateText = proposedVersion;
+        var firstCandidateText = candidateText;
+        var lastExistingCandidateText = candidateText;
         const int maxProbeCount = 24;
 
         for (var index = 0; index < maxProbeCount; index++)
         {
-            if (!_powerShellGalleryFeed.VersionExists(moduleName!, candidateText, timeout: TimeSpan.FromSeconds(20)))
-                return candidateText;
+            try
+            {
+                if (!_powerShellGalleryFeed.VersionExists(moduleName!, candidateText, timeout: TimeSpan.FromSeconds(20)))
+                    return candidateText;
+            }
+            catch (Exception ex)
+            {
+                throw CreateVersionAvailabilityException(moduleName!, candidateText, ex);
+            }
 
             if (!TryParseRepositoryVersion(candidateText, out var candidateVersion))
                 return candidateText;
 
+            lastExistingCandidateText = candidateText;
             candidateText = ComputeNextVersion(expectedVersion, candidateVersion);
         }
 
         throw new InvalidOperationException(
-            $"Unable to resolve a free PowerShell Gallery version for '{moduleName}' from expected version '{expectedVersion}' after {maxProbeCount} probes.");
+            $"PowerShell Gallery reports that all {maxProbeCount} candidate versions from '{firstCandidateText}' through '{lastExistingCandidateText}' already exist for '{moduleName}' while resolving expected version '{expectedVersion}'. " +
+            "No free version was selected. Current-version discovery may be stale or the version pattern may be exhausted; retry after verifying Gallery access or provide an exact module version.");
     }
+
+    private static InvalidOperationException CreateCurrentVersionResolutionException(
+        string expectedVersion,
+        string moduleName,
+        string repository,
+        Exception? galleryLookupFailure,
+        Exception repositoryLookupFailure)
+    {
+        if (galleryLookupFailure is not null &&
+            string.Equals(repository, "PSGallery", StringComparison.OrdinalIgnoreCase))
+        {
+            return new InvalidOperationException(
+                $"Unable to resolve the current version of '{moduleName}' for auto-version pattern '{expectedVersion}' because both PowerShell Gallery lookup paths failed. " +
+                "No candidate version was selected. Verify network access to https://www.powershellgallery.com:443 and retry, or provide an exact module version for an intentional offline/local build. " +
+                $"Gallery lookup: {DescribeLookupFailure(galleryLookupFailure)} Repository 'PSGallery': {DescribeLookupFailure(repositoryLookupFailure)}",
+                new AggregateException(galleryLookupFailure, repositoryLookupFailure));
+        }
+
+        return new InvalidOperationException(
+            $"Unable to resolve the current version of '{moduleName}' for auto-version pattern '{expectedVersion}' from repository '{repository}' because the repository lookup failed. " +
+            "No candidate version was selected. Verify repository access and retry, or provide an exact module version for an intentional offline/local build. " +
+            $"Repository error: {DescribeLookupFailure(repositoryLookupFailure)}",
+            repositoryLookupFailure);
+    }
+
+    private static InvalidOperationException CreateVersionAvailabilityException(
+        string moduleName,
+        string candidateVersion,
+        Exception lookupFailure)
+        => new(
+            $"Unable to verify whether PowerShell Gallery version '{candidateVersion}' is available for '{moduleName}' because the exact-version Gallery request failed. " +
+            "No version was selected to avoid reusing an existing package version. Verify network access to https://www.powershellgallery.com:443 and retry. " +
+            $"Gallery error: {DescribeLookupFailure(lookupFailure)}",
+            lookupFailure);
+
+    private static string DescribeLookupFailure(Exception exception)
+        => exception is OperationCanceledException
+            ? "The request timed out or was canceled."
+            : exception.Message;
+
+    private static bool IsGalleryLookupFailure(Exception exception)
+        => exception is HttpRequestException ||
+           exception is OperationCanceledException ||
+           exception is InvalidDataException ||
+           exception is System.Xml.XmlException;
 
     private Version? TryResolveCurrentVersionFromPowerShellGalleryFeed(string moduleName, bool prerelease)
     {

--- a/PowerForge/Services/ModuleVersionStepper.cs
+++ b/PowerForge/Services/ModuleVersionStepper.cs
@@ -71,7 +71,7 @@ public sealed class ModuleVersionStepper
 
         var (current, source) = ResolveCurrentVersion(expectedVersion, moduleName, localPsd1Path, repository, prerelease);
         var proposed = ComputeNextVersion(expectedVersion, current);
-        if (source != ModuleVersionSource.LocalPsd1)
+        if (source != ModuleVersionSource.LocalPsd1 || current is null)
             proposed = EnsureResolvedVersionIsAvailable(expectedVersion, moduleName, repository, prerelease, proposed);
 
         return new ModuleVersionStepResult(
@@ -174,6 +174,11 @@ public sealed class ModuleVersionStepper
                 return (ver, ModuleVersionSource.Repository);
             }
 
+            return (null, ModuleVersionSource.Repository);
+        }
+        catch (Exception ex) when (ModulePublisher.IsRepositoryPackageNotFound(moduleName!, ex))
+        {
+            _logger.Verbose($"No existing repository version was found for '{moduleName}' on '{repository}'. Using the version-pattern baseline.");
             return (null, ModuleVersionSource.Repository);
         }
         catch (Exception ex)

--- a/PowerForge/Services/ModuleVersionStepper.cs
+++ b/PowerForge/Services/ModuleVersionStepper.cs
@@ -71,7 +71,8 @@ public sealed class ModuleVersionStepper
 
         var (current, source) = ResolveCurrentVersion(expectedVersion, moduleName, localPsd1Path, repository, prerelease);
         var proposed = ComputeNextVersion(expectedVersion, current);
-        proposed = EnsureResolvedVersionIsAvailable(expectedVersion, moduleName, repository, prerelease, proposed);
+        if (source != ModuleVersionSource.LocalPsd1)
+            proposed = EnsureResolvedVersionIsAvailable(expectedVersion, moduleName, repository, prerelease, proposed);
 
         return new ModuleVersionStepResult(
             expectedVersion: expectedVersion,
@@ -146,6 +147,8 @@ public sealed class ModuleVersionStepper
 
                     if (galleryVersion is not null)
                         return (galleryVersion, ModuleVersionSource.Repository);
+
+                    return (null, ModuleVersionSource.Repository);
                 }
                 catch (Exception ex) when (IsGalleryLookupFailure(ex))
                 {

--- a/PowerForge/Services/PowerShellGalleryVersionFeedClient.cs
+++ b/PowerForge/Services/PowerShellGalleryVersionFeedClient.cs
@@ -1,6 +1,7 @@
+using System.Globalization;
+using System.Net;
 using System.Net.Http;
 using System.Xml.Linq;
-using System.Globalization;
 
 namespace PowerForge;
 
@@ -76,6 +77,9 @@ public sealed class PowerShellGalleryVersionFeedClient
     /// Checks whether the exact package/version exists in the gallery metadata endpoint,
     /// including versions that are unlisted or removed from the public feed listing.
     /// </summary>
+    /// <exception cref="HttpRequestException">The Gallery request failed or returned an unexpected HTTP status.</exception>
+    /// <exception cref="TaskCanceledException">The Gallery request timed out.</exception>
+    /// <exception cref="InvalidDataException">The Gallery returned successful but mismatched package metadata.</exception>
     public bool VersionExists(
         string packageId,
         string version,
@@ -94,19 +98,27 @@ public sealed class PowerShellGalleryVersionFeedClient
             Uri.EscapeDataString(packageId.Trim()),
             Uri.EscapeDataString(version.Trim()));
 
-        try
-        {
-            using var response = _client.GetAsync(requestUri, token).GetAwaiter().GetResult();
-            return response.IsSuccessStatusCode;
-        }
-        catch (TaskCanceledException)
-        {
+        using var response = _client.GetAsync(requestUri, token).GetAwaiter().GetResult();
+        if (response.StatusCode == HttpStatusCode.NotFound)
             return false;
-        }
-        catch (HttpRequestException)
+
+        response.EnsureSuccessStatusCode();
+
+        var xml = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        var document = XDocument.Parse(xml);
+        XNamespace d = "http://schemas.microsoft.com/ado/2007/08/dataservices";
+        var returnedVersion = document.Descendants(d + "Version").FirstOrDefault()?.Value?.Trim();
+
+        if (!string.Equals(returnedVersion, version.Trim(), StringComparison.OrdinalIgnoreCase))
         {
-            return false;
+            var returnedDescription = string.IsNullOrWhiteSpace(returnedVersion)
+                ? "no version metadata"
+                : $"version '{returnedVersion}'";
+            throw new InvalidDataException(
+                $"PowerShell Gallery exact-version lookup for '{packageId.Trim()}' version '{version.Trim()}' returned HTTP {(int)response.StatusCode} but contained {returnedDescription}.");
         }
+
+        return true;
     }
 
     private static IEnumerable<PowerShellGalleryPackageVersion> ParseEntries(XDocument document, bool includePrerelease)

--- a/PowerForge/Services/PowerShellGalleryVersionFeedClient.cs
+++ b/PowerForge/Services/PowerShellGalleryVersionFeedClient.cs
@@ -109,7 +109,7 @@ public sealed class PowerShellGalleryVersionFeedClient
         XNamespace d = "http://schemas.microsoft.com/ado/2007/08/dataservices";
         var returnedVersion = document.Descendants(d + "Version").FirstOrDefault()?.Value?.Trim();
 
-        if (!string.Equals(returnedVersion, version.Trim(), StringComparison.OrdinalIgnoreCase))
+        if (!AreEquivalentPackageVersions(returnedVersion, version))
         {
             var returnedDescription = string.IsNullOrWhiteSpace(returnedVersion)
                 ? "no version metadata"
@@ -119,6 +119,35 @@ public sealed class PowerShellGalleryVersionFeedClient
         }
 
         return true;
+    }
+
+    private static bool AreEquivalentPackageVersions(string? returnedVersion, string requestedVersion)
+    {
+        if (!IsValidPackageVersion(returnedVersion) || !IsValidPackageVersion(requestedVersion))
+            return false;
+
+        return ManagedModuleVersionComparer.Instance.Compare(returnedVersion!, requestedVersion) == 0;
+    }
+
+    private static bool IsValidPackageVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+
+        var value = version!.Trim();
+        var plusIndex = value.IndexOf('+');
+        if (plusIndex >= 0)
+            value = value.Substring(0, plusIndex);
+
+        var dashIndex = value.IndexOf('-');
+        if (dashIndex >= 0)
+        {
+            if (dashIndex == value.Length - 1)
+                return false;
+            value = value.Substring(0, dashIndex);
+        }
+
+        return Version.TryParse(value, out _);
     }
 
     private static IEnumerable<PowerShellGalleryPackageVersion> ParseEntries(XDocument document, bool includePrerelease)

--- a/PowerForge/Services/VersionPatternStepper.cs
+++ b/PowerForge/Services/VersionPatternStepper.cs
@@ -43,6 +43,13 @@ internal static class VersionPatternStepper
         }
 
         var baseline = currentVersion ?? new Version(0, 0, 0, 0);
+        if (currentVersion is not null && CompareFixedPrefix(prepared, currentVersion, stepIndex) < 0)
+        {
+            throw new InvalidOperationException(
+                $"ExpectedVersion pattern '{expectedVersion}' cannot produce a version greater than current version '{currentVersion}' because its fixed prefix is lower. " +
+                "Choose a pattern with the same or a higher fixed prefix, or provide an exact version.");
+        }
+
         var stepValue = currentVersion is null ? 1 : GetPart(currentVersion, stepIndex);
         if (stepValue < 0) stepValue = 0;
 
@@ -62,6 +69,20 @@ internal static class VersionPatternStepper
         }
 
         return candidate.ToString();
+    }
+
+    private static int CompareFixedPrefix(int?[] prepared, Version currentVersion, int stepIndex)
+    {
+        for (var index = 0; index < stepIndex; index++)
+        {
+            var expectedPart = prepared[index] ?? 0;
+            var currentPart = GetPart(currentVersion, index);
+            var comparison = expectedPart.CompareTo(currentPart);
+            if (comparison != 0)
+                return comparison;
+        }
+
+        return 0;
     }
 
     private static int GetPart(Version v, int index)


### PR DESCRIPTION
## Summary

- stop automatic version selection when both PowerShell Gallery lookup paths are unavailable, preserving both underlying errors and retry guidance
- distinguish failed exact-version checks from versions that are genuinely absent
- accept NuGet-normalized equivalent metadata while rejecting mismatched or missing version metadata
- reject impossible `X` patterns immediately and report the occupied candidate range when probes are exhausted

## Compatibility

- `-LocalVersioning` stays offline after the local PSD1 version is read; a missing or unreadable PSD1 does not bypass collision checks
- a successful empty raw Gallery feed still permits the first baseline version
- package-not-found responses from private repositories remain valid first-publish baselines, while connectivity failures stop version selection

## Result

Gallery outages no longer end with the misleading "no free version after 24 probes" message or select an unverified candidate. Local builds, first publication, normalized package versions, and normal collision handling retain their intended behavior.