### PR TITLE
Support safe major-upgrade scheduling for mutable MSI files

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -932,6 +932,8 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
 
             var spec = CreateBaseSpec(root, app);
             var authoring = CreateSimpleAuthoring("ProductFiles");
+            authoring.Product.MajorUpgradeSchedule =
+                PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
             authoring.ExitLaunch = new PowerForgeInstallerExitLaunch
             {
                 Text = "Open app",
@@ -983,6 +985,9 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
             var installerPlan = Assert.Single(plan.Installers);
             Assert.NotNull(installerPlan.Authoring);
+            Assert.Equal(
+                PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute,
+                installerPlan.Authoring!.Product.MajorUpgradeSchedule);
             Assert.Equal("ProductFiles", installerPlan.HarvestComponentGroupId);
             Assert.NotNull(installerPlan.Authoring!.ExitLaunch);
             Assert.Equal("Open app", installerPlan.Authoring.ExitLaunch!.Text);

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -223,16 +223,16 @@ public sealed class PowerForgeInstallerAuthoringTests
             ((string?)e.Attribute("Condition"))?.Contains("NOT (WIX_UPGRADE_DETECTED OR " + serviceExistsPropertyId + ")", StringComparison.Ordinal) == true));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.SetBackupCommand" &&
-            (string?)e.Attribute("Before") == "RemoveExistingProducts"));
+            (string?)e.Attribute("Before") == "ServiceComponent.BackupImagePath"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.BackupImagePath" &&
-            (string?)e.Attribute("After") == "ServiceComponent.SetBackupCommand"));
+            (string?)e.Attribute("Before") == "ServiceComponent.SetStopService"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.SetStopService" &&
-            (string?)e.Attribute("After") == "ServiceComponent.BackupImagePath"));
+            (string?)e.Attribute("Before") == "ServiceComponent.StopService"));
         Assert.NotNull(sequenceRows.SingleOrDefault(e =>
             (string?)e.Attribute("Action") == "ServiceComponent.StopService" &&
-            (string?)e.Attribute("After") == "ServiceComponent.SetStopService"));
+            (string?)e.Attribute("Before") == "RemoveExistingProducts"));
     }
 
     [Fact]
@@ -696,6 +696,33 @@ public sealed class PowerForgeInstallerAuthoringTests
             Assert.Contains("INSTALL_CONDITIONAL_SERVICE=1", condition, StringComparison.Ordinal);
             Assert.Contains("WIX_UPGRADE_DETECTED", condition, StringComparison.Ordinal);
         });
+    }
+
+    [Theory]
+    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallValidate, "RemoveExistingProducts")]
+    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallInitialize, "RemoveExistingProducts")]
+    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute, "InstallFiles")]
+    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecuteAgain, "InstallFiles")]
+    [InlineData(PowerForgeInstallerMajorUpgradeSchedule.AfterInstallFinalize, "InstallFiles")]
+    public void EmitSource_SequencesUpgradePreparationBeforeDestructiveUpgradeWork(
+        PowerForgeInstallerMajorUpgradeSchedule schedule,
+        string expectedAnchor)
+    {
+        var definition = CreateSimpleFileInstaller(Path.Combine(Path.GetTempPath(), "payload.txt"));
+        definition.Product.MajorUpgradeSchedule = schedule;
+        definition.Components.Clear();
+        AddScriptService(definition, "ServiceComponent");
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var doc = XDocument.Parse(xml);
+        var rows = doc.Descendants(Wix + "InstallExecuteSequence")
+            .Descendants(Wix + "Custom")
+            .ToDictionary(row => (string)row.Attribute("Action")!, StringComparer.Ordinal);
+
+        Assert.Equal("ServiceComponent.BackupImagePath", (string?)rows["ServiceComponent.SetBackupCommand"].Attribute("Before"));
+        Assert.Equal("ServiceComponent.SetStopService", (string?)rows["ServiceComponent.BackupImagePath"].Attribute("Before"));
+        Assert.Equal("ServiceComponent.StopService", (string?)rows["ServiceComponent.SetStopService"].Attribute("Before"));
+        Assert.Equal(expectedAnchor, (string?)rows["ServiceComponent.StopService"].Attribute("Before"));
     }
 
     [Fact]

