### PR TITLE
Update HtmlTinkerX to 2.0.19

### DIFF
--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -97,8 +97,8 @@
       },
       "HtmlTinkerX": {
         "type": "Transitive",
-        "resolved": "2.0.18",
-        "contentHash": "7d8DcjnNgGVaSUbAj/2U6i5PhrZWlWknbGL5hsS/9DF90PJIzm7lx48z6qO4b9WuyTILVxigdcozeSCwuheS6g==",
+        "resolved": "2.0.19",
+        "contentHash": "aN1x0cqwonG/JNSYxCBtqTTCq1nyaEYiX6WdQvvkGpfYlLKuFjKD+4HfXSfBl1KZqC6SdIUZz3oXAib5AyB8vQ==",
         "dependencies": {
           "AngleSharp": "1.4.1-beta.523",
           "AngleSharp.Css": "1.0.0-beta.213",
@@ -875,7 +875,7 @@
       "powerforge.web": {
         "type": "Project",
         "dependencies": {
-          "HtmlTinkerX": "[2.0.18, )",
+          "HtmlTinkerX": "[2.0.19, )",
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
           "PowerForge": "[1.0.0, )",

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -50,8 +50,8 @@
       },
       "HtmlTinkerX": {
         "type": "Transitive",
-        "resolved": "2.0.18",
-        "contentHash": "7d8DcjnNgGVaSUbAj/2U6i5PhrZWlWknbGL5hsS/9DF90PJIzm7lx48z6qO4b9WuyTILVxigdcozeSCwuheS6g==",
+        "resolved": "2.0.19",
+        "contentHash": "aN1x0cqwonG/JNSYxCBtqTTCq1nyaEYiX6WdQvvkGpfYlLKuFjKD+4HfXSfBl1KZqC6SdIUZz3oXAib5AyB8vQ==",
         "dependencies": {
           "AngleSharp": "1.4.1-beta.523",
           "AngleSharp.Css": "1.0.0-beta.213",
@@ -170,7 +170,7 @@
       "powerforge.web": {
         "type": "Project",
         "dependencies": {
-          "HtmlTinkerX": "[2.0.18, )",
+          "HtmlTinkerX": "[2.0.19, )",
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
           "PowerForge": "[1.0.0, )",
@@ -250,8 +250,8 @@
       },
       "HtmlTinkerX": {
         "type": "Transitive",
-        "resolved": "2.0.18",
-        "contentHash": "7d8DcjnNgGVaSUbAj/2U6i5PhrZWlWknbGL5hsS/9DF90PJIzm7lx48z6qO4b9WuyTILVxigdcozeSCwuheS6g==",
+        "resolved": "2.0.19",
+        "contentHash": "aN1x0cqwonG/JNSYxCBtqTTCq1nyaEYiX6WdQvvkGpfYlLKuFjKD+4HfXSfBl1KZqC6SdIUZz3oXAib5AyB8vQ==",
         "dependencies": {
           "AngleSharp": "1.4.1-beta.523",
           "AngleSharp.Css": "1.0.0-beta.213",
@@ -364,7 +364,7 @@
       "powerforge.web": {
         "type": "Project",
         "dependencies": {
-          "HtmlTinkerX": "[2.0.18, )",
+          "HtmlTinkerX": "[2.0.19, )",
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
           "PowerForge": "[1.0.0, )",

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlTinkerX" Version="2.0.18" />
+    <PackageReference Include="HtmlTinkerX" Version="2.0.19" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
     <PackageReference Include="OfficeIMO.Markdown" Version="0.6.13" />
     <PackageReference Include="Scriban" Version="7.2.5" />

--- a/PowerForge.Web/packages.lock.json
+++ b/PowerForge.Web/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "HtmlTinkerX": {
         "type": "Direct",
-        "requested": "[2.0.18, )",
-        "resolved": "2.0.18",
-        "contentHash": "7d8DcjnNgGVaSUbAj/2U6i5PhrZWlWknbGL5hsS/9DF90PJIzm7lx48z6qO4b9WuyTILVxigdcozeSCwuheS6g==",
+        "requested": "[2.0.19, )",
+        "resolved": "2.0.19",
+        "contentHash": "aN1x0cqwonG/JNSYxCBtqTTCq1nyaEYiX6WdQvvkGpfYlLKuFjKD+4HfXSfBl1KZqC6SdIUZz3oXAib5AyB8vQ==",
         "dependencies": {
           "AngleSharp": "1.4.1-beta.523",
           "AngleSharp.Css": "1.0.0-beta.213",
@@ -198,9 +198,9 @@
     "net8.0": {
       "HtmlTinkerX": {
         "type": "Direct",
-        "requested": "[2.0.18, )",
-        "resolved": "2.0.18",
-        "contentHash": "7d8DcjnNgGVaSUbAj/2U6i5PhrZWlWknbGL5hsS/9DF90PJIzm7lx48z6qO4b9WuyTILVxigdcozeSCwuheS6g==",
+        "requested": "[2.0.19, )",
+        "resolved": "2.0.19",
+        "contentHash": "aN1x0cqwonG/JNSYxCBtqTTCq1nyaEYiX6WdQvvkGpfYlLKuFjKD+4HfXSfBl1KZqC6SdIUZz3oXAib5AyB8vQ==",
         "dependencies": {
           "AngleSharp": "1.4.1-beta.523",
           "AngleSharp.Css": "1.0.0-beta.213",


### PR DESCRIPTION
## Summary
- update PowerForge.Web to the stable public HtmlTinkerX 2.0.19 package
- refresh the direct and transitive lock entries with the published NuGet content hash
- keep the CLI and test consumers aligned with the same package graph

## Why
HtmlTinkerX 2.0.19 contains the stable Playwright self-healing/runtime fix used by unattended PowerForge.Web site rebuilds.

## Validation
- locked-mode restore: PowerForge.Web, PowerForge.Web.Cli, PowerForge.Tests
- `dotnet build PowerForge.Web.Cli/PowerForge.Web.Cli.csproj -c Release --no-restore`
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~WebPipelineRunner` (238 passed)