### PR TITLE
Align X-pattern package versions across project builds

### DIFF
--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -319,10 +319,27 @@ Versioning
 - `VersionTracks.<Name>.AnchorPackageId`: optional explicit package identity when it differs from the project name.
 - `VersionTracks.<Name>.Projects`: sibling projects that should be stamped to the same resolved version. `AnchorProject` is included automatically.
 - When `AnchorPackageId` is used, also set `AnchorProject` so the anchor project itself is stamped automatically.
+- `AlignPackageVersions`: when true, projects using the same X-pattern are stepped from the highest current package version found for any project in that group. For example, if one `2.0.X` package is at `2.0.5` and another is new, both plan `2.0.6`. Exact-version overrides remain exact.
 - When no expected version is provided for a project, the existing csproj version is used.
 - When both `VersionTracks` and `ExpectedVersionMap` are present, the explicit map wins for matching projects.
 - `UpdateVersions`: when false, csproj files are not updated.
 - Version source resolution can use `NugetSource` (v3 index URL or local folder) with optional credentials.
+
+To keep an existing package family and newly added packages on one release version, enable alignment alongside the shared X-pattern:
+
+```json
+{
+  "ExpectedVersion": "2.0.X",
+  "ExpectedVersionMap": {
+    "ExampleSuite.Core": "2.0.X",
+    "ExampleSuite.Excel": "2.0.X",
+    "ExampleSuite.NewPackage": "2.0.X"
+  },
+  "ExpectedVersionMapAsInclude": true,
+  "AlignPackageVersions": true
+}
+```
+
 - `PackStrategy`: optional packing strategy. `PerProject` runs a non-incremental build followed by `dotnet pack --no-build` for each project. `MSBuild` (alias `Batch`) requires `OutputPath` or `StagingPath`, generates a temporary traversal project, and runs `Restore;Rebuild;Pack` for selected projects in parallel. If no package output path is available, it logs a warning and falls back to `PerProject`. Both strategies verify primary managed assemblies under `lib/<tfm>`, `runtimes/<rid>/lib/<tfm>`, and `tools/<tfm>/any` against exact fresh build target directories before package signing or publishing. Native runtime assets and metadata-only packages are not assembly-hash targets. Private feed credentials must already be available to `dotnet`/MSBuild restore. Batch mode stops on the first project failure and treats the whole failed batch as failed, so already-produced packages from that batch are not signed or published. Projects without a resolved version are reported as failed skipped projects.
 
 Staging and outputs

--- a/Module/Docs/Invoke-DotNetRepositoryRelease.md
+++ b/Module/Docs/Invoke-DotNetRepositoryRelease.md
@@ -11,7 +11,7 @@ Repository-wide .NET package release workflow (discover, version, pack, publish)
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Invoke-DotNetRepositoryRelease [-Path <string>] [-ExpectedVersion <string>] [-ExpectedVersionMap <IDictionary>] [-ExpectedVersionMapAsInclude] [-ExpectedVersionMapUseWildcards] [-IncludeProject <string[]>] [-ExcludeProject <string[]>] [-ExcludeDirectories <string[]>] [-NugetSource <string[]>] [-IncludePrerelease] [-NugetCredentialUserName <string>] [-NugetCredentialSecret <string>] [-NugetCredentialSecretFilePath <string>] [-NugetCredentialSecretEnvName <string>] [-Configuration <string>] [-OutputPath <string>] [-CertificateThumbprint <string>] [-CertificateStore <CertificateStoreLocation>] [-TimeStampServer <string>] [-SkipAssemblySigning] [-SignDependencyAssemblies] [-SkipPackageSigning] [-SkipPack] [-IncludeSymbols] [-Publish] [-PublishSource <string>] [-PublishApiKey <string>] [-PublishApiKeyFilePath <string>] [-PublishApiKeyEnvName <string>] [-SkipDuplicate] [-PublishFailFast] [-WhatIf] [-Confirm] [<CommonParameters>]
+Invoke-DotNetRepositoryRelease [-Path <string>] [-ExpectedVersion <string>] [-ExpectedVersionMap <IDictionary>] [-ExpectedVersionMapAsInclude] [-ExpectedVersionMapUseWildcards] [-AlignPackageVersions] [-IncludeProject <string[]>] [-ExcludeProject <string[]>] [-ExcludeDirectories <string[]>] [-NugetSource <string[]>] [-IncludePrerelease] [-NugetCredentialUserName <string>] [-NugetCredentialSecret <string>] [-NugetCredentialSecretFilePath <string>] [-NugetCredentialSecretEnvName <string>] [-Configuration <string>] [-OutputPath <string>] [-CertificateThumbprint <string>] [-CertificateStore <CertificateStoreLocation>] [-TimeStampServer <string>] [-SkipAssemblySigning] [-SignDependencyAssemblies] [-SkipPackageSigning] [-SkipPack] [-IncludeSymbols] [-Publish] [-PublishSource <string>] [-PublishApiKey <string>] [-PublishApiKeyFilePath <string>] [-PublishApiKeyEnvName <string>] [-SkipDuplicate] [-PublishFailFast] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,6 +33,22 @@ Invoke-DotNetRepositoryRelease -Path . -ExpectedVersion '2.0.X' -ExcludeProject 
 
 
 ## PARAMETERS
+
+### -AlignPackageVersions
+Align projects sharing an X-pattern to one next version based on the highest current package version in that group.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
 
 ### -CertificateStore
 Certificate store location used when searching for the signing certificate.

