### PR TITLE
Add generic Linux deployment target for PowerForge.Web

### DIFF
--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -81,6 +81,38 @@ on:
         required: false
         type: boolean
         default: false
+      deployment_target:
+        required: false
+        type: string
+        default: "github-pages"
+      deployment_site:
+        required: false
+        type: string
+        default: ""
+      deployment_host:
+        required: false
+        type: string
+        default: ""
+      deployment_user:
+        required: false
+        type: string
+        default: "powerforge-deploy"
+      deployment_port:
+        required: false
+        type: number
+        default: 22
+      deployment_environment:
+        required: false
+        type: string
+        default: "production"
+      deployment_url:
+        required: false
+        type: string
+        default: ""
+      publisher_runner_labels_json:
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
     secrets:
       indexnow_key:
         required: false
@@ -90,13 +122,15 @@ on:
         required: false
       cloudflare_zone_id:
         required: false
+      deployment_ssh_private_key:
+        required: false
+      deployment_ssh_known_hosts:
+        required: false
 
 permissions:
   actions: write
   contents: read
   packages: read
-  pages: write
-  id-token: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -119,10 +153,15 @@ jobs:
       - name: Validate deploy guardrails
         shell: pwsh
         env:
+          DEPLOYMENT_TARGET: ${{ inputs.deployment_target }}
           PIPELINE_CONFIG: ${{ inputs.pipeline_config }}
           REQUIRE_SEO_DOCTOR_GUARDRAIL: ${{ inputs.require_seo_doctor_guardrail }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          if ($env:DEPLOYMENT_TARGET -notin @('github-pages', 'linux')) {
+            throw "Unsupported deployment_target '$($env:DEPLOYMENT_TARGET)'. Expected github-pages or linux."
+          }
 
           if ($env:REQUIRE_SEO_DOCTOR_GUARDRAIL -ne 'true') {
             Write-Host 'SEO doctor deploy guardrail disabled for this workflow call.'
@@ -231,8 +270,10 @@ jobs:
       powerforge_web_tag: ${{ inputs.powerforge_web_tag }}
       pipeline_mode: ci
       use_playwright_cache: true
-      upload_pages_artifact: true
+      upload_pages_artifact: ${{ inputs.deployment_target == 'github-pages' }}
       pages_artifact_path: ${{ inputs.site_output_path }}
+      site_artifact_name: ${{ inputs.deployment_target == 'linux' && 'powerforge-site' || '' }}
+      site_artifact_path: ${{ inputs.site_output_path }}
     secrets:
       indexnow_key: ${{ secrets.indexnow_key }}
       repository_read_token: ${{ secrets.repository_read_token }}
@@ -240,6 +281,7 @@ jobs:
       cloudflare_zone_id: ${{ secrets.cloudflare_zone_id }}
 
   deploy:
+    if: ${{ inputs.deployment_target == 'github-pages' }}
     needs: build
     runs-on: ${{ fromJson(inputs.runner_labels_json) }}
     environment:
@@ -253,9 +295,123 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
+  deploy-linux:
+    if: ${{ inputs.deployment_target == 'linux' }}
+    needs: build
+    runs-on: ${{ fromJson(inputs.publisher_runner_labels_json) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    environment:
+      name: ${{ inputs.deployment_environment }}
+      url: ${{ inputs.deployment_url }}
+    steps:
+      - name: Validate Linux deployment inputs
+        shell: pwsh
+        env:
+          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
+          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
+          DEPLOYMENT_SITE: ${{ inputs.deployment_site }}
+          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+          DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
+          DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:DEPLOYMENT_SITE -notmatch '^[a-z0-9][a-z0-9.-]{0,62}$') {
+            throw 'deployment_site must be a lowercase DNS-style site identifier.'
+          }
+          if ($env:DEPLOYMENT_HOST -notmatch '^[A-Za-z0-9][A-Za-z0-9.-]{0,252}$') {
+            throw 'deployment_host must be a DNS name or IPv4 address.'
+          }
+          if ($env:DEPLOYMENT_USER -notmatch '^[a-z_][a-z0-9_-]{0,31}$') {
+            throw 'deployment_user is not a valid Linux account name.'
+          }
+          $port = 0
+          if (-not [int]::TryParse($env:DEPLOYMENT_PORT, [ref] $port) -or $port -lt 1 -or $port -gt 65535) {
+            throw 'deployment_port must be an integer from 1 through 65535.'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:DEPLOYMENT_PRIVATE_KEY)) {
+            throw 'deployment_ssh_private_key is required for Linux deployment.'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:DEPLOYMENT_KNOWN_HOSTS)) {
+            throw 'deployment_ssh_known_hosts is required; host key scanning at deploy time is intentionally disabled.'
+          }
+
+      - name: Download validated site artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: powerforge-site
+          path: ${{ runner.temp }}/powerforge-site
+
+      - name: Create deployment provenance
+        shell: pwsh
+        env:
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          ENGINE_REPOSITORY: ${{ needs.build.outputs.engine_repository }}
+          ENGINE_SHA: ${{ needs.build.outputs.engine_sha }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $artifactPath = Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar'
+          if (-not (Test-Path -LiteralPath $artifactPath -PathType Leaf)) {
+            throw "Downloaded site artifact not found: $artifactPath"
+          }
+          $metadata = [ordered]@{
+            schemaVersion = 1
+            sourceRepository = $env:SOURCE_REPOSITORY
+            sourceSha = $env:SOURCE_SHA
+            engineRepository = $env:ENGINE_REPOSITORY
+            engineSha = $env:ENGINE_SHA
+            workflowRunId = '${{ github.run_id }}'
+            workflowRunAttempt = '${{ github.run_attempt }}'
+            artifactSha256 = (Get-FileHash -LiteralPath $artifactPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            deployedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+          }
+          $metadata | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json') -Encoding utf8NoBOM
+
+      - name: Publish and promote Linux release
+        shell: pwsh
+        env:
+          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
+          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
+          DEPLOYMENT_SITE: ${{ inputs.deployment_site }}
+          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+          DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
+          DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $sshRoot = Join-Path $HOME '.ssh'
+          New-Item -ItemType Directory -Force -Path $sshRoot | Out-Null
+          Set-Content -LiteralPath (Join-Path $sshRoot 'id_ed25519') -Value $env:DEPLOYMENT_PRIVATE_KEY -Encoding utf8NoBOM
+          Set-Content -LiteralPath (Join-Path $sshRoot 'known_hosts') -Value $env:DEPLOYMENT_KNOWN_HOSTS -Encoding utf8NoBOM
+          chmod 700 $sshRoot
+          chmod 600 (Join-Path $sshRoot 'id_ed25519') (Join-Path $sshRoot 'known_hosts')
+
+          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}"
+          $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
+          $sshOptions = @('-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes')
+          $scpArgs = @('-P', $env:DEPLOYMENT_PORT) + $sshOptions + @((Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar'), (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json'), "${target}:${remoteBase}/")
+          ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "install -d -m 0700 '$remoteBase'"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          scp @scpArgs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:DEPLOYMENT_SITE)' --archive '$remoteBase/artifact.tar' --metadata '$remoteBase/deployment.json'"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Cleanup remote staging
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: pwsh
+        env:
+          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
+          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
+          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+        run: |
+          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}"
+          $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -p $env:DEPLOYMENT_PORT $target "rm -rf -- '$remoteBase'"
+
   post-deploy:
-    if: ${{ inputs.post_deploy_pipeline_config != '' }}
-    needs: deploy
+    if: ${{ always() && inputs.post_deploy_pipeline_config != '' && ((inputs.deployment_target == 'github-pages' && needs.deploy.result == 'success') || (inputs.deployment_target == 'linux' && needs.deploy-linux.result == 'success')) }}
+    needs: [deploy, deploy-linux]
     uses: ./.github/workflows/powerforge-website-run.yml
     with:
       website_root: ${{ inputs.website_root }}

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -276,7 +276,7 @@ jobs:
       use_playwright_cache: true
       upload_pages_artifact: ${{ inputs.deployment_target == 'github-pages' }}
       pages_artifact_path: ${{ inputs.site_output_path }}
-      site_artifact_name: ${{ inputs.deployment_target == 'linux' && 'powerforge-site' || '' }}
+      site_artifact_name: ${{ inputs.deployment_target == 'linux' && format('powerforge-site-{0}', inputs.deployment_site) || '' }}
       site_artifact_path: ${{ inputs.site_output_path }}
       site_artifact_retention_days: ${{ inputs.deployment_artifact_retention_days }}
     secrets:
@@ -343,7 +343,7 @@ jobs:
       - name: Download validated site artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: powerforge-site
+          name: ${{ format('powerforge-site-{0}', inputs.deployment_site) }}
           path: ${{ runner.temp }}/powerforge-site
 
       - name: Create deployment provenance
@@ -353,6 +353,10 @@ jobs:
           SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           ENGINE_REPOSITORY: ${{ needs.build.outputs.engine_repository }}
           ENGINE_SHA: ${{ needs.build.outputs.engine_sha }}
+          ENGINE_MODE: ${{ needs.build.outputs.engine_mode }}
+          ENGINE_REF: ${{ needs.build.outputs.engine_ref }}
+          ENGINE_ASSET: ${{ needs.build.outputs.engine_asset }}
+          ENGINE_ASSET_SHA256: ${{ needs.build.outputs.engine_asset_sha256 }}
         run: |
           $ErrorActionPreference = 'Stop'
           $artifactPath = Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar'
@@ -363,12 +367,20 @@ jobs:
             schemaVersion = 1
             sourceRepository = $env:SOURCE_REPOSITORY
             sourceSha = $env:SOURCE_SHA
