### PR TITLE
Harden benchmark ordering, cleanup, paths, and fastest-baseline gates

### DIFF
--- a/Module/Docs/Add-BenchmarkComparison.md
+++ b/Module/Docs/Add-BenchmarkComparison.md
@@ -11,7 +11,7 @@ Adds a benchmark comparison definition.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Add-BenchmarkComparison [[-Dimension] <string>] -Baseline <string> [-Metric <string[]>] [-TieTolerance <double>] [<CommonParameters>]
+Add-BenchmarkComparison [[-Dimension] <string>] -Baseline <string> [-Metric <string[]>] [-TieTolerance <double>] [-RequireBaselineFastest] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -64,6 +64,22 @@ Metric names.
 
 ```yaml
 Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -RequireBaselineFastest
+Fail the benchmark when the baseline is materially slower than a successful competitor.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -853,6 +853,18 @@
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RequireBaselineFastest</maml:name>
+          <maml:description>
+            <maml:para>Fail the benchmark when the baseline is materially slower than a successful competitor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>TieTolerance</maml:name>
           <maml:description>
             <maml:para>Fractional tolerance used to label practically equivalent results, such as 0.05 for five percent.</maml:para>
@@ -899,6 +911,18 @@
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
           <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RequireBaselineFastest</maml:name>
+        <maml:description>
+          <maml:para>Fail the benchmark when the baseline is materially slower than a successful competitor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
+++ b/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
@@ -452,9 +452,13 @@ public sealed class AddBenchmarkComparisonCommand : BenchmarkDslCommand
     [ValidateRange(0d, double.MaxValue)]
     public double TieTolerance { get; set; }
 
+    /// <summary>Fail the benchmark when the baseline is materially slower than a successful competitor.</summary>
+    [Parameter]
+    public SwitchParameter RequireBaselineFastest { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord()
-        => PowerShellBenchmarkDslRuntime.Compare(Dimension, Baseline, Metric, TieTolerance);
+        => PowerShellBenchmarkDslRuntime.Compare(Dimension, Baseline, Metric, TieTolerance, RequireBaselineFastest.IsPresent);
 }
 
 /// <summary>

--- a/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
+++ b/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
@@ -275,6 +275,10 @@ public sealed class SetBenchmarkPolicyCommand : BenchmarkDslCommand
     [Parameter]
     public PowerShellBenchmarkRunOrder? Order { get; set; }
 
+    /// <summary>Managed-memory cleanup performed outside timed operations.</summary>
+    [Parameter]
+    public PowerShellBenchmarkMemoryCleanupMode? MemoryCleanup { get; set; }
+
     /// <summary>Delay between measured samples, in milliseconds.</summary>
     [Parameter]
     [ValidateRange(0, int.MaxValue)]
@@ -291,6 +295,7 @@ public sealed class SetBenchmarkPolicyCommand : BenchmarkDslCommand
             Iteration,
             RunMode,
             Order?.ToString(),
+            MemoryCleanup?.ToString(),
             CooldownMilliseconds,
             OutlierMode?.ToString());
 }

--- a/PSPublishModule/Cmdlets/InvokeBenchmarkSuiteCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeBenchmarkSuiteCommand.cs
@@ -67,6 +67,12 @@ public sealed class InvokeBenchmarkSuiteCommand : PSCmdlet
     public PowerShellBenchmarkRunOrder? RunOrder { get; set; }
 
     /// <summary>
+    /// Optional managed-memory cleanup override.
+    /// </summary>
+    [Parameter]
+    public PowerShellBenchmarkMemoryCleanupMode? MemoryCleanup { get; set; }
+
+    /// <summary>
     /// Optional delay between measured samples, in milliseconds.
     /// </summary>
     [Parameter]
@@ -204,6 +210,7 @@ public sealed class InvokeBenchmarkSuiteCommand : PSCmdlet
                     IterationCount = suite.IterationCount,
                     RunMode = suite.RunMode,
                     RunOrder = suite.RunOrder,
+                    MemoryCleanup = suite.MemoryCleanup,
                     CooldownMilliseconds = suite.CooldownMilliseconds,
                     OutlierMode = suite.OutlierMode,
                     SuiteName = suite.Name,
@@ -233,6 +240,7 @@ public sealed class InvokeBenchmarkSuiteCommand : PSCmdlet
                     IterationCount = suite.IterationCount,
                     RunMode = suite.RunMode,
                     RunOrder = suite.RunOrder,
+                    MemoryCleanup = suite.MemoryCleanup,
                     CooldownMilliseconds = suite.CooldownMilliseconds,
                     OutlierMode = suite.OutlierMode,
                     SuiteName = suite.Name,
@@ -258,6 +266,7 @@ public sealed class InvokeBenchmarkSuiteCommand : PSCmdlet
         if (IterationCount.HasValue) suite.IterationCount = Math.Max(1, IterationCount.Value);
         if (!string.IsNullOrWhiteSpace(RunMode)) suite.RunMode = RunMode!;
         if (RunOrder.HasValue) suite.RunOrder = RunOrder.Value;
+        if (MemoryCleanup.HasValue) suite.MemoryCleanup = MemoryCleanup.Value;
         if (CooldownMilliseconds.HasValue) suite.CooldownMilliseconds = Math.Max(0, CooldownMilliseconds.Value);
         if (OutlierMode.HasValue) suite.OutlierMode = OutlierMode.Value;
         if (!string.IsNullOrWhiteSpace(Suite)) suite.Name = Suite!;

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkChildRunnerRequest.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkChildRunnerRequest.cs
@@ -14,6 +14,7 @@ internal sealed class PowerShellBenchmarkChildRunnerRequest
     public int IterationCount { get; set; }
     public string RunMode { get; set; } = string.Empty;
     public string RunOrder { get; set; } = string.Empty;
+    public string MemoryCleanup { get; set; } = string.Empty;
     public int CooldownMilliseconds { get; set; }
     public string OutlierMode { get; set; } = string.Empty;
     public string SuiteName { get; set; } = string.Empty;

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkChildRunnerRequest.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkChildRunnerRequest.cs
@@ -23,4 +23,11 @@ internal sealed class PowerShellBenchmarkChildRunnerRequest
     public string[] ModulePaths { get; set; } = Array.Empty<string>();
     public string RunStartedUtc { get; set; } = string.Empty;
     public bool UpdateReadmeBlocks { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether the child process should enforce comparison gates. Multi-host children defer
+    /// enforcement until the parent has merged every host result so a gate failure remains a comparison
+    /// failure instead of being converted into an external-host execution failure.
+    /// </summary>
+    public bool ValidateComparisonGates { get; set; } = true;
 }

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkComparisonEvaluator.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkComparisonEvaluator.cs
@@ -1,0 +1,123 @@
+using System.Globalization;
+
+namespace PowerForge;
+
+internal static class PowerShellBenchmarkComparisonEvaluator
+{
+    internal static BenchmarkComparisonRow[] Build(
+        PowerShellBenchmarkSuite suite,
+        IReadOnlyList<BenchmarkSummaryRow> summary)
+    {
+        var summarizer = new BenchmarkSummaryService();
+        return suite.Comparisons
+            .Where(comparison => !string.IsNullOrWhiteSpace(comparison.Baseline))
+            .SelectMany(comparison => GetMetrics(comparison)
+                .SelectMany(metric => summarizer.Compare(summary, comparison.Baseline, metric, comparison.TieTolerance)))
+            .ToArray();
+    }
+
+    internal static void ValidateGates(
+        PowerShellBenchmarkSuite suite,
+        IReadOnlyList<BenchmarkSummaryRow> summary)
+    {
+        var summarizer = new BenchmarkSummaryService();
+        foreach (var comparison in suite.Comparisons.Where(static comparison => comparison.RequireBaselineFastest))
+        {
+            foreach (var metric in GetMetrics(comparison))
+            {
+                var rows = summarizer.Compare(summary, comparison.Baseline, metric, comparison.TieTolerance);
+                ValidateBaselineFastest(comparison, metric, rows);
+            }
+        }
+    }
+
+    private static void ValidateBaselineFastest(
+        PowerShellBenchmarkComparison comparison,
+        string metric,
+        IReadOnlyList<BenchmarkComparisonRow> rows)
+    {
+        if (!BenchmarkComparisonSemantics.IsDurationMetric(metric))
+            throw new NotSupportedException($"Benchmark comparison metric '{metric}' cannot require the baseline to be fastest because only duration metrics have lower-is-better semantics.");
+
+        var failures = new List<string>();
+        foreach (var group in rows.GroupBy(GroupKey, StringComparer.Ordinal))
+        {
+            var competitors = group
+                .Where(row => !string.Equals(row.Engine, comparison.Baseline, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (competitors.Length == 0)
+                continue;
+
+            var failedCompetitors = competitors
+                .Where(row => !row.Actual.HasValue && !string.Equals(row.Status, "Skipped", StringComparison.OrdinalIgnoreCase))
+                .Select(row => row.Engine)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (failedCompetitors.Length > 0)
+            {
+                failures.Add($"{Describe(group.First())}: competitor {string.Join(", ", failedCompetitors)} failed");
+                continue;
+            }
+
+            var successfulCompetitors = competitors.Where(static row => row.Actual.HasValue).ToArray();
+            if (successfulCompetitors.Length == 0)
+                continue;
+
+            var baseline = group.FirstOrDefault(row =>
+                string.Equals(row.Engine, comparison.Baseline, StringComparison.OrdinalIgnoreCase));
+            if (baseline?.Actual is null)
+            {
+                failures.Add($"{Describe(group.First())}: baseline {comparison.Baseline} failed");
+                continue;
+            }
+
+            var fastest = successfulCompetitors.OrderBy(static row => row.Actual!.Value).First();
+            var tolerance = Math.Max(0, comparison.TieTolerance);
+            if (baseline.Actual.Value <= fastest.Actual!.Value * (1 + tolerance))
+                continue;
+
+            failures.Add(
+                $"{Describe(group.First())}: {comparison.Baseline} {Format(baseline.Actual.Value)} is slower than {fastest.Engine} {Format(fastest.Actual.Value)} beyond the {tolerance:P0} tie tolerance");
+        }
+
+        if (failures.Count > 0)
+            throw new InvalidOperationException(
+                $"Benchmark comparison gate requires baseline '{comparison.Baseline}' to be fastest or tied for metric '{metric}', but {failures.Count} lane(s) failed. {string.Join("; ", failures)}");
+    }
+
+    private static IEnumerable<string> GetMetrics(PowerShellBenchmarkComparison comparison)
+        => comparison.Metrics is null || comparison.Metrics.Length == 0
+            ? new[] { "MedianMs" }
+            : comparison.Metrics;
+
+    private static string GroupKey(BenchmarkComparisonRow row)
+        => string.Join(
+            "\u001f",
+            row.Suite,
+            row.Scenario,
+            row.Operation,
+            row.Host,
+            row.Os,
+            row.RunMode,
+            row.Metric,
+            string.Join(
+                "\u001e",
+                row.Variables
+                    .OrderBy(variable => variable.Key, StringComparer.OrdinalIgnoreCase)
+                    .Select(variable => variable.Key + "=" + variable.Value)));
+
+    private static string Describe(BenchmarkComparisonRow row)
+    {
+        var variables = row.Variables.Count == 0
+            ? string.Empty
+            : ", variables " + string.Join(
+                ", ",
+                row.Variables
+                    .OrderBy(variable => variable.Key, StringComparer.OrdinalIgnoreCase)
+                    .Select(variable => variable.Key + "=" + variable.Value));
+        return $"scenario '{row.Scenario}', operation '{row.Operation}', host '{row.Host}', OS '{row.Os}'{variables}";
+    }
+
+    private static string Format(double value)
+        => value.ToString("0.###", CultureInfo.InvariantCulture) + "ms";
+}

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkComparisonEvaluator.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkComparisonEvaluator.cs
@@ -42,6 +42,14 @@ internal static class PowerShellBenchmarkComparisonEvaluator
         var failures = new List<string>();
         foreach (var group in rows.GroupBy(GroupKey, StringComparer.Ordinal))
         {
+            var baseline = group.FirstOrDefault(row =>
+                string.Equals(row.Engine, comparison.Baseline, StringComparison.OrdinalIgnoreCase));
+            if (baseline?.Actual is null || IsFailed(baseline))
+            {
+                failures.Add($"{Describe(group.First())}: baseline {comparison.Baseline} failed");
+                continue;
+            }
+
             var competitors = group
                 .Where(row => !string.Equals(row.Engine, comparison.Baseline, StringComparison.OrdinalIgnoreCase))
                 .ToArray();
@@ -65,14 +73,6 @@ internal static class PowerShellBenchmarkComparisonEvaluator
                 .ToArray();
             if (successfulCompetitors.Length == 0)
                 continue;
-
-            var baseline = group.FirstOrDefault(row =>
-                string.Equals(row.Engine, comparison.Baseline, StringComparison.OrdinalIgnoreCase));
-            if (baseline?.Actual is null || IsFailed(baseline))
-            {
-                failures.Add($"{Describe(group.First())}: baseline {comparison.Baseline} failed");
-                continue;
-            }
 
             var fastest = successfulCompetitors.OrderBy(static row => row.Actual!.Value).First();
             var tolerance = Math.Max(0, comparison.TieTolerance);

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkComparisonEvaluator.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkComparisonEvaluator.cs
@@ -49,7 +49,8 @@ internal static class PowerShellBenchmarkComparisonEvaluator
                 continue;
 
             var failedCompetitors = competitors
-                .Where(row => !row.Actual.HasValue && !string.Equals(row.Status, "Skipped", StringComparison.OrdinalIgnoreCase))
+                .Where(row => IsFailed(row)
+                              || (!row.Actual.HasValue && !IsSkipped(row)))
                 .Select(row => row.Engine)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
@@ -59,13 +60,15 @@ internal static class PowerShellBenchmarkComparisonEvaluator
                 continue;
             }
 
-            var successfulCompetitors = competitors.Where(static row => row.Actual.HasValue).ToArray();
+            var successfulCompetitors = competitors
+                .Where(static row => row.Actual.HasValue && !IsFailed(row))
+                .ToArray();
             if (successfulCompetitors.Length == 0)
                 continue;
 
             var baseline = group.FirstOrDefault(row =>
                 string.Equals(row.Engine, comparison.Baseline, StringComparison.OrdinalIgnoreCase));
-            if (baseline?.Actual is null)
+            if (baseline?.Actual is null || IsFailed(baseline))
             {
                 failures.Add($"{Describe(group.First())}: baseline {comparison.Baseline} failed");
                 continue;
@@ -89,6 +92,12 @@ internal static class PowerShellBenchmarkComparisonEvaluator
         => comparison.Metrics is null || comparison.Metrics.Length == 0
             ? new[] { "MedianMs" }
             : comparison.Metrics;
+
+    private static bool IsFailed(BenchmarkComparisonRow row)
+        => string.Equals(row.Status, "Failed", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSkipped(BenchmarkComparisonRow row)
+        => string.Equals(row.Status, "Skipped", StringComparison.OrdinalIgnoreCase);
 
     private static string GroupKey(BenchmarkComparisonRow row)
         => string.Join(

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
@@ -489,6 +489,32 @@ public static class PowerShellBenchmarkDslRuntime
         const string InputBody = "param([Parameter(Position=0, Mandatory=$true)] [string] $Name, [Parameter(Position=1)] [object] $Default, [switch] $Required, [switch] $Int, [switch] $Bool) if ($Int.IsPresent) { $value = $BenchmarkVariables[$Name]; if ([string]::IsNullOrWhiteSpace([string] $value)) { if ($Required.IsPresent) { throw \"Benchmark variable '$Name' is required.\" }; if ($null -eq $Default) { return @() }; if ($Default -is [array]) { return @($Default | ForEach-Object { [int] $_ }) }; return @([string] $Default -split ',' | Where-Object { $_.Trim() } | ForEach-Object { [int] $_.Trim() }) }; $items = @(); foreach ($entry in ([string] $value -split ',')) { $trimmed = $entry.Trim(); if ($trimmed) { $items += [int] $trimmed } }; if ($items.Count -eq 0) { if ($Required.IsPresent) { throw \"Benchmark variable '$Name' did not contain any integer values.\" }; return $Default }; return $items } if ($Bool.IsPresent) { $value = $BenchmarkVariables[$Name]; if ([string]::IsNullOrWhiteSpace([string] $value)) { if ($Required.IsPresent) { throw \"Benchmark variable '$Name' is required.\" }; if ($null -eq $Default) { return $false }; switch -Regex ([string] $Default) { '^(?i:true|1|yes|on)$' { return $true } '^(?i:false|0|no|off)$' { return $false } default { throw \"Benchmark variable '$Name' default '$Default' is not a boolean value.\" } } }; switch -Regex ([string] $value) { '^(?i:true|1|yes|on)$' { return $true } '^(?i:false|0|no|off)$' { return $false } default { throw \"Benchmark variable '$Name' value '$value' is not a boolean value.\" } } } $value = $BenchmarkVariables[$Name]; if ([string]::IsNullOrWhiteSpace([string] $value)) { if ($Required.IsPresent) { throw \"Benchmark variable '$Name' is required.\" }; return $Default }; [string] $value";
         const string InputIntBody = "param([Parameter(Position=0, Mandatory=$true)] [string] $Name, [Parameter(Position=1)] [int[]] $Default, [switch] $Required) $value = $BenchmarkVariables[$Name]; if ([string]::IsNullOrWhiteSpace([string] $value)) { if ($Required.IsPresent) { throw \"Benchmark variable '$Name' is required.\" }; return $Default }; $items = @(); foreach ($entry in ([string] $value -split ',')) { $trimmed = $entry.Trim(); if ($trimmed) { $items += [int] $trimmed } }; if ($items.Count -eq 0) { if ($Required.IsPresent) { throw \"Benchmark variable '$Name' did not contain any integer values.\" }; return $Default }; $items";
         const string InputBoolBody = "param([Parameter(Position=0, Mandatory=$true)] [string] $Name, [Parameter(Position=1)] [object] $Default = $false, [switch] $Required) $value = $BenchmarkVariables[$Name]; if ([string]::IsNullOrWhiteSpace([string] $value)) { if ($Required.IsPresent) { throw \"Benchmark variable '$Name' is required.\" }; switch -Regex ([string] $Default) { '^(?i:true|1|yes|on)$' { return $true } '^(?i:false|0|no|off)$' { return $false } default { throw \"Benchmark variable '$Name' default '$Default' is not a boolean value.\" } } }; switch -Regex ([string] $value) { '^(?i:true|1|yes|on)$' { return $true } '^(?i:false|0|no|off)$' { return $false } default { throw \"Benchmark variable '$Name' value '$value' is not a boolean value.\" } }";
+        const string PolicyBody = """
+param(
+    [Parameter(Position=0)] [int] $Warmup,
+    [Parameter(Position=1)] [Alias('Iterations')] [int] $Iteration,
+    [Parameter(Position=2)] [string] $RunMode,
+    [Parameter(Position=3)] [object] $Order,
+    [Parameter(Position=4)] [int] $CooldownMilliseconds,
+    [Parameter(Position=5)] [object] $OutlierMode,
+    [Parameter(Position=6)] [object] $MemoryCleanup
+)
+$w = $null
+$i = $null
+$c = $null
+if ($PSBoundParameters.ContainsKey('Warmup')) { $w = $Warmup }
+if ($PSBoundParameters.ContainsKey('Iteration')) { $i = $Iteration }
+if ($PSBoundParameters.ContainsKey('CooldownMilliseconds')) { $c = $CooldownMilliseconds }
+$arguments = [object[]]::new(7)
+$arguments[0] = $w
+$arguments[1] = $i
+$arguments[2] = $RunMode
+$arguments[3] = [string] $Order
+$arguments[4] = [string] $MemoryCleanup
+$arguments[5] = $c
+$arguments[6] = [string] $OutlierMode
+__PowerForgeBenchmarkDslInvoke -Name 'Policy' -Arguments $arguments
+""";
 
         return new()
         {
@@ -516,7 +542,7 @@ try {
             ["data"] = Call("Data", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["skip"] = Call("Skip", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["validate"] = Call("Validate", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
-            ["policy"] = "param([int] $Warmup, [Alias('Iterations')] [int] $Iteration, [string] $RunMode, [object] $Order, [object] $MemoryCleanup, [int] $CooldownMilliseconds, [object] $OutlierMode) $w=$null; $i=$null; $c=$null; if ($PSBoundParameters.ContainsKey('Warmup')) { $w=$Warmup }; if ($PSBoundParameters.ContainsKey('Iteration')) { $i=$Iteration }; if ($PSBoundParameters.ContainsKey('CooldownMilliseconds')) { $c=$CooldownMilliseconds }; $arguments = [object[]]::new(7); $arguments[0] = $w; $arguments[1] = $i; $arguments[2] = $RunMode; $arguments[3] = [string] $Order; $arguments[4] = [string] $MemoryCleanup; $arguments[5] = $c; $arguments[6] = [string] $OutlierMode; __PowerForgeBenchmarkDslInvoke -Name 'Policy' -Arguments $arguments",
+            ["policy"] = PolicyBody,
             ["profile"] = Call("Profile", "param([Parameter(Position=0)] [string] $Name, [string] $Cleanup)", "[object[]] @($Name, $Cleanup)"),
             ["cleanup"] = Call("Cleanup", "param([Parameter(Position=0)] [string] $Name)", "[object[]] @($Name)"),
             ["engine"] = Call("Engine", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
@@ -538,7 +564,7 @@ try {
             ["Add-BenchmarkAxis"] = "param([Parameter(Position=0)] [string] $Name, [Parameter(ValueFromRemainingArguments=$true)] [object[]] $Values) $arguments = [object[]]::new(2); $arguments[0] = $Name; $arguments[1] = $Values; __PowerForgeBenchmarkDslInvoke -Name 'Axis' -Arguments $arguments",
             ["Set-BenchmarkSetup"] = Call("Setup", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Set-BenchmarkDataFactory"] = Call("Data", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
-            ["Set-BenchmarkPolicy"] = "param([int] $Warmup, [Alias('Iterations')] [int] $Iteration, [string] $RunMode, [object] $Order, [object] $MemoryCleanup, [int] $CooldownMilliseconds, [object] $OutlierMode) $w=$null; $i=$null; $c=$null; if ($PSBoundParameters.ContainsKey('Warmup')) { $w=$Warmup }; if ($PSBoundParameters.ContainsKey('Iteration')) { $i=$Iteration }; if ($PSBoundParameters.ContainsKey('CooldownMilliseconds')) { $c=$CooldownMilliseconds }; $arguments = [object[]]::new(7); $arguments[0] = $w; $arguments[1] = $i; $arguments[2] = $RunMode; $arguments[3] = [string] $Order; $arguments[4] = [string] $MemoryCleanup; $arguments[5] = $c; $arguments[6] = [string] $OutlierMode; __PowerForgeBenchmarkDslInvoke -Name 'Policy' -Arguments $arguments",
+            ["Set-BenchmarkPolicy"] = PolicyBody,
             ["Set-BenchmarkProfile"] = Call("Profile", "param([Parameter(Position=0)] [string] $Name, [string] $Cleanup)", "[object[]] @($Name, $Cleanup)"),
             ["Set-BenchmarkCleanup"] = Call("Cleanup", "param([Parameter(Position=0)] [string] $Name)", "[object[]] @($Name)"),
             ["Add-BenchmarkEngine"] = Call("Engine", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
@@ -381,7 +381,7 @@ public static class PowerShellBenchmarkDslRuntime
     /// <param name="baseline">Baseline value.</param>
     /// <param name="metric">Metric names.</param>
     public static void Compare(string dimension, string baseline, string[]? metric)
-        => Compare(dimension, baseline, metric, tieTolerance: 0);
+        => Compare(dimension, baseline, metric, tieTolerance: 0, requireBaselineFastest: false);
 
     /// <summary>
     /// Adds a comparison definition with a practical tie tolerance.
@@ -391,12 +391,24 @@ public static class PowerShellBenchmarkDslRuntime
     /// <param name="metric">Metric names.</param>
     /// <param name="tieTolerance">Fractional tolerance used to label practically equivalent results, such as <c>0.05</c> for five percent.</param>
     public static void Compare(string dimension, string baseline, string[]? metric, double tieTolerance)
+        => Compare(dimension, baseline, metric, tieTolerance, requireBaselineFastest: false);
+
+    /// <summary>
+    /// Adds a comparison definition with a practical tie tolerance and an optional fastest-baseline gate.
+    /// </summary>
+    /// <param name="dimension">Dimension name.</param>
+    /// <param name="baseline">Baseline value.</param>
+    /// <param name="metric">Metric names.</param>
+    /// <param name="tieTolerance">Fractional tolerance used to label practically equivalent results, such as <c>0.05</c> for five percent.</param>
+    /// <param name="requireBaselineFastest">Whether to fail when the baseline is materially slower than a successful competitor.</param>
+    public static void Compare(string dimension, string baseline, string[]? metric, double tieTolerance, bool requireBaselineFastest)
         => RequireSuite().Comparisons.Add(new PowerShellBenchmarkComparison
         {
             Dimension = string.IsNullOrWhiteSpace(dimension) ? "Engine" : dimension.Trim(),
             Baseline = baseline ?? string.Empty,
             Metrics = metric is { Length: > 0 } ? metric : new[] { "MedianMs" },
-            TieTolerance = tieTolerance
+            TieTolerance = tieTolerance,
+            RequireBaselineFastest = requireBaselineFastest
         });
 
     /// <summary>
@@ -495,8 +507,8 @@ try {
             ["engine"] = Call("Engine", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
             ["operation"] = Call("Operation", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
             ["metric"] = Call("Metric", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
-            ["compare"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance) $arguments = [object[]]::new(4); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
-            ["comparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance) $arguments = [object[]]::new(4); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
+            ["compare"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance, [switch] $RequireBaselineFastest) $arguments = [object[]]::new(5); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; $arguments[4] = $RequireBaselineFastest.IsPresent; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
+            ["comparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance, [switch] $RequireBaselineFastest) $arguments = [object[]]::new(5); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; $arguments[4] = $RequireBaselineFastest.IsPresent; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
             ["readme"] = Call("Readme", "param([Parameter(Position=0)] [string] $Path, [string] $Block, [string] $Renderer)", "[object[]] @($Path, $Block, $Renderer)"),
             ["artifacts"] = "param([Parameter(ValueFromRemainingArguments=$true)] [object[]] $Values) $arguments = [object[]]::new(1); $arguments[0] = $Values; __PowerForgeBenchmarkDslInvoke -Name 'Artifacts' -Arguments $arguments",
             ["input"] = InputBody,
@@ -519,7 +531,7 @@ try {
             ["Add-BenchmarkSkipRule"] = Call("Skip", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Add-BenchmarkValidation"] = Call("Validate", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Add-BenchmarkMetric"] = Call("Metric", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
-            ["Add-BenchmarkComparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance) $arguments = [object[]]::new(4); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
+            ["Add-BenchmarkComparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance, [switch] $RequireBaselineFastest) $arguments = [object[]]::new(5); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; $arguments[4] = $RequireBaselineFastest.IsPresent; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
             ["Add-BenchmarkReadmeBlock"] = Call("Readme", "param([Parameter(Position=0)] [string] $Path, [string] $Block, [string] $Renderer)", "[object[]] @($Path, $Block, $Renderer)"),
             ["Set-BenchmarkArtifacts"] = "param([Parameter(ValueFromRemainingArguments=$true)] [object[]] $Values) $arguments = [object[]]::new(1); $arguments[0] = $Values; __PowerForgeBenchmarkDslInvoke -Name 'Artifacts' -Arguments $arguments",
             ["Get-BenchmarkInput"] = InputBody,
@@ -774,10 +786,11 @@ try {
         setter.AddCommand("Set-Item")
             .AddArgument("Function:compare")
             .AddParameter("Value", ScriptBlock.Create("""
-param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance)
+param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance, [switch] $RequireBaselineFastest)
 $parameters = @{ Dimension = $Dimension; Baseline = $Baseline }
 if ($PSBoundParameters.ContainsKey('Metric')) { $parameters['Metric'] = $Metric }
 if ($PSBoundParameters.ContainsKey('TieTolerance')) { $parameters['TieTolerance'] = $TieTolerance }
+if ($RequireBaselineFastest.IsPresent) { $parameters['RequireBaselineFastest'] = $true }
 Add-BenchmarkComparison @parameters
 """))
             .AddParameter("Force")

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
@@ -656,7 +656,14 @@ try {
         => InvokeWithNativeExitCheck(scriptBlock, functionsToDefine);
 
     private static Collection<PSObject> InvokeWithNativeExitCheck(ScriptBlock scriptBlock, Hashtable? functionsToDefine)
-        => NativeExitAwareInvokeWrapper.InvokeWithContext(functionsToDefine, CreateInvocationVariables(), new object[] { scriptBlock, Array.Empty<object>(), true, typeof(PowerShellNativeExitCodeTracker) });
+    {
+        // GetNewClosure binds settings to a dynamic module. Run the wrapper in that
+        // module so its injected DSL functions and variables remain visible.
+        var wrapper = scriptBlock.Module is null
+            ? NativeExitAwareInvokeWrapper
+            : scriptBlock.Module.NewBoundScriptBlock(NativeExitAwareInvokeWrapper);
+        return wrapper.InvokeWithContext(functionsToDefine, CreateInvocationVariables(), new object[] { scriptBlock, Array.Empty<object>(), true, typeof(PowerShellNativeExitCodeTracker) });
+    }
 
     private static readonly ScriptBlock NativeExitAwareInvokeWrapper =
         ScriptBlock.Create(EmbeddedScripts.Load("Scripts/Benchmarks/Invoke-NativeExitAwareBlock.ps1"));

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
@@ -229,6 +229,19 @@ public static class PowerShellBenchmarkDslRuntime
     /// <param name="cooldownMilliseconds">Optional delay between measured samples.</param>
     /// <param name="outlierMode">Optional summary outlier policy.</param>
     public static void Policy(int? warmup, int? iteration, string? runMode, string? order, int? cooldownMilliseconds, string? outlierMode)
+        => Policy(warmup, iteration, runMode, order, memoryCleanup: null, cooldownMilliseconds, outlierMode);
+
+    /// <summary>
+    /// Applies benchmark execution policy to the current DSL suite.
+    /// </summary>
+    /// <param name="warmup">Optional warmup iteration count.</param>
+    /// <param name="iteration">Optional measured iteration count.</param>
+    /// <param name="runMode">Optional run mode label.</param>
+    /// <param name="order">Optional work-item ordering strategy.</param>
+    /// <param name="memoryCleanup">Optional managed-memory cleanup policy.</param>
+    /// <param name="cooldownMilliseconds">Optional delay between measured samples.</param>
+    /// <param name="outlierMode">Optional summary outlier policy.</param>
+    public static void Policy(int? warmup, int? iteration, string? runMode, string? order, string? memoryCleanup, int? cooldownMilliseconds, string? outlierMode)
     {
         var suite = RequireSuite();
         if (warmup.HasValue)
@@ -239,6 +252,8 @@ public static class PowerShellBenchmarkDslRuntime
             suite.RunMode = runMode!;
         if (!string.IsNullOrWhiteSpace(order))
             suite.RunOrder = ParseEnum<PowerShellBenchmarkRunOrder>(order!, "run order");
+        if (!string.IsNullOrWhiteSpace(memoryCleanup))
+            suite.MemoryCleanup = ParseEnum<PowerShellBenchmarkMemoryCleanupMode>(memoryCleanup!, "memory cleanup mode");
         if (cooldownMilliseconds.HasValue)
             suite.CooldownMilliseconds = Math.Max(0, cooldownMilliseconds.Value);
         if (!string.IsNullOrWhiteSpace(outlierMode))
@@ -501,7 +516,7 @@ try {
             ["data"] = Call("Data", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["skip"] = Call("Skip", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["validate"] = Call("Validate", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
-            ["policy"] = "param([int] $Warmup, [Alias('Iterations')] [int] $Iteration, [string] $RunMode, [object] $Order, [int] $CooldownMilliseconds, [object] $OutlierMode) $w=$null; $i=$null; $c=$null; if ($PSBoundParameters.ContainsKey('Warmup')) { $w=$Warmup }; if ($PSBoundParameters.ContainsKey('Iteration')) { $i=$Iteration }; if ($PSBoundParameters.ContainsKey('CooldownMilliseconds')) { $c=$CooldownMilliseconds }; $arguments = [object[]]::new(6); $arguments[0] = $w; $arguments[1] = $i; $arguments[2] = $RunMode; $arguments[3] = [string] $Order; $arguments[4] = $c; $arguments[5] = [string] $OutlierMode; __PowerForgeBenchmarkDslInvoke -Name 'Policy' -Arguments $arguments",
+            ["policy"] = "param([int] $Warmup, [Alias('Iterations')] [int] $Iteration, [string] $RunMode, [object] $Order, [object] $MemoryCleanup, [int] $CooldownMilliseconds, [object] $OutlierMode) $w=$null; $i=$null; $c=$null; if ($PSBoundParameters.ContainsKey('Warmup')) { $w=$Warmup }; if ($PSBoundParameters.ContainsKey('Iteration')) { $i=$Iteration }; if ($PSBoundParameters.ContainsKey('CooldownMilliseconds')) { $c=$CooldownMilliseconds }; $arguments = [object[]]::new(7); $arguments[0] = $w; $arguments[1] = $i; $arguments[2] = $RunMode; $arguments[3] = [string] $Order; $arguments[4] = [string] $MemoryCleanup; $arguments[5] = $c; $arguments[6] = [string] $OutlierMode; __PowerForgeBenchmarkDslInvoke -Name 'Policy' -Arguments $arguments",
             ["profile"] = Call("Profile", "param([Parameter(Position=0)] [string] $Name, [string] $Cleanup)", "[object[]] @($Name, $Cleanup)"),
             ["cleanup"] = Call("Cleanup", "param([Parameter(Position=0)] [string] $Name)", "[object[]] @($Name)"),
             ["engine"] = Call("Engine", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
@@ -523,7 +538,7 @@ try {
             ["Add-BenchmarkAxis"] = "param([Parameter(Position=0)] [string] $Name, [Parameter(ValueFromRemainingArguments=$true)] [object[]] $Values) $arguments = [object[]]::new(2); $arguments[0] = $Name; $arguments[1] = $Values; __PowerForgeBenchmarkDslInvoke -Name 'Axis' -Arguments $arguments",
             ["Set-BenchmarkSetup"] = Call("Setup", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Set-BenchmarkDataFactory"] = Call("Data", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
-            ["Set-BenchmarkPolicy"] = "param([int] $Warmup, [Alias('Iterations')] [int] $Iteration, [string] $RunMode, [object] $Order, [int] $CooldownMilliseconds, [object] $OutlierMode) $w=$null; $i=$null; $c=$null; if ($PSBoundParameters.ContainsKey('Warmup')) { $w=$Warmup }; if ($PSBoundParameters.ContainsKey('Iteration')) { $i=$Iteration }; if ($PSBoundParameters.ContainsKey('CooldownMilliseconds')) { $c=$CooldownMilliseconds }; $arguments = [object[]]::new(6); $arguments[0] = $w; $arguments[1] = $i; $arguments[2] = $RunMode; $arguments[3] = [string] $Order; $arguments[4] = $c; $arguments[5] = [string] $OutlierMode; __PowerForgeBenchmarkDslInvoke -Name 'Policy' -Arguments $arguments",
+            ["Set-BenchmarkPolicy"] = "param([int] $Warmup, [Alias('Iterations')] [int] $Iteration, [string] $RunMode, [object] $Order, [object] $MemoryCleanup, [int] $CooldownMilliseconds, [object] $OutlierMode) $w=$null; $i=$null; $c=$null; if ($PSBoundParameters.ContainsKey('Warmup')) { $w=$Warmup }; if ($PSBoundParameters.ContainsKey('Iteration')) { $i=$Iteration }; if ($PSBoundParameters.ContainsKey('CooldownMilliseconds')) { $c=$CooldownMilliseconds }; $arguments = [object[]]::new(7); $arguments[0] = $w; $arguments[1] = $i; $arguments[2] = $RunMode; $arguments[3] = [string] $Order; $arguments[4] = [string] $MemoryCleanup; $arguments[5] = $c; $arguments[6] = [string] $OutlierMode; __PowerForgeBenchmarkDslInvoke -Name 'Policy' -Arguments $arguments",
             ["Set-BenchmarkProfile"] = Call("Profile", "param([Parameter(Position=0)] [string] $Name, [string] $Cleanup)", "[object[]] @($Name, $Cleanup)"),
             ["Set-BenchmarkCleanup"] = Call("Cleanup", "param([Parameter(Position=0)] [string] $Name)", "[object[]] @($Name)"),
             ["Add-BenchmarkEngine"] = Call("Engine", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkEnvironmentMetadata.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkEnvironmentMetadata.cs
@@ -35,6 +35,7 @@ internal static class PowerShellBenchmarkEnvironmentMetadata
             ["warmupCount"] = suite.WarmupCount.ToString(CultureInfo.InvariantCulture),
             ["iterationCount"] = suite.IterationCount.ToString(CultureInfo.InvariantCulture),
             ["runOrder"] = suite.RunOrder.ToString(),
+            ["memoryCleanup"] = suite.MemoryCleanup.ToString(),
             ["cooldownMilliseconds"] = suite.CooldownMilliseconds.ToString(CultureInfo.InvariantCulture),
             ["outlierMode"] = suite.OutlierMode.ToString(),
             ["runMode"] = suite.RunMode

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkHostExecutor.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkHostExecutor.cs
@@ -34,6 +34,9 @@ public sealed class PowerShellBenchmarkHostRunRequest
     /// <summary>Run order after caller-side overrides.</summary>
     public PowerShellBenchmarkRunOrder RunOrder { get; set; } = PowerShellBenchmarkRunOrder.Rotated;
 
+    /// <summary>Managed-memory cleanup after caller-side overrides.</summary>
+    public PowerShellBenchmarkMemoryCleanupMode MemoryCleanup { get; set; } = PowerShellBenchmarkMemoryCleanupMode.None;
+
     /// <summary>Delay between measured samples, in milliseconds.</summary>
     public int CooldownMilliseconds { get; set; }
 
@@ -195,6 +198,7 @@ public sealed class PowerShellBenchmarkHostExecutor
             IterationCount = request.IterationCount,
             RunMode = request.RunMode ?? string.Empty,
             RunOrder = request.RunOrder.ToString(),
+            MemoryCleanup = request.MemoryCleanup.ToString(),
             CooldownMilliseconds = request.CooldownMilliseconds,
             OutlierMode = request.OutlierMode.ToString(),
             SuiteName = request.SuiteName ?? string.Empty,

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkHostExecutor.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkHostExecutor.cs
@@ -97,6 +97,15 @@ public sealed class PowerShellBenchmarkHostExecutor
         }
 
         var merged = PowerShellBenchmarkResultMerger.Merge(suite, results, started);
+        try
+        {
+            PowerShellBenchmarkComparisonEvaluator.ValidateGates(suite, merged.Summary);
+        }
+        catch
+        {
+            PowerShellBenchmarkArtifactWriter.WriteArtifacts(suite, merged);
+            throw;
+        }
         PowerShellBenchmarkArtifactWriter.WriteArtifacts(suite, merged);
         PowerShellBenchmarkArtifactWriter.UpdateReadmeBlocks(suite, merged);
         return merged;

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkHostExecutor.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkHostExecutor.cs
@@ -166,7 +166,7 @@ public sealed class PowerShellBenchmarkHostExecutor
         }
     }
 
-    private static PowerShellBenchmarkChildRunnerRequest CreateChildRequest(
+    internal static PowerShellBenchmarkChildRunnerRequest CreateChildRequest(
         PowerShellBenchmarkHostRunRequest request,
         string host,
         string executable,
@@ -203,7 +203,8 @@ public sealed class PowerShellBenchmarkHostExecutor
             Selection = selection,
             ModulePaths = PowerShellBenchmarkTemporaryUserExecutor.GetImportableCallerModulePaths(),
             RunStartedUtc = started.ToString("O"),
-            UpdateReadmeBlocks = false
+            UpdateReadmeBlocks = false,
+            ValidateComparisonGates = false
         };
     }
 

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
@@ -195,6 +195,11 @@ public sealed class PowerShellBenchmarkComparison
 
     /// <summary>Fractional tolerance used to label practically equivalent results, such as <c>0.05</c> for five percent.</summary>
     public double TieTolerance { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the benchmark run must fail when the baseline is materially slower than a successful competitor.
+    /// </summary>
+    public bool RequireBaselineFastest { get; set; }
 }
 
 /// <summary>

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
@@ -37,11 +37,35 @@ public enum PowerShellBenchmarkRunOrder
     /// <summary>Run work items in their resolved plan order every iteration.</summary>
     Sequential,
 
-    /// <summary>Rotate work item order by iteration to reduce first-lane bias.</summary>
+    /// <summary>
+    /// Rotate equivalent comparison groups and the work items inside each group by iteration to
+    /// reduce both first-group and first-engine bias.
+    /// </summary>
     Rotated,
 
     /// <summary>Shuffle work item order deterministically for each iteration.</summary>
-    Randomized
+    Randomized,
+
+    /// <summary>
+    /// Run every equivalent comparison group as one block while rotating engine order between the
+    /// group's measured iterations. This limits contamination from unrelated benchmark cases.
+    /// </summary>
+    GroupedRotated
+}
+
+/// <summary>
+/// Managed-memory cleanup applied outside timed benchmark operations.
+/// </summary>
+public enum PowerShellBenchmarkMemoryCleanupMode
+{
+    /// <summary>Do not request an explicit managed-memory cleanup.</summary>
+    None,
+
+    /// <summary>
+    /// Complete a full managed collection after setup and data creation, immediately before every
+    /// warmup and measured operation.
+    /// </summary>
+    BeforeIteration
 }
 
 /// <summary>
@@ -66,6 +90,9 @@ public sealed class PowerShellBenchmarkSuite
 
     /// <summary>Measured work-item ordering strategy.</summary>
     public PowerShellBenchmarkRunOrder RunOrder { get; set; } = PowerShellBenchmarkRunOrder.Rotated;
+
+    /// <summary>Managed-memory cleanup performed outside timed operations.</summary>
+    public PowerShellBenchmarkMemoryCleanupMode MemoryCleanup { get; set; } = PowerShellBenchmarkMemoryCleanupMode.None;
 
     /// <summary>Delay between measured samples, in milliseconds.</summary>
     public int CooldownMilliseconds { get; set; }

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkPathSegments.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkPathSegments.cs
@@ -1,9 +1,12 @@
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace PowerForge;
 
 internal static class PowerShellBenchmarkPathSegments
 {
+    private const int MaxMatrixSegmentLength = 80;
     private static readonly HashSet<string> WindowsDeviceNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "CON",
@@ -56,7 +59,18 @@ internal static class PowerShellBenchmarkPathSegments
                 .Where(k => !isBuiltInPathValue(k.Key))
                 .OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase)
                 .Select(k => string.Concat(Value(k.Key), "=", Value(Convert.ToString(k.Value, CultureInfo.InvariantCulture)))));
-        return string.IsNullOrWhiteSpace(text) ? "matrix" : text;
+        if (string.IsNullOrWhiteSpace(text))
+            return "matrix";
+        if (text.Length <= MaxMatrixSegmentLength)
+            return text;
+
+        string hash;
+        using (var sha256 = SHA256.Create())
+        {
+            var bytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(text));
+            hash = BitConverter.ToString(bytes, 0, 6).Replace("-", string.Empty);
+        }
+        return string.Concat(text.Substring(0, MaxMatrixSegmentLength - hash.Length - 1), "~", hash);
     }
 
     private static string EscapeTrailingWindowsIgnoredCharacters(string escaped)

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkResultMerger.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkResultMerger.cs
@@ -10,8 +10,7 @@ internal static class PowerShellBenchmarkResultMerger
             .SelectMany(result => result.Samples)
             .Select(sample => CopySample(sample, runId))
             .ToArray();
-        var summarizer = new BenchmarkSummaryService();
-        var summary = summarizer.Summarize(samples, suite.OutlierMode);
+        var summary = new BenchmarkSummaryService().Summarize(samples, suite.OutlierMode);
         var result = new BenchmarkRunResult
         {
             RunId = runId,
@@ -20,10 +19,7 @@ internal static class PowerShellBenchmarkResultMerger
             FinishedUtc = DateTimeOffset.UtcNow,
             Samples = samples,
             Summary = summary,
-            Comparison = suite.Comparisons
-                .Where(comparison => !string.IsNullOrWhiteSpace(comparison.Baseline))
-                .SelectMany(comparison => GetComparisonMetrics(comparison).SelectMany(metric => summarizer.Compare(summary, comparison.Baseline, metric, comparison.TieTolerance)))
-                .ToArray(),
+            Comparison = PowerShellBenchmarkComparisonEvaluator.Build(suite, summary),
             Metadata = PowerShellBenchmarkEnvironmentMetadata.Build(suite)
         };
 
@@ -51,9 +47,4 @@ internal static class PowerShellBenchmarkResultMerger
             Variables = new Dictionary<string, string?>(sample.Variables, StringComparer.OrdinalIgnoreCase),
             Metrics = new Dictionary<string, double>(sample.Metrics, StringComparer.OrdinalIgnoreCase)
         };
-
-    private static IEnumerable<string> GetComparisonMetrics(PowerShellBenchmarkComparison comparison)
-        => comparison.Metrics is null || comparison.Metrics.Length == 0
-            ? new[] { "MedianMs" }
-            : comparison.Metrics;
 }

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.Measurements.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.Measurements.cs
@@ -1,0 +1,86 @@
+namespace PowerForge;
+
+public sealed partial class PowerShellBenchmarkRunner
+{
+    private List<PowerShellBenchmarkWorkItem> WarmUpWorkItems(
+        PowerShellBenchmarkSuite suite,
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items,
+        string runId,
+        ICollection<BenchmarkSample> samples)
+    {
+        var runnable = new List<PowerShellBenchmarkWorkItem>(items.Count);
+        foreach (var item in items)
+        {
+            var warmupFailed = false;
+            for (var warmup = 0; warmup < Math.Max(0, suite.WarmupCount); warmup++)
+            {
+                var warmupSample = InvokeMeasuredIteration(
+                    suite,
+                    item,
+                    ToPsObject(item.Values),
+                    -warmup - 1,
+                    runId,
+                    recordSample: false);
+                if (warmupSample.Status != BenchmarkSampleStatus.Failed)
+                    continue;
+
+                samples.Add(warmupSample);
+                warmupFailed = true;
+                break;
+            }
+
+            if (!warmupFailed)
+                runnable.Add(item);
+        }
+
+        return runnable;
+    }
+
+    private void RunInterleavedMeasurements(
+        PowerShellBenchmarkSuite suite,
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items,
+        string runId,
+        ICollection<BenchmarkSample> samples)
+    {
+        for (var iteration = 0; iteration < Math.Max(1, suite.IterationCount); iteration++)
+        {
+            foreach (var item in OrderWorkItems(items, iteration, suite.RunOrder))
+            {
+                samples.Add(InvokeMeasuredIteration(
+                    suite,
+                    item,
+                    ToPsObject(item.Values),
+                    iteration,
+                    runId,
+                    recordSample: true));
+                ApplyCooldown(suite);
+            }
+        }
+    }
+
+    private void RunGroupedMeasurements(
+        PowerShellBenchmarkSuite suite,
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items,
+        string runId,
+        ICollection<BenchmarkSample> samples)
+    {
+        foreach (var group in GroupComparisonWorkItems(items))
+        {
+            var runnable = WarmUpWorkItems(suite, group, runId, samples);
+            for (var iteration = 0; iteration < Math.Max(1, suite.IterationCount); iteration++)
+            {
+                foreach (var item in Rotate(runnable, iteration))
+                {
+                    samples.Add(InvokeMeasuredIteration(
+                        suite,
+                        item,
+                        ToPsObject(item.Values),
+                        iteration,
+                        runId,
+                        recordSample: true));
+                    ApplyCooldown(suite);
+                }
+            }
+        }
+    }
+}

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.Ordering.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.Ordering.cs
@@ -1,0 +1,67 @@
+namespace PowerForge;
+
+public sealed partial class PowerShellBenchmarkRunner
+{
+    private static IEnumerable<PowerShellBenchmarkWorkItem> OrderWorkItems(
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items,
+        int iteration,
+        PowerShellBenchmarkRunOrder order)
+        => order switch
+        {
+            PowerShellBenchmarkRunOrder.Sequential => items,
+            PowerShellBenchmarkRunOrder.Randomized => Randomize(items, iteration),
+            _ => RotateComparisonGroups(items, iteration)
+        };
+
+    private static IEnumerable<PowerShellBenchmarkWorkItem> RotateComparisonGroups(
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items,
+        int iteration)
+    {
+        if (items.Count == 0)
+            yield break;
+
+        var groups = GroupComparisonWorkItems(items);
+        var groupOffset = iteration % groups.Length;
+
+        for (var groupIndex = 0; groupIndex < groups.Length; groupIndex++)
+        {
+            var group = groups[(groupOffset + groupIndex) % groups.Length];
+            foreach (var item in Rotate(group, iteration))
+                yield return item;
+        }
+    }
+
+    private static PowerShellBenchmarkWorkItem[][] GroupComparisonWorkItems(
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items)
+        => items
+            .GroupBy(item => ComparisonGroupKey(string.Empty, item), StringComparer.Ordinal)
+            .Select(group => group.ToArray())
+            .ToArray();
+
+    private static IEnumerable<PowerShellBenchmarkWorkItem> Rotate(
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items,
+        int iteration)
+    {
+        if (items.Count == 0)
+            yield break;
+
+        var itemOffset = iteration % items.Count;
+        for (var itemIndex = 0; itemIndex < items.Count; itemIndex++)
+            yield return items[(itemOffset + itemIndex) % items.Count];
+    }
+
+    private static IEnumerable<PowerShellBenchmarkWorkItem> Randomize(
+        IReadOnlyList<PowerShellBenchmarkWorkItem> items,
+        int iteration)
+    {
+        var ordered = items.ToArray();
+        var random = new Random(unchecked((iteration + 1) * 397) ^ ordered.Length);
+        for (var i = ordered.Length - 1; i > 0; i--)
+        {
+            var j = random.Next(i + 1);
+            (ordered[i], ordered[j]) = (ordered[j], ordered[i]);
+        }
+
+        return ordered;
+    }
+}

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.cs
@@ -10,7 +10,7 @@ namespace PowerForge;
 /// <summary>
 /// Executes PowerShell-authored benchmark suites in the current host process.
 /// </summary>
-public sealed class PowerShellBenchmarkRunner
+public sealed partial class PowerShellBenchmarkRunner
 {
     /// <summary>
     /// Expands a suite into concrete work items without executing measurements.
@@ -149,7 +149,7 @@ public sealed class PowerShellBenchmarkRunner
         var samples = new List<BenchmarkSample>();
         var workItems = PlanInCurrentRunspace(suite, allowExternalHosts: false);
         ValidateComparisonWorkItems(suite, workItems);
-        var runnable = new List<PowerShellBenchmarkWorkItem>();
+        var pending = new List<PowerShellBenchmarkWorkItem>();
         foreach (var item in workItems)
         {
             if (item.IsSkipped)
@@ -158,31 +158,17 @@ public sealed class PowerShellBenchmarkRunner
                 continue;
             }
 
-            var warmupFailed = false;
-            for (var warmup = 0; warmup < Math.Max(0, suite.WarmupCount); warmup++)
-            {
-                var warmupSample = InvokeMeasuredIteration(suite, item, ToPsObject(item.Values), -warmup - 1, runId, recordSample: false);
-                if (warmupSample.Status == BenchmarkSampleStatus.Failed)
-                {
-                    samples.Add(warmupSample);
-                    warmupFailed = true;
-                    break;
-                }
-            }
-
-            if (warmupFailed)
-                continue;
-
-            runnable.Add(item);
+            pending.Add(item);
         }
 
-        for (var iteration = 0; iteration < Math.Max(1, suite.IterationCount); iteration++)
+        if (suite.RunOrder == PowerShellBenchmarkRunOrder.GroupedRotated)
         {
-            foreach (var item in OrderWorkItems(runnable, iteration, suite.RunOrder))
-            {
-                samples.Add(InvokeMeasuredIteration(suite, item, ToPsObject(item.Values), iteration, runId, recordSample: true));
-                ApplyCooldown(suite);
-            }
+            RunGroupedMeasurements(suite, pending, runId, samples);
+        }
+        else
+        {
+            var runnable = WarmUpWorkItems(suite, pending, runId, samples);
+            RunInterleavedMeasurements(suite, runnable, runId, samples);
         }
 
         var summarizer = new BenchmarkSummaryService();
@@ -251,6 +237,8 @@ public sealed class PowerShellBenchmarkRunner
             var data = CaptureData(InvokeOptional(suite.Data, caseObject, runObject));
             SetProperty(runObject, "Data", data);
 
+            stage = "Memory cleanup";
+            ApplyMemoryCleanup(suite);
             stage = iteration < 0 ? "Warmup operation" : "Operation";
             operationStopwatch = Stopwatch.StartNew();
             InvokeStrict(item.Handler, caseObject, runObject);
@@ -565,40 +553,20 @@ public sealed class PowerShellBenchmarkRunner
     private static string ComparisonGroupKey(string suite, PowerShellBenchmarkWorkItem item)
         => string.Join("\u001f", suite, item.Scenario, item.Operation, item.Host, GetOperatingSystemLabel(), FormatVariables(ToVariables(item.Values)));
 
-    private static IEnumerable<PowerShellBenchmarkWorkItem> OrderWorkItems(IReadOnlyList<PowerShellBenchmarkWorkItem> items, int iteration, PowerShellBenchmarkRunOrder order)
-        => order switch
-        {
-            PowerShellBenchmarkRunOrder.Sequential => items,
-            PowerShellBenchmarkRunOrder.Randomized => Randomize(items, iteration),
-            _ => Rotate(items, iteration)
-        };
-
-    private static IEnumerable<PowerShellBenchmarkWorkItem> Rotate(IReadOnlyList<PowerShellBenchmarkWorkItem> items, int iteration)
-    {
-        if (items.Count == 0)
-            yield break;
-        var offset = iteration % items.Count;
-        for (var i = 0; i < items.Count; i++)
-            yield return items[(offset + i) % items.Count];
-    }
-
-    private static IEnumerable<PowerShellBenchmarkWorkItem> Randomize(IReadOnlyList<PowerShellBenchmarkWorkItem> items, int iteration)
-    {
-        var ordered = items.ToArray();
-        var random = new Random(unchecked((iteration + 1) * 397) ^ ordered.Length);
-        for (var i = ordered.Length - 1; i > 0; i--)
-        {
-            var j = random.Next(i + 1);
-            (ordered[i], ordered[j]) = (ordered[j], ordered[i]);
-        }
-
-        return ordered;
-    }
-
     private static void ApplyCooldown(PowerShellBenchmarkSuite suite)
     {
         if (suite.CooldownMilliseconds > 0)
             System.Threading.Thread.Sleep(suite.CooldownMilliseconds);
+    }
+
+    private static void ApplyMemoryCleanup(PowerShellBenchmarkSuite suite)
+    {
+        if (suite.MemoryCleanup != PowerShellBenchmarkMemoryCleanupMode.BeforeIteration)
+            return;
+
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: false);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: false);
     }
 
     private static Collection<PSObject> InvokeOptional(ScriptBlock? block, PSObject caseObject, PSObject runObject)

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkRunner.cs
@@ -201,10 +201,8 @@ public sealed class PowerShellBenchmarkRunner
 
         try
         {
-            result.Comparison = suite.Comparisons
-                .Where(c => !string.IsNullOrWhiteSpace(c.Baseline))
-                .SelectMany(c => GetComparisonMetrics(c).SelectMany(m => summarizer.Compare(summary, c.Baseline, m, c.TieTolerance)))
-                .ToArray();
+            result.Comparison = PowerShellBenchmarkComparisonEvaluator.Build(suite, summary);
+            PowerShellBenchmarkComparisonEvaluator.ValidateGates(suite, summary);
         }
         catch
         {
@@ -510,6 +508,8 @@ public sealed class PowerShellBenchmarkRunner
             foreach (var metric in GetComparisonMetrics(comparison))
             {
                 var normalized = string.IsNullOrWhiteSpace(metric) ? "MedianMs" : metric.Trim();
+                if (comparison.RequireBaselineFastest && !BenchmarkComparisonSemantics.IsDurationMetric(normalized))
+                    throw new NotSupportedException($"Benchmark comparison metric '{metric}' cannot require the baseline to be fastest because only duration metrics have lower-is-better semantics.");
                 if (IsPrimaryComparisonMetric(normalized) || customMetrics.Contains(normalized))
                     continue;
                 throw new NotSupportedException($"Benchmark comparison metric '{metric}' is not supported by suite '{suite.Name}'. Use MedianMs, MeanMs, MinMs, MaxMs, P95Ms/P95, P99Ms/P99, StdDevMs/StdDev, StdErrMs/StdErr, or a declared custom metric.");

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkTemporaryUserExecutor.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkTemporaryUserExecutor.cs
@@ -34,6 +34,9 @@ public sealed class PowerShellBenchmarkTemporaryUserRequest
     /// <summary>Run order after caller-side overrides.</summary>
     public PowerShellBenchmarkRunOrder RunOrder { get; set; } = PowerShellBenchmarkRunOrder.Rotated;
 
+    /// <summary>Managed-memory cleanup after caller-side overrides.</summary>
+    public PowerShellBenchmarkMemoryCleanupMode MemoryCleanup { get; set; } = PowerShellBenchmarkMemoryCleanupMode.None;
+
     /// <summary>Delay between measured samples, in milliseconds.</summary>
     public int CooldownMilliseconds { get; set; }
 
@@ -138,6 +141,7 @@ public sealed class PowerShellBenchmarkTemporaryUserExecutor
                 IterationCount = request.IterationCount,
                 RunMode = request.RunMode ?? string.Empty,
                 RunOrder = request.RunOrder.ToString(),
+                MemoryCleanup = request.MemoryCleanup.ToString(),
                 CooldownMilliseconds = request.CooldownMilliseconds,
                 OutlierMode = request.OutlierMode.ToString(),
                 SuiteName = request.SuiteName ?? string.Empty,

--- a/PowerForge.Tests/BenchmarkServicesTests.ComparisonGate.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.ComparisonGate.cs
@@ -73,6 +73,56 @@ benchmark 'gate' {
         Assert.Contains("competitor Other failed", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ComparisonGate_RejectsPartiallyFailedCompetitorLaneWithTiming()
+    {
+        var suite = CreateGateSuite(tieTolerance: 0.05);
+        var summary = new BenchmarkSummaryService().Summarize(new[]
+        {
+            GateSample("Managed", BenchmarkSampleStatus.Succeeded, 100, 0),
+            GateSample("Other", BenchmarkSampleStatus.Succeeded, 90, 0),
+            GateSample("Other", BenchmarkSampleStatus.Failed, 0, 1)
+        });
+        var competitor = Assert.Single(summary, row => row.Engine == "Other");
+
+        Assert.Equal("Failed", competitor.Status);
+        Assert.Equal(90, competitor.MedianMs);
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => PowerShellBenchmarkComparisonEvaluator.ValidateGates(suite, summary));
+
+        Assert.Contains("competitor Other failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HostExecutor_ChildRequestDefersComparisonGateValidation()
+    {
+        var request = new PowerShellBenchmarkHostRunRequest
+        {
+            SpecPath = "suite.benchmark.ps1",
+            WorkingDirectory = "work",
+            OutputRoot = "output"
+        };
+
+        var child = PowerShellBenchmarkHostExecutor.CreateChildRequest(
+            request,
+            "Current",
+            "pwsh",
+            "result.json",
+            "readme-paths.txt",
+            DateTimeOffset.UtcNow);
+
+        Assert.False(child.ValidateComparisonGates);
+    }
+
+    [Fact]
+    public void HostChildRunner_DisablesComparisonGatesOnlyWhenRequested()
+    {
+        var script = PowerForgeScripts.Load("Scripts/Benchmarks/TemporaryUserChildRunner.ps1");
+
+        Assert.Contains("'ValidateComparisonGates'", script, StringComparison.Ordinal);
+        Assert.Contains("$comparison.RequireBaselineFastest = $false", script, StringComparison.Ordinal);
+    }
+
     private static PowerShellBenchmarkSuite CreateGateSuite(double tieTolerance)
     {
         var suite = new PowerShellBenchmarkSuite { Name = "gate" };
@@ -103,5 +153,25 @@ benchmark 'gate' {
             MinMs = median,
             MaxMs = median,
             P95Ms = median
+        };
+
+    private static BenchmarkSample GateSample(
+        string engine,
+        BenchmarkSampleStatus status,
+        double durationMs,
+        int iteration)
+        => new()
+        {
+            RunId = "run",
+            Suite = "gate",
+            Scenario = "case",
+            Operation = "Run",
+            Engine = engine,
+            Host = "Current",
+            Os = "Windows",
+            RunMode = "standard",
+            Iteration = iteration,
+            Status = status,
+            DurationMs = durationMs
         };
 }

--- a/PowerForge.Tests/BenchmarkServicesTests.ComparisonGate.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.ComparisonGate.cs
@@ -94,6 +94,21 @@ benchmark 'gate' {
     }
 
     [Fact]
+    public void ComparisonGate_RejectsFailedBaselineWhenEveryCompetitorIsSkipped()
+    {
+        var suite = CreateGateSuite(tieTolerance: 0.05);
+        var failedBaseline = GateSummary("Managed", null);
+        var skippedCompetitor = GateSummary("Other", null);
+        skippedCompetitor.Status = "Skipped";
+        var summary = new[] { failedBaseline, skippedCompetitor };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => PowerShellBenchmarkComparisonEvaluator.ValidateGates(suite, summary));
+
+        Assert.Contains("baseline Managed failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HostExecutor_ChildRequestDefersComparisonGateValidation()
     {
         var request = new PowerShellBenchmarkHostRunRequest

--- a/PowerForge.Tests/BenchmarkServicesTests.ComparisonGate.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.ComparisonGate.cs
@@ -1,0 +1,107 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed partial class BenchmarkServicesTests
+{
+    [Fact]
+    public void BenchmarkDsl_PropagatesFastestBaselineGate()
+    {
+        var script = System.Management.Automation.ScriptBlock.Create("""
+benchmark 'gate' {
+    axis Operation Run
+    axis Engine Managed, Other
+    engine Managed { operation Run { param($case, $run) } }
+    engine Other { operation Run { param($case, $run) } }
+    comparison Engine -Baseline Managed -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
+}
+""");
+
+        var suite = Assert.Single(EvaluateBenchmarkDsl(script));
+        var comparison = Assert.Single(suite.Comparisons);
+
+        Assert.True(comparison.RequireBaselineFastest);
+        Assert.Equal(0.05, comparison.TieTolerance);
+    }
+
+    [Fact]
+    public void ComparisonGate_AllowsBaselineWithinTieTolerance()
+    {
+        var suite = CreateGateSuite(tieTolerance: 0.05);
+        var summary = new[]
+        {
+            GateSummary("Managed", 104),
+            GateSummary("Other", 100)
+        };
+
+        PowerShellBenchmarkComparisonEvaluator.ValidateGates(suite, summary);
+    }
+
+    [Fact]
+    public void ComparisonGate_RejectsMateriallySlowerBaseline()
+    {
+        var suite = CreateGateSuite(tieTolerance: 0.05);
+        var summary = new[]
+        {
+            GateSummary("Managed", 106),
+            GateSummary("Other", 100)
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => PowerShellBenchmarkComparisonEvaluator.ValidateGates(suite, summary));
+
+        Assert.Contains("Managed", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Other", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("5%", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComparisonGate_RejectsFailedCompetitorLane()
+    {
+        var suite = CreateGateSuite(tieTolerance: 0.05);
+        var failed = GateSummary("Other", null);
+        failed.Status = "Failed";
+        var summary = new[]
+        {
+            GateSummary("Managed", 100),
+            failed
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => PowerShellBenchmarkComparisonEvaluator.ValidateGates(suite, summary));
+
+        Assert.Contains("competitor Other failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static PowerShellBenchmarkSuite CreateGateSuite(double tieTolerance)
+    {
+        var suite = new PowerShellBenchmarkSuite { Name = "gate" };
+        suite.Comparisons.Add(new PowerShellBenchmarkComparison
+        {
+            Dimension = "Engine",
+            Baseline = "Managed",
+            Metrics = new[] { "MedianMs" },
+            TieTolerance = tieTolerance,
+            RequireBaselineFastest = true
+        });
+        return suite;
+    }
+
+    private static BenchmarkSummaryRow GateSummary(string engine, double? median)
+        => new()
+        {
+            Suite = "gate",
+            Scenario = "case",
+            Operation = "Run",
+            Engine = engine,
+            Host = "Current",
+            Os = "Windows",
+            RunMode = "standard",
+            Status = median.HasValue ? "Success" : "Failed",
+            MedianMs = median,
+            MeanMs = median,
+            MinMs = median,
+            MaxMs = median,
+            P95Ms = median
+        };
+}

--- a/PowerForge.Tests/BenchmarkServicesTests.InlineSettingsClosure.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.InlineSettingsClosure.cs
@@ -1,0 +1,38 @@
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed partial class BenchmarkServicesTests
+{
+    [Fact]
+    public void InvokeBenchmarkSuiteCommand_EvaluatesGetNewClosureSettingsWithLocalDslFunctions()
+    {
+        var initialSessionState = InitialSessionState.CreateDefault();
+        initialSessionState.Commands.Add(new SessionStateCmdletEntry("Invoke-BenchmarkSuite", typeof(PSPublishModule.InvokeBenchmarkSuiteCommand), helpFileName: null));
+        using var runspace = RunspaceFactory.CreateRunspace(initialSessionState);
+        runspace.Open();
+        ImportBenchmarkDslCommands(runspace);
+        using var ps = PowerShell.Create(runspace);
+        ps.AddScript("""
+$caseName = 'FromClosure'
+$settings = {
+    benchmark 'inline-closure' {
+        policy -Warmup 0 -Iterations 1
+        cases { case A @{ Probe = $caseName } }
+        axis Operation Run
+        axis Engine Managed
+        engine Managed { operation Run { param($case, $run) } }
+    }
+}.GetNewClosure()
+Invoke-BenchmarkSuite -Settings $settings -Plan
+""");
+
+        var plan = ps.Invoke();
+
+        Assert.Empty(ps.Streams.Error);
+        var item = Assert.IsType<PowerShellBenchmarkWorkItem>(Assert.Single(plan).BaseObject);
+        Assert.Equal("FromClosure", item.Values["Probe"]);
+    }
+}

--- a/PowerForge.Tests/BenchmarkServicesTests.Part04.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Part04.cs
@@ -409,6 +409,26 @@ public sealed partial class BenchmarkServicesTests
     }
 
     [Fact]
+    public void RunnerPathSegments_ShortenLongMatrixValuesDeterministicallyWithoutCollisions()
+    {
+        var common = new string('a', 160);
+        var first = PowerShellBenchmarkPathSegments.Matrix(
+            new Dictionary<string, object?> { ["Label"] = common + "-first", ["Rows"] = 100 },
+            _ => false);
+        var repeated = PowerShellBenchmarkPathSegments.Matrix(
+            new Dictionary<string, object?> { ["Label"] = common + "-first", ["Rows"] = 100 },
+            _ => false);
+        var second = PowerShellBenchmarkPathSegments.Matrix(
+            new Dictionary<string, object?> { ["Label"] = common + "-second", ["Rows"] = 100 },
+            _ => false);
+
+        Assert.Equal(first, repeated);
+        Assert.NotEqual(first, second);
+        Assert.True(first.Length <= 80);
+        Assert.Contains("~", first, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DslRuntime_ResolvesShortAndLongEngineForms()
     {
         var script = ScriptBlock.Create(@"

--- a/PowerForge.Tests/BenchmarkServicesTests.Part05.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Part05.cs
@@ -248,6 +248,29 @@ benchmark 'policy-suite' {
     }
 
     [Fact]
+    public void DslRuntime_PreservesLegacyPositionalBenchmarkPolicyArguments()
+    {
+        var script = ScriptBlock.Create(@"
+benchmark 'legacy-policy-suite' {
+    policy 1 3 publish Rotated 10 ExcludeMinMax
+    axis Operation Run
+    axis Engine Managed
+    engine Managed { operation Run { param($case, $run) } }
+}
+");
+
+        var suite = Assert.Single(EvaluateBenchmarkDsl(script));
+
+        Assert.Equal(1, suite.WarmupCount);
+        Assert.Equal(3, suite.IterationCount);
+        Assert.Equal("publish", suite.RunMode);
+        Assert.Equal(PowerShellBenchmarkRunOrder.Rotated, suite.RunOrder);
+        Assert.Equal(PowerShellBenchmarkMemoryCleanupMode.None, suite.MemoryCleanup);
+        Assert.Equal(10, suite.CooldownMilliseconds);
+        Assert.Equal(PowerShellBenchmarkOutlierMode.ExcludeMinMax, suite.OutlierMode);
+    }
+
+    [Fact]
     public void BenchmarkPolicy_PreservesExistingRunOrderValuesAndLegacyRuntimeSignature()
     {
         Assert.Equal(0, (int)PowerShellBenchmarkRunOrder.Sequential);

--- a/PowerForge.Tests/BenchmarkServicesTests.Part05.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Part05.cs
@@ -229,7 +229,7 @@ benchmark 'temp-user' {
     {
         var script = ScriptBlock.Create(@"
 benchmark 'policy-suite' {
-    policy -Warmup 2 -Iterations 5 -RunMode publish -Order Sequential -CooldownMilliseconds 10 -OutlierMode ExcludeMinMax
+    policy -Warmup 2 -Iterations 5 -RunMode publish -Order Sequential -MemoryCleanup BeforeIteration -CooldownMilliseconds 10 -OutlierMode ExcludeMinMax
     axis Operation Run
     axis Engine Managed
     engine Managed { operation Run { param($case, $run) } }
@@ -242,8 +242,24 @@ benchmark 'policy-suite' {
         Assert.Equal(5, suite.IterationCount);
         Assert.Equal("publish", suite.RunMode);
         Assert.Equal(PowerShellBenchmarkRunOrder.Sequential, suite.RunOrder);
+        Assert.Equal(PowerShellBenchmarkMemoryCleanupMode.BeforeIteration, suite.MemoryCleanup);
         Assert.Equal(10, suite.CooldownMilliseconds);
         Assert.Equal(PowerShellBenchmarkOutlierMode.ExcludeMinMax, suite.OutlierMode);
+    }
+
+    [Fact]
+    public void BenchmarkPolicy_PreservesExistingRunOrderValuesAndLegacyRuntimeSignature()
+    {
+        Assert.Equal(0, (int)PowerShellBenchmarkRunOrder.Sequential);
+        Assert.Equal(1, (int)PowerShellBenchmarkRunOrder.Rotated);
+        Assert.Equal(2, (int)PowerShellBenchmarkRunOrder.Randomized);
+        Assert.Equal(3, (int)PowerShellBenchmarkRunOrder.GroupedRotated);
+
+        var legacyPolicy = typeof(PowerShellBenchmarkDslRuntime).GetMethod(
+            nameof(PowerShellBenchmarkDslRuntime.Policy),
+            new[] { typeof(int?), typeof(int?), typeof(string), typeof(string), typeof(int?), typeof(string) });
+
+        Assert.NotNull(legacyPolicy);
     }
 
     [Fact]

--- a/PowerForge.Tests/BenchmarkServicesTests.Part06.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Part06.cs
@@ -182,6 +182,7 @@ public sealed partial class BenchmarkServicesTests
 
         Assert.Contains("$benchmarkVariables[$property.Name] = $property.Value", script, StringComparison.Ordinal);
         Assert.DoesNotContain("[string] $property.Value", script, StringComparison.Ordinal);
+        Assert.Contains("$suite.MemoryCleanup = [PowerForge.PowerShellBenchmarkMemoryCleanupMode] $request.MemoryCleanup", script, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -352,11 +353,63 @@ benchmark 'stale-native-exit' {
     }
 
     [Fact]
+    public void Runner_RotatesComparisonGroupsAndEngineOrderBetweenMeasuredIterations()
+    {
+        var suite = CreateRunnableSuite();
+        suite.IterationCount = 2;
+        suite.Axes.Add(new PowerShellBenchmarkAxis { Name = "Rows", Values = { 1, 2 } });
+        var other = new PowerShellBenchmarkEngine { Name = "Other" };
+        other.Operations["Run"] = ScriptBlock.Create("param($case, $run)");
+        suite.Engines.Add(other);
+        suite.Axes.Single(axis => axis.Name == "Engine").Values.Add("Other");
+
+        var result = new PowerShellBenchmarkRunner().Run(suite);
+        var firstIteration = result.Samples
+            .Where(sample => sample.Iteration == 0)
+            .Select(sample => $"{sample.Variables["Rows"]}:{sample.Engine}")
+            .ToArray();
+        var secondIteration = result.Samples
+            .Where(sample => sample.Iteration == 1)
+            .Select(sample => $"{sample.Variables["Rows"]}:{sample.Engine}")
+            .ToArray();
+
+        Assert.Equal(new[] { "1:Managed", "1:Other", "2:Managed", "2:Other" }, firstIteration);
+        Assert.Equal(new[] { "2:Other", "2:Managed", "1:Other", "1:Managed" }, secondIteration);
+    }
+
+    [Fact]
+    public void Runner_GroupedRotatedKeepsComparisonIterationsTogetherAndAlternatesEngines()
+    {
+        var suite = CreateRunnableSuite();
+        suite.IterationCount = 2;
+        suite.RunOrder = PowerShellBenchmarkRunOrder.GroupedRotated;
+        suite.Axes.Add(new PowerShellBenchmarkAxis { Name = "Rows", Values = { 1, 2 } });
+        var other = new PowerShellBenchmarkEngine { Name = "Other" };
+        other.Operations["Run"] = ScriptBlock.Create("param($case, $run)");
+        suite.Engines.Add(other);
+        suite.Axes.Single(axis => axis.Name == "Engine").Values.Add("Other");
+
+        var result = new PowerShellBenchmarkRunner().Run(suite);
+        var order = result.Samples
+            .Select(sample => $"{sample.Variables["Rows"]}:{sample.Iteration}:{sample.Engine}")
+            .ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                "1:0:Managed", "1:0:Other", "1:1:Other", "1:1:Managed",
+                "2:0:Managed", "2:0:Other", "2:1:Other", "2:1:Managed"
+            },
+            order);
+    }
+
+    [Fact]
     public void Runner_HonorsSequentialRunOrderPolicy()
     {
         var suite = CreateRunnableSuite();
         suite.IterationCount = 2;
         suite.RunOrder = PowerShellBenchmarkRunOrder.Sequential;
+        suite.MemoryCleanup = PowerShellBenchmarkMemoryCleanupMode.BeforeIteration;
         suite.Axes.Add(new PowerShellBenchmarkAxis { Name = "Rows", Values = { 1, 2, 3 } });
 
         var result = new PowerShellBenchmarkRunner().Run(suite);
@@ -366,6 +419,7 @@ benchmark 'stale-native-exit' {
         Assert.Equal(new[] { "1", "2", "3" }, firstIteration);
         Assert.Equal(new[] { "1", "2", "3" }, secondIteration);
         Assert.Equal("Sequential", result.Metadata["runOrder"]);
+        Assert.Equal("BeforeIteration", result.Metadata["memoryCleanup"]);
     }
 
     [Fact]

--- a/PowerForge/Scripts/Benchmarks/TemporaryUserChildRunner.ps1
+++ b/PowerForge/Scripts/Benchmarks/TemporaryUserChildRunner.ps1
@@ -88,6 +88,11 @@ for ($index = 0; $index -lt $suite.ReadmeBlocks.Count -and $index -lt $readmePat
 if ($request.PSObject.Properties.Name -contains 'UpdateReadmeBlocks' -and -not $request.UpdateReadmeBlocks) {
     $suite.ReadmeBlocks.Clear()
 }
+if ($request.PSObject.Properties.Name -contains 'ValidateComparisonGates' -and -not $request.ValidateComparisonGates) {
+    foreach ($comparison in @($suite.Comparisons)) {
+        $comparison.RequireBaselineFastest = $false
+    }
+}
 try {
     $result = [PowerForge.PowerShellBenchmarkRunner]::new().Run($suite)
     [PowerForge.BenchmarkJson]::Write($request.ResultPath, $result)

--- a/PowerForge/Scripts/Benchmarks/TemporaryUserChildRunner.ps1
+++ b/PowerForge/Scripts/Benchmarks/TemporaryUserChildRunner.ps1
@@ -62,6 +62,9 @@ if (-not [string]::IsNullOrWhiteSpace($request.RunMode)) {
 if (-not [string]::IsNullOrWhiteSpace($request.RunOrder)) {
     $suite.RunOrder = [PowerForge.PowerShellBenchmarkRunOrder] $request.RunOrder
 }
+if (-not [string]::IsNullOrWhiteSpace($request.MemoryCleanup)) {
+    $suite.MemoryCleanup = [PowerForge.PowerShellBenchmarkMemoryCleanupMode] $request.MemoryCleanup
+}
 if (-not [string]::IsNullOrWhiteSpace($request.OutlierMode)) {
     $suite.OutlierMode = [PowerForge.PowerShellBenchmarkOutlierMode] $request.OutlierMode
 }

--- a/PowerForge/Services/Benchmarks/BenchmarkComparisonSemantics.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkComparisonSemantics.cs
@@ -1,0 +1,14 @@
+namespace PowerForge;
+
+internal static class BenchmarkComparisonSemantics
+{
+    internal static bool IsDurationMetric(string? metric)
+    {
+        var name = string.IsNullOrWhiteSpace(metric) ? "MedianMs" : metric!.Trim();
+        return name.EndsWith("Ms", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(name, "P95", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(name, "P99", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(name, "StdDev", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(name, "StdErr", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/PowerForge/Services/Benchmarks/BenchmarkMarkdownRenderer.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkMarkdownRenderer.cs
@@ -145,7 +145,7 @@ public sealed class BenchmarkMarkdownRenderer
         }
 
         var ratio = row.Ratio.HasValue ? row.Ratio.Value.ToString("0.00", CultureInfo.InvariantCulture) + "x" : "n/a";
-        var value = IsDurationMetric(row.Metric)
+        var value = BenchmarkComparisonSemantics.IsDurationMetric(row.Metric)
             ? FormatDuration(row.Actual.Value)
             : Number(row.Actual.Value);
         return $"{ratio} ({value})";
@@ -153,7 +153,7 @@ public sealed class BenchmarkMarkdownRenderer
 
     private static string FormatComparisonResult(string baseline, string? metric, IEnumerable<BenchmarkComparisonRow> rows)
     {
-        if (!IsDurationMetric(metric))
+        if (!BenchmarkComparisonSemantics.IsDurationMetric(metric))
             return $"{baseline} baseline";
 
         var successful = rows
@@ -192,16 +192,6 @@ public sealed class BenchmarkMarkdownRenderer
 
     private static bool IsDefaultDurationMetric(string? metric)
         => string.IsNullOrWhiteSpace(metric) || string.Equals(metric, "MedianMs", StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsDurationMetric(string? metric)
-    {
-        var name = string.IsNullOrWhiteSpace(metric) ? "MedianMs" : metric!.Trim();
-        return name.EndsWith("Ms", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(name, "P95", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(name, "P99", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(name, "StdDev", StringComparison.OrdinalIgnoreCase)
-               || string.Equals(name, "StdErr", StringComparison.OrdinalIgnoreCase);
-    }
 
     private static string FormatDuration(double milliseconds)
         => milliseconds >= 1000


### PR DESCRIPTION
## Summary

- cap generated benchmark matrix path segments while preserving a readable prefix and deterministic SHA-256 suffix
- add the opt-in RequireBaselineFastest comparison gate with a configurable practical-tie tolerance
- add grouped rotation so equivalent cases stay together while group and engine order rotate across iterations
- add opt-in pre-iteration memory cleanup for allocation-heavy PowerShell benchmark lanes
- preserve the original six positional policy arguments and append memory cleanup without reinterpreting existing specs
- fail gated runs when requested lanes contain failed samples, including a failed baseline when every competitor is skipped
- defer multi-host gate decisions until child-host results are merged and preserve comparison artifacts on failure
- evaluate closure-bound inline benchmark settings in their owning module scope, so locally injected DSL functions remain visible without module auto-loading
- preserve existing public enum values and the legacy result-policy overload while extending the benchmark API
- regenerate command and external help for the new benchmark options

These changes keep large correctness/performance matrices stable and turn relative performance claims into same-run release conditions without relying on absolute timing thresholds from unrelated machines.

## Validation

The benchmark-services suite passes 282/282. PowerForge and PowerForge.PowerShell build cleanly for .NET Framework 4.7.2, .NET 8, and .NET 10. Closure-bound inline settings are exercised through the real `Invoke-BenchmarkSuite` command under PowerShell 7 and Windows PowerShell 5.1, and the PSWriteOffice and DbaClientX source plans load the rebuilt module successfully.

The broad repository suite remains susceptible to unrelated parallel process/current-directory interference: the GitSync case reported during the latest broad attempt passes immediately in isolation, while the benchmark subsystem is fully green. Current-head CI remains the authoritative cross-platform gate.

PSWriteOffice and DbaClientX consume these capabilities directly from source for their correctness-validated CSV, Excel, and SQL performance gates. No package publication is part of this PR.