--- a/Module/Docs/New-ConfigurationPackageBuild.md
+++ b/Module/Docs/New-ConfigurationPackageBuild.md
@@ -11,7 +11,7 @@ Creates inline .NET/NuGet package build configuration from the module-build DSL.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-New-ConfigurationPackageBuild [-Name <string>] [-Enabled] [-BuildBeforeModule] [-UseAsReleaseVersionSource] [-ProvideLocalNuGetFeed] [-RootPath <string>] [-ExpectedVersion <string>] [-ExpectedVersionMap <IDictionary>] [-VersionTracks <IDictionary>] [-ExpectedVersionMapAsInclude] [-ExpectedVersionMapUseWildcards] [-IncludeProjects <string[]>] [-ExcludeProjects <string[]>] [-ExcludeDirectories <string[]>] [-NugetSource <string[]>] [-IncludePrerelease] [-Configuration <string>] [-OutputPath <string>] [-ReleaseZipOutputPath <string>] [-StagingPath <string>] [-CleanStaging] [-PlanOnly] [-PlanOutputPath <string>] [-UpdateVersions] [-Build] [-PackStrategy <string>] [-IncludeSymbols] [-PublishNuget] [-PublishGitHub] [-CreateReleaseZip] [-UseGitHubPackages] [-GitHubPackagesOwner <string>] [-PublishSource <string>] [-PublishApiKey <string>] [-PublishApiKeyFilePath <string>] [-PublishApiKeyEnvName <string>] [-SkipDuplicate] [-PublishFailFast] [-CertificateThumbprint <string>] [-CertificateStore <string>] [-TimeStampServer <string>] [-SignAssemblies] [-SignDependencyAssemblies] [-SignPackages] [-NugetCredentialUserName <string>] [-NugetCredentialSecret <string>] [-NugetCredentialSecretFilePath <string>] [-NugetCredentialSecretEnvName <string>] [-GitHubAccessToken <string>] [-GitHubAccessTokenFilePath <string>] [-GitHubAccessTokenEnvName <string>] [-GitHubUsername <string>] [-GitHubRepositoryName <string>] [-GitHubIsPreRelease] [-GitHubIncludeProjectNameInTag] [-GitHubGenerateReleaseNotes] [-GitHubReleaseName <string>] [-GitHubTagName <string>] [-GitHubTagTemplate <string>] [-GitHubReleaseMode <string>] [-GitHubPrimaryProject <string>] [-GitHubTagConflictPolicy <string>] [-Options <IDictionary>] [<CommonParameters>]
+New-ConfigurationPackageBuild [-Name <string>] [-Enabled] [-BuildBeforeModule] [-UseAsReleaseVersionSource] [-ProvideLocalNuGetFeed] [-RootPath <string>] [-ExpectedVersion <string>] [-ExpectedVersionMap <IDictionary>] [-VersionTracks <IDictionary>] [-ExpectedVersionMapAsInclude] [-ExpectedVersionMapUseWildcards] [-AlignPackageVersions] [-IncludeProjects <string[]>] [-ExcludeProjects <string[]>] [-ExcludeDirectories <string[]>] [-NugetSource <string[]>] [-IncludePrerelease] [-Configuration <string>] [-OutputPath <string>] [-ReleaseZipOutputPath <string>] [-StagingPath <string>] [-CleanStaging] [-PlanOnly] [-PlanOutputPath <string>] [-UpdateVersions] [-Build] [-PackStrategy <string>] [-IncludeSymbols] [-PublishNuget] [-PublishGitHub] [-CreateReleaseZip] [-UseGitHubPackages] [-GitHubPackagesOwner <string>] [-PublishSource <string>] [-PublishApiKey <string>] [-PublishApiKeyFilePath <string>] [-PublishApiKeyEnvName <string>] [-SkipDuplicate] [-PublishFailFast] [-CertificateThumbprint <string>] [-CertificateStore <string>] [-TimeStampServer <string>] [-SignAssemblies] [-SignDependencyAssemblies] [-SignPackages] [-NugetCredentialUserName <string>] [-NugetCredentialSecret <string>] [-NugetCredentialSecretFilePath <string>] [-NugetCredentialSecretEnvName <string>] [-GitHubAccessToken <string>] [-GitHubAccessTokenFilePath <string>] [-GitHubAccessTokenEnvName <string>] [-GitHubUsername <string>] [-GitHubRepositoryName <string>] [-GitHubIsPreRelease] [-GitHubIncludeProjectNameInTag] [-GitHubGenerateReleaseNotes] [-GitHubReleaseName <string>] [-GitHubTagName <string>] [-GitHubTagTemplate <string>] [-GitHubReleaseMode <string>] [-GitHubPrimaryProject <string>] [-GitHubTagConflictPolicy <string>] [-Options <IDictionary>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,6 +27,22 @@ New-ConfigurationPackageBuild -GitHubAccessTokenFilePath 'C:\Path'
 
 
 ## PARAMETERS
+
+### -AlignPackageVersions
+Align projects sharing an X-pattern to one next version based on the highest current package version in that group.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
 
 ### -Build
 Whether package projects should be built/packed.

--- a/Module/en-US/PSPublishModule-help.xml
+++ b/Module/en-US/PSPublishModule-help.xml
@@ -19114,6 +19114,18 @@ updates csproj versions, packs, and optionally publishes packages.</maml:para>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Invoke-DotNetRepositoryRelease</maml:name>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AlignPackageVersions</maml:name>
+          <maml:description>
+            <maml:para>Align projects sharing an X-pattern to one next version based on the highest current package version in that group.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>CertificateStore</maml:name>
           <maml:description>
             <maml:para>Certificate store location used when searching for the signing certificate.</maml:para>
@@ -19496,6 +19508,18 @@ updates csproj versions, packs, and optionally publishes packages.</maml:para>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AlignPackageVersions</maml:name>
+        <maml:description>
+          <maml:para>Align projects sharing an X-pattern to one next version based on the highest current package version in that group.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>CertificateStore</maml:name>
         <maml:description>
@@ -43094,6 +43118,18 @@ Build-Module { } to remain the primary authoring surface for combined module and
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>New-ConfigurationPackageBuild</maml:name>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AlignPackageVersions</maml:name>
+          <maml:description>
+            <maml:para>Align projects sharing an X-pattern to one next version based on the highest current package version in that group.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>Build</maml:name>
           <maml:description>
             <maml:para>Whether package projects should be built/packed.</maml:para>
@@ -43852,6 +43888,18 @@ Build-Module { } to remain the primary authoring surface for combined module and
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AlignPackageVersions</maml:name>
+        <maml:description>
+          <maml:para>Align projects sharing an X-pattern to one next version based on the highest current package version in that group.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>Build</maml:name>
         <maml:description>

--- a/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/InvokeDotNetRepositoryReleaseCommand.cs
@@ -50,6 +50,10 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
     [Parameter]
     public SwitchParameter ExpectedVersionMapUseWildcards { get; set; }
 
+    /// <summary>Align projects sharing an X-pattern to one next version based on the highest current package version in that group.</summary>
+    [Parameter]
+    public SwitchParameter AlignPackageVersions { get; set; }
+
     /// <summary>Project names to include (csproj file name without extension).</summary>
     [Parameter]
     public string[]? IncludeProject { get; set; }
@@ -184,6 +188,7 @@ public sealed class InvokeDotNetRepositoryReleaseCommand : PSCmdlet
             ExpectedVersionMap = ExpectedVersionMap,
             ExpectedVersionMapAsInclude = ExpectedVersionMapAsInclude.IsPresent,
             ExpectedVersionMapUseWildcards = ExpectedVersionMapUseWildcards.IsPresent,
+            AlignPackageVersions = AlignPackageVersions.IsPresent,
             IncludeProject = IncludeProject,
             ExcludeProject = ExcludeProject,
             ExcludeDirectories = ExcludeDirectories,

--- a/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPackageBuildCommand.cs
@@ -166,6 +166,9 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
     /// <summary>When true, <c>ExpectedVersionMap</c> keys support wildcard matching.</summary>
     [Parameter] public SwitchParameter ExpectedVersionMapUseWildcards { get; set; }
 
+    /// <summary>Align projects sharing an X-pattern to one next version based on the highest current package version in that group.</summary>
+    [Parameter] public SwitchParameter AlignPackageVersions { get; set; }
+
     /// <summary>Project names to include.</summary>
     [Parameter] public string[]? IncludeProjects { get; set; }
 
@@ -340,6 +343,7 @@ public sealed class NewConfigurationPackageBuildCommand : PSCmdlet
                 VersionTracks = PackageBuildConfiguration.ToVersionTracksDictionary(VersionTracks),
                 ExpectedVersionMapAsInclude = ExpectedVersionMapAsInclude.IsPresent,
                 ExpectedVersionMapUseWildcards = ExpectedVersionMapUseWildcards.IsPresent,
+                AlignPackageVersions = AlignPackageVersions.IsPresent,
                 IncludeProjects = IncludeProjects,
                 ExcludeProjects = ExcludeProjects,
                 ExcludeDirectories = ExcludeDirectories,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PackageBuilds.cs
@@ -825,6 +825,7 @@ public sealed partial class ModulePipelineRunner
             VersionTracks = MapVersionTracks(source.VersionTracks),
             ExpectedVersionMapAsInclude = source.ExpectedVersionMapAsInclude,
             ExpectedVersionMapUseWildcards = source.ExpectedVersionMapUseWildcards,
+            AlignPackageVersions = source.AlignPackageVersions,
             IncludeProjects = source.IncludeProjects,
             ExcludeProjects = source.ExcludeProjects,
             ExcludeDirectories = source.ExcludeDirectories,

--- a/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleasePreparationServiceTests.cs
@@ -24,6 +24,7 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
                 ExpectedVersion = "1.2.X",
                 ExpectedVersionMap = new Hashtable { ["ProjectA"] = "2.0.0" },
                 ExpectedVersionMapAsInclude = true,
+                AlignPackageVersions = true,
                 NugetCredentialUserName = "user",
                 NugetCredentialSecretFilePath = secretPath,
                 PublishApiKeyEnvName = envName,
@@ -44,6 +45,7 @@ public sealed class DotNetRepositoryReleasePreparationServiceTests
             Assert.Equal(Path.Combine(root.FullName, "repo"), context.RootPath);
             Assert.Equal("1.2.X", context.Spec.ExpectedVersion);
             Assert.True(context.Spec.ExpectedVersionMapAsInclude);
+            Assert.True(context.Spec.AlignPackageVersions);
             Assert.Equal("2.0.0", context.Spec.ExpectedVersionsByProject!["ProjectA"]);
             Assert.Equal("user", context.Spec.VersionSourceCredential!.UserName);
             Assert.Equal("from-file", context.Spec.VersionSourceCredential.Secret);

--- a/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
@@ -149,6 +149,57 @@ public sealed class DotNetRepositoryReleaseServiceVersioningTests
     }
 
     [Fact]