+            engineMode = $env:ENGINE_MODE
             engineRepository = $env:ENGINE_REPOSITORY
-            engineSha = $env:ENGINE_SHA
+            engineRef = $env:ENGINE_REF
             workflowRunId = '${{ github.run_id }}'
             workflowRunAttempt = '${{ github.run_attempt }}'
             artifactSha256 = (Get-FileHash -LiteralPath $artifactPath -Algorithm SHA256).Hash.ToLowerInvariant()
             deployedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:ENGINE_SHA)) {
+            $metadata.engineSha = $env:ENGINE_SHA
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:ENGINE_ASSET)) {
+            $metadata.engineAsset = $env:ENGINE_ASSET
+            $metadata.engineAssetSha256 = $env:ENGINE_ASSET_SHA256
           }
           $metadata | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json') -Encoding utf8NoBOM
 

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -113,6 +113,10 @@ on:
         required: false
         type: string
         default: '["ubuntu-latest"]'
+      deployment_artifact_retention_days:
+        required: false
+        type: number
+        default: 7
     secrets:
       indexnow_key:
         required: false
@@ -274,6 +278,7 @@ jobs:
       pages_artifact_path: ${{ inputs.site_output_path }}
       site_artifact_name: ${{ inputs.deployment_target == 'linux' && 'powerforge-site' || '' }}
       site_artifact_path: ${{ inputs.site_output_path }}
+      site_artifact_retention_days: ${{ inputs.deployment_artifact_retention_days }}
     secrets:
       indexnow_key: ${{ secrets.indexnow_key }}
       repository_read_token: ${{ secrets.repository_read_token }}
@@ -378,16 +383,18 @@ jobs:
           DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $sshRoot = Join-Path $HOME '.ssh'
+          $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-deployment-ssh'
           New-Item -ItemType Directory -Force -Path $sshRoot | Out-Null
-          Set-Content -LiteralPath (Join-Path $sshRoot 'id_ed25519') -Value $env:DEPLOYMENT_PRIVATE_KEY -Encoding utf8NoBOM
-          Set-Content -LiteralPath (Join-Path $sshRoot 'known_hosts') -Value $env:DEPLOYMENT_KNOWN_HOSTS -Encoding utf8NoBOM
+          $keyPath = Join-Path $sshRoot 'id_ed25519'
+          $knownHostsPath = Join-Path $sshRoot 'known_hosts'
+          Set-Content -LiteralPath $keyPath -Value $env:DEPLOYMENT_PRIVATE_KEY -Encoding utf8NoBOM
+          Set-Content -LiteralPath $knownHostsPath -Value $env:DEPLOYMENT_KNOWN_HOSTS -Encoding utf8NoBOM
           chmod 700 $sshRoot
-          chmod 600 (Join-Path $sshRoot 'id_ed25519') (Join-Path $sshRoot 'known_hosts')
+          chmod 600 $keyPath $knownHostsPath
 
           $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}"
           $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
-          $sshOptions = @('-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes')
+          $sshOptions = @('-i', $keyPath, '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes', '-o', "UserKnownHostsFile=$knownHostsPath")
           $scpArgs = @('-P', $env:DEPLOYMENT_PORT) + $sshOptions + @((Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar'), (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json'), "${target}:${remoteBase}/")
           ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "install -d -m 0700 '$remoteBase'"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -396,7 +403,7 @@ jobs:
           ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:DEPLOYMENT_SITE)' --archive '$remoteBase/artifact.tar' --metadata '$remoteBase/deployment.json'"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Cleanup remote staging
+      - name: Cleanup deployment credentials and remote staging
         if: ${{ always() }}
         continue-on-error: true
         shell: pwsh
@@ -405,9 +412,20 @@ jobs:
           DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
           DEPLOYMENT_USER: ${{ inputs.deployment_user }}
         run: |
+          $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-deployment-ssh'
+          $keyPath = Join-Path $sshRoot 'id_ed25519'
+          $knownHostsPath = Join-Path $sshRoot 'known_hosts'
           $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}"
           $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
-          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -p $env:DEPLOYMENT_PORT $target "rm -rf -- '$remoteBase'"
+          try {
+            if ((Test-Path -LiteralPath $keyPath) -and (Test-Path -LiteralPath $knownHostsPath)) {
+              ssh -i $keyPath -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$knownHostsPath" -p $env:DEPLOYMENT_PORT $target "rm -rf -- '$remoteBase'"
+            }
+          } finally {
+            if (Test-Path -LiteralPath $sshRoot) {
+              Remove-Item -LiteralPath $sshRoot -Recurse -Force
+            }
+          }
 
   post-deploy:
     if: ${{ always() && inputs.post_deploy_pipeline_config != '' && ((inputs.deployment_target == 'github-pages' && needs.deploy.result == 'success') || (inputs.deployment_target == 'linux' && needs.deploy-linux.result == 'success')) }}

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -404,7 +404,7 @@ jobs:
           chmod 700 $sshRoot
           chmod 600 $keyPath $knownHostsPath
 
-          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}"
+          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}-$($env:DEPLOYMENT_SITE)"
           $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
           $sshOptions = @('-i', $keyPath, '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes', '-o', "UserKnownHostsFile=$knownHostsPath")
           $scpArgs = @('-P', $env:DEPLOYMENT_PORT) + $sshOptions + @((Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar'), (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json'), "${target}:${remoteBase}/")
@@ -427,7 +427,7 @@ jobs:
           $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-deployment-ssh'
           $keyPath = Join-Path $sshRoot 'id_ed25519'
           $knownHostsPath = Join-Path $sshRoot 'known_hosts'