--- a/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerAuthoringTests.cs
@@ -10,6 +10,29 @@ public sealed class PowerForgeInstallerAuthoringTests
     private static readonly XNamespace Util = "http://wixtoolset.org/schemas/v4/wxs/util";
 
     [Fact]
+    public void EmitSource_UsesConfiguredMajorUpgradeSchedule()
+    {
+        var definition = CreateMonitoringInstaller();
+        definition.Product.MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute;
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var majorUpgrade = XDocument.Parse(xml).Descendants(Wix + "MajorUpgrade").Single();
+
+        Assert.Equal("afterInstallExecute", (string?)majorUpgrade.Attribute("Schedule"));
+    }
+
+    [Fact]
+    public void EmitSource_OmitsDefaultMajorUpgradeSchedule()
+    {
+        var definition = CreateMonitoringInstaller();
+
+        var xml = new PowerForgeWixInstallerSourceEmitter().EmitSource(definition);
+        var majorUpgrade = XDocument.Parse(xml).Descendants(Wix + "MajorUpgrade").Single();
+
+        Assert.Null(majorUpgrade.Attribute("Schedule"));
+    }
+
+    [Fact]
     public void EmitSource_ModelsServiceProgramDataInputsAndPayloadGroup()
     {
         var definition = CreateMonitoringInstaller();

--- a/PowerForge.Tests/PowerForgeInstallerUpgradePreservationTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerUpgradePreservationTests.cs
@@ -1,0 +1,194 @@
+using System.Diagnostics;
+
+namespace PowerForge.Tests;
+
+public sealed class PowerForgeInstallerUpgradePreservationTests
+{
+    [Fact]
+    public async Task MajorUpgrade_PreservesMutableConfiguration_WhenOptedIn()
+    {
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("POWERFORGE_RUN_MSI_INSTALL_TESTS"),
+                "1",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var testId = Guid.NewGuid().ToString("N");
+        var root = Path.Combine(Path.GetTempPath(), "powerforge-msi-upgrade-" + testId);
+        var dataFolderName = "PowerForgeUpgradeProof-" + testId;
+        var installedDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            dataFolderName);
+        var installedConfig = Path.Combine(installedDirectory, "settings.json");
+        string? v1Msi = null;
+        string? v2Msi = null;
+
+        Directory.CreateDirectory(root);
+        try
+        {
+            v1Msi = await CompileInstallerAsync(root, dataFolderName, "1.0.0", "v1-default");
+            v2Msi = await CompileInstallerAsync(root, dataFolderName, "1.0.1", "v2-default");
+
+            await RunMsiExecAsync(root, "install-v1.log", "/i", v1Msi);
+            Assert.Equal("v1-default", await File.ReadAllTextAsync(installedConfig));
+
+            await File.WriteAllTextAsync(installedConfig, "user-edited-config");
+            await RunMsiExecAsync(root, "upgrade-v2.log", "/i", v2Msi);
+
+            Assert.Equal("user-edited-config", await File.ReadAllTextAsync(installedConfig));
+        }
+        finally
+        {
+            if (v2Msi is not null)
+                await TryUninstallAsync(root, "uninstall-v2.log", v2Msi);
+            if (v1Msi is not null)
+                await TryUninstallAsync(root, "uninstall-v1.log", v1Msi);
+
+            TryDeleteDirectory(installedDirectory);
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static async Task<string> CompileInstallerAsync(
+        string root,
+        string dataFolderName,
+        string version,
+        string defaultConfig)
+    {
+        var versionRoot = Path.Combine(root, version);
+        Directory.CreateDirectory(versionRoot);
+        var payloadFile = Path.Combine(versionRoot, "settings.json");
+        await File.WriteAllTextAsync(payloadFile, defaultConfig);
+
+        var definition = CreateInstaller(dataFolderName, version, payloadFile);
+        var workspace = Path.Combine(versionRoot, "installer");
+        var result = await new PowerForgeWixInstallerCompiler().CompileAsync(
+            definition,
+            new PowerForgeWixInstallerCompileRequest
+            {
+                WorkingDirectory = workspace,
+                SourceFileName = "Product.wxs",
+                ProjectFileName = "UpgradeProof.wixproj",
+                Configuration = "Release",
+                Timeout = TimeSpan.FromMinutes(5)
+            });
+
+        Assert.True(
+            result.Succeeded,
+            $"WiX compilation failed for {version}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StdOut}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StdErr}");
+
+        var packages = Directory
+            .GetFiles(workspace, "*.msi", SearchOption.AllDirectories)
+            .Where(path => !path.Contains(
+                Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        return Assert.Single(packages);
+    }
+
+    private static PowerForgeInstallerDefinition CreateInstaller(
+        string dataFolderName,
+        string version,
+        string payloadFile)
+    {
+        var definition = new PowerForgeInstallerDefinition
+        {
+            Product =
+            {
+                Name = "PowerForge Upgrade Preservation Proof",
+                Manufacturer = "Evotec",
+                Version = version,
+                UpgradeCode = "{6D245057-9D02-43FA-A2A9-235DB5DD1BD9}",
+                Scope = PowerForgeInstallerScope.PerMachine,
+                MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute
+            },
+            CompanyFolderName = "Evotec",
+            InstallDirectoryName = "PowerForge Upgrade Preservation Proof"
+        };
+        definition.Directories.Add(new PowerForgeInstallerDirectoryTree
+        {
+            StandardDirectoryId = "CommonAppDataFolder",
+            Segments =
+            {
+                new PowerForgeInstallerDirectorySegment
+                {
+                    Id = "UpgradeProofDataFolder",
+                    Name = dataFolderName
+                }
+            }
+        });
+        definition.Components.Add(new PowerForgeInstallerFileComponent
+        {
+            Id = "MutableConfiguration",
+            DirectoryRefId = "UpgradeProofDataFolder",
+            Guid = "{0E869D63-C3C2-4B61-8D70-46255A108E1E}",
+            FileId = "MutableConfigurationFile",
+            Source = payloadFile,
+            Name = "settings.json",
+            Permanent = true,
+            NeverOverwrite = true
+        });
+
+        return definition;
+    }
+
+    private static async Task RunMsiExecAsync(
+        string logDirectory,
+        string logFileName,
+        string operation,
+        string msiPath)
+    {
+        var logPath = Path.Combine(logDirectory, logFileName);
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "msiexec.exe",
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+        process.StartInfo.ArgumentList.Add(operation);
+        process.StartInfo.ArgumentList.Add(msiPath);
+        process.StartInfo.ArgumentList.Add("/qn");
+        process.StartInfo.ArgumentList.Add("/norestart");
+        process.StartInfo.ArgumentList.Add("/l*v");
+        process.StartInfo.ArgumentList.Add(logPath);
+        process.StartInfo.ArgumentList.Add("REBOOT=ReallySuppress");
+
+        Assert.True(process.Start(), "Failed to start Windows Installer.");
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        await process.WaitForExitAsync(timeout.Token);
+
+        Assert.True(
+            process.ExitCode is 0 or 3010,
+            $"Windows Installer returned {process.ExitCode}. Log: {logPath}");
+    }
+
+    private static async Task TryUninstallAsync(string root, string logName, string msiPath)
+    {
+        try
+        {
+            await RunMsiExecAsync(root, logName, "/x", msiPath);
+        }
+        catch
+        {
+            // Best-effort cleanup keeps the original assertion as the useful failure.
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup for installer test artifacts.
+        }
+    }
+}

--- a/PowerForge.Tests/PowerForgeInstallerUpgradePreservationTests.cs
+++ b/PowerForge.Tests/PowerForgeInstallerUpgradePreservationTests.cs
@@ -22,14 +22,28 @@ public sealed class PowerForgeInstallerUpgradePreservationTests
             Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
             dataFolderName);
         var installedConfig = Path.Combine(installedDirectory, "settings.json");
+        var upgradeCode = Guid.NewGuid().ToString("B").ToUpperInvariant();
+        var componentGuid = Guid.NewGuid().ToString("B").ToUpperInvariant();
         string? v1Msi = null;
         string? v2Msi = null;
 
         Directory.CreateDirectory(root);
         try
         {
-            v1Msi = await CompileInstallerAsync(root, dataFolderName, "1.0.0", "v1-default");
-            v2Msi = await CompileInstallerAsync(root, dataFolderName, "1.0.1", "v2-default");
+            v1Msi = await CompileInstallerAsync(
+                root,
+                dataFolderName,
+                "1.0.0",
+                "v1-default",
+                upgradeCode,
+                componentGuid);
+            v2Msi = await CompileInstallerAsync(
+                root,
+                dataFolderName,
+                "1.0.1",
+                "v2-default",
+                upgradeCode,
+                componentGuid);
 
             await RunMsiExecAsync(root, "install-v1.log", "/i", v1Msi);
             Assert.Equal("v1-default", await File.ReadAllTextAsync(installedConfig));
@@ -55,14 +69,16 @@ public sealed class PowerForgeInstallerUpgradePreservationTests
         string root,
         string dataFolderName,
         string version,
-        string defaultConfig)
+        string defaultConfig,
+        string upgradeCode,
+        string componentGuid)
     {
         var versionRoot = Path.Combine(root, version);
         Directory.CreateDirectory(versionRoot);
         var payloadFile = Path.Combine(versionRoot, "settings.json");
         await File.WriteAllTextAsync(payloadFile, defaultConfig);
 
-        var definition = CreateInstaller(dataFolderName, version, payloadFile);
+        var definition = CreateInstaller(dataFolderName, version, payloadFile, upgradeCode, componentGuid);
         var workspace = Path.Combine(versionRoot, "installer");
         var result = await new PowerForgeWixInstallerCompiler().CompileAsync(
             definition,
@@ -91,7 +107,9 @@ public sealed class PowerForgeInstallerUpgradePreservationTests
     private static PowerForgeInstallerDefinition CreateInstaller(
         string dataFolderName,
         string version,
-        string payloadFile)
+        string payloadFile,
+        string upgradeCode,
+        string componentGuid)
     {
         var definition = new PowerForgeInstallerDefinition
         {
@@ -100,7 +118,7 @@ public sealed class PowerForgeInstallerUpgradePreservationTests
                 Name = "PowerForge Upgrade Preservation Proof",
                 Manufacturer = "Evotec",
                 Version = version,
-                UpgradeCode = "{6D245057-9D02-43FA-A2A9-235DB5DD1BD9}",
+                UpgradeCode = upgradeCode,
                 Scope = PowerForgeInstallerScope.PerMachine,
                 MajorUpgradeSchedule = PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute
             },
@@ -123,11 +141,11 @@ public sealed class PowerForgeInstallerUpgradePreservationTests
         {
             Id = "MutableConfiguration",
             DirectoryRefId = "UpgradeProofDataFolder",
-            Guid = "{0E869D63-C3C2-4B61-8D70-46255A108E1E}",
+            Guid = componentGuid,
             FileId = "MutableConfigurationFile",
             Source = payloadFile,
             Name = "settings.json",
-            Permanent = true,
+            Permanent = false,
             NeverOverwrite = true
         });
 

--- a/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
+++ b/PowerForge/Models/Installers/PowerForgeInstallerDefinition.cs
@@ -110,6 +110,12 @@ public sealed class PowerForgeInstallerProduct
     public PowerForgeInstallerScope Scope { get; set; } = PowerForgeInstallerScope.PerMachine;
 
     /// <summary>
+    /// Point in the install execute sequence where the previous product is removed during a major upgrade.
+    /// </summary>
+    public PowerForgeInstallerMajorUpgradeSchedule MajorUpgradeSchedule { get; set; } =
+        PowerForgeInstallerMajorUpgradeSchedule.AfterInstallValidate;
+
+    /// <summary>
     /// Downgrade message shown when a newer version is installed.
     /// </summary>
     public string DowngradeErrorMessage { get; set; } = "A newer version of [ProductName] is already installed.";
@@ -176,6 +182,37 @@ public enum PowerForgeInstallerScope
     /// Install for the current user.
     /// </summary>
     PerUser
+}
+
+/// <summary>
+/// Removal schedule used by WiX for a major upgrade.
+/// </summary>
+public enum PowerForgeInstallerMajorUpgradeSchedule
+{
+    /// <summary>
+    /// Remove the installed product before installing the new product. This is the WiX default.
+    /// </summary>
+    AfterInstallValidate,
+
+    /// <summary>
+    /// Remove the installed product after initialization and before the new install executes.
+    /// </summary>
+    AfterInstallInitialize,
+
+    /// <summary>
+    /// Install the new product first, then remove components that are absent from the new product.
+    /// </summary>
+    AfterInstallExecute,
+
+    /// <summary>
+    /// Remove the previous product after install execution is repeated.
+    /// </summary>
+    AfterInstallExecuteAgain,
+
+    /// <summary>
+    /// Remove the previous product after the new product is fully installed.
+    /// </summary>
+    AfterInstallFinalize
 }
 
 /// <summary>

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -896,6 +896,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 Version = definition.Product.Version,
                 UpgradeCode = definition.Product.UpgradeCode,
                 Scope = definition.Product.Scope,
+                MajorUpgradeSchedule = definition.Product.MajorUpgradeSchedule,
                 DowngradeErrorMessage = definition.Product.DowngradeErrorMessage
             },
             InstallDirectoryId = definition.InstallDirectoryId,

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerFormatting.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerFormatting.cs
@@ -14,6 +14,19 @@ internal static class PowerForgeWixInstallerFormatting
         return scope == PowerForgeInstallerScope.PerUser ? "LocalAppDataFolder" : "ProgramFiles64Folder";
     }
 
