### PR TITLE
Support legacy static-site takeover

### DIFF
--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -10,6 +10,7 @@ site=""
 archive=""
 metadata=""
 promoted=0
+legacy_migrated=0
 previous_target=""
 release_dir=""
 workflow_stage=""
@@ -247,6 +248,9 @@ rollback() {
       rm -f "$SITE_ROOT/current"
     fi
     purge_cloudflare || true
+  elif [[ "$legacy_migrated" == '1' && -n "$previous_target" && -d "$previous_target" && ! -e "$SITE_ROOT/current" ]]; then
+    log 'Promotion failed; restoring the legacy current directory.'
+    mv -T "$previous_target" "$SITE_ROOT/current"
   fi
   [[ -z "$release_dir" || ! -d "$release_dir" || "$release_dir" == "$previous_target" ]] || rm -rf "$release_dir"
   exit "$exit_code"
@@ -261,6 +265,13 @@ install -m 0644 "$metadata" "$release_dir/_powerforge/deployment.json"
 
 if [[ -L "$SITE_ROOT/current" ]]; then
   previous_target="$(readlink -f "$SITE_ROOT/current")"
+elif [[ -e "$SITE_ROOT/current" ]]; then
+  [[ -d "$SITE_ROOT/current" ]] || fail 'Existing current path must be a directory or symlink.'
+  previous_target="$SITE_ROOT/releases/legacy-$(date -u +%Y%m%d%H%M%S)-${source_sha:0:12}"
+  [[ ! -e "$previous_target" ]] || fail "Legacy release already exists: $previous_target"
+  log "Migrating legacy current directory to $previous_target"
+  mv -T "$SITE_ROOT/current" "$previous_target"
+  legacy_migrated=1
 fi
 candidate_link="$SITE_ROOT/.current.${run_id}.${run_attempt}"
 ln -s "$release_dir" "$candidate_link"

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -66,6 +66,11 @@ by another account. It atomically promotes a timestamped release, purges Cloudfl
 without disabling proxying, verifies the exact source SHA through both the origin and
 public URL, and rolls back the symlink if any check fails.
 
+On the first PowerForge deployment, an existing non-symlink `current` directory is
+moved into the release history and becomes the rollback target. This lets the shared
+promoter take over a legacy in-place site without a consumer-specific migration
+script or an unprotected delete-and-replace step.
+
 When `deployment_cloudflare_zone` is set, the workflow uses `cloudflare_zone_id`
 directly and transfers the deploy-only `deployment_cloudflare_api_token` and zone
 id only inside temporary deployment staging. A least-privilege cache-purge token

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -45,6 +45,9 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("Public endpoint did not serve", script, StringComparison.Ordinal);
         Assert.Contains("Origin endpoint did not serve", script, StringComparison.Ordinal);
         Assert.Contains("rolling back", script, StringComparison.Ordinal);
+        Assert.Contains("Migrating legacy current directory", script, StringComparison.Ordinal);
+        Assert.Contains("restoring the legacy current directory", script, StringComparison.Ordinal);
+        Assert.Contains("legacy_migrated=1", script, StringComparison.Ordinal);
         Assert.Contains("mv -Tf", script, StringComparison.Ordinal);
         Assert.Contains("umask 022", script, StringComparison.Ordinal);
         Assert.Contains("Cloudflare zone id is required", script, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- migrate an existing non-symlink current directory into PowerForge release history during the first static deployment
- retain that legacy content as the automatic rollback target
- restore the original directory if promotion fails before the replacement symlink is installed
- document the generic takeover behavior

## Why

A reusable Linux deployment must take over an existing in-place site without a consumer-specific move/delete helper. CasaRay exposed this gap while moving from its legacy deployment lane.

## Validation

- bash syntax validation under WSL
- focused GitHubWebsiteLinuxDeployWorkflowTests: 3 passed on net10.0
- git diff --check
