### PR TITLE
Make server bootstrap prerequisites explicit

### DIFF
--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -68,7 +68,7 @@ powerforge-web server restore-secrets-plan --manifest deploy/linux/example.serve
 
 `server verify` runs the manifest's operational health checks, such as Apache config validation, local service health checks, Certbot dry-runs, Cloudflare origin sync, and public URL checks. Pass `--fail-on-failure` when the command should exit non-zero if a required command or URL check fails.
 
-`server bootstrap-plan` generates a reviewable markdown plan, JSON plan, and LF-normalized shell script draft for rebuilding a fresh host. Manual and sensitive steps are left as blocking TODOs in the script so it cannot silently deploy without restored secrets.
+`server bootstrap-plan` generates a reviewable markdown plan, JSON plan, and LF-normalized shell script draft for rebuilding a fresh host. Managed accounts are created before owned directories. Repositories may declare `bootstrapRequiredFiles` so a private clone fails closed until its isolated SSH key, pinned known-hosts file, and client configuration have been restored. Secret steps are rerunnable presence guards: they stop with an operator-facing restore instruction while state is missing and continue without exposing values after restoration.
 
 `server restore-secrets-plan` generates a markdown plan, JSON plan, and LF-normalized `restore-secrets.sh` draft for an encrypted secret bundle. The script requires `age`, decrypts to a temporary directory, lists archive contents, rejects absolute or path-traversal archive entries, and refuses to extract into `/` unless `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES` is set.
 
@@ -92,6 +92,8 @@ A recovery manifest should describe:
 - expected operating system family and version
 - package prerequisites
 - repository checkouts and branches
+- service accounts required by managed path ownership
+- private-repository bootstrap prerequisite files
 - filesystem layout
 - Apache modules, vhosts, and managed includes
 - systemd services and timers

--- a/PowerForge.Tests/ServerRecoveryBootstrapPlanTests.cs
+++ b/PowerForge.Tests/ServerRecoveryBootstrapPlanTests.cs
@@ -1,0 +1,90 @@
+namespace PowerForge.Tests;
+
+public sealed class ServerRecoveryBootstrapPlanTests
+{
+    [Fact]
+    public void BuildPlan_CreatesAccountsBeforeOwnedPathsAndChecksRepositoryPrerequisites()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Accounts =
+            [
+                new PowerForge.Web.Cli.PowerForgeServerAccount
+                {
+                    Name = "example-service",
+                    System = true,
+                    Home = "/nonexistent",
+                    Shell = "/usr/sbin/nologin"
+                }
+            ],
+            Paths =
+            [
+                new PowerForge.Web.Cli.PowerForgeServerPath
+                {
+                    Id = "service-state",
+                    Path = "/var/lib/example-service",
+                    Kind = "directory",
+                    Owner = "example-service",
+                    Group = "example-service",
+                    Mode = "750"
+                }
+            ],
+            Repositories =
+            [
+                new PowerForge.Web.Cli.PowerForgeServerRepository
+                {
+                    Role = "private-application",
+                    Url = "git@example.test:owner/repository.git",
+                    Path = "/srv/example",
+                    Branch = "main",
+                    BootstrapRequiredFiles = ["/etc/example/id_ed25519", "/etc/example/known_hosts"]
+                }
+            ]
+        };
+
+        var warnings = new List<string>();
+        var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, warnings);
+
+        var account = Assert.Single(steps, step => step.Category == "accounts");
+        var path = Assert.Single(steps, step => step.Category == "filesystem");
+        var repositorySteps = steps.Where(step => step.Category == "repositories").ToArray();
+        Assert.True(account.Order < path.Order);
+        Assert.Equal(2, repositorySteps.Length);
+        Assert.True(repositorySteps[0].Order < repositorySteps[1].Order);
+        Assert.Contains("useradd --system --user-group --no-create-home", account.Command, StringComparison.Ordinal);
+        Assert.Contains("test -s '/etc/example/id_ed25519'", repositorySteps[0].Command, StringComparison.Ordinal);
+        Assert.Contains("test -s '/etc/example/known_hosts'", repositorySteps[0].Command, StringComparison.Ordinal);
+        Assert.Contains("exit 3", repositorySteps[0].Command, StringComparison.Ordinal);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void BuildPlan_UsesRerunnableSecretPresenceGuards()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Secrets =
+            [
+                new PowerForge.Web.Cli.PowerForgeServerSecret { Id = "directory", Path = "/etc/example", RestoreMode = "directory" },
+                new PowerForge.Web.Cli.PowerForgeServerSecret { Id = "file", Path = "/etc/example/token", RestoreMode = "file" },
+                new PowerForge.Web.Cli.PowerForgeServerSecret { Id = "environment", Env = "EXAMPLE_TOKEN" }
+            ]
+        };
+
+        var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []);
+        var secrets = steps.Where(step => step.Category == "secrets").ToArray();
+
+        Assert.Equal(3, secrets.Length);
+        Assert.Contains("test -d '/etc/example'", secrets[0].Command, StringComparison.Ordinal);
+        Assert.Contains("-mindepth 1 -maxdepth 1", secrets[0].Command, StringComparison.Ordinal);
+        Assert.Contains("test -s '/etc/example/token'", secrets[1].Command, StringComparison.Ordinal);
+        Assert.Contains("printenv 'EXAMPLE_TOKEN'", secrets[2].Command, StringComparison.Ordinal);
+        Assert.All(secrets, step =>
+        {
+            Assert.False(step.Manual);
+            Assert.False(step.Sensitive);
+            Assert.DoesNotContain("TODO", step.Command, StringComparison.Ordinal);
+            Assert.Contains("exit 3", step.Command, StringComparison.Ordinal);
+        });
+    }
+}

