### PR TITLE
Support dependency type accelerators on PowerShell Desktop

### DIFF
--- a/Module/PSPublishModule.psm1
+++ b/Module/PSPublishModule.psm1
@@ -53,6 +53,7 @@ if ($PSEdition -eq 'Core') {
     $LibFolder = $FrameworkNet
 }
 
+$PowerForgeDesktopBinaryLoaded = $false
 try {
     $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
     $ModuleAssemblyPath = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder, $Library)
@@ -357,6 +358,10 @@ try {
         $Type = "$Class" -as [Type]
         & $ImportModule -Force -Assembly ($Type.Assembly)
     }
+
+    if ($PSEdition -ne 'Core') {
+        $PowerForgeDesktopBinaryLoaded = $true
+    }
 } catch {
     if ($ErrorActionPreference -eq 'Stop') {
         throw
@@ -365,208 +370,297 @@ try {
     }
 }
 
-if ($PSEdition -ne 'Core') {
+if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded) {
     # Core loads dependencies through the module-scoped AssemblyLoadContext above. Dot-sourcing the libraries script
     # there would load dependency DLLs into the default context and undo the isolation this template exists to provide.
     $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'PSPublishModule.Libraries.ps1')
     if (Test-Path -LiteralPath $LibrariesScript) {
         . $LibrariesScript
     }
-}
 
