### PR TITLE
Allow PowerForge website CI to inspect Actions artifacts

### DIFF
--- a/.github/workflows/powerforge-website-ci.yml
+++ b/.github/workflows/powerforge-website-ci.yml
@@ -76,6 +76,8 @@ on:
         required: false
 
 permissions:
+  # The generated quality preset performs a read-only artifact cleanup preview.
+  actions: read
   contents: read
   packages: read
 

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -19,6 +19,19 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
+    public void WebsiteCiWorkflow_ShouldAllowArtifactInspection()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-ci.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("actions: read", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WebsiteRunWorkflow_ShouldInheritCallerPermissions()
     {
         var repoRoot = FindRepoRoot();

--- a/PowerForge.Tests/WebSiteScaffolderTests.cs
+++ b/PowerForge.Tests/WebSiteScaffolderTests.cs
@@ -79,6 +79,7 @@ public class WebSiteScaffolderTests
 
             var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "website-ci.yml"));
             Assert.Contains("POWERFORGE_LOCK_PATH: ./.powerforge/engine-lock.json", workflow, StringComparison.Ordinal);
+            Assert.Contains("actions: read", workflow, StringComparison.Ordinal);
             Assert.Contains("packages: read", workflow, StringComparison.Ordinal);
             Assert.Contains("uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@main", workflow, StringComparison.Ordinal);
             Assert.Contains("website_root: .", workflow, StringComparison.Ordinal);

--- a/PowerForge.Web/Services/WebSiteScaffolder.cs
+++ b/PowerForge.Web/Services/WebSiteScaffolder.cs
@@ -1067,6 +1067,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   packages: read
 


### PR DESCRIPTION
## Summary

- grant the reusable website CI workflow read-only access to Actions artifacts
- include the same permission in newly scaffolded website CI callers
- protect both contracts with focused tests

## Why

The standard PowerForge.Web quality preset includes a dry-run `github-artifacts-prune` step. Nested reusable workflows downgrade the caller token to the permissions declared by the called workflow, so artifact listing currently fails with HTTP 403 even when a consumer grants `actions: read`.

This keeps the preview read-only while allowing the standard quality pipeline to run as designed. It unblocks [Tactra PR #31](https://github.com/EvotecIT/Tactra/pull/31).

## Validation

- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --filter "FullyQualifiedName~GitHubWebsiteRunWorkflowTests|FullyQualifiedName~WebSiteScaffolderTests"` (15 passed)