+    internal static string ToWixMajorUpgradeSchedule(PowerForgeInstallerMajorUpgradeSchedule schedule)
+    {
+        return schedule switch
+        {
+            PowerForgeInstallerMajorUpgradeSchedule.AfterInstallValidate => "afterInstallValidate",
+            PowerForgeInstallerMajorUpgradeSchedule.AfterInstallInitialize => "afterInstallInitialize",
+            PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute => "afterInstallExecute",
+            PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecuteAgain => "afterInstallExecuteAgain",
+            PowerForgeInstallerMajorUpgradeSchedule.AfterInstallFinalize => "afterInstallFinalize",
+            _ => throw new ArgumentOutOfRangeException(nameof(schedule), schedule, "Unsupported major-upgrade schedule.")
+        };
+    }
+
     internal static string EscapeFormattedText(string value)
     {
         var builder = new StringBuilder(value.Length);

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerServiceScriptEmitter.cs
@@ -22,14 +22,19 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
     {
         var actions = new List<XElement>();
         var sequence = new XElement(WixNamespace + "InstallExecuteSequence");
-        string? upgradeSequenceTail = null;
+        var upgradePreparationActions = new List<UpgradePreparationAction>();
         foreach (var service in definition.Components.OfType<PowerForgeInstallerServiceComponent>())
         {
             if (service.ScriptInstall is null)
                 continue;
 
-            upgradeSequenceTail = EmitServiceActions(service, actions, sequence, upgradeSequenceTail);
+            EmitServiceActions(service, actions, sequence, upgradePreparationActions);
         }
+
+        AddUpgradePreparationSequenceRows(
+            sequence,
+            upgradePreparationActions,
+            definition.Product.MajorUpgradeSchedule);
 
         foreach (var action in actions)
             yield return action;
@@ -54,11 +59,11 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         yield return ids.SetUninstallServiceId;
     }
 
-    private static string? EmitServiceActions(
+    private static void EmitServiceActions(
         PowerForgeInstallerServiceComponent service,
         ICollection<XElement> actions,
         XElement sequence,
-        string? upgradeSequenceTail)
+        ICollection<UpgradePreparationAction> upgradePreparationActions)
     {
         var script = service.ScriptInstall!;
         var ids = BuildIds(service.Id);
@@ -113,39 +118,35 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
         }
 
         actions.Add(CreateSetInstallCommand(ids.SetInstallStandardId, ids.InstallServiceId, script.Command));
-        return AddSequenceRows(sequence, ids, script, standardCondition, upgradeCondition, uninstallCondition, upgradeSequenceTail);
+        AddSequenceRows(
+            sequence,
+            ids,
+            script,
+            standardCondition,
+            upgradeCondition,
+            uninstallCondition,
+            upgradePreparationActions);
     }
 
