### PR TITLE
Optimize managed module installs and benchmark ModuleFast beta1

### DIFF
--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -68,6 +68,40 @@ as skipped for that host instead of being treated as failures.
 Use `ModuleFastPath` to pin the released ModuleFast lane to a specific local
 module path instead of resolving `ModuleFast` from `PSModulePath`.
 
+## Fair Install Comparisons
+
+The default sources compare the normal product paths: managed modules use the
+official PowerShell Gallery while ModuleFast uses its configured ModuleFast
+source. Those results include repository and CDN behavior, so they should not be
+presented as a pure installer-engine comparison.
+
+To isolate installer behavior, point both engines at the same NuGet v3 feed:
+
+```powershell
+Invoke-BenchmarkSuite `
+    -Path .\Benchmarks\ManagedModules\managed-modules.benchmark.ps1 `
+    -Scenario SingleModule, Graph, Az `
+    -Operation Install `
+    -Engine Managed, ModuleFast `
+    -Variable @{
+        RepositoryUri     = 'https://feed.example.test/index.json'
+        ModuleFastSource  = 'https://feed.example.test/index.json'
+        ManagedModulePath = 'C:\Build\PSPublishModule.dll'
+        ModuleFastPath    = 'C:\Modules\ModuleFast\1.0.0\ModuleFast.psd1'
+    }
+```
+
+Every install sample starts with a fresh destination. ModuleFast import and its
+resolution-cache reset happen during setup, outside measured time. The managed
+binary can be pinned with `ManagedModulePath`; validation fails if the measured
+command does not come from that exact file. The managed install intentionally
+uses its operation-local package buffer rather than a
+persistent extracted-package cache because ModuleFast has no equivalent cache
+in this lane. ModuleFast runs with `DestinationOnly`, so neither engine mutates
+the process module path. Validation requires exactly one requested module
+manifest with the exact requested version, and the artifacts record installed
+file count and bytes alongside timing.
+
 ## Native Provider Installs
 
 `Install-PSResource` and `Install-Module` install into the current user profile.

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -114,7 +114,16 @@ official PowerShell Gallery and ModuleFast uses `https://pwsh.gallery/index.json
 The latter includes endpoint and CDN behavior, so it is useful real-world
 evidence but not a pure installer-engine comparison.
 
-### Controlled Identical-Feed Comparison
+> **How to read the comparisons**
+>
+> - **Identical local feed**: PowerForge and ModuleFast both read from the same
+>   temporary local NuGet v3 feed. Neither PSGallery nor pwsh.gallery is timed.
+> - **Default endpoints**: PowerForge reads from the official PowerShell Gallery;
+>   ModuleFast reads from `https://pwsh.gallery/index.json`.
+> - When a compact result uses `PowerForge / ModuleFast` or `PF / MF`, the
+>   PowerForge time is always first and the ModuleFast time is second.
+
+### Identical Local Feed: PowerForge and ModuleFast on the Same Feed
 
 Both engines used the same local feed, exact packages, fresh destinations,
 rotated order, and exact manifest/payload validation. PowerForge was built from
@@ -127,7 +136,7 @@ commit `ab1a417a3ba35dd266fe786b87ccefe05882d510` and ModuleFast was
 | Microsoft.Graph 2.29.1 | 6 | 3.04 s | 4.04 s | 4/6 pairs |
 | Az 14.0.0 | 6 | 4.47 s | 7.98 s | 5/6 pairs |
 
-### Default Sources: PSGallery Versus pwsh.gallery
+### Default Endpoints: PowerForge on PSGallery, ModuleFast on pwsh.gallery
 
 Run `20260716-092623-ef4ac8ed` used PowerShell 7.6.3 on Windows
 10.0.26200, six samples per engine, rotated order, no warmup, and no outlier

--- a/Benchmarks/ManagedModules/README.md
+++ b/Benchmarks/ManagedModules/README.md
@@ -20,7 +20,8 @@ Invoke-BenchmarkSuite `
     -Host Core, Desktop `
     -WarmupCount 1 `
     -IterationCount 3 `
-    -RunMode local
+    -RunMode local `
+    -Variable @{ UpdateReadme = $true }
 ```
 
 That comparison expands the standard scenario set across the lifecycle
@@ -32,9 +33,10 @@ operations and provider engines:
 - `AzAccounts`: `Az.Accounts`
 - `Az`: `Az`
 
-The checked-in README table is usually refreshed with a one-iteration full
-matrix smoke so the full matrix shape is proven without multiplying the large
-Graph/Az download work by the normal warmup policy. For stable local numbers,
+The checked-in root README table is usually refreshed with a one-iteration full
+matrix smoke and `UpdateReadme = $true` so the full matrix shape is proven
+without multiplying the large Graph/Az download work by the normal warmup
+policy. Focused runs do not modify the root README. For stable local numbers,
 keep the warmup and iteration counts above.
 
 ## Select A Matrix
