### PR TITLE
Add generic Cloudflare cache policy automation

### DIFF
--- a/.github/actions/powerforge-cloudflare-cache-policy/Invoke-PowerForgeCloudflareCachePolicy.ps1
+++ b/.github/actions/powerforge-cloudflare-cache-policy/Invoke-PowerForgeCloudflareCachePolicy.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Assert-LastExitCode {
+    param([Parameter(Mandatory)][string] $Operation)
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Operation failed with exit code $LASTEXITCODE."
+    }
+}
+
+if ($env:RUNNER_OS -ne 'Linux') {
+    throw 'PowerForge Cloudflare cache policy requires a Linux runner.'
+}
+if ([string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_API_TOKEN)) {
+    throw 'api-token is required.'
+}
+if ($env:POWERFORGE_CLOUDFLARE_ZONE_ID -notmatch '^[a-fA-F0-9]{32}$') {
+    throw 'zone-id must be a 32-character Cloudflare zone identifier.'
+}
+if ($env:POWERFORGE_CLOUDFLARE_DRY_RUN -notin @('true', 'false')) {
+    throw 'dry-run must be true or false.'
+}
+
+$workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd([IO.Path]::DirectorySeparatorChar)
+$workspacePrefix = $workspace + [IO.Path]::DirectorySeparatorChar
+$siteConfig = [IO.Path]::GetFullPath((Join-Path $workspace $env:POWERFORGE_CLOUDFLARE_SITE_CONFIG))
+if (-not $siteConfig.StartsWith($workspacePrefix, [StringComparison]::Ordinal) -or
+    -not (Test-Path -LiteralPath $siteConfig -PathType Leaf)) {
+    throw 'site-config must identify a file inside the caller repository.'
+}
+
+$engineRoot = [IO.Path]::GetFullPath((Join-Path $env:GITHUB_ACTION_PATH '../../..'))
+$project = Join-Path $engineRoot 'PowerForge.Web.Cli/PowerForge.Web.Cli.csproj'
+$cli = Join-Path $engineRoot 'PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll'
+
+dotnet build $project --configuration Release --framework net10.0 --nologo --verbosity minimal
+Assert-LastExitCode -Operation 'Building PowerForge.Web CLI'
+
+$arguments = @(
+    $cli,
+    'cloudflare',
+    'cache-policy',
+    'apply',
+    '--zone-id', $env:POWERFORGE_CLOUDFLARE_ZONE_ID,
+    '--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN',
+    '--site-config', $siteConfig
+)
+if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_HOSTNAME)) {
+    $arguments += @('--hostname', $env:POWERFORGE_CLOUDFLARE_HOSTNAME)
+}
+if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_POLICY_NAME)) {
+    $arguments += @('--policy-name', $env:POWERFORGE_CLOUDFLARE_POLICY_NAME)
+}
+if ($env:POWERFORGE_CLOUDFLARE_DRY_RUN -eq 'true') {
+    $arguments += '--dry-run'
+}
+
+dotnet @arguments
+Assert-LastExitCode -Operation 'Applying Cloudflare cache policy'

--- a/.github/actions/powerforge-cloudflare-cache-policy/Invoke-PowerForgeCloudflareCachePolicy.ps1
+++ b/.github/actions/powerforge-cloudflare-cache-policy/Invoke-PowerForgeCloudflareCachePolicy.ps1
@@ -55,6 +55,9 @@ if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_HOSTNAME)) {
 if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_POLICY_NAME)) {
     $arguments += @('--policy-name', $env:POWERFORGE_CLOUDFLARE_POLICY_NAME)
 }
+if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_BASE_PATH)) {
+    $arguments += @('--base-path', $env:POWERFORGE_CLOUDFLARE_BASE_PATH)
+}
 if ($env:POWERFORGE_CLOUDFLARE_DRY_RUN -eq 'true') {
     $arguments += '--dry-run'
 }

--- a/.github/actions/powerforge-cloudflare-cache-policy/action.yml
+++ b/.github/actions/powerforge-cloudflare-cache-policy/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: Cloudflare zone identifier from the caller job's protected environment.
     required: true
   api-token:
-    description: Cloudflare API token with Cache Settings Write permission from the caller job's protected environment.
+    description: Cloudflare API token with Zone > Cache Rules > Edit permission from the caller job's protected environment.
     required: true
   hostname:
     description: Optional hostname override; normally derived from the site specification BaseUrl.
@@ -18,6 +18,10 @@ inputs:
     default: ""
   policy-name:
     description: Optional managed description name; normally derived from the site specification Name.
+    required: false
+    default: ""
+  base-path:
+    description: Optional site base-path override; normally derived from the site specification BaseUrl.
     required: false
     default: ""
   dry-run:
@@ -48,6 +52,7 @@ runs:
       shell: pwsh
       env:
         POWERFORGE_CLOUDFLARE_API_TOKEN: ${{ inputs.api-token }}
+        POWERFORGE_CLOUDFLARE_BASE_PATH: ${{ inputs.base-path }}
         POWERFORGE_CLOUDFLARE_DRY_RUN: ${{ inputs.dry-run }}
         POWERFORGE_CLOUDFLARE_HOSTNAME: ${{ inputs.hostname }}
         POWERFORGE_CLOUDFLARE_POLICY_NAME: ${{ inputs.policy-name }}

--- a/.github/actions/powerforge-cloudflare-cache-policy/action.yml
+++ b/.github/actions/powerforge-cloudflare-cache-policy/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: Cloudflare zone identifier from the caller job's protected environment.
     required: true
   api-token:
-    description: Cloudflare API token with Zone > Cache Rules > Edit permission from the caller job's protected environment.
+    description: Protected Cloudflare API token with Zone > Cache Rules > Edit and required account Rulesets/Filter Lists edit permissions.
     required: true
   hostname:
     description: Optional hostname override; normally derived from the site specification BaseUrl.

--- a/.github/actions/powerforge-cloudflare-cache-policy/action.yml
+++ b/.github/actions/powerforge-cloudflare-cache-policy/action.yml
@@ -1,0 +1,56 @@
+name: PowerForge Cloudflare Cache Policy
+description: Apply the generic PowerForge cache policy from a caller-owned protected environment.
+
+inputs:
+  site-config:
+    description: Repository-relative PowerForge site specification used for hostname, policy name, and HTML routes.
+    required: false
+    default: Website/site.json
+  zone-id:
+    description: Cloudflare zone identifier from the caller job's protected environment.
+    required: true
+  api-token:
+    description: Cloudflare API token with Cache Settings Write permission from the caller job's protected environment.
+    required: true
+  hostname:
+    description: Optional hostname override; normally derived from the site specification BaseUrl.
+    required: false
+    default: ""
+  policy-name:
+    description: Optional managed description name; normally derived from the site specification Name.
+    required: false
+    default: ""
+  dry-run:
+    description: Report whether rules would change without writing the ruleset.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Reject pull request cache changes
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
+      shell: pwsh
+      run: throw 'PowerForge protected Cloudflare changes cannot run from pull request events.'
+
+    - name: Checkout caller repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        token: ${{ github.token }}
+        ref: ${{ github.sha }}
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+      with:
+        global-json-file: ${{ github.action_path }}/../../../global.json
+
+    - name: Apply Cloudflare cache policy
+      shell: pwsh
+      env:
+        POWERFORGE_CLOUDFLARE_API_TOKEN: ${{ inputs.api-token }}
+        POWERFORGE_CLOUDFLARE_DRY_RUN: ${{ inputs.dry-run }}
+        POWERFORGE_CLOUDFLARE_HOSTNAME: ${{ inputs.hostname }}
+        POWERFORGE_CLOUDFLARE_POLICY_NAME: ${{ inputs.policy-name }}
+        POWERFORGE_CLOUDFLARE_SITE_CONFIG: ${{ inputs.site-config }}
+        POWERFORGE_CLOUDFLARE_ZONE_ID: ${{ inputs.zone-id }}
+      run: '& "$env:GITHUB_ACTION_PATH/Invoke-PowerForgeCloudflareCachePolicy.ps1"'

