### PR TITLE
Normalize relative PDB paths in API source coverage

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorSourceCoverageTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorSourceCoverageTests.cs
@@ -1,0 +1,33 @@
+using System;
+using PowerForge.Web;
+using Xunit;
+
+public class WebApiDocsGeneratorSourceCoverageTests
+{
+    [Theory]
+    [InlineData("../../../../_/CodeGlyphX/Barcode.cs")]
+    [InlineData("../../CodeGlyphX/CodeGlyphX/Barcode.cs")]
+    public void GitHubRepoMismatchHint_IgnoresLeadingRelativePdbSegments(string sourcePath)
+    {
+        var url = new Uri("https://github.com/EvotecIT/CodeGlyphX/blob/master/CodeGlyphX/Barcode.cs#L49");
+
+        var mismatch = WebApiDocsGenerator.IsGitHubRepoMismatchHint(sourcePath, url, out var hint);
+
+        Assert.False(mismatch);
+        Assert.Equal(string.Empty, hint);
+    }
+
+    [Fact]
+    public void GitHubRepoMismatchHint_StillDetectsWrongRepositoryAfterRelativeSegments()
+    {
+        var url = new Uri("https://github.com/EvotecIT/CodeGlyphX/blob/master/CodeGlyphX/Barcode.cs#L49");
+
+        var mismatch = WebApiDocsGenerator.IsGitHubRepoMismatchHint(
+            "../../WrongRepository/WrongRepository/Barcode.cs",
+            url,
+            out var hint);
+
+        Assert.True(mismatch);
+        Assert.Equal("WrongRepository -> CodeGlyphX", hint);
+    }
+}

--- a/PowerForge.Tests/WebApiDocsGeneratorSourceCoverageTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorSourceCoverageTests.cs
@@ -17,13 +17,15 @@ public class WebApiDocsGeneratorSourceCoverageTests
         Assert.Equal(string.Empty, hint);
     }
 
-    [Fact]
-    public void GitHubRepoMismatchHint_StillDetectsWrongRepositoryAfterRelativeSegments()
+    [Theory]
+    [InlineData("../../WrongRepository/WrongRepository/Barcode.cs")]
+    [InlineData("../../../../_/WrongRepository/WrongRepository/Barcode.cs")]
+    public void GitHubRepoMismatchHint_StillDetectsWrongRepositoryAfterPortablePdbPrefixes(string sourcePath)
     {
         var url = new Uri("https://github.com/EvotecIT/CodeGlyphX/blob/master/CodeGlyphX/Barcode.cs#L49");
 
         var mismatch = WebApiDocsGenerator.IsGitHubRepoMismatchHint(
-            "../../WrongRepository/WrongRepository/Barcode.cs",
+            sourcePath,
             url,
             out var hint);
 

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Coverage.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Coverage.cs
@@ -644,7 +644,12 @@ public static partial class WebApiDocsGenerator
                value.IndexOf("%7D", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
-    private static bool IsGitHubRepoMismatchHint(string? sourcePath, Uri url, out string hint)
+    /// <summary>
+    /// Detects a likely duplicated repository prefix in a generated GitHub source link.
+    /// Leading relative path segments are ignored because portable PDB paths can point outside
+    /// the checkout root before URL generation normalizes them.
+    /// </summary>
+    internal static bool IsGitHubRepoMismatchHint(string? sourcePath, Uri url, out string hint)
     {
         hint = string.Empty;
         if (string.IsNullOrWhiteSpace(sourcePath))
@@ -652,8 +657,7 @@ public static partial class WebApiDocsGenerator
         if (!string.Equals(url.Host, "github.com", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var segments = sourcePath
-            .Replace('\\', '/')
+        var segments = TrimLeadingRelativeSegments(sourcePath.Replace('\\', '/'))
             .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (segments.Length < 2 || !string.Equals(segments[0], segments[1], StringComparison.OrdinalIgnoreCase))
             return false;

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Coverage.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Coverage.cs
@@ -659,7 +659,11 @@ public static partial class WebApiDocsGenerator
 
         var segments = TrimLeadingRelativeSegments(sourcePath.Replace('\\', '/'))
             .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (segments.Length < 2 || !string.Equals(segments[0], segments[1], StringComparison.OrdinalIgnoreCase))
+        var repoSegmentIndex = segments.Length >= 3 && string.Equals(segments[0], "_", StringComparison.Ordinal)
+            ? 1
+            : 0;
+        if (segments.Length < repoSegmentIndex + 2 ||
+            !string.Equals(segments[repoSegmentIndex], segments[repoSegmentIndex + 1], StringComparison.OrdinalIgnoreCase))
             return false;
 
         var uriSegments = url.AbsolutePath
@@ -667,7 +671,7 @@ public static partial class WebApiDocsGenerator
         if (uriSegments.Length < 2)
             return false;
 
-        var inferredRepo = segments[0];
+        var inferredRepo = segments[repoSegmentIndex];
         var urlRepo = uriSegments[1];
         if (string.Equals(inferredRepo, urlRepo, StringComparison.OrdinalIgnoreCase))
             return false;


### PR DESCRIPTION
## Summary

- normalize leading relative PDB path segments and the deterministic `_` root before checking generated GitHub source links for duplicated repository prefixes
- preserve detection for genuine wrong-repository paths
- add focused coverage for the deterministic-PDB path shape seen on GitHub-hosted runners

## Why

CodeGlyphX generated valid source URLs with PSPublishModule 3.0.56, but its strict website job still failed because coverage analysis interpreted the first two `..` segments in paths such as `../../../../_/CodeGlyphX/...` as a duplicated repository name. URL generation already normalizes those segments; the coverage heuristic now applies the same normalization instead of reporting every valid link as a repository mismatch.

The fix belongs in PowerForge so consumers do not need to weaken their coverage thresholds or rewrite source paths for CI.

## Validation

- API source and coverage contract tests: 15/15 passed
- real CodeGlyphX website pipeline with GitHub CI variables: 14/14 steps passed
- generated source report: 375 type links and 3,859 member links; 0 invalid URLs, unresolved tokens, or repository mismatches

## Release dependency

EvotecIT/CodeGlyphX#163 should remain pinned to the current public release until this change is merged and published. After release, that PR can pin the new immutable commit and rerun its website gate without a consumer-side workaround.