@@ -93,14 +95,104 @@ Invoke-BenchmarkSuite `
 
 Every install sample starts with a fresh destination. ModuleFast import and its
 resolution-cache reset happen during setup, outside measured time. The managed
-binary can be pinned with `ManagedModulePath`; validation fails if the measured
-command does not come from that exact file. The managed install intentionally
-uses its operation-local package buffer rather than a
+binary can be pinned with `ManagedModulePath`; validation compares the loaded
+command's SHA-256 with the requested artifact, which also supports exact byte
+validation when an external host copies the assembly before loading it. The
+managed install intentionally uses its operation-local package buffer rather than a
 persistent extracted-package cache because ModuleFast has no equivalent cache
 in this lane. ModuleFast runs with `DestinationOnly`, so neither engine mutates
 the process module path. Validation requires exactly one requested module
 manifest with the exact requested version, and the artifacts record installed
 file count and bytes alongside timing.
+
+## ModuleFast 1.0.0-beta1 Results
+
+These results answer two different questions. The controlled comparison uses an
+identical local NuGet v3 feed to isolate installer behavior. The default-source
+comparison intentionally races the normal product paths: PowerForge uses the
+official PowerShell Gallery and ModuleFast uses `https://pwsh.gallery/index.json`.
+The latter includes endpoint and CDN behavior, so it is useful real-world
+evidence but not a pure installer-engine comparison.
+
+### Controlled Identical-Feed Comparison
+
+Both engines used the same local feed, exact packages, fresh destinations,
+rotated order, and exact manifest/payload validation. PowerForge was built from
+commit `ab1a417a3ba35dd266fe786b87ccefe05882d510` and ModuleFast was
+`1.0.0-beta1`.
+
+| Workload | Samples | PowerForge median | ModuleFast median | PowerForge wins |
+| --- | ---: | ---: | ---: | ---: |
+| PSScriptAnalyzer 1.25.0 | 10 | 640 ms | 757 ms | 7/10 pairs |
+| Microsoft.Graph 2.29.1 | 6 | 3.04 s | 4.04 s | 4/6 pairs |
+| Az 14.0.0 | 6 | 4.47 s | 7.98 s | 5/6 pairs |
+
+### Default Sources: PSGallery Versus pwsh.gallery
+
+Run `20260716-092623-ef4ac8ed` used PowerShell 7.6.3 on Windows
+10.0.26200, six samples per engine, rotated order, no warmup, and no outlier
+removal. On this machine and network, PowerForge won every scenario median even
+while ModuleFast used pwsh.gallery.
+
+| Workload | PowerForge median | ModuleFast median | PowerForge wins |
+| --- | ---: | ---: | ---: |
+| PSScriptAnalyzer 1.25.0 | 889 ms | 1.21 s | 5/6 pairs |
+| Microsoft.Graph 2.29.1 | 6.90 s | 7.60 s | 4/6 pairs |
+| Az 14.0.0 | 5.40 s | 8.19 s | 6/6 pairs |
+
+Pinned benchmark artifacts:
+
+| Product | Version | Binary SHA-256 |
+| --- | --- | --- |
+| PowerForge / PSPublishModule | `1.0.0+2ce9a46b512c6f859a00536704767e4fa813be88` | `9D74D285F3E2A878F4676EF2C52502DC842CCFAFE55093C45EEB3F86D595C905` |
+| ModuleFast | `1.0.0-beta1` | `CC2F05A9D6C60D0FF5FBBEC7405B7C644F03BAB1EED5F3F58AF8D438657AF9E3` |
+
+The requested root packages downloaded from both endpoints were byte-identical:
+
+| Package | Bytes | SHA-256 |
+| --- | ---: | --- |
+| PSScriptAnalyzer 1.25.0 | 14,658,674 | `14E634C828EB98EFB9F40B2918BA90F139ED5ECCDF663A2A747736D996995D60` |
+| Microsoft.Graph 2.29.1 | 17,463 | `29844C04C2B69C536691C868B9F787A785FF508B9795AE4638E71C5D6F3FA9C8` |
+| Az 14.0.0 | 41,951 | `BE8743551FC08A71DB04056FE03D795DD99AEC377313B0D002F04860A5B34709` |
+
+### Windows PowerShell 5.1
+
+Run `20260716-093024-d11767ac` used the same PowerForge commit under
+Windows PowerShell 5.1.26100.8655. All 18 measured PowerForge installs
+succeeded. ModuleFast does not support this host, so one lane per scenario was
+recorded as `Skipped`, not failed or silently omitted.
+
+| Workload | Samples | PowerForge median | ModuleFast |
+| --- | ---: | ---: | --- |
+| PSScriptAnalyzer 1.25.0 | 6 | 1.12 s | Unsupported / skipped |
+| Microsoft.Graph 2.29.1 | 6 | 4.56 s | Unsupported / skipped |
+| Az 14.0.0 | 6 | 4.59 s | Unsupported / skipped |
+
+The pinned net472 PSPublishModule binary SHA-256 was
+`0619D590ABDA7B415D4204CBEA4FB283B1D6B4AD7D493E75B0AB1656637B944E`.
+Each run's `metadata.json` records these versions and hashes under the
+`benchmark.*` keys together with the source endpoints and comparison mode.
+
+To reproduce the exact net472 lane, start Windows PowerShell 5.1, import the
+net472 PSPublishModule binary, and use a short artifact root to stay within the
+legacy host's path limits:
+
+```powershell
+Import-Module .\PSPublishModule\bin\Release\net472\PSPublishModule.dll -Force
+Invoke-BenchmarkSuite `
+    -Path .\Benchmarks\ManagedModules\managed-modules.benchmark.ps1 `
+    -OutputRoot "$env:TEMP\pf-managed-ps51" `
+    -Scenario SingleModule, Graph, Az `
+    -Operation Install `
+    -Engine Managed, ModuleFast `
+    -Host Desktop `
+    -WarmupCount 0 `
+    -IterationCount 6 `
+    -Variable @{
+        ManagedModulePath = (Resolve-Path .\PSPublishModule\bin\Release\net472\PSPublishModule.dll).Path
+        ModuleFastPath = 'C:\Modules\ModuleFast\1.0.0\ModuleFast.psd1'
+    }
+```
 
 ## Native Provider Installs
 
@@ -134,8 +226,9 @@ The suite writes artifacts under `Ignore\Benchmarks\ManagedModules` by default:
 - `metadata.json`
 - `run-report.json`
 
-The suite also declares the root `README.MD` benchmark block, so a normal run can
-refresh the managed-module table directly. To inspect the planned lanes without
+Focused runs leave the root `README.MD` unchanged. To intentionally refresh its
+declared benchmark block after a representative full-matrix run, pass
+`-Variable @{ UpdateReadme = $true }`. To inspect the planned lanes without
 running network or install work:
 
 ```powershell

--- a/Benchmarks/ManagedModules/managed-modules.benchmark.ps1
+++ b/Benchmarks/ManagedModules/managed-modules.benchmark.ps1
@@ -3,6 +3,7 @@ $repositoryName = input RepositoryName PSGallery
 $repositoryUri = input RepositoryUri 'https://www.powershellgallery.com/api/v3/index.json'
 $moduleFastSource = input ModuleFastSource 'https://pwsh.gallery/index.json'
 $moduleFastModulePath = input ModuleFastPath
+$managedModulePath = input ManagedModulePath
 
 benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\ManagedModules') {
     policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
@@ -23,7 +24,9 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
         $run.RepositoryUri = $repositoryUri
         $run.ModuleFastSource = $moduleFastSource
         $run.ModuleFastModulePath = $moduleFastModulePath
-        $hashBytes = [System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($run.OutputDirectory))
+        $run.ManagedModulePath = $managedModulePath
+        $workKey = "$repositoryRoot|$PID|$($case.ModuleName)|$($case.Engine)|$($case.Operation)|$($case.Host)"
+        $hashBytes = [System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($workKey))
         $hash = [System.BitConverter]::ToString($hashBytes).Replace('-', '').Substring(0, 12).ToLowerInvariant()
         $run.WorkRoot = Join-Path ([System.IO.Path]::GetTempPath()) "pf-mm-$hash"
         $run.InstallRoot = Join-Path $run.WorkRoot 'installed'
@@ -34,6 +37,19 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
             Remove-Item -LiteralPath $run.WorkRoot -Recurse -Force
         }
         New-Item -ItemType Directory -Path $run.InstallRoot, $run.SaveRoot, $run.PackageCacheRoot -Force | Out-Null
