### PR TITLE
Use ephemeral Cloudflare credentials for website deploys

### DIFF
--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -105,6 +105,11 @@ on:
         required: false
         type: string
         default: "production"
+      deployment_cloudflare_zone:
+        description: Optional Cloudflare zone name for an ephemeral deploy-time cache token.
+        required: false
+        type: string
+        default: ""
       deployment_url:
         required: false
         type: string
@@ -316,8 +321,10 @@ jobs:
           DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
           DEPLOYMENT_SITE: ${{ inputs.deployment_site }}
           DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+          DEPLOYMENT_CLOUDFLARE_ZONE: ${{ inputs.deployment_cloudflare_zone }}
           DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
           DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
         run: |
           $ErrorActionPreference = 'Stop'
           if ($env:DEPLOYMENT_SITE -notmatch '^[a-z0-9][a-z0-9.-]{0,62}$') {
@@ -338,6 +345,14 @@ jobs:
           }
           if ([string]::IsNullOrWhiteSpace($env:DEPLOYMENT_KNOWN_HOSTS)) {
             throw 'deployment_ssh_known_hosts is required; host key scanning at deploy time is intentionally disabled.'
+          }
+          if (-not [string]::IsNullOrWhiteSpace($env:DEPLOYMENT_CLOUDFLARE_ZONE)) {
+            if ($env:DEPLOYMENT_CLOUDFLARE_ZONE -notmatch '^[A-Za-z0-9.-]+$') {
+              throw 'deployment_cloudflare_zone must be a DNS zone name.'
+            }
+            if ([string]::IsNullOrWhiteSpace($env:CLOUDFLARE_API_TOKEN)) {
+              throw 'cloudflare_api_token is required when deployment_cloudflare_zone is configured.'
+            }
           }
 
       - name: Download validated site artifact
@@ -391,8 +406,10 @@ jobs:
           DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
           DEPLOYMENT_SITE: ${{ inputs.deployment_site }}
           DEPLOYMENT_USER: ${{ inputs.deployment_user }}
+          DEPLOYMENT_CLOUDFLARE_ZONE: ${{ inputs.deployment_cloudflare_zone }}
           DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
           DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
         run: |
           $ErrorActionPreference = 'Stop'
           $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-deployment-ssh'
@@ -404,10 +421,33 @@ jobs:
           chmod 700 $sshRoot
           chmod 600 $keyPath $knownHostsPath
 
