### PR TITLE
Scope website NuGet caches to individual jobs

### DIFF
--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -100,6 +100,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
       POWERFORGE_RUNNER_CACHE_ROOT: ${{ github.workspace }}/.cache/powerforge-runner
+      NUGET_PACKAGES: ${{ runner.temp }}/powerforge-website-nuget-packages
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/powerforge-runner/ms-playwright
       DOTNET_BUNDLE_EXTRACT_BASE_DIR: ${{ github.workspace }}/.cache/powerforge-runner/dotnet-bundle
       BUN_INSTALL_CACHE_DIR: ${{ github.workspace }}/.cache/powerforge-runner/bun-install-cache
@@ -159,16 +160,17 @@ jobs:
       - name: Cache NuGet packages
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/packages.lock.json') }}
+          path: ${{ env.NUGET_PACKAGES }}
+          key: powerforge-website-nuget-v1-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/packages.lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-nuget-
+            powerforge-website-nuget-v1-${{ runner.os }}-
 
       - name: Initialize transient tool cache directories
         shell: pwsh
         run: |
           foreach ($path in @(
             $env:POWERFORGE_RUNNER_CACHE_ROOT,
+            $env:NUGET_PACKAGES,
             $env:PLAYWRIGHT_BROWSERS_PATH,
             $env:DOTNET_BUNDLE_EXTRACT_BASE_DIR,
             $env:BUN_INSTALL_CACHE_DIR,

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -100,7 +100,6 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
       POWERFORGE_RUNNER_CACHE_ROOT: ${{ github.workspace }}/.cache/powerforge-runner
-      NUGET_PACKAGES: ${{ runner.temp }}/powerforge-website-nuget-packages
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/powerforge-runner/ms-playwright
       DOTNET_BUNDLE_EXTRACT_BASE_DIR: ${{ github.workspace }}/.cache/powerforge-runner/dotnet-bundle
       BUN_INSTALL_CACHE_DIR: ${{ github.workspace }}/.cache/powerforge-runner/bun-install-cache
@@ -160,13 +159,15 @@ jobs:
       - name: Cache NuGet packages
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ env.NUGET_PACKAGES }}
+          path: ${{ runner.temp }}/powerforge-website-nuget-packages
           key: powerforge-website-nuget-v1-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/packages.lock.json') }}
           restore-keys: |
             powerforge-website-nuget-v1-${{ runner.os }}-
 
       - name: Initialize transient tool cache directories
         shell: pwsh
+        env:
+          NUGET_PACKAGES: ${{ runner.temp }}/powerforge-website-nuget-packages
         run: |
           foreach ($path in @(
             $env:POWERFORGE_RUNNER_CACHE_ROOT,
@@ -184,6 +185,7 @@ jobs:
       - name: Run website pipeline
         shell: pwsh
         env:
+          NUGET_PACKAGES: ${{ runner.temp }}/powerforge-website-nuget-packages
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}
           LICENSING_PACKAGES_TOKEN: ${{ secrets.repository_read_token || github.token }}

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -77,6 +77,23 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
+    public void WebsiteRunWorkflow_ShouldScopeNuGetCacheToTheWebsiteJob()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("NUGET_PACKAGES: ${{ runner.temp }}/powerforge-website-nuget-packages", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("path: ${{ env.NUGET_PACKAGES }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("powerforge-website-nuget-v1-${{ runner.os }}-", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("$env:NUGET_PACKAGES", workflowYaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("path: ~/.nuget/packages", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WebsiteRunWorkflow_ShouldRemoveTransientToolCacheRoot()
     {
         var repoRoot = FindRepoRoot();

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -86,8 +86,14 @@ public sealed class GitHubWebsiteRunWorkflowTests
 
         var workflowYaml = File.ReadAllText(workflowPath);
 
-        Assert.Contains("NUGET_PACKAGES: ${{ runner.temp }}/powerforge-website-nuget-packages", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("path: ${{ env.NUGET_PACKAGES }}", workflowYaml, StringComparison.Ordinal);
+        var nugetEnvironmentLines = workflowYaml
+            .Split('\n')
+            .Where(static line => line.Contains("NUGET_PACKAGES:", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(2, nugetEnvironmentLines.Length);
+        Assert.All(nugetEnvironmentLines, static line => Assert.StartsWith("          NUGET_PACKAGES:", line, StringComparison.Ordinal));
+        Assert.Contains("path: ${{ runner.temp }}/powerforge-website-nuget-packages", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("powerforge-website-nuget-v1-${{ runner.os }}-", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("$env:NUGET_PACKAGES", workflowYaml, StringComparison.Ordinal);
         Assert.DoesNotContain("path: ~/.nuget/packages", workflowYaml, StringComparison.Ordinal);


### PR DESCRIPTION
## What changed

- gives reusable PowerForge website jobs a dedicated `NUGET_PACKAGES` directory under `runner.temp`
- namespaces the website cache so it cannot restore legacy global NuGet archives
- keeps cache initialization in the shared workflow and adds a focused workflow contract test

## Why it matters

The shared website workflow currently caches the self-hosted runner user’s entire `~/.nuget/packages` directory. In Tactra this produced a 4.03 GB cache and repeatedly held CI inside cache restore on multiple runners. Scoping the package directory keeps the cache limited to dependencies restored by that website job and prevents unrelated runner workloads from leaking into it.

## Validation

- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --configuration Release --filter FullyQualifiedName~GitHubWebsiteRunWorkflowTests --verbosity minimal`
- 9 focused workflow tests passed
- `git diff --check`