+
+        if ($case.Engine -eq 'Managed' -and $run.ManagedModulePath -and $run.ManagedModulePath.Trim()) {
+            Import-Module -Name $run.ManagedModulePath -Force -ErrorAction Stop
+            $run.ManagedCommandPath = [System.IO.Path]::GetFullPath([string] (Get-Command Install-ManagedModule -ErrorAction Stop).DLL)
+        } elseif ($case.Engine -eq 'ModuleFast') {
+            Remove-Module ModuleFast -Force -ErrorAction SilentlyContinue
+            if ($run.ModuleFastModulePath -and $run.ModuleFastModulePath.Trim()) {
+                Import-Module -Name $run.ModuleFastModulePath -Force -ErrorAction Stop
+            } else {
+                Import-Module ModuleFast -Force -ErrorAction Stop
+            }
+            Clear-ModuleFastCache
+        }
     }
 
     skip {
@@ -85,7 +101,6 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
                 -RepositoryName $run.RepositoryName `
                 -Scope Custom `
                 -ModuleRoot $run.InstallRoot `
-                -PackageCacheDirectory $run.PackageCacheRoot `
                 -AcceptLicense:$case.AcceptLicense `
                 -AllowClobber `
                 -Force
@@ -111,17 +126,12 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
         operation Install {
             param($case, $run)
 
-            Remove-Module ModuleFast -Force -ErrorAction SilentlyContinue
-            if ($run.ModuleFastModulePath -and $run.ModuleFastModulePath.Trim()) {
-                Import-Module -Name $run.ModuleFastModulePath -Force
-            } else {
-                Import-Module ModuleFast -ErrorAction Stop
-            }
-
             Install-ModuleFast "$($case.ModuleName)=$($case.Version)" `
                 -Destination $run.InstallRoot `
                 -Source $run.ModuleFastSource `
-                -NoPSModulePathUpdate | Out-Null
+                -DestinationOnly `
+                -NoPSModulePathUpdate `
+                -Confirm:$false | Out-Null
         }
     }
 
@@ -183,7 +193,15 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
             default { return }
         }
 
-        assertPath (Join-Path $root $case.ModuleName)
+        $moduleRoot = Join-Path $root $case.ModuleName
+        assertPath $moduleRoot
+        $manifests = @(Get-ChildItem -LiteralPath $moduleRoot -Recurse -File -Filter "$($case.ModuleName).psd1")
+        assertValue -Actual $manifests.Count -Expected 1 -Message 'Expected exactly one requested module manifest.'
+        $manifest = Import-PowerShellDataFile -Path $manifests[0].FullName
+        assertValue -Actual ([string] $manifest.ModuleVersion) -Expected $case.Version -Message 'Installed manifest version must match the requested exact version.'
+        if ($case.Engine -eq 'Managed' -and $run.ManagedModulePath -and $run.ManagedModulePath.Trim()) {
+            assertValue -Actual $run.ManagedCommandPath -Expected ([System.IO.Path]::GetFullPath($run.ManagedModulePath)) -Message 'Managed benchmark must use the pinned PSPublishModule binary.'
+        }
     }
 
     metric DependencyCount {
@@ -194,6 +212,20 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
         }
 
         return $run.ManagedResult.DependenciesInstalled.Count
+    }
+
+    metric InstalledFileCount {
+        param($case, $run)
+
+        $root = if ($case.Operation -eq 'Save') { $run.SaveRoot } else { $run.InstallRoot }
+        return @(Get-ChildItem -LiteralPath $root -Recurse -File).Count
+    }
+
+    metric InstalledBytes {
+        param($case, $run)
+
+        $root = if ($case.Operation -eq 'Save') { $run.SaveRoot } else { $run.InstallRoot }
+        return [long] ((Get-ChildItem -LiteralPath $root -Recurse -File | Measure-Object -Property Length -Sum).Sum)
     }
 
     comparison Engine -Baseline Managed -Metric MedianMs

--- a/Benchmarks/ManagedModules/managed-modules.benchmark.ps1
+++ b/Benchmarks/ManagedModules/managed-modules.benchmark.ps1
@@ -4,8 +4,50 @@ $repositoryUri = input RepositoryUri 'https://www.powershellgallery.com/api/v3/i
 $moduleFastSource = input ModuleFastSource 'https://pwsh.gallery/index.json'
 $moduleFastModulePath = input ModuleFastPath
 $managedModulePath = input ManagedModulePath
+$updateReadme = inputBool UpdateReadme $false
+$comparisonMode = if ($repositoryUri.TrimEnd('/') -eq $moduleFastSource.TrimEnd('/')) { 'IdenticalFeed' } else { 'DefaultSources' }
+
+$managedArtifactPath = if ($managedModulePath -and $managedModulePath.Trim()) {
+    [System.IO.Path]::GetFullPath($managedModulePath)
+} else {
+    [System.IO.Path]::GetFullPath([string] (Get-Command Install-ManagedModule -ErrorAction Stop).DLL)
+}
+$managedArtifactVersion = $null
+$managedArtifactSha256 = $null
+if (Test-Path -LiteralPath $managedArtifactPath -PathType Leaf) {
+    $managedArtifactVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($managedArtifactPath).ProductVersion
+    $managedArtifactSha256 = (Get-FileHash -LiteralPath $managedArtifactPath -Algorithm SHA256).Hash
+}
+
+$moduleFastManifestPath = if ($moduleFastModulePath -and $moduleFastModulePath.Trim()) {
+    [System.IO.Path]::GetFullPath($moduleFastModulePath)
+} else {
+    [string] (Get-Module -ListAvailable -Name ModuleFast | Sort-Object Version -Descending | Select-Object -First 1).Path
+}
+$moduleFastVersion = $null
+$moduleFastSha256 = $null
+if ($moduleFastManifestPath -and (Test-Path -LiteralPath $moduleFastManifestPath -PathType Leaf)) {
+    $moduleFastManifest = Import-PowerShellDataFile -LiteralPath $moduleFastManifestPath
+    $moduleFastVersion = [string] $moduleFastManifest.ModuleVersion
+    $moduleFastPrerelease = $moduleFastManifest.PrivateData.PSData['Prerelease']
+    if ($moduleFastPrerelease) {
+        $moduleFastVersion += '-' + [string] $moduleFastPrerelease
+    }
+    $moduleFastBinaryPath = Join-Path (Split-Path -Parent $moduleFastManifestPath) 'ModuleFast.dll'
+    if (Test-Path -LiteralPath $moduleFastBinaryPath -PathType Leaf) {
+        $moduleFastSha256 = (Get-FileHash -LiteralPath $moduleFastBinaryPath -Algorithm SHA256).Hash
+    }
+}
 
 benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\ManagedModules') {
+    metadata ComparisonMode $comparisonMode
+    metadata ManagedRepositoryUri $repositoryUri
+    metadata ModuleFastSource $moduleFastSource
+    if ($managedArtifactVersion) { metadata ManagedModuleVersion $managedArtifactVersion }
+    if ($managedArtifactSha256) { metadata ManagedModuleSha256 $managedArtifactSha256 }
+    if ($moduleFastVersion) { metadata ModuleFastVersion $moduleFastVersion }
+    if ($moduleFastSha256) { metadata ModuleFastSha256 $moduleFastSha256 }
+
     policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
     profile Current -Cleanup KeepOnFailure
     caseSource @(
@@ -25,7 +67,7 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
         $run.ModuleFastSource = $moduleFastSource
         $run.ModuleFastModulePath = $moduleFastModulePath
         $run.ManagedModulePath = $managedModulePath
-        $workKey = "$repositoryRoot|$PID|$($case.ModuleName)|$($case.Engine)|$($case.Operation)|$($case.Host)"
+        $workKey = "$repositoryRoot|$PID|$($run.RunId)|$($run.Iteration)|$($case.ModuleName)|$($case.Engine)|$($case.Operation)|$($case.Host)"
         $hashBytes = [System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($workKey))
         $hash = [System.BitConverter]::ToString($hashBytes).Replace('-', '').Substring(0, 12).ToLowerInvariant()
         $run.WorkRoot = Join-Path ([System.IO.Path]::GetTempPath()) "pf-mm-$hash"
@@ -39,14 +81,23 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
         New-Item -ItemType Directory -Path $run.InstallRoot, $run.SaveRoot, $run.PackageCacheRoot -Force | Out-Null
 
         if ($case.Engine -eq 'Managed' -and $run.ManagedModulePath -and $run.ManagedModulePath.Trim()) {
-            Import-Module -Name $run.ManagedModulePath -Force -ErrorAction Stop
+            $requestedManagedPath = [System.IO.Path]::GetFullPath($run.ManagedModulePath)
+            $run.ManagedExpectedSha256 = (Get-FileHash -LiteralPath $requestedManagedPath -Algorithm SHA256).Hash
+            Import-Module -Name $requestedManagedPath -Force -ErrorAction Stop
             $run.ManagedCommandPath = [System.IO.Path]::GetFullPath([string] (Get-Command Install-ManagedModule -ErrorAction Stop).DLL)
+            $run.ManagedCommandSha256 = (Get-FileHash -LiteralPath $run.ManagedCommandPath -Algorithm SHA256).Hash
         } elseif ($case.Engine -eq 'ModuleFast') {
             Remove-Module ModuleFast -Force -ErrorAction SilentlyContinue
             if ($run.ModuleFastModulePath -and $run.ModuleFastModulePath.Trim()) {
                 Import-Module -Name $run.ModuleFastModulePath -Force -ErrorAction Stop
             } else {
                 Import-Module ModuleFast -Force -ErrorAction Stop
+            }
+            if ($run.ModuleFastModulePath -and $run.ModuleFastModulePath.Trim()) {
+                $expectedModuleFastBinary = Join-Path (Split-Path -Parent ([System.IO.Path]::GetFullPath($run.ModuleFastModulePath))) 'ModuleFast.dll'
+                $loadedModuleFastBinary = Join-Path (Get-Module ModuleFast -ErrorAction Stop).ModuleBase 'ModuleFast.dll'
+                $run.ModuleFastExpectedSha256 = (Get-FileHash -LiteralPath $expectedModuleFastBinary -Algorithm SHA256).Hash
+                $run.ModuleFastCommandSha256 = (Get-FileHash -LiteralPath $loadedModuleFastBinary -Algorithm SHA256).Hash
             }
             Clear-ModuleFastCache
         }
@@ -200,7 +251,10 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
         $manifest = Import-PowerShellDataFile -Path $manifests[0].FullName
         assertValue -Actual ([string] $manifest.ModuleVersion) -Expected $case.Version -Message 'Installed manifest version must match the requested exact version.'
         if ($case.Engine -eq 'Managed' -and $run.ManagedModulePath -and $run.ManagedModulePath.Trim()) {
-            assertValue -Actual $run.ManagedCommandPath -Expected ([System.IO.Path]::GetFullPath($run.ManagedModulePath)) -Message 'Managed benchmark must use the pinned PSPublishModule binary.'
+            assertValue -Actual $run.ManagedCommandSha256 -Expected $run.ManagedExpectedSha256 -Message 'Managed benchmark must use the pinned PSPublishModule binary bytes.'
+        }
+        if ($case.Engine -eq 'ModuleFast' -and $run.ModuleFastModulePath -and $run.ModuleFastModulePath.Trim()) {
+            assertValue -Actual $run.ModuleFastCommandSha256 -Expected $run.ModuleFastExpectedSha256 -Message 'ModuleFast benchmark must use the pinned ModuleFast binary bytes.'
         }
     }
 
@@ -229,6 +283,8 @@ benchmark 'managed-modules' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\M
     }
 
     comparison Engine -Baseline Managed -Metric MedianMs
-    readme (Join-Path $repositoryRoot 'README.MD') -Block 'managed-module-benchmark-table' -Renderer ComparisonTable
+    if ($updateReadme) {
+        readme (Join-Path $repositoryRoot 'README.MD') -Block 'managed-module-benchmark-table' -Renderer ComparisonTable
+    }
     artifacts Json, Csv, Markdown
 }

--- a/Docs/PSPublishModule.Benchmarking.md
+++ b/Docs/PSPublishModule.Benchmarking.md
@@ -96,6 +96,7 @@ engine as tied. Omitting it preserves exact ranking.
 | `skip` | `Add-BenchmarkSkipRule` |
 | `validate` | `Add-BenchmarkValidation` |
 | `metric` | `Add-BenchmarkMetric` |
+| `metadata` | `Add-BenchmarkMetadata` |
 | `comparison` | `Add-BenchmarkComparison` |
 | `readme` | `Add-BenchmarkReadmeBlock` |
 | `artifacts` | `Set-BenchmarkArtifacts` |
@@ -132,6 +133,24 @@ benchmark 'sql-import' {
 
 Input helpers keep benchmark files focused on benchmark intent. Use `-Required`
 when a value has no safe default.
+
+### Benchmark Provenance
+
+Use `metadata` for suite-specific provenance that should travel with every
+artifact, such as the exact compared product versions, binary hashes, source
+endpoints, or comparison mode:
+
+```powershell
+benchmark 'installer-race' {
+    metadata ComparisonMode 'DefaultSources'
+    metadata ToolVersion '1.0.0-beta1'
+    metadata ToolSha256 '0123456789ABCDEF'
+}
+```
+
+Declared values are written to `metadata.json`, the returned run metadata, and
+`run-report.json` with a `benchmark.` prefix. Duplicate names and empty values
+are rejected so a benchmark cannot silently replace its own provenance.
 
 ## Running A Suite
 

--- a/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
+++ b/PSPublishModule/Cmdlets/BenchmarkDslCommands.cs
@@ -432,6 +432,28 @@ public sealed class AddBenchmarkMetricCommand : BenchmarkDslCommand
 }
 
 /// <summary>
+/// Adds a suite-specific provenance value to benchmark metadata artifacts.
+/// </summary>
+[Cmdlet(VerbsCommon.Add, "BenchmarkMetadata")]
+[Alias("metadata")]
+public sealed class AddBenchmarkMetadataCommand : BenchmarkDslCommand
+{
+    /// <summary>Metadata name.</summary>
+    [Parameter(Mandatory = true, Position = 0)]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Metadata value.</summary>
+    [Parameter(Mandatory = true, Position = 1)]
+    [ValidateNotNullOrEmpty]
+    public string Value { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    protected override void ProcessRecord()
+        => PowerShellBenchmarkDslRuntime.Metadata(Name, Value);
+}
+
+/// <summary>
 /// Adds a benchmark comparison definition.
 /// </summary>
 [Cmdlet(VerbsCommon.Add, "BenchmarkComparison")]

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.Metadata.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.Metadata.cs
@@ -1,0 +1,20 @@
+namespace PowerForge;
+
+public static partial class PowerShellBenchmarkDslRuntime
+{
+    /// <summary>
+    /// Adds a suite-specific provenance value to benchmark metadata artifacts.
+    /// </summary>
+    /// <param name="name">Metadata name without the artifact's <c>benchmark.</c> prefix.</param>
+    /// <param name="value">Metadata value.</param>
+    public static void Metadata(string name, string value)
+    {
+        var suite = RequireSuite();
+        var metadataName = RequireName(name, "metadata name");
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Benchmark metadata value is required.", nameof(value));
+        if (suite.Metadata.ContainsKey(metadataName))
+            throw new InvalidOperationException($"Benchmark suite '{suite.Name}' already defines metadata '{metadataName}'.");
+        suite.Metadata.Add(metadataName, value.Trim());
+    }
+}

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkDslRuntime.cs
@@ -10,7 +10,7 @@ namespace PowerForge;
 /// <summary>
 /// Runtime used by locally scoped benchmark DSL helper functions.
 /// </summary>
-public static class PowerShellBenchmarkDslRuntime
+public static partial class PowerShellBenchmarkDslRuntime
 {
     private static readonly AsyncLocal<PowerShellBenchmarkDslContext?> Current = new();
 
@@ -548,6 +548,7 @@ try {
             ["engine"] = Call("Engine", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
             ["operation"] = Call("Operation", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
             ["metric"] = Call("Metric", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
+            ["metadata"] = Call("Metadata", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [string] $Value)", "[object[]] @($Name, $Value)"),
             ["compare"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance, [switch] $RequireBaselineFastest) $arguments = [object[]]::new(5); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; $arguments[4] = $RequireBaselineFastest.IsPresent; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
             ["comparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance, [switch] $RequireBaselineFastest) $arguments = [object[]]::new(5); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; $arguments[4] = $RequireBaselineFastest.IsPresent; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
             ["readme"] = Call("Readme", "param([Parameter(Position=0)] [string] $Path, [string] $Block, [string] $Renderer)", "[object[]] @($Path, $Block, $Renderer)"),
@@ -572,6 +573,7 @@ try {
             ["Add-BenchmarkSkipRule"] = Call("Skip", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Add-BenchmarkValidation"] = Call("Validate", "param([Parameter(Position=0)] [scriptblock] $ScriptBlock)", "[object[]] @($ScriptBlock)"),
             ["Add-BenchmarkMetric"] = Call("Metric", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [scriptblock] $ScriptBlock)", "[object[]] @($Name, $ScriptBlock)"),
+            ["Add-BenchmarkMetadata"] = Call("Metadata", "param([Parameter(Position=0)] [string] $Name, [Parameter(Position=1)] [string] $Value)", "[object[]] @($Name, $Value)"),
             ["Add-BenchmarkComparison"] = "param([Parameter(Position=0)] [string] $Dimension, [string] $Baseline, [string[]] $Metric, [ValidateRange(0, [double]::MaxValue)] [double] $TieTolerance, [switch] $RequireBaselineFastest) $arguments = [object[]]::new(5); $arguments[0] = $Dimension; $arguments[1] = $Baseline; $arguments[2] = $Metric; $arguments[3] = $TieTolerance; $arguments[4] = $RequireBaselineFastest.IsPresent; __PowerForgeBenchmarkDslInvoke -Name 'Compare' -Arguments $arguments",
             ["Add-BenchmarkReadmeBlock"] = Call("Readme", "param([Parameter(Position=0)] [string] $Path, [string] $Block, [string] $Renderer)", "[object[]] @($Path, $Block, $Renderer)"),
             ["Set-BenchmarkArtifacts"] = "param([Parameter(ValueFromRemainingArguments=$true)] [object[]] $Values) $arguments = [object[]]::new(1); $arguments[0] = $Values; __PowerForgeBenchmarkDslInvoke -Name 'Artifacts' -Arguments $arguments",

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkEnvironmentMetadata.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkEnvironmentMetadata.cs
@@ -40,6 +40,8 @@ internal static class PowerShellBenchmarkEnvironmentMetadata
             ["outlierMode"] = suite.OutlierMode.ToString(),
             ["runMode"] = suite.RunMode
         };
+        foreach (var item in suite.Metadata)
+            metadata["benchmark." + item.Key] = item.Value;
         AddMetadata(metadata, "gitSha", ReadGitValue("rev-parse HEAD"));
         AddMetadata(metadata, "gitBranch", ReadGitValue("branch --show-current"));
         return metadata;
@@ -52,7 +54,7 @@ internal static class PowerShellBenchmarkEnvironmentMetadata
     }
 
     private static string PSVersionInfo()
-        => Convert.ToString(PSObject.AsPSObject(typeof(PSObject).Assembly.GetName().Version).BaseObject, CultureInfo.InvariantCulture) ?? string.Empty;
+        => Convert.ToString(PSVersionInfoValue("PSVersion"), CultureInfo.InvariantCulture) ?? string.Empty;
 
     private static object? PSVersionInfoValue(string name)
     {

--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkModels.cs
@@ -109,6 +109,9 @@ public sealed class PowerShellBenchmarkSuite
     /// <summary>Cleanup behavior for benchmark-owned temporary environment state.</summary>
     public PowerShellBenchmarkCleanupMode Cleanup { get; set; } = PowerShellBenchmarkCleanupMode.Always;
 
+    /// <summary>Suite-specific provenance written to benchmark metadata artifacts.</summary>
+    public Dictionary<string, string> Metadata { get; } = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Declared benchmark cases.</summary>
     public List<PowerShellBenchmarkCase> Cases { get; } = new();
 

--- a/PowerForge.Tests/BenchmarkServicesTests.Metadata.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Metadata.cs
@@ -10,8 +10,7 @@ public sealed partial class BenchmarkServicesTests
         var metadata = PowerShellBenchmarkEnvironmentMetadata.Build(new PowerShellBenchmarkSuite { Name = "host" });
         var host = PowerShellBenchmarkHostRuntime.GetCurrentHostLabel();
 
-        Assert.EndsWith(metadata["pwsh"], host, StringComparison.OrdinalIgnoreCase);
-        Assert.StartsWith(metadata["psEdition"], host, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal($"{metadata["psEdition"]}-{metadata["pwsh"]}", host, ignoreCase: true);
     }
 
     [Fact]

--- a/PowerForge.Tests/BenchmarkServicesTests.Metadata.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Metadata.cs
@@ -1,0 +1,39 @@
+using PowerForge;
+
+namespace PowerForge.Tests;
+
+public sealed partial class BenchmarkServicesTests
+{
+    [Fact]
+    public void BenchmarkEnvironmentMetadata_RecordsThePowerShellHostVersion()
+    {
+        var metadata = PowerShellBenchmarkEnvironmentMetadata.Build(new PowerShellBenchmarkSuite { Name = "host" });
+        var host = PowerShellBenchmarkHostRuntime.GetCurrentHostLabel();
+
+        Assert.EndsWith(metadata["pwsh"], host, StringComparison.OrdinalIgnoreCase);
+        Assert.StartsWith(metadata["psEdition"], host, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BenchmarkDsl_WritesDeclaredProvenanceToMetadataArtifact()
+    {
+        var root = CreateTempRoot();
+        var escapedRoot = root.Replace("'", "''");
+        var script = System.Management.Automation.ScriptBlock.Create($$"""
+benchmark 'metadata' -out '{{escapedRoot}}' {
+    policy -Warmup 0 -Iterations 1
+    metadata ToolVersion '1.2.3-beta1'
+    axis Operation Run
+    engine Managed { operation Run { param($case, $run) } }
+}
+""");
+
+        var suite = Assert.Single(EvaluateBenchmarkDsl(script));
+        var result = new PowerShellBenchmarkRunner().Run(suite);
+        var artifact = BenchmarkJson.Read<Dictionary<string, string>>(result.Artifacts["metadata.json"]);
+
+        Assert.Equal("1.2.3-beta1", suite.Metadata["ToolVersion"]);
+        Assert.Equal("1.2.3-beta1", result.Metadata["benchmark.ToolVersion"]);
+        Assert.Equal("1.2.3-beta1", artifact["benchmark.ToolVersion"]);
+    }
+}

--- a/PowerForge.Tests/ManagedModuleArchiveExtractorTests.cs
+++ b/PowerForge.Tests/ManagedModuleArchiveExtractorTests.cs
@@ -108,6 +108,46 @@ public sealed class ManagedModuleArchiveExtractorTests
         Assert.True(File.Exists(Path.Combine(destination, "Company.Tools.psm1")));
         Assert.False(File.Exists(Path.Combine(destination, "Company.Tools", "Company.Tools.psd1")));
     }
+
+    [Fact]
+    public async Task ExtractPackageAsync_honors_cancellation_before_writing_payload()
+    {
+        using var temp = new TemporaryDirectory();
+        var packagePath = Path.Combine(temp.Path, "Company.Tools.1.0.0.nupkg");
+        var destination = Path.Combine(temp.Path, "out");
+        CreatePackageWithPackageFolder(packagePath);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await using var stream = File.OpenRead(packagePath);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new ManagedModuleArchiveExtractor().ExtractPackageAsync(stream, destination, cancellation.Token));
+
+        Assert.Empty(Directory.EnumerateFiles(destination, "*", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public void ExtractBufferedPackage_preserves_multi_entry_payload_contents()
+    {
+        using var temp = new TemporaryDirectory();
+        var packagePath = Path.Combine(temp.Path, "Company.Tools.1.0.0.nupkg");
+        var destination = Path.Combine(temp.Path, "out");
+        CreatePackageWithMultiEntryPayload(packagePath);
+        var packageBytes = File.ReadAllBytes(packagePath);
+        using var stream = new MemoryStream(packageBytes.Length);
+        stream.Write(packageBytes, 0, packageBytes.Length);
+        stream.Position = 0;
+
+        var result = new ManagedModuleArchiveExtractor().ExtractBufferedPackage(
+            stream,
+            destination,
+            "Company.Tools",
+            CancellationToken.None);
+
+        Assert.Equal(12, result.FileCount);
+        for (var index = 0; index < result.FileCount; index++)
+            Assert.Equal($"payload-{index}", File.ReadAllText(Path.Combine(destination, "payload", $"file-{index}.txt")));
+    }
 #endif
 
     private static void CreatePackageWithPackageFolder(string packagePath)
@@ -134,6 +174,14 @@ public sealed class ManagedModuleArchiveExtractorTests
         using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
         AddEntry(archive, "Company.Tools/Company.Tools.psd1", "@{ ModuleVersion = '1.0.0' }");
         AddEntry(archive, "Company.Tools/Company.Tools.psm1", string.Empty);
+    }
+
+    private static void CreatePackageWithMultiEntryPayload(string packagePath)
+    {
+        using var archive = ZipFile.Open(packagePath, ZipArchiveMode.Create);
+        AddEntry(archive, "Company.Tools.nuspec", TestPackageFactory.CreateNuspec("Company.Tools", "1.0.0"));
+        for (var index = 0; index < 12; index++)
+            AddEntry(archive, $"payload/file-{index}.txt", $"payload-{index}");
     }
 
     private static void AddEntry(ZipArchive archive, string name, string content)

--- a/PowerForge.Tests/ManagedModuleBenchmarkSuiteTests.cs
+++ b/PowerForge.Tests/ManagedModuleBenchmarkSuiteTests.cs
@@ -78,6 +78,29 @@ public sealed class ManagedModuleBenchmarkSuiteTests
     }
 
     [Fact]
+    public void ManagedModuleSuite_InstallComparisonKeepsProviderSetupOutOfMeasuredHandlers()
+    {
+        var path = Path.Combine(RepoRootLocator.Find(), "Benchmarks", "ManagedModules", "managed-modules.benchmark.ps1");
+        var text = File.ReadAllText(path);
+        var setupStart = text.IndexOf("    setup {", StringComparison.Ordinal);
+        var setupEnd = text.IndexOf("    skip {", StringComparison.Ordinal);
+        var setup = text.Substring(setupStart, setupEnd - setupStart);
+        var managedStart = text.IndexOf("    engine Managed {", StringComparison.Ordinal);
+        var managedEnd = text.IndexOf("        operation Save {", managedStart, StringComparison.Ordinal);
+        var managedInstall = text.Substring(managedStart, managedEnd - managedStart);
+        var moduleFastStart = text.IndexOf("    engine ModuleFast {", StringComparison.Ordinal);
+        var moduleFastEnd = text.IndexOf("    engine PSResourceGet {", moduleFastStart, StringComparison.Ordinal);
+        var moduleFastInstall = text.Substring(moduleFastStart, moduleFastEnd - moduleFastStart);
+
+        Assert.Contains("Import-Module", setup, StringComparison.Ordinal);
+        Assert.Contains("Clear-ModuleFastCache", setup, StringComparison.Ordinal);
+        Assert.Contains("ManagedCommandPath", setup, StringComparison.Ordinal);
+        Assert.DoesNotContain("PackageCacheDirectory", managedInstall, StringComparison.Ordinal);
+        Assert.DoesNotContain("Import-Module", moduleFastInstall, StringComparison.Ordinal);
+        Assert.Contains("DestinationOnly", moduleFastInstall, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ManagedModuleSuite_ExplicitHostSelectionKeepsHostMatrix()
     {
         var suite = LoadSuite(new PowerShellBenchmarkSelection

--- a/PowerForge.Tests/ManagedModuleBenchmarkSuiteTests.cs
+++ b/PowerForge.Tests/ManagedModuleBenchmarkSuiteTests.cs
@@ -28,11 +28,14 @@ public sealed class ManagedModuleBenchmarkSuiteTests
         var text = File.ReadAllText(path);
         var lines = File.ReadLines(path).Where(static line => !string.IsNullOrWhiteSpace(line)).Count();
 
-        Assert.True(lines <= 210, "Managed module benchmark spec should stay readable and data-driven.");
+        Assert.True(lines <= 245, "Managed module benchmark spec should stay readable and data-driven.");
         Assert.Contains("benchmark 'managed-modules'", text, StringComparison.Ordinal);
         Assert.Contains("caseSource", text, StringComparison.Ordinal);
         Assert.Contains("engine Managed", text, StringComparison.Ordinal);
         Assert.Contains("operation Install", text, StringComparison.Ordinal);
+        Assert.Contains("metadata ComparisonMode", text, StringComparison.Ordinal);
+        Assert.Contains("ManagedModuleSha256", text, StringComparison.Ordinal);
+        Assert.Contains("ModuleFastSha256", text, StringComparison.Ordinal);
         Assert.DoesNotContain("ModuleFastCSharp", text, StringComparison.Ordinal);
         Assert.DoesNotContain("New-ManagedModuleBenchmarkSuite", text, StringComparison.Ordinal);
         Assert.DoesNotContain("Invoke-BenchmarkSuite", text, StringComparison.Ordinal);
@@ -94,10 +97,27 @@ public sealed class ManagedModuleBenchmarkSuiteTests
 
         Assert.Contains("Import-Module", setup, StringComparison.Ordinal);
         Assert.Contains("Clear-ModuleFastCache", setup, StringComparison.Ordinal);
-        Assert.Contains("ManagedCommandPath", setup, StringComparison.Ordinal);
+        Assert.Contains("$run.RunId", setup, StringComparison.Ordinal);
+        Assert.Contains("$run.Iteration", setup, StringComparison.Ordinal);
+        Assert.Contains("ManagedCommandSha256", setup, StringComparison.Ordinal);
+        Assert.Contains("ModuleFastCommandSha256", setup, StringComparison.Ordinal);
         Assert.DoesNotContain("PackageCacheDirectory", managedInstall, StringComparison.Ordinal);
         Assert.DoesNotContain("Import-Module", moduleFastInstall, StringComparison.Ordinal);
         Assert.Contains("DestinationOnly", moduleFastInstall, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManagedModuleSuite_OnlyUpdatesRootReadmeWhenExplicitlyRequested()
+    {
+        var normal = LoadSuite();
+        var publishing = LoadSuite(variables: new Dictionary<string, string?>
+        {
+            ["UpdateReadme"] = "true"
+        });
+
+        Assert.Empty(normal.ReadmeBlocks);
+        var block = Assert.Single(publishing.ReadmeBlocks);
+        Assert.Equal("managed-module-benchmark-table", block.BlockId);
     }
 
     [Fact]

--- a/PowerForge/Services/ManagedModules/ManagedModuleArchiveExtractor.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleArchiveExtractor.cs
@@ -7,6 +7,10 @@ namespace PowerForge;
 internal sealed class ManagedModuleArchiveExtractor
 {
     private const int CopyBufferSize = 1024 * 1024;
+    private const int ParallelExtractionFileThreshold = 8;
+    private const int MaximumParallelExtractionFiles = 256;
+    private const int MaximumParallelExtraction = 4;
+    private const long ParallelExtractionByteThreshold = 64L * 1024 * 1024;
     private static readonly string[] PackageMetadataPrefixes = { "_rels/", "package/services/metadata/" };
     private static readonly string[] PackageMetadataFiles = { "[Content_Types].xml", ".signature.p7s" };
 
@@ -20,53 +24,33 @@ internal sealed class ManagedModuleArchiveExtractor
         if (string.IsNullOrWhiteSpace(destinationPath))
             throw new ArgumentException("Destination path is required.", nameof(destinationPath));
 
-        Directory.CreateDirectory(destinationPath);
-        var destinationRoot = Path.GetFullPath(destinationPath);
-        var createdDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            destinationRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-        };
-        var fileCount = 0;
-        long bytesWritten = 0;
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-
         using var archive = ZipFile.OpenRead(packagePath);
-        var packageRoot = ResolvePackageRootFolder(archive, packageId);
-        foreach (var entry in archive.Entries)
-        {
-            var normalized = Normalize(entry.FullName);
-            if (string.IsNullOrWhiteSpace(normalized) || IsPackageMetadata(normalized))
-                continue;
-            if (!IsSafePath(normalized))
-                throw new InvalidOperationException($"Package contains unsafe path '{entry.FullName}'.");
-
-            var extractionPath = TrimPackageRootFolder(normalized, packageRoot);
-            if (string.IsNullOrWhiteSpace(extractionPath) || IsPackageMetadata(extractionPath))
-                continue;
-
-            var targetPath = Path.GetFullPath(Path.Combine(destinationRoot, extractionPath.Replace('/', Path.DirectorySeparatorChar)));
-            if (!IsInsideDirectory(destinationRoot, targetPath))
-                throw new InvalidOperationException($"Package entry '{entry.FullName}' escapes the destination directory.");
-
-            if (entry.FullName.EndsWith("/", StringComparison.Ordinal) || entry.FullName.EndsWith("\\", StringComparison.Ordinal))
-            {
-                EnsureDirectory(targetPath, createdDirectories);
-                continue;
-            }
-
-            EnsureDirectory(Path.GetDirectoryName(targetPath)!, createdDirectories);
-            using var source = entry.Open();
-            using var destination = new FileStream(targetPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, CopyBufferSize, FileOptions.SequentialScan);
-            source.CopyTo(destination, CopyBufferSize);
-            fileCount++;
-            bytesWritten += destination.Length;
-        }
-
-        stopwatch.Stop();
-        return new ManagedModuleArchiveExtractionResult(fileCount, bytesWritten, stopwatch.Elapsed, fromCache: false, cacheLockWaitElapsed: TimeSpan.Zero);
+        return ExtractArchive(archive, destinationPath, packageId, CancellationToken.None);
     }
 
 #if !NET472
+    public ManagedModuleArchiveExtractionResult ExtractBufferedPackage(
+        MemoryStream packageStream,
+        string destinationPath,
+        string? packageId,
+        CancellationToken cancellationToken)
+    {
+        ValidateBufferedPackageArguments(packageStream, destinationPath);
+        using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
+        if (ShouldExtractBufferedPackageInParallel(archive) && packageStream.TryGetBuffer(out var packageBuffer))
+        {
+            return ExtractBufferedPackageInParallel(
+                packageBuffer,
+                checked((int)packageStream.Length),
+                archive,
+                destinationPath,
+                packageId,
+                cancellationToken);
+        }
+
+        return ExtractArchive(archive, destinationPath, packageId, cancellationToken);
+    }
+
     public Task<ManagedModuleArchiveExtractionResult> ExtractPackageAsync(
         Stream packageStream,
         string destinationPath,
@@ -79,11 +63,17 @@ internal sealed class ManagedModuleArchiveExtractor
         string? packageId,
         CancellationToken cancellationToken)
     {
-        if (packageStream is null)
-            throw new ArgumentNullException(nameof(packageStream));
-        if (string.IsNullOrWhiteSpace(destinationPath))
-            throw new ArgumentException("Destination path is required.", nameof(destinationPath));
+        ValidateBufferedPackageArguments(packageStream, destinationPath);
+        using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
+        return await ExtractArchiveAsync(archive, destinationPath, packageId, cancellationToken).ConfigureAwait(false);
+    }
 
+    private static async Task<ManagedModuleArchiveExtractionResult> ExtractArchiveAsync(
+        ZipArchive archive,
+        string destinationPath,
+        string? packageId,
+        CancellationToken cancellationToken)
+    {
         Directory.CreateDirectory(destinationPath);
         var destinationRoot = Path.GetFullPath(destinationPath);
         var createdDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -93,8 +83,6 @@ internal sealed class ManagedModuleArchiveExtractor
         var fileCount = 0;
         long bytesWritten = 0;
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-
-        using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true);
         var packageRoot = ResolvePackageRootFolder(archive, packageId);
         foreach (var entry in archive.Entries)
         {
@@ -136,7 +124,210 @@ internal sealed class ManagedModuleArchiveExtractor
         stopwatch.Stop();
         return new ManagedModuleArchiveExtractionResult(fileCount, bytesWritten, stopwatch.Elapsed, fromCache: false, cacheLockWaitElapsed: TimeSpan.Zero);
     }
+
+    private static void ValidateBufferedPackageArguments(Stream packageStream, string destinationPath)
+    {
+        if (packageStream is null)
+            throw new ArgumentNullException(nameof(packageStream));
+        if (string.IsNullOrWhiteSpace(destinationPath))
+            throw new ArgumentException("Destination path is required.", nameof(destinationPath));
+    }
+
+    private static bool ShouldExtractBufferedPackageInParallel(ZipArchive archive)
+    {
+        var fileCount = 0;
+        long uncompressedBytes = 0;
+        foreach (var entry in archive.Entries)
+        {
+            var normalized = Normalize(entry.FullName);
+            if (string.IsNullOrWhiteSpace(normalized) ||
+                IsPackageMetadata(normalized) ||
+                entry.FullName.EndsWith("/", StringComparison.Ordinal) ||
+                entry.FullName.EndsWith("\\", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            fileCount++;
+            if (fileCount > MaximumParallelExtractionFiles)
+                return false;
+            if (uncompressedBytes < ParallelExtractionByteThreshold)
+                uncompressedBytes += Math.Min(entry.Length, ParallelExtractionByteThreshold - uncompressedBytes);
+        }
+
+        return fileCount >= ParallelExtractionFileThreshold &&
+               uncompressedBytes >= ParallelExtractionByteThreshold &&
+               Environment.ProcessorCount > 1;
+    }
+
+    private static ManagedModuleArchiveExtractionResult ExtractBufferedPackageInParallel(
+        ArraySegment<byte> packageBuffer,
+        int packageLength,
+        ZipArchive archive,
+        string destinationPath,
+        string? packageId,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var destinationRoot = Path.GetFullPath(destinationPath);
+        var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            destinationRoot
+        };
+        var files = new List<BufferedArchiveEntry>();
+        var packageRoot = ResolvePackageRootFolder(archive, packageId);
+
+        for (var index = 0; index < archive.Entries.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var entry = archive.Entries[index];
+            var normalized = Normalize(entry.FullName);
+            if (string.IsNullOrWhiteSpace(normalized) || IsPackageMetadata(normalized))
+                continue;
+            if (!IsSafePath(normalized))
+                throw new InvalidOperationException($"Package contains unsafe path '{entry.FullName}'.");
+
+            var extractionPath = TrimPackageRootFolder(normalized, packageRoot);
+            if (string.IsNullOrWhiteSpace(extractionPath) || IsPackageMetadata(extractionPath))
+                continue;
+
+            var targetPath = Path.GetFullPath(Path.Combine(destinationRoot, extractionPath.Replace('/', Path.DirectorySeparatorChar)));
+            if (!IsInsideDirectory(destinationRoot, targetPath))
+                throw new InvalidOperationException($"Package entry '{entry.FullName}' escapes the destination directory.");
+
+            if (entry.FullName.EndsWith("/", StringComparison.Ordinal) || entry.FullName.EndsWith("\\", StringComparison.Ordinal))
+            {
+                directories.Add(targetPath);
+                continue;
+            }
+
+            directories.Add(Path.GetDirectoryName(targetPath)!);
+            files.Add(new BufferedArchiveEntry(index, targetPath));
+        }
+
+        foreach (var directory in directories)
+            Directory.CreateDirectory(directory);
+
+        long bytesWritten = 0;
+        var options = new ParallelOptions
+        {
+            CancellationToken = cancellationToken,
+            MaxDegreeOfParallelism = Math.Min(MaximumParallelExtraction, Math.Max(1, Environment.ProcessorCount))
+        };
+        Parallel.ForEachAsync(files, options, (file, token) =>
+        {
+            using var packageCopy = new MemoryStream(
+                packageBuffer.Array!,
+                packageBuffer.Offset,
+                packageLength,
+                writable: false,
+                publiclyVisible: true);
+            using var archiveCopy = new ZipArchive(packageCopy, ZipArchiveMode.Read, leaveOpen: false);
+            using var source = archiveCopy.Entries[file.ArchiveIndex].Open();
+            using var destination = new FileStream(
+                file.TargetPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                CopyBufferSize,
+                FileOptions.SequentialScan);
+            CopyStream(source, destination, token);
+            Interlocked.Add(ref bytesWritten, destination.Length);
+            return ValueTask.CompletedTask;
+        }).GetAwaiter().GetResult();
+
+        stopwatch.Stop();
+        return new ManagedModuleArchiveExtractionResult(files.Count, bytesWritten, stopwatch.Elapsed, fromCache: false, cacheLockWaitElapsed: TimeSpan.Zero);
+    }
 #endif
+
+    private static ManagedModuleArchiveExtractionResult ExtractArchive(
+        ZipArchive archive,
+        string destinationPath,
+        string? packageId,
+        CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(destinationPath);
+        var destinationRoot = Path.GetFullPath(destinationPath);
+        var createdDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            destinationRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+        };
+        var fileCount = 0;
+        long bytesWritten = 0;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var packageRoot = ResolvePackageRootFolder(archive, packageId);
+        foreach (var entry in archive.Entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var normalized = Normalize(entry.FullName);
+            if (string.IsNullOrWhiteSpace(normalized) || IsPackageMetadata(normalized))
+                continue;
+            if (!IsSafePath(normalized))
+                throw new InvalidOperationException($"Package contains unsafe path '{entry.FullName}'.");
+
+            var extractionPath = TrimPackageRootFolder(normalized, packageRoot);
+            if (string.IsNullOrWhiteSpace(extractionPath) || IsPackageMetadata(extractionPath))
+                continue;
+
+            var targetPath = Path.GetFullPath(Path.Combine(destinationRoot, extractionPath.Replace('/', Path.DirectorySeparatorChar)));
+            if (!IsInsideDirectory(destinationRoot, targetPath))
+                throw new InvalidOperationException($"Package entry '{entry.FullName}' escapes the destination directory.");
+
+            if (entry.FullName.EndsWith("/", StringComparison.Ordinal) || entry.FullName.EndsWith("\\", StringComparison.Ordinal))
+            {
+                EnsureDirectory(targetPath, createdDirectories);
+                continue;
+            }
+
+            EnsureDirectory(Path.GetDirectoryName(targetPath)!, createdDirectories);
+            using var source = entry.Open();
+            using var destination = new FileStream(
+                targetPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                CopyBufferSize,
+                FileOptions.SequentialScan);
+            CopyStream(source, destination, cancellationToken);
+            fileCount++;
+            bytesWritten += destination.Length;
+        }
+
+        stopwatch.Stop();
+        return new ManagedModuleArchiveExtractionResult(fileCount, bytesWritten, stopwatch.Elapsed, fromCache: false, cacheLockWaitElapsed: TimeSpan.Zero);
+    }
+
+    private static void CopyStream(Stream source, Stream destination, CancellationToken cancellationToken)
+    {
+        var buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(CopyBufferSize);
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                destination.Write(buffer, 0, bytesRead);
+            }
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private readonly struct BufferedArchiveEntry
+    {
+        public BufferedArchiveEntry(int archiveIndex, string targetPath)
+        {
+            ArchiveIndex = archiveIndex;
+            TargetPath = targetPath;
+        }
+
+        public int ArchiveIndex { get; }
+
+        public string TargetPath { get; }
+    }
 
     private static string Normalize(string path)
         => path.Replace('\\', '/').Trim('/');

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallContext.cs
@@ -93,6 +93,12 @@ internal sealed class ManagedModuleInstallContext : IDisposable
     public bool IsActive(string moduleName)
         => _active.Contains(moduleName.Trim());
 
+    /// <summary>
+    /// Gets whether the current branch is installing below the root request and may run alongside sibling branches.
+    /// </summary>
+    public bool IsDependencyInstall
+        => _active.Count > 1;
+
     public bool TryBeginInstall(
         string key,
         out Task<ManagedModuleInstallResult> existingInstall,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.BufferedPackage.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.BufferedPackage.cs
@@ -32,9 +32,19 @@ public sealed partial class ManagedModuleInstallService
     private async Task<ManagedModuleArchiveExtractionResult> ExtractBufferedPackageForInstallAsync(
         ManagedModuleBufferedPackage bufferedPackage,
         string stageModulePath,
+        ManagedModuleInstallContext context,
         CancellationToken cancellationToken)
     {
         bufferedPackage.PackageStream.Position = 0;
+        if (!context.IsDependencyInstall)
+        {
+            return _extractor.ExtractBufferedPackage(
+                bufferedPackage.PackageStream,
+                stageModulePath,
+                bufferedPackage.Download.Metadata?.Id,
+                cancellationToken);
+        }
+
         return await _extractor.ExtractPackageAsync(
                 bufferedPackage.PackageStream,
                 stageModulePath,

--- a/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
+++ b/PowerForge/Services/ManagedModules/ManagedModuleInstallService.cs
@@ -727,6 +727,7 @@ public sealed partial class ManagedModuleInstallService
                     extraction = await ExtractBufferedPackageForInstallAsync(
                         bufferedPackage,
                         stageModulePath,
+                        context,
                         cancellationToken).ConfigureAwait(false);
                 }
                 else

--- a/README.MD
+++ b/README.MD
@@ -390,6 +390,11 @@ is not changed.
 | SingleModule | AcceptLicense=False, ModuleName=PSScriptAnalyzer, Version=1.25.0 | Desktop-5.1.26100.8655 | Save | 1.00x (1.15s) | Skipped | 2.60x (2.99s) | Skipped | Managed fastest |
 <!-- managed-module-benchmark-table:end -->
 
+For the controlled identical-feed results, the default-source race between the
+official PowerShell Gallery and pwsh.gallery, exact product versions/hashes, and
+the Windows PowerShell 5.1 support lane, see
+[Managed Module Benchmarks](Benchmarks/ManagedModules/README.md#modulefast-100-beta1-results).
+
 Run the managed module benchmark:
 
 ```powershell
@@ -400,7 +405,8 @@ Invoke-BenchmarkSuite `
     -Engine Managed, ModuleFast, PSResourceGet, PowerShellGet `
     -Host Core, Desktop `
     -WarmupCount 1 `
-    -IterationCount 3
+    -IterationCount 3 `
+    -Variable @{ UpdateReadme = $true }
 ```
 
 Import existing artifacts or BenchmarkDotNet output:


### PR DESCRIPTION
## Summary

- extract large buffered root packages with bounded parallel ZIP readers while dependency branches retain the existing async path
- preserve path traversal checks, SHA-256 verification, trust/license validation, staging, receipts, and atomic promotion
- make managed-module comparisons use fresh destinations, rotated samples, exact manifest/payload validation, and pinned-binary SHA-256 provenance
- document both the identical-feed installer comparison and the intentional official-PSGallery-versus-pwsh.gallery race, including Windows PowerShell 5.1 coverage

## ModuleFast 1.0.0-beta1 comparison

The controlled comparison used one identical local NuGet v3 feed for both engines. The default-source comparison used each product's normal path: PowerForge on the official PowerShell Gallery and ModuleFast on `https://pwsh.gallery/index.json`.

> **How to read this table:** In the identical-local-feed column, both tools use the same temporary local NuGet v3 feed, so neither remote gallery is timed. In the default-endpoints column, PowerForge uses the official PowerShell Gallery and ModuleFast uses pwsh.gallery. Every combined value is ordered **PowerForge / ModuleFast**.

| Workload | Identical local feed (PowerForge / ModuleFast) | Default endpoints (PowerForge: PSGallery / ModuleFast: pwsh.gallery) |
| --- | ---: | ---: |
| PSScriptAnalyzer 1.25.0 | 640 ms / 757 ms | 889 ms / 1.21 s |
| Microsoft.Graph 2.29.1 | 3.04 s / 4.04 s | 6.90 s / 7.60 s |
| Az 14.0.0 | 4.47 s / 7.98 s | 5.40 s / 8.19 s |

The current-head default-source run used six rotated samples per engine on PowerShell 7.6.3 and completed with 36/36 successful samples. PowerForge won 5/6, 4/6, and 6/6 paired samples respectively. Run: `20260716-092623-ef4ac8ed`.

## Windows PowerShell 5.1

PowerForge's pinned net472 build completed all 18 measured installs under Windows PowerShell 5.1.26100.8655. ModuleFast does not support that host, so its three scenario lanes are explicitly recorded as skipped.

| Workload | PowerForge median | ModuleFast |
| --- | ---: | --- |
| PSScriptAnalyzer 1.25.0 | 1.12 s | Unsupported / skipped |
| Microsoft.Graph 2.29.1 | 4.56 s | Unsupported / skipped |
| Az 14.0.0 | 4.59 s | Unsupported / skipped |

Run: `20260716-093024-d11767ac`.

## Reproducibility

`metadata.json` now records the comparison mode, source endpoints, exact PowerForge and ModuleFast versions, pinned binary SHA-256 values, Git commit, PowerShell host, and run policy. Focused runs no longer overwrite the root README unless `UpdateReadme = $true` is explicitly supplied. The benchmark guide contains the exact run IDs, artifact hashes, endpoint package hashes, and PS 5.1 reproduction command.

All PowerForge/PSPublishModule target frameworks build without warnings, and the full test suite passes 4,145 tests.