--- a/PowerForge.Web.Cli/ServerRecoveryModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryModels.cs
@@ -7,6 +7,7 @@ internal sealed class PowerForgeServerRecoveryManifest
     public string? Description { get; set; }
     public PowerForgeServerTarget? Target { get; set; }
     public PowerForgeServerRepository[]? Repositories { get; set; }
+    public PowerForgeServerAccount[]? Accounts { get; set; }
     public PowerForgeServerPackages? Packages { get; set; }
     public PowerForgeServerPath[]? Paths { get; set; }
     public PowerForgeServerApache? Apache { get; set; }
@@ -39,6 +40,16 @@ internal sealed class PowerForgeServerRepository
     public string? Path { get; set; }
     public string? Branch { get; set; }
     public bool Required { get; set; }
+    public string[]? BootstrapRequiredFiles { get; set; }
+}
+
+internal sealed class PowerForgeServerAccount
+{
+    public string Name { get; set; } = string.Empty;
+    public bool System { get; set; }
+    public bool CreateHome { get; set; }
+    public string? Home { get; set; }
+    public string? Shell { get; set; }
 }
 
 internal sealed class PowerForgeServerPackages
@@ -184,6 +195,7 @@ internal sealed class PowerForgeServerRecoveryPlanResult
     public string? SshAlias { get; set; }
     public int? SshPort { get; set; }
     public int RepositoryCount { get; set; }
+    public int AccountCount { get; set; }
     public int PackageCount { get; set; }
     public int ApacheModuleCount { get; set; }
     public int SystemdServiceCount { get; set; }

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
@@ -77,7 +77,7 @@ internal static partial class WebCliCommandHandlers
         return Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "_server-state", name, "bootstrap-plan"));
     }
 
