### PR TITLE
Defer publish secrets until the publish gate

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,5 +1,8 @@
 [CmdletBinding()]
 param(
+    [Alias('ConfigurationGateMode')]
+    [ValidateSet('Manifest', 'Documentation', 'Build', 'Publish')]
+    [string] $RunMode = 'Build',
     [ValidateSet('auto', 'net10.0', 'net8.0')][string] $Framework = 'auto',
     [ValidateSet('Release', 'Debug')][string] $Configuration = 'Release',
     [switch] $NoBuild,
@@ -17,6 +20,7 @@ if ($PSBoundParameters.ContainsKey('JsonPath')) {
 }
 
 $invoke = @{
+    RunMode        = $RunMode
     Framework      = $Framework
     Configuration  = $Configuration
 }

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -18,8 +18,9 @@
     [switch] $SignIncludeExe,
     [switch] $NoInteractive,
     [switch] $NoExitCode,
+    [Alias('ConfigurationGateMode')]
     [ValidateSet('Manifest', 'Documentation', 'Build', 'Publish')]
-    [string] $RunMode,
+    [string] $RunMode = 'Build',
     [string] $DiagnosticsBaselinePath,
     [switch] $GenerateDiagnosticsBaseline,
     [switch] $UpdateDiagnosticsBaseline,
@@ -114,7 +115,6 @@ if ($JsonOnly) {
     $buildParams.JsonPath = $JsonPath
 }
 if ($NoInteractive.IsPresent) { $buildParams.NoInteractive = $true }
-if ($PSBoundParameters.ContainsKey('RunMode')) { $buildParams.RunMode = $RunMode }
 if ($PSBoundParameters.ContainsKey('DiagnosticsBaselinePath')) { $buildParams.DiagnosticsBaselinePath = $DiagnosticsBaselinePath }
 if ($PSBoundParameters.ContainsKey('GenerateDiagnosticsBaseline')) { $buildParams.GenerateDiagnosticsBaseline = $GenerateDiagnosticsBaseline.IsPresent }
 if ($PSBoundParameters.ContainsKey('UpdateDiagnosticsBaseline')) { $buildParams.UpdateDiagnosticsBaseline = $UpdateDiagnosticsBaseline.IsPresent }
@@ -256,6 +256,8 @@ Invoke-ModuleBuild @buildParams -Settings {
     No PAT, username, or password should be needed for normal interactive users.
     #>
 
+
+    New-ConfigurationGate -Mode $RunMode
 
     ### FOR TESTING PURPOSES ONLY ###
     ### SHOWING HOW THINGS WORK HERE ###

--- a/Module/Build/Build-ModuleSelf.ps1
+++ b/Module/Build/Build-ModuleSelf.ps1
@@ -2,6 +2,9 @@
 # Builds PowerForge.Cli and runs `powerforge pipeline` using the same configuration as Build-Module.ps1.
 [CmdletBinding()]
 param(
+    [Alias('ConfigurationGateMode')]
+    [ValidateSet('Manifest', 'Documentation', 'Build', 'Publish')]
+    [string] $RunMode = 'Build',
     [ValidateSet('auto', 'net10.0', 'net8.0')][string] $Framework = 'auto',
     [ValidateSet('Release', 'Debug')][string] $Configuration = 'Release',
     [switch] $NoBuild,
@@ -103,6 +106,7 @@ try {
     $buildArgs = @{
         JsonOnly       = $true
         JsonPath       = $configPath
+        RunMode        = $RunMode
         Configuration  = $Configuration
         Framework      = $Framework
         NoDotnetBuild  = $true

--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -56,13 +56,10 @@ internal sealed class PublishConfigurationFactory
             throw new ArgumentException("ApiKey is required when enabling inline-key publish configuration.", nameof(request));
         }
 
-        var shouldResolveApiKeyNow = request.Enabled || string.IsNullOrWhiteSpace(apiKeyFilePathToUse);
         var apiKeyToUse = request.ParameterSetName switch
         {
-            "ApiFromFile" when shouldResolveApiKeyNow && !string.IsNullOrWhiteSpace(apiKeyFilePathToUse) => ReadSingleLineSecretFile(apiKeyFilePathToUse!, nameof(request.FilePath)),
             "ApiFromFile" => string.Empty,
             "AzureArtifacts" => AzureArtifactsApiKeyPlaceholder,
-            "JFrog" when shouldResolveApiKeyNow && !string.IsNullOrWhiteSpace(apiKeyFilePathToUse) => ReadSingleLineSecretFile(apiKeyFilePathToUse!, nameof(request.FilePath)),
             "JFrog" when !string.IsNullOrWhiteSpace(apiKeyFilePathToUse) => string.Empty,
             _ => ValidateSingleLineSecret(request.ApiKey, nameof(PublishConfigurationRequest.ApiKey))
         };

--- a/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
+++ b/PowerForge.Tests/ModulePublisherRepositoryVersionTests.cs
@@ -105,6 +105,29 @@ public sealed class ModulePublisherRepositoryVersionTests
     }
 
     [Fact]
+    public void ResolvePublishApiKey_RejectsDeferredMultilineSecretAtPublishRuntime()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForgeTests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var path = Path.Combine(root.FullName, "gallery.key");
+            File.WriteAllText(path, "first-line" + Environment.NewLine + "second-line");
+
+            var ex = Assert.Throws<ArgumentException>(() => ModulePublisher.ResolvePublishApiKey(
+                new PublishConfiguration { ApiKeyFilePath = path },
+                root.FullName));
+
+            Assert.Contains("multi-line secret", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("single line", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("not a script", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void EnsureVersionIsGreaterThanRepository_UsesUnlistedPowerShellGalleryVersions()
     {
         using var client = new HttpClient(new FakePowerShellGalleryFeedHandler());

--- a/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
+++ b/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
@@ -133,6 +133,22 @@ public sealed class PSPublishModuleManifestContractTests
     }
 
     [Fact]
+    public void Self_build_defaults_to_build_gate_and_forwards_run_mode_once()
+    {
+        var repoRoot = RepoRootLocator.Find();
+        var wrapperScript = File.ReadAllText(Path.Combine(repoRoot, "Build", "Build-Module.ps1"));
+        var selfBuildScript = File.ReadAllText(Path.Combine(repoRoot, "Module", "Build", "Build-ModuleSelf.ps1"));
+        var buildScript = File.ReadAllText(Path.Combine(repoRoot, "Module", "Build", "Build-Module.ps1"));
+
+        Assert.Contains("[string] $RunMode = 'Build'", wrapperScript, StringComparison.Ordinal);
+        Assert.Contains("RunMode        = $RunMode", wrapperScript, StringComparison.Ordinal);
+        Assert.Contains("[string] $RunMode = 'Build'", selfBuildScript, StringComparison.Ordinal);
+        Assert.Contains("RunMode        = $RunMode", selfBuildScript, StringComparison.Ordinal);
+        Assert.Contains("New-ConfigurationGate -Mode $RunMode", buildScript, StringComparison.Ordinal);
+        Assert.DoesNotContain("$buildParams.RunMode", buildScript, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Module_exports_embedded_dependency_cmdlets()
     {
         var repoRoot = RepoRootLocator.Find();

--- a/PowerForge.Tests/PublishConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/PublishConfigurationFactoryTests.cs
@@ -5,31 +5,23 @@ namespace PowerForge.Tests;
 public sealed class PublishConfigurationFactoryTests
 {
     [Fact]
-    public void Create_reads_publish_api_key_from_file()
+    public void Create_defers_enabled_publish_api_key_file_until_publish_runtime()
     {
         var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
-        File.WriteAllText(path, " api-key " + Environment.NewLine);
-        try
-        {
-            var factory = new PublishConfigurationFactory();
+        var factory = new PublishConfigurationFactory();
 
-            var segment = factory.Create(new PublishConfigurationRequest
-            {
-                ParameterSetName = "ApiFromFile",
-                Type = PublishDestination.PowerShellGallery,
-                FilePath = path,
-                Enabled = true
-            });
-
-            Assert.Equal("api-key", segment.Configuration.ApiKey);
-            Assert.Equal(PublishDestination.PowerShellGallery, segment.Configuration.Destination);
-            Assert.True(segment.Configuration.Enabled);
-        }
-        finally
+        var segment = factory.Create(new PublishConfigurationRequest
         {
-            if (File.Exists(path))
-                File.Delete(path);
-        }
+            ParameterSetName = "ApiFromFile",
+            Type = PublishDestination.PowerShellGallery,
+            FilePath = path,
+            Enabled = true
+        });
+
+        Assert.Equal(string.Empty, segment.Configuration.ApiKey);
+        Assert.Equal(path, segment.Configuration.ApiKeyFilePath);
+        Assert.Equal(PublishDestination.PowerShellGallery, segment.Configuration.Destination);
+        Assert.True(segment.Configuration.Enabled);
     }
 
     [Fact]
@@ -176,7 +168,7 @@ public sealed class PublishConfigurationFactoryTests
     }
 
     [Fact]
-    public void Create_rejects_multiline_publish_api_key_file()
+    public void Create_defers_multiline_publish_api_key_validation_until_publish_runtime()
     {
         var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".ps1");
         File.WriteAllText(path, "Write-Host 'not a key'" + Environment.NewLine + "Write-Host 'still not a key'");
@@ -184,17 +176,16 @@ public sealed class PublishConfigurationFactoryTests
         {
             var factory = new PublishConfigurationFactory();
 
-            var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+            var segment = factory.Create(new PublishConfigurationRequest
             {
                 ParameterSetName = "ApiFromFile",
                 Type = PublishDestination.PowerShellGallery,
                 FilePath = path,
                 Enabled = true
-            }));
+            });
 
-            Assert.Contains("multi-line secret", ex.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("single line", ex.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("not a script", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(string.Empty, segment.Configuration.ApiKey);
+            Assert.Equal(path, segment.Configuration.ApiKeyFilePath);
         }
         finally
         {
@@ -344,7 +335,8 @@ public sealed class PublishConfigurationFactoryTests
                 Enabled = true
             });
 
-            Assert.Equal("pat", segment.Configuration.ApiKey);
+            Assert.Equal(string.Empty, segment.Configuration.ApiKey);
+            Assert.Equal(secretPath, segment.Configuration.ApiKeyFilePath);
             Assert.Equal("JFrogPS", segment.Configuration.RepositoryName);
 
             var repository = Assert.IsType<PublishRepositoryConfiguration>(segment.Configuration.Repository);


### PR DESCRIPTION
## Summary

- defer `-FilePath` API-key reads until the publisher actually runs
- default the PSPublishModule self-build to an explicit `Build` gate and forward an opt-in `Publish` mode through both wrappers
- keep multiline-secret validation at the publish boundary

## Why

The post-3.0.60 build recipe enables PSGallery and GitHub destinations with maintainer-local secret paths. CI was resolving those files while creating configuration, before its build gate could suppress publication, so Windows, Linux, and macOS failed before tests. A normal local build on a maintainer machine could also publish simply because the files existed.

With this change, ordinary builds package and validate but cannot publish. Publication requires `-RunMode Publish` (or the `-ConfigurationGateMode Publish` alias), and secret files are read only when that publish phase executes.

## Release state

PSPublishModule 3.0.61 was produced while validating this corrected working tree. Merge this PR before another publication so repository source, CI, and future packages all carry the same gate behavior.

## Validation

- focused publish/gate contracts: 58/58
- full PowerForge suite: 4,073/4,076, with the three unrelated timing/temp failures passing 3/3 on exact rerun
- generated pipeline: one `Build` gate, two deferred secret paths, zero embedded API keys
- real self-build completed with `Publish: Disabled` and `Gate mode Build enabled: skipping publish phase`