### PR TITLE
Automate encrypted server recovery backups

### DIFF
--- a/.github/workflows/powerforge-server-backup.yml
+++ b/.github/workflows/powerforge-server-backup.yml
@@ -199,6 +199,7 @@ jobs:
           $backupKey = Join-Path $sshRoot 'backup_repository_ed25519'
           $backupKnownHosts = Join-Path $sshRoot 'backup_repository_known_hosts'
           $configPath = Join-Path $sshRoot 'config'
+          $serverSshCommand = Join-Path $sshRoot 'server-ssh'
           Set-Content -LiteralPath $serverKey -Value $env:SERVER_PRIVATE_KEY -Encoding utf8NoBOM
           Set-Content -LiteralPath $serverKnownHosts -Value $env:SERVER_KNOWN_HOSTS -Encoding utf8NoBOM
           Set-Content -LiteralPath $backupKey -Value $env:BACKUP_PRIVATE_KEY -Encoding utf8NoBOM
@@ -224,14 +225,23 @@ jobs:
             IdentitiesOnly yes
             BatchMode yes
           "@ | Set-Content -LiteralPath $configPath -Encoding utf8NoBOM
+          @'
+          #!/usr/bin/env bash
+          set -Eeuo pipefail
+          exec /usr/bin/ssh -F "${POWERFORGE_SERVER_SSH_CONFIG:?}" "$@"
+          '@ | Set-Content -LiteralPath $serverSshCommand -Encoding utf8NoBOM
           chmod 700 $sshRoot
           chmod 600 $serverKey $serverKnownHosts $backupKey $backupKnownHosts $configPath
+          chmod 700 $serverSshCommand
           "GIT_SSH_COMMAND=ssh -F $configPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "POWERFORGE_SERVER_SSH_CONFIG=$configPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "SERVER_SSH_COMMAND=$serverSshCommand" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "SSH_CONFIG_PATH=$configPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Verify capture host identity
         shell: bash
-        run: ssh -F "$SSH_CONFIG_PATH" "$CAPTURE_SSH_ALIAS" 'printf capture-host-ok'
+        run: |
+          "$SERVER_SSH_COMMAND" "$CAPTURE_SSH_ALIAS" 'printf capture-host-ok'
 
       - name: Build pinned PowerForge capture CLI
         shell: pwsh