-    private static List<PowerForgeServerBootstrapPlanStep> BuildBootstrapPlanSteps(
+    internal static List<PowerForgeServerBootstrapPlanStep> BuildBootstrapPlanSteps(
         PowerForgeServerRecoveryManifest manifest,
         ICollection<string> warnings)
     {
@@ -93,6 +93,29 @@ internal static partial class WebCliCommandHandlers
         {
             AddStep(steps, ref order, "packages", "Install apt prerequisites",
                 "apt-get update && apt-get install -y " + string.Join(' ', manifest.Packages.Apt),
+                plannedCommands: plannedCommands);
+        }
+
+        foreach (var account in manifest.Accounts ?? Array.Empty<PowerForgeServerAccount>())
+        {
+            if (string.IsNullOrWhiteSpace(account.Name)) continue;
+            var useradd = new List<string> { "useradd" };
+            if (account.System) useradd.Add("--system");
+            useradd.Add("--user-group");
+            useradd.Add(account.CreateHome ? "--create-home" : "--no-create-home");
+            if (!string.IsNullOrWhiteSpace(account.Home))
+            {
+                useradd.Add("--home-dir");
+                useradd.Add(ShellQuote(account.Home));
+            }
+            if (!string.IsNullOrWhiteSpace(account.Shell))
+            {
+                useradd.Add("--shell");
+                useradd.Add(ShellQuote(account.Shell));
+            }
+            useradd.Add(ShellQuote(account.Name));
+            AddStep(steps, ref order, "accounts", $"Create account {account.Name}",
+                $"id -u {ShellQuote(account.Name)} >/dev/null 2>&1 || {string.Join(' ', useradd)}",
                 plannedCommands: plannedCommands);
         }
 
@@ -113,6 +136,18 @@ internal static partial class WebCliCommandHandlers
         foreach (var repository in manifest.Repositories ?? Array.Empty<PowerForgeServerRepository>())
         {
             if (string.IsNullOrWhiteSpace(repository.Path)) continue;
+            var prerequisites = repository.BootstrapRequiredFiles?
+                .Where(static path => !string.IsNullOrWhiteSpace(path))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray() ?? Array.Empty<string>();
+            if (prerequisites.Length > 0)
+            {
+                var checks = string.Join(" && ", prerequisites.Select(path => $"test -s {ShellQuote(path)}"));
+                var message = ShellQuote($"Restore bootstrap prerequisite files for repository {repository.Role} before continuing.");
+                AddStep(steps, ref order, "repositories", $"Verify {repository.Role} repository prerequisites",
+                    $"{checks} || {{ echo {message} >&2; exit 3; }}",
+                    plannedCommands: plannedCommands);
+            }
             if (string.IsNullOrWhiteSpace(repository.Url))
             {
                 warnings.Add($"Repository URL is missing for role '{repository.Role}'. Bootstrap script leaves a manual clone step.");
@@ -177,8 +212,23 @@ internal static partial class WebCliCommandHandlers
 
         foreach (var secret in manifest.Secrets ?? Array.Empty<PowerForgeServerSecret>())
         {
-            AddStep(steps, ref order, "secrets", $"Restore secret {secret.Id}",
-                $"# TODO: restore encrypted secret to {secret.Path ?? secret.Env ?? secret.Id}", manual: true, sensitive: true, plannedCommands: plannedCommands);
+            var message = ShellQuote($"Restore encrypted secret {secret.Id} before continuing.");
+            string guard;
+            if (!string.IsNullOrWhiteSpace(secret.Path))
+            {
+                guard = secret.RestoreMode?.Equals("directory", StringComparison.OrdinalIgnoreCase) == true
+                    ? $"test -d {ShellQuote(secret.Path)} && find {ShellQuote(secret.Path)} -mindepth 1 -maxdepth 1 -print -quit | grep -q . || {{ echo {message} >&2; exit 3; }}"
+                    : $"test -s {ShellQuote(secret.Path)} || {{ echo {message} >&2; exit 3; }}";
+            }
+            else if (!string.IsNullOrWhiteSpace(secret.Env))
+            {
+                guard = $"test -n \"$(printenv {ShellQuote(secret.Env)} 2>/dev/null)\" || {{ echo {message} >&2; exit 3; }}";
+            }
+            else
+            {
+                guard = $"echo {message} >&2; exit 3";
+            }
+            AddStep(steps, ref order, "secrets", $"Confirm restored secret {secret.Id}", guard, plannedCommands: plannedCommands);
         }
 
         foreach (var command in manifest.Deploy?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>())

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -78,6 +78,7 @@ internal static partial class WebCliCommandHandlers
             SshAlias = manifest.Target?.SshAlias,
             SshPort = manifest.Target?.SshPort,
             RepositoryCount = manifest.Repositories?.Length ?? 0,
+            AccountCount = manifest.Accounts?.Length ?? 0,
             PackageCount = manifest.Packages?.Apt?.Length ?? 0,
             ApacheModuleCount = manifest.Packages?.ApacheModules?.Length ?? manifest.Apache?.Modules?.Length ?? 0,
             SystemdServiceCount = manifest.Systemd?.Services?.Length ?? 0,
@@ -112,7 +113,7 @@ internal static partial class WebCliCommandHandlers
         logger.Success("Server recovery manifest loaded.");
         logger.Info($"Manifest: {fullManifestPath}");
         logger.Info($"Target: {manifest.Target?.SshAlias ?? manifest.Target?.Host ?? "(unknown)"} port {manifest.Target?.SshPort?.ToString() ?? "(default)"}");
-        logger.Info($"Repositories: {result.RepositoryCount}; packages: {result.PackageCount}; services: {result.SystemdServiceCount}; timers: {result.SystemdTimerCount}");
+        logger.Info($"Repositories: {result.RepositoryCount}; accounts: {result.AccountCount}; packages: {result.PackageCount}; services: {result.SystemdServiceCount}; timers: {result.SystemdTimerCount}");
         logger.Info($"Certificates: {result.CertificateCount}; plain captures: {result.PlainCaptureCount}; encrypted captures: {result.EncryptedCaptureCount}; secrets: {result.SecretCount}");
         if (!string.IsNullOrWhiteSpace(result.BackupTarget))
             logger.Info($"Backup target: {result.BackupTarget} ({result.BackupEncryption ?? "no encryption configured"})");

--- a/Schemas/powerforge.web.serverrecovery.schema.json
+++ b/Schemas/powerforge.web.serverrecovery.schema.json
@@ -14,6 +14,10 @@
       "type": "array",
       "items": { "$ref": "#/$defs/Repository" }
     },
+    "accounts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Account" }
+    },
     "packages": { "$ref": "#/$defs/Packages" },
     "paths": {
       "type": "array",
@@ -66,9 +70,25 @@
         "url": { "type": "string" },
         "path": { "type": "string" },
         "branch": { "type": "string" },
-        "required": { "type": "boolean" }
+        "required": { "type": "boolean" },
+        "bootstrapRequiredFiles": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
       },
       "required": ["role", "path"]
+    },
+    "Account": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "pattern": "^[a-z_][a-z0-9_-]{0,31}$" },
+        "system": { "type": "boolean" },
+        "createHome": { "type": "boolean" },
+        "home": { "type": "string" },
+        "shell": { "type": "string" }
+      },
+      "required": ["name"]
     },
     "Packages": {
       "type": "object",


### PR DESCRIPTION
## Summary

- add managed Linux accounts to server-recovery manifests and create them before owned directories
- let private repositories declare bootstrap prerequisite files that must exist before clone
- replace unconditional secret TODO exits with rerunnable presence guards
- expose managed account counts in recovery plans
- document and test the ordering contract

## Why

CasaRay's recovery canary exposed two generic fresh-host ordering failures: service-owned paths were planned before service accounts existed, and a private repository clone ran before its isolated SSH identity and pinned host keys were restored. These belong in the shared recovery engine, not in a CasaRay-only bootstrap wrapper.

## Validation

- focused ServerRecoveryBootstrapPlanTests: 2 passed on net10.0
- schema JSON parse
- git diff --check