-          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}"
+          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.deployment_site }}"
           $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
           try {
             if ((Test-Path -LiteralPath $keyPath) -and (Test-Path -LiteralPath $knownHostsPath)) {

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -2,6 +2,13 @@ name: PowerForge Website Run
 
 on:
   workflow_call:
+    outputs:
+      engine_repository:
+        description: Repository used to build the website.
+        value: ${{ jobs.website-run.outputs.engine_repository }}
+      engine_sha:
+        description: Exact PowerForge commit used to build the website.
+        value: ${{ jobs.website-run.outputs.engine_sha }}
     inputs:
       website_root:
         required: true
@@ -81,6 +88,14 @@ on:
         required: false
         type: string
         default: ""
+      site_artifact_name:
+        required: false
+        type: string
+        default: ""
+      site_artifact_path:
+        required: false
+        type: string
+        default: ""
     secrets:
       indexnow_key:
         required: false
@@ -96,6 +111,9 @@ env:
 
 jobs:
   website-run:
+    outputs:
+      engine_repository: ${{ steps.workflow_source.outputs.repository }}
+      engine_sha: ${{ steps.engine_commit.outputs.sha }}
     runs-on: ${{ fromJson(inputs.runner_labels_json) }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
@@ -150,6 +168,16 @@ jobs:
           path: ./.powerforge-runner
           token: ${{ github.token }}
           fetch-depth: 1
+
+      - name: Resolve exact PowerForge commit
+        id: engine_commit
+        shell: pwsh
+        run: |
+          $sha = (git -C ./.powerforge-runner rev-parse HEAD).Trim()
+          if ($sha -notmatch '^[0-9a-f]{40}$') {
+            throw "Unable to resolve exact PowerForge commit: $sha"
+          }
+          "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
@@ -227,8 +255,8 @@ jobs:
             ./${{ inputs.website_root }}/_site/_reports/**
           if-no-files-found: ignore
 
-      - name: Cleanup transient tool caches before Pages artifact
-        if: ${{ inputs.upload_pages_artifact || inputs.validate_pages_artifact }}
+      - name: Cleanup transient tool caches before site artifact
+        if: ${{ inputs.upload_pages_artifact || inputs.validate_pages_artifact || inputs.site_artifact_name != '' }}
         shell: pwsh
         run: |
           $cacheRoot = [System.IO.Path]::GetFullPath($env:POWERFORGE_RUNNER_CACHE_ROOT)
@@ -238,55 +266,55 @@ jobs:
             Remove-Item -LiteralPath $cacheRoot -Recurse -Force
           }
 
-      - name: Archive Pages artifact
-        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact) && runner.os == 'Linux' }}
+      - name: Archive site artifact
+        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact || inputs.site_artifact_name != '') && runner.os == 'Linux' }}
         shell: sh
         env:
-          PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
+          SITE_ARTIFACT_PATH: ${{ inputs.site_artifact_path || inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
         run: |
-          echo "::group::Archive Pages artifact"
+          echo "::group::Archive site artifact"
           tar \
             --dereference --hard-dereference \
-            --directory "$PAGES_ARTIFACT_PATH" \
+            --directory "$SITE_ARTIFACT_PATH" \
             -cf "$RUNNER_TEMP/artifact.tar" \
             --exclude=.git \
             --exclude=.github \
             .
           echo "::endgroup::"
 
-      - name: Archive Pages artifact
-        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact) && runner.os == 'macOS' }}
+      - name: Archive site artifact
+        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact || inputs.site_artifact_name != '') && runner.os == 'macOS' }}
         shell: sh
         env:
-          PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
+          SITE_ARTIFACT_PATH: ${{ inputs.site_artifact_path || inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
         run: |
-          echo "::group::Archive Pages artifact"
+          echo "::group::Archive site artifact"
           gtar \
             --dereference --hard-dereference \
-            --directory "$PAGES_ARTIFACT_PATH" \
+            --directory "$SITE_ARTIFACT_PATH" \
             -cf "$RUNNER_TEMP/artifact.tar" \
             --exclude=.git \
             --exclude=.github \
             .
           echo "::endgroup::"
 
-      - name: Archive Pages artifact
-        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact) && runner.os == 'Windows' }}
+      - name: Archive site artifact
+        if: ${{ (inputs.upload_pages_artifact || inputs.validate_pages_artifact || inputs.site_artifact_name != '') && runner.os == 'Windows' }}
         shell: pwsh
         env:
-          PAGES_ARTIFACT_PATH: ${{ inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
+          SITE_ARTIFACT_PATH: ${{ inputs.site_artifact_path || inputs.pages_artifact_path || format('./{0}/_site', inputs.website_root) }}
         run: |
-          Write-Host "::group::Archive Pages artifact"
-          $resolvedArtifactPath = [System.IO.Path]::GetFullPath($env:PAGES_ARTIFACT_PATH)
+          Write-Host "::group::Archive site artifact"
+          $resolvedArtifactPath = [System.IO.Path]::GetFullPath($env:SITE_ARTIFACT_PATH)
           if (-not (Test-Path -LiteralPath $resolvedArtifactPath)) {
-            throw "Pages artifact path not found: $resolvedArtifactPath"
+            throw "Site artifact path not found: $resolvedArtifactPath"
           }
 
           $tempRoot = [System.IO.Path]::GetPathRoot($env:RUNNER_TEMP)
           $freeBytes = ([System.IO.DriveInfo]::new($tempRoot)).AvailableFreeSpace
           $sourceBytes = (Get-ChildItem -LiteralPath $resolvedArtifactPath -Recurse -Force -File | Measure-Object -Property Length -Sum).Sum
           $requiredBytes = [Math]::Max(1GB, [int64]($sourceBytes * 1.1))
-          Write-Host ("Pages artifact source: {0:n0} bytes; runner temp free: {1:n0} bytes; required estimate: {2:n0} bytes" -f $sourceBytes, $freeBytes, $requiredBytes)
+          Write-Host ("Site artifact source: {0:n0} bytes; runner temp free: {1:n0} bytes; required estimate: {2:n0} bytes" -f $sourceBytes, $freeBytes, $requiredBytes)
           if ($freeBytes -lt $requiredBytes) {
             throw "Not enough free space on $tempRoot to archive Pages artifact. Free $freeBytes bytes, estimated need $requiredBytes bytes for $resolvedArtifactPath."
           }
@@ -312,6 +340,15 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload site artifact
+        if: ${{ inputs.site_artifact_name != '' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ inputs.site_artifact_name }}
           path: ${{ runner.temp }}/artifact.tar
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -96,6 +96,10 @@ on:
         required: false
         type: string
         default: ""
+      site_artifact_retention_days:
+        required: false
+        type: number
+        default: 7
     secrets:
       indexnow_key:
         required: false
@@ -350,7 +354,7 @@ jobs:
         with:
           name: ${{ inputs.site_artifact_name }}
           path: ${{ runner.temp }}/artifact.tar
-          retention-days: 1
+          retention-days: ${{ inputs.site_artifact_retention_days }}
           if-no-files-found: error
 
       - name: Cleanup transient tool caches

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -9,6 +9,18 @@ on:
       engine_sha:
         description: Exact PowerForge commit used to build the website.
         value: ${{ jobs.website-run.outputs.engine_sha }}
+      engine_mode:
+        description: Resolved source or binary engine mode.
+        value: ${{ jobs.website-run.outputs.engine_mode }}
+      engine_ref:
+        description: Exact source commit or binary release tag used to build.
+        value: ${{ jobs.website-run.outputs.engine_ref }}
+      engine_asset:
+        description: Binary release asset used to build, when applicable.
+        value: ${{ jobs.website-run.outputs.engine_asset }}
+      engine_asset_sha256:
+        description: Exact binary release asset digest, when applicable.
+        value: ${{ jobs.website-run.outputs.engine_asset_sha256 }}
     inputs:
       website_root:
         required: true
@@ -116,8 +128,12 @@ env:
 jobs:
   website-run:
     outputs:
-      engine_repository: ${{ steps.workflow_source.outputs.repository }}
-      engine_sha: ${{ steps.engine_commit.outputs.sha }}
+      engine_repository: ${{ steps.engine_provenance.outputs.repository }}
+      engine_sha: ${{ steps.engine_provenance.outputs.sha }}
+      engine_mode: ${{ steps.engine_provenance.outputs.mode }}
+      engine_ref: ${{ steps.engine_provenance.outputs.ref }}
+      engine_asset: ${{ steps.engine_provenance.outputs.asset }}
+      engine_asset_sha256: ${{ steps.engine_provenance.outputs.asset_sha256 }}
     runs-on: ${{ fromJson(inputs.runner_labels_json) }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
@@ -173,16 +189,6 @@ jobs:
           token: ${{ github.token }}
           fetch-depth: 1
 
-      - name: Resolve exact PowerForge commit
-        id: engine_commit
-        shell: pwsh
-        run: |
-          $sha = (git -C ./.powerforge-runner rev-parse HEAD).Trim()
-          if ($sha -notmatch '^[0-9a-f]{40}$') {
-            throw "Unable to resolve exact PowerForge commit: $sha"
-          }
-          "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
@@ -226,6 +232,7 @@ jobs:
           POWERFORGE_REPOSITORY_TOKEN: ${{ secrets.repository_read_token }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
+          POWERFORGE_RUNNER_RESULT_PATH: ${{ runner.temp }}/powerforge-website-runner-result.json
         run: |
           $runnerArgs = @(
             'website-runner',
@@ -239,7 +246,8 @@ jobs:
             '--powerforge-repository-override', '${{ inputs.powerforge_repository_override }}',
             '--powerforge-ref-override', '${{ inputs.powerforge_ref_override }}',
             '--powerforge-tool-lock-path', '${{ inputs.powerforge_tool_lock_path }}',
-            '--powerforge-web-tag', '${{ inputs.powerforge_web_tag }}'
+            '--powerforge-web-tag', '${{ inputs.powerforge_web_tag }}',
+            '--result-path', $env:POWERFORGE_RUNNER_RESULT_PATH
           )
 
           if ('${{ inputs.maintenance_mode_note }}' -eq 'true') {
@@ -247,6 +255,56 @@ jobs:
           }
 
           dotnet run --framework net10.0 -p:RestoreLockedMode=false --project ./.powerforge-runner/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -- $runnerArgs
+
+      - name: Resolve actual PowerForge engine provenance
+        id: engine_provenance
+        shell: pwsh
+        env:
+          POWERFORGE_RUNNER_RESULT_PATH: ${{ runner.temp }}/powerforge-website-runner-result.json
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path -LiteralPath $env:POWERFORGE_RUNNER_RESULT_PATH -PathType Leaf)) {
+            throw "Website runner result not found: $($env:POWERFORGE_RUNNER_RESULT_PATH)"
+          }
+          $result = Get-Content -LiteralPath $env:POWERFORGE_RUNNER_RESULT_PATH -Raw | ConvertFrom-Json
+          $mode = [string]$result.engineMode
+          $repository = [string]$result.repository
+          if ($mode -notin @('source', 'binary')) {
+            throw "Website runner returned unsupported engine mode '$mode'."
+          }
+          if ($repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+            throw "Website runner returned invalid engine repository '$repository'."
+          }
+
+          $ref = ''
+          $sha = ''
+          $asset = ''
+          $assetSha256 = ''
+          if ($mode -eq 'source') {
+            $ref = [string]$result.ref
+            if ($ref -notmatch '^[0-9a-fA-F]{40,64}$') {
+              throw "Website runner returned invalid source engine commit '$ref'."
+            }
+            $ref = $ref.ToLowerInvariant()
+            $sha = $ref
+          } else {
+            $ref = [string]$result.tag
+            $asset = [string]$result.asset
+            $assetSha256 = [string]$result.assetSha256
+            if ([string]::IsNullOrWhiteSpace($ref) -or [string]::IsNullOrWhiteSpace($asset)) {
+              throw 'Website runner did not report the binary release tag and asset.'
+            }
+            if ($assetSha256 -notmatch '^[0-9a-f]{64}$') {
+              throw "Website runner returned invalid binary asset SHA-256 '$assetSha256'."
+            }
+          }
+
+          "mode=$mode" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "repository=$repository" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "ref=$ref" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "asset=$asset" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "asset_sha256=$assetSha256" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Upload website reports
         if: always()

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+umask 027
+
+CONFIG_ROOT="${POWERFORGE_SITE_CONFIG_ROOT:-/etc/powerforge/sites}"
+LOCK_ROOT="${POWERFORGE_SITE_LOCK_ROOT:-/var/lock}"
+site=""
+archive=""
+metadata=""
+promoted=0
+previous_target=""
+release_dir=""
+
+log() {
+  printf '[powerforge-site-deploy] %s\n' "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  return 1
+}
+
+usage() {
+  echo 'Usage: powerforge-site-deploy --site <id> --archive <artifact.tar> --metadata <deployment.json>'
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --site)
+      site="${2:-}"
+      shift 2
+      ;;
+    --archive)
+      archive="${2:-}"
+      shift 2
+      ;;
+    --metadata)
+      metadata="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$site" =~ ^[a-z0-9][a-z0-9.-]{0,62}$ ]] || fail 'Invalid site identifier.'
+[[ -n "$archive" && -n "$metadata" ]] || fail 'Both --archive and --metadata are required.'
+
+config_path="${CONFIG_ROOT}/${site}.env"
+[[ -f "$config_path" && ! -L "$config_path" ]] || fail "Site is not configured: $site"
+if [[ "$(id -u)" -eq 0 ]]; then
+  [[ "$(stat -c '%u' "$config_path")" -eq 0 ]] || fail "Site config must be owned by root: $config_path"
+  config_mode="$(stat -c '%a' "$config_path")"
+  (( (8#$config_mode & 0022) == 0 )) || fail "Site config must not be group/world writable: $config_path"
+fi
+
+# The config is trusted, root-owned operator input and contains no values supplied by the workflow.
+# shellcheck disable=SC1090
+source "$config_path"
+
+: "${SITE_ROOT:?SITE_ROOT is required in $config_path}"
+: "${PUBLIC_URL:?PUBLIC_URL is required in $config_path}"
+: "${RELEASES_TO_KEEP:=5}"
+: "${SMOKE_PATHS:=/}"
+: "${CLOUDFLARE_PURGE_ENABLED:=0}"
+: "${ORIGIN_ADDRESS:=}"
+: "${ORIGIN_HOST:=}"
+
+[[ "$SITE_ROOT" == /* && "$SITE_ROOT" != '/' ]] || fail 'SITE_ROOT must be an absolute non-root path.'
+[[ "$SITE_ROOT" != *[[:space:]]* ]] || fail 'SITE_ROOT must not contain whitespace.'
+[[ "$PUBLIC_URL" =~ ^https://[A-Za-z0-9.-]+(:[0-9]+)?$ ]] || fail 'PUBLIC_URL must be an HTTPS origin without a path.'
+[[ "$RELEASES_TO_KEEP" =~ ^[1-9][0-9]*$ ]] || fail 'RELEASES_TO_KEEP must be a positive integer.'
+if [[ -n "$ORIGIN_ADDRESS" || -n "$ORIGIN_HOST" ]]; then
+  [[ -n "$ORIGIN_ADDRESS" && "$ORIGIN_HOST" =~ ^[A-Za-z0-9.-]+$ ]] || fail 'ORIGIN_ADDRESS and ORIGIN_HOST must be configured together.'
+fi
+
+archive="$(realpath -e "$archive")"
+metadata="$(realpath -e "$metadata")"
+[[ -f "$archive" && ! -L "$archive" ]] || fail 'Artifact must be a regular file, not a symlink.'
+[[ -f "$metadata" && ! -L "$metadata" ]] || fail 'Metadata must be a regular file, not a symlink.'
+case "$archive" in
+  /tmp/powerforge-[0-9]*-[0-9]*/artifact.tar) ;;
+  *) fail 'Artifact is outside the workflow staging path.' ;;
+esac
+case "$metadata" in
+  /tmp/powerforge-[0-9]*-[0-9]*/deployment.json) ;;
+  *) fail 'Metadata is outside the workflow staging path.' ;;
+esac
+if [[ -n "${SUDO_UID:-}" ]]; then
+  [[ "$(stat -c '%u' "$archive")" -eq "$SUDO_UID" ]] || fail 'Artifact owner does not match the invoking deployment account.'
+  [[ "$(stat -c '%u' "$metadata")" -eq "$SUDO_UID" ]] || fail 'Metadata owner does not match the invoking deployment account.'
+fi
+
+json_string() {
+  local key="$1"
+  sed -n "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$metadata" | head -n 1
+}
+
+source_sha="$(json_string sourceSha)"
+artifact_sha="$(json_string artifactSha256)"
+run_id="$(json_string workflowRunId)"
+run_attempt="$(json_string workflowRunAttempt)"
+[[ "$source_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] || fail 'Metadata sourceSha is missing or invalid.'
+[[ "$artifact_sha" =~ ^[0-9a-f]{64}$ ]] || fail 'Metadata artifactSha256 is missing or invalid.'
+[[ "$run_id" =~ ^[0-9]+$ && "$run_attempt" =~ ^[0-9]+$ ]] || fail 'Metadata workflow run identity is invalid.'
+actual_artifact_sha="$(sha256sum "$archive" | awk '{print $1}')"
+[[ "$actual_artifact_sha" == "$artifact_sha" ]] || fail 'Artifact checksum does not match deployment metadata.'
+
+while IFS= read -r entry; do
+  stripped="${entry#./}"
+  [[ "$entry" != /* ]] || fail "Archive contains an absolute path: $entry"
+  [[ "/${stripped}/" != *'/../'* ]] || fail "Archive contains path traversal: $entry"
+done < <(tar -tf "$archive")
+
+while IFS= read -r listing; do
+  entry_type="${listing:0:1}"
+  [[ "$entry_type" == '-' || "$entry_type" == 'd' ]] || fail 'Archive contains links or special files.'
+done < <(tar -tvf "$archive")
+
+mkdir -p "$SITE_ROOT/releases"
+mkdir -p "$LOCK_ROOT"
+exec 9>"${LOCK_ROOT}/powerforge-site-${site}.lock"
+flock -n 9 || fail "Another deployment is active for $site."
+
+release_id="$(date -u +%Y%m%d%H%M%S)-${run_id}-${run_attempt}-${source_sha:0:12}"
+release_dir="$SITE_ROOT/releases/$release_id"
+[[ ! -e "$release_dir" ]] || fail "Release already exists: $release_id"
+
+purge_cloudflare() {
+  [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]] || return 0
+  : "${CLOUDFLARE_ZONE_ID:?CLOUDFLARE_ZONE_ID is required when purge is enabled}"
+  : "${CLOUDFLARE_API_TOKEN_FILE:?CLOUDFLARE_API_TOKEN_FILE is required when purge is enabled}"
+  [[ -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'Cloudflare API token file is not readable.'
+  local response
+  response="$(curl -fsS --retry 3 --max-time 30 \
+    -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+    -H "Authorization: Bearer $(<"$CLOUDFLARE_API_TOKEN_FILE")" \
+    -H 'Content-Type: application/json' \
+    --data '{"purge_everything":true}')"
+  grep -Eq '"success"[[:space:]]*:[[:space:]]*true' <<<"$response" || fail 'Cloudflare cache purge was rejected.'
+}
+
+smoke_url() {
+  local base_url="$1"
+  local path="$2"
+  shift 2
+  curl -fsS --retry 3 --retry-all-errors --max-time 30 "$@" "${base_url}${path}?powerforge-deploy=${run_id}-${run_attempt}"
+}
+
+verify_release() {
+  local marker_path='/_powerforge/deployment.json'
+  local public_marker
+  public_marker="$(smoke_url "$PUBLIC_URL" "$marker_path")"
+  grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted source SHA.'
+
+  if [[ -n "$ORIGIN_ADDRESS" ]]; then
+    local origin_marker
+    origin_marker="$(smoke_url "https://${ORIGIN_HOST}" "$marker_path" --resolve "${ORIGIN_HOST}:443:${ORIGIN_ADDRESS}")"
+    grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted source SHA.'
+  fi
+
+  local smoke_path
+  for smoke_path in $SMOKE_PATHS; do
+    [[ "$smoke_path" == /* ]] || fail "Smoke path must begin with '/': $smoke_path"
+    smoke_url "$PUBLIC_URL" "$smoke_path" >/dev/null
+    if [[ -n "$ORIGIN_ADDRESS" ]]; then
+      smoke_url "https://${ORIGIN_HOST}" "$smoke_path" --resolve "${ORIGIN_HOST}:443:${ORIGIN_ADDRESS}" >/dev/null
+    fi
+  done
+}
+
+rollback() {
+  local exit_code="$1"
+  set +e
+  if [[ "$promoted" == '1' ]]; then
+    if [[ -n "$previous_target" && -d "$previous_target" ]]; then
+      log "Deployment failed; rolling back to $previous_target"
+      rollback_link="$SITE_ROOT/.current.rollback.$$"
+      ln -s "$previous_target" "$rollback_link"
+      mv -Tf "$rollback_link" "$SITE_ROOT/current"
+    else
+      log 'Deployment failed; removing the first release from current.'
+      rm -f "$SITE_ROOT/current"
+    fi
+    purge_cloudflare || true
+  fi
+  [[ -z "$release_dir" || ! -d "$release_dir" || "$release_dir" == "$previous_target" ]] || rm -rf "$release_dir"
+  rm -rf "$(dirname "$archive")"
+  exit "$exit_code"
+}
+trap 'rollback $?' ERR INT TERM
+
+mkdir -p "$release_dir"
+tar --extract --file "$archive" --directory "$release_dir" --no-same-owner --no-same-permissions
+[[ -s "$release_dir/index.html" ]] || fail 'Artifact does not contain a non-empty index.html.'
+mkdir -p "$release_dir/_powerforge"
+install -m 0644 "$metadata" "$release_dir/_powerforge/deployment.json"
+
+if [[ -L "$SITE_ROOT/current" ]]; then
+  previous_target="$(readlink -f "$SITE_ROOT/current")"
+fi
+candidate_link="$SITE_ROOT/.current.${run_id}.${run_attempt}"
+ln -s "$release_dir" "$candidate_link"
+mv -Tf "$candidate_link" "$SITE_ROOT/current"
+promoted=1
+
+purge_cloudflare
+verify_release
+
+mapfile -t old_releases < <(find "$SITE_ROOT/releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | awk '{print $2}')
+for ((index=RELEASES_TO_KEEP; index<${#old_releases[@]}; index++)); do
+  [[ "${old_releases[$index]}" == "$release_dir" || "${old_releases[$index]}" == "$previous_target" ]] || rm -rf "${old_releases[$index]}"
+done
+
+trap - ERR INT TERM
+rm -rf "$(dirname "$archive")"
+log "Promoted $site release $release_id from $source_sha"

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-umask 027
+umask 022
 
 CONFIG_ROOT="${POWERFORGE_SITE_CONFIG_ROOT:-/etc/powerforge/sites}"
 LOCK_ROOT="${POWERFORGE_SITE_LOCK_ROOT:-/var/lock}"
@@ -80,6 +80,11 @@ source "$config_path"
 if [[ -n "$ORIGIN_ADDRESS" || -n "$ORIGIN_HOST" ]]; then
   [[ -n "$ORIGIN_ADDRESS" && "$ORIGIN_HOST" =~ ^[A-Za-z0-9.-]+$ ]] || fail 'ORIGIN_ADDRESS and ORIGIN_HOST must be configured together.'
 fi
+if [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]]; then
+  [[ "${CLOUDFLARE_ZONE_ID:-}" =~ ^[A-Za-z0-9]+$ ]] || fail 'CLOUDFLARE_ZONE_ID is required when purge is enabled.'
+  [[ "${CLOUDFLARE_API_TOKEN_FILE:-}" == /* && -s "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'CLOUDFLARE_API_TOKEN_FILE must be an absolute, non-empty readable file when purge is enabled.'
+  [[ -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'Cloudflare API token file is not readable.'
+fi
 
 archive="$(realpath -e "$archive")"
 metadata="$(realpath -e "$metadata")"
@@ -135,9 +140,6 @@ release_dir="$SITE_ROOT/releases/$release_id"
 
 purge_cloudflare() {
   [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]] || return 0
-  : "${CLOUDFLARE_ZONE_ID:?CLOUDFLARE_ZONE_ID is required when purge is enabled}"
-  : "${CLOUDFLARE_API_TOKEN_FILE:?CLOUDFLARE_API_TOKEN_FILE is required when purge is enabled}"
-  [[ -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'Cloudflare API token file is not readable.'
   local response
   response="$(curl -fsS --retry 3 --max-time 30 \
     -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -5,12 +5,22 @@ umask 022
 
 CONFIG_ROOT="${POWERFORGE_SITE_CONFIG_ROOT:-/etc/powerforge/sites}"
 LOCK_ROOT="${POWERFORGE_SITE_LOCK_ROOT:-/var/lock}"
+TRUSTED_STAGE_ROOT="${POWERFORGE_SITE_TRUSTED_STAGE_ROOT:-/var/lib/powerforge/deployment-staging}"
 site=""
 archive=""
 metadata=""
 promoted=0
 previous_target=""
 release_dir=""
+workflow_stage=""
+trusted_stage=""
+
+cleanup_staging() {
+  [[ -z "$workflow_stage" || ! -d "$workflow_stage" ]] || rm -rf -- "$workflow_stage"
+  [[ -z "$trusted_stage" || ! -d "$trusted_stage" ]] || rm -rf -- "$trusted_stage"
+}
+
+trap cleanup_staging EXIT
 
 log() {
   printf '[powerforge-site-deploy] %s\n' "$*"
@@ -75,6 +85,7 @@ source "$config_path"
 
 [[ "$SITE_ROOT" == /* && "$SITE_ROOT" != '/' ]] || fail 'SITE_ROOT must be an absolute non-root path.'
 [[ "$SITE_ROOT" != *[[:space:]]* ]] || fail 'SITE_ROOT must not contain whitespace.'
+[[ "$TRUSTED_STAGE_ROOT" == /* && "$TRUSTED_STAGE_ROOT" != '/' ]] || fail 'Trusted staging root must be an absolute non-root path.'
 [[ "$PUBLIC_URL" =~ ^https://[A-Za-z0-9.-]+(:[0-9]+)?$ ]] || fail 'PUBLIC_URL must be an HTTPS origin without a path.'
 [[ "$RELEASES_TO_KEEP" =~ ^[1-9][0-9]*$ ]] || fail 'RELEASES_TO_KEEP must be a positive integer.'
 if [[ -n "$ORIGIN_ADDRESS" || -n "$ORIGIN_HOST" ]]; then
@@ -102,6 +113,15 @@ if [[ -n "${SUDO_UID:-}" ]]; then
   [[ "$(stat -c '%u' "$archive")" -eq "$SUDO_UID" ]] || fail 'Artifact owner does not match the invoking deployment account.'
   [[ "$(stat -c '%u' "$metadata")" -eq "$SUDO_UID" ]] || fail 'Metadata owner does not match the invoking deployment account.'
 fi
+
+workflow_stage="$(dirname "$archive")"
+install -d -m 0700 "$TRUSTED_STAGE_ROOT"
+trusted_stage="$(mktemp -d "${TRUSTED_STAGE_ROOT}/${site}.XXXXXXXX")"
+chmod 0700 "$trusted_stage"
+install -m 0600 "$archive" "$trusted_stage/artifact.tar"
+install -m 0600 "$metadata" "$trusted_stage/deployment.json"
+archive="$trusted_stage/artifact.tar"
+metadata="$trusted_stage/deployment.json"
 
 json_string() {
   local key="$1"
@@ -194,7 +214,6 @@ rollback() {
     purge_cloudflare || true
   fi
   [[ -z "$release_dir" || ! -d "$release_dir" || "$release_dir" == "$previous_target" ]] || rm -rf "$release_dir"
-  rm -rf "$(dirname "$archive")"
   exit "$exit_code"
 }
 trap 'rollback $?' ERR INT TERM
@@ -222,5 +241,6 @@ for ((index=RELEASES_TO_KEEP; index<${#old_releases[@]}; index++)); do
 done
 
 trap - ERR INT TERM
-rm -rf "$(dirname "$archive")"
+cleanup_staging
+trap - EXIT
 log "Promoted $site release $release_id from $source_sha"

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -101,20 +101,16 @@ archive="$(realpath -e "$archive")"
 metadata="$(realpath -e "$metadata")"
 [[ -f "$archive" && ! -L "$archive" ]] || fail 'Artifact must be a regular file, not a symlink.'
 [[ -f "$metadata" && ! -L "$metadata" ]] || fail 'Metadata must be a regular file, not a symlink.'
-case "$archive" in
-  /tmp/powerforge-[0-9]*-[0-9]*/artifact.tar) ;;
-  *) fail 'Artifact is outside the workflow staging path.' ;;
-esac
-case "$metadata" in
-  /tmp/powerforge-[0-9]*-[0-9]*/deployment.json) ;;
-  *) fail 'Metadata is outside the workflow staging path.' ;;
-esac
+workflow_stage="$(dirname "$archive")"
+[[ "$workflow_stage" =~ ^/tmp/powerforge-([0-9]+)-([0-9]+)-([a-z0-9][a-z0-9.-]{0,62})$ ]] || fail 'Artifact is outside the workflow staging path.'
+[[ "${BASH_REMATCH[3]}" == "$site" ]] || fail 'Artifact staging site does not match the configured site.'
+[[ "$archive" == "$workflow_stage/artifact.tar" ]] || fail 'Artifact filename is invalid.'
+[[ "$metadata" == "$workflow_stage/deployment.json" ]] || fail 'Metadata must share the artifact workflow staging directory.'
 if [[ -n "${SUDO_UID:-}" ]]; then
   [[ "$(stat -c '%u' "$archive")" -eq "$SUDO_UID" ]] || fail 'Artifact owner does not match the invoking deployment account.'
   [[ "$(stat -c '%u' "$metadata")" -eq "$SUDO_UID" ]] || fail 'Metadata owner does not match the invoking deployment account.'
 fi
 