+          $deploymentSources = @(
+            (Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar')
+            (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json')
+          )
+          if (-not [string]::IsNullOrWhiteSpace($env:DEPLOYMENT_CLOUDFLARE_ZONE)) {
+            $headers = @{ Authorization = "Bearer $($env:CLOUDFLARE_API_TOKEN)" }
+            $zoneName = [Uri]::EscapeDataString($env:DEPLOYMENT_CLOUDFLARE_ZONE)
+            $zoneResponse = Invoke-RestMethod -Method Get -Uri "https://api.cloudflare.com/client/v4/zones?name=$zoneName&status=active&per_page=2" -Headers $headers
+            if (-not $zoneResponse.success -or @($zoneResponse.result).Count -ne 1) {
+              throw "Cloudflare did not return exactly one active zone for '$($env:DEPLOYMENT_CLOUDFLARE_ZONE)'."
+            }
+            $zoneId = [string]$zoneResponse.result[0].id
+            if ($zoneId -notmatch '^[A-Fa-f0-9]{32}$') {
+              throw 'Cloudflare returned an invalid zone id.'
+            }
+            $cloudflareTokenPath = Join-Path $sshRoot 'cloudflare-api.token'
+            $cloudflareZonePath = Join-Path $sshRoot 'cloudflare-zone-id'
+            Set-Content -LiteralPath $cloudflareTokenPath -Value $env:CLOUDFLARE_API_TOKEN -Encoding utf8NoBOM -NoNewline
+            Set-Content -LiteralPath $cloudflareZonePath -Value $zoneId.ToLowerInvariant() -Encoding ascii -NoNewline
+            chmod 600 $cloudflareTokenPath $cloudflareZonePath
+            $deploymentSources += $cloudflareTokenPath, $cloudflareZonePath
+          }
+
           $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}-$($env:DEPLOYMENT_SITE)"
           $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
           $sshOptions = @('-i', $keyPath, '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes', '-o', "UserKnownHostsFile=$knownHostsPath")
-          $scpArgs = @('-P', $env:DEPLOYMENT_PORT) + $sshOptions + @((Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar'), (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json'), "${target}:${remoteBase}/")
+          $scpArgs = @('-P', $env:DEPLOYMENT_PORT) + $sshOptions + $deploymentSources + @("${target}:${remoteBase}/")
           ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "install -d -m 0700 '$remoteBase'"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           scp @scpArgs

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -325,6 +325,7 @@ jobs:
           DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
           DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
         run: |
           $ErrorActionPreference = 'Stop'
           if ($env:DEPLOYMENT_SITE -notmatch '^[a-z0-9][a-z0-9.-]{0,62}$') {
@@ -410,6 +411,7 @@ jobs:
           DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
           DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
         run: |
           $ErrorActionPreference = 'Stop'
           $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-deployment-ssh'
@@ -426,15 +428,18 @@ jobs:
             (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json')
           )
           if (-not [string]::IsNullOrWhiteSpace($env:DEPLOYMENT_CLOUDFLARE_ZONE)) {
-            $headers = @{ Authorization = "Bearer $($env:CLOUDFLARE_API_TOKEN)" }
-            $zoneName = [Uri]::EscapeDataString($env:DEPLOYMENT_CLOUDFLARE_ZONE)
-            $zoneResponse = Invoke-RestMethod -Method Get -Uri "https://api.cloudflare.com/client/v4/zones?name=$zoneName&status=active&per_page=2" -Headers $headers
-            if (-not $zoneResponse.success -or @($zoneResponse.result).Count -ne 1) {
-              throw "Cloudflare did not return exactly one active zone for '$($env:DEPLOYMENT_CLOUDFLARE_ZONE)'."
+            $zoneId = [string]$env:CLOUDFLARE_ZONE_ID
+            if ([string]::IsNullOrWhiteSpace($zoneId)) {
+              $headers = @{ Authorization = "Bearer $($env:CLOUDFLARE_API_TOKEN)" }
+              $zoneName = [Uri]::EscapeDataString($env:DEPLOYMENT_CLOUDFLARE_ZONE)
+              $zoneResponse = Invoke-RestMethod -Method Get -Uri "https://api.cloudflare.com/client/v4/zones?name=$zoneName&status=active&per_page=5" -Headers $headers
+              if (-not $zoneResponse.success -or @($zoneResponse.result).Count -ne 1) {
+                throw "Cloudflare did not return exactly one active zone for '$($env:DEPLOYMENT_CLOUDFLARE_ZONE)'."
+              }
+              $zoneId = [string]$zoneResponse.result[0].id
             }
-            $zoneId = [string]$zoneResponse.result[0].id
             if ($zoneId -notmatch '^[A-Fa-f0-9]{32}$') {
-              throw 'Cloudflare returned an invalid zone id.'
+              throw 'cloudflare_zone_id is invalid and zone discovery did not return a valid id.'
             }
             $cloudflareTokenPath = Join-Path $sshRoot 'cloudflare-api.token'
             $cloudflareZonePath = Join-Path $sshRoot 'cloudflare-zone-id'

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -131,6 +131,8 @@ on:
         required: false
       cloudflare_zone_id:
         required: false
+      deployment_cloudflare_api_token:
+        required: false
       deployment_ssh_private_key:
         required: false
       deployment_ssh_known_hosts:
@@ -324,7 +326,7 @@ jobs:
           DEPLOYMENT_CLOUDFLARE_ZONE: ${{ inputs.deployment_cloudflare_zone }}
           DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
           DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.deployment_cloudflare_api_token }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
         run: |
           $ErrorActionPreference = 'Stop'
@@ -352,7 +354,7 @@ jobs:
               throw 'deployment_cloudflare_zone must be a DNS zone name.'
             }
             if ([string]::IsNullOrWhiteSpace($env:CLOUDFLARE_API_TOKEN)) {
-              throw 'cloudflare_api_token is required when deployment_cloudflare_zone is configured.'
+              throw 'deployment_cloudflare_api_token is required when deployment_cloudflare_zone is configured.'
             }
           }
 
@@ -410,7 +412,7 @@ jobs:
           DEPLOYMENT_CLOUDFLARE_ZONE: ${{ inputs.deployment_cloudflare_zone }}
           DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
           DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.deployment_cloudflare_api_token }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
         run: |
           $ErrorActionPreference = 'Stop'

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -80,6 +80,8 @@ source "$config_path"
 : "${RELEASES_TO_KEEP:=5}"
 : "${SMOKE_PATHS:=/}"
 : "${CLOUDFLARE_PURGE_ENABLED:=0}"