-    private static string? AddSequenceRows(
+    private static void AddSequenceRows(
         XElement sequence,
         ServiceScriptActionIds ids,
         PowerForgeInstallerServiceScriptInstall script,
         string standardCondition,
         string upgradeCondition,
         string uninstallCondition,
-        string? upgradeSequenceTail)
+        ICollection<UpgradePreparationAction> upgradePreparationActions)
     {
-        string? tail = upgradeSequenceTail;
         if (script.BackupExistingImagePath)
         {
-            AddUpgradeSequenceRow(sequence, ids.SetBackupCommandId, tail, upgradeCondition);
-            sequence.Add(new XElement(
-                WixNamespace + "Custom",
-                new XAttribute("Action", ids.BackupImagePathId),
-                new XAttribute("After", ids.SetBackupCommandId),
-                new XAttribute("Condition", upgradeCondition)));
-            tail = ids.BackupImagePathId;
+            upgradePreparationActions.Add(new UpgradePreparationAction(ids.SetBackupCommandId, upgradeCondition));
+            upgradePreparationActions.Add(new UpgradePreparationAction(ids.BackupImagePathId, upgradeCondition));
         }
 
         if (script.StopServiceForUpgrade)
         {
-            AddUpgradeSequenceRow(sequence, ids.SetStopServiceId, tail, upgradeCondition);
-            sequence.Add(new XElement(
-                WixNamespace + "Custom",
-                new XAttribute("Action", ids.StopServiceId),
-                new XAttribute("After", ids.SetStopServiceId),
-                new XAttribute("Condition", upgradeCondition)));
-            tail = ids.StopServiceId;
+            upgradePreparationActions.Add(new UpgradePreparationAction(ids.SetStopServiceId, upgradeCondition));
+            upgradePreparationActions.Add(new UpgradePreparationAction(ids.StopServiceId, upgradeCondition));
         }
 
         if (!string.IsNullOrWhiteSpace(script.UpgradeCommand))
@@ -181,24 +182,47 @@ internal static class PowerForgeWixInstallerServiceScriptEmitter
             new XAttribute("Action", ids.InstallServiceId),
             new XAttribute("Before", "InstallFinalize"),
             new XAttribute("Condition", script.Condition)));