+    public void Execute_AlignsVersionTrackFromExplicitAnchorPackageId()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            WritePackableProject(root.FullName, "Suite.Core", "Suite.Core.Project");
+            WritePackableProject(root.FullName, "Suite.NewPackage", "Suite.NewPackage");
+
+            var source = Directory.CreateDirectory(Path.Combine(root.FullName, "source"));
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Anchor.2.0.5.nupkg"), string.Empty);
+
+            var context = new ProjectBuildPreparationService().Prepare(
+                new ProjectBuildConfiguration
+                {
+                    RootPath = root.FullName,
+                    ExpectedVersionMapAsInclude = true,
+                    AlignPackageVersions = true,
+                    UpdateVersions = true,
+                    Build = false,
+                    PublishNuget = false,
+                    PublishGitHub = false,
+                    VersionTracks = new Dictionary<string, ProjectBuildVersionTrack>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Suite"] = new()
+                        {
+                            ExpectedVersion = "2.0.X",
+                            AnchorProject = "Suite.Core",
+                            AnchorPackageId = "Suite.Anchor",
+                            Projects = new[] { "Suite.NewPackage" },
+                            NugetSource = new[] { source.FullName }
+                        }
+                    }
+                },
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions());
+
+            context.Spec.WhatIf = true;
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(context.Spec);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("2.0.6", result.ResolvedVersion);
+            Assert.All(result.ResolvedVersionsByProject.Values, version => Assert.Equal("2.0.6", version));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_KeepsExactVersionsOutsideXPatternAlignment()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
@@ -8,6 +8,92 @@ namespace PowerForge.Tests;
 public sealed class DotNetRepositoryReleaseServiceVersioningTests
 {
     [Fact]
+    public void Execute_AlignsXPatternProjectsAfterHighestCurrentPackageVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            WritePackableProject(root.FullName, "Suite.Core", "Suite.Core");
+            WritePackableProject(root.FullName, "Suite.Rendering", "Suite.Renderer");
+            WritePackableProject(root.FullName, "Suite.NewPackage", "Suite.NewPackage");
+
+            var source = Directory.CreateDirectory(Path.Combine(root.FullName, "source"));
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Core.2.0.2.nupkg"), string.Empty);
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Renderer.2.0.5.nupkg"), string.Empty);
+
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                ExpectedVersionsByProject = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Suite.Core"] = "2.0.X",
+                    ["Suite.Rendering"] = "2.0.X",
+                    ["Suite.NewPackage"] = "2.0.X"
+                },
+                ExpectedVersionMapAsInclude = true,
+                AlignPackageVersions = true,
+                VersionSources = new[] { source.FullName },
+                UpdateVersions = true,
+                Pack = false,
+                WhatIf = true
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("2.0.6", result.ResolvedVersion);
+            Assert.Equal("2.0.6", result.ResolvedVersionsByProject["Suite.Core"]);
+            Assert.Equal("2.0.6", result.ResolvedVersionsByProject["Suite.Rendering"]);
+            Assert.Equal("2.0.6", result.ResolvedVersionsByProject["Suite.NewPackage"]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_KeepsExactVersionsOutsideXPatternAlignment()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            WritePackableProject(root.FullName, "Suite.Core", "Suite.Core");
+            WritePackableProject(root.FullName, "Suite.Fixed", "Suite.Fixed");
+
+            var source = Directory.CreateDirectory(Path.Combine(root.FullName, "source"));
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Core.2.0.5.nupkg"), string.Empty);
+
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                ExpectedVersionsByProject = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Suite.Core"] = "2.0.X",
+                    ["Suite.Fixed"] = "2.0.3"
+                },
+                ExpectedVersionMapAsInclude = true,
+                AlignPackageVersions = true,
+                VersionSources = new[] { source.FullName },
+                UpdateVersions = true,
+                Pack = false,
+                WhatIf = true
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Null(result.ResolvedVersion);
+            Assert.Equal("2.0.6", result.ResolvedVersionsByProject["Suite.Core"]);
+            Assert.Equal("2.0.3", result.ResolvedVersionsByProject["Suite.Fixed"]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_AcceptsExactPrereleasePackageVersion()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -200,5 +286,21 @@ public sealed class DotNetRepositoryReleaseServiceVersioningTests
         {
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
+    }
+
+    private static void WritePackableProject(string rootPath, string projectName, string packageId)
+    {
+        var projectDirectory = Directory.CreateDirectory(Path.Combine(rootPath, projectName));
+        File.WriteAllText(Path.Combine(projectDirectory.FullName, projectName + ".csproj"), string.Join(Environment.NewLine, new[]
+        {
+            "<Project Sdk=\"Microsoft.NET.Sdk\">",
+            "  <PropertyGroup>",
+            "    <TargetFramework>net8.0</TargetFramework>",
+            $"    <PackageId>{packageId}</PackageId>",
+            "    <Version>1.0.0</Version>",
+            "    <IsPackable>true</IsPackable>",
+            "  </PropertyGroup>",
+            "</Project>"
+        }));
     }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseService.VersioningTests.cs
@@ -53,6 +53,102 @@ public sealed class DotNetRepositoryReleaseServiceVersioningTests
     }
 
     [Fact]
