### PR TITLE
Support practical ties in benchmark comparison tables

### DIFF
--- a/Docs/PSPublishModule.Benchmarking.md
+++ b/Docs/PSPublishModule.Benchmarking.md
@@ -65,7 +65,7 @@ benchmark 'managed-modules' -out 'Ignore/Benchmarks/ManagedModules' {
         }
     }
 
-    comparison Engine -Baseline Managed -Metric MedianMs
+    comparison Engine -Baseline Managed -Metric MedianMs -TieTolerance 0.05
     readme 'README.MD' -Block 'managed-module-benchmark-table' -Renderer ComparisonTable
     artifacts Json, Csv, Markdown
 }
@@ -75,6 +75,10 @@ Benchmark declaration words are real PSPublishModule commands. The shorter DSL
 keywords are aliases over the explicit command names, so a spec can use a compact
 Pester-style form while still being backed by normal PowerShell parameter
 binding.
+
+`-TieTolerance` is a fractional threshold for practical equivalence. For
+example, `0.05` labels results within five percent of the fastest successful
+engine as tied. Omitting it preserves exact ranking.
 
 | Short form | Explicit form |
 | --- | --- |

--- a/Module/Docs/Add-BenchmarkComparison.md
+++ b/Module/Docs/Add-BenchmarkComparison.md
@@ -11,7 +11,7 @@ Adds a benchmark comparison definition.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Add-BenchmarkComparison [[-Dimension] <string>] -Baseline <string> [-Metric <string[]>] [<CommonParameters>]
+Add-BenchmarkComparison [[-Dimension] <string>] -Baseline <string> [-Metric <string[]>] [-TieTolerance <double>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -64,6 +64,22 @@ Metric names.
 
 ```yaml
 Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -TieTolerance
+Fractional tolerance used to label practically equivalent results, such as 0.05 for five percent.
+
+```yaml
+Type: Double
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -852,6 +852,18 @@
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TieTolerance</maml:name>
+          <maml:description>
+            <maml:para>Fractional tolerance used to label practically equivalent results, such as 0.05 for five percent.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -887,6 +899,18 @@
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
           <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TieTolerance</maml:name>
+        <maml:description>
+          <maml:para>Fractional tolerance used to label practically equivalent results, such as 0.05 for five percent.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
+++ b/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
@@ -447,9 +447,14 @@ public sealed class AddBenchmarkComparisonCommand : BenchmarkDslCommand
     [Parameter]
     public string[]? Metric { get; set; }
 
+    /// <summary>Fractional tolerance used to label practically equivalent results, such as <c>0.05</c> for five percent.</summary>
+    [Parameter]
+    [ValidateRange(0d, double.MaxValue)]
+    public double TieTolerance { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord()
-        => PowerShellBenchmarkDslRuntime.Compare(Dimension, Baseline, Metric);
+        => PowerShellBenchmarkDslRuntime.Compare(Dimension, Baseline, Metric, TieTolerance);
 }
 
 /// <summary>

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
@@ -381,11 +381,22 @@ public static class PowerShellBenchmarkDslRuntime
     /// <param name="baseline">Baseline value.</param>
     /// <param name="metric">Metric names.</param>
     public static void Compare(string dimension, string baseline, string[]? metric)
+        => Compare(dimension, baseline, metric, tieTolerance: 0);
+
+    /// <summary>
+    /// Adds a comparison definition with a practical tie tolerance.
+    /// </summary>
+    /// <param name="dimension">Dimension name.</param>
+    /// <param name="baseline">Baseline value.</param>
+    /// <param name="metric">Metric names.</param>
+    /// <param name="tieTolerance">Fractional tolerance used to label practically equivalent results, such as <c>0.05</c> for five percent.</param>
+    public static void Compare(string dimension, string baseline, string[]? metric, double tieTolerance)
         => RequireSuite().Comparisons.Add(new PowerShellBenchmarkComparison
         {
             Dimension = string.IsNullOrWhiteSpace(dimension) ? "Engine" : dimension.Trim(),
             Baseline = baseline ?? string.Empty,
-            Metrics = metric is { Length: > 0 } ? metric : new[] { "MedianMs" }
+            Metrics = metric is { Length: > 0 } ? metric : new[] { "MedianMs" },
+            TieTolerance = tieTolerance
         });
 
     /// <summary>
@@ -484,8 +495,8 @@ try {
             ["engine"] = Call("Engine", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
             ["operation"] = Call("Operation", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
             ["metric"] = Call("Metric", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
-            ["compare"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric) $arguments = [object[]]::new(3); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
-            ["comparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric) $arguments = [object[]]::new(3); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
+            ["compare"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance) $arguments = [object[]]::new(4); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
+            ["comparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance) $arguments = [object[]]::new(4); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
             ["readme"] = Call("Readme", "param([Parameter(Position=0)] [string] $Path, [string] $Block, [string] $Renderer)", "[object[]] @($Path, $Block, $Renderer)"),
             ["artifacts"] = "param([Parameter(ValueFromRemainingArguments=$true)] [object[]] $Values) $arguments = [object[]]::new(1); $arguments[0] = $Values; __PowerForgeBenchmarkDslInvoke -Name 'Artifacts' -Arguments $arguments",
             ["input"] = InputBody,
@@ -508,7 +519,7 @@ try {
             ["Add-BenchmarkSkipRule"] = Call("Skip", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Add-BenchmarkValidation"] = Call("Validate", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Add-BenchmarkMetric"] = Call("Metric", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
-            ["Add-BenchmarkComparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric) $arguments = [object[]]::new(3); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
+            ["Add-BenchmarkComparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance) $arguments = [object[]]::new(4); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
             ["Add-BenchmarkReadmeBlock"] = Call("Readme", "param([Parameter(Position=0)] [string] $Path, [string] $Block, [string] $Renderer)", "[object[]] @($Path, $Block, $Renderer)"),
             ["Set-BenchmarkArtifacts"] = "param([Parameter(ValueFromRemainingArguments=$true)] [object[]] $Values) $arguments = [object[]]::new(1); $arguments[0] = $Values; __PowerForgeBenchmarkDslInvoke -Name 'Artifacts' -Arguments $arguments",
             ["Get-BenchmarkInput"] = InputBody,
@@ -763,9 +774,10 @@ try {
         setter.AddCommand("Set-Item")
             .AddArgument("Function:compare")
             .AddParameter("Value", ScriptBlock.Create("""
-param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric)
+param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance)
 $parameters = @{ Dimension = $Dimension; Baseline = $Baseline }
 if ($PSBoundParameters.ContainsKey('Metric')) { $parameters['Metric'] = $Metric }
+if ($PSBoundParameters.ContainsKey('TieTolerance')) { $parameters['TieTolerance'] = $TieTolerance }
 Add-BenchmarkComparison @parameters
 """))
             .AddParameter("Force")

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
@@ -192,6 +192,9 @@ public sealed class PowerShellBenchmarkComparison
 
     /// <summary>Metric names to compare.</summary>
     public string[] Metrics { get; set; } = { "MedianMs" };
+
+    /// <summary>Fractional tolerance used to label practically equivalent results, such as <c>0.05</c> for five percent.</summary>
+    public double TieTolerance { get; set; }
 }
 
 /// <summary>

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkResultMerger.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkResultMerger.cs
@@ -22,7 +22,7 @@ internal static class PowerShellBenchmarkResultMerger
             Summary = summary,
             Comparison = suite.Comparisons
                 .Where(comparison => !string.IsNullOrWhiteSpace(comparison.Baseline))
-                .SelectMany(comparison => GetComparisonMetrics(comparison).SelectMany(metric => summarizer.Compare(summary, comparison.Baseline, metric)))
+                .SelectMany(comparison => GetComparisonMetrics(comparison).SelectMany(metric => summarizer.Compare(summary, comparison.Baseline, metric, comparison.TieTolerance)))
                 .ToArray(),
             Metadata = PowerShellBenchmarkEnvironmentMetadata.Build(suite)
         };

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.cs
@@ -203,7 +203,7 @@ public sealed class PowerShellBenchmarkRunner
         {
             result.Comparison = suite.Comparisons
                 .Where(c => !string.IsNullOrWhiteSpace(c.Baseline))
-                .SelectMany(c => GetComparisonMetrics(c).SelectMany(m => summarizer.Compare(summary, c.Baseline, m)))
+                .SelectMany(c => GetComparisonMetrics(c).SelectMany(m => summarizer.Compare(summary, c.Baseline, m, c.TieTolerance)))
                 .ToArray();
         }
         catch

--- a/PowerForge.Tests/BenchmarkServicesTests.MarkdownTieTolerance.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.MarkdownTieTolerance.cs
@@ -5,6 +5,31 @@ namespace PowerForge.Tests;
 public sealed partial class BenchmarkServicesTests
 {
     [Fact]
+    public void BenchmarkDsl_PropagatesTieToleranceToGeneratedComparisonRows()
+    {
+        var root = CreateTempRoot();
+        var escapedRoot = root.Replace("'", "''");
+        var script = System.Management.Automation.ScriptBlock.Create($$"""
+benchmark 'ties' -out '{{escapedRoot}}' {
+    policy -Warmup 0 -Iterations 1
+    axis Operation Run
+    axis Engine Managed, Other
+    engine Managed { operation Run { param($case, $run) } }
+    engine Other { operation Run { param($case, $run) } }
+    comparison Engine -Baseline Managed -Metric MedianMs -TieTolerance 0.05
+}
+""");
+
+        var suite = Assert.Single(EvaluateBenchmarkDsl(script));
+        var comparison = Assert.Single(suite.Comparisons);
+        var result = new PowerShellBenchmarkRunner().Run(suite);
+
+        Assert.Equal(0.05, comparison.TieTolerance);
+        Assert.Equal(2, result.Comparison.Length);
+        Assert.All(result.Comparison, row => Assert.Equal(0.05, row.TieTolerance));
+    }
+
+    [Fact]
     public void MarkdownRenderer_LabelsDurationResultsWithinConfiguredToleranceAsTied()
     {
         var markdown = new BenchmarkMarkdownRenderer().RenderComparisonTable(new[]

--- a/PowerForge.Tests/BenchmarkServicesTests.MarkdownTieTolerance.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.MarkdownTieTolerance.cs
@@ -1,0 +1,123 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed partial class BenchmarkServicesTests
+{
+    [Fact]
+    public void MarkdownRenderer_LabelsDurationResultsWithinConfiguredToleranceAsTied()
+    {
+        var markdown = new BenchmarkMarkdownRenderer().RenderComparisonTable(new[]
+        {
+            new BenchmarkComparisonRow
+            {
+                Scenario = "baseline narrowly faster",
+                Operation = "Run",
+                Engine = "Managed",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 100,
+                Baseline = 100,
+                Ratio = 1,
+                TieTolerance = 0.05
+            },
+            new BenchmarkComparisonRow
+            {
+                Scenario = "baseline narrowly faster",
+                Operation = "Run",
+                Engine = "Other",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 104,
+                Baseline = 100,
+                Ratio = 1.04,
+                TieTolerance = 0.05
+            },
+            new BenchmarkComparisonRow
+            {
+                Scenario = "baseline narrowly slower",
+                Operation = "Run",
+                Engine = "Managed",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 104,
+                Baseline = 104,
+                Ratio = 1,
+                TieTolerance = 0.05
+            },
+            new BenchmarkComparisonRow
+            {
+                Scenario = "baseline narrowly slower",
+                Operation = "Run",
+                Engine = "Other",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 100,
+                Baseline = 104,
+                Ratio = 100d / 104d,
+                TieTolerance = 0.05
+            },
+            new BenchmarkComparisonRow
+            {
+                Scenario = "baseline materially slower",
+                Operation = "Run",
+                Engine = "Managed",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 106,
+                Baseline = 106,
+                Ratio = 1,
+                TieTolerance = 0.05
+            },
+            new BenchmarkComparisonRow
+            {
+                Scenario = "baseline materially slower",
+                Operation = "Run",
+                Engine = "Other",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 100,
+                Baseline = 106,
+                Ratio = 100d / 106d,
+                TieTolerance = 0.05
+            }
+        });
+
+        Assert.Contains("| baseline narrowly faster | Current | Run | 1.00x (100ms) | 1.04x (104ms) | Managed tied with Other |", markdown);
+        Assert.Contains("| baseline narrowly slower | Current | Run | 1.00x (104ms) | 0.96x (100ms) | Managed tied with Other |", markdown);
+        Assert.Contains("| baseline materially slower | Current | Run | 1.00x (106ms) | 0.94x (100ms) | Managed slower than Other |", markdown);
+    }
+
+    [Fact]
+    public void MarkdownRenderer_PreservesExactRankingWithoutConfiguredTieTolerance()
+    {
+        var markdown = new BenchmarkMarkdownRenderer().RenderComparisonTable(new[]
+        {
+            new BenchmarkComparisonRow
+            {
+                Scenario = "case",
+                Operation = "Run",
+                Engine = "Managed",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 101,
+                Baseline = 101,
+                Ratio = 1
+            },
+            new BenchmarkComparisonRow
+            {
+                Scenario = "case",
+                Operation = "Run",
+                Engine = "Other",
+                Host = "Current",
+                BaselineEngine = "Managed",
+                Actual = 100,
+                Baseline = 101,
+                Ratio = 100d / 101d
+            }
+        });
+
+        Assert.Contains("Managed slower than Other", markdown);
+        Assert.DoesNotContain("tied", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/PowerForge.Tests/BenchmarkServicesTests.Part05.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Part05.cs
@@ -702,6 +702,7 @@ benchmark 'comparison-default' {
 
         Assert.Equal("Engine", comparison.Dimension);
         Assert.Equal("Managed", comparison.Baseline);
+        Assert.Equal(0, comparison.TieTolerance);
     }
 
     [Fact]

--- a/PowerForge/Models/Benchmarks/BenchmarkModels.cs
+++ b/PowerForge/Models/Benchmarks/BenchmarkModels.cs
@@ -251,6 +251,12 @@ public sealed class BenchmarkComparisonRow
 
     /// <summary>Metric name used for comparison.</summary>
     public string Metric { get; set; } = "MedianMs";
+
+    /// <summary>
+    /// Optional relative tolerance used to label practically equivalent duration results as ties.
+    /// A value of <c>0.05</c> treats results within five percent of the fastest result as tied.
+    /// </summary>
+    public double TieTolerance { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Services/Benchmarks/BenchmarkMarkdownRenderer.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkMarkdownRenderer.cs
@@ -91,7 +91,7 @@ public sealed class BenchmarkMarkdownRenderer
         markdown.AppendLine(" --- |");
 
         foreach (var group in rows
-                     .GroupBy(r => string.Join("\u001f", r.Scenario, FormatVariables(r.Variables), r.Operation, r.Host, r.Os, r.RunMode, r.Metric, r.BaselineEngine), StringComparer.Ordinal)
+                     .GroupBy(r => string.Join("\u001f", r.Scenario, FormatVariables(r.Variables), r.Operation, r.Host, r.Os, r.RunMode, r.Metric, r.BaselineEngine, r.TieTolerance.ToString("G17", CultureInfo.InvariantCulture)), StringComparer.Ordinal)
                      .OrderBy(g => DisplayScenario(g.First()), StringComparer.OrdinalIgnoreCase)
                      .ThenBy(g => g.First().Operation, StringComparer.OrdinalIgnoreCase)
                      .ThenBy(g => g.First().Host, StringComparer.OrdinalIgnoreCase)
@@ -163,16 +163,31 @@ public sealed class BenchmarkMarkdownRenderer
         if (successful.Length == 0)
             return "No successful rows";
 
-        var fastest = successful[0].Engine;
+        var fastest = successful[0];
         var baselineSucceeded = successful.Any(row => string.Equals(row.Engine, baseline, StringComparison.OrdinalIgnoreCase));
         if (!baselineSucceeded)
             return $"{baseline} failed";
         if (successful.Length == 1)
             return $"{baseline} only successful";
-        if (string.Equals(fastest, baseline, StringComparison.OrdinalIgnoreCase))
+
+        var tieTolerance = Math.Max(0, successful[0].TieTolerance);
+        if (tieTolerance > 0)
+        {
+            var tiedEngines = successful
+                .Where(row => row.Actual!.Value <= fastest.Actual!.Value * (1 + tieTolerance))
+                .Select(row => row.Engine)
+                .ToArray();
+            if (tiedEngines.Any(engine => string.Equals(engine, baseline, StringComparison.OrdinalIgnoreCase)) && tiedEngines.Length > 1)
+            {
+                var peers = tiedEngines.Where(engine => !string.Equals(engine, baseline, StringComparison.OrdinalIgnoreCase));
+                return $"{baseline} tied with {string.Join(", ", peers)}";
+            }
+        }
+
+        if (string.Equals(fastest.Engine, baseline, StringComparison.OrdinalIgnoreCase))
             return $"{baseline} fastest";
 
-        return $"{baseline} slower than {fastest}";
+        return $"{baseline} slower than {fastest.Engine}";
     }
 
     private static bool IsDefaultDurationMetric(string? metric)

--- a/PowerForge/Services/Benchmarks/BenchmarkSummaryService.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkSummaryService.cs
@@ -39,7 +39,25 @@ public sealed class BenchmarkSummaryService
     /// <param name="metric">Metric name to compare.</param>
     /// <returns>Comparison rows.</returns>
     public BenchmarkComparisonRow[] Compare(IEnumerable<BenchmarkSummaryRow> summary, string baselineEngine, string metric = "MedianMs")
+        => Compare(summary, baselineEngine, metric, tieTolerance: 0);
+
+    /// <summary>
+    /// Creates comparison rows against a baseline engine with a practical tie tolerance.
+    /// </summary>
+    /// <param name="summary">Summary rows.</param>
+    /// <param name="baselineEngine">Baseline engine name.</param>
+    /// <param name="metric">Metric name to compare.</param>
+    /// <param name="tieTolerance">Fractional tolerance used to label practically equivalent results, such as <c>0.05</c> for five percent.</param>
+    /// <returns>Comparison rows.</returns>
+    public BenchmarkComparisonRow[] Compare(
+        IEnumerable<BenchmarkSummaryRow> summary,
+        string baselineEngine,
+        string metric,
+        double tieTolerance)
     {
+        if (double.IsNaN(tieTolerance) || double.IsInfinity(tieTolerance) || tieTolerance < 0)
+            throw new ArgumentOutOfRangeException(nameof(tieTolerance), "Tie tolerance must be a finite non-negative number.");
+
         var rows = (summary ?? Array.Empty<BenchmarkSummaryRow>()).ToArray();
         var result = new List<BenchmarkComparisonRow>();
         foreach (var group in rows.GroupBy(r => MakeKey(r.Suite, r.Scenario, r.Operation, string.Empty, r.Host, r.Os, r.RunMode, ComparisonVariables(r.Variables)), StringComparer.Ordinal))
@@ -69,6 +87,7 @@ public sealed class BenchmarkSummaryService
                     Metric = metric,
                     Actual = actual,
                     Baseline = baselineValue,
+                    TieTolerance = tieTolerance,
                     Ratio = actual.HasValue && baselineValue.HasValue && Math.Abs(baselineValue.Value) > double.Epsilon
                         ? actual.Value / baselineValue.Value
                         : null


### PR DESCRIPTION
## Summary

- add an optional practical tie tolerance to benchmark comparison rows and Markdown rendering
- expose the threshold through both `comparison` and `Add-BenchmarkComparison` as `-TieTolerance`
- propagate the configured value through suite evaluation, execution, result merging, JSON output, and README blocks
- preserve exact fastest/slower ranking when no tolerance is configured

This lets benchmark owners state a meaningful threshold such as 5%, so a 0.1% timing difference is not presented as a material win or loss.

## Example

```powershell
comparison Engine -Baseline Managed -Metric MedianMs -TieTolerance 0.05
```

With that setting, 100 ms versus 104 ms is rendered as a tie; 100 ms versus 106 ms retains the faster/slower result.

## Validation

- 13 focused DSL, propagation, default-behavior, and Markdown renderer tests pass on .NET 10
- PSPublishModule builds cleanly for .NET 8 and .NET 10
- generated command Markdown and MAML help were refreshed; the MAML XML validates successfully
- the broader benchmark-service suite has three pre-existing Windows-path failures on macOS, reproduced unchanged on `main`