-        return tail;
     }
 
-    private static void AddUpgradeSequenceRow(
+    private static void AddUpgradePreparationSequenceRows(
         XElement sequence,
-        string actionId,
-        string? afterActionId,
-        string condition)
+        IReadOnlyList<UpgradePreparationAction> actions,
+        PowerForgeInstallerMajorUpgradeSchedule schedule)
     {
-        var element = new XElement(
-            WixNamespace + "Custom",
-            new XAttribute("Action", actionId),
-            new XAttribute("Condition", condition));
-        if (string.IsNullOrWhiteSpace(afterActionId))
-            element.Add(new XAttribute("Before", "RemoveExistingProducts"));
-        else
-            element.Add(new XAttribute("After", afterActionId!));
-        sequence.Add(element);
+        if (actions.Count == 0)
+            return;
+
+        string anchor = schedule is PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecute or
+            PowerForgeInstallerMajorUpgradeSchedule.AfterInstallExecuteAgain or
+            PowerForgeInstallerMajorUpgradeSchedule.AfterInstallFinalize
+                ? "InstallFiles"
+                : "RemoveExistingProducts";
+
+        for (int index = 0; index < actions.Count; index++)
+        {
+            var action = actions[index];
+            string before = index + 1 < actions.Count
+                ? actions[index + 1].ActionId
+                : anchor;
+            sequence.Add(new XElement(
+                WixNamespace + "Custom",
+                new XAttribute("Action", action.ActionId),
+                new XAttribute("Before", before),
+                new XAttribute("Condition", action.Condition)));
+        }
+    }
+
+    private sealed class UpgradePreparationAction
+    {
+        public UpgradePreparationAction(string actionId, string condition)
+        {
+            ActionId = actionId;
+            Condition = condition;
+        }
+
+        public string ActionId { get; }
+
+        public string Condition { get; }
     }
 
     private static XElement CreateQuietExecAction(string id, string execute, bool hideTarget = false)