+    public void Execute_AlignsProjectsSelectedByWildcardVersionMap()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            WritePackableProject(root.FullName, "Suite.Core", "Suite.Core");
+            WritePackableProject(root.FullName, "Suite.Rendering", "Suite.Renderer");
+
+            var source = Directory.CreateDirectory(Path.Combine(root.FullName, "source"));
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Core.2.0.2.nupkg"), string.Empty);
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Renderer.2.0.5.nupkg"), string.Empty);
+
+            var spec = new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                ExpectedVersionsByProject = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Suite.*"] = "2.0.X"
+                },
+                ExpectedVersionMapAsInclude = true,
+                ExpectedVersionMapUseWildcards = true,
+                AlignPackageVersions = true,
+                VersionSources = new[] { source.FullName },
+                UpdateVersions = true,
+                Pack = false,
+                WhatIf = true
+            };
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(spec);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("2.0.6", result.ResolvedVersion);
+            Assert.All(result.ResolvedVersionsByProject.Values, version => Assert.Equal("2.0.6", version));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_AlignsVersionTrackAfterHighestTrackedPackageVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            WritePackableProject(root.FullName, "Suite.Core", "Suite.Core");
+            WritePackableProject(root.FullName, "Suite.Rendering", "Suite.Renderer");
+            WritePackableProject(root.FullName, "Suite.NewPackage", "Suite.NewPackage");
+
+            var source = Directory.CreateDirectory(Path.Combine(root.FullName, "source"));
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Core.2.0.2.nupkg"), string.Empty);
+            File.WriteAllText(Path.Combine(source.FullName, "Suite.Renderer.2.0.5.nupkg"), string.Empty);
+
+            var context = new ProjectBuildPreparationService().Prepare(
+                new ProjectBuildConfiguration
+                {
+                    RootPath = root.FullName,
+                    ExpectedVersionMapAsInclude = true,
+                    AlignPackageVersions = true,
+                    UpdateVersions = true,
+                    Build = false,
+                    PublishNuget = false,
+                    PublishGitHub = false,
+                    VersionTracks = new Dictionary<string, ProjectBuildVersionTrack>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["Suite"] = new()
+                        {
+                            ExpectedVersion = "2.0.X",
+                            AnchorProject = "Suite.Core",
+                            Projects = new[] { "Suite.Rendering", "Suite.NewPackage" },
+                            NugetSource = new[] { source.FullName }
+                        }
+                    }
+                },
+                root.FullName,
+                null,
+                new ProjectBuildRequestedActions());
+
+            Assert.NotNull(context.Spec.ExpectedVersionsByProject);
+            Assert.All(context.Spec.ExpectedVersionsByProject!.Values, version => Assert.Equal("2.0.X", version));
+
+            context.Spec.WhatIf = true;
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(context.Spec);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("2.0.6", result.ResolvedVersion);
+            Assert.All(result.ResolvedVersionsByProject.Values, version => Assert.Equal("2.0.6", version));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_KeepsExactVersionsOutsideXPatternAlignment()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
+++ b/PowerForge.Tests/ModulePipelinePackageBuildTests.cs
@@ -69,6 +69,7 @@ public sealed partial class ModulePipelinePackageBuildTests
                             {
                                 ["HtmlTinkerX"] = "2.0.X"
                             },
+                            AlignPackageVersions = true,
                             BuildBeforeModule = true,
                             Build = true,
                             PublishNuget = false,
@@ -98,6 +99,7 @@ public sealed partial class ModulePipelinePackageBuildTests
             var inlineConfiguration = calls[1].Configuration!;
             Assert.Equal(Path.Combine(root.FullName, "Sources"), inlineConfiguration.RootPath);
             Assert.Equal("2.0.X", inlineConfiguration.ExpectedVersionMap?["HtmlTinkerX"]);
+            Assert.True(inlineConfiguration.AlignPackageVersions);
             Assert.True(calls[1].Request.Build);
             Assert.False(calls[1].Request.PublishNuget);
             Assert.False(calls[1].Request.PublishGitHub);

--- a/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
+++ b/PowerForge.Tests/PowerForgeProjectCmdletTests.cs
@@ -151,6 +151,7 @@ public sealed class PowerForgeProjectCmdletTests
                     ["IncludePrerelease"] = true
                 }
             })
+            .AddParameter("AlignPackageVersions")
             .AddParameter("BuildBeforeModule")
             .AddParameter("IncludeSymbols")
             .AddParameter("PublishNuget", false)
@@ -164,6 +165,7 @@ public sealed class PowerForgeProjectCmdletTests
         var segment = Assert.IsType<ConfigurationPackageBuildSegment>(Assert.Single(results).BaseObject);
         Assert.Equal(".\\Sources", segment.Configuration.RootPath);
         Assert.Equal("2.0.X", segment.Configuration.ExpectedVersionMap?["HtmlTinkerX"]);
+        Assert.True(segment.Configuration.AlignPackageVersions);
         Assert.True(segment.Configuration.BuildBeforeModule);
         Assert.True(segment.Configuration.IncludeSymbols);
         Assert.False(segment.Configuration.PublishNuget);

--- a/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildPreparationServiceTests.cs
@@ -25,6 +25,24 @@ public sealed class ProjectBuildPreparationServiceTests
     }
 
     [Fact]
+    public void Prepare_propagates_package_version_alignment()
+    {
+        var service = new ProjectBuildPreparationService();
+
+        var context = service.Prepare(
+            new ProjectBuildConfiguration
+            {
+                ExpectedVersion = "2.0.X",
+                AlignPackageVersions = true
+            },
+            Directory.GetCurrentDirectory(),
+            null,
+            new ProjectBuildRequestedActions());
+
+        Assert.True(context.Spec.AlignPackageVersions);
+    }
+
+    [Fact]
     public void Prepare_honors_explicit_action_overrides_and_derives_default_output_paths()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "pf-projectbuild-prepare-" + Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ProjectBuildSupportServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildSupportServiceTests.cs
