### PR TITLE
Fix mixed publish prebuilds and fail-closed signing

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -592,6 +592,83 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
+    public void GetPreBuildProjectPaths_LeavesUnversionedTargetsInMixedInstallerPlans()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var cli = CreateProject(root, "Cli/Cli.csproj");
+            var spec = CreateBaseSpec(root, app);
+            spec.DotNet.Restore = true;
+            spec.DotNet.Build = true;
+            spec.DotNet.NoBuildInPublish = true;
+            spec.Targets = new[]
+            {
+                spec.Targets[0],
+                new DotNetPublishTarget
+                {
+                    Name = "cli",
+                    ProjectPath = cli,
+                    Publish = new DotNetPublishPublishOptions
+                    {
+                        Framework = "net10.0",
+                        Runtimes = new[] { "win-x64" },
+                        Style = DotNetPublishStyle.PortableCompat,
+                        UseStaging = false
+                    }
+                }
+            };
+            spec.Installers = new[]
+            {
+                new DotNetPublishInstaller
+                {
+                    Id = "app.msi",
+                    PrepareFromTarget = "app",
+                    Authoring = CreateSimpleAuthoring("ProductFiles"),
+                    Versioning = new DotNetPublishMsiVersionOptions
+                    {
+                        Enabled = true,
+                        Major = 26,
+                        Minor = 6,
+                        FloorDateUtc = "2026-06-01",
+                        Monotonic = false,
+                        ApplyToPublish = true
+                    }
+                }
+            };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var projectPaths = DotNetPublishPipelineRunner.GetPreBuildProjectPaths(plan, "win-x64");
+
+            Assert.Equal(new[] { Path.GetFullPath(cli) }, projectPaths);
+            Assert.Empty(DotNetPublishPipelineRunner.GetPreBuildProjectPaths(plan, "linux-x64"));
+
+            var cliPlan = Assert.Single(plan.Targets, target => target.Name == "cli");
+            var combination = Assert.Single(cliPlan.Combinations);
+            var buildArguments = DotNetPublishPipelineRunner.BuildPreBuildArguments(
+                plan,
+                cliPlan,
+                combination.Framework,
+                combination.Runtime,
+                combination.Style);
+
+            Assert.Equal("build", buildArguments[0]);
+            Assert.Contains("--no-restore", buildArguments);
+            Assert.Contains("--self-contained", buildArguments);
+            Assert.Contains("/p:PublishSingleFile=true", buildArguments);
+            Assert.Contains("-f", buildArguments);
+            Assert.Contains("-r", buildArguments);
+            Assert.DoesNotContain("--no-build", buildArguments);
+            Assert.DoesNotContain("--output", buildArguments);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Plan_ApplyToPublishMsiVersions_AdvancesMonotonicStateAcrossCombinations()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerMsiBuildTests.cs
@@ -592,7 +592,7 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     }
 
     [Fact]
-    public void GetPreBuildProjectPaths_LeavesUnversionedTargetsInMixedInstallerPlans()
+    public void Plan_LeavesUnversionedTargetPreBuildInMixedInstallerPlans()
     {
         var root = CreateTempRoot();
         try
@@ -639,10 +639,11 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             };
 
             var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
-            var projectPaths = DotNetPublishPipelineRunner.GetPreBuildProjectPaths(plan, "win-x64");
-
-            Assert.Equal(new[] { Path.GetFullPath(cli) }, projectPaths);
-            Assert.Empty(DotNetPublishPipelineRunner.GetPreBuildProjectPaths(plan, "linux-x64"));
+            var buildStep = Assert.Single(plan.Steps, step => step.Kind == DotNetPublishStepKind.Build);
+            Assert.Equal("cli", buildStep.TargetName);
+            Assert.Equal("net10.0", buildStep.Framework);
+            Assert.Equal("win-x64", buildStep.Runtime);
+            Assert.Equal(DotNetPublishStyle.PortableCompat, buildStep.Style);
 
             var cliPlan = Assert.Single(plan.Targets, target => target.Name == "cli");
             var combination = Assert.Single(cliPlan.Combinations);
@@ -661,6 +662,66 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
             Assert.Contains("-r", buildArguments);
             Assert.DoesNotContain("--no-build", buildArguments);
             Assert.DoesNotContain("--output", buildArguments);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_NoBuildPublish_InterleavesEachStyleBuildWithItsPublish()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var spec = CreateBaseSpec(root, app);