--- a/Docs/PowerForge.Web.Cloudflare.md
+++ b/Docs/PowerForge.Web.Cloudflare.md
@@ -25,21 +25,23 @@ powerforge-web cloudflare cache-policy apply \
   --site-config ./site.json
 ```
 
-PowerForge derives the hostname from `BaseUrl`, the managed description prefix from
-`Name`, and additional HTML routes from features and navigation. The policy manages
-exactly three rules for that site:
+PowerForge derives the hostname and optional deployment base path from `BaseUrl`, the
+managed description prefix from `Name`, and additional HTML routes from features and
+navigation. The policy manages exactly three rules for that site:
 
 - static assets, with query strings excluded from the cache key
 - data and discovery files, preserving normal query behavior
 - HTML, docs, API, and site-specific navigation routes, preserving normal query behavior
 
 The command creates the phase entry-point ruleset when it is absent, preserves rules
-outside the site's `PowerForge <Name>:` prefix, and avoids a ruleset update when the
-effective policy is already current. Use `--dry-run` to read the current ruleset and
-report whether a write would be required.
+outside the site's `PowerForge <Name>:` prefix in their existing positions, and avoids
+a ruleset update when the effective policy is already current. Generated expressions
+are rejected locally when they exceed Cloudflare's 4,096-character limit. Use
+`--dry-run` to read the current ruleset and report whether a write would be required.
 
 If a site specification is not available, pass `--hostname`, `--policy-name`, and
-optional `--html-path` values explicitly.
+optional `--base-path` and `--html-path` values explicitly. HTML paths are relative to
+the site base path.
 
 ## CLI
 
@@ -143,9 +145,11 @@ jobs:
           api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
-Pin `POWERFORGE_COMMIT` to an exact commit. The token needs `Cache Settings Write`
-for the target zone. The action rejects pull-request events before protected inputs
-are used.
+Pin `POWERFORGE_COMMIT` to an exact commit. The token needs
+`Zone > Cache Rules > Edit` for the target zone, as documented by Cloudflare's
+[Cache Rules API guide](https://developers.cloudflare.com/cache/how-to/cache-rules/create-api/).
+If the same token is also used by deployment purge, grant `Zone > Cache Purge > Purge`.
+The action rejects pull-request events before protected inputs are used.
 
 ### Post-Deploy Purge
 

--- a/Docs/PowerForge.Web.Cloudflare.md
+++ b/Docs/PowerForge.Web.Cloudflare.md
@@ -1,6 +1,6 @@
-# Cloudflare Cache Purge (Optional)
+# Cloudflare Cache Policy, Purge, and Verification
 
-Last updated: 2026-02-18
+Last updated: 2026-07-16
 
 If your site is behind Cloudflare and you cache HTML aggressively, deploys can appear "stale"
 until Cloudflare revalidates or you hard refresh. The best long-term pattern is:
@@ -8,7 +8,38 @@ until Cloudflare revalidates or you hard refresh. The best long-term pattern is:
 - hash/version static assets (CSS/JS/images) so they can be cached for a long time
 - keep HTML caching conservative, or purge HTML after deploy
 
-PowerForge.Web includes small Cloudflare purge + verify commands to make this repeatable in CI.
+PowerForge.Web owns the repeatable Cloudflare operations used by a static site:
+
+- apply the standard host-scoped cache policy without replacing unrelated rules
+- purge newly deployed routes
+- verify public cache behavior after warmup
+
+## Cache Policy
+
+Apply the standard policy from a PowerForge `site.json`:
+
+```bash
+powerforge-web cloudflare cache-policy apply \
+  --zone-id <ZONE_ID> \
+  --token-env CLOUDFLARE_API_TOKEN \
+  --site-config ./site.json
+```
+
+PowerForge derives the hostname from `BaseUrl`, the managed description prefix from
+`Name`, and additional HTML routes from features and navigation. The policy manages
+exactly three rules for that site:
+
+- static assets, with query strings excluded from the cache key
+- data and discovery files, preserving normal query behavior
+- HTML, docs, API, and site-specific navigation routes, preserving normal query behavior
+
+The command creates the phase entry-point ruleset when it is absent, preserves rules
+outside the site's `PowerForge <Name>:` prefix, and avoids a ruleset update when the
+effective policy is already current. Use `--dry-run` to read the current ruleset and
+report whether a write would be required.
+
+If a site specification is not available, pass `--hostname`, `--policy-name`, and
+optional `--html-path` values explicitly.
 
 ## CLI
 
@@ -90,7 +121,33 @@ Verify example step (no token/zone required):
 }
 ```
 
-## GitHub Actions (Recommended)
+## GitHub Actions
+
+Configure cache rules from a caller-owned protected environment with the composite
+action. The consumer workflow remains declarative; the API token is passed to the
+PowerForge CLI through an environment-variable name and never appears in command
+arguments.
+
+```yaml
+jobs:
+  cloudflare-cache-policy:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: EvotecIT/PSPublishModule/.github/actions/powerforge-cloudflare-cache-policy@POWERFORGE_COMMIT
+        with:
+          site-config: Website/site.json
+          zone-id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+Pin `POWERFORGE_COMMIT` to an exact commit. The token needs `Cache Settings Write`
+for the target zone. The action rejects pull-request events before protected inputs
+are used.
+
+### Post-Deploy Purge
 
 For GitHub Pages workflows that deploy via `actions/deploy-pages@v4`, the purge should run
 in the deploy job **after** the deployment step, using secrets:
@@ -109,9 +166,9 @@ Pseudo-snippet:
     powerforge-web cloudflare verify --site-config ./site.json --warmup 1
 ```
 
-## Cloudflare Rules (Free Plan Friendly)
+## Standard Rule Expressions
 
-Use 3 cache rules for all PowerForge websites.
+The standard policy uses three cache rules for each PowerForge website.
 These expressions only use `eq`/`wildcard` (no `matches`), so they work on Free plans.
 
 1) `Static assets`

--- a/Docs/PowerForge.Web.Cloudflare.md
+++ b/Docs/PowerForge.Web.Cloudflare.md
@@ -145,9 +145,14 @@ jobs:
           api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
-Pin `POWERFORGE_COMMIT` to an exact commit. The token needs
-`Zone > Cache Rules > Edit` for the target zone, as documented by Cloudflare's
-[Cache Rules API guide](https://developers.cloudflare.com/cache/how-to/cache-rules/create-api/).
+Pin `POWERFORGE_COMMIT` to an exact commit. Cloudflare's current
+[Cache Rules API guide](https://developers.cloudflare.com/cache/how-to/cache-rules/create-api/)
+lists these token permissions:
+
+- `Zone > Cache Rules > Edit`, scoped to the target zones
+- `Account > Account Rulesets > Edit`, scoped to the owning account
+- `Account > Account Filter Lists > Edit`, scoped to the owning account
+
 If the same token is also used by deployment purge, grant `Zone > Cache Purge > Purge`.
 The action rejects pull-request events before protected inputs are used.
 

--- a/PowerForge.Tests/CloudflareCachePolicyTests.cs
+++ b/PowerForge.Tests/CloudflareCachePolicyTests.cs
@@ -30,6 +30,25 @@ public sealed class CloudflareCachePolicyTests
     }
 
     [Fact]
+    public void BuildManagedRules_ShouldScopeEveryRouteToSiteBasePath()
+    {
+        var rules = CloudflareCachePolicyBuilder.BuildManagedRules(
+            "example.com",
+            "Project",
+            ["/docs/"],
+            basePath: "/project/");
+
+        var staticExpression = rules[0]!["expression"]!.GetValue<string>();
+        var dataExpression = rules[1]!["expression"]!.GetValue<string>();
+        var htmlExpression = rules[2]!["expression"]!.GetValue<string>();
+        Assert.Contains("/project/css/*", staticExpression, StringComparison.Ordinal);
+        Assert.Contains("/project/*.css", staticExpression, StringComparison.Ordinal);
+        Assert.Contains("/project/sitemap.xml", dataExpression, StringComparison.Ordinal);
+        Assert.Contains("/project/docs/*", htmlExpression, StringComparison.Ordinal);
+        Assert.DoesNotContain("uri.path eq \"/docs/\"", htmlExpression, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Apply_ShouldReplaceManagedRulesAndPreserveUnrelatedRules()
     {
         var existingRules = new JsonArray
@@ -72,6 +91,40 @@ public sealed class CloudflareCachePolicyTests
         Assert.Equal("custom-id", rules[3]!["id"]!.GetValue<string>());
         Assert.Null(rules[3]!["version"]);
         Assert.Null(rules[3]!["last_updated"]);
+    }
+
+    [Fact]
+    public void Apply_ShouldPreserveUnmanagedRulePositions()
+    {
+        var existingRules = new JsonArray
+        {
+            ExistingRule("custom-before", "Operator before", "before"),
+            ExistingRule("managed-static-id", "PowerForge Example: static assets", "old-static"),
+            ExistingRule("custom-between", "Operator between", "between"),
+            ExistingRule("managed-data-id", "PowerForge Example: data files", "old-data"),
+            ExistingRule("managed-html-id", "PowerForge Example: HTML docs and API", "old-html"),
+            ExistingRule("custom-after", "Operator after", "after")
+        };
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, ExistingEnvelope(existingRules)),
+            JsonResponse(HttpStatusCode.OK, SuccessEnvelope()));
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            htmlPaths: null,
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        var rules = JsonNode.Parse(handler.Requests[1].Body)!["rules"]!.AsArray();
+        Assert.Equal(
+            ["Operator before", "PowerForge Example: static assets", "Operator between", "PowerForge Example: data files", "PowerForge Example: HTML docs and API", "Operator after"],
+            rules.Select(rule => rule!["description"]!.GetValue<string>()).ToArray());
     }
 
     [Fact]
@@ -218,6 +271,30 @@ public sealed class CloudflareCachePolicyTests
     }
 
     [Fact]