--- a/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
+++ b/PowerForge/Services/Installers/PowerForgeWixInstallerSourceEmitter.cs
@@ -41,9 +41,7 @@ public sealed class PowerForgeWixInstallerSourceEmitter
             new XAttribute("UpgradeCode", definition.Product.UpgradeCode),
             new XAttribute("Scope", PowerForgeWixInstallerFormatting.ToWixScope(definition.Product.Scope)),
             new XAttribute("Compressed", "yes"),
-            new XElement(
-                WixNamespace + "MajorUpgrade",
-                new XAttribute("DowngradeErrorMessage", definition.Product.DowngradeErrorMessage)),
+            EmitMajorUpgrade(definition.Product),
             new XElement(WixNamespace + "MediaTemplate", new XAttribute("EmbedCab", "yes")));
 
         EmitLaunchConditions(package, definition);
@@ -64,6 +62,22 @@ public sealed class PowerForgeWixInstallerSourceEmitter
 
         var document = new XDocument(new XDeclaration("1.0", "utf-8", null), root);
         return document.ToString(SaveOptions.None);
+    }
+
+    private static XElement EmitMajorUpgrade(PowerForgeInstallerProduct product)
+    {
+        var element = new XElement(
+            WixNamespace + "MajorUpgrade",
+            new XAttribute("DowngradeErrorMessage", product.DowngradeErrorMessage));
+
+        if (product.MajorUpgradeSchedule != PowerForgeInstallerMajorUpgradeSchedule.AfterInstallValidate)
+        {
+            element.Add(new XAttribute(
+                "Schedule",
+                PowerForgeWixInstallerFormatting.ToWixMajorUpgradeSchedule(product.MajorUpgradeSchedule)));
+        }
+
+        return element;
     }
 
     /// <summary>

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -152,6 +152,10 @@
       "type": "string",
       "enum": ["PerMachine", "PerUser"]
     },
