### PR TITLE
Handle automatic internal TestFlight groups

### DIFF
--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -1226,6 +1226,78 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task TestFlightDistributionService_RejectsMissingTesterWhenAnyTargetGroupIsInternal()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-9",
+                      "type": "builds",
+                      "attributes": { "version": "9", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.5", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-manual-internal",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Manual Internal", "isInternalGroup": true, "hasAccessToAllBuilds": false }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-external",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Discord Testers", "isInternalGroup": false }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+            new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectTestFlightDistributionService(client);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => service.DistributeAsync(
+            new AppStoreConnectTestFlightDistributionRequest
+            {
+                AppId = "app-1",
+                VersionString = "1.0.5",
+                BuildNumber = "9",
+                Platform = ApplePlatform.iOS,
+                BetaGroupNames = new[] { "Manual Internal", "Discord Testers" },
+                Testers = new[]
+                {
+                    new AppStoreConnectBetaTesterSpec { Email = "missing@example.test" }
+                }
+            }));
+
+        Assert.Contains("must already exist in App Store Connect", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(6, handler.RequestUris.Count);
+        Assert.DoesNotContain(handler.RequestUris, uri =>
+            string.Equals(uri.AbsolutePath, "/v1/betaTesters", StringComparison.Ordinal) &&
+            !string.IsNullOrEmpty(handler.RequestBodies[handler.RequestUris.IndexOf(uri)]));
+    }
+
+    [Fact]
     public async Task BetaAppReviewSubmissionService_SubmitsBuildForExternalTesting()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -1076,6 +1076,72 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task TestFlightDistributionService_SkipsBuildAssignmentForInternalGroups()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-9",
