### PR TITLE
Add generic Linux service deployment

### DIFF
--- a/.github/workflows/powerforge-service-deploy.yml
+++ b/.github/workflows/powerforge-service-deploy.yml
@@ -1,0 +1,266 @@
+name: PowerForge Linux Service Deploy
+
+on:
+  workflow_call:
+    inputs:
+      service_root:
+        description: Repository-relative service source or prepared output directory to package.
+        required: true
+        type: string
+      service_validation_script:
+        description: Optional repository-relative Bash script that tests and prepares the service before packaging.
+        required: false
+        type: string
+        default: ""
+      deployment_service:
+        description: Host-configured service identifier.
+        required: true
+        type: string
+      deployment_host:
+        required: true
+        type: string
+      deployment_user:
+        required: false
+        type: string
+        default: "powerforge-deploy"
+      deployment_port:
+        required: false
+        type: number
+        default: 22
+      deployment_environment:
+        required: false
+        type: string
+        default: "production"
+      deployment_url:
+        required: false
+        type: string
+        default: ""
+      package_runner_labels_json:
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
+      publisher_runner_labels_json:
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
+      timeout_minutes:
+        required: false
+        type: number
+        default: 20
+      deployment_artifact_retention_days:
+        required: false
+        type: number
+        default: 7
+    secrets:
+      deployment_ssh_private_key:
+        required: true
+      deployment_ssh_known_hosts:
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: powerforge-service-deploy-${{ github.repository }}-${{ inputs.deployment_service }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    runs-on: ${{ fromJson(inputs.package_runner_labels_json) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ github.token }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Validate, test, and prepare service
+        shell: pwsh
+        env:
+          DEPLOYMENT_SERVICE: ${{ inputs.deployment_service }}
+          SERVICE_ROOT: ${{ inputs.service_root }}
+          SERVICE_VALIDATION_SCRIPT: ${{ inputs.service_validation_script }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:RUNNER_OS -ne 'Linux') {
+            throw 'The service packaging runner must be Linux.'
+          }
+          if ($env:DEPLOYMENT_SERVICE -notmatch '^[a-z0-9][a-z0-9.-]{0,62}$') {
+            throw 'deployment_service must be a lowercase DNS-style service identifier.'
+          }
+
+          $workspace = [System.IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+          $workspacePrefix = $workspace + [System.IO.Path]::DirectorySeparatorChar
+
+          if (-not [string]::IsNullOrWhiteSpace($env:SERVICE_VALIDATION_SCRIPT)) {
+            $scriptPath = [System.IO.Path]::GetFullPath((Join-Path $workspace $env:SERVICE_VALIDATION_SCRIPT))
+            if (-not $scriptPath.StartsWith($workspacePrefix, [System.StringComparison]::Ordinal)) {
+              throw 'service_validation_script must remain inside the caller repository.'
+            }
+            if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+              throw "Service validation script not found: $scriptPath"
+            }
+            bash $scriptPath
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
+          $serviceRoot = [System.IO.Path]::GetFullPath((Join-Path $workspace $env:SERVICE_ROOT))
+          if (-not [string]::Equals($serviceRoot, $workspace, [System.StringComparison]::Ordinal) -and
+              -not $serviceRoot.StartsWith($workspacePrefix, [System.StringComparison]::Ordinal)) {
+            throw 'service_root must remain inside the caller repository.'
+          }
+          if (-not (Test-Path -LiteralPath $serviceRoot -PathType Container)) {
+            throw "Service root not found after validation: $serviceRoot"
+          }
+          "SERVICE_ROOT_RESOLVED=$serviceRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Archive service artifact
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          resolved_root="$(realpath -e "$SERVICE_ROOT_RESOLVED")"
+          case "$resolved_root" in
+            "$GITHUB_WORKSPACE"|"$GITHUB_WORKSPACE"/*) ;;
+            *) echo 'service_root must resolve inside the caller repository.' >&2; exit 1 ;;
+          esac
+          tar \
+            --directory "$resolved_root" \
+            -cf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=_powerforge \
+            .
+
+      - name: Upload service artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ format('powerforge-service-{0}', inputs.deployment_service) }}
+          path: ${{ runner.temp }}/artifact.tar
+          if-no-files-found: error
+          retention-days: ${{ inputs.deployment_artifact_retention_days }}
+
+  deploy:
+    needs: package
+    runs-on: ${{ fromJson(inputs.publisher_runner_labels_json) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    environment:
+      name: ${{ inputs.deployment_environment }}
+      url: ${{ inputs.deployment_url }}
+    steps:
+      - name: Validate Linux service deployment inputs
+        shell: pwsh
+        env:
+          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
+          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
+          DEPLOYMENT_SERVICE: ${{ inputs.deployment_service }}
+          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+          DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
+          DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:DEPLOYMENT_SERVICE -notmatch '^[a-z0-9][a-z0-9.-]{0,62}$') {
+            throw 'deployment_service must be a lowercase DNS-style service identifier.'
+          }
+          if ($env:DEPLOYMENT_HOST -notmatch '^[A-Za-z0-9][A-Za-z0-9.-]{0,252}$') {
+            throw 'deployment_host must be a DNS name or IPv4 address.'
+          }
+          if ($env:DEPLOYMENT_USER -notmatch '^[a-z_][a-z0-9_-]{0,31}$') {
+            throw 'deployment_user is not a valid Linux account name.'
+          }
+          $port = 0
+          if (-not [int]::TryParse($env:DEPLOYMENT_PORT, [ref] $port) -or $port -lt 1 -or $port -gt 65535) {
+            throw 'deployment_port must be an integer from 1 through 65535.'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:DEPLOYMENT_PRIVATE_KEY)) {
+            throw 'deployment_ssh_private_key is required.'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:DEPLOYMENT_KNOWN_HOSTS)) {
+            throw 'deployment_ssh_known_hosts is required; host key scanning at deploy time is intentionally disabled.'
+          }
+
+      - name: Download validated service artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: ${{ format('powerforge-service-{0}', inputs.deployment_service) }}
+          path: ${{ runner.temp }}/powerforge-service
+
+      - name: Create deployment provenance
+        shell: pwsh
+        env:
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $artifactPath = Join-Path $env:RUNNER_TEMP 'powerforge-service/artifact.tar'
+          if (-not (Test-Path -LiteralPath $artifactPath -PathType Leaf)) {
+            throw "Downloaded service artifact not found: $artifactPath"
+          }
+          $metadata = [ordered]@{
+            schemaVersion = 1
+            sourceRepository = $env:SOURCE_REPOSITORY
+            sourceSha = $env:SOURCE_SHA
+            workflowRunId = '${{ github.run_id }}'
+            workflowRunAttempt = '${{ github.run_attempt }}'
+            artifactSha256 = (Get-FileHash -LiteralPath $artifactPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            deployedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+          }
+          $metadata | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $env:RUNNER_TEMP 'powerforge-service/deployment.json') -Encoding utf8NoBOM
+
+      - name: Publish and promote Linux service release
+        shell: pwsh
+        env:
+          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
+          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
+          DEPLOYMENT_SERVICE: ${{ inputs.deployment_service }}
+          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+          DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
+          DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-service-deployment-ssh'
+          New-Item -ItemType Directory -Force -Path $sshRoot | Out-Null
+          $keyPath = Join-Path $sshRoot 'id_ed25519'
+          $knownHostsPath = Join-Path $sshRoot 'known_hosts'
+          Set-Content -LiteralPath $keyPath -Value $env:DEPLOYMENT_PRIVATE_KEY -Encoding utf8NoBOM
+          Set-Content -LiteralPath $knownHostsPath -Value $env:DEPLOYMENT_KNOWN_HOSTS -Encoding utf8NoBOM
+          chmod 700 $sshRoot
+          chmod 600 $keyPath $knownHostsPath
+
+          $remoteBase = "/tmp/powerforge-service-$($env:DEPLOYMENT_SERVICE)"
+          $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
+          $sshOptions = @('-i', $keyPath, '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes', '-o', "UserKnownHostsFile=$knownHostsPath")
+          $scpArgs = @('-P', $env:DEPLOYMENT_PORT) + $sshOptions + @((Join-Path $env:RUNNER_TEMP 'powerforge-service/artifact.tar'), (Join-Path $env:RUNNER_TEMP 'powerforge-service/deployment.json'), "${target}:${remoteBase}/")
+          ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "rm -rf -- '$remoteBase' && install -d -m 0700 '$remoteBase'"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          scp @scpArgs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "sudo /usr/local/sbin/powerforge-service-deploy --service '$($env:DEPLOYMENT_SERVICE)'"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Cleanup deployment credentials and remote staging
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: pwsh
+        env:
+          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
+          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
+          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+        run: |
+          $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-service-deployment-ssh'
+          $keyPath = Join-Path $sshRoot 'id_ed25519'
+          $knownHostsPath = Join-Path $sshRoot 'known_hosts'
+          $remoteBase = "/tmp/powerforge-service-${{ inputs.deployment_service }}"
+          $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
+          try {
+            if ((Test-Path -LiteralPath $keyPath) -and (Test-Path -LiteralPath $knownHostsPath)) {
+              ssh -i $keyPath -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$knownHostsPath" -p $env:DEPLOYMENT_PORT $target "rm -rf -- '$remoteBase'"
+            }
+          } finally {
+            if (Test-Path -LiteralPath $sshRoot) {
+              Remove-Item -LiteralPath $sshRoot -Recurse -Force
+            }
+          }

--- a/Deployment/Linux/powerforge-service-deploy.sh
+++ b/Deployment/Linux/powerforge-service-deploy.sh
@@ -88,6 +88,10 @@ for health_url in $PUBLIC_HEALTH_URLS; do
   [[ "$health_url" =~ ^https://[^[:space:]]+$ ]] || fail "Public health URL must use HTTPS: $health_url"
 done
 
+mkdir -p "$LOCK_ROOT"
+exec 9>"${LOCK_ROOT}/powerforge-service-${service_id}.lock"
+flock -n 9 || fail "Another deployment is active for $service_id."
+
 archive="$(realpath -e "$archive")"
 metadata="$(realpath -e "$metadata")"
 [[ -f "$archive" && ! -L "$archive" ]] || fail 'Artifact must be a regular file, not a symlink.'
@@ -134,10 +138,6 @@ while IFS= read -r listing; do
 done < <(tar -tvf "$archive")
 
 mkdir -p "$SERVICE_ROOT/releases"
-mkdir -p "$LOCK_ROOT"
-exec 9>"${LOCK_ROOT}/powerforge-service-${service_id}.lock"
-flock -n 9 || fail "Another deployment is active for $service_id."
-
 release_id="$(date -u +%Y%m%d%H%M%S)-${run_id}-${run_attempt}-${source_sha:0:12}"
 release_dir="$SERVICE_ROOT/releases/$release_id"
 [[ ! -e "$release_dir" ]] || fail "Release already exists: $release_id"
@@ -153,6 +153,8 @@ verify_health() {
     response="$(health_response "$url")"
     if [[ "$REQUIRE_HEALTH_PROVENANCE" == '1' ]]; then
       grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$response" || fail "Health endpoint did not report promoted source SHA: $url"
+      grep -Eq "\"workflowRunId\"[[:space:]]*:[[:space:]]*\"${run_id}\"" <<<"$response" || fail "Health endpoint did not report promoted workflow run: $url"
+      grep -Eq "\"workflowRunAttempt\"[[:space:]]*:[[:space:]]*\"${run_attempt}\"" <<<"$response" || fail "Health endpoint did not report promoted workflow attempt: $url"
     fi
   done
 }

--- a/Deployment/Linux/powerforge-service-deploy.sh
+++ b/Deployment/Linux/powerforge-service-deploy.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+umask 022
+
+CONFIG_ROOT="${POWERFORGE_SERVICE_CONFIG_ROOT:-/etc/powerforge/services}"
+LOCK_ROOT="${POWERFORGE_SERVICE_LOCK_ROOT:-/var/lock}"
+TRUSTED_STAGE_ROOT="${POWERFORGE_SERVICE_TRUSTED_STAGE_ROOT:-/var/lib/powerforge/service-deployment-staging}"
+service_id=""
+archive=""
+metadata=""
+promoted=0
+previous_target=""
+release_dir=""
+workflow_stage=""
+trusted_stage=""
+
+cleanup_staging() {
+  [[ -z "$workflow_stage" || ! -d "$workflow_stage" ]] || rm -rf -- "$workflow_stage"
+  [[ -z "$trusted_stage" || ! -d "$trusted_stage" ]] || rm -rf -- "$trusted_stage"
+}
+
+trap cleanup_staging EXIT
+
+log() {
+  printf '[powerforge-service-deploy] %s\n' "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  return 1
+}
+
+usage() {
+  echo 'Usage: powerforge-service-deploy --service <id>'
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --service)
+      service_id="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$service_id" =~ ^[a-z0-9][a-z0-9.-]{0,62}$ ]] || fail 'Invalid service identifier.'
+workflow_stage="/tmp/powerforge-service-${service_id}"
+archive="$workflow_stage/artifact.tar"
+metadata="$workflow_stage/deployment.json"
+
+config_path="${CONFIG_ROOT}/${service_id}.env"
+[[ -f "$config_path" && ! -L "$config_path" ]] || fail "Service is not configured: $service_id"
+if [[ "$(id -u)" -eq 0 ]]; then
+  [[ "$(stat -c '%u' "$config_path")" -eq 0 ]] || fail "Service config must be owned by root: $config_path"
+  config_mode="$(stat -c '%a' "$config_path")"
+  (( (8#$config_mode & 0022) == 0 )) || fail "Service config must not be group/world writable: $config_path"
+fi
+
+# The config is trusted, root-owned operator input and contains no values supplied by the workflow.
+# shellcheck disable=SC1090
+source "$config_path"
+
+: "${SERVICE_ROOT:?SERVICE_ROOT is required in $config_path}"
+: "${SYSTEMD_SERVICE:?SYSTEMD_SERVICE is required in $config_path}"
+: "${LOCAL_HEALTH_URL:?LOCAL_HEALTH_URL is required in $config_path}"
+: "${RELEASES_TO_KEEP:=5}"
+: "${REQUIRED_RELEASE_PATHS:=}"
+: "${PUBLIC_HEALTH_URLS:=}"
+: "${REQUIRE_HEALTH_PROVENANCE:=1}"
+
+[[ "$SERVICE_ROOT" == /* && "$SERVICE_ROOT" != '/' ]] || fail 'SERVICE_ROOT must be an absolute non-root path.'
+[[ "$SERVICE_ROOT" != *[[:space:]]* ]] || fail 'SERVICE_ROOT must not contain whitespace.'
+[[ "$TRUSTED_STAGE_ROOT" == /* && "$TRUSTED_STAGE_ROOT" != '/' ]] || fail 'Trusted staging root must be an absolute non-root path.'
+[[ "$SYSTEMD_SERVICE" =~ ^[A-Za-z0-9_.@-]+\.service$ ]] || fail 'SYSTEMD_SERVICE must be a systemd service unit name.'
+[[ "$LOCAL_HEALTH_URL" =~ ^https?://[^[:space:]]+$ ]] || fail 'LOCAL_HEALTH_URL must be an HTTP or HTTPS URL.'
+[[ "$RELEASES_TO_KEEP" =~ ^[1-9][0-9]*$ ]] || fail 'RELEASES_TO_KEEP must be a positive integer.'
+[[ "$REQUIRE_HEALTH_PROVENANCE" == '0' || "$REQUIRE_HEALTH_PROVENANCE" == '1' ]] || fail 'REQUIRE_HEALTH_PROVENANCE must be 0 or 1.'
+for health_url in $PUBLIC_HEALTH_URLS; do
+  [[ "$health_url" =~ ^https://[^[:space:]]+$ ]] || fail "Public health URL must use HTTPS: $health_url"
+done
+
+archive="$(realpath -e "$archive")"
+metadata="$(realpath -e "$metadata")"
+[[ -f "$archive" && ! -L "$archive" ]] || fail 'Artifact must be a regular file, not a symlink.'
+[[ -f "$metadata" && ! -L "$metadata" ]] || fail 'Metadata must be a regular file, not a symlink.'
+[[ "$archive" == "$workflow_stage/artifact.tar" ]] || fail 'Artifact is outside the service staging path.'
+[[ "$metadata" == "$workflow_stage/deployment.json" ]] || fail 'Metadata is outside the service staging path.'
+if [[ -n "${SUDO_UID:-}" ]]; then
+  [[ "$(stat -c '%u' "$archive")" -eq "$SUDO_UID" ]] || fail 'Artifact owner does not match the invoking deployment account.'
+  [[ "$(stat -c '%u' "$metadata")" -eq "$SUDO_UID" ]] || fail 'Metadata owner does not match the invoking deployment account.'
+fi
+
+install -d -m 0700 "$TRUSTED_STAGE_ROOT"
+trusted_stage="$(mktemp -d "${TRUSTED_STAGE_ROOT}/${service_id}.XXXXXXXX")"
+chmod 0700 "$trusted_stage"
+install -m 0600 "$archive" "$trusted_stage/artifact.tar"
+install -m 0600 "$metadata" "$trusted_stage/deployment.json"
+archive="$trusted_stage/artifact.tar"
+metadata="$trusted_stage/deployment.json"
+
+json_string() {
+  local key="$1"
+  sed -n "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$metadata" | head -n 1
+}
+
+source_sha="$(json_string sourceSha)"
+artifact_sha="$(json_string artifactSha256)"
+run_id="$(json_string workflowRunId)"
+run_attempt="$(json_string workflowRunAttempt)"
+[[ "$source_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] || fail 'Metadata sourceSha is missing or invalid.'
+[[ "$artifact_sha" =~ ^[0-9a-f]{64}$ ]] || fail 'Metadata artifactSha256 is missing or invalid.'
+[[ "$run_id" =~ ^[0-9]+$ && "$run_attempt" =~ ^[0-9]+$ ]] || fail 'Metadata workflow run identity is invalid.'
+actual_artifact_sha="$(sha256sum "$archive" | awk '{print $1}')"
+[[ "$actual_artifact_sha" == "$artifact_sha" ]] || fail 'Artifact checksum does not match deployment metadata.'
+
+while IFS= read -r entry; do
+  stripped="${entry#./}"
+  [[ "$entry" != /* ]] || fail "Archive contains an absolute path: $entry"
+  [[ "/${stripped}/" != *'/../'* ]] || fail "Archive contains path traversal: $entry"
+done < <(tar -tf "$archive")
+
+while IFS= read -r listing; do
+  entry_type="${listing:0:1}"
+  [[ "$entry_type" == '-' || "$entry_type" == 'd' ]] || fail 'Archive contains links or special files.'
+done < <(tar -tvf "$archive")
+
+mkdir -p "$SERVICE_ROOT/releases"
+mkdir -p "$LOCK_ROOT"
+exec 9>"${LOCK_ROOT}/powerforge-service-${service_id}.lock"
+flock -n 9 || fail "Another deployment is active for $service_id."
+
+release_id="$(date -u +%Y%m%d%H%M%S)-${run_id}-${run_attempt}-${source_sha:0:12}"
+release_dir="$SERVICE_ROOT/releases/$release_id"
+[[ ! -e "$release_dir" ]] || fail "Release already exists: $release_id"
+
+health_response() {
+  local url="$1"
+  curl -fsS --retry 3 --retry-all-errors --max-time 30 "${url}?powerforge-deploy=${run_id}-${run_attempt}"
+}
+
+verify_health() {
+  local url response
+  for url in "$LOCAL_HEALTH_URL" $PUBLIC_HEALTH_URLS; do
+    response="$(health_response "$url")"
+    if [[ "$REQUIRE_HEALTH_PROVENANCE" == '1' ]]; then
+      grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$response" || fail "Health endpoint did not report promoted source SHA: $url"
+    fi
+  done
+}
+
+rollback() {
+  local exit_code="$1"
+  set +e
+  if [[ "$promoted" == '1' ]]; then
+    if [[ -n "$previous_target" && -d "$previous_target" ]]; then
+      log "Deployment failed; rolling back to $previous_target"
+      rollback_link="$SERVICE_ROOT/.current.rollback.$$"
+      ln -s "$previous_target" "$rollback_link"
+      mv -Tf "$rollback_link" "$SERVICE_ROOT/current"
+      systemctl restart "$SYSTEMD_SERVICE"
+    else
+      log 'Deployment failed; removing the first release from current and stopping the service.'
+      rm -f "$SERVICE_ROOT/current"
+      systemctl stop "$SYSTEMD_SERVICE"
+    fi
+  fi
+  [[ -z "$release_dir" || ! -d "$release_dir" || "$release_dir" == "$previous_target" ]] || rm -rf "$release_dir"
+  exit "$exit_code"
+}
+trap 'rollback $?' ERR INT TERM
+
+mkdir -p "$release_dir"
+tar --extract --file "$archive" --directory "$release_dir" --no-same-owner --no-same-permissions
+for required_path in $REQUIRED_RELEASE_PATHS; do
+  [[ "$required_path" != /* && "/${required_path}/" != *'/../'* ]] || fail "Required release path must be relative and remain inside the release: $required_path"
+  [[ -e "$release_dir/$required_path" ]] || fail "Artifact does not contain required release path: $required_path"
+done
+mkdir -p "$release_dir/_powerforge"
+install -m 0644 "$metadata" "$release_dir/_powerforge/deployment.json"
+
+if [[ -L "$SERVICE_ROOT/current" ]]; then
+  previous_target="$(readlink -f "$SERVICE_ROOT/current")"
+fi
+candidate_link="$SERVICE_ROOT/.current.${run_id}.${run_attempt}"
+ln -s "$release_dir" "$candidate_link"
+mv -Tf "$candidate_link" "$SERVICE_ROOT/current"
+promoted=1
+
+systemctl restart "$SYSTEMD_SERVICE"
+verify_health
+
+mapfile -t old_releases < <(find "$SERVICE_ROOT/releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | awk '{print $2}')
+for ((index=RELEASES_TO_KEEP; index<${#old_releases[@]}; index++)); do
+  [[ "${old_releases[$index]}" == "$release_dir" || "${old_releases[$index]}" == "$previous_target" ]] || rm -rf "${old_releases[$index]}"
+done
+
+trap - ERR INT TERM
+cleanup_staging
+trap - EXIT
+log "Promoted $service_id release $release_id from $source_sha"

--- a/Deployment/Linux/powerforge-service.env.example
+++ b/Deployment/Linux/powerforge-service.env.example
@@ -1,0 +1,8 @@
+# Root-owned configuration for /usr/local/sbin/powerforge-service-deploy.
+SERVICE_ROOT=/srv/example/service
+SYSTEMD_SERVICE=example.service
+LOCAL_HEALTH_URL=http://127.0.0.1:8080/healthz
+PUBLIC_HEALTH_URLS="https://api.example.com/healthz https://api-alt.example.com/healthz"
+REQUIRED_RELEASE_PATHS="package.json src/server.mjs"
+RELEASES_TO_KEEP=5
+REQUIRE_HEALTH_PROVENANCE=1

--- a/Docs/PowerForge.Web.LinuxServiceDeployment.md
+++ b/Docs/PowerForge.Web.LinuxServiceDeployment.md
@@ -1,0 +1,126 @@
+# PowerForge.Web Linux Service Deployment
+
+PowerForge provides a generic release workflow and a root-owned promoter for small Linux systemd services. It complements server recovery: the workflow deploys reproducible application code, while the recovery manifest captures host configuration, service units, certificates, encrypted secrets, and mutable state.
+
+The service repository stays thin. It owns the service code, a validation script, and one workflow call. PowerForge owns packaging, provenance, SSH hygiene, archive validation, atomic promotion, health checks, retention, and rollback.
+
+## Runtime Contract
+
+The service must:
+
+- run from a stable `current` symlink under `SERVICE_ROOT`
+- keep secrets and mutable state outside the release directory
+- read `_powerforge/deployment.json` from the current release
+- expose the deployed `sourceSha` through each configured health endpoint
+- use a systemd unit whose restart is safe during deployment and rollback
+
+The provenance health contract is enabled by default. Set `REQUIRE_HEALTH_PROVENANCE=0` only for a deliberate transitional deployment; a successful HTTP response alone does not prove which release is serving traffic.
+
+## Host Setup
+
+Install the promoter as root:
+
+```bash
+install -o root -g root -m 0755 \
+  Deployment/Linux/powerforge-service-deploy.sh \
+  /usr/local/sbin/powerforge-service-deploy
+```
+
+Create one root-owned configuration per service under `/etc/powerforge/services`:
+
+```bash
+install -d -o root -g root -m 0750 /etc/powerforge/services
+install -o root -g root -m 0640 \
+  Deployment/Linux/powerforge-service.env.example \
+  /etc/powerforge/services/example.env
+```
+
+Example configuration:
+
+```dotenv
+SERVICE_ROOT=/srv/example/service
+SYSTEMD_SERVICE=example.service
+LOCAL_HEALTH_URL=http://127.0.0.1:8080/healthz
+PUBLIC_HEALTH_URLS="https://api.example.com/healthz https://api-alt.example.com/healthz"
+REQUIRED_RELEASE_PATHS="package.json src/server.mjs"
+RELEASES_TO_KEEP=5
+REQUIRE_HEALTH_PROVENANCE=1
+```
+
+Give the dedicated deployment account only the exact promoter command it needs. Keep the service identifier fixed in sudoers rather than granting general root shell or `systemctl` access:
+
+```sudoers
+powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-service-deploy --service example
+```
+
+Validate the effective sudoers rule with `visudo -cf` and `sudo -l -U powerforge-example` on the host.
+The privileged command accepts no caller-controlled paths. It only reads
+`/tmp/powerforge-service-example/artifact.tar` and `deployment.json`, then validates
+their ownership and copies them into root-only staging before inspection.
+
+## Caller Workflow
+
+Pin the reusable workflow to an exact PowerForge commit:
+
+```yaml
+name: Deploy service
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Services/Example/**"
+      - "deploy/linux/validate-service.sh"
+      - ".github/workflows/deploy-service.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-service-deploy.yml@POWERFORGE_COMMIT
+    with:
+      service_root: Services/Example
+      service_validation_script: deploy/linux/validate-service.sh
+      deployment_service: example
+      deployment_host: ${{ vars.POWERFORGE_SERVICE_DEPLOY_HOST }}
+      deployment_port: ${{ fromJson(vars.POWERFORGE_SERVICE_DEPLOY_PORT) }}
+      deployment_user: ${{ vars.POWERFORGE_SERVICE_DEPLOY_USER }}
+      deployment_environment: production
+      deployment_url: https://api.example.com/healthz
+    secrets:
+      deployment_ssh_private_key: ${{ secrets.SERVICE_DEPLOY_SSH_PRIVATE_KEY }}
+      deployment_ssh_known_hosts: ${{ secrets.SERVICE_DEPLOY_SSH_KNOWN_HOSTS }}
+```
+
+The optional validation script runs in the checked-out caller repository before packaging. It should run contract tests and prepare generated output when needed. `service_root` is resolved after that script completes, so it may point at either committed source or a generated release directory.
+
+## Promotion And Rollback
+
+The workflow uploads an artifact unique to `deployment_service`, writes metadata containing the source repository, exact source SHA, workflow run identity, and archive SHA-256, then publishes both files with temporary SSH credentials.
+
+The root promoter:
+
+1. Validates the root-owned service configuration and dedicated workflow staging path.
+2. Copies the workflow files into root-only staging before checksum or archive inspection.
+3. Rejects checksum mismatches, path traversal, links, and special files.
+4. Extracts a timestamped release and writes `_powerforge/deployment.json`.
+5. Atomically switches `current` and restarts the configured systemd unit.
+6. Requires local and public health endpoints to report the promoted source SHA.
+7. Restores the previous symlink and restarts it when deployment or health verification fails.
+8. Stops the service after a failed first deployment and removes the failed release.
+9. Retains the configured number of known-good releases.
+
+The promoter never copies or removes files outside `SERVICE_ROOT`, its lock, and its deployment staging. Environment files, private keys, API credentials, queues, databases, registration stores, and other mutable state must remain external and be covered by the server-recovery manifest.
+
+## Recovery Coverage
+
+For a recoverable service, the repository recovery manifest should include:
+
+- the promoter and root-owned service configuration
+- the systemd unit and any Apache or nginx reverse-proxy configuration
+- certificate names and renewal dry-runs
+- encrypted capture of service environment files and private key material
+- encrypted capture of non-rebuildable mutable state
+- plain capture of service status, current symlink, and deployment metadata
+- bootstrap, deploy, local health, public health, and provenance verification commands
+
+Use `powerforge-web server inspect`, `capture`, `bootstrap-plan`, `restore-secrets-plan`, `deploy`, and `verify` to prove that deployment and disaster recovery describe the same runtime.

--- a/Docs/PowerForge.Web.LinuxServiceDeployment.md
+++ b/Docs/PowerForge.Web.LinuxServiceDeployment.md
@@ -11,7 +11,7 @@ The service must:
 - run from a stable `current` symlink under `SERVICE_ROOT`
 - keep secrets and mutable state outside the release directory
 - read `_powerforge/deployment.json` from the current release
-- expose the deployed `sourceSha` through each configured health endpoint
+- expose the deployed `sourceSha`, `workflowRunId`, and `workflowRunAttempt` through each configured health endpoint
 - use a systemd unit whose restart is safe during deployment and rollback
 
 The provenance health contract is enabled by default. Set `REQUIRE_HEALTH_PROVENANCE=0` only for a deliberate transitional deployment; a successful HTTP response alone does not prove which release is serving traffic.
@@ -104,7 +104,7 @@ The root promoter:
 3. Rejects checksum mismatches, path traversal, links, and special files.
 4. Extracts a timestamped release and writes `_powerforge/deployment.json`.
 5. Atomically switches `current` and restarts the configured systemd unit.
-6. Requires local and public health endpoints to report the promoted source SHA.
+6. Requires local and public health endpoints to report the promoted source SHA and workflow run identity.
 7. Restores the previous symlink and restarts it when deployment or health verification fails.
 8. Stops the service after a failed first deployment and removes the failed release.
 9. Retains the configured number of known-good releases.

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -27,6 +27,8 @@ Git repositories + recovery manifest + encrypted secrets + deploy pipeline
 
 PowerForge owns the generic workflow. Each website owns a small manifest that names hosts, paths, services, packages, domains, and secrets.
 
+For systemd application releases, pair this recovery model with [PowerForge.Web Linux Service Deployment](PowerForge.Web.LinuxServiceDeployment.md). The service promoter owns reproducible code release and rollback; the recovery manifest owns host rebuild, certificates, encrypted secrets, and mutable state.
+
 ## Engine Commands
 
 The first implementation should expose the same workflow through the CLI and PowerShell module.

--- a/PowerForge.Tests/GitHubServiceLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubServiceLinuxDeployWorkflowTests.cs
@@ -1,0 +1,43 @@
+namespace PowerForge.Tests;
+
+public sealed class GitHubServiceLinuxDeployWorkflowTests
+{
+    [Fact]
+    public void WorkflowPackagesUniqueArtifactAndUsesTemporarySshCredentials()
+    {
+        var workflow = ReadRepoFile(".github", "workflows", "powerforge-service-deploy.yml");
+
+        Assert.Contains("powerforge-service-{0}", workflow, StringComparison.Ordinal);
+        Assert.Contains("service_validation_script", workflow, StringComparison.Ordinal);
+        Assert.Contains("artifactSha256", workflow, StringComparison.Ordinal);
+        Assert.Contains("realpath -e", workflow, StringComparison.Ordinal);
+        Assert.Contains("powerforge-service-deployment-ssh", workflow, StringComparison.Ordinal);
+        Assert.Contains("UserKnownHostsFile=$knownHostsPath", workflow, StringComparison.Ordinal);
+        Assert.Contains("powerforge-service-deploy --service", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("--archive '$remoteBase", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssh-keyscan", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("$HOME/.ssh", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("--dereference", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PromoterUsesTrustedStagingAndRollsBackSystemdService()
+    {
+        var script = ReadRepoFile("Deployment", "Linux", "powerforge-service-deploy.sh");
+
+        Assert.Contains("POWERFORGE_SERVICE_TRUSTED_STAGE_ROOT", script, StringComparison.Ordinal);
+        Assert.Contains("install -m 0600 \"$archive\"", script, StringComparison.Ordinal);
+        Assert.Contains("artifactSha256", script, StringComparison.Ordinal);
+        Assert.Contains("tar -tvf", script, StringComparison.Ordinal);
+        Assert.Contains("mv -Tf", script, StringComparison.Ordinal);
+        Assert.Contains("systemctl restart", script, StringComparison.Ordinal);
+        Assert.Contains("systemctl stop", script, StringComparison.Ordinal);
+        Assert.Contains("sourceSha", script, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(params string[] relativePath)
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        return File.ReadAllText(Path.Combine(new[] { root }.Concat(relativePath).ToArray()));
+    }
+}

--- a/PowerForge.Tests/GitHubServiceLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubServiceLinuxDeployWorkflowTests.cs
@@ -33,6 +33,9 @@ public sealed class GitHubServiceLinuxDeployWorkflowTests
         Assert.Contains("systemctl restart", script, StringComparison.Ordinal);
         Assert.Contains("systemctl stop", script, StringComparison.Ordinal);
         Assert.Contains("sourceSha", script, StringComparison.Ordinal);
+        Assert.Contains("workflowRunId", script, StringComparison.Ordinal);
+        Assert.Contains("workflowRunAttempt", script, StringComparison.Ordinal);
+        Assert.True(script.IndexOf("flock -n", StringComparison.Ordinal) < script.IndexOf("realpath -e", StringComparison.Ordinal));
     }
 
     private static string ReadRepoFile(params string[] relativePath)

--- a/Tests/Linux/powerforge-service-deploy.tests.sh
+++ b/Tests/Linux/powerforge-service-deploy.tests.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+deploy_script="$repo_root/Deployment/Linux/powerforge-service-deploy.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root" /tmp/powerforge-service-example /tmp/powerforge-service-fresh' EXIT
+
+mkdir -p "$test_root/config" "$test_root/locks" "$test_root/bin" "$test_root/service"
+export POWERFORGE_SERVICE_CONFIG_ROOT="$test_root/config"
+export POWERFORGE_SERVICE_LOCK_ROOT="$test_root/locks"
+export POWERFORGE_SERVICE_TRUSTED_STAGE_ROOT="$test_root/trusted-stage"
+export TEST_SYSTEMCTL_LOG="$test_root/systemctl.log"
+
+cat >"$test_root/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >>"$TEST_SYSTEMCTL_LOG"
+EOF
+
+cat >"$test_root/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+marker="$TEST_SERVICE_ROOT/current/_powerforge/deployment.json"
+if [[ -n "${FAIL_SOURCE_SHA:-}" ]] && grep -q "$FAIL_SOURCE_SHA" "$marker"; then
+  exit 22
+fi
+cat "$marker"
+EOF
+chmod +x "$test_root/bin/systemctl" "$test_root/bin/curl"
+export PATH="$test_root/bin:$PATH"
+
+write_config() {
+  local id="$1"
+  local root="$2"
+  cat >"$test_root/config/${id}.env" <<EOF
+SERVICE_ROOT=$root
+SYSTEMD_SERVICE=${id}.service
+LOCAL_HEALTH_URL=http://127.0.0.1:8791/healthz
+PUBLIC_HEALTH_URLS="https://push.example.test/healthz https://push-fallback.example.test/healthz"
+REQUIRED_RELEASE_PATHS="package.json src/server.mjs"
+RELEASES_TO_KEEP=3
+REQUIRE_HEALTH_PROVENANCE=1
+EOF
+  chmod 0640 "$test_root/config/${id}.env"
+}
+
+create_stage() {
+  local service_id="$1"
+  local run_id="$2"
+  local run_attempt="$3"
+  local source_sha="$4"
+  local stage="/tmp/powerforge-service-${service_id}"
+  local source="$test_root/source-${run_id}-${run_attempt}"
+  rm -rf "$stage" "$source"
+  mkdir -p "$stage" "$source/src"
+  printf '{"name":"example"}\n' >"$source/package.json"
+  printf 'console.log("%s")\n' "$source_sha" >"$source/src/server.mjs"
+  tar -C "$source" -cf "$stage/artifact.tar" .
+  local artifact_sha
+  artifact_sha="$(sha256sum "$stage/artifact.tar" | awk '{print $1}')"
+  cat >"$stage/deployment.json" <<EOF
+{
+  "schemaVersion": 1,
+  "sourceRepository": "Example/Service",
+  "sourceSha": "$source_sha",
+  "workflowRunId": "$run_id",
+  "workflowRunAttempt": "$run_attempt",
+  "artifactSha256": "$artifact_sha",
+  "deployedAtUtc": "2026-07-15T00:00:00Z"
+}
+EOF
+  chmod 0600 "$stage/artifact.tar" "$stage/deployment.json"
+}
+
+write_config example "$test_root/service"
+create_stage example 92001 1 1111111111111111111111111111111111111111
+TEST_SERVICE_ROOT="$test_root/service" "$deploy_script" \
+  --service example
+
+first_target="$(readlink -f "$test_root/service/current")"
+[[ -s "$first_target/package.json" ]]
+grep -q '1111111111111111111111111111111111111111' "$first_target/_powerforge/deployment.json"
+grep -q '^restart example.service$' "$TEST_SYSTEMCTL_LOG"
+[[ ! -e /tmp/powerforge-service-example ]]
+if TEST_SERVICE_ROOT="$test_root/service" "$deploy_script" --service example --archive /etc/passwd; then
+  echo 'Promoter unexpectedly accepted a caller-controlled archive path.' >&2
+  exit 1
+fi
+[[ "$(readlink -f "$test_root/service/current")" == "$first_target" ]]
+
+create_stage example 92002 1 2222222222222222222222222222222222222222
+if TEST_SERVICE_ROOT="$test_root/service" FAIL_SOURCE_SHA=2222222222222222222222222222222222222222 "$deploy_script" \
+  --service example; then
+  echo 'Deployment unexpectedly succeeded when exact provenance health failed.' >&2
+  exit 1
+fi
+[[ "$(readlink -f "$test_root/service/current")" == "$first_target" ]]
+[[ ! -e /tmp/powerforge-service-example ]]
+[[ "$(grep -c '^restart example.service$' "$TEST_SYSTEMCTL_LOG")" -ge 3 ]]
+
+mkdir -p "$test_root/fresh-service"
+write_config fresh "$test_root/fresh-service"
+create_stage fresh 92003 1 3333333333333333333333333333333333333333
+if TEST_SERVICE_ROOT="$test_root/fresh-service" FAIL_SOURCE_SHA=3333333333333333333333333333333333333333 "$deploy_script" \
+  --service fresh; then
+  echo 'First deployment unexpectedly succeeded when health failed.' >&2
+  exit 1
+fi
+[[ ! -e "$test_root/fresh-service/current" ]]
+grep -q '^stop fresh.service$' "$TEST_SYSTEMCTL_LOG"
+
+if [[ -d "$POWERFORGE_SERVICE_TRUSTED_STAGE_ROOT" ]] && find "$POWERFORGE_SERVICE_TRUSTED_STAGE_ROOT" -mindepth 1 -maxdepth 1 | grep -q .; then
+  echo 'Root-owned service deployment staging was not cleaned.' >&2
+  exit 1
+fi
+
+echo 'powerforge-service-deploy integration tests passed.'


### PR DESCRIPTION
## Summary

- add a reusable workflow that validates, packages, publishes, and promotes Linux systemd service releases
- add a root-owned promoter with trusted staging, checksum and archive validation, exact-SHA health checks, atomic `current` switching, retention, and rollback
- keep secrets and mutable state outside releases and connect service deployment to the existing server-recovery model

## Usage

Service repositories provide a small validation script, service root, protected deployment environment, dedicated SSH account, and fixed service id. The host owns service paths, systemd unit, required files, and local/public health endpoints in `/etc/powerforge/services/<id>.env`.

The sudo boundary is intentionally exact: the deploy account may invoke only `powerforge-service-deploy --service <fixed-id>`; it cannot provide root-read archive paths or select another service.

## Validation

- `actionlint` and `shellcheck`
- Linux promoter integration tests
- full `PowerForge.Tests`
- Windows, Linux, and macOS CI builds