### PR TITLE
Inspect privileged server paths correctly

### DIFF
--- a/PowerForge.Tests/ServerRecoveryInspectCommandTests.cs
+++ b/PowerForge.Tests/ServerRecoveryInspectCommandTests.cs
@@ -1,0 +1,29 @@
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed class ServerRecoveryInspectCommandTests
+{
+    [Theory]
+    [InlineData("directory", "/etc/powerforge/repository-ssh", "sudo -n test -d '/etc/powerforge/repository-ssh'")]
+    [InlineData("file", "/etc/powerforge/sites/example.env", "sudo -n test -e '/etc/powerforge/sites/example.env'")]
+    [InlineData("symlink", "/var/www/example/current", "sudo -n test -e '/var/www/example/current'")]
+    public void ManagedPathChecksUseNonInteractiveSudo(string kind, string path, string expected)
+    {
+        var managedPath = new PowerForgeServerPath
+        {
+            Kind = kind,
+            Path = path
+        };
+
+        Assert.Equal(expected, WebCliCommandHandlers.BuildManagedPathCheckCommand(managedPath));
+    }
+
+    [Fact]
+    public void ManagedSymlinkResolutionUsesNonInteractiveSudo()
+    {
+        var command = WebCliCommandHandlers.BuildManagedSymlinkTargetCommand("/var/www/example/current");
+
+        Assert.Equal("sudo -n readlink -f '/var/www/example/current'", command);
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
@@ -77,11 +77,8 @@ internal static partial class WebCliCommandHandlers
         foreach (var path in manifest.Paths ?? Array.Empty<PowerForgeServerPath>())
         {
             if (string.IsNullOrWhiteSpace(path.Path)) continue;
-            var test = path.Kind?.Equals("directory", StringComparison.OrdinalIgnoreCase) == true
-                ? $"test -d {ShellQuote(path.Path)}"
-                : $"test -e {ShellQuote(path.Path)}";
             AddBooleanCheck(checks, $"path.{path.Id ?? path.Path}", "paths", $"Managed path exists: {path.Path}",
-                ExecuteRemote(sshCommand, target, test).Success,
+                ExecuteRemote(sshCommand, target, BuildManagedPathCheckCommand(path)).Success,
                 path.Kind ?? "exists",
                 path.Path);
         }
@@ -90,7 +87,7 @@ internal static partial class WebCliCommandHandlers
         {
             if (string.IsNullOrWhiteSpace(path.Path)) continue;
             AddCommandCheck(checks, $"path.{path.Id ?? path.Path}.target", "paths", $"Managed symlink resolves: {path.Path}",
-                ExecuteRemote(sshCommand, target, $"readlink -f {ShellQuote(path.Path)}"), "symlink target");
+                ExecuteRemote(sshCommand, target, BuildManagedSymlinkTargetCommand(path.Path)), "symlink target");
         }
 
         InspectSystemdUnits(sshCommand, target, manifest.Systemd?.Services, "service", checks);
@@ -182,6 +179,15 @@ internal static partial class WebCliCommandHandlers
 
     private static ProcessResult ExecuteRemote(string sshCommand, string target, string command)
         => RunProcessCaptureText(sshCommand, BuildSshArguments(target, command));
+
+    internal static string BuildManagedPathCheckCommand(PowerForgeServerPath path)
+    {
+        var predicate = path.Kind?.Equals("directory", StringComparison.OrdinalIgnoreCase) == true ? "-d" : "-e";
+        return $"sudo -n test {predicate} {ShellQuote(path.Path ?? string.Empty)}";
+    }
+
+    internal static string BuildManagedSymlinkTargetCommand(string path)
+        => $"sudo -n readlink -f {ShellQuote(path)}";
 
     private static void InspectSystemdUnits(
         string sshCommand,


### PR DESCRIPTION
## Summary
- inspect manifest-managed paths through the same non-interactive sudo boundary used for SSH policy, firewall, and secret checks
- resolve managed symlink targets with sudo so protected parent directories do not produce false drift
- cover directory, file, symlink, and target command generation

## Why
A recovery manifest can intentionally place root-owned state below 0700 or 0750 parents. The previous unprivileged test and readlink commands reported those healthy paths as missing.

## Validation
- focused server recovery tests: 6 passed on net10
- PowerForge.Web CLI: net8 release build passed with zero warnings
- CasaRay production manifest: live server inspect with fail-on-drift passed with zero warnings
