### PR TITLE
Expose exact website source selection and provenance

### DIFF
--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -9,6 +9,11 @@ on:
       pipeline_config:
         required: true
         type: string
+      source_ref:
+        description: Optional caller repository ref to build instead of the event commit.
+        required: false
+        type: string
+        default: ""
       site_output_path:
         required: false
         type: string
@@ -162,7 +167,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ github.token }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.source_ref || github.event.pull_request.head.sha || github.sha }}
 
       - name: Validate deploy guardrails
         shell: pwsh
@@ -270,6 +275,7 @@ jobs:
     with:
       website_root: ${{ inputs.website_root }}
       pipeline_config: ${{ inputs.pipeline_config }}
+      source_ref: ${{ inputs.source_ref }}
       engine_mode: ${{ inputs.engine_mode }}
       runner_labels_json: ${{ inputs.runner_labels_json }}
       timeout_minutes: ${{ inputs.build_timeout_minutes }}
@@ -371,7 +377,7 @@ jobs:
         shell: pwsh
         env:
           SOURCE_REPOSITORY: ${{ github.repository }}
-          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           ENGINE_REPOSITORY: ${{ needs.build.outputs.engine_repository }}
           ENGINE_SHA: ${{ needs.build.outputs.engine_sha }}
           ENGINE_MODE: ${{ needs.build.outputs.engine_mode }}
@@ -496,6 +502,7 @@ jobs:
     with:
       website_root: ${{ inputs.website_root }}
       pipeline_config: ${{ inputs.post_deploy_pipeline_config }}
+      source_ref: ${{ inputs.source_ref }}
       engine_mode: ${{ inputs.engine_mode }}
       runner_labels_json: ${{ inputs.runner_labels_json }}
       timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -3,6 +3,9 @@ name: PowerForge Website Run
 on:
   workflow_call:
     outputs:
+      source_sha:
+        description: Exact caller repository commit used to build the website.
+        value: ${{ jobs.website-run.outputs.source_sha }}
       engine_repository:
         description: Repository used to build the website.
         value: ${{ jobs.website-run.outputs.engine_repository }}
@@ -28,6 +31,11 @@ on:
       pipeline_config:
         required: true
         type: string
+      source_ref:
+        description: Optional caller repository ref to build instead of the event commit.
+        required: false
+        type: string
+        default: ""
       engine_mode:
         required: false
         type: string
@@ -128,6 +136,7 @@ env:
 jobs:
   website-run:
     outputs:
+      source_sha: ${{ steps.source_provenance.outputs.sha }}
       engine_repository: ${{ steps.engine_provenance.outputs.repository }}
       engine_sha: ${{ steps.engine_provenance.outputs.sha }}
       engine_mode: ${{ steps.engine_provenance.outputs.mode }}
@@ -148,7 +157,18 @@ jobs:
         with:
           token: ${{ github.token }}
           # workflow_call can otherwise default to refs/pull/<n>/merge, which is not available in some repos.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.source_ref || github.event.pull_request.head.sha || github.sha }}
+
+      - name: Resolve website source provenance
+        id: source_provenance
+        shell: pwsh
+        run: |
+          $sourceSha = (git rev-parse HEAD).Trim().ToLowerInvariant()
+          if ($sourceSha -notmatch '^[a-f0-9]{40,64}$') {
+            throw "Unable to resolve the exact website source commit."
+          }
+
+          "sha=$sourceSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Resolve shared workflow source
         id: workflow_source

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -30,6 +30,11 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         var deployWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
         var runWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-run.yml");
 
+        Assert.Contains("source_ref:", deployWorkflow, StringComparison.Ordinal);
+        Assert.Contains("ref: ${{ inputs.source_ref || github.event.pull_request.head.sha || github.sha }}", deployWorkflow, StringComparison.Ordinal);
+        Assert.Equal(2, deployWorkflow.Split("source_ref: ${{ inputs.source_ref }}", StringSplitOptions.None).Length - 1);
+        Assert.Contains("SOURCE_SHA: ${{ needs.build.outputs.source_sha }}", deployWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("--result-path", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("Resolve actual PowerForge engine provenance", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("assetSha256", runWorkflow, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -60,6 +60,23 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
+    public void WebsiteRunWorkflow_ShouldResolveOptionalCallerSourceRefToExactProvenance()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("source_ref:", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("ref: ${{ inputs.source_ref || github.event.pull_request.head.sha || github.sha }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("source_sha: ${{ steps.source_provenance.outputs.sha }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("value: ${{ jobs.website-run.outputs.source_sha }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("$sourceSha = (git rev-parse HEAD).Trim().ToLowerInvariant()", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WebsiteRunWorkflow_ShouldKeepTransientToolCachesInsideWorkspace()
     {
         var repoRoot = FindRepoRoot();


### PR DESCRIPTION
## Summary
- let reusable website callers select an explicit source ref when an event SHA is not the desired production revision
- expose the exact checked-out source SHA from the shared runner
- carry source selection through the public all-in-one deploy wrapper, guardrails, post-deploy checks, and deployment provenance
- keep existing callers on their current event-derived checkout by default

## Why
Release events can point at an older tag commit. A production website refresh may need to query release data while still building the current default-branch source. The shared workflows now own that distinction and give protected deploy jobs exact provenance without consumer-side Git or shell logic.

## Consumer shape

```yaml
with:
  source_ref: master
# ...
source-sha: ${{ needs.build.outputs.source_sha }}
```