+    public void Apply_ShouldRejectOversizedExpressionBeforeCallingCloudflare()
+    {
+        var longPaths = Enumerable.Range(0, 40)
+            .Select(index => $"/{new string('x', 120)}-{index}/")
+            .ToArray();
+        var handler = new SequenceHandler();
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            longPaths,
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.False(result.Success);
+        Assert.Contains("maximum is 4096", result.Message, StringComparison.Ordinal);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
     public void Apply_ShouldAvoidRulesetVersionChurnWhenPolicyIsCurrent()
     {
         var currentRules = CloudflareCachePolicyBuilder.BuildManagedRules(
@@ -261,9 +338,11 @@ public sealed class CloudflareCachePolicyTests
         Assert.Contains("Reject pull request cache changes", action, StringComparison.Ordinal);
         Assert.Contains("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", action, StringComparison.Ordinal);
         Assert.Contains("actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7", action, StringComparison.Ordinal);
+        Assert.Contains("Zone > Cache Rules > Edit", action, StringComparison.Ordinal);
         Assert.Contains("Invoke-PowerForgeCloudflareCachePolicy.ps1", action, StringComparison.Ordinal);
         Assert.Contains("--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN'", script, StringComparison.Ordinal);
         Assert.DoesNotContain("--token', $env:POWERFORGE_CLOUDFLARE_API_TOKEN", script, StringComparison.Ordinal);
+        Assert.Contains("--base-path", script, StringComparison.Ordinal);
         Assert.Contains("site-config must identify a file inside the caller repository", script, StringComparison.Ordinal);
         Assert.True(script.Split('\n').Length < 100, "The action entrypoint should remain a bounded adapter over the CLI.");
     }

--- a/PowerForge.Tests/CloudflareCachePolicyTests.cs
+++ b/PowerForge.Tests/CloudflareCachePolicyTests.cs
@@ -1,0 +1,340 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json.Nodes;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed class CloudflareCachePolicyTests
+{
+    [Fact]
+    public void BuildManagedRules_ShouldScopePolicyAndIncludeSiteRoutes()
+    {
+        var rules = CloudflareCachePolicyBuilder.BuildManagedRules(
+            "tactra.dev",
+            "Tactra",
+            ["/privacy/", "/support/", "/sitemap.xml"]);
+
+        Assert.Equal(3, rules.Count);
+        var staticRule = Assert.IsType<JsonObject>(rules[0]);
+        var htmlRule = Assert.IsType<JsonObject>(rules[2]);
+        Assert.Equal("PowerForge Tactra: static assets", staticRule["description"]!.GetValue<string>());
+        Assert.Contains("http.host eq \"tactra.dev\"", staticRule["expression"]!.GetValue<string>(), StringComparison.Ordinal);
+        Assert.True(staticRule["action_parameters"]!["cache_key"]!["custom_key"]!["query_string"]!["exclude"]!["all"]!.GetValue<bool>());
+
+        var htmlExpression = htmlRule["expression"]!.GetValue<string>();
+        Assert.Contains("/privacy/*", htmlExpression, StringComparison.Ordinal);
+        Assert.Contains("/support/*", htmlExpression, StringComparison.Ordinal);
+        Assert.DoesNotContain("sitemap.xml", htmlExpression, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Apply_ShouldReplaceManagedRulesAndPreserveUnrelatedRules()
+    {
+        var existingRules = new JsonArray
+        {
+            ExistingRule("managed-static-id", "PowerForge CodeGlyphX: static assets", "old-static"),
+            ExistingRule("managed-data-id", "PowerForge CodeGlyphX: data files", "old-data"),
+            ExistingRule("managed-html-id", "PowerForge CodeGlyphX: HTML docs and API", "old-html"),
+            ExistingRule("custom-id", "Operator custom bypass", "custom", action: "set_cache_settings")
+        };
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, ExistingEnvelope(existingRules)),
+            JsonResponse(HttpStatusCode.OK, SuccessEnvelope()));
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "codeglyphx.com",
+            "CodeGlyphX",
+            ["/downloads/"],
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.True(result.Changed);
+        Assert.Equal(3, result.ManagedRuleCount);
+        Assert.Equal(1, result.PreservedRuleCount);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Put, handler.Requests[1].Method);
+        Assert.Equal("Bearer", handler.Requests[1].Authorization?.Scheme);
+        Assert.Equal("secret-token", handler.Requests[1].Authorization?.Parameter);
+
+        var payload = JsonNode.Parse(handler.Requests[1].Body)!.AsObject();
+        var rules = payload["rules"]!.AsArray();
+        Assert.Equal(4, rules.Count);
+        Assert.Equal("managed-static-id", rules[0]!["id"]!.GetValue<string>());
+        Assert.Contains("/downloads/*", rules[2]!["expression"]!.GetValue<string>(), StringComparison.Ordinal);
+        Assert.Equal("Operator custom bypass", rules[3]!["description"]!.GetValue<string>());
+        Assert.Equal("custom-id", rules[3]!["id"]!.GetValue<string>());
+        Assert.Null(rules[3]!["version"]);
+        Assert.Null(rules[3]!["last_updated"]);
+    }
+
+    [Fact]
+    public void Apply_ShouldCreateMissingEntryPointRuleset()
+    {
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.NotFound, """{"success":false,"errors":[{"message":"not found"}]}"""),
+            JsonResponse(HttpStatusCode.OK, SuccessEnvelope()));
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            htmlPaths: null,
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.True(result.Changed);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Post, handler.Requests[1].Method);
+        Assert.EndsWith("/zones/0123456789abcdef0123456789abcdef/rulesets", handler.Requests[1].Uri.AbsolutePath, StringComparison.Ordinal);
+        var payload = JsonNode.Parse(handler.Requests[1].Body)!.AsObject();
+        Assert.Equal("zone", payload["kind"]!.GetValue<string>());
+        Assert.Equal("http_request_cache_settings", payload["phase"]!.GetValue<string>());
+        Assert.Equal(3, payload["rules"]!.AsArray().Count);
+    }
+
+    [Fact]
+    public void Apply_DryRun_ShouldReadWithoutWriting()
+    {
+        var existingRules = new JsonArray
+        {
+            ExistingRule("custom-id", "Operator custom rule", "custom")
+        };
+        var handler = new SequenceHandler(JsonResponse(HttpStatusCode.OK, ExistingEnvelope(existingRules)));
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            htmlPaths: null,
+            dryRun: true,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.True(result.DryRun);
+        Assert.True(result.ChangesRequired);
+        Assert.False(result.Changed);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+    }
+
+    [Fact]
+    public void Apply_ShouldFailClosedWhenExistingRulesAreMissing()
+    {
+        var handler = new SequenceHandler(JsonResponse(HttpStatusCode.OK, SuccessEnvelope()));
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            htmlPaths: null,
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.False(result.Success);
+        Assert.Contains("refusing to replace", result.Message, StringComparison.Ordinal);
+        Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
+    }
+
+    [Fact]
+    public void Apply_ShouldFailClosedWhenExistingRuleIsMalformed()
+    {
+        var rules = new JsonArray { ExistingRule("custom-id", "Operator custom rule", "custom"), "not-a-rule" };
+        var handler = new SequenceHandler(JsonResponse(HttpStatusCode.OK, ExistingEnvelope(rules)));
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            htmlPaths: null,
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.False(result.Success);
+        Assert.Contains("malformed rule", result.Message, StringComparison.Ordinal);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public void Apply_ShouldRejectInvalidZoneBeforeCallingCloudflare()
+    {
+        var handler = new SequenceHandler();
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "not-a-zone-id",
+            "secret-token",
+            "example.com",
+            "Example",
+            htmlPaths: null,
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.False(result.Success);
+        Assert.Contains("32-character hexadecimal", result.Message, StringComparison.Ordinal);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public void Apply_ShouldRejectUnsafeRoutesBeforeCallingCloudflare()
+    {
+        var handler = new SequenceHandler();
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            ["/docs/*"],
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.False(result.Success);
+        Assert.Contains("Invalid Cloudflare HTML route", result.Message, StringComparison.Ordinal);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public void Apply_ShouldAvoidRulesetVersionChurnWhenPolicyIsCurrent()
+    {
+        var currentRules = CloudflareCachePolicyBuilder.BuildManagedRules(
+            "example.com",
+            "Example",
+            ["/support/"]);
+        for (var i = 0; i < currentRules.Count; i++)
+        {
+            currentRules[i]!["id"] = $"managed-{i}";
+            currentRules[i]!["ref"] = $"managed-{i}";
+            currentRules[i]!["version"] = "7";
+            currentRules[i]!["last_updated"] = "2026-07-16T00:00:00Z";
+        }
+        currentRules.Add(ExistingRule("custom-id", "Operator custom rule", "custom"));
+
+        var handler = new SequenceHandler(JsonResponse(HttpStatusCode.OK, ExistingEnvelope(currentRules)));
+        using var client = NewClient(handler);
+
+        var result = CloudflareCachePolicyManager.Apply(
+            "0123456789abcdef0123456789abcdef",
+            "secret-token",
+            "example.com",
+            "Example",
+            ["/support/"],
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.False(result.ChangesRequired);
+        Assert.False(result.Changed);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public void CompositeAction_ShouldKeepCallerWorkflowDeclarativeAndTokenOutOfArguments()
+    {
+        var action = ReadRepoFile(".github", "actions", "powerforge-cloudflare-cache-policy", "action.yml");
+        var script = ReadRepoFile(".github", "actions", "powerforge-cloudflare-cache-policy", "Invoke-PowerForgeCloudflareCachePolicy.ps1");
+
+        Assert.Contains("Reject pull request cache changes", action, StringComparison.Ordinal);
+        Assert.Contains("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", action, StringComparison.Ordinal);
+        Assert.Contains("actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7", action, StringComparison.Ordinal);
+        Assert.Contains("Invoke-PowerForgeCloudflareCachePolicy.ps1", action, StringComparison.Ordinal);
+        Assert.Contains("--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("--token', $env:POWERFORGE_CLOUDFLARE_API_TOKEN", script, StringComparison.Ordinal);
+        Assert.Contains("site-config must identify a file inside the caller repository", script, StringComparison.Ordinal);
+        Assert.True(script.Split('\n').Length < 100, "The action entrypoint should remain a bounded adapter over the CLI.");
+    }
+
+    private static JsonObject ExistingRule(string id, string description, string expression, string action = "set_cache_settings") => new()
+    {
+        ["id"] = id,
+        ["ref"] = id,
+        ["version"] = "3",
+        ["last_updated"] = "2026-07-15T00:00:00Z",
+        ["description"] = description,
+        ["expression"] = expression,
+        ["action"] = action,
+        ["action_parameters"] = new JsonObject { ["cache"] = true },
+        ["enabled"] = true
+    };
+
+    private static string ExistingEnvelope(JsonArray rules) => new JsonObject
+    {
+        ["success"] = true,
+        ["result"] = new JsonObject { ["rules"] = rules }
+    }.ToJsonString();
+
+    private static string SuccessEnvelope() => new JsonObject
+    {
+        ["success"] = true,
+        ["result"] = new JsonObject()
+    }.ToJsonString();
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string body) => new(statusCode)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json")
+    };
+
+    private static HttpClient NewClient(SequenceHandler handler) => new(handler)
+    {
+        BaseAddress = new Uri("https://api.cloudflare.test/client/v4/")
+    };
+
+    private static string ReadRepoFile(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && current is not null; i++)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return File.ReadAllText(Path.Combine([current.FullName, .. relativePath]));
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+
+    private sealed class SequenceHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        internal List<CapturedRequest> Requests { get; } = [];
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            CaptureAndRespond(request);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(CaptureAndRespond(request));
+
+        private HttpResponseMessage CaptureAndRespond(HttpRequestMessage request)
+        {
+            var body = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult() ?? string.Empty;
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri!, request.Headers.Authorization, body));
+            return _responses.Dequeue();
+        }
+    }
+
+    private sealed record CapturedRequest(HttpMethod Method, Uri Uri, AuthenticationHeaderValue? Authorization, string Body);
+}