-if ($PSEdition -ne 'Core') {
-    # Desktop loads module dependencies into the default AppDomain, so expose the same configured scripting types as Core.
-    $RegisterPowerForgeDesktopAssemblyTypeAccelerators = {
-        param([Parameter(Mandatory = $true)][string] $LibraryDirectory)
+    if ($PSEdition -ne 'Core') {
+        # Desktop loads module dependencies into the default AppDomain, so expose the same configured scripting types as Core.
+        $RegisterPowerForgeDesktopAssemblyTypeAccelerators = {
+            param([Parameter(Mandatory = $true)][string] $LibraryDirectory)
 
-        $Mode = 'AllowList'
-        $RequestedTypes = @('PowerForge.ModuleTestFailureAnalysis', 'PowerForge.ModuleTestSuiteResult', 'PowerForge.ModuleRepositoryProfileScope', 'PowerForge.PrivateGalleryBootstrapMode', 'PowerForge.PrivateGalleryCredentialSource', 'PowerForge.PublishTool', 'PowerForge.RepositoryRegistrationTool')
-        $RequestedAssemblies = @()
+            $Mode = 'AllowList'
+            $RequestedTypes = @('PowerForge.ModuleTestFailureAnalysis', 'PowerForge.ModuleTestSuiteResult', 'PowerForge.ModuleRepositoryProfileScope', 'PowerForge.PrivateGalleryBootstrapMode', 'PowerForge.PrivateGalleryCredentialSource', 'PowerForge.PublishTool', 'PowerForge.RepositoryRegistrationTool')
+            $RequestedAssemblies = @()
+            $IgnoredLibraryFileNames = @()
 
-        if ([string]::IsNullOrWhiteSpace($LibraryDirectory) -or -not (Test-Path -LiteralPath $LibraryDirectory)) {
-            Write-Warning -Message 'Module library directory was not available. Desktop dependency type exposure is disabled.'
-            return
-        }
-
-        if ($Mode -eq 'AllowList' -and $RequestedTypes.Count -eq 0) {
-            Write-Warning -Message 'AllowList type accelerator mode was configured without type names. No Desktop dependency type accelerators will be registered.'
-            return
-        }
-
-        if (($Mode -eq 'Assembly' -or $Mode -eq 'Enums') -and $RequestedAssemblies.Count -eq 0) {
-            if ($RequestedTypes.Count -eq 0) {
-                Write-Warning -Message "$Mode type accelerator mode was configured without assembly names or type names. No Desktop dependency type accelerators will be registered."
+            if ([string]::IsNullOrWhiteSpace($LibraryDirectory) -or -not (Test-Path -LiteralPath $LibraryDirectory)) {
+                Write-Warning -Message 'Module library directory was not available. Desktop dependency type exposure is disabled.'
                 return
             }
 
-            Write-Warning -Message "$Mode type accelerator mode was configured without assembly names. Only explicitly configured type names will be registered."
-        }
-
-        $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
-        if ($null -eq $TypeAccelerators) {
-            Write-Warning -Message 'PowerShell type accelerator APIs are not available. Desktop dependency type exposure is disabled.'
-            return
-        }
-
-        $AddTypeAccelerator = $TypeAccelerators.GetMethod('Add', [type[]]@([string], [type]))
-        $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
-        if ($null -eq $AddTypeAccelerator -or $null -eq $GetTypeAccelerators) {
-            Write-Warning -Message 'PowerShell type accelerator APIs are incomplete. Desktop dependency type exposure is disabled.'
-            return
-        }
-
-        if ($null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {
-            $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{}
-        }
-
-        $ImportPowerForgeDesktopAssembly = {
-            param([Parameter(Mandatory = $true)][string] $AssemblyName)
-
-            $SimpleName = [IO.Path]::GetFileNameWithoutExtension($AssemblyName)
-            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
-                if ($Assembly.GetName().Name -eq $SimpleName) {
-                    return $Assembly
-                }
-            }
-
-            $AssemblyPath = [IO.Path]::Combine($LibraryDirectory, $SimpleName + '.dll')
-            if (-not (Test-Path -LiteralPath $AssemblyPath)) {
-                return $null
-            }
-
-            try {
-                return [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
-            } catch {
-                Write-Warning -Message "Could not load Desktop assembly '$SimpleName' for type accelerator exposure: $($_.Exception.Message)"
-                return $null
-            }
-        }
-
-        $FindPowerForgeDesktopType = {
-            param([Parameter(Mandatory = $true)][string] $TypeName)
-
-            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
-                $Type = $Assembly.GetType($TypeName, $false, $false)
-                if ($null -ne $Type) {
-                    return $Type
-                }
-            }
-
-            foreach ($File in Get-ChildItem -LiteralPath $LibraryDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {
-                $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $File.BaseName
-                if ($null -eq $Assembly) {
-                    continue
-                }
-
-                $Type = $Assembly.GetType($TypeName, $false, $false)
-                if ($null -ne $Type) {
-                    return $Type
-                }
-            }
-
-            return $null
-        }
-
-        $AddPowerForgeDesktopTypeAccelerator = {
-            param([Parameter(Mandatory = $true)][type] $Type)
-
-            if ([string]::IsNullOrWhiteSpace($Type.FullName)) {
+            if ($Mode -eq 'AllowList' -and $RequestedTypes.Count -eq 0) {
+                Write-Warning -Message 'AllowList type accelerator mode was configured without type names. No Desktop dependency type accelerators will be registered.'
                 return
             }
 
-            $Name = $Type.FullName
-            $Existing = $GetTypeAccelerators.GetValue($null)
-            if ($Existing.ContainsKey($Name)) {
-                $ExistingType = $Existing[$Name]
-                if ([object]::ReferenceEquals($ExistingType, $Type)) {
+            if (($Mode -eq 'Assembly' -or $Mode -eq 'Enums') -and $RequestedAssemblies.Count -eq 0) {
+                if ($RequestedTypes.Count -eq 0) {
+                    Write-Warning -Message "$Mode type accelerator mode was configured without assembly names or type names. No Desktop dependency type accelerators will be registered."
                     return
                 }
 
-                Write-Warning -Message "Type accelerator '$Name' already exists from $($ExistingType.Assembly.GetName().FullName). Keeping it and skipping the Desktop type from $($Type.Assembly.GetName().FullName)."
+                Write-Warning -Message "$Mode type accelerator mode was configured without assembly names. Only explicitly configured type names will be registered."
+            }
+
+            $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+            if ($null -eq $TypeAccelerators) {
+                Write-Warning -Message 'PowerShell type accelerator APIs are not available. Desktop dependency type exposure is disabled.'
                 return
             }
 
-            try {
-                $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
-            } catch {
-                Write-Warning -Message "Type accelerator '$Name' could not be registered from $($Type.Assembly.GetName().Name): $($_.Exception.Message)"
+            $AddTypeAccelerator = $TypeAccelerators.GetMethod('Add', [type[]]@([string], [type]))
+            $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+            if ($null -eq $AddTypeAccelerator -or $null -eq $GetTypeAccelerators) {
+                Write-Warning -Message 'PowerShell type accelerator APIs are incomplete. Desktop dependency type exposure is disabled.'
                 return
             }
 
-            $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
-        }
+            if ($null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {
+                $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{}
+            }
 
-        if ($Mode -eq 'Assembly' -or $Mode -eq 'Enums') {
-            foreach ($AssemblyName in $RequestedAssemblies) {
-                $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $AssemblyName
-                if ($null -eq $Assembly) {
-                    Write-Warning -Message "Assembly '$AssemblyName' was not found in the module library directory. No Desktop type accelerators were registered for it."
-                    continue
+            $ResolvedPowerForgeDesktopAssemblies = @{}
+            $FailedPowerForgeDesktopAssemblies = @{}
+            $LibraryDirectoryFullPath = [IO.Path]::GetFullPath($LibraryDirectory)
+            $LibraryDirectoryPrefix = $LibraryDirectoryFullPath.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+
+            $TestPowerForgeDesktopIgnoredAssembly = {
+                param([Parameter(Mandatory = $true)] $Assembly)
+
+                return $IgnoredLibraryFileNames -contains ($Assembly.GetName().Name + '.dll')
+            }
+
+            $TestPowerForgeDesktopModuleAssembly = {
+                param([Parameter(Mandatory = $true)] $Assembly)
+
+                if ($Assembly.IsDynamic) {
+                    return $false
                 }
 
                 try {
-                    $ExportedTypes = @($Assembly.GetExportedTypes())
+                    if ([string]::IsNullOrWhiteSpace($Assembly.Location)) {
+                        return $false
+                    }
+
+                    $AssemblyFullPath = [IO.Path]::GetFullPath($Assembly.Location)
+                    return $AssemblyFullPath.StartsWith($LibraryDirectoryPrefix, [StringComparison]::OrdinalIgnoreCase)
                 } catch {
-                    Write-Warning -Message "Could not enumerate exported types from Desktop assembly '$AssemblyName' for type accelerator exposure: $($_.Exception.Message)"
-                    continue
+                    return $false
+                }
+            }
+
+            $ImportPowerForgeDesktopAssembly = {
+                param([Parameter(Mandatory = $true)][string] $AssemblyName)
+
+                $SimpleName = [IO.Path]::GetFileNameWithoutExtension($AssemblyName)
+                $AssemblyFileName = $SimpleName + '.dll'
+                if ($IgnoredLibraryFileNames -contains $AssemblyFileName) {
+                    $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                    return $null
                 }
 
-                foreach ($Type in $ExportedTypes) {
-                    if ($Mode -eq 'Enums' -and -not $Type.IsEnum) {
+                if ($ResolvedPowerForgeDesktopAssemblies.ContainsKey($SimpleName)) {
+                    return $ResolvedPowerForgeDesktopAssemblies[$SimpleName]
+                }
+                if ($FailedPowerForgeDesktopAssemblies.ContainsKey($SimpleName)) {
+                    return $null
+                }
+
+                foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                    if ($Assembly.GetName().Name -eq $SimpleName -and (& $TestPowerForgeDesktopModuleAssembly -Assembly $Assembly)) {
+                        $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $Assembly
+                        return $Assembly
+                    }
+                }
+
+                $AssemblyPath = [IO.Path]::Combine($LibraryDirectory, $AssemblyFileName)
+                if (Test-Path -LiteralPath $AssemblyPath) {
+                    try {
+                        $LoadedAssembly = [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
+                        if (& $TestPowerForgeDesktopModuleAssembly -Assembly $LoadedAssembly) {
+                            $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $LoadedAssembly
+                            return $LoadedAssembly
+                        }
+
+                        $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                        Write-Warning -Message "Desktop assembly '$SimpleName' resolved outside the module library directory. Skipping type accelerator exposure to avoid registering the wrong assembly version."
+                        return $null
+                    } catch {
+                        $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                        Write-Warning -Message "Could not load Desktop assembly '$SimpleName' for type accelerator exposure: $($_.Exception.Message)"
+                        return $null
+                    }
+                }
+
+                foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                    if ($Assembly.GetName().Name -eq $SimpleName) {
+                        $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $Assembly
+                        return $Assembly
+                    }
+                }
+
+                $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                return $null
+            }
+
+            $FindPowerForgeDesktopType = {
+                param([Parameter(Mandatory = $true)][string] $TypeName)
+
+                foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                    if ((& $TestPowerForgeDesktopIgnoredAssembly -Assembly $Assembly) -or
+                        -not (& $TestPowerForgeDesktopModuleAssembly -Assembly $Assembly)) {
                         continue
                     }
 
-                    & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+                    $Type = $Assembly.GetType($TypeName, $false, $false)
+                    if ($null -ne $Type) {
+                        return $Type
+                    }
+                }
+
+                foreach ($File in Get-ChildItem -LiteralPath $LibraryDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {
+                    if ($IgnoredLibraryFileNames -contains $File.Name) {
+                        continue
+                    }
+
+                    $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $File.BaseName
+                    if ($null -eq $Assembly) {
+                        continue
+                    }
+
+                    $Type = $Assembly.GetType($TypeName, $false, $false)
+                    if ($null -ne $Type) {
+                        return $Type
+                    }
+                }
+
+                foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                    if (& $TestPowerForgeDesktopIgnoredAssembly -Assembly $Assembly) {
+                        continue
+                    }
+
+                    $AssemblyFileName = $Assembly.GetName().Name + '.dll'
+                    if (Test-Path -LiteralPath ([IO.Path]::Combine($LibraryDirectory, $AssemblyFileName))) {
+                        # A module-owned assembly with this identity exists but could not be selected above. Do not
+                        # silently fall back to a globally loaded copy with a different location or version.
+                        continue
+                    }
+
+                    $Type = $Assembly.GetType($TypeName, $false, $false)
+                    if ($null -ne $Type) {
+                        return $Type
+                    }
+                }
+
+                return $null
+            }
+
+            $AddPowerForgeDesktopTypeAccelerator = {
+                param([Parameter(Mandatory = $true)][type] $Type)
+
+                if ([string]::IsNullOrWhiteSpace($Type.FullName)) {
+                    return
+                }
+
+                $Name = $Type.FullName
+                $Existing = $GetTypeAccelerators.GetValue($null)
+                if ($Existing.ContainsKey($Name)) {
+                    $ExistingType = $Existing[$Name]
+                    if ([object]::ReferenceEquals($ExistingType, $Type)) {
+                        return
+                    }
+
+                    Write-Warning -Message "Type accelerator '$Name' already exists from $($ExistingType.Assembly.GetName().FullName). Keeping it and skipping the Desktop type from $($Type.Assembly.GetName().FullName)."
+                    return
+                }
+
+                try {
+                    $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
+                } catch {
+                    Write-Warning -Message "Type accelerator '$Name' could not be registered from $($Type.Assembly.GetName().Name): $($_.Exception.Message)"
+                    return
+                }
+
+                $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
+            }
+
+            if ($Mode -eq 'Assembly' -or $Mode -eq 'Enums') {
+                foreach ($AssemblyName in $RequestedAssemblies) {
+                    $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $AssemblyName
+                    if ($null -eq $Assembly) {
+                        Write-Warning -Message "Assembly '$AssemblyName' was not found in the module library directory. No Desktop type accelerators were registered for it."
+                        continue
+                    }
+
+                    try {
+                        $ExportedTypes = @($Assembly.GetExportedTypes())
+                    } catch {
+                        Write-Warning -Message "Could not enumerate exported types from Desktop assembly '$AssemblyName' for type accelerator exposure: $($_.Exception.Message)"
+                        continue
+                    }
+
+                    foreach ($Type in $ExportedTypes) {
+                        if ($Mode -eq 'Enums' -and -not $Type.IsEnum) {
+                            continue
+                        }
+
+                        & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+                    }
                 }
             }
-        }
 
-        foreach ($TypeName in $RequestedTypes) {
-            $Type = & $FindPowerForgeDesktopType -TypeName $TypeName
-            if ($null -eq $Type) {
-                Write-Warning -Message "Type '$TypeName' was not found in the module AppDomain. No Desktop type accelerator was registered."
-                continue
+            foreach ($TypeName in $RequestedTypes) {
+                $Type = & $FindPowerForgeDesktopType -TypeName $TypeName
+                if ($null -eq $Type) {
+                    Write-Warning -Message "Type '$TypeName' was not found in the module AppDomain. No Desktop type accelerator was registered."
+                    continue
+                }
+
+                & $AddPowerForgeDesktopTypeAccelerator -Type $Type
             }
 
-            & $AddPowerForgeDesktopTypeAccelerator -Type $Type
-        }
+            if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {
+                $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+                $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
+                $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
+                $ExecutionContext.SessionState.Module.OnRemove = {
+                    try {
+                        $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+                        if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {
+                            return
+                        }
 
-        if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {
-            $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
-            $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
-            $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
-            $ExecutionContext.SessionState.Module.OnRemove = {
-                try {
-                    $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
-                    if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {
-                        return
-                    }
+                        $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+                        $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
+                        if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {
+                            return
+                        }
 
-                    $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
-                    $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
-                    if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {
-                        return
-                    }
-
-                    $Existing = $GetTypeAccelerators.GetValue($null)
-                    foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {
-                        if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {
-                            $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                        $Existing = $GetTypeAccelerators.GetValue($null)
+                        foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {
+                            if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {
+                                $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                            }
+                        }
+                    } finally {
+                        if ($null -ne $PreviousPowerForgeOnRemove) {
+                            & $PreviousPowerForgeOnRemove @args
                         }
                     }
-                } finally {
-                    if ($null -ne $PreviousPowerForgeOnRemove) {
-                        & $PreviousPowerForgeOnRemove @args
-                    }
-                }
-            }.GetNewClosure()
+                }.GetNewClosure()
+            }
         }
-    }
 
-    try {
-        & $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))
-    } catch {
-        Write-Warning -Message "Desktop type accelerator registration failed: $($_.Exception.Message)"
+        try {
+            & $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))
+        } catch {
+            Write-Warning -Message "Desktop type accelerator registration failed: $($_.Exception.Message)"
+        }
     }
 }
 

--- a/Module/PSPublishModule.psm1
+++ b/Module/PSPublishModule.psm1
@@ -269,11 +269,12 @@ try {
 
             if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {
                 $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+                $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
                 $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
                 $ExecutionContext.SessionState.Module.OnRemove = {
                     try {
                         $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
-                        if ($null -eq $TypeAccelerators -or $null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {
+                        if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {
                             return
                         }
 
@@ -284,7 +285,7 @@ try {
                         }
 
                         $Existing = $GetTypeAccelerators.GetValue($null)
-                        foreach ($Entry in @($script:PowerForgeRegisteredAssemblyTypeAccelerators.GetEnumerator())) {
+                        foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {
                             if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {
                                 $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
                             }
@@ -370,6 +371,202 @@ if ($PSEdition -ne 'Core') {
     $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'PSPublishModule.Libraries.ps1')
     if (Test-Path -LiteralPath $LibrariesScript) {
         . $LibrariesScript
+    }
+}
+
+if ($PSEdition -ne 'Core') {
+    # Desktop loads module dependencies into the default AppDomain, so expose the same configured scripting types as Core.
+    $RegisterPowerForgeDesktopAssemblyTypeAccelerators = {
+        param([Parameter(Mandatory = $true)][string] $LibraryDirectory)
+
+        $Mode = 'AllowList'
+        $RequestedTypes = @('PowerForge.ModuleTestFailureAnalysis', 'PowerForge.ModuleTestSuiteResult', 'PowerForge.ModuleRepositoryProfileScope', 'PowerForge.PrivateGalleryBootstrapMode', 'PowerForge.PrivateGalleryCredentialSource', 'PowerForge.PublishTool', 'PowerForge.RepositoryRegistrationTool')
+        $RequestedAssemblies = @()
+
+        if ([string]::IsNullOrWhiteSpace($LibraryDirectory) -or -not (Test-Path -LiteralPath $LibraryDirectory)) {
+            Write-Warning -Message 'Module library directory was not available. Desktop dependency type exposure is disabled.'
+            return
+        }
+
+        if ($Mode -eq 'AllowList' -and $RequestedTypes.Count -eq 0) {
+            Write-Warning -Message 'AllowList type accelerator mode was configured without type names. No Desktop dependency type accelerators will be registered.'
+            return
+        }
+
+        if (($Mode -eq 'Assembly' -or $Mode -eq 'Enums') -and $RequestedAssemblies.Count -eq 0) {
+            if ($RequestedTypes.Count -eq 0) {
+                Write-Warning -Message "$Mode type accelerator mode was configured without assembly names or type names. No Desktop dependency type accelerators will be registered."
+                return
+            }
+
+            Write-Warning -Message "$Mode type accelerator mode was configured without assembly names. Only explicitly configured type names will be registered."
+        }
+
+        $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+        if ($null -eq $TypeAccelerators) {
+            Write-Warning -Message 'PowerShell type accelerator APIs are not available. Desktop dependency type exposure is disabled.'
+            return
+        }
+
+        $AddTypeAccelerator = $TypeAccelerators.GetMethod('Add', [type[]]@([string], [type]))
+        $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+        if ($null -eq $AddTypeAccelerator -or $null -eq $GetTypeAccelerators) {
+            Write-Warning -Message 'PowerShell type accelerator APIs are incomplete. Desktop dependency type exposure is disabled.'
+            return
+        }
+
+        if ($null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {
+            $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{}
+        }
+
+        $ImportPowerForgeDesktopAssembly = {
+            param([Parameter(Mandatory = $true)][string] $AssemblyName)
+
+            $SimpleName = [IO.Path]::GetFileNameWithoutExtension($AssemblyName)
+            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                if ($Assembly.GetName().Name -eq $SimpleName) {
+                    return $Assembly
+                }
+            }
+
+            $AssemblyPath = [IO.Path]::Combine($LibraryDirectory, $SimpleName + '.dll')
+            if (-not (Test-Path -LiteralPath $AssemblyPath)) {
+                return $null
+            }
+
+            try {
+                return [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
+            } catch {
+                Write-Warning -Message "Could not load Desktop assembly '$SimpleName' for type accelerator exposure: $($_.Exception.Message)"
+                return $null
+            }
+        }
+
+        $FindPowerForgeDesktopType = {
+            param([Parameter(Mandatory = $true)][string] $TypeName)
+
+            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                $Type = $Assembly.GetType($TypeName, $false, $false)
+                if ($null -ne $Type) {
+                    return $Type
+                }
+            }
+
+            foreach ($File in Get-ChildItem -LiteralPath $LibraryDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {
+                $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $File.BaseName
+                if ($null -eq $Assembly) {
+                    continue
+                }
+
+                $Type = $Assembly.GetType($TypeName, $false, $false)
+                if ($null -ne $Type) {
+                    return $Type
+                }
+            }
+
+            return $null
+        }
+
+        $AddPowerForgeDesktopTypeAccelerator = {
+            param([Parameter(Mandatory = $true)][type] $Type)
+
+            if ([string]::IsNullOrWhiteSpace($Type.FullName)) {
+                return
+            }
+
+            $Name = $Type.FullName
+            $Existing = $GetTypeAccelerators.GetValue($null)
+            if ($Existing.ContainsKey($Name)) {
+                $ExistingType = $Existing[$Name]
+                if ([object]::ReferenceEquals($ExistingType, $Type)) {
+                    return
+                }
+
+                Write-Warning -Message "Type accelerator '$Name' already exists from $($ExistingType.Assembly.GetName().FullName). Keeping it and skipping the Desktop type from $($Type.Assembly.GetName().FullName)."
+                return
+            }
+
+            try {
+                $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
+            } catch {
+                Write-Warning -Message "Type accelerator '$Name' could not be registered from $($Type.Assembly.GetName().Name): $($_.Exception.Message)"
+                return
+            }
+
+            $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
+        }
+
+        if ($Mode -eq 'Assembly' -or $Mode -eq 'Enums') {
+            foreach ($AssemblyName in $RequestedAssemblies) {
+                $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $AssemblyName
+                if ($null -eq $Assembly) {
+                    Write-Warning -Message "Assembly '$AssemblyName' was not found in the module library directory. No Desktop type accelerators were registered for it."
+                    continue
+                }
+
+                try {
+                    $ExportedTypes = @($Assembly.GetExportedTypes())
+                } catch {
+                    Write-Warning -Message "Could not enumerate exported types from Desktop assembly '$AssemblyName' for type accelerator exposure: $($_.Exception.Message)"
+                    continue
+                }
+
+                foreach ($Type in $ExportedTypes) {
+                    if ($Mode -eq 'Enums' -and -not $Type.IsEnum) {
+                        continue
+                    }
+
+                    & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+                }
+            }
+        }
+
+        foreach ($TypeName in $RequestedTypes) {
+            $Type = & $FindPowerForgeDesktopType -TypeName $TypeName
+            if ($null -eq $Type) {
+                Write-Warning -Message "Type '$TypeName' was not found in the module AppDomain. No Desktop type accelerator was registered."
+                continue
+            }
+
+            & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+        }
+
+        if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {
+            $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+            $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
+            $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
+            $ExecutionContext.SessionState.Module.OnRemove = {
+                try {
+                    $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+                    if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {
+                        return
+                    }
+
+                    $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+                    $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
+                    if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {
+                        return
+                    }
+
+                    $Existing = $GetTypeAccelerators.GetValue($null)
+                    foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {
+                        if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {
+                            $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                        }
+                    }
+                } finally {
+                    if ($null -ne $PreviousPowerForgeOnRemove) {
+                        & $PreviousPowerForgeOnRemove @args
+                    }
+                }
+            }.GetNewClosure()
+        }
+    }
+
+    try {
+        & $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))
+    } catch {
+        Write-Warning -Message "Desktop type accelerator registration failed: $($_.Exception.Message)"
     }
 }
 

--- a/PowerForge.Tests/InstallManifestVersioningTests.cs
+++ b/PowerForge.Tests/InstallManifestVersioningTests.cs
@@ -96,6 +96,48 @@ public sealed class InstallManifestVersioningTests
         }
     }
 
+    [Fact]
+    public void InstallFromStaging_IncrementsExistingFourthComponentWithoutCreatingInvalidFivePartVersion()
+    {
+        var temp = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "Foo";
+            var staging = Path.Combine(temp.FullName, "staging");
+            var roots = Path.Combine(temp.FullName, "roots");
+            Directory.CreateDirectory(staging);
+            Directory.CreateDirectory(roots);
+
+            WriteMinimalModule(staging, moduleName, "3.0.57.2");
+
+            var pipeline = ModuleBuildPipelineFactory.Create(new NullLogger());
+            var spec = new ModuleInstallSpec
+            {
+                Name = moduleName,
+                Version = "3.0.57.2",
+                StagingPath = staging,
+                Strategy = InstallationStrategy.AutoRevision,
+                KeepVersions = 10,
+                Roots = new[] { roots },
+                UpdateManifestToResolvedVersion = true
+            };
+
+            var result = pipeline.InstallFromStaging(spec);
+
+            Assert.Equal("3.0.57.3", result.Version);
+            Assert.Contains(Path.Combine(roots, moduleName, "3.0.57.3"), result.InstalledPaths, StringComparer.OrdinalIgnoreCase);
+
+            var installedPsd1 = Path.Combine(roots, moduleName, "3.0.57.3", $"{moduleName}.psd1");
+            Assert.True(ManifestEditor.TryGetTopLevelString(installedPsd1, "ModuleVersion", out var installedVersion));
+            Assert.Equal("3.0.57.3", installedVersion);
+            Assert.True(Version.TryParse(installedVersion, out _));
+        }
+        finally
+        {
+            try { temp.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static void WriteMinimalModule(string moduleRoot, string moduleName, string version)
     {
         Directory.CreateDirectory(moduleRoot);

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests.cs
@@ -1,0 +1,79 @@
+using PowerForge;
+
+public sealed class ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests
+{
+    [Fact]
+    public void Generate_WithTypeAccelerators_WritesDesktopRegistrationAfterLibrariesLoad()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-desktop-types-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "Lib", "Core"));
+        File.WriteAllText(Path.Combine(root, "Lib", "Core", "DemoModule.dll"), string.Empty);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true,
+                assemblyTypeAcceleratorMode: AssemblyTypeAcceleratorExportMode.AllowList,
+                assemblyTypeAccelerators: new[] { "Dependency.Widget" });
+
+            var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
+            Assert.Contains("$RegisterPowerForgeDesktopAssemblyTypeAccelerators = {", bootstrapper);
+            Assert.Contains("[AppDomain]::CurrentDomain.GetAssemblies()", bootstrapper);
+            Assert.Contains("$RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators", bootstrapper);
+            Assert.Contains("& $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))", bootstrapper);
+            Assert.True(
+                bootstrapper.IndexOf(". $LibrariesScript", StringComparison.Ordinal) <
+                bootstrapper.IndexOf("& $RegisterPowerForgeDesktopAssemblyTypeAccelerators", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_WithDevelopmentBinaries_UsesSelectedDesktopBinaryDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-bootstrapper-desktop-development-types-" + Guid.NewGuid().ToString("N"));
+        var moduleRoot = Path.Combine(root, "Module");
+        Directory.CreateDirectory(moduleRoot);
+
+        try
+        {
+            var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
+            var developmentOptions = new ModuleDevelopmentBinaryBootstrapperOptions(
+                ModuleDevelopmentBinaryMode.Environment,
+                Path.Combine(root, "Sources", "Demo", "bin"),
+                "DEMO_USE_DEVELOPMENT_BINARIES",
+                "DEMO_DEVELOPMENT_CONFIGURATION",
+                new[] { "net8.0", "net472" },
+                new[] { "net472", "net8.0" });
+
+            ModuleBootstrapperGenerator.Generate(
+                moduleRoot,
+                "DemoModule",
+                exports,
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false,
+                useAssemblyLoadContext: true,
+                assemblyTypeAcceleratorMode: AssemblyTypeAcceleratorExportMode.AllowList,
+                assemblyTypeAccelerators: new[] { "Demo.Dependency" },
+                developmentBinaries: developmentOptions);
+
+            var bootstrapper = File.ReadAllText(Path.Combine(moduleRoot, "DemoModule.psm1"));
+            Assert.Contains("& $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath))", bootstrapper);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+}

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests.cs
@@ -20,16 +20,29 @@ public sealed class ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests
                 handleRuntimes: false,
                 useAssemblyLoadContext: true,
                 assemblyTypeAcceleratorMode: AssemblyTypeAcceleratorExportMode.AllowList,
-                assemblyTypeAccelerators: new[] { "Dependency.Widget" });
+                assemblyTypeAccelerators: new[] { "Dependency.Widget" },
+                ignoreLibrariesOnLoad: new[] { "Ignored.Dependency.dll" });
 
             var bootstrapper = File.ReadAllText(Path.Combine(root, "DemoModule.psm1"));
             Assert.Contains("$RegisterPowerForgeDesktopAssemblyTypeAccelerators = {", bootstrapper);
             Assert.Contains("[AppDomain]::CurrentDomain.GetAssemblies()", bootstrapper);
             Assert.Contains("$RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators", bootstrapper);
+            Assert.Contains("$IgnoredLibraryFileNames = @('Ignored.Dependency.dll')", bootstrapper);
+            Assert.Contains("if ($IgnoredLibraryFileNames -contains $File.Name)", bootstrapper);
+            Assert.Contains("$TestPowerForgeDesktopIgnoredAssembly = {", bootstrapper);
+            Assert.Contains("$ResolvedPowerForgeDesktopAssemblies = @{}", bootstrapper);
+            Assert.Contains("$FailedPowerForgeDesktopAssemblies = @{}", bootstrapper);
+            Assert.Contains("if ($Assembly.GetName().Name -eq $SimpleName -and (& $TestPowerForgeDesktopModuleAssembly -Assembly $Assembly))", bootstrapper);
+            Assert.Contains("A module-owned assembly with this identity exists but could not be selected above", bootstrapper);
+            Assert.Contains("if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded)", bootstrapper);
             Assert.Contains("& $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))", bootstrapper);
+            Assert.True(
+                bootstrapper.IndexOf("$PowerForgeDesktopBinaryLoaded = $true", StringComparison.Ordinal) <
+                bootstrapper.IndexOf(". $LibrariesScript", StringComparison.Ordinal));
             Assert.True(
                 bootstrapper.IndexOf(". $LibrariesScript", StringComparison.Ordinal) <
                 bootstrapper.IndexOf("& $RegisterPowerForgeDesktopAssemblyTypeAccelerators", StringComparison.Ordinal));
+            Assert.Contains("    if ($PSEdition -ne 'Core') {\r\n        # Desktop loads module dependencies", bootstrapper);
         }
         finally
         {

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -50,7 +50,8 @@ if ($PSEdition -eq 'Core') {
     $LibFolder = $FrameworkNet
 }
 
-{{RuntimeHandlerBlock}}try {
+{{RuntimeHandlerBlock}}$PowerForgeDesktopBinaryLoaded = $false
+try {
     $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
     $ModuleAssemblyPath = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder, $Library)
 
@@ -111,6 +112,10 @@ if ($PSEdition -eq 'Core') {
         $Type = "$Class" -as [Type]
         & $ImportModule -Force -Assembly ($Type.Assembly)
     }
+
+    if ($PSEdition -ne 'Core') {
+        $PowerForgeDesktopBinaryLoaded = $true
+    }
 } catch {
     if ($ErrorActionPreference -eq 'Stop') {
         throw
@@ -119,13 +124,13 @@ if ($PSEdition -eq 'Core') {
     }
 }
 
-if ($PSEdition -ne 'Core') {
+if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded) {
     # Core loads dependencies through the module-scoped AssemblyLoadContext above. Dot-sourcing the libraries script
     # there would load dependency DLLs into the default context and undo the isolation this template exists to provide.
     $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, '{{ModuleName}}.Libraries.ps1')
     if (Test-Path -LiteralPath $LibrariesScript) {
         . $LibrariesScript
     }
-}
 
 {{DesktopTypeAcceleratorBlock}}
+}

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -127,3 +127,5 @@ if ($PSEdition -ne 'Core') {
         . $LibrariesScript
     }
 }
+
+{{DesktopTypeAcceleratorBlock}}

--- a/PowerForge/Scripts/ModuleBootstrapper/DevelopmentBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/DevelopmentBinaryLoader.Template.ps1
@@ -54,6 +54,7 @@ if ($PowerForgeDevelopmentEnabled) {
                     & $ImportModule $PowerForgeDevelopmentBinaryPath -ErrorAction Stop
                 }
             }
+{{DesktopTypeAcceleratorBlock}}
             $PowerForgeDevelopmentBinaryLoaded = $true
         } catch {
             if ($ErrorActionPreference -eq 'Stop') {

--- a/PowerForge/Services/ModuleBootstrapperGenerator.DesktopTypeAccelerators.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.DesktopTypeAccelerators.cs
@@ -1,0 +1,215 @@
+namespace PowerForge;
+
+internal static partial class ModuleBootstrapperGenerator
+{
+    internal static string BuildDesktopTypeAcceleratorBlock(
+        AssemblyTypeAcceleratorExportMode mode,
+        IReadOnlyList<string>? typeNames,
+        IReadOnlyList<string>? assemblyNames,
+        string libraryDirectoryExpression)
+    {
+        var normalizedTypes = NormalizePowerShellStringArray(typeNames);
+        var normalizedAssemblies = NormalizePowerShellStringArray(assemblyNames);
+        if (mode == AssemblyTypeAcceleratorExportMode.None)
+            return string.Empty;
+
+        if (string.IsNullOrWhiteSpace(libraryDirectoryExpression))
+            throw new ArgumentException("A Desktop library directory expression is required.", nameof(libraryDirectoryExpression));
+
+        return $@"if ($PSEdition -ne 'Core') {{
+    # Desktop loads module dependencies into the default AppDomain, so expose the same configured scripting types as Core.
+    $RegisterPowerForgeDesktopAssemblyTypeAccelerators = {{
+        param([Parameter(Mandatory = $true)][string] $LibraryDirectory)
+
+        $Mode = '{mode}'
+        $RequestedTypes = {BuildPowerShellArrayLiteral(normalizedTypes)}
+        $RequestedAssemblies = {BuildPowerShellArrayLiteral(normalizedAssemblies)}
+
+        if ([string]::IsNullOrWhiteSpace($LibraryDirectory) -or -not (Test-Path -LiteralPath $LibraryDirectory)) {{
+            Write-Warning -Message 'Module library directory was not available. Desktop dependency type exposure is disabled.'
+            return
+        }}
+
+        if ($Mode -eq 'AllowList' -and $RequestedTypes.Count -eq 0) {{
+            Write-Warning -Message 'AllowList type accelerator mode was configured without type names. No Desktop dependency type accelerators will be registered.'
+            return
+        }}
+
+        if (($Mode -eq 'Assembly' -or $Mode -eq 'Enums') -and $RequestedAssemblies.Count -eq 0) {{
+            if ($RequestedTypes.Count -eq 0) {{
+                Write-Warning -Message ""$Mode type accelerator mode was configured without assembly names or type names. No Desktop dependency type accelerators will be registered.""
+                return
+            }}
+
+            Write-Warning -Message ""$Mode type accelerator mode was configured without assembly names. Only explicitly configured type names will be registered.""
+        }}
+
+        $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+        if ($null -eq $TypeAccelerators) {{
+            Write-Warning -Message 'PowerShell type accelerator APIs are not available. Desktop dependency type exposure is disabled.'
+            return
+        }}
+
+        $AddTypeAccelerator = $TypeAccelerators.GetMethod('Add', [type[]]@([string], [type]))
+        $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+        if ($null -eq $AddTypeAccelerator -or $null -eq $GetTypeAccelerators) {{
+            Write-Warning -Message 'PowerShell type accelerator APIs are incomplete. Desktop dependency type exposure is disabled.'
+            return
+        }}
+
+        if ($null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {{
+            $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{{}}
+        }}
+
+        $ImportPowerForgeDesktopAssembly = {{
+            param([Parameter(Mandatory = $true)][string] $AssemblyName)
+
+            $SimpleName = [IO.Path]::GetFileNameWithoutExtension($AssemblyName)
+            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {{
+                if ($Assembly.GetName().Name -eq $SimpleName) {{
+                    return $Assembly
+                }}
+            }}
+
+            $AssemblyPath = [IO.Path]::Combine($LibraryDirectory, $SimpleName + '.dll')
+            if (-not (Test-Path -LiteralPath $AssemblyPath)) {{
+                return $null
+            }}
+
+            try {{
+                return [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
+            }} catch {{
+                Write-Warning -Message ""Could not load Desktop assembly '$SimpleName' for type accelerator exposure: $($_.Exception.Message)""
+                return $null
+            }}
+        }}
+
+        $FindPowerForgeDesktopType = {{
+            param([Parameter(Mandatory = $true)][string] $TypeName)
+
+            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {{
+                $Type = $Assembly.GetType($TypeName, $false, $false)
+                if ($null -ne $Type) {{
+                    return $Type
+                }}
+            }}
+
+            foreach ($File in Get-ChildItem -LiteralPath $LibraryDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {{
+                $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $File.BaseName
+                if ($null -eq $Assembly) {{
+                    continue
+                }}
+
+                $Type = $Assembly.GetType($TypeName, $false, $false)
+                if ($null -ne $Type) {{
+                    return $Type
+                }}
+            }}
+
+            return $null
+        }}
+
+        $AddPowerForgeDesktopTypeAccelerator = {{
+            param([Parameter(Mandatory = $true)][type] $Type)
+
+            if ([string]::IsNullOrWhiteSpace($Type.FullName)) {{
+                return
+            }}
+
+            $Name = $Type.FullName
+            $Existing = $GetTypeAccelerators.GetValue($null)
+            if ($Existing.ContainsKey($Name)) {{
+                $ExistingType = $Existing[$Name]
+                if ([object]::ReferenceEquals($ExistingType, $Type)) {{
+                    return
+                }}
+
+                Write-Warning -Message ""Type accelerator '$Name' already exists from $($ExistingType.Assembly.GetName().FullName). Keeping it and skipping the Desktop type from $($Type.Assembly.GetName().FullName).""
+                return
+            }}
+
+            try {{
+                $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
+            }} catch {{
+                Write-Warning -Message ""Type accelerator '$Name' could not be registered from $($Type.Assembly.GetName().Name): $($_.Exception.Message)""
+                return
+            }}
+
+            $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
+        }}
+
+        if ($Mode -eq 'Assembly' -or $Mode -eq 'Enums') {{
+            foreach ($AssemblyName in $RequestedAssemblies) {{
+                $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $AssemblyName
+                if ($null -eq $Assembly) {{
+                    Write-Warning -Message ""Assembly '$AssemblyName' was not found in the module library directory. No Desktop type accelerators were registered for it.""
+                    continue
+                }}
+
+                try {{
+                    $ExportedTypes = @($Assembly.GetExportedTypes())
+                }} catch {{
+                    Write-Warning -Message ""Could not enumerate exported types from Desktop assembly '$AssemblyName' for type accelerator exposure: $($_.Exception.Message)""
+                    continue
+                }}
+
+                foreach ($Type in $ExportedTypes) {{
+                    if ($Mode -eq 'Enums' -and -not $Type.IsEnum) {{
+                        continue
+                    }}
+
+                    & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+                }}
+            }}
+        }}
+
+        foreach ($TypeName in $RequestedTypes) {{
+            $Type = & $FindPowerForgeDesktopType -TypeName $TypeName
+            if ($null -eq $Type) {{
+                Write-Warning -Message ""Type '$TypeName' was not found in the module AppDomain. No Desktop type accelerator was registered.""
+                continue
+            }}
+
+            & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+        }}
+
+        if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {{
+            $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+            $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
+            $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
+            $ExecutionContext.SessionState.Module.OnRemove = {{
+                try {{
+                    $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+                    if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {{
+                        return
+                    }}
+
+                    $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+                    $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
+                    if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {{
+                        return
+                    }}
+
+                    $Existing = $GetTypeAccelerators.GetValue($null)
+                    foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {{
+                        if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {{
+                            $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                        }}
+                    }}
+                }} finally {{
+                    if ($null -ne $PreviousPowerForgeOnRemove) {{
+                        & $PreviousPowerForgeOnRemove @args
+                    }}
+                }}
+            }}.GetNewClosure()
+        }}
+    }}
+
+    try {{
+        & $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ({libraryDirectoryExpression})
+    }} catch {{
+        Write-Warning -Message ""Desktop type accelerator registration failed: $($_.Exception.Message)""
+    }}
+}}";
+    }
+}

--- a/PowerForge/Services/ModuleBootstrapperGenerator.DesktopTypeAccelerators.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.DesktopTypeAccelerators.cs
@@ -6,10 +6,14 @@ internal static partial class ModuleBootstrapperGenerator
         AssemblyTypeAcceleratorExportMode mode,
         IReadOnlyList<string>? typeNames,
         IReadOnlyList<string>? assemblyNames,
-        string libraryDirectoryExpression)
+        string libraryDirectoryExpression,
+        IReadOnlyList<string>? ignoreLibrariesOnLoad = null)
     {
         var normalizedTypes = NormalizePowerShellStringArray(typeNames);
         var normalizedAssemblies = NormalizePowerShellStringArray(assemblyNames);
+        var ignoredLibraryFileNames = NormalizeFileNameSet(ignoreLibrariesOnLoad)
+            .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
         if (mode == AssemblyTypeAcceleratorExportMode.None)
             return string.Empty;
 
@@ -24,6 +28,7 @@ internal static partial class ModuleBootstrapperGenerator
         $Mode = '{mode}'
         $RequestedTypes = {BuildPowerShellArrayLiteral(normalizedTypes)}
         $RequestedAssemblies = {BuildPowerShellArrayLiteral(normalizedAssemblies)}
+        $IgnoredLibraryFileNames = {BuildPowerShellArrayLiteral(ignoredLibraryFileNames)}
 
         if ([string]::IsNullOrWhiteSpace($LibraryDirectory) -or -not (Test-Path -LiteralPath $LibraryDirectory)) {{
             Write-Warning -Message 'Module library directory was not available. Desktop dependency type exposure is disabled.'
@@ -61,33 +66,99 @@ internal static partial class ModuleBootstrapperGenerator
             $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{{}}
         }}
 
+        $ResolvedPowerForgeDesktopAssemblies = @{{}}
+        $FailedPowerForgeDesktopAssemblies = @{{}}
+        $LibraryDirectoryFullPath = [IO.Path]::GetFullPath($LibraryDirectory)
+        $LibraryDirectoryPrefix = $LibraryDirectoryFullPath.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+
+        $TestPowerForgeDesktopIgnoredAssembly = {{
+            param([Parameter(Mandatory = $true)] $Assembly)
+
+            return $IgnoredLibraryFileNames -contains ($Assembly.GetName().Name + '.dll')
+        }}
+
+        $TestPowerForgeDesktopModuleAssembly = {{
+            param([Parameter(Mandatory = $true)] $Assembly)
+
+            if ($Assembly.IsDynamic) {{
+                return $false
+            }}
+
+            try {{
+                if ([string]::IsNullOrWhiteSpace($Assembly.Location)) {{
+                    return $false
+                }}
+
+                $AssemblyFullPath = [IO.Path]::GetFullPath($Assembly.Location)
+                return $AssemblyFullPath.StartsWith($LibraryDirectoryPrefix, [StringComparison]::OrdinalIgnoreCase)
+            }} catch {{
+                return $false
+            }}
+        }}
+
         $ImportPowerForgeDesktopAssembly = {{
             param([Parameter(Mandatory = $true)][string] $AssemblyName)
 
             $SimpleName = [IO.Path]::GetFileNameWithoutExtension($AssemblyName)
+            $AssemblyFileName = $SimpleName + '.dll'
+            if ($IgnoredLibraryFileNames -contains $AssemblyFileName) {{
+                $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                return $null
+            }}
+
+            if ($ResolvedPowerForgeDesktopAssemblies.ContainsKey($SimpleName)) {{
+                return $ResolvedPowerForgeDesktopAssemblies[$SimpleName]
+            }}
+            if ($FailedPowerForgeDesktopAssemblies.ContainsKey($SimpleName)) {{
+                return $null
+            }}
+
             foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {{
-                if ($Assembly.GetName().Name -eq $SimpleName) {{
+                if ($Assembly.GetName().Name -eq $SimpleName -and (& $TestPowerForgeDesktopModuleAssembly -Assembly $Assembly)) {{
+                    $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $Assembly
                     return $Assembly
                 }}
             }}
 
-            $AssemblyPath = [IO.Path]::Combine($LibraryDirectory, $SimpleName + '.dll')
-            if (-not (Test-Path -LiteralPath $AssemblyPath)) {{
-                return $null
+            $AssemblyPath = [IO.Path]::Combine($LibraryDirectory, $AssemblyFileName)
+            if (Test-Path -LiteralPath $AssemblyPath) {{
+                try {{
+                    $LoadedAssembly = [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
+                    if (& $TestPowerForgeDesktopModuleAssembly -Assembly $LoadedAssembly) {{
+                        $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $LoadedAssembly
+                        return $LoadedAssembly
+                    }}
+
+                    $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                    Write-Warning -Message ""Desktop assembly '$SimpleName' resolved outside the module library directory. Skipping type accelerator exposure to avoid registering the wrong assembly version.""
+                    return $null
+                }} catch {{
+                    $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                    Write-Warning -Message ""Could not load Desktop assembly '$SimpleName' for type accelerator exposure: $($_.Exception.Message)""
+                    return $null
+                }}
             }}
 
-            try {{
-                return [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
-            }} catch {{
-                Write-Warning -Message ""Could not load Desktop assembly '$SimpleName' for type accelerator exposure: $($_.Exception.Message)""
-                return $null
+            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {{
+                if ($Assembly.GetName().Name -eq $SimpleName) {{
+                    $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $Assembly
+                    return $Assembly
+                }}
             }}
+
+            $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+            return $null
         }}
 
         $FindPowerForgeDesktopType = {{
             param([Parameter(Mandatory = $true)][string] $TypeName)
 
             foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {{
+                if ((& $TestPowerForgeDesktopIgnoredAssembly -Assembly $Assembly) -or
+                    -not (& $TestPowerForgeDesktopModuleAssembly -Assembly $Assembly)) {{
+                    continue
+                }}
+
                 $Type = $Assembly.GetType($TypeName, $false, $false)
                 if ($null -ne $Type) {{
                     return $Type
@@ -95,8 +166,30 @@ internal static partial class ModuleBootstrapperGenerator
             }}
 
             foreach ($File in Get-ChildItem -LiteralPath $LibraryDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {{
+                if ($IgnoredLibraryFileNames -contains $File.Name) {{
+                    continue
+                }}
+
                 $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $File.BaseName
                 if ($null -eq $Assembly) {{
+                    continue
+                }}
+
+                $Type = $Assembly.GetType($TypeName, $false, $false)
+                if ($null -ne $Type) {{
+                    return $Type
+                }}
+            }}
+
+            foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {{
+                if (& $TestPowerForgeDesktopIgnoredAssembly -Assembly $Assembly) {{
+                    continue
+                }}
+
+                $AssemblyFileName = $Assembly.GetName().Name + '.dll'
+                if (Test-Path -LiteralPath ([IO.Path]::Combine($LibraryDirectory, $AssemblyFileName))) {{
+                    # A module-owned assembly with this identity exists but could not be selected above. Do not
+                    # silently fall back to a globally loaded copy with a different location or version.
                     continue
                 }}
 

--- a/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
@@ -35,6 +35,13 @@ internal static partial class ModuleBootstrapperGenerator
                 ["RuntimeHandlerBlock"] = handleRuntimes
                     ? IndentPowerShell(BuildDevelopmentRuntimeHandlerBlock().TrimEnd(), 12)
                     : string.Empty,
+                ["DesktopTypeAcceleratorBlock"] = IndentPowerShell(
+                    BuildDesktopTypeAcceleratorBlock(
+                        assemblyTypeAcceleratorMode,
+                        assemblyTypeAccelerators,
+                        assemblyTypeAcceleratorAssemblies,
+                        "[IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)").TrimEnd(),
+                    12),
                 ["AssemblyLoadContextImportBlock"] = BuildDevelopmentAssemblyLoadContextImportBlock(
                     moduleName,
                     libraryName,

--- a/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.Development.cs
@@ -12,6 +12,7 @@ internal static partial class ModuleBootstrapperGenerator
         AssemblyTypeAcceleratorExportMode assemblyTypeAcceleratorMode,
         IReadOnlyList<string>? assemblyTypeAccelerators,
         IReadOnlyList<string>? assemblyTypeAcceleratorAssemblies,
+        IReadOnlyList<string>? ignoreLibrariesOnLoad,
         ModuleDevelopmentBinaryBootstrapperOptions options)
     {
         var binaryRootExpression = BuildPowerShellPathExpression(moduleRoot, options.BinaryRootPath);
@@ -40,7 +41,8 @@ internal static partial class ModuleBootstrapperGenerator
                         assemblyTypeAcceleratorMode,
                         assemblyTypeAccelerators,
                         assemblyTypeAcceleratorAssemblies,
-                        "[IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)").TrimEnd(),
+                        "[IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath)",
+                        ignoreLibrariesOnLoad).TrimEnd(),
                     12),
                 ["AssemblyLoadContextImportBlock"] = BuildDevelopmentAssemblyLoadContextImportBlock(
                     moduleName,

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -289,7 +289,12 @@ internal static partial class ModuleBootstrapperGenerator
                     ["TypeAcceleratorBlock"] = BuildTypeAcceleratorBlock(
                         assemblyTypeAcceleratorMode,
                         assemblyTypeAccelerators,
-                        assemblyTypeAcceleratorAssemblies)
+                        assemblyTypeAcceleratorAssemblies),
+                    ["DesktopTypeAcceleratorBlock"] = BuildDesktopTypeAcceleratorBlock(
+                        assemblyTypeAcceleratorMode,
+                        assemblyTypeAccelerators,
+                        assemblyTypeAcceleratorAssemblies,
+                        "[IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder)")
                 })
             : string.Empty;
 
@@ -1334,11 +1339,12 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
 
     if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {{
         $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+        $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
         $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
         $ExecutionContext.SessionState.Module.OnRemove = {{
             try {{
                 $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
-                if ($null -eq $TypeAccelerators -or $null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {{
+                if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {{
                     return
                 }}
 
@@ -1349,7 +1355,7 @@ $RegisterPowerForgeAssemblyTypeAccelerators = {{
                 }}
 
                 $Existing = $GetTypeAccelerators.GetValue($null)
-                foreach ($Entry in @($script:PowerForgeRegisteredAssemblyTypeAccelerators.GetEnumerator())) {{
+                foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {{
                     if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {{
                         $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
                     }}

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -75,6 +75,7 @@ internal static partial class ModuleBootstrapperGenerator
             assemblyTypeAcceleratorMode: assemblyTypeAcceleratorMode,
             assemblyTypeAccelerators: assemblyTypeAccelerators,
             assemblyTypeAcceleratorAssemblies: assemblyTypeAcceleratorAssemblies,
+            ignoreLibrariesOnLoad: ignoreLibrariesOnLoad,
             conditionalFunctionDependencies: conditionalFunctionDependencies,
             developmentBinaries: developmentBinaries,
             moduleRoot: root);
@@ -265,6 +266,7 @@ internal static partial class ModuleBootstrapperGenerator
         AssemblyTypeAcceleratorExportMode assemblyTypeAcceleratorMode,
         IReadOnlyList<string>? assemblyTypeAccelerators,
         IReadOnlyList<string>? assemblyTypeAcceleratorAssemblies,
+        IReadOnlyList<string>? ignoreLibrariesOnLoad,
         IReadOnlyDictionary<string, string[]>? conditionalFunctionDependencies,
         ModuleDevelopmentBinaryBootstrapperOptions? developmentBinaries = null,
         string? moduleRoot = null)
@@ -290,11 +292,14 @@ internal static partial class ModuleBootstrapperGenerator
                         assemblyTypeAcceleratorMode,
                         assemblyTypeAccelerators,
                         assemblyTypeAcceleratorAssemblies),
-                    ["DesktopTypeAcceleratorBlock"] = BuildDesktopTypeAcceleratorBlock(
-                        assemblyTypeAcceleratorMode,
-                        assemblyTypeAccelerators,
-                        assemblyTypeAcceleratorAssemblies,
-                        "[IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder)")
+                    ["DesktopTypeAcceleratorBlock"] = IndentPowerShell(
+                        BuildDesktopTypeAcceleratorBlock(
+                            assemblyTypeAcceleratorMode,
+                            assemblyTypeAccelerators,
+                            assemblyTypeAcceleratorAssemblies,
+                            "[IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder)",
+                            ignoreLibrariesOnLoad).TrimEnd(),
+                        4)
                 })
             : string.Empty;
 
@@ -313,6 +318,7 @@ internal static partial class ModuleBootstrapperGenerator
                 assemblyTypeAcceleratorMode,
                 assemblyTypeAccelerators,
                 assemblyTypeAcceleratorAssemblies,
+                ignoreLibrariesOnLoad,
                 developmentBinaries);
 
             binaryLoaderBlock = string.IsNullOrWhiteSpace(binaryLoaderBlock)

--- a/PowerForge/Services/ModuleInstaller.cs
+++ b/PowerForge/Services/ModuleInstaller.cs
@@ -431,6 +431,27 @@ public sealed class ModuleInstaller
 
     private static string NextRevision(string baseVersion, IEnumerable<string> existing)
     {
+        if (Version.TryParse(baseVersion, out var parsedBaseVersion) && parsedBaseVersion.Build >= 0)
+        {
+            var versionFamily = $"{parsedBaseVersion.Major}.{parsedBaseVersion.Minor}.{parsedBaseVersion.Build}";
+            var maxRevision = Math.Max(parsedBaseVersion.Revision, 0);
+
+            foreach (var candidate in existing)
+            {
+                if (!Version.TryParse(candidate, out var parsedCandidate) ||
+                    parsedCandidate.Major != parsedBaseVersion.Major ||
+                    parsedCandidate.Minor != parsedBaseVersion.Minor ||
+                    parsedCandidate.Build != parsedBaseVersion.Build)
+                {
+                    continue;
+                }
+
+                maxRevision = Math.Max(maxRevision, Math.Max(parsedCandidate.Revision, 0));
+            }
+
+            return $"{versionFamily}.{maxRevision + 1}";
+        }
+
         // Accept v, v.x patterns
         var prefix = Regex.Escape(baseVersion) + "(?:\\.(\\d+))?$";
         var re = new Regex(prefix, RegexOptions.IgnoreCase);


### PR DESCRIPTION
## Summary

- register configured dependency type accelerators on Windows PowerShell/Desktop after the module binary and libraries load successfully
- prefer assemblies from the selected module `Lib` directory, reject shadowing global versions, and honor `NETIgnoreLibraryOnLoad` during allow-list scans
- remove only accelerators owned by the unloading module on Desktop and Core
- support packaged and development-binary bootstrappers through the same generated contract
- keep `AutoRevision` valid when a local build already uses a four-part module version by incrementing the fourth component

## Why this matters

Binary cmdlet parameters can use intentional public dependency types on both supported PowerShell editions. Desktop imports now fail closed: a failed primary import, an ignored DLL, or a conflicting same-name assembly cannot expose types from the wrong dependency version.

## Validation

- focused bootstrapper generator contracts: 25/25
- Release solution build: 0 warnings and 0 errors
- PSPublishModule self-build, 184-command documentation parity, validation, packaging, and installation completed successfully
- generated PSPublishModule registered module-owned accelerators and removed them on Windows PowerShell 5.1 and PowerShell 7
- a Windows PowerShell 5.1 package with its primary DLL removed registered no accelerators
- preloading the previous `PowerForge.dll` before the new package registered no type from the shadowing global assembly
- public PSGallery 3.0.57 embeds merge commit `64c72dfb`, including the successful-import gate, ignore-list propagation, and module-assembly collision guard
- ImagePlayground packaged with that public release against CodeGlyphX PR #163 head `c7f84b7` completed a real QR round trip and accelerator cleanup on Windows PowerShell 5.1 and PowerShell 7
