### PR TITLE
Support protected environment deploy secrets

### DIFF
--- a/.github/workflows/powerforge-service-deploy.yml
+++ b/.github/workflows/powerforge-service-deploy.yml
@@ -53,9 +53,9 @@ on:
         default: 7
     secrets:
       deployment_ssh_private_key:
-        required: true
+        required: false
       deployment_ssh_known_hosts:
-        required: true
+        required: false
 
 permissions:
   contents: read

--- a/Docs/PowerForge.Web.LinuxServiceDeployment.md
+++ b/Docs/PowerForge.Web.LinuxServiceDeployment.md
@@ -86,10 +86,15 @@ jobs:
       deployment_user: ${{ vars.POWERFORGE_SERVICE_DEPLOY_USER }}
       deployment_environment: production
       deployment_url: https://api.example.com/healthz
-    secrets:
-      deployment_ssh_private_key: ${{ secrets.SERVICE_DEPLOY_SSH_PRIVATE_KEY }}
-      deployment_ssh_known_hosts: ${{ secrets.SERVICE_DEPLOY_SSH_KNOWN_HOSTS }}
 ```
+
+Store `DEPLOYMENT_SSH_PRIVATE_KEY` and `DEPLOYMENT_SSH_KNOWN_HOSTS` in the
+protected environment named by `deployment_environment`. GitHub supplies those
+environment secrets directly to the reusable deploy job, so the caller does not
+need repository-level deployment credentials. Callers may still pass
+`deployment_ssh_private_key` and `deployment_ssh_known_hosts` explicitly when
+their security model requires it. The workflow validates both values before it
+downloads or transfers the artifact.
 
 The optional validation script runs in the checked-out caller repository before packaging. It should run contract tests and prepare generated output when needed. `service_root` is resolved after that script completes, so it may point at either committed source or a generated release directory.
 

--- a/PowerForge.Tests/GitHubServiceLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubServiceLinuxDeployWorkflowTests.cs
@@ -6,8 +6,13 @@ public sealed class GitHubServiceLinuxDeployWorkflowTests
     public void WorkflowPackagesUniqueArtifactAndUsesTemporarySshCredentials()
     {
         var workflow = ReadRepoFile(".github", "workflows", "powerforge-service-deploy.yml");
+        var normalizedWorkflow = workflow.Replace("\r\n", "\n", StringComparison.Ordinal);
 
         Assert.Contains("powerforge-service-{0}", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_ssh_private_key:\n        required: false", normalizedWorkflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_ssh_known_hosts:\n        required: false", normalizedWorkflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_ssh_private_key is required", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_ssh_known_hosts is required", workflow, StringComparison.Ordinal);
         Assert.Contains("service_validation_script", workflow, StringComparison.Ordinal);
         Assert.Contains("artifactSha256", workflow, StringComparison.Ordinal);
         Assert.Contains("realpath -e", workflow, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- allow the reusable Linux service deploy to source SSH credentials from its protected deployment environment
- keep explicit caller-passed secrets compatible for repositories that use that model
- retain mandatory pre-transfer validation for both the private key and pinned known-hosts data

## Why

GitHub environment secrets cannot be passed from a caller workflow, but a reusable job that declares an environment receives those secrets directly. Making the `workflow_call` declarations optional lets repositories keep deployment credentials out of repository/org secret scope while the deploy job still fails closed when either value is missing.

## Usage

Store `DEPLOYMENT_SSH_PRIVATE_KEY` and `DEPLOYMENT_SSH_KNOWN_HOSTS` in the environment named by `deployment_environment`. Callers then only provide deployment inputs; no SSH secret mapping is needed.

## Validation

- `actionlint`
- focused `GitHubServiceLinuxDeployWorkflowTests`: 2 passed
- exact workflow contract still rejects missing SSH material before artifact download or transfer