+    "PowerForgeInstallerMajorUpgradeSchedule": {
+      "type": "string",
+      "enum": ["AfterInstallValidate", "AfterInstallInitialize", "AfterInstallExecute", "AfterInstallExecuteAgain", "AfterInstallFinalize"]
+    },
     "PowerForgeInstallerInputKind": {
       "type": "string",
       "enum": ["Text", "Password", "FilePath", "FolderPath", "Checkbox", "RadioGroup", "ComboBox", "LicenseKey"]
@@ -165,6 +169,7 @@
         "Version": { "type": "string", "minLength": 1 },
         "UpgradeCode": { "type": "string", "minLength": 1 },
         "Scope": { "$ref": "#/$defs/PowerForgeInstallerScope" },
+        "MajorUpgradeSchedule": { "$ref": "#/$defs/PowerForgeInstallerMajorUpgradeSchedule" },
         "DowngradeErrorMessage": { "type": "string" }
       },
       "required": ["Name", "UpgradeCode"]


### PR DESCRIPTION
## What changed

- adds a typed `MajorUpgradeSchedule` option for PowerForge-authored WiX installers
- carries the setting through planning, JSON schema validation, and generated WiX while preserving the WiX default when omitted
- sequences service backup/stop preparation before old-product removal for early schedules and before file installation for late schedules
- adds a gated Windows Installer integration proof using isolated MSI identities and a removable `NeverOverwrite` config component

## Why

Mutable ProgramData files can be removed too early during a default major upgrade. Products need a reusable declarative way to install the replacement first without losing operator-edited configuration, while explicit uninstall remains able to remove the component.

## Usage

```json
{
  "Product": {
    "MajorUpgradeSchedule": "AfterInstallExecute"
  }
}
```

Late scheduling requires stable component identity and compatible component authoring across versions.

## Validation

- 4,045 PowerForge owner tests passed
- 74 WiX authoring/compile contracts passed
- real per-machine v1 -> edited ProgramData config -> v2 upgrade proof passed with a removable component