--- a/PowerForge.Web.Cli/CloudflareApiClient.cs
+++ b/PowerForge.Web.Cli/CloudflareApiClient.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace PowerForge.Web.Cli;
+
+internal sealed class CloudflareApiResponse
+{
+    public bool Success { get; init; }
+    public HttpStatusCode StatusCode { get; init; }
+    public JsonElement? Result { get; init; }
+    public string? TransportError { get; init; }
+    public string ErrorMessage { get; init; } = string.Empty;
+}
+
+internal static class CloudflareApiClient
+{
+    internal static CloudflareApiResponse Send(
+        HttpClient httpClient,
+        HttpMethod method,
+        string relativeUri,
+        string apiToken,
+        JsonNode? body)
+    {
+        using var request = new HttpRequestMessage(method, relativeUri);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {apiToken}");
+        if (body is not null)
+            request.Content = new StringContent(body.ToJsonString(WebCliJson.Options), Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = httpClient.Send(request);
+        }
+        catch (Exception ex)
+        {
+            return new CloudflareApiResponse
+            {
+                Success = false,
+                TransportError = $"Cloudflare API request failed: {ex.GetType().Name}: {ex.Message}",
+                ErrorMessage = $"Cloudflare API request failed: {ex.GetType().Name}: {ex.Message}"
+            };
+        }
+
+        using (response)
+        {
+            var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            JsonElement? result = null;
+            var apiSuccess = response.IsSuccessStatusCode;
+            var apiMessage = string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                try
+                {
+                    using var document = JsonDocument.Parse(content);
+                    var root = document.RootElement;
+                    if (root.TryGetProperty("success", out var successElement) && successElement.ValueKind is JsonValueKind.True or JsonValueKind.False)
+                        apiSuccess = response.IsSuccessStatusCode && successElement.GetBoolean();
+                    if (root.TryGetProperty("result", out var resultElement))
+                        result = resultElement.Clone();
+                    apiMessage = ReadApiMessages(root);
+                }
+                catch (JsonException)
+                {
+                    apiMessage = "Cloudflare returned a non-JSON response.";
+                }
+            }
+
+            if (!apiSuccess && string.IsNullOrWhiteSpace(apiMessage))
+                apiMessage = response.ReasonPhrase ?? "Cloudflare API error.";
+
+            return new CloudflareApiResponse
+            {
+                Success = apiSuccess,
+                StatusCode = response.StatusCode,
+                Result = result,
+                ErrorMessage = apiSuccess
+                    ? string.Empty
+                    : $"Cloudflare API request failed (HTTP {(int)response.StatusCode}): {apiMessage}"
+            };
+        }
+    }
+
+    private static string ReadApiMessages(JsonElement root)
+    {
+        var messages = new List<string>();
+        foreach (var propertyName in new[] { "errors", "messages" })
+        {
+            if (!root.TryGetProperty(propertyName, out var values) || values.ValueKind != JsonValueKind.Array)
+                continue;
+
+            foreach (var value in values.EnumerateArray())
+            {
+                if (value.ValueKind == JsonValueKind.Object && value.TryGetProperty("message", out var message))
+                    messages.Add(message.GetString() ?? string.Empty);
+                else if (value.ValueKind == JsonValueKind.String)
+                    messages.Add(value.GetString() ?? string.Empty);
+            }
+        }
+
+        return string.Join("; ", messages.Where(message => !string.IsNullOrWhiteSpace(message)));
+    }
+}