+: "${CLOUDFLARE_ZONE_ID:=}"
+: "${CLOUDFLARE_API_TOKEN_FILE:=}"
 : "${ORIGIN_ADDRESS:=}"
 : "${ORIGIN_HOST:=}"
 
@@ -88,13 +90,16 @@ source "$config_path"
 [[ "$TRUSTED_STAGE_ROOT" == /* && "$TRUSTED_STAGE_ROOT" != '/' ]] || fail 'Trusted staging root must be an absolute non-root path.'
 [[ "$PUBLIC_URL" =~ ^https://[A-Za-z0-9.-]+(:[0-9]+)?$ ]] || fail 'PUBLIC_URL must be an HTTPS origin without a path.'
 [[ "$RELEASES_TO_KEEP" =~ ^[1-9][0-9]*$ ]] || fail 'RELEASES_TO_KEEP must be a positive integer.'
+[[ "$CLOUDFLARE_PURGE_ENABLED" == '0' || "$CLOUDFLARE_PURGE_ENABLED" == '1' ]] || fail 'CLOUDFLARE_PURGE_ENABLED must be 0 or 1.'
 if [[ -n "$ORIGIN_ADDRESS" || -n "$ORIGIN_HOST" ]]; then
   [[ -n "$ORIGIN_ADDRESS" && "$ORIGIN_HOST" =~ ^[A-Za-z0-9.-]+$ ]] || fail 'ORIGIN_ADDRESS and ORIGIN_HOST must be configured together.'
 fi
 if [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]]; then
-  [[ "${CLOUDFLARE_ZONE_ID:-}" =~ ^[A-Za-z0-9]+$ ]] || fail 'CLOUDFLARE_ZONE_ID is required when purge is enabled.'
-  [[ "${CLOUDFLARE_API_TOKEN_FILE:-}" == /* && -s "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'CLOUDFLARE_API_TOKEN_FILE must be an absolute, non-empty readable file when purge is enabled.'
-  [[ -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'Cloudflare API token file is not readable.'
+  [[ -z "$CLOUDFLARE_ZONE_ID" || "$CLOUDFLARE_ZONE_ID" =~ ^[A-Fa-f0-9]{32}$ ]] || fail 'CLOUDFLARE_ZONE_ID must be a 32-character hexadecimal id.'
+  if [[ -n "$CLOUDFLARE_API_TOKEN_FILE" ]]; then
+    [[ "$CLOUDFLARE_API_TOKEN_FILE" == /* && -s "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'CLOUDFLARE_API_TOKEN_FILE must be an absolute, non-empty readable file.'
+    [[ -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'Cloudflare API token file is not readable.'
+  fi
 fi
 
 archive="$(realpath -e "$archive")"
@@ -111,13 +116,41 @@ if [[ -n "${SUDO_UID:-}" ]]; then
   [[ "$(stat -c '%u' "$metadata")" -eq "$SUDO_UID" ]] || fail 'Metadata owner does not match the invoking deployment account.'
 fi
 
+workflow_cloudflare_token="$workflow_stage/cloudflare-api.token"
+workflow_cloudflare_zone="$workflow_stage/cloudflare-zone-id"
+if [[ -e "$workflow_cloudflare_token" || -L "$workflow_cloudflare_token" || -e "$workflow_cloudflare_zone" || -L "$workflow_cloudflare_zone" ]]; then
+  [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]] || fail 'Ephemeral Cloudflare credentials were provided but purge is disabled.'
+  [[ -f "$workflow_cloudflare_token" && ! -L "$workflow_cloudflare_token" && -s "$workflow_cloudflare_token" ]] || fail 'Ephemeral Cloudflare token must be a non-empty regular file.'
+  [[ -f "$workflow_cloudflare_zone" && ! -L "$workflow_cloudflare_zone" && -s "$workflow_cloudflare_zone" ]] || fail 'Ephemeral Cloudflare zone id must be a non-empty regular file.'
+  if [[ -n "${SUDO_UID:-}" ]]; then
+    [[ "$(stat -c '%u' "$workflow_cloudflare_token")" -eq "$SUDO_UID" ]] || fail 'Cloudflare token owner does not match the invoking deployment account.'
+    [[ "$(stat -c '%u' "$workflow_cloudflare_zone")" -eq "$SUDO_UID" ]] || fail 'Cloudflare zone owner does not match the invoking deployment account.'
+  fi
+fi
 install -d -m 0700 "$TRUSTED_STAGE_ROOT"
 trusted_stage="$(mktemp -d "${TRUSTED_STAGE_ROOT}/${site}.XXXXXXXX")"
 chmod 0700 "$trusted_stage"
 install -m 0600 "$archive" "$trusted_stage/artifact.tar"
 install -m 0600 "$metadata" "$trusted_stage/deployment.json"
+if [[ -f "$workflow_cloudflare_token" ]]; then
+  install -m 0600 "$workflow_cloudflare_token" "$trusted_stage/cloudflare-api.token"
+  install -m 0600 "$workflow_cloudflare_zone" "$trusted_stage/cloudflare-zone-id"
+  ephemeral_zone_id="$(tr -d '[:space:]' <"$trusted_stage/cloudflare-zone-id")"
+  [[ "$ephemeral_zone_id" =~ ^[A-Fa-f0-9]{32}$ ]] || fail 'Ephemeral Cloudflare zone id is invalid.'
+  if [[ -n "$CLOUDFLARE_ZONE_ID" && "${CLOUDFLARE_ZONE_ID,,}" != "${ephemeral_zone_id,,}" ]]; then
+    fail 'Ephemeral Cloudflare zone id does not match the host configuration.'
+  fi
+  CLOUDFLARE_ZONE_ID="${ephemeral_zone_id,,}"
+  CLOUDFLARE_API_TOKEN_FILE="$trusted_stage/cloudflare-api.token"
+fi
 archive="$trusted_stage/artifact.tar"
 metadata="$trusted_stage/deployment.json"
+
+if [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]]; then
+  CLOUDFLARE_ZONE_ID="${CLOUDFLARE_ZONE_ID,,}"
+  [[ "$CLOUDFLARE_ZONE_ID" =~ ^[a-f0-9]{32}$ ]] || fail 'Cloudflare zone id is required when purge is enabled.'
+  [[ "$CLOUDFLARE_API_TOKEN_FILE" == /* && -s "$CLOUDFLARE_API_TOKEN_FILE" && -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'A readable Cloudflare API token is required when purge is enabled.'
+fi
 
 json_string() {
   local key="$1"

--- a/Deployment/Linux/powerforge-site.env.example
+++ b/Deployment/Linux/powerforge-site.env.example
@@ -11,7 +11,7 @@ SMOKE_PATHS="/ /sitemap.xml"
 
 # Cloudflare remains proxied. Set the zone id and token file for persistent host
 # credentials, or omit both and use deployment_cloudflare_zone plus the reusable
-# workflow's cloudflare_api_token secret for ephemeral deploy-time credentials.
+# workflow's deployment_cloudflare_api_token secret for ephemeral deploy-time credentials.
 CLOUDFLARE_PURGE_ENABLED=1
 # CLOUDFLARE_ZONE_ID=replace-with-zone-id
 # CLOUDFLARE_API_TOKEN_FILE=/etc/powerforge/secrets/cloudflare-cache-purge.token

--- a/Deployment/Linux/powerforge-site.env.example
+++ b/Deployment/Linux/powerforge-site.env.example
@@ -9,7 +9,9 @@ ORIGIN_ADDRESS=127.0.0.1
 RELEASES_TO_KEEP=5
 SMOKE_PATHS="/ /sitemap.xml"
 
-# Cloudflare remains proxied. The token file is local server state, not a workflow secret.
+# Cloudflare remains proxied. Set the zone id and token file for persistent host
+# credentials, or omit both and use deployment_cloudflare_zone plus the reusable
+# workflow's cloudflare_api_token secret for ephemeral deploy-time credentials.
 CLOUDFLARE_PURGE_ENABLED=1
-CLOUDFLARE_ZONE_ID=replace-with-zone-id
-CLOUDFLARE_API_TOKEN_FILE=/etc/powerforge/secrets/cloudflare-cache-purge.token
+# CLOUDFLARE_ZONE_ID=replace-with-zone-id
+# CLOUDFLARE_API_TOKEN_FILE=/etc/powerforge/secrets/cloudflare-cache-purge.token

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -33,7 +33,9 @@ jobs:
       deployment_site: example.com
       deployment_host: deploy.example.com
       deployment_url: https://example.com
+      deployment_cloudflare_zone: example.com
     secrets:
+      cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       deployment_ssh_private_key: ${{ secrets.WEBSITE_DEPLOY_SSH_PRIVATE_KEY }}
       deployment_ssh_known_hosts: ${{ secrets.WEBSITE_DEPLOY_SSH_KNOWN_HOSTS }}
 ```
@@ -62,6 +64,14 @@ unconfigured site ids, mutable site configuration, and workflow staging files ow
 by another account. It atomically promotes a timestamped release, purges Cloudflare
 without disabling proxying, verifies the exact source SHA through both the origin and
 public URL, and rolls back the symlink if any check fails.
+
+When `deployment_cloudflare_zone` is set, the workflow resolves exactly one active
+zone with `cloudflare_api_token` and transfers the token and zone id only inside the
+temporary deployment staging. The promoter copies them into root-only staging,
+purges before exact-SHA verification, and erases them on every success or failure.
+This keeps Cloudflare proxying and cache analytics enabled without storing a broad
+CI token permanently on the web host. Sites may instead use a scoped, root-owned
+host token file when that is their preferred recovery model.
 
 ## Host Build Flow (Special Case)
 

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -35,7 +35,7 @@ jobs:
       deployment_url: https://example.com
       deployment_cloudflare_zone: example.com
     secrets:
-      cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      deployment_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       deployment_ssh_private_key: ${{ secrets.WEBSITE_DEPLOY_SSH_PRIVATE_KEY }}
       deployment_ssh_known_hosts: ${{ secrets.WEBSITE_DEPLOY_SSH_KNOWN_HOSTS }}
@@ -67,12 +67,15 @@ without disabling proxying, verifies the exact source SHA through both the origi
 public URL, and rolls back the symlink if any check fails.
 
 When `deployment_cloudflare_zone` is set, the workflow uses `cloudflare_zone_id`
-directly and transfers the token and zone id only inside temporary deployment
-staging. A least-privilege cache-purge token therefore does not need Zone Read. If
+directly and transfers the deploy-only `deployment_cloudflare_api_token` and zone
+id only inside temporary deployment staging. A least-privilege cache-purge token
+therefore does not need Zone Read. If
 the zone-id secret is absent, the workflow may discover exactly one active zone by
 name; that fallback also requires Zone Read and uses Cloudflare's valid page size.
 The promoter copies the credentials into root-only staging,
 purges before exact-SHA verification, and erases them on every success or failure.
+The normal `cloudflare_api_token` remains isolated to the website pipeline and is
+never reused for Linux promotion.
 This keeps Cloudflare proxying and cache analytics enabled without storing a broad
 CI token permanently on the web host. Sites may instead use a scoped, root-owned
 host token file when that is their preferred recovery model.

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -36,6 +36,7 @@ jobs:
       deployment_cloudflare_zone: example.com
     secrets:
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       deployment_ssh_private_key: ${{ secrets.WEBSITE_DEPLOY_SSH_PRIVATE_KEY }}
       deployment_ssh_known_hosts: ${{ secrets.WEBSITE_DEPLOY_SSH_KNOWN_HOSTS }}
 ```
@@ -65,9 +66,12 @@ by another account. It atomically promotes a timestamped release, purges Cloudfl
 without disabling proxying, verifies the exact source SHA through both the origin and
 public URL, and rolls back the symlink if any check fails.
 
-When `deployment_cloudflare_zone` is set, the workflow resolves exactly one active
-zone with `cloudflare_api_token` and transfers the token and zone id only inside the
-temporary deployment staging. The promoter copies them into root-only staging,
+When `deployment_cloudflare_zone` is set, the workflow uses `cloudflare_zone_id`
+directly and transfers the token and zone id only inside temporary deployment
+staging. A least-privilege cache-purge token therefore does not need Zone Read. If
+the zone-id secret is absent, the workflow may discover exactly one active zone by
+name; that fallback also requires Zone Read and uses Cloudflare's valid page size.
+The promoter copies the credentials into root-only staging,
 purges before exact-SHA verification, and erases them on every success or failure.
 This keeps Cloudflare proxying and cache analytics enabled without storing a broad
 CI token permanently on the web host. Sites may instead use a scoped, root-owned

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -55,6 +55,9 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("artifactSha256", script, StringComparison.Ordinal);
         Assert.Contains("^/tmp/powerforge-([0-9]+)-([0-9]+)-", script, StringComparison.Ordinal);
         Assert.Contains("BASH_REMATCH[3]", script, StringComparison.Ordinal);
+        Assert.Contains("deployment_cloudflare_zone", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
+        Assert.Contains("cloudflare-api.token", script, StringComparison.Ordinal);
+        Assert.Contains("Ephemeral Cloudflare zone id does not match", script, StringComparison.Ordinal);
     }
 
     private static string ReadRepoFile(params string[] relativePath)

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -56,6 +56,8 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("^/tmp/powerforge-([0-9]+)-([0-9]+)-", script, StringComparison.Ordinal);
         Assert.Contains("BASH_REMATCH[3]", script, StringComparison.Ordinal);
         Assert.Contains("deployment_cloudflare_zone", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
+        Assert.Contains("CLOUDFLARE_ZONE_ID", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
+        Assert.Contains("per_page=5", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
         Assert.Contains("cloudflare-api.token", script, StringComparison.Ordinal);
         Assert.Contains("Ephemeral Cloudflare zone id does not match", script, StringComparison.Ordinal);
     }

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -47,7 +47,7 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("rolling back", script, StringComparison.Ordinal);
         Assert.Contains("mv -Tf", script, StringComparison.Ordinal);
         Assert.Contains("umask 022", script, StringComparison.Ordinal);
-        Assert.Contains("CLOUDFLARE_ZONE_ID is required", script, StringComparison.Ordinal);
+        Assert.Contains("Cloudflare zone id is required", script, StringComparison.Ordinal);
         Assert.Contains("POWERFORGE_SITE_TRUSTED_STAGE_ROOT", script, StringComparison.Ordinal);
         Assert.Contains("install -m 0600 \"$archive\"", script, StringComparison.Ordinal);
         Assert.Contains("powerforge-site-{0}", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
@@ -55,9 +55,13 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("artifactSha256", script, StringComparison.Ordinal);
         Assert.Contains("^/tmp/powerforge-([0-9]+)-([0-9]+)-", script, StringComparison.Ordinal);
         Assert.Contains("BASH_REMATCH[3]", script, StringComparison.Ordinal);
-        Assert.Contains("deployment_cloudflare_zone", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
-        Assert.Contains("CLOUDFLARE_ZONE_ID", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
-        Assert.Contains("per_page=5", ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml"), StringComparison.Ordinal);
+        string workflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
+        Assert.Contains("deployment_cloudflare_zone", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_cloudflare_api_token", workflow, StringComparison.Ordinal);
+        Assert.Contains("CLOUDFLARE_API_TOKEN: ${{ secrets.deployment_cloudflare_api_token }}", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("CLOUDFLARE_ZONE_ID", workflow, StringComparison.Ordinal);
+        Assert.Contains("per_page=5", workflow, StringComparison.Ordinal);
         Assert.Contains("cloudflare-api.token", script, StringComparison.Ordinal);
         Assert.Contains("Ephemeral Cloudflare zone id does not match", script, StringComparison.Ordinal);
     }

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -62,6 +62,9 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.DoesNotContain("CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}", workflow, StringComparison.Ordinal);
         Assert.Contains("CLOUDFLARE_ZONE_ID", workflow, StringComparison.Ordinal);
         Assert.Contains("per_page=5", workflow, StringComparison.Ordinal);
+        string environmentExample = ReadRepoFile("Deployment", "Linux", "powerforge-site.env.example");
+        Assert.Contains("deployment_cloudflare_api_token", environmentExample, StringComparison.Ordinal);
+        Assert.DoesNotContain("workflow's cloudflare_api_token secret", environmentExample, StringComparison.Ordinal);
         Assert.Contains("cloudflare-api.token", script, StringComparison.Ordinal);
         Assert.Contains("Ephemeral Cloudflare zone id does not match", script, StringComparison.Ordinal);
     }

--- a/Tests/Linux/powerforge-site-deploy.tests.sh
+++ b/Tests/Linux/powerforge-site-deploy.tests.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 deploy_script="$repo_root/Deployment/Linux/powerforge-site-deploy.sh"
 test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root" /tmp/powerforge-91001-1-example /tmp/powerforge-91002-1-example /tmp/powerforge-91003-1-first /tmp/powerforge-91004-1-cloudflare /tmp/powerforge-91007-1-example /tmp/powerforge-91008-1-example /tmp/powerforge-9' EXIT
+trap 'rm -rf "$test_root" /tmp/powerforge-91001-1-example /tmp/powerforge-91002-1-example /tmp/powerforge-91003-1-first /tmp/powerforge-91004-1-cloudflare /tmp/powerforge-91005-1-cloudflare /tmp/powerforge-91006-1-cloudflare-mismatch /tmp/powerforge-91007-1-example /tmp/powerforge-91008-1-example /tmp/powerforge-9' EXIT
 
 mkdir -p "$test_root/config" "$test_root/locks" "$test_root/site" "$test_root/bin"
 export POWERFORGE_SITE_TRUSTED_STAGE_ROOT="$test_root/trusted-stage"
@@ -21,6 +21,10 @@ cat >"$test_root/bin/curl" <<'EOF'
 set -e
 if [[ "${FAKE_CURL_FAIL:-0}" == '1' ]]; then
   exit 22
+fi
+if [[ "$*" == *'api.cloudflare.com'* ]]; then
+  printf '{"success":true}\n'
+  exit 0
 fi
 if [[ -n "${FAKE_STALE_MARKER:-}" ]]; then
   cat "$FAKE_STALE_MARKER"
@@ -162,6 +166,41 @@ if env \
   exit 1
 fi
 [[ ! -e "$test_root/cloudflare-site/current" ]]
+
+create_deployment 91005 '5555555555555555555555555555555555555555' 'ephemeral-cloudflare-release' cloudflare
+printf 'test-token' >/tmp/powerforge-91005-1-cloudflare/cloudflare-api.token
+printf 'abcdefabcdefabcdefabcdefabcdefab' >/tmp/powerforge-91005-1-cloudflare/cloudflare-zone-id
+env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_SITE_ROOT="$test_root/cloudflare-site" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site cloudflare --archive /tmp/powerforge-91005-1-cloudflare/artifact.tar --metadata /tmp/powerforge-91005-1-cloudflare/deployment.json
+grep -Fq 'ephemeral-cloudflare-release' "$test_root/cloudflare-site/current/index.html"
+[[ ! -e "$test_root/cloudflare-site/current/cloudflare-api.token" ]]
+[[ ! -e /tmp/powerforge-91005-1-cloudflare ]]
+
+mkdir -p "$test_root/cloudflare-mismatch-site"
+cat >"$test_root/config/cloudflare-mismatch.env" <<EOF
+SITE_ROOT=$test_root/cloudflare-mismatch-site
+PUBLIC_URL=https://cloudflare-mismatch.example.test
+CLOUDFLARE_PURGE_ENABLED=1
+CLOUDFLARE_ZONE_ID=11111111111111111111111111111111
+EOF
+create_deployment 91006 '6666666666666666666666666666666666666666' 'cloudflare-zone-mismatch' cloudflare-mismatch
+printf 'test-token' >/tmp/powerforge-91006-1-cloudflare-mismatch/cloudflare-api.token
+printf 'abcdefabcdefabcdefabcdefabcdefab' >/tmp/powerforge-91006-1-cloudflare-mismatch/cloudflare-zone-id
+if env \
+  PATH="$test_root/bin:$PATH" \
+  FAKE_SITE_ROOT="$test_root/cloudflare-mismatch-site" \
+  POWERFORGE_SITE_CONFIG_ROOT="$test_root/config" \
+  POWERFORGE_SITE_LOCK_ROOT="$test_root/locks" \
+  "$deploy_script" --site cloudflare-mismatch --archive /tmp/powerforge-91006-1-cloudflare-mismatch/artifact.tar --metadata /tmp/powerforge-91006-1-cloudflare-mismatch/deployment.json; then
+  echo 'Expected mismatched workflow and host Cloudflare zones to fail preflight.' >&2
+  exit 1
+fi
+[[ ! -e "$test_root/cloudflare-mismatch-site/current" ]]
+
 if [[ -d "$POWERFORGE_SITE_TRUSTED_STAGE_ROOT" ]] && find "$POWERFORGE_SITE_TRUSTED_STAGE_ROOT" -mindepth 1 -maxdepth 1 | grep -q .; then
   echo 'Root-owned deployment staging was not cleaned.' >&2
   exit 1


### PR DESCRIPTION
## Summary

- add a deploy-only `deployment_cloudflare_api_token` secret for Linux website promotion
- prefer the caller-provided zone ID and use exact-name zone discovery only as a fallback
- transfer token and zone ID in temporary SSH staging, copy them into root-only staging before purge, and erase them on every success or failure

## Why

This preserves Cloudflare proxying, cache behavior, and traffic analytics without storing a broad CI token on the web host or exposing the deploy credential to website build and post-deploy pipeline code. Existing sites with a scoped root-owned token file remain supported.

## Validation

- `actionlint` and `shellcheck`
- Linux promoter integration and contract tests
- full `PowerForge.Tests`
- Windows, Linux, and macOS CI builds