@@ -253,12 +263,15 @@ jobs:
           dotnet $env:POWERFORGE_CLI server capture `
             --manifest $env:MANIFEST_FULL_PATH `
             --out $env:CAPTURE_ROOT `
+            --ssh $env:SERVER_SSH_COMMAND `
             --encrypt-remote `
             --fail-on-failure
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Validate capture and write provenance
         shell: pwsh
+        env:
+          SOURCE_SHA_INPUT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           $ErrorActionPreference = 'Stop'
           $requiredFiles = @(
@@ -278,6 +291,10 @@ jobs:
           if (@($summary.Warnings).Count -ne 0) {
             throw "Capture summary contains warnings: $($summary.Warnings -join '; ')"
           }
+          if ($env:SOURCE_SHA_INPUT -notmatch '^[a-f0-9]{40,64}$') {
+            throw 'Unable to resolve exact caller source provenance.'
+          }
+          "SOURCE_SHA=$env:SOURCE_SHA_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           $engineSha = (git -C $env:ENGINE_ROOT rev-parse HEAD).Trim()
           if ($engineSha -notmatch '^[a-f0-9]{40}$') {
             throw 'Unable to resolve exact PowerForge engine provenance.'
@@ -285,7 +302,7 @@ jobs:
           [ordered]@{
             schemaVersion = 1
             sourceRepository = $env:GITHUB_REPOSITORY
-            sourceSha = $env:GITHUB_SHA
+            sourceSha = $env:SOURCE_SHA_INPUT
             engineRepository = '${{ inputs.powerforge_repository }}'
             engineSha = $engineSha
             workflowRunId = $env:GITHUB_RUN_ID
@@ -338,7 +355,7 @@ jobs:
           git -C $checkout config user.name 'PowerForge Server Backup'
           git -C $checkout config user.email 'powerforge-backup@users.noreply.github.com'
           git -C $checkout add -- $env:BACKUP_PATH
-          git -C $checkout commit -m "Backup $env:GITHUB_REPOSITORY at $env:GITHUB_SHA"
+          git -C $checkout commit -m "Backup $env:GITHUB_REPOSITORY at $env:SOURCE_SHA"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Publish backup with race-safe retry
@@ -351,6 +368,20 @@ jobs:
             if ! git rebase "origin/$BACKUP_BRANCH"; then
               git rebase --abort || true
               exit 1
+            fi
+            mapfile -t captures < <(find "$BACKUP_PATH" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
+            retained=0
+            for capture in "${captures[@]}"; do
+              [[ "$capture" =~ ^[0-9]{8}T[0-9]{6}Z-[0-9]+-[0-9]+$ ]] || continue
+              if (( retained < BACKUP_KEEP_LATEST )); then
+                ((retained += 1))
+                continue
+              fi
+              rm -rf -- "$BACKUP_PATH/$capture"
+            done
+            git add -- "$BACKUP_PATH"
+            if ! git diff --cached --quiet; then
+              git commit --amend --no-edit
             fi
             if git push origin "HEAD:$BACKUP_BRANCH"; then
               exit 0

--- a/.github/workflows/powerforge-server-backup.yml
+++ b/.github/workflows/powerforge-server-backup.yml
@@ -380,6 +380,10 @@ jobs:
               rm -rf -- "$BACKUP_PATH/$capture"
             done
             git add -- "$BACKUP_PATH"
+            if git diff --cached --quiet "origin/$BACKUP_BRANCH"; then
+              echo 'Backup was superseded by a newer retained capture; no publication is required.'
+              exit 0
+            fi
             if ! git diff --cached --quiet; then
               git commit --amend --no-edit
             fi

--- a/.github/workflows/powerforge-server-backup.yml
+++ b/.github/workflows/powerforge-server-backup.yml
@@ -1,0 +1,378 @@
+name: PowerForge Server Backup
+
+on:
+  workflow_call:
+    inputs:
+      manifest_path:
+        description: Repository-relative PowerForge server recovery manifest.
+        required: true
+        type: string
+      capture_user:
+        description: Dedicated least-privilege SSH account used for capture.
+        required: true
+        type: string
+      deployment_environment:
+        required: false
+        type: string
+        default: production
+      runner_labels_json:
+        required: false
+        type: string
+        default: '["ubuntu-latest"]'
+      timeout_minutes:
+        required: false
+        type: number
+        default: 30
+      dotnet_version:
+        required: false
+        type: string
+        default: 10.0.x
+      powerforge_repository:
+        required: true
+        type: string
+      powerforge_ref:
+        description: Exact PowerForge commit used to run the capture contract.
+        required: true
+        type: string
+    secrets:
+      repository_read_token:
+        required: false
+      server_ssh_private_key:
+        required: false
+      server_ssh_known_hosts:
+        required: false
+      backup_repository_ssh_private_key:
+        required: false
+      backup_repository_ssh_known_hosts:
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: powerforge-server-backup-${{ github.repository }}-${{ inputs.manifest_path }}
+  cancel-in-progress: false
+
+jobs:
+  capture-and-publish:
+    runs-on: ${{ fromJson(inputs.runner_labels_json) }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    environment:
+      name: ${{ inputs.deployment_environment }}
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ github.token }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout PowerForge source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.powerforge_repository }}
+          ref: ${{ inputs.powerforge_ref }}
+          path: .powerforge-source
+          token: ${{ secrets.repository_read_token || github.token }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Validate manifest and backup policy
+        shell: pwsh
+        env:
+          CAPTURE_USER_INPUT: ${{ inputs.capture_user }}
+          MANIFEST_PATH_INPUT: ${{ inputs.manifest_path }}
+          POWERFORGE_REF_INPUT: ${{ inputs.powerforge_ref }}
+          POWERFORGE_REPOSITORY_INPUT: ${{ inputs.powerforge_repository }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:RUNNER_OS -ne 'Linux') {
+            throw 'PowerForge server backup requires a Linux runner.'
+          }
+          if ($env:CAPTURE_USER_INPUT -notmatch '^[a-z_][a-z0-9_-]{0,31}$') {
+            throw 'capture_user is not a valid Linux account name.'
+          }
+          if ($env:POWERFORGE_REPOSITORY_INPUT -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+            throw 'powerforge_repository must be an owner/repository name.'
+          }
+          if ($env:POWERFORGE_REF_INPUT -notmatch '^[a-fA-F0-9]{40}$') {
+            throw 'powerforge_ref must be an exact 40-character commit.'
+          }
+
+          $workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd([IO.Path]::DirectorySeparatorChar)
+          $workspacePrefix = $workspace + [IO.Path]::DirectorySeparatorChar
+          $manifestPath = [IO.Path]::GetFullPath((Join-Path $workspace $env:MANIFEST_PATH_INPUT))
+          if (-not $manifestPath.StartsWith($workspacePrefix, [StringComparison]::Ordinal) -or
+              -not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+            throw 'manifest_path must identify a file inside the caller repository.'
+          }
+
+          $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+          if ($manifest.target.sshAlias -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$') {
+            throw 'The backup workflow requires target.sshAlias with a safe SSH alias.'
+          }
+          if ($manifest.target.host -notmatch '^[A-Za-z0-9][A-Za-z0-9.:-]{0,252}$') {
+            throw 'target.host is not a valid hostname or IP address.'
+          }
+          $capturePort = 0
+          if (-not [int]::TryParse([string]$manifest.target.sshPort, [ref]$capturePort) -or
+              $capturePort -lt 1 -or $capturePort -gt 65535) {
+            throw 'target.sshPort must be an integer from 1 through 65535.'
+          }
+
+          $backupRepository = [string]$manifest.backupTarget.repository
+          $backupBranch = [string]$manifest.backupTarget.branch
+          $backupPath = ([string]$manifest.backupTarget.path).Replace('\', '/')
+          $keepLatest = 0
+          if ($backupRepository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+            throw 'backupTarget.repository must be an owner/repository name.'
+          }
+          if ($backupBranch -notmatch '^[A-Za-z0-9._/-]+$' -or $backupBranch.Contains('..') -or $backupBranch.StartsWith('/')) {
+            throw 'backupTarget.branch contains unsupported characters.'
+          }
+          if ($backupPath -notmatch '^[A-Za-z0-9._/-]+$' -or $backupPath.Contains('..') -or $backupPath.StartsWith('/')) {
+            throw 'backupTarget.path must be a safe repository-relative path.'
+          }
+          if (-not [int]::TryParse([string]$manifest.backupTarget.retention.keepLatest, [ref]$keepLatest) -or
+              $keepLatest -lt 1 -or $keepLatest -gt 365) {
+            throw 'backupTarget.retention.keepLatest must be from 1 through 365.'
+          }
+          if (-not [string]::Equals([string]$manifest.backupTarget.encryption, 'age', [StringComparison]::OrdinalIgnoreCase) -or
+              [string]::IsNullOrWhiteSpace([string]$manifest.backupTarget.recipient)) {
+            throw 'Automated encrypted capture requires backupTarget.encryption=age and a public recipient.'
+          }
+
+          $engineRoot = [IO.Path]::GetFullPath((Join-Path $workspace '.powerforge-source'))
+          $captureRoot = Join-Path $env:RUNNER_TEMP 'powerforge-server-backup-capture'
+          $backupCheckout = Join-Path $env:RUNNER_TEMP 'powerforge-server-backup-repository'
+          foreach ($stalePath in @($captureRoot, $backupCheckout)) {
+            $resolvedStalePath = [IO.Path]::GetFullPath($stalePath)
+            $runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP).TrimEnd([IO.Path]::DirectorySeparatorChar)
+            if (-not $resolvedStalePath.StartsWith($runnerTemp + [IO.Path]::DirectorySeparatorChar, [StringComparison]::Ordinal)) {
+              throw 'Backup staging path escaped the runner temporary directory.'
+            }
+            if (Test-Path -LiteralPath $resolvedStalePath) {
+              Remove-Item -LiteralPath $resolvedStalePath -Recurse -Force
+            }
+          }
+          @{
+            BACKUP_BRANCH = $backupBranch
+            BACKUP_CHECKOUT = $backupCheckout
+            BACKUP_KEEP_LATEST = $keepLatest
+            BACKUP_PATH = $backupPath
+            BACKUP_REPOSITORY = $backupRepository
+            CAPTURE_HOST = [string]$manifest.target.host
+            CAPTURE_PORT = $capturePort
+            CAPTURE_ROOT = $captureRoot
+            CAPTURE_SSH_ALIAS = [string]$manifest.target.sshAlias
+            CAPTURE_USER = $env:CAPTURE_USER_INPUT
+            ENGINE_ROOT = $engineRoot
+            MANIFEST_FULL_PATH = $manifestPath
+          }.GetEnumerator() | ForEach-Object {
+            "$($_.Key)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
+
+      - name: Configure isolated SSH identities
+        shell: pwsh
+        env:
+          BACKUP_PRIVATE_KEY: ${{ secrets.backup_repository_ssh_private_key }}
+          BACKUP_KNOWN_HOSTS: ${{ secrets.backup_repository_ssh_known_hosts }}
+          SERVER_PRIVATE_KEY: ${{ secrets.server_ssh_private_key }}
+          SERVER_KNOWN_HOSTS: ${{ secrets.server_ssh_known_hosts }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          foreach ($value in @($env:BACKUP_PRIVATE_KEY, $env:BACKUP_KNOWN_HOSTS, $env:SERVER_PRIVATE_KEY, $env:SERVER_KNOWN_HOSTS)) {
+            if ([string]::IsNullOrWhiteSpace($value)) {
+              throw 'Server and backup repository SSH keys and pinned known-host entries are required.'
+            }
+          }
+
+          $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-server-backup-ssh'
+          New-Item -ItemType Directory -Force -Path $sshRoot | Out-Null
+          $serverKey = Join-Path $sshRoot 'server_ed25519'
+          $serverKnownHosts = Join-Path $sshRoot 'server_known_hosts'
+          $backupKey = Join-Path $sshRoot 'backup_repository_ed25519'
+          $backupKnownHosts = Join-Path $sshRoot 'backup_repository_known_hosts'
+          $configPath = Join-Path $sshRoot 'config'
+          Set-Content -LiteralPath $serverKey -Value $env:SERVER_PRIVATE_KEY -Encoding utf8NoBOM
+          Set-Content -LiteralPath $serverKnownHosts -Value $env:SERVER_KNOWN_HOSTS -Encoding utf8NoBOM
+          Set-Content -LiteralPath $backupKey -Value $env:BACKUP_PRIVATE_KEY -Encoding utf8NoBOM
+          Set-Content -LiteralPath $backupKnownHosts -Value $env:BACKUP_KNOWN_HOSTS -Encoding utf8NoBOM
+          @"
+          Host $env:CAPTURE_SSH_ALIAS
+            HostName $env:CAPTURE_HOST
+            User $env:CAPTURE_USER
+            Port $env:CAPTURE_PORT
+            IdentityFile $serverKey
+            UserKnownHostsFile $serverKnownHosts
+            StrictHostKeyChecking yes
+            IdentitiesOnly yes
+            BatchMode yes
+
+          Host github.com-powerforge-backup
+            HostName github.com
+            User git
+            Port 22
+            IdentityFile $backupKey
+            UserKnownHostsFile $backupKnownHosts
+            StrictHostKeyChecking yes
+            IdentitiesOnly yes
+            BatchMode yes
+          "@ | Set-Content -LiteralPath $configPath -Encoding utf8NoBOM
+          chmod 700 $sshRoot
+          chmod 600 $serverKey $serverKnownHosts $backupKey $backupKnownHosts $configPath
+          "GIT_SSH_COMMAND=ssh -F $configPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "SSH_CONFIG_PATH=$configPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Verify capture host identity
+        shell: bash
+        run: ssh -F "$SSH_CONFIG_PATH" "$CAPTURE_SSH_ALIAS" 'printf capture-host-ok'
+
+      - name: Build pinned PowerForge capture CLI
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $project = Join-Path $env:ENGINE_ROOT 'PowerForge.Web.Cli/PowerForge.Web.Cli.csproj'
+          dotnet build $project -c Release -f net10.0 --nologo
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $cli = Join-Path $env:ENGINE_ROOT 'PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll'
+          if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) {
+            throw "PowerForge capture CLI was not produced: $cli"
+          }
+          "POWERFORGE_CLI=$cli" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Capture and encrypt server recovery state
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          dotnet $env:POWERFORGE_CLI server capture `
+            --manifest $env:MANIFEST_FULL_PATH `
+            --out $env:CAPTURE_ROOT `
+            --encrypt-remote `
+            --fail-on-failure
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Validate capture and write provenance
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $requiredFiles = @(
+            'capture-summary.json',
+            'manifest.json',
+            'plain-files.tar.gz',
+            'encrypted-secrets.tar.gz.age',
+            'restore-checklist.md'
+          )
+          foreach ($relativePath in $requiredFiles) {
+            $path = Join-Path $env:CAPTURE_ROOT $relativePath
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf) -or (Get-Item -LiteralPath $path).Length -eq 0) {
+              throw "Required capture artifact is missing or empty: $relativePath"
+            }
+          }
+          $summary = Get-Content -LiteralPath (Join-Path $env:CAPTURE_ROOT 'capture-summary.json') -Raw | ConvertFrom-Json
+          if (@($summary.Warnings).Count -ne 0) {
+            throw "Capture summary contains warnings: $($summary.Warnings -join '; ')"
+          }
+          $engineSha = (git -C $env:ENGINE_ROOT rev-parse HEAD).Trim()
+          if ($engineSha -notmatch '^[a-f0-9]{40}$') {
+            throw 'Unable to resolve exact PowerForge engine provenance.'
+          }
+          [ordered]@{
+            schemaVersion = 1
+            sourceRepository = $env:GITHUB_REPOSITORY
+            sourceSha = $env:GITHUB_SHA
+            engineRepository = '${{ inputs.powerforge_repository }}'
+            engineSha = $engineSha
+            workflowRunId = $env:GITHUB_RUN_ID
+            workflowRunAttempt = $env:GITHUB_RUN_ATTEMPT
+            capturedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+          } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $env:CAPTURE_ROOT 'capture-metadata.json') -Encoding utf8NoBOM
+
+          $hashLines = Get-ChildItem -LiteralPath $env:CAPTURE_ROOT -File -Recurse |
+            Where-Object Name -ne 'SHA256SUMS.txt' |
+            Sort-Object FullName |
+            ForEach-Object {
+              $relative = [IO.Path]::GetRelativePath($env:CAPTURE_ROOT, $_.FullName).Replace('\', '/')
+              "$((Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant())  $relative"
+            }
+          $hashLines | Set-Content -LiteralPath (Join-Path $env:CAPTURE_ROOT 'SHA256SUMS.txt') -Encoding utf8NoBOM
+
+      - name: Clone private backup repository
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          git clone \
+            --single-branch \
+            --branch "$BACKUP_BRANCH" \
+            "git@github.com-powerforge-backup:${BACKUP_REPOSITORY}.git" \
+            "$BACKUP_CHECKOUT"
+
+      - name: Stage timestamped capture and retention
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $checkout = [IO.Path]::GetFullPath($env:BACKUP_CHECKOUT).TrimEnd([IO.Path]::DirectorySeparatorChar)
+          $targetRoot = [IO.Path]::GetFullPath((Join-Path $checkout $env:BACKUP_PATH))
+          if (-not $targetRoot.StartsWith($checkout + [IO.Path]::DirectorySeparatorChar, [StringComparison]::Ordinal)) {
+            throw 'Resolved backup target escaped the backup repository checkout.'
+          }
+          New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+          $captureName = '{0}-{1}-{2}' -f [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ'), $env:GITHUB_RUN_ID, $env:GITHUB_RUN_ATTEMPT
+          $destination = Join-Path $targetRoot $captureName
+          New-Item -ItemType Directory -Path $destination | Out-Null
+          Get-ChildItem -LiteralPath $env:CAPTURE_ROOT -Force | Copy-Item -Destination $destination -Recurse -Force
+
+          $keepLatest = [int]$env:BACKUP_KEEP_LATEST
+          $captures = @(Get-ChildItem -LiteralPath $targetRoot -Directory |
+            Where-Object Name -Match '^\d{8}T\d{6}Z-\d+-\d+$' |
+            Sort-Object Name -Descending)
+          foreach ($stale in @($captures | Select-Object -Skip $keepLatest)) {
+            Remove-Item -LiteralPath $stale.FullName -Recurse -Force
+          }
+
+          git -C $checkout config user.name 'PowerForge Server Backup'
+          git -C $checkout config user.email 'powerforge-backup@users.noreply.github.com'
+          git -C $checkout add -- $env:BACKUP_PATH
+          git -C $checkout commit -m "Backup $env:GITHUB_REPOSITORY at $env:GITHUB_SHA"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Publish backup with race-safe retry
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          cd "$BACKUP_CHECKOUT"
+          for attempt in 1 2 3; do
+            git fetch origin "$BACKUP_BRANCH"
+            if ! git rebase "origin/$BACKUP_BRANCH"; then
+              git rebase --abort || true
+              exit 1
+            fi
+            if git push origin "HEAD:$BACKUP_BRANCH"; then
+              exit 0
+            fi
+            sleep "$((attempt * 5))"
+          done
+          echo 'Backup publication failed after three push attempts.' >&2
+          exit 1
+
+      - name: Cleanup isolated credentials and capture staging
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          $runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP).TrimEnd([IO.Path]::DirectorySeparatorChar)
+          foreach ($path in @(
+            (Join-Path $runnerTemp 'powerforge-server-backup-ssh'),
+            (Join-Path $runnerTemp 'powerforge-server-backup-capture'),
+            (Join-Path $runnerTemp 'powerforge-server-backup-repository')
+          )) {
+            $resolved = [IO.Path]::GetFullPath($path)
+            if ($resolved.StartsWith($runnerTemp + [IO.Path]::DirectorySeparatorChar, [StringComparison]::Ordinal) -and
+                (Test-Path -LiteralPath $resolved)) {
+              Remove-Item -LiteralPath $resolved -Recurse -Force
+            }
+          }

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -128,6 +128,8 @@ Encrypted capture:
 
 Encrypted capture requires an explicit recipient such as an age or GPG public key. If no recipient is configured, PowerForge should skip encrypted capture and report the missing secret recovery coverage.
 
+Mark capture entries with `required: true` when a successful recovery depends on them. If either archive contains a required entry, PowerForge runs that archive in strict mode and any missing listed path fails capture. An archive whose entries are all optional retains best-effort missing-file behavior.
+
 ## Bootstrap Stages
 
 The engine should plan and run these stages:
@@ -182,7 +184,26 @@ PowerForge may publish capture artifacts to a private GitHub repository, but onl
 
 For most sites, a separate private backup repository is cleaner than storing generated backup artifacts in the engine source repository.
 
-`backupTarget.retention.keepLatest` can define how many timestamped captures should remain in the backup repository working tree. This is a publication policy for wrappers or future publish commands; Git history still preserves older committed captures unless repository history is rewritten.
+Use `.github/workflows/powerforge-server-backup.yml` to run encrypted capture and publication on a schedule or manual dispatch. The caller pins the reusable workflow and `powerforge_ref` to the same exact commit, supplies the manifest path and a dedicated capture username, and names a protected deployment environment. The called job reads these environment secrets directly:
+
+- `SERVER_SSH_PRIVATE_KEY` and `SERVER_SSH_KNOWN_HOSTS` for the least-privilege server capture account
+- `BACKUP_REPOSITORY_SSH_PRIVATE_KEY` and `BACKUP_REPOSITORY_SSH_KNOWN_HOSTS` for a write-scoped deploy key on the private backup repository
+
+The two identities must remain separate. The server account should only be able to execute the exact read-only inspection and archive commands required by the manifest. The backup repository key should be a deploy key for that repository only.
+
+```yaml
+jobs:
+  backup:
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-server-backup.yml@POWERFORGE_COMMIT
+    with:
+      manifest_path: deploy/linux/example.serverrecovery.json
+      capture_user: powerforge-example-backup
+      deployment_environment: production
+      powerforge_repository: EvotecIT/PSPublishModule
+      powerforge_ref: POWERFORGE_COMMIT
+```
+
+The workflow requires remote age encryption, a non-empty plain archive, a non-empty encrypted archive, a warning-free capture summary, exact source/engine/run provenance, and SHA-256 checksums before it clones the backup repository. It commits a timestamped directory under `backupTarget.path`, applies `backupTarget.retention.keepLatest`, and retries fetch/rebase/push races without uploading recovery material as a GitHub Actions artifact. Git history still preserves older committed captures unless repository history is rewritten.
 
 ## Evotec Reference
 

--- a/PowerForge.Tests/GitHubServerBackupWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubServerBackupWorkflowTests.cs
@@ -15,6 +15,8 @@ public sealed class GitHubServerBackupWorkflowTests
         Assert.Contains("backup_repository_ed25519", workflow, StringComparison.Ordinal);
         Assert.Contains("StrictHostKeyChecking yes", workflow, StringComparison.Ordinal);
         Assert.Contains("IdentitiesOnly yes", workflow, StringComparison.Ordinal);
+        Assert.Contains("SERVER_SSH_COMMAND", workflow, StringComparison.Ordinal);
+        Assert.Contains("--ssh $env:SERVER_SSH_COMMAND", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("ssh-keyscan", workflow, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -30,6 +32,8 @@ public sealed class GitHubServerBackupWorkflowTests
         Assert.Contains("capture-metadata.json", workflow, StringComparison.Ordinal);
         Assert.Contains("SHA256SUMS.txt", workflow, StringComparison.Ordinal);
         Assert.Contains("engineSha", workflow, StringComparison.Ordinal);
+        Assert.Contains("sourceSha = $env:SOURCE_SHA_INPUT", workflow, StringComparison.Ordinal);
+        Assert.Contains("SOURCE_SHA_INPUT: ${{ github.event.pull_request.head.sha || github.sha }}", workflow, StringComparison.Ordinal);
         Assert.Contains("workflowRunAttempt", workflow, StringComparison.Ordinal);
     }
 
@@ -41,6 +45,8 @@ public sealed class GitHubServerBackupWorkflowTests
         Assert.Contains("backupTarget.retention.keepLatest", workflow, StringComparison.Ordinal);
         Assert.Contains("Select-Object -Skip $keepLatest", workflow, StringComparison.Ordinal);
         Assert.Contains("git rebase \"origin/$BACKUP_BRANCH\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("mapfile -t captures", workflow, StringComparison.Ordinal);
+        Assert.Contains("git commit --amend --no-edit", workflow, StringComparison.Ordinal);
         Assert.Contains("for attempt in 1 2 3", workflow, StringComparison.Ordinal);
         Assert.Contains("git push origin \"HEAD:$BACKUP_BRANCH\"", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("upload-artifact", workflow, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Tests/GitHubServerBackupWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubServerBackupWorkflowTests.cs
@@ -1,0 +1,61 @@
+namespace PowerForge.Tests;
+
+public sealed class GitHubServerBackupWorkflowTests
+{
+    [Fact]
+    public void Workflow_ShouldUseSeparatePinnedSshIdentitiesAndEnvironmentSecrets()
+    {
+        var workflow = ReadRepoFile(".github", "workflows", "powerforge-server-backup.yml");
+
+        Assert.Contains("environment:", workflow, StringComparison.Ordinal);
+        Assert.Contains("server_ssh_private_key", workflow, StringComparison.Ordinal);
+        Assert.Contains("backup_repository_ssh_private_key", workflow, StringComparison.Ordinal);
+        Assert.Contains("repository_read_token || github.token", workflow, StringComparison.Ordinal);
+        Assert.Contains("server_ed25519", workflow, StringComparison.Ordinal);
+        Assert.Contains("backup_repository_ed25519", workflow, StringComparison.Ordinal);
+        Assert.Contains("StrictHostKeyChecking yes", workflow, StringComparison.Ordinal);
+        Assert.Contains("IdentitiesOnly yes", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssh-keyscan", workflow, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Workflow_ShouldRequireEncryptedCompleteCaptureAndExactProvenance()
+    {
+        var workflow = ReadRepoFile(".github", "workflows", "powerforge-server-backup.yml");
+
+        Assert.Contains("--encrypt-remote", workflow, StringComparison.Ordinal);
+        Assert.Contains("--fail-on-failure", workflow, StringComparison.Ordinal);
+        Assert.Contains("plain-files.tar.gz", workflow, StringComparison.Ordinal);
+        Assert.Contains("encrypted-secrets.tar.gz.age", workflow, StringComparison.Ordinal);
+        Assert.Contains("capture-metadata.json", workflow, StringComparison.Ordinal);
+        Assert.Contains("SHA256SUMS.txt", workflow, StringComparison.Ordinal);
+        Assert.Contains("engineSha", workflow, StringComparison.Ordinal);
+        Assert.Contains("workflowRunAttempt", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Workflow_ShouldPublishManifestRetentionWithPushRaceRetry()
+    {
+        var workflow = ReadRepoFile(".github", "workflows", "powerforge-server-backup.yml");
+
+        Assert.Contains("backupTarget.retention.keepLatest", workflow, StringComparison.Ordinal);
+        Assert.Contains("Select-Object -Skip $keepLatest", workflow, StringComparison.Ordinal);
+        Assert.Contains("git rebase \"origin/$BACKUP_BRANCH\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("for attempt in 1 2 3", workflow, StringComparison.Ordinal);
+        Assert.Contains("git push origin \"HEAD:$BACKUP_BRANCH\"", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("upload-artifact", workflow, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ReadRepoFile(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && current is not null; i++)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return File.ReadAllText(Path.Combine([current.FullName, .. relativePath]));
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+}

--- a/PowerForge.Tests/GitHubServerBackupWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubServerBackupWorkflowTests.cs
@@ -46,6 +46,8 @@ public sealed class GitHubServerBackupWorkflowTests
         Assert.Contains("Select-Object -Skip $keepLatest", workflow, StringComparison.Ordinal);
         Assert.Contains("git rebase \"origin/$BACKUP_BRANCH\"", workflow, StringComparison.Ordinal);
         Assert.Contains("mapfile -t captures", workflow, StringComparison.Ordinal);
+        Assert.Contains("git diff --cached --quiet \"origin/$BACKUP_BRANCH\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("Backup was superseded by a newer retained capture", workflow, StringComparison.Ordinal);
         Assert.Contains("git commit --amend --no-edit", workflow, StringComparison.Ordinal);
         Assert.Contains("for attempt in 1 2 3", workflow, StringComparison.Ordinal);
         Assert.Contains("git push origin \"HEAD:$BACKUP_BRANCH\"", workflow, StringComparison.Ordinal);

--- a/PowerForge.Tests/WebCliServerCaptureTests.cs
+++ b/PowerForge.Tests/WebCliServerCaptureTests.cs
@@ -1,0 +1,42 @@
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed class WebCliServerCaptureTests
+{
+    [Fact]
+    public void BuildRemoteTarScript_EnforcesRequiredExactAndGlobPaths()
+    {
+        var script = WebCliCommandHandlers.BuildRemoteTarScript(
+        [
+            new PowerForgeServerManagedFile { Target = "/etc/example.conf", Required = true },
+            new PowerForgeServerManagedFile { Target = "/etc/example/*.json", Required = true },
+            new PowerForgeServerManagedFile { Target = "/var/lib/example/optional.json" }
+        ]);
+
+        Assert.Equal("set -e; sudo -n tar -czf - /etc/example.conf /etc/example/*.json /var/lib/example/optional.json", script);
+    }
+
+    [Fact]
+    public void BuildRemoteTarScript_AllowsMissingPathsOnlyForOptionalArchive()
+    {
+        var script = WebCliCommandHandlers.BuildRemoteTarScript(
+        [
+            new PowerForgeServerManagedFile { Target = "/var/lib/example/optional.json" }
+        ]);
+
+        Assert.Equal("set -e; sudo -n tar -czf - --ignore-failed-read /var/lib/example/optional.json", script);
+    }
+
+    [Fact]
+    public void BuildRemoteTarScript_RejectsUnsafePathCharacters()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            WebCliCommandHandlers.BuildRemoteTarScript(
+            [
+                new PowerForgeServerManagedFile { Target = "/etc/example;id", Required = true }
+            ]));
+
+        Assert.Contains("unsupported characters", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/PowerForge.Tests/WebCliServerCaptureTests.cs
+++ b/PowerForge.Tests/WebCliServerCaptureTests.cs
@@ -39,4 +39,17 @@ public sealed class WebCliServerCaptureTests
 
         Assert.Contains("unsupported characters", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void BuildRemoteEncryptedTarScript_PropagatesTarFailuresThroughEncryptionPipeline()
+    {
+        var script = WebCliCommandHandlers.BuildRemoteEncryptedTarScript(
+        [
+            new PowerForgeServerManagedFile { Target = "/etc/example/required.env", Required = true }
+        ], "age1example");
+
+        Assert.StartsWith("bash -o pipefail -c ", script, StringComparison.Ordinal);
+        Assert.Contains("sudo -n tar -czf - /etc/example/required.env", script, StringComparison.Ordinal);
+        Assert.Contains("| age -r", script, StringComparison.Ordinal);
+    }
 }

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -446,23 +446,28 @@ internal static partial class WebCliCommandHandlers
         return RunProcessCaptureBinary(sshCommand, BuildSshArguments(target, script), outputPath);
     }
 
-    private static string BuildRemoteTarScript(PowerForgeServerManagedFile[] files)
+    internal static string BuildRemoteTarScript(PowerForgeServerManagedFile[] files)
     {
-        var paths = files
-            .Select(static file => file.Target)
-            .Where(static target => !string.IsNullOrWhiteSpace(target))
-            .Select(static target => target!)
+        var captureFiles = files
+            .Where(static file => !string.IsNullOrWhiteSpace(file.Target))
+            .Select(static file => new { Target = file.Target!, file.Required })
             .ToArray();
-        if (paths.Length == 0)
+        if (captureFiles.Length == 0)
             throw new InvalidOperationException("No target paths are defined for capture.");
 
-        foreach (var path in paths)
+        foreach (var file in captureFiles)
         {
+            var path = file.Target;
             if (path.Any(static c => !(char.IsLetterOrDigit(c) || c is '/' or '.' or '_' or '-' or '*' or '?' or '[' or ']')))
                 throw new InvalidOperationException($"Capture path contains unsupported characters: {path}");
         }
 
-        return "set -e; sudo -n tar -czf - --ignore-failed-read " + string.Join(' ', paths);
+        var script = new StringBuilder("set -e; sudo -n tar -czf - ");
+        if (!captureFiles.Any(static file => file.Required))
+            script.Append("--ignore-failed-read ");
+        script
+            .AppendJoin(' ', captureFiles.Select(static file => file.Target));
+        return script.ToString();
     }
 
     private static string BuildRemoteEncryptedTarScript(PowerForgeServerManagedFile[] files, string recipient)

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -470,10 +470,11 @@ internal static partial class WebCliCommandHandlers
         return script.ToString();
     }
 
-    private static string BuildRemoteEncryptedTarScript(PowerForgeServerManagedFile[] files, string recipient)
+    internal static string BuildRemoteEncryptedTarScript(PowerForgeServerManagedFile[] files, string recipient)
     {
         var tarScript = BuildRemoteTarScript(files);
-        return $"{tarScript} | age -r {ShellQuote(recipient)} -o -";
+        var pipeline = $"{tarScript} | age -r {ShellQuote(recipient)} -o -";
+        return $"bash -o pipefail -c {ShellQuote(pipeline)}";
     }
 
     private static string ShellQuote(string value)


### PR DESCRIPTION
## Summary
- add a reusable protected-environment workflow that captures, remotely age-encrypts, validates, checksums, retains, and publishes server recovery state to a private Git repository
- keep server capture and backup-repository write credentials as separate pinned SSH identities
- make `ManagedFile.required` effective by switching any archive with required entries to strict tar behavior
- document the caller and credential contract

## Safety and recovery guarantees
- exact PowerForge commit and captured source/run provenance
- pinned known hosts; no `ssh-keyscan`
- non-empty plain and encrypted archives with warning-free summary
- no recovery artifacts uploaded to GitHub Actions storage
- repository-relative backup paths and bounded retention
- fetch/rebase/push retry for cross-repository publication races
- runner-temp cleanup on success or failure

## Validation
- actionlint: reusable workflow clean
- locked restore: PowerForge.Tests
- focused tests: 6 passed