@@ -16,6 +16,7 @@ public sealed class ProjectBuildSupportServiceTests
 {
   // comment
   "PublishGitHub": true,
+  "AlignPackageVersions": true,
   "GitHubRepositoryName": "PSPublishModule",
 }
 """);
@@ -24,6 +25,7 @@ public sealed class ProjectBuildSupportServiceTests
             var config = service.LoadConfig(configPath);
 
             Assert.True(config.PublishGitHub);
+            Assert.True(config.AlignPackageVersions);
             Assert.Equal("PSPublishModule", config.GitHubRepositoryName);
         }
         finally

--- a/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPackageBuildSegment.cs
@@ -119,6 +119,9 @@ public sealed class PackageBuildConfiguration
     /// <summary>When true, <see cref="ExpectedVersionMap"/> keys support wildcard matching.</summary>
     public bool ExpectedVersionMapUseWildcards { get; set; }
 
+    /// <summary>When true, projects sharing an X-pattern receive one next version based on the highest current package version in that group.</summary>
+    public bool AlignPackageVersions { get; set; }
+
     /// <summary>Project names to include.</summary>
     public string[]? IncludeProjects { get; set; }
 

--- a/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
+++ b/PowerForge/Models/DotNetRepositoryReleasePreparationRequest.cs
@@ -10,6 +10,7 @@ internal sealed class DotNetRepositoryReleasePreparationRequest
     public IDictionary? ExpectedVersionMap { get; set; }
     public bool ExpectedVersionMapAsInclude { get; set; }
     public bool ExpectedVersionMapUseWildcards { get; set; }
+    public bool AlignPackageVersions { get; set; }
     public string[]? IncludeProject { get; set; }
     public string[]? ExcludeProject { get; set; }
     public string[]? ExcludeDirectories { get; set; }

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -41,6 +41,12 @@ public sealed class DotNetRepositoryReleaseSpec
     /// </summary>
     public bool ExpectedVersionMapUseWildcards { get; set; }
 
+    /// <summary>
+    /// When true, projects using the same X-pattern are stepped from the highest current
+    /// package version found across that group and receive one aligned next version.
+    /// </summary>
+    public bool AlignPackageVersions { get; set; }
+
     /// <summary>Sources used to resolve the current package version (v3 index or local path).</summary>
     public string[]? VersionSources { get; set; }
 

--- a/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSpec.cs
@@ -47,6 +47,11 @@ public sealed class DotNetRepositoryReleaseSpec
     /// </summary>
     public bool AlignPackageVersions { get; set; }
 
+    /// <summary>
+    /// Project-build version tracks that need package-version alignment after project discovery.
+    /// </summary>
+    internal IReadOnlyList<ProjectBuildVersionAlignmentGroup>? VersionAlignmentGroups { get; set; }
+
     /// <summary>Sources used to resolve the current package version (v3 index or local path).</summary>
     public string[]? VersionSources { get; set; }
 

--- a/PowerForge/Models/ProjectBuildConfiguration.cs
+++ b/PowerForge/Models/ProjectBuildConfiguration.cs
@@ -13,6 +13,7 @@ internal sealed class ProjectBuildConfiguration
     public Dictionary<string, ProjectBuildVersionTrack>? VersionTracks { get; set; }
     public bool ExpectedVersionMapAsInclude { get; set; }
     public bool ExpectedVersionMapUseWildcards { get; set; }
+    public bool AlignPackageVersions { get; set; }
     public string[]? IncludeProjects { get; set; }
     public string[]? ExcludeProjects { get; set; }
     public string[]? ExcludeDirectories { get; set; }

--- a/PowerForge/Models/ProjectBuildVersionAlignmentGroup.cs
+++ b/PowerForge/Models/ProjectBuildVersionAlignmentGroup.cs
@@ -15,6 +15,12 @@ internal sealed class ProjectBuildVersionAlignmentGroup
     /// <summary>Project names participating in the track.</summary>
     public string[] Projects { get; set; } = System.Array.Empty<string>();
 
+    /// <summary>Project whose package identity anchors the track.</summary>
+    public string? AnchorProject { get; set; }
+
+    /// <summary>Optional feed package identifier used for the anchor project.</summary>
+    public string? AnchorPackageId { get; set; }
+
     /// <summary>NuGet sources used to resolve current versions for this track.</summary>
     public string[]? VersionSources { get; set; }
 

--- a/PowerForge/Models/ProjectBuildVersionAlignmentGroup.cs
+++ b/PowerForge/Models/ProjectBuildVersionAlignmentGroup.cs
@@ -1,0 +1,23 @@
+namespace PowerForge;
+
+/// <summary>
+/// Carries a project-build version track into repository package-version alignment so
+/// discovered package identifiers can be compared using the track's feed settings.
+/// </summary>
+internal sealed class ProjectBuildVersionAlignmentGroup
+{
+    /// <summary>Unique version-track name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>X-pattern shared by the projects in this track.</summary>
+    public string ExpectedVersion { get; set; } = string.Empty;
+
+    /// <summary>Project names participating in the track.</summary>
+    public string[] Projects { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>NuGet sources used to resolve current versions for this track.</summary>
+    public string[]? VersionSources { get; set; }
+
+    /// <summary>Whether prerelease versions participate in current-version resolution.</summary>
+    public bool IncludePrerelease { get; set; }
+}

--- a/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleasePreparationService.cs
@@ -49,6 +49,7 @@ internal sealed class DotNetRepositoryReleasePreparationService
                 ExpectedVersionsByProject = expectedByProject.Count == 0 ? null : expectedByProject,
                 ExpectedVersionMapAsInclude = request.ExpectedVersionMapAsInclude,
                 ExpectedVersionMapUseWildcards = request.ExpectedVersionMapUseWildcards,
+                AlignPackageVersions = request.AlignPackageVersions,
                 IncludeProjects = request.IncludeProject,
                 ExcludeProjects = request.ExcludeProject,
                 ExcludeDirectories = request.ExcludeDirectories,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -244,19 +244,11 @@ public sealed partial class DotNetRepositoryReleaseService
                 var wildcard = spec.ExpectedVersionMapUseWildcards ? ", wildcards enabled" : string.Empty;
                 _logger.Info($"Expected version map: {expectedMap.Count} project(s) ({mode}{wildcard}).");
             }
+
+            var alignedVersions = ResolveAlignedPackageVersions(packable, expectedGlobal, expectedMap, spec);
             foreach (var project in packable)
             {
-                var expectedVersion = expectedGlobal;
-                var expectedSource = "global";
-                if (expectedMap.TryGetValue(project.ProjectName, out var overrideVersion) && !string.IsNullOrWhiteSpace(overrideVersion))
-                {
-                    expectedVersion = overrideVersion;
-                    expectedSource = "per-project";
-                }
-                else if (string.IsNullOrWhiteSpace(expectedGlobal))
-                {
-                    expectedSource = "csproj";
-                }
+                var expectedVersion = ResolveExpectedVersion(project.ProjectName, expectedGlobal, expectedMap, out var expectedSource);
 
                 if (!string.IsNullOrWhiteSpace(expectedVersion))
                     _logger.Info($"{project.ProjectName}: expected version {expectedVersion} ({expectedSource}).");
@@ -267,7 +259,15 @@ public sealed partial class DotNetRepositoryReleaseService
                 string? resolutionWarning;
                 try
                 {
-                    resolvedVersion = ResolveVersion(project, expectedVersion, spec, out resolutionWarning);
+                    if (alignedVersions.TryGetValue(project.ProjectName, out var alignedVersion))
+                    {
+                        resolvedVersion = alignedVersion;
+                        resolutionWarning = null;
+                    }
+                    else
+                    {
+                        resolvedVersion = ResolveVersion(project, expectedVersion, spec, out resolutionWarning);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -248,7 +248,12 @@ public sealed partial class DotNetRepositoryReleaseService
             var alignedVersions = ResolveAlignedPackageVersions(packable, expectedGlobal, expectedMap, spec);
             foreach (var project in packable)
             {
-                var expectedVersion = ResolveExpectedVersion(project.ProjectName, expectedGlobal, expectedMap, out var expectedSource);
+                var expectedVersion = ResolveExpectedVersion(
+                    project.ProjectName,
+                    expectedGlobal,
+                    expectedMap,
+                    spec.ExpectedVersionMapUseWildcards,
+                    out var expectedSource);
 
                 if (!string.IsNullOrWhiteSpace(expectedVersion))
                     _logger.Info($"{project.ProjectName}: expected version {expectedVersion} ({expectedSource}).");

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAlignment.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAlignment.cs
@@ -40,11 +40,8 @@ public sealed partial class DotNetRepositoryReleaseService
 
             foreach (var item in group)
             {
-                var packageId = string.IsNullOrWhiteSpace(item.Project.PackageId)
-                    ? item.Project.ProjectName
-                    : item.Project.PackageId;
                 var current = _resolver.ResolveLatest(
-                    packageId,
+                    item.PackageId,
                     settings.VersionSources,
                     spec.VersionSourceCredential,
                     spec.VersionSourceCredentials,
@@ -53,7 +50,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 if (current is not null && (highestCurrent is null || current.CompareTo(highestCurrent) > 0))
                 {
                     highestCurrent = current;
-                    highestPackageId = packageId;
+                    highestPackageId = item.PackageId;
                 }
             }
 
@@ -94,8 +91,14 @@ public sealed partial class DotNetRepositoryReleaseService
                     !configured.Projects.Contains(project.ProjectName, StringComparer.OrdinalIgnoreCase))
                     continue;
 
+                var packageId = string.Equals(configured.AnchorProject, project.ProjectName, StringComparison.OrdinalIgnoreCase) &&
+                                !string.IsNullOrWhiteSpace(configured.AnchorPackageId)
+                    ? configured.AnchorPackageId!
+                    : ResolveAlignmentPackageId(project);
+
                 return new PackageVersionAlignmentCandidate(
                     project,
+                    packageId,
                     expectedVersion,
                     "track:" + configured.Name,
                     configured.VersionSources,
@@ -105,11 +108,17 @@ public sealed partial class DotNetRepositoryReleaseService
 
         return new PackageVersionAlignmentCandidate(
             project,
+            ResolveAlignmentPackageId(project),
             expectedVersion,
             "pattern:" + expectedVersion,
             spec.VersionSources,
             spec.IncludePrerelease);
     }
+
+    private static string ResolveAlignmentPackageId(DotNetRepositoryProjectResult project)
+        => string.IsNullOrWhiteSpace(project.PackageId)
+            ? project.ProjectName
+            : project.PackageId;
 
     private static string? ResolveExpectedVersion(
         string projectName,
@@ -150,12 +159,14 @@ public sealed partial class DotNetRepositoryReleaseService
     {
         public PackageVersionAlignmentCandidate(
             DotNetRepositoryProjectResult project,
+            string packageId,
             string expectedVersion,
             string groupKey,
             IReadOnlyList<string>? versionSources,
             bool includePrerelease)
         {
             Project = project;
+            PackageId = packageId;
             ExpectedVersion = expectedVersion.Trim();
             GroupKey = groupKey;
             VersionSources = versionSources;
@@ -163,6 +174,7 @@ public sealed partial class DotNetRepositoryReleaseService
         }
 
         public DotNetRepositoryProjectResult Project { get; }
+        public string PackageId { get; }
         public string ExpectedVersion { get; }
         public string GroupKey { get; }
         public IReadOnlyList<string>? VersionSources { get; }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAlignment.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAlignment.cs
@@ -20,14 +20,21 @@ public sealed partial class DotNetRepositoryReleaseService
             .Select(project => new
             {
                 Project = project,
-                ExpectedVersion = ResolveExpectedVersion(project.ProjectName, expectedGlobal, expectedMap, out _)
+                ExpectedVersion = ResolveExpectedVersion(
+                    project.ProjectName,
+                    expectedGlobal,
+                    expectedMap,
+                    spec.ExpectedVersionMapUseWildcards,
+                    out _)
             })
             .Where(item => !string.IsNullOrWhiteSpace(item.ExpectedVersion) &&
                            !PackageVersionUtility.TryNormalizeExact(item.ExpectedVersion, out _))
-            .GroupBy(item => item.ExpectedVersion!.Trim(), StringComparer.OrdinalIgnoreCase);
+            .Select(item => CreateAlignmentCandidate(item.Project, item.ExpectedVersion!, spec))
+            .GroupBy(item => item.GroupKey, StringComparer.OrdinalIgnoreCase);
 
         foreach (var group in patternGroups)
         {
+            var settings = group.First();
             Version? highestCurrent = null;
             string? highestPackageId = null;
 
@@ -38,10 +45,10 @@ public sealed partial class DotNetRepositoryReleaseService
                     : item.Project.PackageId;
                 var current = _resolver.ResolveLatest(
                     packageId,
-                    spec.VersionSources,
+                    settings.VersionSources,
                     spec.VersionSourceCredential,
                     spec.VersionSourceCredentials,
-                    spec.IncludePrerelease);
+                    settings.IncludePrerelease);
 
                 if (current is not null && (highestCurrent is null || current.CompareTo(highestCurrent) > 0))
                 {
@@ -50,7 +57,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 }
             }
 
-            var alignedVersion = VersionPatternStepper.Step(group.Key, highestCurrent);
+            var alignedVersion = VersionPatternStepper.Step(settings.ExpectedVersion, highestCurrent);
             var members = group.ToArray();
             foreach (var item in members)
                 aligned[item.Project.ProjectName] = alignedVersion;
@@ -58,13 +65,13 @@ public sealed partial class DotNetRepositoryReleaseService
             if (highestCurrent is null)
             {
                 _logger.Info(
-                    $"Aligned {members.Length} project(s) using pattern '{group.Key}' to {alignedVersion}; " +
+                    $"Aligned {members.Length} project(s) using pattern '{settings.ExpectedVersion}' to {alignedVersion}; " +
                     "no current package version was found, so the X-pattern baseline was used.");
             }
             else
             {
                 _logger.Info(
-                    $"Aligned {members.Length} project(s) using pattern '{group.Key}' to {alignedVersion}; " +
+                    $"Aligned {members.Length} project(s) using pattern '{settings.ExpectedVersion}' to {alignedVersion}; " +
                     $"highest current package version is {highestCurrent} ({highestPackageId}).");
             }
         }
@@ -72,16 +79,61 @@ public sealed partial class DotNetRepositoryReleaseService
         return aligned;
     }
 
+    private static PackageVersionAlignmentCandidate CreateAlignmentCandidate(
+        DotNetRepositoryProjectResult project,
+        string expectedVersion,
+        DotNetRepositoryReleaseSpec spec)
+    {
+        var configuredGroups = spec.VersionAlignmentGroups;
+        if (configuredGroups is not null)
+        {
+            for (var index = configuredGroups.Count - 1; index >= 0; index--)
+            {
+                var configured = configuredGroups[index];
+                if (!string.Equals(configured.ExpectedVersion, expectedVersion, StringComparison.OrdinalIgnoreCase) ||
+                    !configured.Projects.Contains(project.ProjectName, StringComparer.OrdinalIgnoreCase))
+                    continue;
+
+                return new PackageVersionAlignmentCandidate(
+                    project,
+                    expectedVersion,
+                    "track:" + configured.Name,
+                    configured.VersionSources,
+                    configured.IncludePrerelease);
+            }
+        }
+
+        return new PackageVersionAlignmentCandidate(
+            project,
+            expectedVersion,
+            "pattern:" + expectedVersion,
+            spec.VersionSources,
+            spec.IncludePrerelease);
+    }
+
     private static string? ResolveExpectedVersion(
         string projectName,
         string? expectedGlobal,
         IReadOnlyDictionary<string, string> expectedMap,
+        bool allowWildcards,
         out string source)
     {
         if (expectedMap.TryGetValue(projectName, out var overrideVersion) && !string.IsNullOrWhiteSpace(overrideVersion))
         {
             source = "per-project";
             return overrideVersion;
+        }
+
+        if (allowWildcards)
+        {
+            foreach (var entry in expectedMap)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Value) || !MatchesPattern(projectName, entry.Key, allowWildcards))
+                    continue;
+
+                source = $"per-project wildcard '{entry.Key}'";
+                return entry.Value;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(expectedGlobal))
@@ -92,5 +144,28 @@ public sealed partial class DotNetRepositoryReleaseService
 
         source = "global";
         return expectedGlobal;
+    }
+
+    private sealed class PackageVersionAlignmentCandidate
+    {
+        public PackageVersionAlignmentCandidate(
+            DotNetRepositoryProjectResult project,
+            string expectedVersion,
+            string groupKey,
+            IReadOnlyList<string>? versionSources,
+            bool includePrerelease)
+        {
+            Project = project;
+            ExpectedVersion = expectedVersion.Trim();
+            GroupKey = groupKey;
+            VersionSources = versionSources;
+            IncludePrerelease = includePrerelease;
+        }
+
+        public DotNetRepositoryProjectResult Project { get; }
+        public string ExpectedVersion { get; }
+        public string GroupKey { get; }
+        public IReadOnlyList<string>? VersionSources { get; }
+        public bool IncludePrerelease { get; }
     }
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAlignment.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAlignment.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private Dictionary<string, string> ResolveAlignedPackageVersions(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        string? expectedGlobal,
+        IReadOnlyDictionary<string, string> expectedMap,
+        DotNetRepositoryReleaseSpec spec)
+    {
+        var aligned = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!spec.AlignPackageVersions || !spec.UpdateVersions)
+            return aligned;
+
+        var patternGroups = projects
+            .Select(project => new
+            {
+                Project = project,
+                ExpectedVersion = ResolveExpectedVersion(project.ProjectName, expectedGlobal, expectedMap, out _)
+            })
+            .Where(item => !string.IsNullOrWhiteSpace(item.ExpectedVersion) &&
+                           !PackageVersionUtility.TryNormalizeExact(item.ExpectedVersion, out _))
+            .GroupBy(item => item.ExpectedVersion!.Trim(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in patternGroups)
+        {
+            Version? highestCurrent = null;
+            string? highestPackageId = null;
+
+            foreach (var item in group)
+            {
+                var packageId = string.IsNullOrWhiteSpace(item.Project.PackageId)
+                    ? item.Project.ProjectName
+                    : item.Project.PackageId;
+                var current = _resolver.ResolveLatest(
+                    packageId,
+                    spec.VersionSources,
+                    spec.VersionSourceCredential,
+                    spec.VersionSourceCredentials,
+                    spec.IncludePrerelease);
+
+                if (current is not null && (highestCurrent is null || current.CompareTo(highestCurrent) > 0))
+                {
+                    highestCurrent = current;
+                    highestPackageId = packageId;
+                }
+            }
+
+            var alignedVersion = VersionPatternStepper.Step(group.Key, highestCurrent);
+            var members = group.ToArray();
+            foreach (var item in members)
+                aligned[item.Project.ProjectName] = alignedVersion;
+
+            if (highestCurrent is null)
+            {
+                _logger.Info(
+                    $"Aligned {members.Length} project(s) using pattern '{group.Key}' to {alignedVersion}; " +
+                    "no current package version was found, so the X-pattern baseline was used.");
+            }
+            else
+            {
+                _logger.Info(
+                    $"Aligned {members.Length} project(s) using pattern '{group.Key}' to {alignedVersion}; " +
+                    $"highest current package version is {highestCurrent} ({highestPackageId}).");
+            }
+        }
+
+        return aligned;
+    }
+
+    private static string? ResolveExpectedVersion(
+        string projectName,
+        string? expectedGlobal,
+        IReadOnlyDictionary<string, string> expectedMap,
+        out string source)
+    {
+        if (expectedMap.TryGetValue(projectName, out var overrideVersion) && !string.IsNullOrWhiteSpace(overrideVersion))
+        {
+            source = "per-project";
+            return overrideVersion;
+        }
+
+        if (string.IsNullOrWhiteSpace(expectedGlobal))
+        {
+            source = "csproj";
+            return null;
+        }
+
+        source = "global";
+        return expectedGlobal;
+    }
+}

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -93,6 +93,7 @@ internal sealed class ProjectBuildPreparationService
             ExpectedVersionsByProject = expectedVersionMap,
             ExpectedVersionMapAsInclude = config.ExpectedVersionMapAsInclude,
             ExpectedVersionMapUseWildcards = config.ExpectedVersionMapUseWildcards,
+            AlignPackageVersions = config.AlignPackageVersions,
             IncludeProjects = config.IncludeProjects,
             ExcludeProjects = config.ExcludeProjects,
             ExcludeDirectories = config.ExcludeDirectories,

--- a/PowerForge/Services/ProjectBuildPreparationService.cs
+++ b/PowerForge/Services/ProjectBuildPreparationService.cs
@@ -73,11 +73,13 @@ internal sealed class ProjectBuildPreparationService
 
         var feed = ProjectBuildPackageFeedResolver.Resolve(config, configDir);
         var nugetCredential = feed.VersionSourceCredential;
-        var expectedVersionMap = new ProjectBuildVersionTrackService(_logger).ResolveExpectedVersionMap(
+        var versionTrackService = new ProjectBuildVersionTrackService(_logger);
+        var expectedVersionMap = versionTrackService.ResolveExpectedVersionMap(
             config,
             feed.VersionSources,
             nugetCredential,
             feed.VersionSourceCredentials);
+        var versionAlignmentGroups = versionTrackService.ResolveVersionAlignmentGroups(config, feed.VersionSources);
 
         context.PublishApiKey = feed.PublishApiKey;
         context.GitHubToken = feed.GitHubToken;
@@ -94,6 +96,7 @@ internal sealed class ProjectBuildPreparationService
             ExpectedVersionMapAsInclude = config.ExpectedVersionMapAsInclude,
             ExpectedVersionMapUseWildcards = config.ExpectedVersionMapUseWildcards,
             AlignPackageVersions = config.AlignPackageVersions,
+            VersionAlignmentGroups = versionAlignmentGroups,
             IncludeProjects = config.IncludeProjects,
             ExcludeProjects = config.ExcludeProjects,
             ExcludeDirectories = config.ExcludeDirectories,

--- a/PowerForge/Services/ProjectBuildVersionTrackService.cs
+++ b/PowerForge/Services/ProjectBuildVersionTrackService.cs
@@ -39,7 +39,14 @@ internal sealed class ProjectBuildVersionTrackService
 
         var resolved = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var entry in ExpandTracks(config.VersionTracks, config.ExpectedVersion, defaultSources, credential, credentialsBySource, config.IncludePrerelease))
+        foreach (var entry in ExpandTracks(
+                     config.VersionTracks,
+                     config.ExpectedVersion,
+                     defaultSources,
+                     credential,
+                     credentialsBySource,
+                     config.IncludePrerelease,
+                     config.AlignPackageVersions))
             resolved[entry.Key] = entry.Value;
 
         var explicitMap = config.ExpectedVersionMap;
@@ -57,13 +64,55 @@ internal sealed class ProjectBuildVersionTrackService
         return resolved.Count == 0 ? null : resolved;
     }
 
+    /// <summary>
+    /// Describes X-pattern version tracks that must be resolved after repository project
+    /// discovery so every project's actual package identifier can participate.
+    /// </summary>
+    public IReadOnlyList<ProjectBuildVersionAlignmentGroup>? ResolveVersionAlignmentGroups(
+        ProjectBuildConfiguration config,
+        IReadOnlyList<string>? defaultSources)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+        if (!config.AlignPackageVersions || config.VersionTracks is null || config.VersionTracks.Count == 0)
+            return null;
+
+        var groups = new List<ProjectBuildVersionAlignmentGroup>();
+        foreach (var entry in config.VersionTracks)
+        {
+            var trackName = string.IsNullOrWhiteSpace(entry.Key) ? "<unnamed>" : entry.Key.Trim();
+            var track = entry.Value ?? throw new ArgumentException($"VersionTracks entry '{trackName}' is null.", nameof(config));
+            var expectedVersion = NormalizeNullable(track.ExpectedVersion) ?? NormalizeNullable(config.ExpectedVersion);
+            if (string.IsNullOrWhiteSpace(expectedVersion) || PackageVersionUtility.TryNormalizeExact(expectedVersion, out _))
+                continue;
+
+            var sources = (track.NugetSource ?? defaultSources ?? Array.Empty<string>())
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Select(value => value.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            groups.Add(new ProjectBuildVersionAlignmentGroup
+            {
+                Name = trackName,
+                ExpectedVersion = expectedVersion!,
+                Projects = ResolveProjects(trackName, track).ToArray(),
+                VersionSources = sources.Length == 0 ? null : sources,
+                IncludePrerelease = track.IncludePrerelease ?? config.IncludePrerelease
+            });
+        }
+
+        return groups.Count == 0 ? null : groups;
+    }
+
     private IEnumerable<KeyValuePair<string, string>> ExpandTracks(
         IReadOnlyDictionary<string, ProjectBuildVersionTrack>? tracks,
         string? defaultExpectedVersion,
         IReadOnlyList<string>? defaultSources,
         RepositoryCredential? credential,
         IReadOnlyDictionary<string, RepositoryCredential>? credentialsBySource,
-        bool defaultIncludePrerelease)
+        bool defaultIncludePrerelease,
+        bool preservePatternsForAlignment)
     {
         if (tracks is null || tracks.Count == 0)
             yield break;
@@ -76,8 +125,17 @@ internal sealed class ProjectBuildVersionTrackService
             if (string.IsNullOrWhiteSpace(expectedVersion))
                 throw new ArgumentException($"VersionTracks['{trackName}'] must define ExpectedVersion or rely on a non-empty top-level ExpectedVersion.", nameof(tracks));
 
-            var resolvedVersion = ResolveTrackVersion(trackName, track, expectedVersion!, defaultSources, credential, credentialsBySource, defaultIncludePrerelease);
-            foreach (var project in ResolveProjects(trackName, track))
+            var projects = ResolveProjects(trackName, track);
+            var resolvedVersion = ResolveTrackVersion(
+                trackName,
+                track,
+                expectedVersion!,
+                defaultSources,
+                credential,
+                credentialsBySource,
+                defaultIncludePrerelease,
+                preservePatternsForAlignment);
+            foreach (var project in projects)
                 yield return new KeyValuePair<string, string>(project, resolvedVersion);
         }
     }
@@ -89,7 +147,8 @@ internal sealed class ProjectBuildVersionTrackService
         IReadOnlyList<string>? defaultSources,
         RepositoryCredential? credential,
         IReadOnlyDictionary<string, RepositoryCredential>? credentialsBySource,
-        bool defaultIncludePrerelease)
+        bool defaultIncludePrerelease,
+        bool preservePatternForAlignment)
     {
         if (PackageVersionUtility.TryNormalizeExact(expectedVersion, out var exact))
             return exact;
@@ -97,6 +156,9 @@ internal sealed class ProjectBuildVersionTrackService
         var anchorPackageId = NormalizeNullable(track.AnchorPackageId) ?? NormalizeNullable(track.AnchorProject);
         if (anchorPackageId is null)
             throw new ArgumentException($"VersionTracks['{trackName}'] uses pattern version '{expectedVersion}' but does not define AnchorProject or AnchorPackageId.");
+
+        if (preservePatternForAlignment)
+            return expectedVersion;
 
         var sources = (track.NugetSource ?? defaultSources ?? Array.Empty<string>())
             .Where(value => !string.IsNullOrWhiteSpace(value))

--- a/PowerForge/Services/ProjectBuildVersionTrackService.cs
+++ b/PowerForge/Services/ProjectBuildVersionTrackService.cs
@@ -97,6 +97,8 @@ internal sealed class ProjectBuildVersionTrackService
                 Name = trackName,
                 ExpectedVersion = expectedVersion!,
                 Projects = ResolveProjects(trackName, track).ToArray(),
+                AnchorProject = NormalizeNullable(track.AnchorProject),
+                AnchorPackageId = NormalizeNullable(track.AnchorPackageId),
                 VersionSources = sources.Length == 0 ? null : sources,
                 IncludePrerelease = track.IncludePrerelease ?? config.IncludePrerelease
             });

--- a/Schemas/project.build.schema.json
+++ b/Schemas/project.build.schema.json
@@ -40,6 +40,10 @@
     "ExpectedVersionMapUseWildcards": {
       "type": "boolean"
     },
+    "AlignPackageVersions": {
+      "type": "boolean",
+      "description": "When true, projects sharing the same X-pattern are stepped from the highest current package version found across that group and receive one aligned next version."
+    },
     "IncludeProjects": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Summary

- add opt-in `AlignPackageVersions` support to `project.build.json`, the package-build DSL, and `Invoke-DotNetRepositoryRelease`
- resolve one next version per shared X-pattern from the highest current version found across the selected NuGet package IDs
- keep exact-version overrides exact and honor each project's declared `<PackageId>`
- update the schema, narrative guidance, generated command docs, and external help

## Usage

```json
{
  "ExpectedVersion": "2.0.X",
  "ExpectedVersionMap": {
    "ExampleSuite.Core": "2.0.X",
    "ExampleSuite.NewPackage": "2.0.X"
  },
  "ExpectedVersionMapAsInclude": true,
  "AlignPackageVersions": true
}
```

With this enabled, if an existing package is currently `2.0.5` and another package is new, both plan `2.0.6` instead of splitting between `2.0.6` and `2.0.0`.

The current OfficeIMO remote-head plan reproduced the real case: the existing configuration planned 57 projects at `2.0.2` and the new `OfficeIMO.Drawing.CodeGlyphX` package at `2.0.0`; alignment planned all 58 matched projects at `2.0.2`.