+            spec.DotNet.Build = true;
+            spec.DotNet.NoBuildInPublish = true;
+            spec.Targets[0].Publish.Styles = new[]
+            {
+                DotNetPublishStyle.FrameworkDependent,
+                DotNetPublishStyle.PortableCompat
+            };
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var buildAndPublishSteps = plan.Steps
+                .Where(step => step.Kind == DotNetPublishStepKind.Build || step.Kind == DotNetPublishStepKind.Publish)
+                .ToArray();
+
+            Assert.Collection(
+                buildAndPublishSteps,
+                step => AssertCombinationStep(step, DotNetPublishStepKind.Build, DotNetPublishStyle.FrameworkDependent),
+                step => AssertCombinationStep(step, DotNetPublishStepKind.Publish, DotNetPublishStyle.FrameworkDependent),
+                step => AssertCombinationStep(step, DotNetPublishStepKind.Build, DotNetPublishStyle.PortableCompat),
+                step => AssertCombinationStep(step, DotNetPublishStepKind.Publish, DotNetPublishStyle.PortableCompat));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Plan_GlobalBuild_PreservesConfiguredSolutionPath()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var app = CreateProject(root, "App/App.csproj");
+            var solution = Path.Combine(root, "App.sln");
+            File.WriteAllText(solution, string.Empty);
+            var spec = CreateBaseSpec(root, app);
+            spec.DotNet.Build = true;
+            spec.DotNet.NoBuildInPublish = false;
+            spec.DotNet.SolutionPath = solution;
+
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(spec, null);
+            var buildStep = Assert.Single(plan.Steps, step => step.Kind == DotNetPublishStepKind.Build);
+
+            Assert.Null(buildStep.TargetName);
+            Assert.Equal(new[] { Path.GetFullPath(solution) }, DotNetPublishPipelineRunner.GetGlobalBuildPaths(plan, runtime: null));
         }
         finally
         {
@@ -1967,6 +2028,18 @@ public sealed class DotNetPublishPipelineRunnerMsiBuildTests
     {
         var floor = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         return (int)(utcDate - floor).TotalDays;
+    }
+
+    private static void AssertCombinationStep(
+        DotNetPublishStep step,
+        DotNetPublishStepKind kind,
+        DotNetPublishStyle style)
+    {
+        Assert.Equal(kind, step.Kind);
+        Assert.Equal("app", step.TargetName);
+        Assert.Equal("net10.0", step.Framework);
+        Assert.Equal("win-x64", step.Runtime);
+        Assert.Equal(style, step.Style);
     }
 
     private static DotNetPublishSpec CreateBaseSpec(string root, string projectPath)

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -2080,6 +2080,16 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void SigningScript_FailsClosedForInvalidCertificatesAndUnknownSignatures()
+    {
+        var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
+
+        Assert.Contains("outside its validity period", script, StringComparison.Ordinal);
+        Assert.Contains("if ($status -eq 'Valid')", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("$status -eq 'Valid' -or $status -eq 'UnknownError'", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RunTestsAfterMerge_IncludesFailedTestNamesAndMessages()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -140,6 +140,11 @@ try {
     throw "Code signing certificate not configured or not found. Provide CertificateThumbprint/CertificatePFXPath/CertificatePFXBase64 (and password for PFX)."
   }
 
+  $now = [DateTime]::UtcNow
+  if ($now -lt $cert.NotBefore.ToUniversalTime() -or $now -gt $cert.NotAfter.ToUniversalTime()) {
+    throw ("Code signing certificate '{0}' is outside its validity period ({1:u} through {2:u})." -f $cert.Thumbprint, $cert.NotBefore.ToUniversalTime(), $cert.NotAfter.ToUniversalTime())
+  }
+
   $thisTp = ($cert.Thumbprint -replace '\s','').ToUpperInvariant()
 
   # Enumerate files (include patterns, then apply exclude substrings)
@@ -225,7 +230,7 @@ try {
         $status = if ($r) { [string]$r.Status } else { 'Unknown' }
         if ($status -eq 'UnknownError') { $unknownError++ }
 
-        if ($status -eq 'Valid' -or $status -eq 'UnknownError') {
+        if ($status -eq 'Valid') {
           if ($wasSigned) { $resigned++ } else { $signedNew++ }
         } else {
           $failed++
@@ -284,7 +289,7 @@ try {
         $status = if ($r) { [string]$r.Status } else { 'Unknown' }
         if ($status -eq 'UnknownError') { $unknownError++ }
 
-        if ($status -eq 'Valid' -or $status -eq 'UnknownError') {
+        if ($status -eq 'Valid') {
           if ($wasSigned) { $resigned++ } else { $signedNew++ }
         } else {
           $failed++

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -357,31 +357,39 @@ public sealed partial class DotNetPublishPipelineRunner
 
         AddCommandHookSteps(steps, hooks, DotNetPublishCommandHookPhase.BeforeBuild, cfg, targetName: null, framework: null, runtime: null, style: null, bundleId: null);
 
-        if (spec.DotNet.Build)
+        var buildPerCombination = spec.DotNet.Build
+            && spec.DotNet.NoBuildInPublish
+            && distinctRuntimes.Length > 0;
+
+        if (spec.DotNet.Build && !buildPerCombination)
         {
-            if (spec.DotNet.NoBuildInPublish && distinctRuntimes.Length > 0)
-            {
-                foreach (var rid in distinctRuntimes)
-                {
-                    steps.Add(new DotNetPublishStep
-                    {
-                        Key = $"build:{rid}",
-                        Kind = DotNetPublishStepKind.Build,
-                        Title = "Build",
-                        Runtime = rid
-                    });
-                }
-            }
-            else
-            {
-                steps.Add(new DotNetPublishStep { Key = "build", Kind = DotNetPublishStepKind.Build, Title = "Build" });
-            }
+            steps.Add(new DotNetPublishStep { Key = "build", Kind = DotNetPublishStepKind.Build, Title = "Build" });
         }
 
         foreach (var t in targets)
         {
             foreach (var combo in t.Combinations ?? Array.Empty<DotNetPublishTargetCombination>())
             {
+                if (buildPerCombination && !TargetUsesPublishMsiVersionProperties(
+                    installers,
+                    msiVersions,
+                    t.Name,
+                    combo.Framework,
+                    combo.Runtime,
+                    combo.Style))
+                {
+                    steps.Add(new DotNetPublishStep
+                    {
+                        Key = $"build:{t.Name}:{combo.Framework}:{combo.Runtime}:{combo.Style}",
+                        Kind = DotNetPublishStepKind.Build,
+                        Title = "Build",
+                        TargetName = t.Name,
+                        Framework = combo.Framework,
+                        Runtime = combo.Runtime,
+                        Style = combo.Style
+                    });
+                }
+
                 AddCommandHookSteps(steps, hooks, DotNetPublishCommandHookPhase.BeforeTargetPublish, cfg, t.Name, combo.Framework, combo.Runtime, combo.Style, bundleId: null);
 
                 var key = $"publish:{t.Name}:{combo.Framework}:{combo.Runtime}:{combo.Style}";

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -53,7 +53,7 @@ public sealed partial class DotNetPublishPipelineRunner
                             Clean(plan);
                             break;
                         case DotNetPublishStepKind.Build:
-                            Build(plan, step.Runtime);
+                            Build(plan, step);
                             break;
                         case DotNetPublishStepKind.Publish:
                             artefacts.Add(Publish(plan, step.TargetName!, step.Framework ?? string.Empty, step.Runtime!, step.Style));

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -207,54 +207,70 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
-    private void Build(DotNetPublishPlan plan, string? runtime)
+    private void Build(DotNetPublishPlan plan, DotNetPublishStep step)
     {
-        var workDir = plan.ProjectRoot;
-        var built = false;
-        foreach (var target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+        if (!string.IsNullOrWhiteSpace(step.TargetName))
         {
-            var allCombinations = target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>();
-            var combinations = allCombinations
-                .Where(combination => string.IsNullOrWhiteSpace(runtime)
-                    || string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
-                .ToArray();
-
-            if (combinations.Length == 0)
-            {
-                if (allCombinations.Length > 0)
-                    continue;
-
-                if (!TargetRequiresPreBuild(plan, target, runtime))
-                    continue;
-
-                _logger.Info($"Build -> {target.ProjectPath}");
-                var fallbackArgs = new List<string> { "build", target.ProjectPath, "-c", plan.Configuration, "--nologo" };
-                if (!string.IsNullOrWhiteSpace(runtime)) fallbackArgs.AddRange(new[] { "-r", runtime! });
-                if (plan.Restore) fallbackArgs.Add("--no-restore");
-                fallbackArgs.AddRange(BuildMsBuildPropertyArgs(plan.MsBuildProperties));
-                RunDotnet(workDir, fallbackArgs, plan.EnvironmentVariables);
-                built = true;
-                continue;
-            }
-
-            foreach (var combination in combinations)
-            {
-                var framework = combination.Framework ?? string.Empty;
-                var targetRuntime = combination.Runtime ?? string.Empty;
-                if (TargetUsesPublishMsiVersionProperties(plan, target.Name, framework, targetRuntime, combination.Style))
-                    continue;
-
-                _logger.Info($"Build {target.Name} ({framework}, {targetRuntime}, {combination.Style}) -> {target.ProjectPath}");
-                RunDotnet(
-                    workDir,
-                    BuildPreBuildArguments(plan, target, framework, targetRuntime, combination.Style),
-                    plan.EnvironmentVariables);
-                built = true;
-            }
+            BuildTargetCombination(plan, step);
+            return;
         }
 
-        if (!built)
-            _logger.Info("Build skipped because every target builds an isolated versioned payload during publish.");
+        BuildGlobal(plan, step.Runtime);
+    }
+
+    private void BuildTargetCombination(DotNetPublishPlan plan, DotNetPublishStep step)
+    {
+        var target = (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+            .FirstOrDefault(candidate => string.Equals(candidate.Name, step.TargetName, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException($"Build target not found: {step.TargetName}");
+        var framework = step.Framework ?? string.Empty;
+        var runtime = step.Runtime ?? string.Empty;
+        var style = step.Style ?? target.Publish.Style;
+
+        if (TargetUsesPublishMsiVersionProperties(plan, target.Name, framework, runtime, style))
+        {
+            _logger.Info($"Build skipped for {target.Name} ({framework}, {runtime}, {style}) because publish builds an isolated versioned MSI payload.");
+            return;
+        }
+
+        _logger.Info($"Build {target.Name} ({framework}, {runtime}, {style}) -> {target.ProjectPath}");
+        RunDotnet(
+            plan.ProjectRoot,
+            BuildPreBuildArguments(plan, target, framework, runtime, style),
+            plan.EnvironmentVariables);
+    }
+
+    private void BuildGlobal(DotNetPublishPlan plan, string? runtime)
+    {
+        var workDir = plan.ProjectRoot;
+        var props = BuildMsBuildPropertyArgs(plan.MsBuildProperties);
+        foreach (var path in GetGlobalBuildPaths(plan, runtime))
+        {
+            var label = string.IsNullOrWhiteSpace(runtime) ? string.Empty : $" ({runtime})";
+            _logger.Info($"Build{label} -> {path}");
+
+            var args = new List<string> { "build", path, "-c", plan.Configuration, "--nologo" };
+            if (!string.IsNullOrWhiteSpace(runtime))
+            {
+                args.AddRange(new[] { "-r", runtime! });
+                if (plan.Restore) args.Add("--no-restore");
+            }
+            args.AddRange(props);
+            RunDotnet(workDir, args, plan.EnvironmentVariables);
+        }
+    }
+
+    internal static string[] GetGlobalBuildPaths(DotNetPublishPlan plan, string? runtime)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        if (string.IsNullOrWhiteSpace(runtime) && !string.IsNullOrWhiteSpace(plan.SolutionPath))
+            return new[] { plan.SolutionPath! };
+
+        return (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+            .Select(target => target.ProjectPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     internal static List<string> BuildPreBuildArguments(
@@ -274,41 +290,6 @@ public sealed partial class DotNetPublishPipelineRunner
         AppendPublishStyleArgs(args, target.Publish, style);
         args.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildProperties(plan, target, framework, runtime, style)));
         return args;
-    }
-
-    internal static string[] GetPreBuildProjectPaths(DotNetPublishPlan plan, string? runtime)
-    {
-        if (plan is null) throw new ArgumentNullException(nameof(plan));
-
-        return (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
-            .Where(target => TargetRequiresPreBuild(plan, target, runtime))
-            .Select(target => target.ProjectPath)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-    }
-
-    private static bool TargetRequiresPreBuild(
-        DotNetPublishPlan plan,
-        DotNetPublishTargetPlan target,
-        string? runtime)
-    {
-        var allCombinations = target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>();
-        if (allCombinations.Length == 0)
-            return true;
-
-        var combinations = allCombinations
-            .Where(combination => string.IsNullOrWhiteSpace(runtime)
-                || string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-        if (combinations.Length == 0)
-            return false;
-
-        return combinations.Any(combination => !TargetUsesPublishMsiVersionProperties(
-            plan,
-            target.Name,
-            combination.Framework ?? string.Empty,
-            combination.Runtime ?? string.Empty,
-            combination.Style));
     }
 
     private DotNetPublishArtefactResult Publish(DotNetPublishPlan plan, string targetName, string framework, string rid, DotNetPublishStyle? styleOverride)
@@ -576,13 +557,28 @@ public sealed partial class DotNetPublishPipelineRunner
         string framework,
         string runtime,
         DotNetPublishStyle style)
+        => TargetUsesPublishMsiVersionProperties(
+            plan.Installers,
+            plan.MsiVersions,
+            targetName,
+            framework,
+            runtime,
+            style);
+
+    private static bool TargetUsesPublishMsiVersionProperties(
+        IEnumerable<DotNetPublishInstallerPlan> installers,
+        IReadOnlyDictionary<string, DotNetPublishMsiVersionPlan> msiVersions,
+        string targetName,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
     {
-        return (plan.Installers ?? Array.Empty<DotNetPublishInstallerPlan>())
+        return (installers ?? Array.Empty<DotNetPublishInstallerPlan>())
             .Where(installer => string.Equals(installer.PrepareFromTarget, targetName, StringComparison.OrdinalIgnoreCase))
             .Any(installer =>
                 installer.Versioning?.Enabled == true
                 && installer.Versioning.ApplyToPublish
-                && FindResolvedMsiVersion(plan, installer.Id, targetName, framework, runtime, style) is not null);
+                && msiVersions.ContainsKey(BuildMsiVersionKey(installer.Id, targetName, framework, runtime, style)));
     }
 
     private static string[] ResolvePublishVersionProperties(DotNetPublishMsiVersionOptions versioning)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Steps.cs
@@ -210,46 +210,105 @@ public sealed partial class DotNetPublishPipelineRunner
     private void Build(DotNetPublishPlan plan, string? runtime)
     {
         var workDir = plan.ProjectRoot;
-        var props = BuildMsBuildPropertyArgs(plan.MsBuildProperties);
-
-        if (PlanUsesPublishMsiVersionProperties(plan))
+        var built = false;
+        foreach (var target in plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
         {
-            _logger.Info("Build skipped because one or more installers apply resolved MSI versions to publish; publish steps will build isolated payloads.");
-            return;
-        }
+            var allCombinations = target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>();
+            var combinations = allCombinations
+                .Where(combination => string.IsNullOrWhiteSpace(runtime)
+                    || string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
 
-        if (!string.IsNullOrWhiteSpace(runtime))
-        {
-            foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
+            if (combinations.Length == 0)
             {
-                _logger.Info($"Build ({runtime}) -> {p}");
+                if (allCombinations.Length > 0)
+                    continue;
 
-                var args = new List<string> { "build", p, "-c", plan.Configuration, "--nologo" };
-                args.AddRange(new[] { "-r", runtime! });
-                if (plan.Restore) args.Add("--no-restore");
-                args.AddRange(props);
+                if (!TargetRequiresPreBuild(plan, target, runtime))
+                    continue;
 
-                RunDotnet(workDir, args, plan.EnvironmentVariables);
+                _logger.Info($"Build -> {target.ProjectPath}");
+                var fallbackArgs = new List<string> { "build", target.ProjectPath, "-c", plan.Configuration, "--nologo" };
+                if (!string.IsNullOrWhiteSpace(runtime)) fallbackArgs.AddRange(new[] { "-r", runtime! });
+                if (plan.Restore) fallbackArgs.Add("--no-restore");
+                fallbackArgs.AddRange(BuildMsBuildPropertyArgs(plan.MsBuildProperties));
+                RunDotnet(workDir, fallbackArgs, plan.EnvironmentVariables);
+                built = true;
+                continue;
             }
 
-            return;
+            foreach (var combination in combinations)
+            {
+                var framework = combination.Framework ?? string.Empty;
+                var targetRuntime = combination.Runtime ?? string.Empty;
+                if (TargetUsesPublishMsiVersionProperties(plan, target.Name, framework, targetRuntime, combination.Style))
+                    continue;
+
+                _logger.Info($"Build {target.Name} ({framework}, {targetRuntime}, {combination.Style}) -> {target.ProjectPath}");
+                RunDotnet(
+                    workDir,
+                    BuildPreBuildArguments(plan, target, framework, targetRuntime, combination.Style),
+                    plan.EnvironmentVariables);
+                built = true;
+            }
         }
 
-        if (!string.IsNullOrWhiteSpace(plan.SolutionPath))
-        {
-            _logger.Info($"Build -> {plan.SolutionPath}");
-            var args = new List<string> { "build", plan.SolutionPath!, "-c", plan.Configuration, "--nologo" };
-            if (plan.Restore) args.Add("--no-restore");
-            args.AddRange(props);
-            RunDotnet(workDir, args, plan.EnvironmentVariables);
-            return;
-        }
+        if (!built)
+            _logger.Info("Build skipped because every target builds an isolated versioned payload during publish.");
+    }
 
-        foreach (var p in plan.Targets.Select(t => t.ProjectPath).Distinct(StringComparer.OrdinalIgnoreCase))
-        {
-            _logger.Info($"Build -> {p}");
-            RunDotnet(workDir, new[] { "build", p, "-c", plan.Configuration, "--nologo" }.Concat(props).ToArray(), plan.EnvironmentVariables);
-        }
+    internal static List<string> BuildPreBuildArguments(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        string framework,
+        string runtime,
+        DotNetPublishStyle style)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+        if (target is null) throw new ArgumentNullException(nameof(target));
+
+        var args = new List<string> { "build", target.ProjectPath, "-c", plan.Configuration, "--nologo" };
+        if (!string.IsNullOrWhiteSpace(framework)) args.AddRange(new[] { "-f", framework });
+        if (!string.IsNullOrWhiteSpace(runtime)) args.AddRange(new[] { "-r", runtime });
+        if (plan.Restore) args.Add("--no-restore");
+        AppendPublishStyleArgs(args, target.Publish, style);
+        args.AddRange(BuildMsBuildPropertyArgs(BuildPublishMsBuildProperties(plan, target, framework, runtime, style)));
+        return args;
+    }
+
+    internal static string[] GetPreBuildProjectPaths(DotNetPublishPlan plan, string? runtime)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        return (plan.Targets ?? Array.Empty<DotNetPublishTargetPlan>())
+            .Where(target => TargetRequiresPreBuild(plan, target, runtime))
+            .Select(target => target.ProjectPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static bool TargetRequiresPreBuild(
+        DotNetPublishPlan plan,
+        DotNetPublishTargetPlan target,
+        string? runtime)
+    {
+        var allCombinations = target.Combinations ?? Array.Empty<DotNetPublishTargetCombination>();
+        if (allCombinations.Length == 0)
+            return true;
+
+        var combinations = allCombinations
+            .Where(combination => string.IsNullOrWhiteSpace(runtime)
+                || string.Equals(combination.Runtime, runtime, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (combinations.Length == 0)
+            return false;
+
+        return combinations.Any(combination => !TargetUsesPublishMsiVersionProperties(
+            plan,
+            target.Name,
+            combination.Framework ?? string.Empty,
+            combination.Runtime ?? string.Empty,
+            combination.Style));
     }
 
     private DotNetPublishArtefactResult Publish(DotNetPublishPlan plan, string targetName, string framework, string rid, DotNetPublishStyle? styleOverride)
@@ -510,10 +569,6 @@ public sealed partial class DotNetPublishPipelineRunner
             }
         }
     }
-
-    private static bool PlanUsesPublishMsiVersionProperties(DotNetPublishPlan plan)
-        => (plan.Installers ?? Array.Empty<DotNetPublishInstallerPlan>())
-            .Any(installer => installer.Versioning?.Enabled == true && installer.Versioning.ApplyToPublish);
 
     private static bool TargetUsesPublishMsiVersionProperties(
         DotNetPublishPlan plan,


### PR DESCRIPTION
## Summary

- prebuild each target, framework, runtime, and publish style immediately before its matching `--no-build` publish
- preserve configured solution-level builds for normal publish plans
- skip only payloads intentionally rebuilt with resolved MSI version properties, so mixed app/CLI plans remain valid
- fail module signing when a certificate is outside its validity period or the resulting signature is not `Valid`

## Why this matters

A versioned MSI target previously suppressed the shared prebuild for every target in the plan. Unrelated self-contained CLI targets then reached `dotnet publish --no-build` without matching single-file/self-contained inputs. Prebuilding several styles before publishing could also let shared intermediates from a later style overwrite an earlier style's inputs. Module signing additionally counted `UnknownError` as success, which could report unsigned release artifacts as signed.

## Validation

- 84 focused publishing and hosted-operation tests pass
- 177 tests matching `DotNetPublish` pass
- a real two-style DesktopManager CLI run proves build/publish interleaving and both executables return help successfully
- the full DesktopManager wrapper produced app, net8/net10 CLI, MSI, NuGet, and release archives
- the expired local signing certificate now stops the module build with a clear validity-period error