+                      "type": "builds",
+                      "attributes": { "version": "9", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.5", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-internal",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Home", "isInternalGroup": true }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-external",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Discord Testers", "isInternalGroup": false }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectTestFlightDistributionService(client);
+
+        var result = await service.DistributeAsync(new AppStoreConnectTestFlightDistributionRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.5",
+            BuildNumber = "9",
+            Platform = ApplePlatform.iOS,
+            BetaGroupNames = new[] { "Home", "Discord Testers" }
+        });
+
+        Assert.Equal(2, result.BetaGroups.Length);
+        Assert.Contains(result.Messages, message => message.Contains("skipped explicit build assignment", StringComparison.Ordinal));
+        Assert.Contains(result.Messages, message => message.Contains("Discord Testers", StringComparison.Ordinal));
+        Assert.Equal(4, handler.RequestUris.Count);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-external/relationships/builds", handler.RequestUris[3].ToString());
+        Assert.DoesNotContain(handler.RequestUris, uri => uri.ToString().Contains("group-internal/relationships/builds", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task BetaAppReviewSubmissionService_SubmitsBuildForExternalTesting()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -1076,7 +1076,7 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
-    public async Task TestFlightDistributionService_SkipsBuildAssignmentForInternalGroups()
+    public async Task TestFlightDistributionService_SkipsOnlyAutomaticInternalGroupBuildAssignment()
     {
         var handler = new SequenceHandler(
             new SequenceResponse(HttpStatusCode.OK,
@@ -1102,7 +1102,19 @@ public sealed partial class AppStoreConnectClientTests
                     {
                       "id": "group-internal",
                       "type": "betaGroups",
-                      "attributes": { "name": "Home", "isInternalGroup": true }
+                      "attributes": { "name": "Home", "isInternalGroup": true, "hasAccessToAllBuilds": true }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-manual-internal",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Manual Internal", "isInternalGroup": true, "hasAccessToAllBuilds": false }
                     }
                   ]
                 }
@@ -1119,6 +1131,7 @@ public sealed partial class AppStoreConnectClientTests
                   ]
                 }
                 """),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
             new SequenceResponse(HttpStatusCode.NoContent, string.Empty));
         using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
         using var client = new AppStoreConnectClient(CreateCredential(), http);
@@ -1130,15 +1143,86 @@ public sealed partial class AppStoreConnectClientTests
             VersionString = "1.0.5",
             BuildNumber = "9",
             Platform = ApplePlatform.iOS,
-            BetaGroupNames = new[] { "Home", "Discord Testers" }
+            BetaGroupNames = new[] { "Home", "Manual Internal", "Discord Testers" }
         });
 
-        Assert.Equal(2, result.BetaGroups.Length);
+        Assert.Equal(3, result.BetaGroups.Length);
         Assert.Contains(result.Messages, message => message.Contains("skipped explicit build assignment", StringComparison.Ordinal));
+        Assert.Contains(result.Messages, message => message.Contains("Manual Internal", StringComparison.Ordinal));
         Assert.Contains(result.Messages, message => message.Contains("Discord Testers", StringComparison.Ordinal));
-        Assert.Equal(4, handler.RequestUris.Count);
-        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-external/relationships/builds", handler.RequestUris[3].ToString());
+        Assert.Equal(6, handler.RequestUris.Count);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-manual-internal/relationships/builds", handler.RequestUris[4].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-external/relationships/builds", handler.RequestUris[5].ToString());
         Assert.DoesNotContain(handler.RequestUris, uri => uri.ToString().Contains("group-internal/relationships/builds", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TestFlightDistributionService_AssignsExistingTesterToManualInternalGroup()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "build-9",
+                      "type": "builds",
+                      "attributes": { "version": "9", "processingState": "VALID", "expired": false },
+                      "relationships": { "preReleaseVersion": { "data": { "id": "pre-1", "type": "preReleaseVersions" } } }
+                    }
+                  ],
+                  "included": [
+                    { "id": "pre-1", "type": "preReleaseVersions", "attributes": { "version": "1.0.5", "platform": "IOS" } }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "group-manual-internal",
+                      "type": "betaGroups",
+                      "attributes": { "name": "Manual Internal", "isInternalGroup": true, "hasAccessToAllBuilds": false }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "tester-internal",
+                      "type": "betaTesters",
+                      "attributes": { "email": "internal@example.test", "firstName": "Internal", "lastName": "User" }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.NoContent, string.Empty));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var service = new AppStoreConnectTestFlightDistributionService(client);
+
+        var result = await service.DistributeAsync(new AppStoreConnectTestFlightDistributionRequest
+        {
+            AppId = "app-1",
+            VersionString = "1.0.5",
+            BuildNumber = "9",
+            Platform = ApplePlatform.iOS,
+            BetaGroupNames = new[] { "Manual Internal" },
+            Testers = new[]
+            {
+                new AppStoreConnectBetaTesterSpec { Email = "internal@example.test" }
+            }
+        });
+
+        Assert.Equal("internal@example.test", Assert.Single(result.Testers).Email);
+        Assert.Equal(5, handler.RequestUris.Count);
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-manual-internal/relationships/builds", handler.RequestUris[2].ToString());
+        Assert.Equal("https://api.appstoreconnect.apple.com/v1/betaGroups/group-manual-internal/relationships/betaTesters", handler.RequestUris[4].ToString());
     }
 
     [Fact]

--- a/PowerForge/Models/AppStoreConnectTestFlightModels.cs
+++ b/PowerForge/Models/AppStoreConnectTestFlightModels.cs
@@ -25,6 +25,9 @@ public sealed class AppStoreConnectBetaGroupInfo
 
     /// <summary>Whether this is an internal beta group when reported by App Store Connect.</summary>
     public bool? IsInternalGroup { get; set; }
+
+    /// <summary>Whether the group automatically receives access to every eligible build.</summary>
+    public bool? HasAccessToAllBuilds { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
+++ b/PowerForge/Services/AppStoreConnectClient.TestFlight.cs
@@ -249,7 +249,8 @@ public sealed partial class AppStoreConnectClient
             PublicLinkLimit = GetInt32(attrs, "publicLinkLimit"),
             PublicLink = GetString(attrs, "publicLink"),
             FeedbackEnabled = GetBool(attrs, "feedbackEnabled"),
-            IsInternalGroup = GetBool(attrs, "isInternalGroup")
+            IsInternalGroup = GetBool(attrs, "isInternalGroup"),
+            HasAccessToAllBuilds = GetBool(attrs, "hasAccessToAllBuilds")
         };
     }
 

--- a/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
+++ b/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
@@ -50,18 +50,30 @@ public sealed class AppStoreConnectTestFlightDistributionService
         var messages = new List<string>();
         foreach (var group in groups)
         {
+            if (group.IsInternalGroup == true)
+            {
+                messages.Add($"Internal beta group '{group.Name ?? group.Id}' receives eligible builds automatically; skipped explicit build assignment.");
+                continue;
+            }
+
             await _client.AddBuildsToBetaGroupAsync(group.Id, new[] { build.Id }, cancellationToken).ConfigureAwait(false);
             messages.Add($"Added build '{request.BuildNumber}' to beta group '{group.Name ?? group.Id}'.");
         }
 
+        var testerGroups = groups
+            .Where(static group => group.IsInternalGroup != true)
+            .ToArray();
         var testers = new List<AppStoreConnectBetaTesterInfo>();
         foreach (var testerSpec in request.Testers ?? Array.Empty<AppStoreConnectBetaTesterSpec>())
         {
-            var tester = await ResolveTesterAsync(testerSpec, request.CreateMissingTesters, groups, cancellationToken).ConfigureAwait(false);
+            if (testerGroups.Length == 0)
+                throw new InvalidOperationException("Beta testers cannot be added to internal TestFlight groups; configure at least one external beta group.");
+
+            var tester = await ResolveTesterAsync(testerSpec, request.CreateMissingTesters, testerGroups, cancellationToken).ConfigureAwait(false);
             testers.Add(tester);
-            foreach (var group in groups)
+            foreach (var group in testerGroups)
                 await _client.AddBetaTestersToBetaGroupAsync(group.Id, new[] { tester.Id }, cancellationToken).ConfigureAwait(false);
-            messages.Add($"Added beta tester '{tester.Email ?? tester.Id}' to {groups.Length} beta group(s).");
+            messages.Add($"Added beta tester '{tester.Email ?? tester.Id}' to {testerGroups.Length} external beta group(s).");
         }
 
         return new AppStoreConnectTestFlightDistributionResult

--- a/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
+++ b/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
@@ -130,19 +130,16 @@ public sealed class AppStoreConnectTestFlightDistributionService
         if (!createMissing)
             throw new InvalidOperationException($"Beta tester '{testerSpec.Email}' was not found and CreateMissingTesters is false.");
 
-        var targetGroups = groups
-            .Where(static group => group.IsInternalGroup != true)
-            .ToArray();
-        if (targetGroups.Length == 0)
-            throw new InvalidOperationException($"Beta tester '{testerSpec.Email}' was not found. New external testers cannot be created for internal-only TestFlight groups.");
+        if (groups.Any(static group => group.IsInternalGroup == true))
+            throw new InvalidOperationException($"Beta tester '{testerSpec.Email}' was not found. Testers assigned to internal TestFlight groups must already exist in App Store Connect.");
 
         var created = await _client.CreateBetaTesterAsync(
             testerSpec.Email,
             testerSpec.FirstName,
             testerSpec.LastName,
-            targetGroups.Select(static group => group.Id).ToArray(),
+            groups.Select(static group => group.Id).ToArray(),
             cancellationToken).ConfigureAwait(false);
-        return (created, targetGroups);
+        return (created, groups);
     }
 
     private static void ValidateBuildIsDistributable(AppStoreConnectBuildInfo build, string buildNumber)

--- a/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
+++ b/PowerForge/Services/AppStoreConnectTestFlightDistributionService.cs
@@ -50,9 +50,9 @@ public sealed class AppStoreConnectTestFlightDistributionService
         var messages = new List<string>();
         foreach (var group in groups)
         {
-            if (group.IsInternalGroup == true)
+            if (group.IsInternalGroup == true && group.HasAccessToAllBuilds == true)
             {
-                messages.Add($"Internal beta group '{group.Name ?? group.Id}' receives eligible builds automatically; skipped explicit build assignment.");
+                messages.Add($"Internal beta group '{group.Name ?? group.Id}' has access to all builds; skipped explicit build assignment.");
                 continue;
             }
 
@@ -60,20 +60,14 @@ public sealed class AppStoreConnectTestFlightDistributionService
             messages.Add($"Added build '{request.BuildNumber}' to beta group '{group.Name ?? group.Id}'.");
         }
 
-        var testerGroups = groups
-            .Where(static group => group.IsInternalGroup != true)
-            .ToArray();
         var testers = new List<AppStoreConnectBetaTesterInfo>();
         foreach (var testerSpec in request.Testers ?? Array.Empty<AppStoreConnectBetaTesterSpec>())
         {
-            if (testerGroups.Length == 0)
-                throw new InvalidOperationException("Beta testers cannot be added to internal TestFlight groups; configure at least one external beta group.");
-
-            var tester = await ResolveTesterAsync(testerSpec, request.CreateMissingTesters, testerGroups, cancellationToken).ConfigureAwait(false);
-            testers.Add(tester);
-            foreach (var group in testerGroups)
-                await _client.AddBetaTestersToBetaGroupAsync(group.Id, new[] { tester.Id }, cancellationToken).ConfigureAwait(false);
-            messages.Add($"Added beta tester '{tester.Email ?? tester.Id}' to {testerGroups.Length} external beta group(s).");
+            var resolution = await ResolveTesterAsync(testerSpec, request.CreateMissingTesters, groups, cancellationToken).ConfigureAwait(false);
+            testers.Add(resolution.Tester);
+            foreach (var group in resolution.TargetGroups)
+                await _client.AddBetaTestersToBetaGroupAsync(group.Id, new[] { resolution.Tester.Id }, cancellationToken).ConfigureAwait(false);
+            messages.Add($"Added beta tester '{resolution.Tester.Email ?? resolution.Tester.Id}' to {resolution.TargetGroups.Length} beta group(s).");
         }
 
         return new AppStoreConnectTestFlightDistributionResult
@@ -121,7 +115,7 @@ public sealed class AppStoreConnectTestFlightDistributionService
             .ToArray();
     }
 
-    private async Task<AppStoreConnectBetaTesterInfo> ResolveTesterAsync(
+    private async Task<(AppStoreConnectBetaTesterInfo Tester, AppStoreConnectBetaGroupInfo[] TargetGroups)> ResolveTesterAsync(
         AppStoreConnectBetaTesterSpec testerSpec,
         bool createMissing,
         AppStoreConnectBetaGroupInfo[] groups,
@@ -132,16 +126,23 @@ public sealed class AppStoreConnectTestFlightDistributionService
 
         var existing = (await _client.GetBetaTestersAsync(testerSpec.Email.Trim(), limit: 10, cancellationToken).ConfigureAwait(false)).FirstOrDefault();
         if (existing is not null)
-            return existing;
+            return (existing, groups);
         if (!createMissing)
             throw new InvalidOperationException($"Beta tester '{testerSpec.Email}' was not found and CreateMissingTesters is false.");
 
-        return await _client.CreateBetaTesterAsync(
+        var targetGroups = groups
+            .Where(static group => group.IsInternalGroup != true)
+            .ToArray();
+        if (targetGroups.Length == 0)
+            throw new InvalidOperationException($"Beta tester '{testerSpec.Email}' was not found. New external testers cannot be created for internal-only TestFlight groups.");
+
+        var created = await _client.CreateBetaTesterAsync(
             testerSpec.Email,
             testerSpec.FirstName,
             testerSpec.LastName,
-            groups.Select(static group => group.Id).ToArray(),
+            targetGroups.Select(static group => group.Id).ToArray(),
             cancellationToken).ConfigureAwait(false);
+        return (created, targetGroups);
     }
 
     private static void ValidateBuildIsDistributable(AppStoreConnectBuildInfo build, string buildNumber)


### PR DESCRIPTION
## Summary

- read App Store Connect hasAccessToAllBuilds for beta groups
- skip explicit build assignment only for internal groups that automatically receive every eligible build
- continue assigning builds to manual internal and external groups
- preserve existing internal-user tester assignment
- fail clearly instead of partially creating a missing tester when any requested group is internal
- cover automatic internal, manual internal, external, existing internal tester, and missing mixed-group tester paths

## Why

App Store Connect rejects explicit build assignment for an internal beta group when that group already has access to all builds. Unified releases must distinguish those automatic groups from manual internal groups and external groups, and tester operations must not report success when only part of the requested group membership can be fulfilled.

## Validation

- 125 focused App Store Connect and unified release tests passed
- PSPublishModule net472 build: 0 warnings, 0 errors
- PSPublishModule net8.0 build: 0 warnings, 0 errors
- live Tactra group discovery: Home is internal with hasAccessToAllBuilds=true; Discord Testers is external