### PR TITLE
Fix package provenance for conditional target frameworks

### DIFF
--- a/PowerForge.Tests/DotNetRepositoryReleasePlanLoggingTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleasePlanLoggingTests.cs
@@ -1,0 +1,67 @@
+namespace PowerForge.Tests;
+
+public sealed class DotNetRepositoryReleasePlanLoggingTests
+{
+    [Fact]
+    public void Execute_WhatIfPublish_ReportsPlannedArtifactsWithoutClaimingPublication()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Package"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Package.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.Package</PackageId>
+                    <VersionPrefix>1.2.3</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var logger = new RecordingLogger();
+            var result = new DotNetRepositoryReleaseService(logger).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = Path.Combine(root.FullName, "packages"),
+                Pack = true,
+                Publish = true,
+                WhatIf = true,
+                PublishApiKey = "not-used-by-what-if",
+                PublishSource = "https://api.nuget.org/v3/index.json",
+                UpdateVersions = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Contains(logger.SuccessMessages, message =>
+                message.Contains("NuGet publish plan prepared", StringComparison.Ordinal) &&
+                message.Contains("1 package artifact(s) would be published", StringComparison.Ordinal));
+            Assert.DoesNotContain(logger.SuccessMessages, message =>
+                message.Contains("NuGet publish phase completed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> SuccessMessages { get; } = new();
+
+        public bool IsVerbose => false;
+
+        public void Info(string message) { }
+
+        public void Success(string message) => SuccessMessages.Add(message);
+
+        public void Warn(string message) { }
+
+        public void Error(string message) { }
+
+        public void Verbose(string message) { }
+    }
+}

--- a/PowerForge.Tests/DotNetRepositoryReleaseTargetFrameworkTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseTargetFrameworkTests.cs
@@ -1,0 +1,70 @@
+using System.IO.Compression;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetRepositoryReleaseTargetFrameworkTests
+{
+    [Fact]
+    public void ProjectPackagePayloadValidation_IncludesFrameworksAddedByConditionalTargetFrameworks()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Conditional"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Conditional.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0</TargetFrameworks>
+                    <TargetFrameworks Condition="'$(Configuration)' == 'Release'">$(TargetFrameworks);netstandard2.0</TargetFrameworks>
+                    <AssemblyName>Sample.Conditional</AssemblyName>
+                    <PackageId>Sample.Conditional</PackageId>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var net8Output = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "bin", "Release", "net8.0"));
+            File.WriteAllBytes(Path.Combine(net8Output.FullName, "Sample.Conditional.dll"), new byte[] { 1, 2, 3 });
+            var conditionalOutput = Directory.CreateDirectory(Path.Combine(projectDirectory.FullName, "bin", "Release", "netstandard2.0"));
+            var conditionalAssembly = new byte[] { 4, 5, 6 };
+            File.WriteAllBytes(Path.Combine(conditionalOutput.FullName, "Sample.Conditional.dll"), conditionalAssembly);
+
+            var packagePath = Path.Combine(root.FullName, "Sample.Conditional.1.0.0.nupkg");
+            using (var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create))
+                WriteArchiveEntry(archive, "lib/netstandard2.0/Sample.Conditional.dll", conditionalAssembly);
+
+            var success = DotNetRepositoryReleaseService.TryValidateProjectPackagePayloads(
+                new DotNetRepositoryProjectResult
+                {
+                    ProjectName = "Sample.Conditional",
+                    PackageId = "Sample.Conditional",
+                    CsprojPath = projectPath,
+                    IsPackable = true,
+                    NewVersion = "1.0.0"
+                },
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    Configuration = "Release"
+                },
+                new[] { packagePath },
+                new NullLogger(),
+                out var error);
+
+            Assert.True(success, error);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static void WriteArchiveEntry(ZipArchive archive, string path, byte[] content)
+    {
+        var entry = archive.CreateEntry(path);
+        using var stream = entry.Open();
+        stream.Write(content);
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -642,7 +642,9 @@ public sealed partial class DotNetRepositoryReleaseService
                     }
                 }
                 publishWatch.Stop();
-                var publishSummary = $"NuGet publish phase completed in {FormatDuration(publishWatch.Elapsed)} ({result.PublishedPackages.Count} published, {result.SkippedDuplicatePackages.Count} skipped duplicate, {result.FailedPackages.Count} failed).";
+                var publishSummary = spec.WhatIf
+                    ? $"NuGet publish plan prepared in {FormatDuration(publishWatch.Elapsed)} ({result.PublishedPackages.Count} package artifact(s) would be published)."
+                    : $"NuGet publish phase completed in {FormatDuration(publishWatch.Elapsed)} ({result.PublishedPackages.Count} published, {result.SkippedDuplicatePackages.Count} skipped duplicate, {result.FailedPackages.Count} failed).";
                 if (result.FailedPackages.Count == 0)
                     _logger.Success(publishSummary);
                 else

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
@@ -242,14 +242,6 @@ public sealed partial class DotNetRepositoryReleaseService
         string projectName,
         ILogger logger)
     {
-        var declaredFrameworks = ReadTargetFrameworks(csproj)
-            .Where(static framework => !string.IsNullOrWhiteSpace(framework))
-            .Select(static framework => framework!.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (declaredFrameworks.Length > 0)
-            return declaredFrameworks.Cast<string?>().ToArray();
-
         foreach (var propertyName in new[] { "TargetFrameworks", "TargetFramework" })
         {
             var exitCode = RunDotnetMsBuildGetProperty(
@@ -276,6 +268,14 @@ public sealed partial class DotNetRepositoryReleaseService
             if (evaluatedFrameworks.Length > 0)
                 return evaluatedFrameworks.Cast<string?>().ToArray();
         }
+
+        var declaredFrameworks = ReadTargetFrameworks(csproj)
+            .Where(static framework => !string.IsNullOrWhiteSpace(framework))
+            .Select(static framework => framework!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (declaredFrameworks.Length > 0)
+            return declaredFrameworks.Cast<string?>().ToArray();
 
         return new string?[] { null };
     }


### PR DESCRIPTION
## Summary

- Evaluate `TargetFrameworks` and `TargetFramework` through MSBuild before validating fresh package payloads, so conditionally added frameworks such as Windows-only `net472` participate in signing and provenance checks.
- Keep raw project XML as the fallback when MSBuild evaluation is unavailable.
- Report WhatIf NuGet work as planned artifacts instead of claiming packages were published.
- Add focused regression coverage for conditional frameworks and WhatIf reporting.

## Release impact

Consumers need a new PSPublishModule/PowerForge build before installed-module workflows receive this fix.