-workflow_stage="$(dirname "$archive")"
 install -d -m 0700 "$TRUSTED_STAGE_ROOT"
 trusted_stage="$(mktemp -d "${TRUSTED_STAGE_ROOT}/${site}.XXXXXXXX")"
 chmod 0700 "$trusted_stage"
@@ -181,11 +177,17 @@ verify_release() {
   local public_marker
   public_marker="$(smoke_url "$PUBLIC_URL" "$marker_path")"
   grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted source SHA.'
+  grep -Eq "\"artifactSha256\"[[:space:]]*:[[:space:]]*\"${artifact_sha}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted artifact.'
+  grep -Eq "\"workflowRunId\"[[:space:]]*:[[:space:]]*\"${run_id}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted workflow run.'
+  grep -Eq "\"workflowRunAttempt\"[[:space:]]*:[[:space:]]*\"${run_attempt}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted workflow attempt.'
 
   if [[ -n "$ORIGIN_ADDRESS" ]]; then
     local origin_marker
     origin_marker="$(smoke_url "https://${ORIGIN_HOST}" "$marker_path" --resolve "${ORIGIN_HOST}:443:${ORIGIN_ADDRESS}")"
     grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted source SHA.'
+    grep -Eq "\"artifactSha256\"[[:space:]]*:[[:space:]]*\"${artifact_sha}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted artifact.'
+    grep -Eq "\"workflowRunId\"[[:space:]]*:[[:space:]]*\"${run_id}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted workflow run.'
+    grep -Eq "\"workflowRunAttempt\"[[:space:]]*:[[:space:]]*\"${run_attempt}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted workflow attempt.'
   fi
 
   local smoke_path

--- a/Deployment/Linux/powerforge-site.env.example
+++ b/Deployment/Linux/powerforge-site.env.example
@@ -1,0 +1,15 @@
+# Install as /etc/powerforge/sites/example.env with root ownership and mode 0640.
+SITE_ROOT=/var/www/example/site
+PUBLIC_URL=https://example.com
+
+# Verify the Apache origin directly while preserving TLS SNI and the Host header.
+ORIGIN_HOST=example.com
+ORIGIN_ADDRESS=127.0.0.1
+
+RELEASES_TO_KEEP=5
+SMOKE_PATHS="/ /sitemap.xml"
+
+# Cloudflare remains proxied. The token file is local server state, not a workflow secret.
+CLOUDFLARE_PURGE_ENABLED=1
+CLOUDFLARE_ZONE_ID=replace-with-zone-id
+CLOUDFLARE_API_TOKEN_FILE=/etc/powerforge/secrets/cloudflare-cache-purge.token

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -7,22 +7,78 @@ This pattern is the reusable baseline for static PowerForge.Web sites hosted on 
 ## Goals
 
 - Build deploy artifacts from a clean checkout.
+- Build on the runner required by each website instead of assuming the web host can build it.
 - Publish each deploy into a timestamped release directory.
 - Promote the release by moving a `current` symlink.
+- Record the exact source commit, PowerForge commit, workflow run, and artifact checksum.
+- Roll back automatically when origin or public smoke checks fail.
 - Keep generated web-server redirect artifacts in sync.
-- Run cheap hourly change checks without rebuilding when nothing changed.
 - Keep provider-specific cache purges in environment variables, not in repo files.
 
-## Repository Flow
+## CI Artifact Flow (Recommended)
 
-Use one website checkout and, when developing against a local engine checkout, one engine checkout:
+Use `.github/workflows/powerforge-website-deploy.yml` with `deployment_target: linux`.
+The build still runs on `runner_labels_json`, so Windows-only and Linux-compatible
+sites use the same publication contract without moving their toolchains onto the web
+server.
+
+```yaml
+jobs:
+  website:
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@<full-commit-sha>
+    with:
+      website_root: Website
+      pipeline_config: Website/pipeline.json
+      deployment_target: linux
+      deployment_site: example.com
+      deployment_host: deploy.example.com
+      deployment_url: https://example.com
+    secrets:
+      deployment_ssh_private_key: ${{ secrets.WEBSITE_DEPLOY_SSH_PRIVATE_KEY }}
+      deployment_ssh_known_hosts: ${{ secrets.WEBSITE_DEPLOY_SSH_KNOWN_HOSTS }}
+```
+
+The workflow:
+
+1. runs the normal PowerForge CI pipeline and quality guardrails
+2. archives the validated `_site` output on its native build runner
+3. records exact source and engine SHAs plus the artifact SHA-256
+4. transfers the artifact through a pinned SSH host key
+5. invokes the root-owned server promoter for an allowlisted site id
+
+Install `Deployment/Linux/powerforge-site-deploy.sh` as
+`/usr/local/sbin/powerforge-site-deploy`. Install one root-owned configuration from
+`Deployment/Linux/powerforge-site.env.example` under
+`/etc/powerforge/sites/<site>.env`. The workflow cannot provide release roots,
+Cloudflare credentials, origin addresses, or smoke policy; those remain trusted host
+configuration.
+
+Give each repository a separate deployment key and a protected GitHub environment.
+Restrict its server account/sudo rule to the expected site argument. Do not share one
+unrestricted deployment key across every repository.
+
+The promoter rejects path traversal, links, special files, checksum mismatches,
+unconfigured site ids, mutable site configuration, and workflow staging files owned
+by another account. It atomically promotes a timestamped release, purges Cloudflare
+without disabling proxying, verifies the exact source SHA through both the origin and
+public URL, and rolls back the symlink if any check fails.
+
+## Host Build Flow (Special Case)
+
+Some sites intentionally regenerate from changing external inputs even when Git has
+not changed. Those sites may retain a host-side daily rebuild as a safety lane. Use
+one website checkout and one engine checkout:
 
 ```text
 /srv/example/Website
 /srv/example/PSPublishModule
 ```
 
-The deploy script should fetch both repositories, reset them to configured branches, and compare the current commits with the last successful deploy metadata. If both commits are unchanged and `DEPLOY_ONLY_ON_CHANGE=1`, exit successfully without running the pipeline.
+The deploy script should fetch both repositories, reset them to configured branches,
+and compare current commits with the last successful metadata. It must install every
+runtime dependency required by the strict pipeline, including the configured
+Playwright browser. Prefer the CI artifact flow for normal commits so host tool drift
+cannot silently stop publication.
 
 Recommended environment variables:
 
@@ -36,12 +92,12 @@ DEPLOY_ONLY_ON_CHANGE=0
 DEPLOY_STATE_ROOT=/srv/example/deploy-state/website
 ```
 
-## Timers
+## Optional Timers
 
 Use two timers:
 
 - Daily full rebuild: catches generated content, external data, feeds, and slow-moving maintenance work.
-- Hourly change rebuild: fetches repositories and deploys only when `Website` or the engine commit changed.
+- Hourly change rebuild: only for sites that intentionally use the host-build flow.
 
 Example change-check service:
 

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -51,6 +51,10 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("POWERFORGE_SITE_TRUSTED_STAGE_ROOT", script, StringComparison.Ordinal);
         Assert.Contains("install -m 0600 \"$archive\"", script, StringComparison.Ordinal);
         Assert.Contains("powerforge-site-{0}", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
+        Assert.Contains("workflowRunAttempt", script, StringComparison.Ordinal);
+        Assert.Contains("artifactSha256", script, StringComparison.Ordinal);
+        Assert.Contains("^/tmp/powerforge-([0-9]+)-([0-9]+)-", script, StringComparison.Ordinal);
+        Assert.Contains("BASH_REMATCH[3]", script, StringComparison.Ordinal);
     }
 
     private static string ReadRepoFile(params string[] relativePath)

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -1,0 +1,58 @@
+namespace PowerForge.Tests;
+
+public sealed class GitHubWebsiteLinuxDeployWorkflowTests
+{
+    [Fact]
+    public void DeployWorkflow_ShouldKeepPagesDefaultAndExposeLinuxTarget()
+    {
+        var workflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
+
+        Assert.Contains("default: \"github-pages\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_target == 'linux'", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_site", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_ssh_private_key", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_ssh_known_hosts", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssh-keyscan", workflow, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DeployWorkflow_ShouldPublishExactProvenance()
+    {
+        var deployWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
+        var runWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-run.yml");
+
+        Assert.Contains("git -C ./.powerforge-runner rev-parse HEAD", runWorkflow, StringComparison.Ordinal);
+        Assert.Contains("sourceSha", deployWorkflow, StringComparison.Ordinal);
+        Assert.Contains("engineSha", deployWorkflow, StringComparison.Ordinal);
+        Assert.Contains("artifactSha256", deployWorkflow, StringComparison.Ordinal);
+        Assert.Contains("workflowRunAttempt", deployWorkflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LinuxPromoter_ShouldProtectPromotionAndRollbackContracts()
+    {
+        var script = ReadRepoFile("Deployment", "Linux", "powerforge-site-deploy.sh");
+
+        Assert.Contains("/etc/powerforge/sites", script, StringComparison.Ordinal);
+        Assert.Contains("Artifact checksum does not match", script, StringComparison.Ordinal);
+        Assert.Contains("Archive contains path traversal", script, StringComparison.Ordinal);
+        Assert.Contains("purge_cloudflare", script, StringComparison.Ordinal);
+        Assert.Contains("Public endpoint did not serve", script, StringComparison.Ordinal);
+        Assert.Contains("Origin endpoint did not serve", script, StringComparison.Ordinal);
+        Assert.Contains("rolling back", script, StringComparison.Ordinal);
+        Assert.Contains("mv -Tf", script, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && current is not null; i++)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return File.ReadAllText(Path.Combine([current.FullName, .. relativePath]));
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+}

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -13,6 +13,9 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("deployment_ssh_private_key", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment_ssh_known_hosts", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("ssh-keyscan", workflow, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("deployment_artifact_retention_days", workflow, StringComparison.Ordinal);
+        Assert.Contains("$env:RUNNER_TEMP 'powerforge-deployment-ssh'", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("Join-Path $HOME '.ssh'", workflow, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -41,6 +44,8 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("Origin endpoint did not serve", script, StringComparison.Ordinal);
         Assert.Contains("rolling back", script, StringComparison.Ordinal);
         Assert.Contains("mv -Tf", script, StringComparison.Ordinal);
+        Assert.Contains("umask 022", script, StringComparison.Ordinal);
+        Assert.Contains("CLOUDFLARE_ZONE_ID is required", script, StringComparison.Ordinal);
     }
 
     private static string ReadRepoFile(params string[] relativePath)

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -24,7 +24,9 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         var deployWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
         var runWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-run.yml");
 
-        Assert.Contains("git -C ./.powerforge-runner rev-parse HEAD", runWorkflow, StringComparison.Ordinal);
+        Assert.Contains("--result-path", runWorkflow, StringComparison.Ordinal);
+        Assert.Contains("Resolve actual PowerForge engine provenance", runWorkflow, StringComparison.Ordinal);
+        Assert.Contains("assetSha256", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("sourceSha", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("engineSha", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("artifactSha256", deployWorkflow, StringComparison.Ordinal);
@@ -46,6 +48,9 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("mv -Tf", script, StringComparison.Ordinal);
         Assert.Contains("umask 022", script, StringComparison.Ordinal);
         Assert.Contains("CLOUDFLARE_ZONE_ID is required", script, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_SITE_TRUSTED_STAGE_ROOT", script, StringComparison.Ordinal);
+        Assert.Contains("install -m 0600 \"$archive\"", script, StringComparison.Ordinal);
+        Assert.Contains("powerforge-site-{0}", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
     }
 
     private static string ReadRepoFile(params string[] relativePath)

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -110,7 +110,7 @@ public sealed class GitHubWebsiteRunWorkflowTests
         var workflowYaml = File.ReadAllText(workflowPath);
 
         Assert.Contains("Initialize transient tool cache directories", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("Cleanup transient tool caches before Pages artifact", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("Cleanup transient tool caches before site artifact", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("Cleanup transient tool caches", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("GetFullPath($env:POWERFORGE_RUNNER_CACHE_ROOT)", workflowYaml, StringComparison.Ordinal);
         Assert.Contains("GetFullPath($env:GITHUB_WORKSPACE)", workflowYaml, StringComparison.Ordinal);

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.WebsiteRunnerCommands.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.WebsiteRunnerCommands.cs
@@ -41,6 +41,18 @@ internal static partial class WebCliCommandHandlers
                 outputJson ? null : Console.WriteLine,
                 outputJson ? null : Console.Error.WriteLine);
 
+            var resultPath = TryGetOptionValue(subArgs, "--result-path") ?? TryGetOptionValue(subArgs, "--resultPath");
+            if (!string.IsNullOrWhiteSpace(resultPath))
+            {
+                var resolvedResultPath = Path.GetFullPath(resultPath);
+                var resultDirectory = Path.GetDirectoryName(resolvedResultPath);
+                if (!string.IsNullOrWhiteSpace(resultDirectory))
+                    Directory.CreateDirectory(resultDirectory);
+                File.WriteAllText(
+                    resolvedResultPath,
+                    WebCliJson.SerializeToElement(result, WebCliJson.Context.WebWebsiteRunnerResult).GetRawText());
+            }
+
             if (outputJson)
             {
                 WebCliJsonWriter.Write(new WebCliJsonEnvelope

--- a/PowerForge.Web/Models/WebWebsiteRunnerResult.cs
+++ b/PowerForge.Web/Models/WebWebsiteRunnerResult.cs
@@ -27,6 +27,9 @@ public sealed class WebWebsiteRunnerResult
     /// <summary>Resolved release asset when binary mode is used.</summary>
     public string? Asset { get; set; }
 
+    /// <summary>SHA-256 of the downloaded release asset when binary mode is used.</summary>
+    public string? AssetSha256 { get; set; }
+
     /// <summary>Resolved executable or project path used to launch the pipeline.</summary>
     public string LaunchedPath { get; set; } = string.Empty;
 }

--- a/PowerForge.Web/Services/WebWebsiteRunner.cs
+++ b/PowerForge.Web/Services/WebWebsiteRunner.cs
@@ -177,6 +177,7 @@ public static class WebWebsiteRunner
         var assetPath = Path.Combine(sessionRoot, resolvedAsset.Name);
         DownloadFile(resolvedAsset.DownloadUrl, assetPath, options.GitHubToken);
         VerifySha256IfPresent(assetPath, string.IsNullOrWhiteSpace(toolLock.Sha256) ? resolvedAsset.Sha256 : toolLock.Sha256);
+        var assetSha256 = ComputeSha256(assetPath);
 
         var extractRoot = Path.Combine(sessionRoot, "tool");
         ExtractArchive(assetPath, extractRoot);
@@ -200,6 +201,7 @@ public static class WebWebsiteRunner
             Repository = repository,
             Tag = toolLock.Tag,
             Asset = resolvedAsset.Name,
+            AssetSha256 = assetSha256,
             LaunchedPath = executablePath
         };
     }
@@ -654,6 +656,12 @@ public static class WebWebsiteRunner
         var actual = Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
         if (!actual.Equals(normalizedExpected, StringComparison.Ordinal))
             throw new InvalidOperationException($"Downloaded asset SHA-256 mismatch for '{Path.GetFileName(assetPath)}'. Expected {normalizedExpected} but got {actual}.");
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
     }
 
     private static void TryDeleteDirectory(string path)

--- a/Tests/Linux/powerforge-site-deploy.tests.sh
+++ b/Tests/Linux/powerforge-site-deploy.tests.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 deploy_script="$repo_root/Deployment/Linux/powerforge-site-deploy.sh"
 test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root" /tmp/powerforge-91001-1 /tmp/powerforge-91002-1 /tmp/powerforge-91003-1' EXIT
+trap 'rm -rf "$test_root" /tmp/powerforge-91001-1 /tmp/powerforge-91002-1 /tmp/powerforge-91003-1 /tmp/powerforge-91004-1' EXIT
 
 mkdir -p "$test_root/config" "$test_root/locks" "$test_root/site" "$test_root/bin"
 cat >"$test_root/config/example.env" <<EOF
@@ -64,6 +64,8 @@ env \
 
 grep -Fq 'release-one' "$test_root/site/current/index.html"
 grep -Fq "$sha_one" "$test_root/site/current/_powerforge/deployment.json"
+[[ "$(stat -L -c '%a' "$test_root/site/current")" == '755' ]]
+[[ "$(stat -c '%a' "$test_root/site/current/index.html")" == '644' ]]
 first_release="$(readlink -f "$test_root/site/current")"
 
 create_deployment 91002 "$sha_two" 'release-two'
@@ -109,5 +111,23 @@ if find "$test_root/first-site/releases" -mindepth 1 -maxdepth 1 -type d | grep 
   echo 'Failed first release was not removed.' >&2
   exit 1
 fi
+
+mkdir -p "$test_root/cloudflare-site"
+cat >"$test_root/config/cloudflare.env" <<EOF
+SITE_ROOT=$test_root/cloudflare-site
+PUBLIC_URL=https://cloudflare.example.test
+CLOUDFLARE_PURGE_ENABLED=1
+EOF
+create_deployment 91004 '4444444444444444444444444444444444444444' 'cloudflare-preflight-failure'
+if env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_SITE_ROOT="$test_root/cloudflare-site" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site cloudflare --archive /tmp/powerforge-91004-1/artifact.tar --metadata /tmp/powerforge-91004-1/deployment.json; then
+  echo 'Expected incomplete Cloudflare configuration to fail preflight.' >&2
+  exit 1
+fi
+[[ ! -e "$test_root/cloudflare-site/current" ]]
 
 echo 'powerforge-site-deploy integration tests passed.'

--- a/Tests/Linux/powerforge-site-deploy.tests.sh
+++ b/Tests/Linux/powerforge-site-deploy.tests.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 deploy_script="$repo_root/Deployment/Linux/powerforge-site-deploy.sh"
 test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root" /tmp/powerforge-91001-1 /tmp/powerforge-91002-1 /tmp/powerforge-91003-1 /tmp/powerforge-91004-1' EXIT
+trap 'rm -rf "$test_root" /tmp/powerforge-91001-1-example /tmp/powerforge-91002-1-example /tmp/powerforge-91003-1-first /tmp/powerforge-91004-1-cloudflare /tmp/powerforge-91007-1-example /tmp/powerforge-91008-1-example /tmp/powerforge-9' EXIT
 
 mkdir -p "$test_root/config" "$test_root/locks" "$test_root/site" "$test_root/bin"
 export POWERFORGE_SITE_TRUSTED_STAGE_ROOT="$test_root/trusted-stage"
@@ -22,6 +22,10 @@ set -e
 if [[ "${FAKE_CURL_FAIL:-0}" == '1' ]]; then
   exit 22
 fi
+if [[ -n "${FAKE_STALE_MARKER:-}" ]]; then
+  cat "$FAKE_STALE_MARKER"
+  exit 0
+fi
 cat "$FAKE_SITE_ROOT/current/_powerforge/deployment.json"
 EOF
 chmod +x "$test_root/bin/curl"
@@ -30,7 +34,8 @@ create_deployment() {
   local run_id="$1"
   local source_sha="$2"
   local body="$3"
-  local staging="/tmp/powerforge-${run_id}-1"
+  local site_id="${4:-example}"
+  local staging="/tmp/powerforge-${run_id}-1-${site_id}"
   local content="$test_root/content-${run_id}"
   mkdir -p "$staging" "$content"
   printf '%s\n' "$body" >"$content/index.html"
@@ -61,7 +66,7 @@ env \
   FAKE_SITE_ROOT="$test_root/site" \
   POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
   POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
-  "$deploy_script" --site example --archive /tmp/powerforge-91001-1/artifact.tar --metadata /tmp/powerforge-91001-1/deployment.json
+  "$deploy_script" --site example --archive /tmp/powerforge-91001-1-example/artifact.tar --metadata /tmp/powerforge-91001-1-example/deployment.json
 
 grep -Fq 'release-one' "$test_root/site/current/index.html"
 grep -Fq "$sha_one" "$test_root/site/current/_powerforge/deployment.json"
@@ -76,7 +81,7 @@ if env \
   FAKE_SITE_ROOT="$test_root/site" \
   POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
   POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
-  "$deploy_script" --site example --archive /tmp/powerforge-91002-1/artifact.tar --metadata /tmp/powerforge-91002-1/deployment.json; then
+  "$deploy_script" --site example --archive /tmp/powerforge-91002-1-example/artifact.tar --metadata /tmp/powerforge-91002-1-example/deployment.json; then
   echo 'Expected failed smoke deployment to return non-zero.' >&2
   exit 1
 fi
@@ -88,6 +93,33 @@ if find "$test_root/site/releases" -mindepth 1 -maxdepth 1 -type d -name '*91002
   exit 1
 fi
 
+create_deployment 91007 "$sha_one" 'same-source-new-artifact'
+if env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_SITE_ROOT="$test_root/site" \
+  FAKE_STALE_MARKER="$first_release/_powerforge/deployment.json" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site example --archive /tmp/powerforge-91007-1-example/artifact.tar --metadata /tmp/powerforge-91007-1-example/deployment.json; then
+  echo 'Expected a cached marker from an older deployment of the same source SHA to fail.' >&2
+  exit 1
+fi
+[[ "$(readlink -f "$test_root/site/current")" == "$first_release" ]]
+
+create_deployment 91008 '8888888888888888888888888888888888888888' 'nested-staging-path'
+mkdir -p /tmp/powerforge-9
+mv /tmp/powerforge-91008-1-example /tmp/powerforge-9/nested-2-example
+if env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_SITE_ROOT="$test_root/site" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site example --archive /tmp/powerforge-9/nested-2-example/artifact.tar --metadata /tmp/powerforge-9/nested-2-example/deployment.json; then
+  echo 'Expected a nested path matching the old shell glob to be rejected.' >&2
+  exit 1
+fi
+[[ "$(readlink -f "$test_root/site/current")" == "$first_release" ]]
+
 mkdir -p "$test_root/first-site"
 cat >"$test_root/config/first.env" <<EOF
 SITE_ROOT=$test_root/first-site
@@ -96,14 +128,14 @@ RELEASES_TO_KEEP=3
 SMOKE_PATHS="/"
 CLOUDFLARE_PURGE_ENABLED=0
 EOF
-create_deployment 91003 '3333333333333333333333333333333333333333' 'failed-first-release'
+create_deployment 91003 '3333333333333333333333333333333333333333' 'failed-first-release' first
 if env \
   PATH="$test_root/bin:$PATH" \
   FAKE_CURL_FAIL=1 \
   FAKE_SITE_ROOT="$test_root/first-site" \
   POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
   POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
-  "$deploy_script" --site first --archive /tmp/powerforge-91003-1/artifact.tar --metadata /tmp/powerforge-91003-1/deployment.json; then
+  "$deploy_script" --site first --archive /tmp/powerforge-91003-1-first/artifact.tar --metadata /tmp/powerforge-91003-1-first/deployment.json; then
   echo 'Expected failed first deployment to return non-zero.' >&2
   exit 1
 fi
@@ -119,13 +151,13 @@ SITE_ROOT=$test_root/cloudflare-site
 PUBLIC_URL=https://cloudflare.example.test
 CLOUDFLARE_PURGE_ENABLED=1
 EOF
-create_deployment 91004 '4444444444444444444444444444444444444444' 'cloudflare-preflight-failure'
+create_deployment 91004 '4444444444444444444444444444444444444444' 'cloudflare-preflight-failure' cloudflare
 if env \
   PATH="$test_root/bin:$PATH" \
   FAKE_SITE_ROOT="$test_root/cloudflare-site" \
   POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
   POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
-  "$deploy_script" --site cloudflare --archive /tmp/powerforge-91004-1/artifact.tar --metadata /tmp/powerforge-91004-1/deployment.json; then
+  "$deploy_script" --site cloudflare --archive /tmp/powerforge-91004-1-cloudflare/artifact.tar --metadata /tmp/powerforge-91004-1-cloudflare/deployment.json; then
   echo 'Expected incomplete Cloudflare configuration to fail preflight.' >&2
   exit 1
 fi

--- a/Tests/Linux/powerforge-site-deploy.tests.sh
+++ b/Tests/Linux/powerforge-site-deploy.tests.sh
@@ -7,6 +7,7 @@ test_root="$(mktemp -d)"
 trap 'rm -rf "$test_root" /tmp/powerforge-91001-1 /tmp/powerforge-91002-1 /tmp/powerforge-91003-1 /tmp/powerforge-91004-1' EXIT
 
 mkdir -p "$test_root/config" "$test_root/locks" "$test_root/site" "$test_root/bin"
+export POWERFORGE_SITE_TRUSTED_STAGE_ROOT="$test_root/trusted-stage"
 cat >"$test_root/config/example.env" <<EOF
 SITE_ROOT=$test_root/site
 PUBLIC_URL=https://example.test
@@ -129,5 +130,9 @@ if env \
   exit 1
 fi
 [[ ! -e "$test_root/cloudflare-site/current" ]]
+if [[ -d "$POWERFORGE_SITE_TRUSTED_STAGE_ROOT" ]] && find "$POWERFORGE_SITE_TRUSTED_STAGE_ROOT" -mindepth 1 -maxdepth 1 | grep -q .; then
+  echo 'Root-owned deployment staging was not cleaned.' >&2
+  exit 1
+fi
 
 echo 'powerforge-site-deploy integration tests passed.'

--- a/Tests/Linux/powerforge-site-deploy.tests.sh
+++ b/Tests/Linux/powerforge-site-deploy.tests.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+deploy_script="$repo_root/Deployment/Linux/powerforge-site-deploy.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root" /tmp/powerforge-91001-1 /tmp/powerforge-91002-1 /tmp/powerforge-91003-1' EXIT
+
+mkdir -p "$test_root/config" "$test_root/locks" "$test_root/site" "$test_root/bin"
+cat >"$test_root/config/example.env" <<EOF
+SITE_ROOT=$test_root/site
+PUBLIC_URL=https://example.test
+RELEASES_TO_KEEP=3
+SMOKE_PATHS="/"
+CLOUDFLARE_PURGE_ENABLED=0
+EOF
+
+cat >"$test_root/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -e
+if [[ "${FAKE_CURL_FAIL:-0}" == '1' ]]; then
+  exit 22
+fi
+cat "$FAKE_SITE_ROOT/current/_powerforge/deployment.json"
+EOF
+chmod +x "$test_root/bin/curl"
+
+create_deployment() {
+  local run_id="$1"
+  local source_sha="$2"
+  local body="$3"
+  local staging="/tmp/powerforge-${run_id}-1"
+  local content="$test_root/content-${run_id}"
+  mkdir -p "$staging" "$content"
+  printf '%s\n' "$body" >"$content/index.html"
+  tar -C "$content" -cf "$staging/artifact.tar" .
+  local artifact_sha
+  artifact_sha="$(sha256sum "$staging/artifact.tar" | awk '{print $1}')"
+  cat >"$staging/deployment.json" <<EOF
+{
+  "schemaVersion": 1,
+  "sourceRepository": "Example/Site",
+  "sourceSha": "$source_sha",
+  "engineRepository": "Example/PowerForge",
+  "engineSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "workflowRunId": "$run_id",
+  "workflowRunAttempt": "1",
+  "artifactSha256": "$artifact_sha",
+  "deployedAtUtc": "2026-07-15T00:00:00Z"
+}
+EOF
+}
+
+sha_one='1111111111111111111111111111111111111111'
+sha_two='2222222222222222222222222222222222222222'
+create_deployment 91001 "$sha_one" 'release-one'
+
+env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_SITE_ROOT="$test_root/site" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site example --archive /tmp/powerforge-91001-1/artifact.tar --metadata /tmp/powerforge-91001-1/deployment.json
+
+grep -Fq 'release-one' "$test_root/site/current/index.html"
+grep -Fq "$sha_one" "$test_root/site/current/_powerforge/deployment.json"
+first_release="$(readlink -f "$test_root/site/current")"
+
+create_deployment 91002 "$sha_two" 'release-two'
+if env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_CURL_FAIL=1 \
+  FAKE_SITE_ROOT="$test_root/site" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site example --archive /tmp/powerforge-91002-1/artifact.tar --metadata /tmp/powerforge-91002-1/deployment.json; then
+  echo 'Expected failed smoke deployment to return non-zero.' >&2
+  exit 1
+fi
+
+[[ "$(readlink -f "$test_root/site/current")" == "$first_release" ]]
+grep -Fq 'release-one' "$test_root/site/current/index.html"
+if find "$test_root/site/releases" -mindepth 1 -maxdepth 1 -type d -name '*91002*' | grep -q .; then
+  echo 'Failed release was not removed after rollback.' >&2
+  exit 1
+fi
+
+mkdir -p "$test_root/first-site"
+cat >"$test_root/config/first.env" <<EOF
+SITE_ROOT=$test_root/first-site
+PUBLIC_URL=https://first.example.test
+RELEASES_TO_KEEP=3
+SMOKE_PATHS="/"
+CLOUDFLARE_PURGE_ENABLED=0
+EOF
+create_deployment 91003 '3333333333333333333333333333333333333333' 'failed-first-release'
+if env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_CURL_FAIL=1 \
+  FAKE_SITE_ROOT="$test_root/first-site" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site first --archive /tmp/powerforge-91003-1/artifact.tar --metadata /tmp/powerforge-91003-1/deployment.json; then
+  echo 'Expected failed first deployment to return non-zero.' >&2
+  exit 1
+fi
+[[ ! -e "$test_root/first-site/current" ]]
+if find "$test_root/first-site/releases" -mindepth 1 -maxdepth 1 -type d | grep -q .; then
+  echo 'Failed first release was not removed.' >&2
+  exit 1
+fi
+
+echo 'powerforge-site-deploy integration tests passed.'


### PR DESCRIPTION
## What changed

- adds a `linux` target to the reusable PowerForge.Web deployment workflow while keeping GitHub Pages as the default
- builds on each caller's existing runner, then publishes a uniquely named validated static artifact through a separate Linux publisher job
- records the exact source commit, resolved source-engine commit or binary asset digest, workflow run, attempt, and artifact checksum in every release
- adds a root-owned, allowlisted promoter with anchored site staging, archive validation, trusted root staging, atomic symlink promotion, Cloudflare purge, deployment-unique origin/public smoke checks, retention, and automatic rollback
- documents the generic host contract and keeps site roots, domains, origin addresses, and credentials out of the reusable workflow

## Operator contract

The host installs `powerforge-site-deploy` once and owns one `/etc/powerforge/sites/<site>.env` file per site. Each caller uses a protected GitHub environment and a site-scoped SSH key. Cloudflare remains proxied; the promoter purges it after promotion instead of disabling caching or analytics.

This PR adds the shared static-site capability only. Site-specific host configuration and cutovers follow through exact workflow pins.

## Validation

- full `PowerForge.Tests` project
- Linux integration coverage for promotion, failed-update rollback, failed-first-deploy cleanup, cached-marker rejection, and staging-path rejection
- ShellCheck 0.11.0
- actionlint 1.7.12 with the repository's existing `job.workflow_repository` baseline suppressed
- exact-head Windows, Linux, macOS, dependency-audit, and focused publish CI