### PR TITLE
Fix App Store readiness with inherited screenshots

### DIFF
--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -452,6 +452,120 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task ReleasePreparationService_ChecksRemoteScreenshotsWithoutLocalScreenshotSync()
+    {
+        var versionResponse = new SequenceResponse(HttpStatusCode.OK,
+            """
+            {
+              "data": [
+                {
+                  "id": "version-1",
+                  "type": "appStoreVersions",
+                  "attributes": { "versionString": "1.0.5", "platform": "IOS" }
+                }
+              ]
+            }
+            """);
+        var handler = new SequenceHandler(
+            versionResponse,
+            versionResponse,
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-9",
+                      "type": "builds",
+                      "attributes": { "version": "9", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.5", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": { "id": "build-9", "type": "builds" } }"""),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "loc-1",
+                      "type": "appStoreVersionLocalizations",
+                      "attributes": {
+                        "locale": "en-US",
+                        "description": "Premium remote.",
+                        "keywords": "media,remote",
+                        "supportUrl": "https://example.test/support"
+                      }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "set-1",
+                      "type": "appScreenshotSets",
+                      "attributes": { "screenshotDisplayType": "APP_IPHONE_65" }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "shot-1",
+                      "type": "appScreenshots",
+                      "attributes": {
+                        "fileName": "01.png",
+                        "assetDeliveryState": { "state": "COMPLETE" }
+                      }
+                    }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectReleasePreparationService(client);
+
+        var result = await service.PrepareAsync(new AppStoreConnectReleasePreparationRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.5",
+            BuildNumber = "9",
+            Platform = ApplePlatform.iOS,
+            CreateVersion = false,
+            SelectBuild = false,
+            CheckReadiness = true,
+            ReadinessRequest = new AppStoreConnectReleaseReadinessRequest
+            {
+                ScreenshotSpec = new AppStoreConnectScreenshotSyncSpec
+                {
+                    ScreenshotSets = new[]
+                    {
+                        new AppStoreConnectScreenshotSetSyncSpec
+                        {
+                            ScreenshotDisplayType = "APP_IPHONE_65",
+                            Path = "missing-local-screenshots"
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Null(result.Screenshots);
+        Assert.True(result.Readiness?.IsReady);
+        Assert.Equal("APP_IPHONE_65", Assert.Single(result.Readiness!.ScreenshotSets).ScreenshotDisplayType);
+        Assert.Equal(7, handler.RequestUris.Count);
+    }
+
+    [Fact]
     public async Task GetSubscriptionsForAppAsync_ListsGroupsAndSubscriptions()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.cs
@@ -805,6 +805,103 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleApps_ReadinessUsesScreenshotSpecWithoutRequestingScreenshotSync()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "Tactra.xcodeproj", "1.0.5", "9");
+            var keyPath = Path.Combine(root, "AuthKey_ABC123DEFG.p8");
+            var screenshotConfigPath = Path.Combine(root, "screenshots.json");
+            File.WriteAllText(keyPath, "private-key");
+            File.WriteAllText(screenshotConfigPath,
+                """
+                {
+                  "appId": "app-1",
+                  "versionString": "1.0.5",
+                  "platform": "iOS",
+                  "locale": "en-US",
+                  "screenshotSets": [
+                    {
+                      "screenshotDisplayType": "APP_IPHONE_65",
+                      "path": "../missing-local-screenshots",
+                      "filter": "*.png"
+                    }
+                  ]
+                }
+                """);
+            var requests = new List<AppStoreConnectReleasePreparationRequest>();
+
+            var service = new PowerForgeReleaseService(
+                new NullLogger(),
+                executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
+                planTools: (_, _, _) => throw new InvalidOperationException("Legacy tools should not run."),
+                runTools: _ => throw new InvalidOperationException("Legacy tools should not run."),
+                loadDotNetToolsSpec: (_, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                planDotNetTools: (_, _, _, _) => throw new InvalidOperationException("DotNet tools should not run."),
+                runDotNetTools: _ => throw new InvalidOperationException("DotNet tools should not run."),
+                publishGitHubRelease: _ => throw new InvalidOperationException("GitHub should not run."),
+                archiveAppleApp: _ => throw new InvalidOperationException("Archive should not run."),
+                uploadAppleApp: _ => throw new InvalidOperationException("Upload should not run."),
+                prepareAppleDistribution: request =>
+                {
+                    requests.Add(request);
+                    return new AppStoreConnectReleasePreparationResult
+                    {
+                        AppId = request.AppId,
+                        VersionString = request.VersionString,
+                        BuildNumber = request.BuildNumber,
+                        Platform = request.Platform,
+                        Version = new AppStoreConnectVersionInfo { Id = "version-1", VersionString = request.VersionString }
+                    };
+                });
+
+            var result = service.Execute(
+                new PowerForgeReleaseSpec
+                {
+                    AppleApps = new PowerForgeAppleReleaseOptions
+                    {
+                        ProjectRoot = ".",
+                        Archive = false,
+                        CheckReleaseReadiness = true,
+                        SyncScreenshots = false,
+                        ScreenshotConfigPath = screenshotConfigPath,
+                        AppStoreConnectApiKeyPath = keyPath,
+                        AppStoreConnectApiKeyId = "ABC123DEFG",
+                        AppStoreConnectApiIssuerId = "issuer-id",
+                        Apps = new[]
+                        {
+                            new AppleAppConfiguration
+                            {
+                                Name = "Tactra",
+                                ProjectPath = "Tactra.xcodeproj",
+                                Scheme = "Tactra",
+                                Platform = ApplePlatform.iOS,
+                                AppStoreConnectAppId = "app-1"
+                            }
+                        }
+                    }
+                },
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json")
+                });
+
+            Assert.True(result.Success);
+            var request = Assert.Single(requests);
+            Assert.True(request.CheckReadiness);
+            Assert.Null(request.ScreenshotSpec);
+            Assert.NotNull(request.ReadinessRequest?.ScreenshotSpec);
+            Assert.Equal("APP_IPHONE_65",
+                Assert.Single(request.ReadinessRequest!.ScreenshotSpec!.ScreenshotSets).ScreenshotDisplayType);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleApps_AcceptsTestFlightDistributionInUnifiedPlan()
     {
         var root = CreateSandbox();

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -280,7 +280,7 @@ public sealed class AppStoreConnectReleasePreparationService
             RequireCompleteScreenshots = source.RequireCompleteScreenshots,
             MinimumScreenshotsPerSet = source.MinimumScreenshotsPerSet,
             RequiredScreenshotDisplayTypes = source.RequiredScreenshotDisplayTypes,
-            ScreenshotSpec = screenshotSpec
+            ScreenshotSpec = screenshotSpec ?? source.ScreenshotSpec
         };
     }
 }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -1044,11 +1044,17 @@ internal sealed partial class PowerForgeReleaseService
                     CreateVersion = plan.PrepareDistribution,
                     SelectBuild = plan.PrepareDistribution && plan.SelectBuildForDistribution,
                     RequireValidBuild = !plan.AllowUnprocessedDistributionBuild,
-                    ScreenshotSpec = matchingScreenshotSpec?.Spec,
+                    ScreenshotSpec = plan.SyncScreenshots ? matchingScreenshotSpec?.Spec : null,
                     MetadataSpec = matchingMetadataSpec?.Spec,
                     AppInfoMetadataSpecs = appInfoMetadataSpecs,
                     ReplaceScreenshots = plan.ReplaceScreenshots,
                     CheckReadiness = plan.CheckReleaseReadiness,
+                    ReadinessRequest = plan.CheckReleaseReadiness && matchingScreenshotSpec is not null
+                        ? new AppStoreConnectReleaseReadinessRequest
+                        {
+                            ScreenshotSpec = matchingScreenshotSpec.Value.Spec
+                        }
+                        : null,
                     BaseDirectory = matchingScreenshotSpec is null
                         ? matchingMetadataSpec is null
                             ? plan.ProjectRoot


### PR DESCRIPTION
## Summary

- separate local screenshot synchronization from screenshot requirements used by release readiness
- preserve readiness screenshot specs when distribution preparation does not upload screenshots
- cover the unified runner and real App Store Connect preparation flow with regression tests

## Why

Apps can reuse screenshots already present in App Store Connect. A readiness-only run previously passed that configuration into the local screenshot synchronization path, which failed when no local upload folder existed. The release now validates the inherited remote screenshot sets without attempting an upload.

## Validation

- 122 focused App Store Connect and unified release tests passed
- PSPublishModule net472 build: 0 warnings, 0 errors
- PSPublishModule net8.0 build: 0 warnings, 0 errors