### PR TITLE
Resolve dotnet environment paths from the project root

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerEnvironmentTests.cs
@@ -131,6 +131,57 @@ public sealed class DotNetPublishPipelineRunnerEnvironmentTests
     }
 
     [Fact]
+    public void Plan_ResolvesConfiguredEnvironmentPathAgainstProjectRoot()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var projectPath = CreateProject(root);
+            var plan = new DotNetPublishPipelineRunner(new NullLogger()).Plan(
+                new DotNetPublishSpec
+                {
+                    Profile = "msi",
+                    Profiles = new[]
+                    {
+                        new DotNetPublishProfile
+                        {
+                            Name = "msi",
+                            Default = true,
+                            Targets = new[] { "app" },
+                            Runtimes = new[] { "win-x64" }
+                        }
+                    },
+                    DotNet = new DotNetPublishDotNetOptions
+                    {
+                        ProjectRoot = root,
+                        Restore = false,
+                        Build = false,
+                        Runtimes = new[] { "win-x64" },
+                        EnvironmentVariables = new Dictionary<string, DotNetPublishEnvironmentVariable>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["NUGET_PACKAGES"] = new()
+                            {
+                                Value = Path.Combine("Artifacts", ".nuget", "packages"),
+                                ResolvePathRelativeToProjectRoot = true,
+                                Secret = false
+                            }
+                        }
+                    },
+                    Targets = new[] { NewTarget(projectPath) }
+                },
+                configPath: null);
+
+            Assert.Equal(
+                Path.GetFullPath(Path.Combine(root, "Artifacts", ".nuget", "packages")),
+                plan.EnvironmentVariables["NUGET_PACKAGES"]);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Plan_PreservesTwoArgumentOverloadForBinaryCompatibility()
     {
         var overload = typeof(DotNetPublishPipelineRunner).GetMethod(

--- a/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
+++ b/PowerForge/Models/DotNetPublish/DotNetPublishSpec.cs
@@ -1072,6 +1072,12 @@ public sealed class DotNetPublishEnvironmentVariable
     public bool Required { get; set; }
 
     /// <summary>
+    /// When true, resolves the value as a path relative to the dotnet publish project root.
+    /// Absolute values remain absolute.
+    /// </summary>
+    public bool ResolvePathRelativeToProjectRoot { get; set; }
+
+    /// <summary>
     /// Indicates that the value is sensitive and should not be written to logs.
     /// </summary>
     public bool Secret { get; set; } = true;

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Plan.cs
@@ -560,6 +560,7 @@ public sealed partial class DotNetPublishPipelineRunner
             MsBuildProperties = msbuildProps,
             EnvironmentVariables = ResolveDotNetEnvironmentVariables(
                 spec.DotNet.EnvironmentVariables,
+                projectRoot,
                 enforceRequiredEnvironmentVariables),
             Targets = targets.ToArray(),
             Bundles = bundles,
@@ -731,6 +732,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 FromEnvironmentVariable = value.FromEnvironmentVariable,
                 FromEnvironmentVariables = (value.FromEnvironmentVariables ?? Array.Empty<string>()).ToArray(),
                 Required = value.Required,
+                ResolvePathRelativeToProjectRoot = value.ResolvePathRelativeToProjectRoot,
                 Secret = value.Secret
             };
         }
@@ -740,6 +742,7 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static Dictionary<string, string?> ResolveDotNetEnvironmentVariables(
         Dictionary<string, DotNetPublishEnvironmentVariable>? environmentVariables,
+        string projectRoot,
         bool enforceRequired)
     {
         var resolved = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
@@ -775,6 +778,9 @@ public sealed partial class DotNetPublishPipelineRunner
                     $"Required dotnet environment variable '{targetName}' could not be resolved. " +
                     $"Set one of: {sourceList}.");
             }
+
+            if (value is not null && definition.ResolvePathRelativeToProjectRoot)
+                value = ResolvePath(projectRoot, value);
 
             if (value is not null)
                 resolved[targetName] = value;

--- a/Schemas/powerforge.dotnetpublish.schema.json
+++ b/Schemas/powerforge.dotnetpublish.schema.json
@@ -113,6 +113,7 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "Required": { "type": "boolean" },
+        "ResolvePathRelativeToProjectRoot": { "type": "boolean" },
         "Secret": { "type": "boolean" }
       }
     },


### PR DESCRIPTION
## Summary

- add an opt-in `ResolvePathRelativeToProjectRoot` contract for dotnet publish environment variables
- resolve relative values after profile selection while preserving already-absolute paths
- expose the contract in the PowerForge JSON schema

This lets consumers use repository-scoped NuGet caches without hardcoding machine-specific paths.

## Example

```json
"NUGET_PACKAGES": {
  "Value": "Artifacts/DotNetPublish/.nuget/packages",
  "ResolvePathRelativeToProjectRoot": true,
  "Secret": false
}
```

## Release impact

EvotecIT/GraphEssentialsX#63 consumes this contract. Publish the PowerForge/PSPublishModule release containing this PR before merging that consumer PR.

## Validation

- `PowerForge.Tests`: 4,075/4,075 passed
- focused environment resolution tests: 5/5 passed
- focused restore argument contract: 1/1 passed