--- a/PowerForge.Web.Cli/CloudflareCachePolicyBuilder.cs
+++ b/PowerForge.Web.Cli/CloudflareCachePolicyBuilder.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace PowerForge.Web.Cli;
+
+internal static class CloudflareCachePolicyBuilder
+{
+    private const int MaxHtmlPaths = 64;
+
+    private static readonly string[] DefaultHtmlPaths =
+    {
+        "/",
+        "/docs/",
+        "/api/",
+        "/blog/",
+        "/showcase/",
+        "/playground/",
+        "/pricing/",
+        "/benchmarks/",
+        "/faq/",
+        "/search/",
+        "/404/"
+    };
+
+    internal static JsonArray BuildManagedRules(
+        string hostname,
+        string policyName,
+        IReadOnlyCollection<string>? htmlPaths)
+    {
+        hostname = NormalizeHostname(hostname);
+        policyName = NormalizePolicyName(policyName, hostname);
+        var hostFilter = $"http.host eq \"{hostname}\" and http.request.method eq \"GET\" and ";
+
+        var staticExpression = $"({hostFilter}(" + string.Join(" or ", new[]
+        {
+            "http.request.uri.path wildcard \"/css/*\"",
+            "http.request.uri.path wildcard \"/js/*\"",
+            "http.request.uri.path wildcard \"/assets/*\"",
+            "http.request.uri.path wildcard \"/fonts/*\"",
+            "http.request.uri.path wildcard \"/images/*\"",
+            "http.request.uri.path wildcard \"/img/*\"",
+            "http.request.uri.path wildcard \"/*.css\"",
+            "http.request.uri.path wildcard \"/*.js\"",
+            "http.request.uri.path wildcard \"/*.mjs\"",
+            "http.request.uri.path wildcard \"/*.png\"",
+            "http.request.uri.path wildcard \"/*.jpg\"",
+            "http.request.uri.path wildcard \"/*.jpeg\"",
+            "http.request.uri.path wildcard \"/*.webp\"",
+            "http.request.uri.path wildcard \"/*.svg\"",
+            "http.request.uri.path wildcard \"/*.ico\"",
+            "http.request.uri.path wildcard \"/*.woff\"",
+            "http.request.uri.path wildcard \"/*.woff2\""
+        }) + "))";
+
+        var dataExpression = $"({hostFilter}(" + string.Join(" or ", new[]
+        {
+            "http.request.uri.path wildcard \"/data/*\"",
+            "http.request.uri.path eq \"/sitemap.xml\"",
+            "http.request.uri.path eq \"/llms.txt\"",
+            "http.request.uri.path eq \"/llms-full.txt\"",
+            "http.request.uri.path eq \"/llms.json\""
+        }) + "))";
+
+        var routeClauses = BuildHtmlRouteClauses(htmlPaths);
+        routeClauses.Add("http.request.uri.path wildcard \"*.html\"");
+        var htmlExpression = $"({hostFilter}(" + string.Join(" or ", routeClauses) + "))";
+
+        return new JsonArray
+        {
+            BuildRule($"PowerForge {policyName}: static assets", staticExpression, ignoreQueryString: true),
+            BuildRule($"PowerForge {policyName}: data files", dataExpression, ignoreQueryString: false),
+            BuildRule($"PowerForge {policyName}: HTML docs and API", htmlExpression, ignoreQueryString: false)
+        };
+    }
+
+    internal static string NormalizeHostname(string hostname)
+    {
+        var normalized = (hostname ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+        if (Uri.CheckHostName(normalized) != UriHostNameType.Dns)
+            throw new ArgumentException($"Invalid Cloudflare hostname '{hostname}'.", nameof(hostname));
+        return normalized;
+    }
+
+    internal static string NormalizePolicyName(string policyName, string hostname)
+    {
+        var normalized = string.IsNullOrWhiteSpace(policyName) ? hostname : policyName.Trim();
+        if (normalized.Length > 80 || normalized.Contains(':') || normalized.Any(char.IsControl))
+            throw new ArgumentException("Cloudflare policy name must be 1-80 characters and cannot contain a colon or control character.", nameof(policyName));
+        return normalized;
+    }
+
+    private static List<string> BuildHtmlRouteClauses(IReadOnlyCollection<string>? htmlPaths)
+    {
+        var paths = DefaultHtmlPaths
+            .Concat(htmlPaths ?? Array.Empty<string>())
+            .Select(NormalizeHtmlPath)
+            .Where(path => path is not null)
+            .Cast<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(MaxHtmlPaths + 1)
+            .ToArray();
+
+        if (paths.Length > MaxHtmlPaths)
+            throw new ArgumentException($"Cloudflare cache policy supports at most {MaxHtmlPaths} HTML routes.", nameof(htmlPaths));
+
+        var clauses = new List<string>();
+        foreach (var path in paths)
+        {
+            var escaped = EscapeExpressionString(path);
+            clauses.Add($"http.request.uri.path eq \"{escaped}\"");
+            if (path.Length > 1 && path.EndsWith("/", StringComparison.Ordinal))
+                clauses.Add($"http.request.uri.path wildcard \"{escaped}*\"");
+        }
+
+        return clauses;
+    }
+
+    private static string? NormalizeHtmlPath(string? rawPath)
+    {
+        if (string.IsNullOrWhiteSpace(rawPath))
+            return null;
+
+        var path = rawPath.Trim().Replace('\\', '/');
+        var delimiter = path.IndexOfAny(new[] { '?', '#' });
+        if (delimiter >= 0)
+            path = path[..delimiter];
+        if (!path.StartsWith("/", StringComparison.Ordinal))
+            path = "/" + path;
+        while (path.Contains("//", StringComparison.Ordinal))
+            path = path.Replace("//", "/", StringComparison.Ordinal);
+
+        if (path.Contains("..", StringComparison.Ordinal) ||
+            path.Contains('*') ||
+            path.Any(char.IsControl))
+            throw new ArgumentException($"Invalid Cloudflare HTML route '{rawPath}'.", nameof(rawPath));
+
+        if (path.Equals("/sitemap.xml", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ||
+            path.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith("/data/", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return path;
+    }
+
+    private static JsonObject BuildRule(string description, string expression, bool ignoreQueryString)
+    {
+        var actionParameters = new JsonObject
+        {
+            ["cache"] = true,
+            ["edge_ttl"] = new JsonObject { ["mode"] = "respect_origin" },
+            ["browser_ttl"] = new JsonObject { ["mode"] = "respect_origin" },
+            ["respect_strong_etags"] = true
+        };
+
+        if (ignoreQueryString)
+        {
+            actionParameters["cache_key"] = new JsonObject
+            {
+                ["custom_key"] = new JsonObject
+                {
+                    ["query_string"] = new JsonObject
+                    {
+                        ["exclude"] = new JsonObject { ["all"] = true }
+                    }
+                }
+            };
+        }
+
+        return new JsonObject
+        {
+            ["description"] = description,
+            ["expression"] = expression,
+            ["action"] = "set_cache_settings",
+            ["action_parameters"] = actionParameters,
+            ["enabled"] = true
+        };
+    }
+
+    private static string EscapeExpressionString(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+}

--- a/PowerForge.Web.Cli/CloudflareCachePolicyBuilder.cs
+++ b/PowerForge.Web.Cli/CloudflareCachePolicyBuilder.cs
@@ -8,6 +8,7 @@ namespace PowerForge.Web.Cli;
 internal static class CloudflareCachePolicyBuilder
 {
     private const int MaxHtmlPaths = 64;
+    private const int MaxRuleExpressionLength = 4096;
 
     private static readonly string[] DefaultHtmlPaths =
     {
@@ -27,45 +28,51 @@ internal static class CloudflareCachePolicyBuilder
     internal static JsonArray BuildManagedRules(
         string hostname,
         string policyName,
-        IReadOnlyCollection<string>? htmlPaths)
+        IReadOnlyCollection<string>? htmlPaths,
+        string? basePath = null)
     {
         hostname = NormalizeHostname(hostname);
         policyName = NormalizePolicyName(policyName, hostname);
+        basePath = NormalizeBasePath(basePath);
         var hostFilter = $"http.host eq \"{hostname}\" and http.request.method eq \"GET\" and ";
 
         var staticExpression = $"({hostFilter}(" + string.Join(" or ", new[]
         {
-            "http.request.uri.path wildcard \"/css/*\"",
-            "http.request.uri.path wildcard \"/js/*\"",
-            "http.request.uri.path wildcard \"/assets/*\"",
-            "http.request.uri.path wildcard \"/fonts/*\"",
-            "http.request.uri.path wildcard \"/images/*\"",
-            "http.request.uri.path wildcard \"/img/*\"",
-            "http.request.uri.path wildcard \"/*.css\"",
-            "http.request.uri.path wildcard \"/*.js\"",
-            "http.request.uri.path wildcard \"/*.mjs\"",
-            "http.request.uri.path wildcard \"/*.png\"",
-            "http.request.uri.path wildcard \"/*.jpg\"",
-            "http.request.uri.path wildcard \"/*.jpeg\"",
-            "http.request.uri.path wildcard \"/*.webp\"",
-            "http.request.uri.path wildcard \"/*.svg\"",
-            "http.request.uri.path wildcard \"/*.ico\"",
-            "http.request.uri.path wildcard \"/*.woff\"",
-            "http.request.uri.path wildcard \"/*.woff2\""
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/css/*")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/js/*")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/assets/*")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/fonts/*")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/images/*")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/img/*")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.css")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.js")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.mjs")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.png")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.jpg")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.jpeg")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.webp")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.svg")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.ico")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.woff")),
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/*.woff2"))
         }) + "))";
 
         var dataExpression = $"({hostFilter}(" + string.Join(" or ", new[]
         {
-            "http.request.uri.path wildcard \"/data/*\"",
-            "http.request.uri.path eq \"/sitemap.xml\"",
-            "http.request.uri.path eq \"/llms.txt\"",
-            "http.request.uri.path eq \"/llms-full.txt\"",
-            "http.request.uri.path eq \"/llms.json\""
+            BuildPathClause("wildcard", CombineBasePath(basePath, "/data/*")),
+            BuildPathClause("eq", CombineBasePath(basePath, "/sitemap.xml")),
+            BuildPathClause("eq", CombineBasePath(basePath, "/llms.txt")),
+            BuildPathClause("eq", CombineBasePath(basePath, "/llms-full.txt")),
+            BuildPathClause("eq", CombineBasePath(basePath, "/llms.json"))
         }) + "))";
 
-        var routeClauses = BuildHtmlRouteClauses(htmlPaths);
-        routeClauses.Add("http.request.uri.path wildcard \"*.html\"");
+        var routeClauses = BuildHtmlRouteClauses(basePath, htmlPaths);
+        routeClauses.Add(BuildPathClause("wildcard", CombineBasePath(basePath, "/*.html")));
         var htmlExpression = $"({hostFilter}(" + string.Join(" or ", routeClauses) + "))";
+
+        ValidateExpressionLength("static assets", staticExpression);
+        ValidateExpressionLength("data files", dataExpression);
+        ValidateExpressionLength("HTML docs and API", htmlExpression);
 
         return new JsonArray
         {
@@ -91,13 +98,37 @@ internal static class CloudflareCachePolicyBuilder
         return normalized;
     }
 
-    private static List<string> BuildHtmlRouteClauses(IReadOnlyCollection<string>? htmlPaths)
+    internal static string NormalizeBasePath(string? rawBasePath)
+    {
+        var normalized = string.IsNullOrWhiteSpace(rawBasePath)
+            ? "/"
+            : rawBasePath.Trim().Replace('\\', '/');
+        var delimiter = normalized.IndexOfAny(new[] { '?', '#' });
+        if (delimiter >= 0)
+            normalized = normalized[..delimiter];
+        if (!normalized.StartsWith("/", StringComparison.Ordinal))
+            normalized = "/" + normalized;
+        while (normalized.Contains("//", StringComparison.Ordinal))
+            normalized = normalized.Replace("//", "/", StringComparison.Ordinal);
+
+        if (normalized.Contains("..", StringComparison.Ordinal) ||
+            normalized.Contains('*') ||
+            normalized.Any(char.IsControl))
+            throw new ArgumentException($"Invalid Cloudflare base path '{rawBasePath}'.", nameof(rawBasePath));
+
+        if (!normalized.EndsWith("/", StringComparison.Ordinal))
+            normalized += "/";
+        return normalized;
+    }
+
+    private static List<string> BuildHtmlRouteClauses(string basePath, IReadOnlyCollection<string>? htmlPaths)
     {
         var paths = DefaultHtmlPaths
             .Concat(htmlPaths ?? Array.Empty<string>())
             .Select(NormalizeHtmlPath)
             .Where(path => path is not null)
             .Cast<string>()
+            .Select(path => CombineBasePath(basePath, path))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Take(MaxHtmlPaths + 1)
             .ToArray();
@@ -108,10 +139,9 @@ internal static class CloudflareCachePolicyBuilder
         var clauses = new List<string>();
         foreach (var path in paths)
         {
-            var escaped = EscapeExpressionString(path);
-            clauses.Add($"http.request.uri.path eq \"{escaped}\"");
+            clauses.Add(BuildPathClause("eq", path));
             if (path.Length > 1 && path.EndsWith("/", StringComparison.Ordinal))
-                clauses.Add($"http.request.uri.path wildcard \"{escaped}*\"");
+                clauses.Add(BuildPathClause("wildcard", path + "*"));
         }
 
         return clauses;
@@ -143,6 +173,29 @@ internal static class CloudflareCachePolicyBuilder
             return null;
 
         return path;
+    }
+
+    private static string CombineBasePath(string basePath, string path)
+    {
+        if (basePath == "/")
+            return path;
+        if (path == "/")
+            return basePath;
+        if (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
+            return path;
+        return basePath.TrimEnd('/') + path;
+    }
+
+    private static string BuildPathClause(string operation, string path) =>
+        $"http.request.uri.path {operation} \"{EscapeExpressionString(path)}\"";
+
+    private static void ValidateExpressionLength(string ruleName, string expression)
+    {
+        if (expression.Length > MaxRuleExpressionLength)
+        {
+            throw new ArgumentException(
+                $"Cloudflare {ruleName} expression is {expression.Length} characters; the maximum is {MaxRuleExpressionLength}.");
+        }
     }
 
     private static JsonObject BuildRule(string description, string expression, bool ignoreQueryString)

--- a/PowerForge.Web.Cli/CloudflareCachePolicyManager.cs
+++ b/PowerForge.Web.Cli/CloudflareCachePolicyManager.cs
@@ -33,7 +33,8 @@ internal static class CloudflareCachePolicyManager
         IReadOnlyCollection<string>? htmlPaths,
         bool dryRun,
         WebConsoleLogger? logger,
-        HttpClient? httpClient = null)
+        HttpClient? httpClient = null,
+        string? basePath = null)
     {
         if (string.IsNullOrWhiteSpace(zoneId))
             return Failure("Missing zoneId.", hostname, policyName, dryRun);
@@ -49,7 +50,7 @@ internal static class CloudflareCachePolicyManager
         {
             hostname = CloudflareCachePolicyBuilder.NormalizeHostname(hostname);
             policyName = CloudflareCachePolicyBuilder.NormalizePolicyName(policyName, hostname);
-            managedRules = CloudflareCachePolicyBuilder.BuildManagedRules(hostname, policyName, htmlPaths);
+            managedRules = CloudflareCachePolicyBuilder.BuildManagedRules(hostname, policyName, htmlPaths, basePath);
         }
         catch (ArgumentException ex)
         {
@@ -88,7 +89,6 @@ internal static class CloudflareCachePolicyManager
                     policyName,
                     dryRun);
             }
-            var preservedRules = new JsonArray();
             var existingManaged = new List<JsonObject>();
 
             foreach (var ruleNode in existingRules)
@@ -99,26 +99,15 @@ internal static class CloudflareCachePolicyManager
                 var description = rule["description"]?.GetValue<string>() ?? string.Empty;
                 if (description.StartsWith(managedPrefix, StringComparison.Ordinal))
                     existingManaged.Add(rule);
-                else
-                    preservedRules.Add(PrepareRuleForUpdate(rule));
             }
 
             CopyManagedRuleIdentity(existingManaged, managedRules);
-
-            var desiredRules = new JsonArray();
-            foreach (var rule in managedRules)
-            {
-                if (rule is not null)
-                    desiredRules.Add(rule.DeepClone());
-            }
-            foreach (var rule in preservedRules)
-                desiredRules.Add(rule?.DeepClone());
+            var desiredRules = BuildDesiredRuleSequence(existingRules, managedRules, managedPrefix, out var preservedCount);
 
             var normalizedCurrent = NormalizeRulesForComparison(existingRules);
             var normalizedDesired = NormalizeRulesForComparison(desiredRules);
             var changesRequired = !JsonNode.DeepEquals(normalizedCurrent, normalizedDesired);
             var managedCount = managedRules.Count;
-            var preservedCount = preservedRules.Count;
 
             if (!changesRequired)
             {
@@ -193,6 +182,66 @@ internal static class CloudflareCachePolicyManager
                 if (existing[identityName] is not null)
                     desired[identityName] = existing[identityName]!.DeepClone();
             }
+        }
+    }
+
+    private static JsonArray BuildDesiredRuleSequence(
+        JsonArray existingRules,
+        JsonArray managedRules,
+        string managedPrefix,
+        out int preservedCount)
+    {
+        var desiredByDescription = managedRules
+            .OfType<JsonObject>()
+            .ToDictionary(
+                rule => rule["description"]?.GetValue<string>() ?? string.Empty,
+                rule => rule,
+                StringComparer.Ordinal);
+        var emittedDescriptions = new HashSet<string>(StringComparer.Ordinal);
+        var lastManagedIndex = -1;
+        for (var index = 0; index < existingRules.Count; index++)
+        {
+            var description = existingRules[index]!["description"]?.GetValue<string>() ?? string.Empty;
+            if (description.StartsWith(managedPrefix, StringComparison.Ordinal))
+                lastManagedIndex = index;
+        }
+
+        var desiredRules = new JsonArray();
+        if (lastManagedIndex < 0)
+            AddMissingManagedRules(desiredRules, managedRules, emittedDescriptions);
+
+        preservedCount = 0;
+        for (var index = 0; index < existingRules.Count; index++)
+        {
+            var existing = existingRules[index]!.AsObject();
+            var description = existing["description"]?.GetValue<string>() ?? string.Empty;
+            if (!description.StartsWith(managedPrefix, StringComparison.Ordinal))
+            {
+                desiredRules.Add(PrepareRuleForUpdate(existing));
+                preservedCount++;
+                continue;
+            }
+
+            if (desiredByDescription.TryGetValue(description, out var desired) && emittedDescriptions.Add(description))
+                desiredRules.Add(desired.DeepClone());
+
+            if (index == lastManagedIndex)
+                AddMissingManagedRules(desiredRules, managedRules, emittedDescriptions);
+        }
+
+        return desiredRules;
+    }
+
+    private static void AddMissingManagedRules(
+        JsonArray destination,
+        JsonArray managedRules,
+        HashSet<string> emittedDescriptions)
+    {
+        foreach (var managed in managedRules.OfType<JsonObject>())
+        {
+            var description = managed["description"]?.GetValue<string>() ?? string.Empty;
+            if (emittedDescriptions.Add(description))
+                destination.Add(managed.DeepClone());
         }
     }
 

--- a/PowerForge.Web.Cli/CloudflareCachePolicyManager.cs
+++ b/PowerForge.Web.Cli/CloudflareCachePolicyManager.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace PowerForge.Web.Cli;
+
+internal sealed class CloudflareCachePolicyApplyResult
+{
+    public bool Success { get; init; }
+    public bool DryRun { get; init; }
+    public bool ChangesRequired { get; init; }
+    public bool Changed { get; init; }
+    public string Hostname { get; init; } = string.Empty;
+    public string PolicyName { get; init; } = string.Empty;
+    public int ManagedRuleCount { get; init; }
+    public int PreservedRuleCount { get; init; }
+    public string Message { get; init; } = string.Empty;
+}
+
+internal static class CloudflareCachePolicyManager
+{
+    private const string CachePhase = "http_request_cache_settings";
+
+    internal static CloudflareCachePolicyApplyResult Apply(
+        string zoneId,
+        string apiToken,
+        string hostname,
+        string policyName,
+        IReadOnlyCollection<string>? htmlPaths,
+        bool dryRun,
+        WebConsoleLogger? logger,
+        HttpClient? httpClient = null)
+    {
+        if (string.IsNullOrWhiteSpace(zoneId))
+            return Failure("Missing zoneId.", hostname, policyName, dryRun);
+        if (string.IsNullOrWhiteSpace(apiToken))
+            return Failure("Missing apiToken.", hostname, policyName, dryRun);
+
+        var normalizedZoneId = zoneId.Trim();
+        if (normalizedZoneId.Length != 32 || normalizedZoneId.Any(character => !Uri.IsHexDigit(character)))
+            return Failure("Cloudflare zoneId must be a 32-character hexadecimal identifier.", hostname, policyName, dryRun);
+
+        JsonArray managedRules;
+        try
+        {
+            hostname = CloudflareCachePolicyBuilder.NormalizeHostname(hostname);
+            policyName = CloudflareCachePolicyBuilder.NormalizePolicyName(policyName, hostname);
+            managedRules = CloudflareCachePolicyBuilder.BuildManagedRules(hostname, policyName, htmlPaths);
+        }
+        catch (ArgumentException ex)
+        {
+            return Failure(ex.Message, hostname, policyName, dryRun);
+        }
+
+        var managedPrefix = $"PowerForge {policyName}:";
+        var ownsHttpClient = httpClient is null;
+        httpClient ??= new HttpClient { BaseAddress = new Uri("https://api.cloudflare.com/client/v4/") };
+
+        try
+        {
+            var entrypoint = $"zones/{Uri.EscapeDataString(normalizedZoneId)}/rulesets/phases/{CachePhase}/entrypoint";
+            var getResponse = CloudflareApiClient.Send(httpClient, HttpMethod.Get, entrypoint, apiToken, body: null);
+            if (getResponse.TransportError is not null)
+                return Failure(getResponse.TransportError, hostname, policyName, dryRun);
+
+            var entrypointExists = getResponse.StatusCode != HttpStatusCode.NotFound;
+            if (entrypointExists && !getResponse.Success)
+                return Failure(getResponse.ErrorMessage, hostname, policyName, dryRun);
+
+            var existingRules = new JsonArray();
+            if (entrypointExists && !TryReadRules(getResponse.Result, out existingRules))
+            {
+                return Failure(
+                    "Cloudflare entry-point response did not contain a rules array; refusing to replace the existing ruleset.",
+                    hostname,
+                    policyName,
+                    dryRun);
+            }
+            if (existingRules.Any(rule => rule is not JsonObject))
+            {
+                return Failure(
+                    "Cloudflare entry-point response contained a malformed rule; refusing to replace the existing ruleset.",
+                    hostname,
+                    policyName,
+                    dryRun);
+            }
+            var preservedRules = new JsonArray();
+            var existingManaged = new List<JsonObject>();
+
+            foreach (var ruleNode in existingRules)
+            {
+                if (ruleNode is not JsonObject rule)
+                    continue;
+
+                var description = rule["description"]?.GetValue<string>() ?? string.Empty;
+                if (description.StartsWith(managedPrefix, StringComparison.Ordinal))
+                    existingManaged.Add(rule);
+                else
+                    preservedRules.Add(PrepareRuleForUpdate(rule));
+            }
+
+            CopyManagedRuleIdentity(existingManaged, managedRules);
+
+            var desiredRules = new JsonArray();
+            foreach (var rule in managedRules)
+            {
+                if (rule is not null)
+                    desiredRules.Add(rule.DeepClone());
+            }
+            foreach (var rule in preservedRules)
+                desiredRules.Add(rule?.DeepClone());
+
+            var normalizedCurrent = NormalizeRulesForComparison(existingRules);
+            var normalizedDesired = NormalizeRulesForComparison(desiredRules);
+            var changesRequired = !JsonNode.DeepEquals(normalizedCurrent, normalizedDesired);
+            var managedCount = managedRules.Count;
+            var preservedCount = preservedRules.Count;
+
+            if (!changesRequired)
+            {
+                var unchanged = $"Cloudflare cache policy is already current for {hostname} ({managedCount} managed rule(s), {preservedCount} preserved rule(s)).";
+                logger?.Info(unchanged);
+                return SuccessfulResult(hostname, policyName, dryRun, changesRequired: false, changed: false, managedCount, preservedCount, unchanged);
+            }
+
+            if (dryRun)
+            {
+                var preview = $"Cloudflare cache policy would update {managedCount} managed rule(s) for {hostname} and preserve {preservedCount} unrelated rule(s).";
+                logger?.Info(preview);
+                return SuccessfulResult(hostname, policyName, dryRun: true, changesRequired: true, changed: false, managedCount, preservedCount, preview);
+            }
+
+            var updateResponse = entrypointExists
+                ? CloudflareApiClient.Send(
+                    httpClient,
+                    HttpMethod.Put,
+                    entrypoint,
+                    apiToken,
+                    new JsonObject { ["rules"] = desiredRules })
+                : CloudflareApiClient.Send(
+                    httpClient,
+                    HttpMethod.Post,
+                    $"zones/{Uri.EscapeDataString(normalizedZoneId)}/rulesets",
+                    apiToken,
+                    new JsonObject
+                    {
+                        ["name"] = "PowerForge cache policy",
+                        ["description"] = "PowerForge-managed cache policy",
+                        ["kind"] = "zone",
+                        ["phase"] = CachePhase,
+                        ["rules"] = desiredRules
+                    });
+
+            if (!updateResponse.Success)
+                return Failure(updateResponse.ErrorMessage, hostname, policyName, dryRun);
+
+            var message = $"Applied {managedCount} Cloudflare cache rule(s) for {hostname}; preserved {preservedCount} unrelated rule(s).";
+            logger?.Info(message);
+            return SuccessfulResult(hostname, policyName, dryRun: false, changesRequired: true, changed: true, managedCount, preservedCount, message);
+        }
+        catch (Exception ex)
+        {
+            return Failure($"Cloudflare cache policy failed: {ex.GetType().Name}: {ex.Message}", hostname, policyName, dryRun);
+        }
+        finally
+        {
+            if (ownsHttpClient)
+                httpClient.Dispose();
+        }
+    }
+
+    private static void CopyManagedRuleIdentity(IEnumerable<JsonObject> existingRules, JsonArray desiredRules)
+    {
+        var byDescription = existingRules
+            .Where(rule => rule["description"] is not null)
+            .GroupBy(rule => rule["description"]!.GetValue<string>(), StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+
+        foreach (var desiredNode in desiredRules)
+        {
+            if (desiredNode is not JsonObject desired)
+                continue;
+            var description = desired["description"]?.GetValue<string>() ?? string.Empty;
+            if (!byDescription.TryGetValue(description, out var existing))
+                continue;
+
+            foreach (var identityName in new[] { "id", "ref" })
+            {
+                if (existing[identityName] is not null)
+                    desired[identityName] = existing[identityName]!.DeepClone();
+            }
+        }
+    }
+
+    private static bool TryReadRules(JsonElement? result, out JsonArray rules)
+    {
+        rules = new JsonArray();
+        if (result is null || result.Value.ValueKind != JsonValueKind.Object ||
+            !result.Value.TryGetProperty("rules", out var rulesElement) ||
+            rulesElement.ValueKind != JsonValueKind.Array)
+            return false;
+
+        rules = JsonNode.Parse(rulesElement.GetRawText()) as JsonArray ?? new JsonArray();
+        return true;
+    }
+
+    private static JsonArray NormalizeRulesForComparison(JsonArray rules)
+    {
+        var normalized = new JsonArray();
+        foreach (var node in rules)
+        {
+            if (node is JsonObject rule)
+                normalized.Add(PrepareRuleForComparison(rule));
+        }
+        return normalized;
+    }
+
+    private static JsonObject PrepareRuleForUpdate(JsonObject source)
+    {
+        var clone = source.DeepClone().AsObject();
+        clone.Remove("version");
+        clone.Remove("last_updated");
+        return clone;
+    }
+
+    private static JsonObject PrepareRuleForComparison(JsonObject source)
+    {
+        var clone = PrepareRuleForUpdate(source);
+        clone.Remove("id");
+        clone.Remove("ref");
+        return clone;
+    }
+
+    private static CloudflareCachePolicyApplyResult Failure(string message, string hostname, string policyName, bool dryRun) => new()
+    {
+        Success = false,
+        DryRun = dryRun,
+        Hostname = hostname ?? string.Empty,
+        PolicyName = policyName ?? string.Empty,
+        Message = message
+    };
+
+    private static CloudflareCachePolicyApplyResult SuccessfulResult(
+        string hostname,
+        string policyName,
+        bool dryRun,
+        bool changesRequired,
+        bool changed,
+        int managedRuleCount,
+        int preservedRuleCount,
+        string message) => new()
+    {
+        Success = true,
+        DryRun = dryRun,
+        ChangesRequired = changesRequired,
+        Changed = changed,
+        Hostname = hostname,
+        PolicyName = policyName,
+        ManagedRuleCount = managedRuleCount,
+        PreservedRuleCount = preservedRuleCount,
+        Message = message
+    };
+}

--- a/PowerForge.Web.Cli/CloudflareRouteProfileResolver.cs
+++ b/PowerForge.Web.Cli/CloudflareRouteProfileResolver.cs
@@ -9,6 +9,7 @@ namespace PowerForge.Web.Cli;
 internal sealed class CloudflareSiteRouteProfile
 {
     public string SiteConfigPath { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
     public string BaseUrl { get; init; } = string.Empty;
     public string[] VerifyPaths { get; init; } = Array.Empty<string>();
     public string[] PurgePaths { get; init; } = Array.Empty<string>();
@@ -46,6 +47,7 @@ internal static class CloudflareRouteProfileResolver
         return new CloudflareSiteRouteProfile
         {
             SiteConfigPath = specPath,
+            Name = (spec.Name ?? string.Empty).Trim(),
             BaseUrl = baseUrl,
             VerifyPaths = verifyPaths,
             PurgePaths = purgePaths

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.cs
@@ -27,7 +27,106 @@ internal static partial class WebCliCommandHandlers
         if (verb.Equals("verify", StringComparison.OrdinalIgnoreCase))
             return HandleCloudflareVerify(subArgs, outputJson, logger, outputSchemaVersion);
 
-        return Fail($"Unknown cloudflare verb '{verb}'. Supported: purge, verify.", outputJson, logger, "web.cloudflare");
+        if (verb.Equals("cache-policy", StringComparison.OrdinalIgnoreCase) ||
+            verb.Equals("policy", StringComparison.OrdinalIgnoreCase) ||
+            verb.Equals("rules", StringComparison.OrdinalIgnoreCase))
+        {
+            if (subArgs.Length > 0 && !subArgs[0].StartsWith("-", StringComparison.Ordinal))
+            {
+                if (!subArgs[0].Equals("apply", StringComparison.OrdinalIgnoreCase))
+                    return Fail($"Unknown cloudflare cache-policy verb '{subArgs[0]}'. Supported: apply.", outputJson, logger, "web.cloudflare.cache-policy");
+                subArgs = subArgs.Skip(1).ToArray();
+            }
+
+            return HandleCloudflareCachePolicy(subArgs, outputJson, logger, outputSchemaVersion);
+        }
+
+        return Fail($"Unknown cloudflare verb '{verb}'. Supported: purge, verify, cache-policy.", outputJson, logger, "web.cloudflare");
+    }
+
+    private static int HandleCloudflareCachePolicy(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        const string command = "web.cloudflare.cache-policy.apply";
+        if (!TryLoadCloudflareSiteProfile(subArgs, outputJson, logger, command, out var siteProfile, out var loadError))
+            return loadError;
+
+        var zoneId = TryGetOptionValue(subArgs, "--zone-id") ??
+                     TryGetOptionValue(subArgs, "--zone") ??
+                     TryGetOptionValue(subArgs, "--zoneId");
+        if (string.IsNullOrWhiteSpace(zoneId))
+            return Fail("Missing required --zone-id.", outputJson, logger, command);
+
+        var token = TryGetOptionValue(subArgs, "--token") ??
+                    TryGetOptionValue(subArgs, "--api-token") ??
+                    TryGetOptionValue(subArgs, "--apiToken");
+        var tokenEnv = TryGetOptionValue(subArgs, "--token-env") ??
+                       TryGetOptionValue(subArgs, "--api-token-env") ??
+                       TryGetOptionValue(subArgs, "--apiTokenEnv") ??
+                       "CLOUDFLARE_API_TOKEN";
+        if (string.IsNullOrWhiteSpace(token))
+            token = Environment.GetEnvironmentVariable(tokenEnv);
+        if (string.IsNullOrWhiteSpace(token))
+            return Fail($"Missing Cloudflare API token. Provide --token or set env var '{tokenEnv}'.", outputJson, logger, command);
+
+        var hostname = TryGetOptionValue(subArgs, "--hostname") ??
+                       TryGetOptionValue(subArgs, "--host");
+        if (string.IsNullOrWhiteSpace(hostname) && !string.IsNullOrWhiteSpace(siteProfile?.BaseUrl) &&
+            Uri.TryCreate(siteProfile.BaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            hostname = baseUri.Host;
+        }
+        if (string.IsNullOrWhiteSpace(hostname))
+            return Fail("Missing --hostname (or a --site-config with BaseUrl).", outputJson, logger, command);
+
+        var policyName = TryGetOptionValue(subArgs, "--policy-name") ??
+                         TryGetOptionValue(subArgs, "--policyName") ??
+                         siteProfile?.Name ??
+                         hostname;
+        var htmlPaths = ReadOptionList(subArgs, "--html-path", "--html-paths");
+        if (siteProfile is not null)
+            htmlPaths.AddRange(siteProfile.VerifyPaths);
+
+        var dryRun = HasOption(subArgs, "--dry-run") || HasOption(subArgs, "--dryRun");
+        var result = CloudflareCachePolicyManager.Apply(
+            zoneId,
+            token,
+            hostname,
+            policyName,
+            htmlPaths,
+            dryRun,
+            logger);
+
+        if (outputJson)
+        {
+            var element = JsonSerializer.SerializeToElement(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["siteConfig"] = siteProfile?.SiteConfigPath,
+                ["zoneId"] = zoneId,
+                ["hostname"] = result.Hostname,
+                ["policyName"] = result.PolicyName,
+                ["managedRuleCount"] = result.ManagedRuleCount,
+                ["preservedRuleCount"] = result.PreservedRuleCount,
+                ["dryRun"] = result.DryRun,
+                ["changesRequired"] = result.ChangesRequired,
+                ["changed"] = result.Changed,
+                ["message"] = result.Message
+            }, WebCliJson.Options);
+
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = command,
+                Success = result.Success,
+                ExitCode = result.Success ? 0 : 1,
+                Result = element,
+                Error = result.Success ? null : result.Message
+            });
+            return result.Success ? 0 : 1;
+        }
+
+        if (result.Success) logger.Success(result.Message);
+        else logger.Error(result.Message);
+        return result.Success ? 0 : 1;
     }
 
     private static int HandleCloudflarePurge(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.cs
@@ -68,16 +68,25 @@ internal static partial class WebCliCommandHandlers
         if (string.IsNullOrWhiteSpace(token))
             return Fail($"Missing Cloudflare API token. Provide --token or set env var '{tokenEnv}'.", outputJson, logger, command);
 
+        Uri? siteBaseUri = null;
+        if (!string.IsNullOrWhiteSpace(siteProfile?.BaseUrl))
+        {
+            if (!Uri.TryCreate(siteProfile.BaseUrl, UriKind.Absolute, out siteBaseUri) ||
+                (siteBaseUri.Scheme != Uri.UriSchemeHttps && siteBaseUri.Scheme != Uri.UriSchemeHttp))
+                return Fail("site config BaseUrl must be an absolute HTTP or HTTPS URL.", outputJson, logger, command);
+        }
+
         var hostname = TryGetOptionValue(subArgs, "--hostname") ??
                        TryGetOptionValue(subArgs, "--host");
-        if (string.IsNullOrWhiteSpace(hostname) && !string.IsNullOrWhiteSpace(siteProfile?.BaseUrl) &&
-            Uri.TryCreate(siteProfile.BaseUrl, UriKind.Absolute, out var baseUri))
-        {
-            hostname = baseUri.Host;
-        }
+        if (string.IsNullOrWhiteSpace(hostname) && siteBaseUri is not null)
+            hostname = siteBaseUri.Host;
         if (string.IsNullOrWhiteSpace(hostname))
             return Fail("Missing --hostname (or a --site-config with BaseUrl).", outputJson, logger, command);
 
+        var basePath = TryGetOptionValue(subArgs, "--base-path") ??
+                       TryGetOptionValue(subArgs, "--basePath") ??
+                       siteBaseUri?.AbsolutePath ??
+                       "/";
         var policyName = TryGetOptionValue(subArgs, "--policy-name") ??
                          TryGetOptionValue(subArgs, "--policyName") ??
                          siteProfile?.Name ??
@@ -94,7 +103,8 @@ internal static partial class WebCliCommandHandlers
             policyName,
             htmlPaths,
             dryRun,
-            logger);
+            logger,
+            basePath: basePath);
 
         if (outputJson)
         {
@@ -103,6 +113,7 @@ internal static partial class WebCliCommandHandlers
                 ["siteConfig"] = siteProfile?.SiteConfigPath,
                 ["zoneId"] = zoneId,
                 ["hostname"] = result.Hostname,
+                ["basePath"] = basePath,
                 ["policyName"] = result.PolicyName,
                 ["managedRuleCount"] = result.ManagedRuleCount,
                 ["preservedRuleCount"] = result.PreservedRuleCount,

--- a/PowerForge.Web.Cli/WebCliHelpers.Help.ServerCloudflare.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.Help.ServerCloudflare.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliHelpers
+{
+    private static void PrintServerAndCloudflareUsage()
+    {
+        Console.WriteLine("  powerforge-web server inspect --manifest <serverrecovery.json> [--fail-on-drift] [--output json]");
+        Console.WriteLine("  powerforge-web server plan --manifest <serverrecovery.json> [--output json]");
+        Console.WriteLine("  powerforge-web server validate --manifest <serverrecovery.json> [--output json] (alias for plan)");
+        Console.WriteLine("  powerforge-web server capture --manifest <serverrecovery.json> [--out <dir>] [--dry-run] [--skip-files] [--skip-encrypted] [--encrypt-remote] [--fail-on-failure] [--output json]");
+        Console.WriteLine("  powerforge-web server deploy --manifest <serverrecovery.json> [--dry-run] [--fail-on-failure] [--output json]");
+        Console.WriteLine("  powerforge-web server verify --manifest <serverrecovery.json> [--fail-on-failure] [--url-timeout-seconds <n>] [--output json]");
+        Console.WriteLine("  powerforge-web server bootstrap-plan --manifest <serverrecovery.json> [--out <dir>] [--output json]");
+        Console.WriteLine("  powerforge-web server restore-secrets-plan --manifest <serverrecovery.json> [--out <dir>] [--archive <encrypted-secrets.tar.gz.age>] [--output json]");
+        Console.WriteLine("  powerforge-web cloudflare purge --zone-id <id> [--token <token> | --token-env <env>]");
+        Console.WriteLine("                     [--purge-everything] [--site-config <site.json>] [--base-url <url>] [--path <p[,p...]>] [--url <u[,u...]>] [--dry-run]");
+        Console.WriteLine("  powerforge-web cloudflare verify [--site-config <site.json>] [--base-url <url>] [--path <p[,p...]>] [--url <u[,u...]>]");
+        Console.WriteLine("                     [--warmup <n>] [--allow-status <HIT,REVALIDATED,EXPIRED,STALE>] [--timeout-ms <n>]");
+        Console.WriteLine("  powerforge-web cloudflare cache-policy apply --zone-id <id> [--token <token> | --token-env <env>]");
+        Console.WriteLine("                     [--site-config <site.json> | --hostname <host>] [--policy-name <name>] [--html-path <p[,p...]>] [--dry-run]");
+    }
+}

--- a/PowerForge.Web.Cli/WebCliHelpers.Help.ServerCloudflare.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.Help.ServerCloudflare.cs
@@ -19,6 +19,7 @@ internal static partial class WebCliHelpers
         Console.WriteLine("  powerforge-web cloudflare verify [--site-config <site.json>] [--base-url <url>] [--path <p[,p...]>] [--url <u[,u...]>]");
         Console.WriteLine("                     [--warmup <n>] [--allow-status <HIT,REVALIDATED,EXPIRED,STALE>] [--timeout-ms <n>]");
         Console.WriteLine("  powerforge-web cloudflare cache-policy apply --zone-id <id> [--token <token> | --token-env <env>]");
-        Console.WriteLine("                     [--site-config <site.json> | --hostname <host>] [--policy-name <name>] [--html-path <p[,p...]>] [--dry-run]");
+        Console.WriteLine("                     [--site-config <site.json> | --hostname <host>] [--base-path <path>] [--policy-name <name>]");
+        Console.WriteLine("                     [--html-path <p[,p...]>] [--dry-run]");
     }
 }

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -9,7 +9,7 @@ using PowerForge.Web;
 
 namespace PowerForge.Web.Cli;
 
-internal static class WebCliHelpers
+internal static partial class WebCliHelpers
 {
     private const int ErrorSchemaVersion = 1;
 
@@ -137,18 +137,7 @@ internal static class WebCliHelpers
         Console.WriteLine("  powerforge-web xref-merge --out <file> --map <file|dir[,file|dir...]> [--pattern *.json] [--top-only]");
         Console.WriteLine("                     [--prefer-last] [--fail-on-duplicates] [--max-references <n>] [--max-duplicates <n>]");
         Console.WriteLine("                     [--max-reference-growth-count <n>] [--max-reference-growth-percent <n>] [--fail-on-warnings]");
-        Console.WriteLine("  powerforge-web server inspect --manifest <serverrecovery.json> [--fail-on-drift] [--output json]");
-        Console.WriteLine("  powerforge-web server plan --manifest <serverrecovery.json> [--output json]");
-        Console.WriteLine("  powerforge-web server validate --manifest <serverrecovery.json> [--output json] (alias for plan)");
-        Console.WriteLine("  powerforge-web server capture --manifest <serverrecovery.json> [--out <dir>] [--dry-run] [--skip-files] [--skip-encrypted] [--encrypt-remote] [--fail-on-failure] [--output json]");
-        Console.WriteLine("  powerforge-web server deploy --manifest <serverrecovery.json> [--dry-run] [--fail-on-failure] [--output json]");
-        Console.WriteLine("  powerforge-web server verify --manifest <serverrecovery.json> [--fail-on-failure] [--url-timeout-seconds <n>] [--output json]");
-        Console.WriteLine("  powerforge-web server bootstrap-plan --manifest <serverrecovery.json> [--out <dir>] [--output json]");
-        Console.WriteLine("  powerforge-web server restore-secrets-plan --manifest <serverrecovery.json> [--out <dir>] [--archive <encrypted-secrets.tar.gz.age>] [--output json]");
-        Console.WriteLine("  powerforge-web cloudflare purge --zone-id <id> [--token <token> | --token-env <env>]");
-        Console.WriteLine("                     [--purge-everything] [--site-config <site.json>] [--base-url <url>] [--path <p[,p...]>] [--url <u[,u...]>] [--dry-run]");
-        Console.WriteLine("  powerforge-web cloudflare verify [--site-config <site.json>] [--base-url <url>] [--path <p[,p...]>] [--url <u[,u...]>]");
-        Console.WriteLine("                     [--warmup <n>] [--allow-status <HIT,REVALIDATED,EXPIRED,STALE>] [--timeout-ms <n>]");
+        PrintServerAndCloudflareUsage();
     }
 
     internal static int Fail(string message, bool outputJson, WebConsoleLogger logger, string command)


### PR DESCRIPTION
## Summary

- add a generic `powerforge-web cloudflare cache-policy apply` command that derives host and routes from `site.json`
- manage three host-scoped cache rules while preserving operator-owned rules and avoiding no-op ruleset churn
- fail closed on incomplete or malformed Cloudflare responses, support dry-run, and validate route/zone inputs before writes
- add a caller-owned protected composite action so consumer workflows stay declarative and tokens remain out of command arguments
- document cache policy, post-deploy purge, and exact action pinning

## Validation

- `dotnet build PowerForge.Web.Cli/PowerForge.Web.Cli.csproj --configuration Release --nologo`
- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj --configuration Release --nologo --filter "FullyQualifiedName~Cloudflare" --no-restore` (19 passed)
- PowerShell parser: 0 errors
- PSScriptAnalyzer: 0 findings
- `git diff --check`

