### PR TITLE
Verify proxied site deploys outside the origin

### DIFF
--- a/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
+++ b/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
@@ -185,16 +185,11 @@ try {
     Assert-LastExitCode 'Promoting the site release for external public verification'
 
     $releaseMatch = $promotionOutput | Select-String -Pattern '^POWERFORGE_RELEASE_ID=(?<value>[A-Za-z0-9][A-Za-z0-9._-]{0,127})$' | Select-Object -Last 1
-    $previousMatch = $promotionOutput | Select-String -Pattern '^POWERFORGE_PREVIOUS_RELEASE_ID=(?<value>[A-Za-z0-9._-]*)$' | Select-Object -Last 1
-    if ($null -eq $releaseMatch -or $null -eq $previousMatch) {
+    if ($null -eq $releaseMatch) {
         throw 'The remote promoter did not return a valid deferred release identity.'
     }
     $releaseId = $releaseMatch.Matches[0].Groups['value'].Value
-    $previousReleaseId = $previousMatch.Matches[0].Groups['value'].Value
     $releaseArguments = "--release-id '$releaseId'"
-    if (-not [string]::IsNullOrWhiteSpace($previousReleaseId)) {
-        $releaseArguments += " --previous-release-id '$previousReleaseId'"
-    }
 
     try {
         Assert-PowerForgePublicSite -BaseUri $publicUri -SmokePaths $smokePaths -SourceSha $metadata.sourceSha -ArtifactSha256 $metadata.artifactSha256 -RunId $metadata.workflowRunId -RunAttempt $metadata.workflowRunAttempt

--- a/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
+++ b/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
@@ -4,11 +4,27 @@ param()
 $ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 
+. "$PSScriptRoot/Test-PowerForgePublicSite.ps1"
+
 function Assert-LastExitCode {
     param([Parameter(Mandatory)][string] $Operation)
 
     if ($LASTEXITCODE -ne 0) {
         throw "$Operation failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Invoke-CloudflarePurge {
+    param(
+        [Parameter(Mandatory)][string] $ZoneId,
+        [Parameter(Mandatory)][string] $ApiToken
+    )
+
+    $headers = @{ Authorization = "Bearer $ApiToken" }
+    $body = @{ purge_everything = $true } | ConvertTo-Json -Compress
+    $response = Invoke-RestMethod -Method Post -Uri "https://api.cloudflare.com/client/v4/zones/$ZoneId/purge_cache" -Headers $headers -ContentType 'application/json' -Body $body
+    if (-not $response.success) {
+        throw 'Cloudflare cache purge was rejected after deferred rollback.'
     }
 }
 
@@ -66,6 +82,24 @@ if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_ZONE)) {
     }
 }
 
+$publicUrl = [string]$env:POWERFORGE_DEPLOYMENT_PUBLIC_URL
+if ([string]::IsNullOrWhiteSpace($publicUrl)) {
+    $publicUrl = "https://$($env:POWERFORGE_DEPLOYMENT_SITE)"
+}
+$publicUri = $null
+if (-not [Uri]::TryCreate($publicUrl, [UriKind]::Absolute, [ref] $publicUri) -or
+    $publicUri.Scheme -ne 'https' -or $publicUri.AbsolutePath -ne '/' -or
+    -not [string]::IsNullOrEmpty($publicUri.Query) -or -not [string]::IsNullOrEmpty($publicUri.Fragment)) {
+    throw 'deployment-public-url must be an HTTPS origin without a path, query, or fragment.'
+}
+$smokePaths = @(
+    ([string]$env:POWERFORGE_DEPLOYMENT_SMOKE_PATHS -split '\s+') |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+)
+if ($smokePaths.Count -eq 0) {
+    throw 'deployment-smoke-paths must contain at least one absolute path.'
+}
+
 $artifactPath = [IO.Path]::GetFullPath($env:POWERFORGE_ARTIFACT_PATH)
 if (-not (Test-Path -LiteralPath $artifactPath -PathType Leaf)) {
     throw "Downloaded site artifact not found: $artifactPath"
@@ -80,6 +114,7 @@ $keyPath = Join-Path $sshRoot 'id_ed25519'
 $knownHostsPath = Join-Path $sshRoot 'known_hosts'
 $sshOptions = @('-i', $keyPath, '-o', 'IdentitiesOnly=yes', '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes', '-o', "UserKnownHostsFile=$knownHostsPath")
 $remoteCreated = $false
+$zoneId = ''
 
 try {
     $metadata = [ordered]@{
@@ -143,8 +178,45 @@ try {
     scp @scpArguments
     Assert-LastExitCode 'Uploading the site deployment payload'
 
-    ssh @sshOptions -p $deploymentPort $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:POWERFORGE_DEPLOYMENT_SITE)' --archive '$remoteBase/artifact.tar' --metadata '$remoteBase/deployment.json'"
-    Assert-LastExitCode 'Promoting the site release'
+    $promotionOutput = @(ssh @sshOptions -p $deploymentPort $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:POWERFORGE_DEPLOYMENT_SITE)' --archive '$remoteBase/artifact.tar' --metadata '$remoteBase/deployment.json' --defer-public-verification")
+    $promotionExitCode = $LASTEXITCODE
+    $promotionOutput | ForEach-Object { Write-Host $_ }
+    $global:LASTEXITCODE = $promotionExitCode
+    Assert-LastExitCode 'Promoting the site release for external public verification'
+
+    $releaseMatch = $promotionOutput | Select-String -Pattern '^POWERFORGE_RELEASE_ID=(?<value>[A-Za-z0-9][A-Za-z0-9._-]{0,127})$' | Select-Object -Last 1
+    $previousMatch = $promotionOutput | Select-String -Pattern '^POWERFORGE_PREVIOUS_RELEASE_ID=(?<value>[A-Za-z0-9._-]*)$' | Select-Object -Last 1
+    if ($null -eq $releaseMatch -or $null -eq $previousMatch) {
+        throw 'The remote promoter did not return a valid deferred release identity.'
+    }
+    $releaseId = $releaseMatch.Matches[0].Groups['value'].Value
+    $previousReleaseId = $previousMatch.Matches[0].Groups['value'].Value
+    $releaseArguments = "--release-id '$releaseId'"
+    if (-not [string]::IsNullOrWhiteSpace($previousReleaseId)) {
+        $releaseArguments += " --previous-release-id '$previousReleaseId'"
+    }
+
+    try {
+        Assert-PowerForgePublicSite -BaseUri $publicUri -SmokePaths $smokePaths -SourceSha $metadata.sourceSha -ArtifactSha256 $metadata.artifactSha256 -RunId $metadata.workflowRunId -RunAttempt $metadata.workflowRunAttempt
+        ssh @sshOptions -p $deploymentPort $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:POWERFORGE_DEPLOYMENT_SITE)' --finalize $releaseArguments"
+        Assert-LastExitCode 'Finalizing the externally verified site release'
+    } catch {
+        $deploymentError = $_
+        $rollbackError = $null
+        try {
+            ssh @sshOptions -p $deploymentPort $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:POWERFORGE_DEPLOYMENT_SITE)' --rollback $releaseArguments"
+            Assert-LastExitCode 'Rolling back the externally rejected site release'
+            if (-not [string]::IsNullOrWhiteSpace($zoneId)) {
+                Invoke-CloudflarePurge -ZoneId $zoneId -ApiToken $env:POWERFORGE_CLOUDFLARE_API_TOKEN
+            }
+        } catch {
+            $rollbackError = $_
+        }
+        if ($null -ne $rollbackError) {
+            throw "External public verification failed: $($deploymentError.Exception.Message) Rollback also failed: $($rollbackError.Exception.Message)"
+        }
+        throw "External public verification failed and the release was rolled back: $($deploymentError.Exception.Message)"
+    }
 }
 finally {
     if ($remoteCreated -and (Test-Path -LiteralPath $keyPath) -and (Test-Path -LiteralPath $knownHostsPath)) {

--- a/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
+++ b/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
@@ -116,6 +116,25 @@ $sshOptions = @('-i', $keyPath, '-o', 'IdentitiesOnly=yes', '-o', 'BatchMode=yes
 $remoteCreated = $false
 $zoneId = ''
 
+function Invoke-DeferredReleaseOperation {
+    param(
+        [Parameter(Mandatory)][ValidateSet('finalize', 'rollback')][string] $Operation,
+        [Parameter(Mandatory)][string] $ReleaseArguments
+    )
+
+    $operationArgument = if ($Operation -eq 'finalize') { '--finalize' } else { '--rollback' }
+    foreach ($attempt in 1..2) {
+        ssh @sshOptions -p $deploymentPort $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:POWERFORGE_DEPLOYMENT_SITE)' $operationArgument $ReleaseArguments"
+        if ($LASTEXITCODE -eq 0) {
+            return
+        }
+        if ($attempt -eq 1) {
+            Write-Warning "$Operation acknowledgement failed; retrying once to confirm terminal state."
+        }
+    }
+    throw "$Operation failed after two attempts with exit code $LASTEXITCODE."
+}
+
 try {
     $metadata = [ordered]@{
         schemaVersion      = 1
@@ -193,14 +212,12 @@ try {
 
     try {
         Assert-PowerForgePublicSite -BaseUri $publicUri -SmokePaths $smokePaths -SourceSha $metadata.sourceSha -ArtifactSha256 $metadata.artifactSha256 -RunId $metadata.workflowRunId -RunAttempt $metadata.workflowRunAttempt
-        ssh @sshOptions -p $deploymentPort $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:POWERFORGE_DEPLOYMENT_SITE)' --finalize $releaseArguments"
-        Assert-LastExitCode 'Finalizing the externally verified site release'
+        Invoke-DeferredReleaseOperation -Operation finalize -ReleaseArguments $releaseArguments
     } catch {
         $deploymentError = $_
         $rollbackError = $null
         try {
-            ssh @sshOptions -p $deploymentPort $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:POWERFORGE_DEPLOYMENT_SITE)' --rollback $releaseArguments"
-            Assert-LastExitCode 'Rolling back the externally rejected site release'
+            Invoke-DeferredReleaseOperation -Operation rollback -ReleaseArguments $releaseArguments
             if (-not [string]::IsNullOrWhiteSpace($zoneId)) {
                 Invoke-CloudflarePurge -ZoneId $zoneId -ApiToken $env:POWERFORGE_CLOUDFLARE_API_TOKEN
             }

--- a/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
+++ b/.github/actions/powerforge-linux-site-deploy/Invoke-PowerForgeLinuxSiteDeploy.ps1
@@ -84,7 +84,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_ZONE)) {
 
 $publicUrl = [string]$env:POWERFORGE_DEPLOYMENT_PUBLIC_URL
 if ([string]::IsNullOrWhiteSpace($publicUrl)) {
-    $publicUrl = "https://$($env:POWERFORGE_DEPLOYMENT_SITE)"
+    throw 'deployment-public-url is required for external public verification.'
 }
 $publicUri = $null
 if (-not [Uri]::TryCreate($publicUrl, [UriKind]::Absolute, [ref] $publicUri) -or

--- a/.github/actions/powerforge-linux-site-deploy/Test-PowerForgePublicSite.ps1
+++ b/.github/actions/powerforge-linux-site-deploy/Test-PowerForgePublicSite.ps1
@@ -1,0 +1,76 @@
+function Invoke-PowerForgePublicRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][Uri] $Uri,
+        [int] $MaximumAttempts = 4
+    )
+
+    $lastError = $null
+    for ($attempt = 1; $attempt -le $MaximumAttempts; $attempt++) {
+        try {
+            return Invoke-WebRequest -Uri $Uri -Method Get -TimeoutSec 30 -MaximumRedirection 5 -ErrorAction Stop
+        } catch {
+            $lastError = $_
+            if ($attempt -lt $MaximumAttempts) {
+                Start-Sleep -Seconds ([math]::Pow(2, $attempt - 1))
+            }
+        }
+    }
+
+    throw "Public website request failed after $MaximumAttempts attempts: $Uri. $($lastError.Exception.Message)"
+}
+
+function New-PowerForgeSmokeUri {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][Uri] $BaseUri,
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $RunId,
+        [Parameter(Mandatory)][string] $RunAttempt
+    )
+
+    if (-not $Path.StartsWith('/', [StringComparison]::Ordinal) -or $Path.Contains('?') -or $Path.Contains('#')) {
+        throw "Public smoke path must be an absolute path without a query or fragment: $Path"
+    }
+
+    $builder = [UriBuilder]::new([Uri]::new($BaseUri, $Path))
+    $builder.Query = "powerforge-deploy=$RunId-$RunAttempt"
+    return $builder.Uri
+}
+
+function Assert-PowerForgePublicSite {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][Uri] $BaseUri,
+        [Parameter(Mandatory)][string[]] $SmokePaths,
+        [Parameter(Mandatory)][string] $SourceSha,
+        [Parameter(Mandatory)][string] $ArtifactSha256,
+        [Parameter(Mandatory)][string] $RunId,
+        [Parameter(Mandatory)][string] $RunAttempt
+    )
+
+    $markerUri = New-PowerForgeSmokeUri -BaseUri $BaseUri -Path '/_powerforge/deployment.json' -RunId $RunId -RunAttempt $RunAttempt
+    $markerResponse = Invoke-PowerForgePublicRequest -Uri $markerUri
+    try {
+        $marker = $markerResponse.Content | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw "Public deployment marker is not valid JSON: $markerUri. $($_.Exception.Message)"
+    }
+
+    $expected = [ordered]@{
+        sourceSha          = $SourceSha
+        artifactSha256     = $ArtifactSha256
+        workflowRunId      = $RunId
+        workflowRunAttempt = $RunAttempt
+    }
+    foreach ($entry in $expected.GetEnumerator()) {
+        if ([string]$marker.($entry.Key) -ne [string]$entry.Value) {
+            throw "Public deployment marker has unexpected $($entry.Key): expected '$($entry.Value)', observed '$($marker.($entry.Key))'."
+        }
+    }
+
+    foreach ($path in $SmokePaths) {
+        $smokeUri = New-PowerForgeSmokeUri -BaseUri $BaseUri -Path $path -RunId $RunId -RunAttempt $RunAttempt
+        $null = Invoke-PowerForgePublicRequest -Uri $smokeUri
+    }
+}

--- a/.github/actions/powerforge-linux-site-deploy/action.yml
+++ b/.github/actions/powerforge-linux-site-deploy/action.yml
@@ -23,6 +23,14 @@ inputs:
     description: Optional Cloudflare zone whose cache is purged during promotion.
     required: false
     default: ""
+  deployment-public-url:
+    description: Public HTTPS origin verified from the runner after host-origin promotion.
+    required: false
+    default: ""
+  deployment-smoke-paths:
+    description: Space-separated public paths verified after exact provenance.
+    required: false
+    default: "/"
   deployment-ssh-private-key:
     description: Private key from the caller job's protected environment.
     required: true
@@ -88,7 +96,9 @@ runs:
         POWERFORGE_CLOUDFLARE_ZONE_ID: ${{ inputs.cloudflare-zone-id }}
         POWERFORGE_DEPLOYMENT_HOST: ${{ inputs.deployment-host }}
         POWERFORGE_DEPLOYMENT_PORT: ${{ inputs.deployment-port }}
+        POWERFORGE_DEPLOYMENT_PUBLIC_URL: ${{ inputs.deployment-public-url }}
         POWERFORGE_DEPLOYMENT_SITE: ${{ inputs.deployment-site }}
+        POWERFORGE_DEPLOYMENT_SMOKE_PATHS: ${{ inputs.deployment-smoke-paths }}
         POWERFORGE_DEPLOYMENT_SSH_KNOWN_HOSTS: ${{ inputs.deployment-ssh-known-hosts }}
         POWERFORGE_DEPLOYMENT_SSH_PRIVATE_KEY: ${{ inputs.deployment-ssh-private-key }}
         POWERFORGE_DEPLOYMENT_USER: ${{ inputs.deployment-user }}

--- a/.github/actions/powerforge-linux-site-deploy/action.yml
+++ b/.github/actions/powerforge-linux-site-deploy/action.yml
@@ -25,8 +25,7 @@ inputs:
     default: ""
   deployment-public-url:
     description: Public HTTPS origin verified from the runner after host-origin promotion.
-    required: false
-    default: ""
+    required: true
   deployment-smoke-paths:
     description: Space-separated public paths verified after exact provenance.
     required: false

--- a/.github/workflows/BuildModule.yml
+++ b/.github/workflows/BuildModule.yml
@@ -272,6 +272,10 @@ jobs:
         timeout-minutes: 10
         run: .\Build\Build-Module.ps1
 
+      - name: Test Linux website deployment state machine
+        shell: bash
+        run: sudo bash Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
+
       - name: Test with Pester
         shell: pwsh
         timeout-minutes: 10

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -119,6 +119,7 @@ on:
         type: string
         default: ""
       deployment_url:
+        description: Public HTTPS origin. Required when deployment_target is linux.
         required: false
         type: string
         default: ""
@@ -177,6 +178,7 @@ jobs:
         shell: pwsh
         env:
           DEPLOYMENT_TARGET: ${{ inputs.deployment_target }}
+          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
           PIPELINE_CONFIG: ${{ inputs.pipeline_config }}
           REQUIRE_SEO_DOCTOR_GUARDRAIL: ${{ inputs.require_seo_doctor_guardrail }}
         run: |
@@ -184,6 +186,9 @@ jobs:
 
           if ($env:DEPLOYMENT_TARGET -notin @('github-pages', 'linux')) {
             throw "Unsupported deployment_target '$($env:DEPLOYMENT_TARGET)'. Expected github-pages or linux."
+          }
+          if ($env:DEPLOYMENT_TARGET -eq 'linux' -and [string]::IsNullOrWhiteSpace($env:DEPLOYMENT_URL)) {
+            throw 'deployment_url is required when deployment_target is linux.'
           }
 
           if ($env:REQUIRE_SEO_DOCTOR_GUARDRAIL -ne 'true') {

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -122,6 +122,10 @@ on:
         required: false
         type: string
         default: ""
+      deployment_smoke_paths:
+        required: false
+        type: string
+        default: "/"
       publisher_runner_labels_json:
         required: false
         type: string
@@ -324,176 +328,55 @@ jobs:
     environment:
       name: ${{ inputs.deployment_environment }}
       url: ${{ inputs.deployment_url }}
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - name: Validate Linux deployment inputs
+      - name: Resolve shared deployment action source
+        id: deployment_action_source
         shell: pwsh
-        env:
-          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
-          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
-          DEPLOYMENT_SITE: ${{ inputs.deployment_site }}
-          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
-          DEPLOYMENT_CLOUDFLARE_ZONE: ${{ inputs.deployment_cloudflare_zone }}
-          DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
-          DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.deployment_cloudflare_api_token }}
-          CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
         run: |
           $ErrorActionPreference = 'Stop'
-          if ($env:DEPLOYMENT_SITE -notmatch '^[a-z0-9][a-z0-9.-]{0,62}$') {
-            throw 'deployment_site must be a lowercase DNS-style site identifier.'
+          $repository = [string]'${{ job.workflow_repository }}'
+          $sha = [string]'${{ job.workflow_sha }}'
+          if ([string]::IsNullOrWhiteSpace($repository) -or $sha -notmatch '^[a-fA-F0-9]{40,64}$') {
+            throw 'Unable to resolve the exact shared deployment action source.'
           }
-          if ($env:DEPLOYMENT_HOST -notmatch '^[A-Za-z0-9][A-Za-z0-9.-]{0,252}$') {
-            throw 'deployment_host must be a DNS name or IPv4 address.'
-          }
-          if ($env:DEPLOYMENT_USER -notmatch '^[a-z_][a-z0-9_-]{0,31}$') {
-            throw 'deployment_user is not a valid Linux account name.'
-          }
-          $port = 0
-          if (-not [int]::TryParse($env:DEPLOYMENT_PORT, [ref] $port) -or $port -lt 1 -or $port -gt 65535) {
-            throw 'deployment_port must be an integer from 1 through 65535.'
-          }
-          if ([string]::IsNullOrWhiteSpace($env:DEPLOYMENT_PRIVATE_KEY)) {
-            throw 'deployment_ssh_private_key is required for Linux deployment.'
-          }
-          if ([string]::IsNullOrWhiteSpace($env:DEPLOYMENT_KNOWN_HOSTS)) {
-            throw 'deployment_ssh_known_hosts is required; host key scanning at deploy time is intentionally disabled.'
-          }
-          if (-not [string]::IsNullOrWhiteSpace($env:DEPLOYMENT_CLOUDFLARE_ZONE)) {
-            if ($env:DEPLOYMENT_CLOUDFLARE_ZONE -notmatch '^[A-Za-z0-9.-]+$') {
-              throw 'deployment_cloudflare_zone must be a DNS zone name.'
-            }
-            if ([string]::IsNullOrWhiteSpace($env:CLOUDFLARE_API_TOKEN)) {
-              throw 'deployment_cloudflare_api_token is required when deployment_cloudflare_zone is configured.'
-            }
-          }
+          "repository=$repository" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "sha=$($sha.ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
-      - name: Download validated site artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      - name: Checkout shared deployment action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          name: ${{ format('powerforge-site-{0}', inputs.deployment_site) }}
-          path: ${{ runner.temp }}/powerforge-site
+          repository: ${{ steps.deployment_action_source.outputs.repository }}
+          ref: ${{ steps.deployment_action_source.outputs.sha }}
+          path: ./.powerforge-deployment
+          token: ${{ github.token }}
+          fetch-depth: 1
 
-      - name: Create deployment provenance
-        shell: pwsh
-        env:
-          SOURCE_REPOSITORY: ${{ github.repository }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          ENGINE_REPOSITORY: ${{ needs.build.outputs.engine_repository }}
-          ENGINE_SHA: ${{ needs.build.outputs.engine_sha }}
-          ENGINE_MODE: ${{ needs.build.outputs.engine_mode }}
-          ENGINE_REF: ${{ needs.build.outputs.engine_ref }}
-          ENGINE_ASSET: ${{ needs.build.outputs.engine_asset }}
-          ENGINE_ASSET_SHA256: ${{ needs.build.outputs.engine_asset_sha256 }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $artifactPath = Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar'
-          if (-not (Test-Path -LiteralPath $artifactPath -PathType Leaf)) {
-            throw "Downloaded site artifact not found: $artifactPath"
-          }
-          $metadata = [ordered]@{
-            schemaVersion = 1
-            sourceRepository = $env:SOURCE_REPOSITORY
-            sourceSha = $env:SOURCE_SHA
-            engineMode = $env:ENGINE_MODE
-            engineRepository = $env:ENGINE_REPOSITORY
-            engineRef = $env:ENGINE_REF
-            workflowRunId = '${{ github.run_id }}'
-            workflowRunAttempt = '${{ github.run_attempt }}'
-            artifactSha256 = (Get-FileHash -LiteralPath $artifactPath -Algorithm SHA256).Hash.ToLowerInvariant()
-            deployedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
-          }
-          if (-not [string]::IsNullOrWhiteSpace($env:ENGINE_SHA)) {
-            $metadata.engineSha = $env:ENGINE_SHA
-          }
-          if (-not [string]::IsNullOrWhiteSpace($env:ENGINE_ASSET)) {
-            $metadata.engineAsset = $env:ENGINE_ASSET
-            $metadata.engineAssetSha256 = $env:ENGINE_ASSET_SHA256
-          }
-          $metadata | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json') -Encoding utf8NoBOM
-
-      - name: Publish and promote Linux release
-        shell: pwsh
-        env:
-          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
-          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
-          DEPLOYMENT_SITE: ${{ inputs.deployment_site }}
-          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
-          DEPLOYMENT_CLOUDFLARE_ZONE: ${{ inputs.deployment_cloudflare_zone }}
-          DEPLOYMENT_PRIVATE_KEY: ${{ secrets.deployment_ssh_private_key }}
-          DEPLOYMENT_KNOWN_HOSTS: ${{ secrets.deployment_ssh_known_hosts }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.deployment_cloudflare_api_token }}
-          CLOUDFLARE_ZONE_ID: ${{ secrets.cloudflare_zone_id }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-deployment-ssh'
-          New-Item -ItemType Directory -Force -Path $sshRoot | Out-Null
-          $keyPath = Join-Path $sshRoot 'id_ed25519'
-          $knownHostsPath = Join-Path $sshRoot 'known_hosts'
-          Set-Content -LiteralPath $keyPath -Value $env:DEPLOYMENT_PRIVATE_KEY -Encoding utf8NoBOM
-          Set-Content -LiteralPath $knownHostsPath -Value $env:DEPLOYMENT_KNOWN_HOSTS -Encoding utf8NoBOM
-          chmod 700 $sshRoot
-          chmod 600 $keyPath $knownHostsPath
-
-          $deploymentSources = @(
-            (Join-Path $env:RUNNER_TEMP 'powerforge-site/artifact.tar')
-            (Join-Path $env:RUNNER_TEMP 'powerforge-site/deployment.json')
-          )
-          if (-not [string]::IsNullOrWhiteSpace($env:DEPLOYMENT_CLOUDFLARE_ZONE)) {
-            $zoneId = [string]$env:CLOUDFLARE_ZONE_ID
-            if ([string]::IsNullOrWhiteSpace($zoneId)) {
-              $headers = @{ Authorization = "Bearer $($env:CLOUDFLARE_API_TOKEN)" }
-              $zoneName = [Uri]::EscapeDataString($env:DEPLOYMENT_CLOUDFLARE_ZONE)
-              $zoneResponse = Invoke-RestMethod -Method Get -Uri "https://api.cloudflare.com/client/v4/zones?name=$zoneName&status=active&per_page=5" -Headers $headers
-              if (-not $zoneResponse.success -or @($zoneResponse.result).Count -ne 1) {
-                throw "Cloudflare did not return exactly one active zone for '$($env:DEPLOYMENT_CLOUDFLARE_ZONE)'."
-              }
-              $zoneId = [string]$zoneResponse.result[0].id
-            }
-            if ($zoneId -notmatch '^[A-Fa-f0-9]{32}$') {
-              throw 'cloudflare_zone_id is invalid and zone discovery did not return a valid id.'
-            }
-            $cloudflareTokenPath = Join-Path $sshRoot 'cloudflare-api.token'
-            $cloudflareZonePath = Join-Path $sshRoot 'cloudflare-zone-id'
-            Set-Content -LiteralPath $cloudflareTokenPath -Value $env:CLOUDFLARE_API_TOKEN -Encoding utf8NoBOM -NoNewline
-            Set-Content -LiteralPath $cloudflareZonePath -Value $zoneId.ToLowerInvariant() -Encoding ascii -NoNewline
-            chmod 600 $cloudflareTokenPath $cloudflareZonePath
-            $deploymentSources += $cloudflareTokenPath, $cloudflareZonePath
-          }
-
-          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}-$($env:DEPLOYMENT_SITE)"
-          $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
-          $sshOptions = @('-i', $keyPath, '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=yes', '-o', "UserKnownHostsFile=$knownHostsPath")
-          $scpArgs = @('-P', $env:DEPLOYMENT_PORT) + $sshOptions + $deploymentSources + @("${target}:${remoteBase}/")
-          ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "install -d -m 0700 '$remoteBase'"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          scp @scpArgs
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          ssh @sshOptions -p $env:DEPLOYMENT_PORT $target "sudo /usr/local/sbin/powerforge-site-deploy --site '$($env:DEPLOYMENT_SITE)' --archive '$remoteBase/artifact.tar' --metadata '$remoteBase/deployment.json'"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Cleanup deployment credentials and remote staging
-        if: ${{ always() }}
-        continue-on-error: true
-        shell: pwsh
-        env:
-          DEPLOYMENT_HOST: ${{ inputs.deployment_host }}
-          DEPLOYMENT_PORT: ${{ inputs.deployment_port }}
-          DEPLOYMENT_USER: ${{ inputs.deployment_user }}
-        run: |
-          $sshRoot = Join-Path $env:RUNNER_TEMP 'powerforge-deployment-ssh'
-          $keyPath = Join-Path $sshRoot 'id_ed25519'
-          $knownHostsPath = Join-Path $sshRoot 'known_hosts'
-          $remoteBase = "/tmp/powerforge-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.deployment_site }}"
-          $target = "$($env:DEPLOYMENT_USER)@$($env:DEPLOYMENT_HOST)"
-          try {
-            if ((Test-Path -LiteralPath $keyPath) -and (Test-Path -LiteralPath $knownHostsPath)) {
-              ssh -i $keyPath -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$knownHostsPath" -p $env:DEPLOYMENT_PORT $target "rm -rf -- '$remoteBase'"
-            }
-          } finally {
-            if (Test-Path -LiteralPath $sshRoot) {
-              Remove-Item -LiteralPath $sshRoot -Recurse -Force
-            }
-          }
+      - name: Deploy validated Linux website artifact
+        uses: ./.powerforge-deployment/.github/actions/powerforge-linux-site-deploy
+        with:
+          artifact-name: ${{ format('powerforge-site-{0}', inputs.deployment_site) }}
+          deployment-site: ${{ inputs.deployment_site }}
+          deployment-host: ${{ inputs.deployment_host }}
+          deployment-port: ${{ inputs.deployment_port }}
+          deployment-user: ${{ inputs.deployment_user }}
+          deployment-cloudflare-zone: ${{ inputs.deployment_cloudflare_zone }}
+          deployment-public-url: ${{ inputs.deployment_url }}
+          deployment-smoke-paths: ${{ inputs.deployment_smoke_paths }}
+          deployment-ssh-private-key: ${{ secrets.deployment_ssh_private_key }}
+          deployment-ssh-known-hosts: ${{ secrets.deployment_ssh_known_hosts }}
+          deployment-cloudflare-api-token: ${{ secrets.deployment_cloudflare_api_token }}
+          cloudflare-zone-id: ${{ secrets.cloudflare_zone_id }}
+          source-repository: ${{ github.repository }}
+          source-sha: ${{ needs.build.outputs.source_sha }}
+          engine-mode: ${{ needs.build.outputs.engine_mode }}
+          engine-repository: ${{ needs.build.outputs.engine_repository }}
+          engine-ref: ${{ needs.build.outputs.engine_ref }}
+          engine-sha: ${{ needs.build.outputs.engine_sha }}
+          engine-asset: ${{ needs.build.outputs.engine_asset }}
+          engine-asset-sha256: ${{ needs.build.outputs.engine_asset_sha256 }}
 
   post-deploy:
     if: ${{ always() && inputs.post_deploy_pipeline_config != '' && ((inputs.deployment_target == 'github-pages' && needs.deploy.result == 'success') || (inputs.deployment_target == 'linux' && needs.deploy-linux.result == 'success')) }}

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -6,6 +6,7 @@ umask 022
 CONFIG_ROOT="${POWERFORGE_SITE_CONFIG_ROOT:-/etc/powerforge/sites}"
 LOCK_ROOT="${POWERFORGE_SITE_LOCK_ROOT:-/var/lock}"
 TRUSTED_STAGE_ROOT="${POWERFORGE_SITE_TRUSTED_STAGE_ROOT:-/var/lib/powerforge/deployment-staging}"
+PENDING_STATE_ROOT="${POWERFORGE_SITE_PENDING_STATE_ROOT:-/var/lib/powerforge/site-pending}"
 site=""
 archive=""
 metadata=""
@@ -19,10 +20,18 @@ previous_target=""
 release_dir=""
 workflow_stage=""
 trusted_stage=""
+pending_stage=""
+pending_dir=""
+pending_state_file=""
+pending_release_id=""
+pending_previous_release_id=""
+pending_expires_at_epoch=""
+pending_created=0
 
 cleanup_staging() {
   [[ -z "$workflow_stage" || ! -d "$workflow_stage" ]] || rm -rf -- "$workflow_stage"
   [[ -z "$trusted_stage" || ! -d "$trusted_stage" ]] || rm -rf -- "$trusted_stage"
+  [[ -z "$pending_stage" || ! -d "$pending_stage" ]] || rm -rf -- "$pending_stage"
 }
 
 trap cleanup_staging EXIT
@@ -42,6 +51,7 @@ Usage:
   powerforge-site-deploy --site <id> --archive <artifact.tar> --metadata <deployment.json> [--defer-public-verification]
   powerforge-site-deploy --site <id> --finalize --release-id <id> [--previous-release-id <id>]
   powerforge-site-deploy --site <id> --rollback --release-id <id> [--previous-release-id <id>]
+  powerforge-site-deploy --site <id> --expire-pending
 EOF
 }
 
@@ -73,6 +83,11 @@ while (($# > 0)); do
       operation="rollback"
       shift
       ;;
+    --expire-pending)
+      [[ "$operation" == 'promote' ]] || fail 'Only one deployment operation may be selected.'
+      operation="expire"
+      shift
+      ;;
     --release-id)
       release_id_argument="${2:-}"
       shift 2
@@ -99,6 +114,9 @@ if [[ "$operation" == 'promote' ]]; then
 else
   [[ -z "$archive" && -z "$metadata" ]] || fail 'Archive and metadata are only valid during promotion.'
   [[ "$defer_public_verification" == '0' ]] || fail 'Deferred verification is only valid during promotion.'
+  if [[ "$operation" == 'expire' ]]; then
+    [[ -z "$release_id_argument" && -z "$previous_release_id_argument" ]] || fail 'Release identity arguments are not valid during pending-release expiry.'
+  fi
 fi
 
 config_path="${CONFIG_ROOT}/${site}.env"
@@ -122,12 +140,17 @@ source "$config_path"
 : "${CLOUDFLARE_API_TOKEN_FILE:=}"
 : "${ORIGIN_ADDRESS:=}"
 : "${ORIGIN_HOST:=}"
+: "${PENDING_TTL_SECONDS:=600}"
+: "${PENDING_RECONCILE_REQUIRED:=1}"
 
 [[ "$SITE_ROOT" == /* && "$SITE_ROOT" != '/' ]] || fail 'SITE_ROOT must be an absolute non-root path.'
 [[ "$SITE_ROOT" != *[[:space:]]* ]] || fail 'SITE_ROOT must not contain whitespace.'
 [[ "$TRUSTED_STAGE_ROOT" == /* && "$TRUSTED_STAGE_ROOT" != '/' ]] || fail 'Trusted staging root must be an absolute non-root path.'
+[[ "$PENDING_STATE_ROOT" == /* && "$PENDING_STATE_ROOT" != '/' ]] || fail 'Pending state root must be an absolute non-root path.'
 [[ "$PUBLIC_URL" =~ ^https://[A-Za-z0-9.-]+(:[0-9]+)?$ ]] || fail 'PUBLIC_URL must be an HTTPS origin without a path.'
 [[ "$RELEASES_TO_KEEP" =~ ^[1-9][0-9]*$ ]] || fail 'RELEASES_TO_KEEP must be a positive integer.'
+[[ "$PENDING_TTL_SECONDS" =~ ^[0-9]+$ && "$PENDING_TTL_SECONDS" -ge 60 && "$PENDING_TTL_SECONDS" -le 3600 ]] || fail 'PENDING_TTL_SECONDS must be from 60 through 3600.'
+[[ "$PENDING_RECONCILE_REQUIRED" == '0' || "$PENDING_RECONCILE_REQUIRED" == '1' ]] || fail 'PENDING_RECONCILE_REQUIRED must be 0 or 1.'
 [[ "$CLOUDFLARE_PURGE_ENABLED" == '0' || "$CLOUDFLARE_PURGE_ENABLED" == '1' ]] || fail 'CLOUDFLARE_PURGE_ENABLED must be 0 or 1.'
 if [[ -n "$ORIGIN_ADDRESS" || -n "$ORIGIN_HOST" ]]; then
   [[ -n "$ORIGIN_ADDRESS" && "$ORIGIN_HOST" =~ ^[A-Za-z0-9.-]+$ ]] || fail 'ORIGIN_ADDRESS and ORIGIN_HOST must be configured together.'
@@ -149,6 +172,19 @@ release_path() {
   printf '%s/releases/%s' "$SITE_ROOT" "$1"
 }
 
+purge_cloudflare() {
+  [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]] || return 0
+  [[ "$CLOUDFLARE_ZONE_ID" =~ ^[A-Fa-f0-9]{32}$ ]] || fail 'Cloudflare zone id is required when purge is enabled.'
+  [[ "$CLOUDFLARE_API_TOKEN_FILE" == /* && -s "$CLOUDFLARE_API_TOKEN_FILE" && -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'A readable Cloudflare API token is required when purge is enabled.'
+  local response
+  response="$(curl -fsS --retry 3 --max-time 30 \
+    -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+    -H "Authorization: Bearer $(<"$CLOUDFLARE_API_TOKEN_FILE")" \
+    -H 'Content-Type: application/json' \
+    --data '{"purge_everything":true}')"
+  grep -Eq '"success"[[:space:]]*:[[:space:]]*true' <<<"$response" || fail 'Cloudflare cache purge was rejected.'
+}
+
 prune_releases() {
   local current_release="$1"
   local rollback_release="$2"
@@ -159,63 +195,179 @@ prune_releases() {
   done
 }
 
+load_pending_release() {
+  local pending_mode
+  local pending_dir_mode
+  local -a pending_values
+  pending_state_file="$pending_dir/state"
+  [[ -d "$pending_dir" && ! -L "$pending_dir" ]] || fail "No pending release exists for $site."
+  [[ -f "$pending_state_file" && ! -L "$pending_state_file" ]] || fail 'Pending release state is missing or invalid.'
+  if [[ "$(id -u)" -eq 0 ]]; then
+    [[ "$(stat -c '%u' "$pending_dir")" -eq 0 && "$(stat -c '%u' "$pending_state_file")" -eq 0 ]] || fail 'Pending release state must be owned by root.'
+    pending_dir_mode="$(stat -c '%a' "$pending_dir")"
+    pending_mode="$(stat -c '%a' "$pending_state_file")"
+    (( (8#$pending_dir_mode & 0077) == 0 )) || fail 'Pending release directory must not be group/world accessible.'
+    (( (8#$pending_mode & 0077) == 0 )) || fail 'Pending release state must not be group/world accessible.'
+  fi
+  mapfile -t pending_values <"$pending_state_file"
+  [[ "${#pending_values[@]}" -eq 3 ]] || fail 'Pending release state must contain exactly three lines.'
+  pending_release_id="${pending_values[0]}"
+  pending_previous_release_id="${pending_values[1]}"
+  pending_expires_at_epoch="${pending_values[2]}"
+  validate_release_id "$pending_release_id"
+  [[ -z "$pending_previous_release_id" ]] || validate_release_id "$pending_previous_release_id"
+  [[ "$pending_expires_at_epoch" =~ ^[0-9]+$ ]] || fail 'Pending release expiry is invalid.'
+}
+
+assert_pending_identity() {
+  [[ "$release_id_argument" == "$pending_release_id" ]] || fail 'Deferred release id does not match pending state.'
+  [[ "$previous_release_id_argument" == "$pending_previous_release_id" ]] || fail 'Deferred previous release id does not match pending state.'
+}
+
+configure_pending_cloudflare() {
+  local pending_token="$pending_dir/cloudflare-api.token"
+  local pending_zone="$pending_dir/cloudflare-zone-id"
+  local pending_token_mode
+  local pending_zone_mode
+  if [[ -e "$pending_token" || -L "$pending_token" || -e "$pending_zone" || -L "$pending_zone" ]]; then
+    [[ -f "$pending_token" && ! -L "$pending_token" && -s "$pending_token" ]] || fail 'Pending Cloudflare token is missing or invalid.'
+    [[ -f "$pending_zone" && ! -L "$pending_zone" && -s "$pending_zone" ]] || fail 'Pending Cloudflare zone id is missing or invalid.'
+    if [[ "$(id -u)" -eq 0 ]]; then
+      [[ "$(stat -c '%u' "$pending_token")" -eq 0 && "$(stat -c '%u' "$pending_zone")" -eq 0 ]] || fail 'Pending Cloudflare credentials must be owned by root.'
+      pending_token_mode="$(stat -c '%a' "$pending_token")"
+      pending_zone_mode="$(stat -c '%a' "$pending_zone")"
+      (( (8#$pending_token_mode & 0077) == 0 && (8#$pending_zone_mode & 0077) == 0 )) || fail 'Pending Cloudflare credentials must not be group/world accessible.'
+    fi
+    CLOUDFLARE_ZONE_ID="$(tr -d '[:space:]' <"$pending_zone")"
+    CLOUDFLARE_API_TOKEN_FILE="$pending_token"
+  fi
+  if [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]]; then
+    CLOUDFLARE_ZONE_ID="${CLOUDFLARE_ZONE_ID,,}"
+    [[ "$CLOUDFLARE_ZONE_ID" =~ ^[a-f0-9]{32}$ ]] || fail 'Pending rollback requires a Cloudflare zone id.'
+    [[ "$CLOUDFLARE_API_TOKEN_FILE" == /* && -s "$CLOUDFLARE_API_TOKEN_FILE" && -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'Pending rollback requires a readable Cloudflare API token.'
+  fi
+}
+
+remove_pending_release() {
+  rm -rf -- "$pending_dir"
+}
+
 finalize_deferred_release() {
   local selected_release
   local selected_previous=""
   local current_target
-  selected_release="$(release_path "$release_id_argument")"
-  [[ -d "$selected_release" ]] || fail "Deferred release does not exist: $release_id_argument"
-  if [[ -n "$previous_release_id_argument" ]]; then
-    selected_previous="$(release_path "$previous_release_id_argument")"
-    [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $previous_release_id_argument"
+  selected_release="$(release_path "$pending_release_id")"
+  [[ -d "$selected_release" ]] || fail "Deferred release does not exist: $pending_release_id"
+  if [[ -n "$pending_previous_release_id" ]]; then
+    selected_previous="$(release_path "$pending_previous_release_id")"
+    [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $pending_previous_release_id"
   fi
   [[ -L "$SITE_ROOT/current" ]] || fail 'Current release is not a symlink during finalization.'
   current_target="$(readlink -f "$SITE_ROOT/current")"
   [[ "$current_target" == "$selected_release" ]] || fail 'Current release changed before deferred finalization.'
   [[ -s "$selected_release/_powerforge/deployment.json" ]] || fail 'Deferred release provenance is missing.'
   prune_releases "$selected_release" "$selected_previous"
-  log "Finalized $site release $release_id_argument after external public verification"
+  remove_pending_release
+  log "Finalized $site release $pending_release_id after external public verification"
 }
 
 rollback_deferred_release() {
   local selected_release
   local selected_previous=""
   local current_target=""
-  selected_release="$(release_path "$release_id_argument")"
-  [[ -d "$selected_release" ]] || fail "Deferred release does not exist: $release_id_argument"
-  if [[ -n "$previous_release_id_argument" ]]; then
-    selected_previous="$(release_path "$previous_release_id_argument")"
-    [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $previous_release_id_argument"
+  selected_release="$(release_path "$pending_release_id")"
+  if [[ -n "$pending_previous_release_id" ]]; then
+    selected_previous="$(release_path "$pending_previous_release_id")"
   fi
   if [[ -L "$SITE_ROOT/current" ]]; then
     current_target="$(readlink -f "$SITE_ROOT/current")"
   fi
-  [[ "$current_target" == "$selected_release" ]] || fail 'Current release changed before deferred rollback.'
-  if [[ -n "$selected_previous" ]]; then
-    rollback_link="$SITE_ROOT/.current.rollback.$$"
-    ln -s "$selected_previous" "$rollback_link"
-    mv -Tf "$rollback_link" "$SITE_ROOT/current"
+  if [[ "$current_target" == "$selected_release" && -d "$selected_release" ]]; then
+    if [[ -n "$selected_previous" ]]; then
+      [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $pending_previous_release_id"
+      rollback_link="$SITE_ROOT/.current.rollback.$$"
+      ln -s "$selected_previous" "$rollback_link"
+      mv -Tf "$rollback_link" "$SITE_ROOT/current"
+    else
+      rm -f "$SITE_ROOT/current"
+    fi
+    rm -rf "$selected_release"
+  elif [[ -n "$selected_previous" && "$current_target" == "$selected_previous" && ! -e "$selected_release" ]]; then
+    log "Deferred $site release $pending_release_id was already restored; retrying cache purge"
+  elif [[ -n "$selected_previous" && "$current_target" == "$selected_previous" && -d "$selected_release" ]]; then
+    log "Deferred $site release $pending_release_id was prepared but not promoted; removing it"
+    rm -rf "$selected_release"
+  elif [[ -z "$selected_previous" && -z "$current_target" && ! -e "$selected_release" ]]; then
+    log "Deferred first $site release $pending_release_id was already removed; retrying cache purge"
+  elif [[ -z "$selected_previous" && -z "$current_target" && -d "$selected_release" ]]; then
+    log "Deferred first $site release $pending_release_id was prepared but not promoted; removing it"
+    rm -rf "$selected_release"
   else
-    rm -f "$SITE_ROOT/current"
+    fail 'Current release changed before deferred rollback.'
   fi
-  rm -rf "$selected_release"
-  log "Rolled back deferred $site release $release_id_argument"
+  configure_pending_cloudflare
+  purge_cloudflare
+  remove_pending_release
+  log "Rolled back deferred $site release $pending_release_id"
+}
+
+expire_pending_release() {
+  local now_epoch
+  load_pending_release
+  now_epoch="$(date -u +%s)"
+  if [[ "$now_epoch" -lt "$pending_expires_at_epoch" ]]; then
+    log "Pending $site release $pending_release_id has not expired"
+    return 0
+  fi
+  log "Pending $site release $pending_release_id expired; restoring the previous release"
+  rollback_deferred_release
+}
+
+ensure_pending_reconciler() {
+  [[ "$PENDING_RECONCILE_REQUIRED" == '1' ]] || return 0
+  [[ -x /usr/local/sbin/powerforge-site-reconcile ]] || fail 'Deferred verification requires /usr/local/sbin/powerforge-site-reconcile.'
+  command -v systemctl >/dev/null || fail 'Deferred verification requires systemd.'
+  systemctl is-enabled --quiet powerforge-site-reconcile.timer || fail 'Deferred verification requires the pending-release reconciler timer to be enabled.'
+  systemctl is-active --quiet powerforge-site-reconcile.timer || fail 'Deferred verification requires the pending-release reconciler timer to be active.'
 }
 
 mkdir -p "$SITE_ROOT/releases"
 mkdir -p "$LOCK_ROOT"
+install -d -m 0700 "$PENDING_STATE_ROOT"
+[[ -d "$PENDING_STATE_ROOT" && ! -L "$PENDING_STATE_ROOT" ]] || fail 'Pending state root must be a directory, not a symlink.'
+if [[ "$(id -u)" -eq 0 ]]; then
+  [[ "$(stat -c '%u' "$PENDING_STATE_ROOT")" -eq 0 ]] || fail 'Pending state root must be owned by root.'
+fi
+pending_dir="$PENDING_STATE_ROOT/$site"
 exec 9>"${LOCK_ROOT}/powerforge-site-${site}.lock"
-flock -n 9 || fail "Another deployment is active for $site."
+if [[ "$operation" == 'expire' ]]; then
+  flock -w 30 9 || fail "Timed out waiting to reconcile $site."
+else
+  flock -n 9 || fail "Another deployment is active for $site."
+fi
 
 if [[ "$operation" == 'finalize' ]]; then
   [[ -n "$release_id_argument" ]] || fail '--release-id is required during finalization.'
+  load_pending_release
+  assert_pending_identity
   finalize_deferred_release
   exit 0
 fi
 if [[ "$operation" == 'rollback' ]]; then
   [[ -n "$release_id_argument" ]] || fail '--release-id is required during rollback.'
+  load_pending_release
+  assert_pending_identity
   rollback_deferred_release
   exit 0
+fi
+if [[ "$operation" == 'expire' ]]; then
+  expire_pending_release
+  exit 0
+fi
+
+[[ ! -e "$pending_dir" && ! -L "$pending_dir" ]] || fail "A deferred release is already pending for $site."
+if [[ "$defer_public_verification" == '1' ]]; then
+  ensure_pending_reconciler
 fi
 
 archive="$(realpath -e "$archive")"
@@ -298,17 +450,6 @@ release_id="$(date -u +%Y%m%d%H%M%S)-${run_id}-${run_attempt}-${source_sha:0:12}
 release_dir="$SITE_ROOT/releases/$release_id"
 [[ ! -e "$release_dir" ]] || fail "Release already exists: $release_id"
 
-purge_cloudflare() {
-  [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]] || return 0
-  local response
-  response="$(curl -fsS --retry 3 --max-time 30 \
-    -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-    -H "Authorization: Bearer $(<"$CLOUDFLARE_API_TOKEN_FILE")" \
-    -H 'Content-Type: application/json' \
-    --data '{"purge_everything":true}')"
-  grep -Eq '"success"[[:space:]]*:[[:space:]]*true' <<<"$response" || fail 'Cloudflare cache purge was rejected.'
-}
-
 smoke_url() {
   local base_url="$1"
   local path="$2"
@@ -356,6 +497,25 @@ verify_release() {
   verify_origin_release
 }
 
+create_pending_release() {
+  local previous_release_id=""
+  pending_expires_at_epoch="$(( $(date -u +%s) + PENDING_TTL_SECONDS ))"
+  if [[ -n "$previous_target" ]]; then
+    previous_release_id="$(basename "$previous_target")"
+  fi
+  pending_stage="$(mktemp -d "${PENDING_STATE_ROOT}/.${site}.XXXXXXXX")"
+  chmod 0700 "$pending_stage"
+  printf '%s\n%s\n%s\n' "$release_id" "$previous_release_id" "$pending_expires_at_epoch" >"$pending_stage/state"
+  chmod 0600 "$pending_stage/state"
+  if [[ -f "$trusted_stage/cloudflare-api.token" ]]; then
+    install -m 0600 "$trusted_stage/cloudflare-api.token" "$pending_stage/cloudflare-api.token"
+    install -m 0600 "$trusted_stage/cloudflare-zone-id" "$pending_stage/cloudflare-zone-id"
+  fi
+  mv -T "$pending_stage" "$pending_dir"
+  pending_stage=""
+  pending_created=1
+}
+
 rollback() {
   local exit_code="$1"
   set +e
@@ -375,6 +535,7 @@ rollback() {
     mv -T "$previous_target" "$SITE_ROOT/current"
   fi
   [[ -z "$release_dir" || ! -d "$release_dir" || "$release_dir" == "$previous_target" ]] || rm -rf "$release_dir"
+  [[ "$pending_created" != '1' || ! -d "$pending_dir" ]] || rm -rf -- "$pending_dir"
   exit "$exit_code"
 }
 trap 'rollback $?' ERR INT TERM
@@ -394,6 +555,9 @@ elif [[ -e "$SITE_ROOT/current" ]]; then
   log "Migrating legacy current directory to $previous_target"
   mv -T "$SITE_ROOT/current" "$previous_target"
   legacy_migrated=1
+fi
+if [[ "$defer_public_verification" == '1' ]]; then
+  create_pending_release
 fi
 candidate_link="$SITE_ROOT/.current.${run_id}.${run_attempt}"
 ln -s "$release_dir" "$candidate_link"
@@ -418,6 +582,7 @@ if [[ "$defer_public_verification" == '1' ]]; then
   else
     printf 'POWERFORGE_PREVIOUS_RELEASE_ID=\n'
   fi
+  printf 'POWERFORGE_PENDING_EXPIRES_AT=%s\n' "$pending_expires_at_epoch"
   log "Promoted $site release $release_id pending external public verification"
 else
   log "Promoted $site release $release_id from $source_sha"

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -13,7 +13,6 @@ metadata=""
 operation="promote"
 defer_public_verification=0
 release_id_argument=""
-previous_release_id_argument=""
 promoted=0
 legacy_migrated=0
 previous_target=""
@@ -24,7 +23,7 @@ pending_stage=""
 pending_dir=""
 pending_state_file=""
 pending_release_id=""
-pending_previous_release_id=""
+pending_previous_target=""
 pending_expires_at_epoch=""
 pending_created=0
 
@@ -49,8 +48,8 @@ usage() {
   cat <<'EOF'
 Usage:
   powerforge-site-deploy --site <id> --archive <artifact.tar> --metadata <deployment.json> [--defer-public-verification]
-  powerforge-site-deploy --site <id> --finalize --release-id <id> [--previous-release-id <id>]
-  powerforge-site-deploy --site <id> --rollback --release-id <id> [--previous-release-id <id>]
+  powerforge-site-deploy --site <id> --finalize --release-id <id>
+  powerforge-site-deploy --site <id> --rollback --release-id <id>
   powerforge-site-deploy --site <id> --expire-pending
 EOF
 }
@@ -92,10 +91,6 @@ while (($# > 0)); do
       release_id_argument="${2:-}"
       shift 2
       ;;
-    --previous-release-id)
-      previous_release_id_argument="${2:-}"
-      shift 2
-      ;;
     --help|-h)
       usage
       exit 0
@@ -110,12 +105,12 @@ done
 [[ "$site" =~ ^[a-z0-9][a-z0-9.-]{0,62}$ ]] || fail 'Invalid site identifier.'
 if [[ "$operation" == 'promote' ]]; then
   [[ -n "$archive" && -n "$metadata" ]] || fail 'Both --archive and --metadata are required.'
-  [[ -z "$release_id_argument" && -z "$previous_release_id_argument" ]] || fail 'Release identity arguments are not valid during promotion.'
+  [[ -z "$release_id_argument" ]] || fail 'Release identity arguments are not valid during promotion.'
 else
   [[ -z "$archive" && -z "$metadata" ]] || fail 'Archive and metadata are only valid during promotion.'
   [[ "$defer_public_verification" == '0' ]] || fail 'Deferred verification is only valid during promotion.'
   if [[ "$operation" == 'expire' ]]; then
-    [[ -z "$release_id_argument" && -z "$previous_release_id_argument" ]] || fail 'Release identity arguments are not valid during pending-release expiry.'
+    [[ -z "$release_id_argument" ]] || fail 'Release identity arguments are not valid during pending-release expiry.'
   fi
 fi
 
@@ -212,16 +207,15 @@ load_pending_release() {
   mapfile -t pending_values <"$pending_state_file"
   [[ "${#pending_values[@]}" -eq 3 ]] || fail 'Pending release state must contain exactly three lines.'
   pending_release_id="${pending_values[0]}"
-  pending_previous_release_id="${pending_values[1]}"
+  pending_previous_target="${pending_values[1]}"
   pending_expires_at_epoch="${pending_values[2]}"
   validate_release_id "$pending_release_id"
-  [[ -z "$pending_previous_release_id" ]] || validate_release_id "$pending_previous_release_id"
+  [[ -z "$pending_previous_target" || ( "$pending_previous_target" == /* && "$pending_previous_target" != '/' ) ]] || fail 'Pending previous release target is invalid.'
   [[ "$pending_expires_at_epoch" =~ ^[0-9]+$ ]] || fail 'Pending release expiry is invalid.'
 }
 
 assert_pending_identity() {
   [[ "$release_id_argument" == "$pending_release_id" ]] || fail 'Deferred release id does not match pending state.'
-  [[ "$previous_release_id_argument" == "$pending_previous_release_id" ]] || fail 'Deferred previous release id does not match pending state.'
 }
 
 configure_pending_cloudflare() {
@@ -258,9 +252,9 @@ finalize_deferred_release() {
   local current_target
   selected_release="$(release_path "$pending_release_id")"
   [[ -d "$selected_release" ]] || fail "Deferred release does not exist: $pending_release_id"
-  if [[ -n "$pending_previous_release_id" ]]; then
-    selected_previous="$(release_path "$pending_previous_release_id")"
-    [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $pending_previous_release_id"
+  if [[ -n "$pending_previous_target" ]]; then
+    selected_previous="$pending_previous_target"
+    [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $pending_previous_target"
   fi
   [[ -L "$SITE_ROOT/current" ]] || fail 'Current release is not a symlink during finalization.'
   current_target="$(readlink -f "$SITE_ROOT/current")"
@@ -276,15 +270,15 @@ rollback_deferred_release() {
   local selected_previous=""
   local current_target=""
   selected_release="$(release_path "$pending_release_id")"
-  if [[ -n "$pending_previous_release_id" ]]; then
-    selected_previous="$(release_path "$pending_previous_release_id")"
+  if [[ -n "$pending_previous_target" ]]; then
+    selected_previous="$pending_previous_target"
   fi
   if [[ -L "$SITE_ROOT/current" ]]; then
     current_target="$(readlink -f "$SITE_ROOT/current")"
   fi
   if [[ "$current_target" == "$selected_release" && -d "$selected_release" ]]; then
     if [[ -n "$selected_previous" ]]; then
-      [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $pending_previous_release_id"
+      [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $pending_previous_target"
       rollback_link="$SITE_ROOT/.current.rollback.$$"
       ln -s "$selected_previous" "$rollback_link"
       mv -Tf "$rollback_link" "$SITE_ROOT/current"
@@ -498,14 +492,10 @@ verify_release() {
 }
 
 create_pending_release() {
-  local previous_release_id=""
   pending_expires_at_epoch="$(( $(date -u +%s) + PENDING_TTL_SECONDS ))"
-  if [[ -n "$previous_target" ]]; then
-    previous_release_id="$(basename "$previous_target")"
-  fi
   pending_stage="$(mktemp -d "${PENDING_STATE_ROOT}/.${site}.XXXXXXXX")"
   chmod 0700 "$pending_stage"
-  printf '%s\n%s\n%s\n' "$release_id" "$previous_release_id" "$pending_expires_at_epoch" >"$pending_stage/state"
+  printf '%s\n%s\n%s\n' "$release_id" "$previous_target" "$pending_expires_at_epoch" >"$pending_stage/state"
   chmod 0600 "$pending_stage/state"
   if [[ -f "$trusted_stage/cloudflare-api.token" ]]; then
     install -m 0600 "$trusted_stage/cloudflare-api.token" "$pending_stage/cloudflare-api.token"
@@ -577,11 +567,6 @@ cleanup_staging
 trap - EXIT
 if [[ "$defer_public_verification" == '1' ]]; then
   printf 'POWERFORGE_RELEASE_ID=%s\n' "$release_id"
-  if [[ -n "$previous_target" ]]; then
-    printf 'POWERFORGE_PREVIOUS_RELEASE_ID=%s\n' "$(basename "$previous_target")"
-  else
-    printf 'POWERFORGE_PREVIOUS_RELEASE_ID=\n'
-  fi
   printf 'POWERFORGE_PENDING_EXPIRES_AT=%s\n' "$pending_expires_at_epoch"
   log "Promoted $site release $release_id pending external public verification"
 else

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -218,6 +218,25 @@ assert_pending_identity() {
   [[ "$release_id_argument" == "$pending_release_id" ]] || fail 'Deferred release id does not match pending state.'
 }
 
+confirm_completed_operation() {
+  local completed_operation="$1"
+  local selected_release
+  local current_target=""
+  selected_release="$(release_path "$release_id_argument")"
+  if [[ -L "$SITE_ROOT/current" ]]; then
+    current_target="$(readlink -f "$SITE_ROOT/current" 2>/dev/null || true)"
+  fi
+  if [[ "$completed_operation" == 'finalize' && "$current_target" == "$selected_release" && -d "$selected_release" && -s "$selected_release/_powerforge/deployment.json" ]]; then
+    log "Deferred $site release $release_id_argument was already finalized"
+    return 0
+  fi
+  if [[ "$completed_operation" == 'rollback' && "$current_target" != "$selected_release" && ! -e "$selected_release" && ! -L "$selected_release" ]]; then
+    log "Deferred $site release $release_id_argument was already rolled back"
+    return 0
+  fi
+  return 1
+}
+
 configure_pending_cloudflare() {
   local pending_token="$pending_dir/cloudflare-api.token"
   local pending_zone="$pending_dir/cloudflare-zone-id"
@@ -342,6 +361,9 @@ fi
 
 if [[ "$operation" == 'finalize' ]]; then
   [[ -n "$release_id_argument" ]] || fail '--release-id is required during finalization.'
+  if [[ ! -e "$pending_dir" && ! -L "$pending_dir" ]] && confirm_completed_operation finalize; then
+    exit 0
+  fi
   load_pending_release
   assert_pending_identity
   finalize_deferred_release
@@ -349,6 +371,9 @@ if [[ "$operation" == 'finalize' ]]; then
 fi
 if [[ "$operation" == 'rollback' ]]; then
   [[ -n "$release_id_argument" ]] || fail '--release-id is required during rollback.'
+  if [[ ! -e "$pending_dir" && ! -L "$pending_dir" ]] && confirm_completed_operation rollback; then
+    exit 0
+  fi
   load_pending_release
   assert_pending_identity
   rollback_deferred_release

--- a/Deployment/Linux/powerforge-site-deploy.sh
+++ b/Deployment/Linux/powerforge-site-deploy.sh
@@ -9,6 +9,10 @@ TRUSTED_STAGE_ROOT="${POWERFORGE_SITE_TRUSTED_STAGE_ROOT:-/var/lib/powerforge/de
 site=""
 archive=""
 metadata=""
+operation="promote"
+defer_public_verification=0
+release_id_argument=""
+previous_release_id_argument=""
 promoted=0
 legacy_migrated=0
 previous_target=""
@@ -33,7 +37,12 @@ fail() {
 }
 
 usage() {
-  echo 'Usage: powerforge-site-deploy --site <id> --archive <artifact.tar> --metadata <deployment.json>'
+  cat <<'EOF'
+Usage:
+  powerforge-site-deploy --site <id> --archive <artifact.tar> --metadata <deployment.json> [--defer-public-verification]
+  powerforge-site-deploy --site <id> --finalize --release-id <id> [--previous-release-id <id>]
+  powerforge-site-deploy --site <id> --rollback --release-id <id> [--previous-release-id <id>]
+EOF
 }
 
 while (($# > 0)); do
@@ -50,6 +59,28 @@ while (($# > 0)); do
       metadata="${2:-}"
       shift 2
       ;;
+    --defer-public-verification)
+      defer_public_verification=1
+      shift
+      ;;
+    --finalize)
+      [[ "$operation" == 'promote' ]] || fail 'Only one deployment operation may be selected.'
+      operation="finalize"
+      shift
+      ;;
+    --rollback)
+      [[ "$operation" == 'promote' ]] || fail 'Only one deployment operation may be selected.'
+      operation="rollback"
+      shift
+      ;;
+    --release-id)
+      release_id_argument="${2:-}"
+      shift 2
+      ;;
+    --previous-release-id)
+      previous_release_id_argument="${2:-}"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -62,7 +93,13 @@ while (($# > 0)); do
 done
 
 [[ "$site" =~ ^[a-z0-9][a-z0-9.-]{0,62}$ ]] || fail 'Invalid site identifier.'
-[[ -n "$archive" && -n "$metadata" ]] || fail 'Both --archive and --metadata are required.'
+if [[ "$operation" == 'promote' ]]; then
+  [[ -n "$archive" && -n "$metadata" ]] || fail 'Both --archive and --metadata are required.'
+  [[ -z "$release_id_argument" && -z "$previous_release_id_argument" ]] || fail 'Release identity arguments are not valid during promotion.'
+else
+  [[ -z "$archive" && -z "$metadata" ]] || fail 'Archive and metadata are only valid during promotion.'
+  [[ "$defer_public_verification" == '0' ]] || fail 'Deferred verification is only valid during promotion.'
+fi
 
 config_path="${CONFIG_ROOT}/${site}.env"
 [[ -f "$config_path" && ! -L "$config_path" ]] || fail "Site is not configured: $site"
@@ -101,6 +138,84 @@ if [[ "$CLOUDFLARE_PURGE_ENABLED" == '1' ]]; then
     [[ "$CLOUDFLARE_API_TOKEN_FILE" == /* && -s "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'CLOUDFLARE_API_TOKEN_FILE must be an absolute, non-empty readable file.'
     [[ -r "$CLOUDFLARE_API_TOKEN_FILE" ]] || fail 'Cloudflare API token file is not readable.'
   fi
+fi
+
+validate_release_id() {
+  [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || fail "Invalid release id: $1"
+}
+
+release_path() {
+  validate_release_id "$1"
+  printf '%s/releases/%s' "$SITE_ROOT" "$1"
+}
+
+prune_releases() {
+  local current_release="$1"
+  local rollback_release="$2"
+  local index
+  mapfile -t old_releases < <(find "$SITE_ROOT/releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | awk '{print $2}')
+  for ((index=RELEASES_TO_KEEP; index<${#old_releases[@]}; index++)); do
+    [[ "${old_releases[$index]}" == "$current_release" || "${old_releases[$index]}" == "$rollback_release" ]] || rm -rf "${old_releases[$index]}"
+  done
+}
+
+finalize_deferred_release() {
+  local selected_release
+  local selected_previous=""
+  local current_target
+  selected_release="$(release_path "$release_id_argument")"
+  [[ -d "$selected_release" ]] || fail "Deferred release does not exist: $release_id_argument"
+  if [[ -n "$previous_release_id_argument" ]]; then
+    selected_previous="$(release_path "$previous_release_id_argument")"
+    [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $previous_release_id_argument"
+  fi
+  [[ -L "$SITE_ROOT/current" ]] || fail 'Current release is not a symlink during finalization.'
+  current_target="$(readlink -f "$SITE_ROOT/current")"
+  [[ "$current_target" == "$selected_release" ]] || fail 'Current release changed before deferred finalization.'
+  [[ -s "$selected_release/_powerforge/deployment.json" ]] || fail 'Deferred release provenance is missing.'
+  prune_releases "$selected_release" "$selected_previous"
+  log "Finalized $site release $release_id_argument after external public verification"
+}
+
+rollback_deferred_release() {
+  local selected_release
+  local selected_previous=""
+  local current_target=""
+  selected_release="$(release_path "$release_id_argument")"
+  [[ -d "$selected_release" ]] || fail "Deferred release does not exist: $release_id_argument"
+  if [[ -n "$previous_release_id_argument" ]]; then
+    selected_previous="$(release_path "$previous_release_id_argument")"
+    [[ -d "$selected_previous" ]] || fail "Deferred rollback release does not exist: $previous_release_id_argument"
+  fi
+  if [[ -L "$SITE_ROOT/current" ]]; then
+    current_target="$(readlink -f "$SITE_ROOT/current")"
+  fi
+  [[ "$current_target" == "$selected_release" ]] || fail 'Current release changed before deferred rollback.'
+  if [[ -n "$selected_previous" ]]; then
+    rollback_link="$SITE_ROOT/.current.rollback.$$"
+    ln -s "$selected_previous" "$rollback_link"
+    mv -Tf "$rollback_link" "$SITE_ROOT/current"
+  else
+    rm -f "$SITE_ROOT/current"
+  fi
+  rm -rf "$selected_release"
+  log "Rolled back deferred $site release $release_id_argument"
+}
+
+mkdir -p "$SITE_ROOT/releases"
+mkdir -p "$LOCK_ROOT"
+exec 9>"${LOCK_ROOT}/powerforge-site-${site}.lock"
+flock -n 9 || fail "Another deployment is active for $site."
+
+if [[ "$operation" == 'finalize' ]]; then
+  [[ -n "$release_id_argument" ]] || fail '--release-id is required during finalization.'
+  finalize_deferred_release
+  exit 0
+fi
+if [[ "$operation" == 'rollback' ]]; then
+  [[ -n "$release_id_argument" ]] || fail '--release-id is required during rollback.'
+  rollback_deferred_release
+  exit 0
 fi
 
 archive="$(realpath -e "$archive")"
@@ -179,11 +294,6 @@ while IFS= read -r listing; do
   [[ "$entry_type" == '-' || "$entry_type" == 'd' ]] || fail 'Archive contains links or special files.'
 done < <(tar -tvf "$archive")
 
-mkdir -p "$SITE_ROOT/releases"
-mkdir -p "$LOCK_ROOT"
-exec 9>"${LOCK_ROOT}/powerforge-site-${site}.lock"
-flock -n 9 || fail "Another deployment is active for $site."
-
 release_id="$(date -u +%Y%m%d%H%M%S)-${run_id}-${run_attempt}-${source_sha:0:12}"
 release_dir="$SITE_ROOT/releases/$release_id"
 [[ ! -e "$release_dir" ]] || fail "Release already exists: $release_id"
@@ -206,32 +316,44 @@ smoke_url() {
   curl -fsS --retry 3 --retry-all-errors --max-time 30 "$@" "${base_url}${path}?powerforge-deploy=${run_id}-${run_attempt}"
 }
 
-verify_release() {
+verify_marker() {
+  local marker="$1"
+  local endpoint="$2"
+  grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$marker" || fail "$endpoint did not serve the promoted source SHA."
+  grep -Eq "\"artifactSha256\"[[:space:]]*:[[:space:]]*\"${artifact_sha}\"" <<<"$marker" || fail "$endpoint did not serve the promoted artifact."
+  grep -Eq "\"workflowRunId\"[[:space:]]*:[[:space:]]*\"${run_id}\"" <<<"$marker" || fail "$endpoint did not serve the promoted workflow run."
+  grep -Eq "\"workflowRunAttempt\"[[:space:]]*:[[:space:]]*\"${run_attempt}\"" <<<"$marker" || fail "$endpoint did not serve the promoted workflow attempt."
+}
+
+verify_public_release() {
   local marker_path='/_powerforge/deployment.json'
   local public_marker
-  public_marker="$(smoke_url "$PUBLIC_URL" "$marker_path")"
-  grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted source SHA.'
-  grep -Eq "\"artifactSha256\"[[:space:]]*:[[:space:]]*\"${artifact_sha}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted artifact.'
-  grep -Eq "\"workflowRunId\"[[:space:]]*:[[:space:]]*\"${run_id}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted workflow run.'
-  grep -Eq "\"workflowRunAttempt\"[[:space:]]*:[[:space:]]*\"${run_attempt}\"" <<<"$public_marker" || fail 'Public endpoint did not serve the promoted workflow attempt.'
-
-  if [[ -n "$ORIGIN_ADDRESS" ]]; then
-    local origin_marker
-    origin_marker="$(smoke_url "https://${ORIGIN_HOST}" "$marker_path" --resolve "${ORIGIN_HOST}:443:${ORIGIN_ADDRESS}")"
-    grep -Eq "\"sourceSha\"[[:space:]]*:[[:space:]]*\"${source_sha}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted source SHA.'
-    grep -Eq "\"artifactSha256\"[[:space:]]*:[[:space:]]*\"${artifact_sha}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted artifact.'
-    grep -Eq "\"workflowRunId\"[[:space:]]*:[[:space:]]*\"${run_id}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted workflow run.'
-    grep -Eq "\"workflowRunAttempt\"[[:space:]]*:[[:space:]]*\"${run_attempt}\"" <<<"$origin_marker" || fail 'Origin endpoint did not serve the promoted workflow attempt.'
-  fi
-
   local smoke_path
+  public_marker="$(smoke_url "$PUBLIC_URL" "$marker_path")"
+  verify_marker "$public_marker" 'Public endpoint'
   for smoke_path in $SMOKE_PATHS; do
     [[ "$smoke_path" == /* ]] || fail "Smoke path must begin with '/': $smoke_path"
     smoke_url "$PUBLIC_URL" "$smoke_path" >/dev/null
-    if [[ -n "$ORIGIN_ADDRESS" ]]; then
-      smoke_url "https://${ORIGIN_HOST}" "$smoke_path" --resolve "${ORIGIN_HOST}:443:${ORIGIN_ADDRESS}" >/dev/null
-    fi
   done
+}
+
+verify_origin_release() {
+  local marker_path='/_powerforge/deployment.json'
+  local smoke_path
+  if [[ -n "$ORIGIN_ADDRESS" ]]; then
+    local origin_marker
+    origin_marker="$(smoke_url "https://${ORIGIN_HOST}" "$marker_path" --resolve "${ORIGIN_HOST}:443:${ORIGIN_ADDRESS}")"
+    verify_marker "$origin_marker" 'Origin endpoint'
+    for smoke_path in $SMOKE_PATHS; do
+      [[ "$smoke_path" == /* ]] || fail "Smoke path must begin with '/': $smoke_path"
+      smoke_url "https://${ORIGIN_HOST}" "$smoke_path" --resolve "${ORIGIN_HOST}:443:${ORIGIN_ADDRESS}" >/dev/null
+    done
+  fi
+}
+
+verify_release() {
+  verify_public_release
+  verify_origin_release
 }
 
 rollback() {
@@ -279,14 +401,24 @@ mv -Tf "$candidate_link" "$SITE_ROOT/current"
 promoted=1
 
 purge_cloudflare
-verify_release
-
-mapfile -t old_releases < <(find "$SITE_ROOT/releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | awk '{print $2}')
-for ((index=RELEASES_TO_KEEP; index<${#old_releases[@]}; index++)); do
-  [[ "${old_releases[$index]}" == "$release_dir" || "${old_releases[$index]}" == "$previous_target" ]] || rm -rf "${old_releases[$index]}"
-done
+if [[ "$defer_public_verification" == '1' ]]; then
+  verify_origin_release
+else
+  verify_release
+  prune_releases "$release_dir" "$previous_target"
+fi
 
 trap - ERR INT TERM
 cleanup_staging
 trap - EXIT
-log "Promoted $site release $release_id from $source_sha"
+if [[ "$defer_public_verification" == '1' ]]; then
+  printf 'POWERFORGE_RELEASE_ID=%s\n' "$release_id"
+  if [[ -n "$previous_target" ]]; then
+    printf 'POWERFORGE_PREVIOUS_RELEASE_ID=%s\n' "$(basename "$previous_target")"
+  else
+    printf 'POWERFORGE_PREVIOUS_RELEASE_ID=\n'
+  fi
+  log "Promoted $site release $release_id pending external public verification"
+else
+  log "Promoted $site release $release_id from $source_sha"
+fi

--- a/Deployment/Linux/powerforge-site-reconcile.sh
+++ b/Deployment/Linux/powerforge-site-reconcile.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PENDING_STATE_ROOT="${POWERFORGE_SITE_PENDING_STATE_ROOT:-/var/lib/powerforge/site-pending}"
+CONFIG_ROOT="${POWERFORGE_SITE_CONFIG_ROOT:-/etc/powerforge/sites}"
+DEPLOY_COMMAND="${POWERFORGE_SITE_DEPLOY_COMMAND:-/usr/local/sbin/powerforge-site-deploy}"
+
+log() {
+  printf '[powerforge-site-reconcile] %s\n' "$*"
+}
+
+[[ "$(id -u)" -eq 0 ]] || { log 'ERROR: Reconciliation must run as root.' >&2; exit 1; }
+[[ "$PENDING_STATE_ROOT" == /* && "$PENDING_STATE_ROOT" != '/' ]] || { log 'ERROR: Pending state root is invalid.' >&2; exit 1; }
+[[ "$CONFIG_ROOT" == /* && "$CONFIG_ROOT" != '/' ]] || { log 'ERROR: Config root is invalid.' >&2; exit 1; }
+[[ "$DEPLOY_COMMAND" == /* && -x "$DEPLOY_COMMAND" ]] || { log 'ERROR: Site deploy command is not executable.' >&2; exit 1; }
+[[ -e "$PENDING_STATE_ROOT" || -L "$PENDING_STATE_ROOT" ]] || exit 0
+[[ -d "$PENDING_STATE_ROOT" && ! -L "$PENDING_STATE_ROOT" ]] || { log 'ERROR: Pending state root must be a directory, not a symlink.' >&2; exit 1; }
+[[ "$(stat -c '%u' "$PENDING_STATE_ROOT")" -eq 0 ]] || { log 'ERROR: Pending state root must be owned by root.' >&2; exit 1; }
+
+failed=0
+shopt -s nullglob
+for pending_dir in "$PENDING_STATE_ROOT"/*; do
+  [[ -d "$pending_dir" && ! -L "$pending_dir" ]] || continue
+  site="$(basename "$pending_dir")"
+  [[ "$site" == .* ]] && continue
+  if [[ ! "$site" =~ ^[a-z0-9][a-z0-9.-]{0,62}$ ]]; then
+    log "ERROR: Ignoring invalid pending site directory: $site" >&2
+    failed=1
+    continue
+  fi
+  if [[ ! -f "$CONFIG_ROOT/$site.env" || -L "$CONFIG_ROOT/$site.env" ]]; then
+    log "ERROR: Pending site has no trusted configuration: $site" >&2
+    failed=1
+    continue
+  fi
+  if ! "$DEPLOY_COMMAND" --site "$site" --expire-pending; then
+    log "ERROR: Failed to reconcile pending site: $site" >&2
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/Deployment/Linux/powerforge-site.env.example
+++ b/Deployment/Linux/powerforge-site.env.example
@@ -7,6 +7,10 @@ ORIGIN_HOST=example.com
 ORIGIN_ADDRESS=127.0.0.1
 
 RELEASES_TO_KEEP=5
+# Deferred promotions expire unless the runner finalizes them. Keep the generic
+# powerforge-site-reconcile.timer enabled; disabling this guard is test-only.
+PENDING_TTL_SECONDS=600
+PENDING_RECONCILE_REQUIRED=1
 # The promoter checks these paths against both URLs in standalone mode. The
 # composite action uses them for direct-origin checks on the host and repeats the
 # public checks from the GitHub runner via deployment-smoke-paths.

--- a/Deployment/Linux/powerforge-site.env.example
+++ b/Deployment/Linux/powerforge-site.env.example
@@ -7,6 +7,9 @@ ORIGIN_HOST=example.com
 ORIGIN_ADDRESS=127.0.0.1
 
 RELEASES_TO_KEEP=5
+# The promoter checks these paths against both URLs in standalone mode. The
+# composite action uses them for direct-origin checks on the host and repeats the
+# public checks from the GitHub runner via deployment-smoke-paths.
 SMOKE_PATHS="/ /sitemap.xml"
 
 # Cloudflare remains proxied. Set the zone id and token file for persistent host

--- a/Deployment/Linux/systemd/powerforge-site-reconcile.service
+++ b/Deployment/Linux/systemd/powerforge-site-reconcile.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Reconcile abandoned PowerForge website releases
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/powerforge-site-reconcile

--- a/Deployment/Linux/systemd/powerforge-site-reconcile.timer
+++ b/Deployment/Linux/systemd/powerforge-site-reconcile.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reconcile abandoned PowerForge website releases every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Persistent=true
+Unit=powerforge-site-reconcile.service
+
+[Install]
+WantedBy=timers.target

--- a/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
+++ b/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
@@ -22,6 +22,8 @@ trap cleanup EXIT
 mkdir -p "$fixture_root/bin" "$fixture_root/config" "$fixture_root/locks" "$fixture_root/trusted" "$fixture_root/content"
 install -m 0755 "$repo_root/Deployment/Linux/powerforge-site-deploy.sh" "$fixture_root/bin/powerforge-site-deploy"
 install -m 0755 "$repo_root/Deployment/Linux/powerforge-site-reconcile.sh" "$fixture_root/bin/powerforge-site-reconcile"
+# The quoted literal is the body of the generated curl shim.
+# shellcheck disable=SC2016
 printf '%s\n' \
   '#!/usr/bin/env bash' \
   'printf "%s\\n" "$*" >>"$POWERFORGE_FIXTURE_CURL_LOG"' \
@@ -88,7 +90,6 @@ promote_release() {
     --metadata "/tmp/powerforge-${run_id}-1-example.com/deployment.json" \
     --defer-public-verification)"
   release_id="$(sed -n 's/^POWERFORGE_RELEASE_ID=//p' <<<"$output" | tail -n 1)"
-  previous_release_id="$(sed -n 's/^POWERFORGE_PREVIOUS_RELEASE_ID=//p' <<<"$output" | tail -n 1)"
   [[ -n "$release_id" ]]
 }
 
@@ -97,7 +98,8 @@ run1="$base_run"
 stage_release "$run1" '1111111111111111111111111111111111111111' ephemeral
 promote_release "$run1"
 release1="$release_id"
-[[ -z "$previous_release_id" && -s "$fixture_root/pending/example.com/cloudflare-api.token" ]]
+[[ -s "$fixture_root/pending/example.com/cloudflare-api.token" ]]
+[[ -z "$(sed -n '2p' "$fixture_root/pending/example.com/state")" ]]
 $deploy_command --site example.com --expire-pending
 [[ -d "$fixture_root/pending/example.com" ]]
 $deploy_command --site example.com --finalize --release-id "$release1"
@@ -108,8 +110,8 @@ run2="$((base_run + 1))"
 stage_release "$run2" '2222222222222222222222222222222222222222' ephemeral
 promote_release "$run2"
 release2="$release_id"
-[[ "$previous_release_id" == "$release1" ]]
-$deploy_command --site example.com --rollback --release-id "$release2" --previous-release-id "$release1"
+[[ "$(sed -n '2p' "$fixture_root/pending/example.com/state")" == "$fixture_root/site/releases/$release1" ]]
+$deploy_command --site example.com --rollback --release-id "$release2"
 [[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$release2" ]]
 [[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
 
@@ -118,18 +120,18 @@ stage_release "$run3" '3333333333333333333333333333333333333333' ephemeral
 promote_release "$run3"
 release3="$release_id"
 sed -i '$s/.*/0/' "$fixture_root/pending/example.com/state"
-$fixture_root/bin/powerforge-site-reconcile
+"$fixture_root/bin/powerforge-site-reconcile"
 [[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$release3" ]]
 [[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
 
 prepared_release="prepared-${base_run}"
 mkdir -p "$fixture_root/site/releases/$prepared_release" "$fixture_root/pending/example.com"
-printf '%s\n%s\n%s\n' "$prepared_release" "$release1" '0' >"$fixture_root/pending/example.com/state"
+printf '%s\n%s\n%s\n' "$prepared_release" "$fixture_root/site/releases/$release1" '0' >"$fixture_root/pending/example.com/state"
 printf '%s' 'fixture-token' >"$fixture_root/pending/example.com/cloudflare-api.token"
 printf '%s' '0123456789abcdef0123456789abcdef' >"$fixture_root/pending/example.com/cloudflare-zone-id"
 chmod 0700 "$fixture_root/pending/example.com"
 chmod 0600 "$fixture_root/pending/example.com/"*
-$fixture_root/bin/powerforge-site-reconcile
+"$fixture_root/bin/powerforge-site-reconcile"
 [[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$prepared_release" ]]
 [[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
 
@@ -138,12 +140,26 @@ run4="$((base_run + 3))"
 stage_release "$run4" '4444444444444444444444444444444444444444' host
 promote_release "$run4"
 release4="$release_id"
-[[ "$previous_release_id" == "$release1" && ! -e "$fixture_root/pending/example.com/cloudflare-api.token" ]]
-$deploy_command --site example.com --rollback --release-id "$release4" --previous-release-id "$release1"
+[[ "$(sed -n '2p' "$fixture_root/pending/example.com/state")" == "$fixture_root/site/releases/$release1" ]]
+[[ ! -e "$fixture_root/pending/example.com/cloudflare-api.token" ]]
+$deploy_command --site example.com --rollback --release-id "$release4"
 [[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$release4" ]]
-[[ "$(wc -l <"$fixture_root/curl.log")" -eq 8 ]]
+
+external_target="$fixture_root/external-release"
+mkdir -p "$external_target"
+rm -f "$fixture_root/site/current"
+ln -s "$external_target" "$fixture_root/site/current"
+run5="$((base_run + 4))"
+stage_release "$run5" '5555555555555555555555555555555555555555' host
+promote_release "$run5"
+release5="$release_id"
+[[ "$(sed -n '2p' "$fixture_root/pending/example.com/state")" == "$external_target" ]]
+$deploy_command --site example.com --rollback --release-id "$release5"
+[[ "$(readlink -f "$fixture_root/site/current")" == "$external_target" ]]
+[[ "$(wc -l <"$fixture_root/curl.log")" -eq 10 ]]
 
 printf '%s\n' \
   'deferred_finalize_and_rollback=passed' \
   'expired_and_prepared_release_reconciliation=passed' \
-  'ephemeral_and_host_cache_purge=passed'
+  'ephemeral_and_host_cache_purge=passed' \
+  'external_rollback_target=passed'

--- a/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
+++ b/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+[[ "$(id -u)" -eq 0 ]] || { echo 'This fixture must run as root.' >&2; exit 1; }
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+fixture_root="$(mktemp -d /tmp/powerforge-site-fixture.XXXXXXXX)"
+base_run="$((900000 + $$))"
+stage_paths=()
+
+cleanup() {
+  if [[ "$fixture_root" == /tmp/powerforge-site-fixture.* ]]; then
+    rm -rf -- "$fixture_root"
+  fi
+  local stage_path
+  for stage_path in "${stage_paths[@]}"; do
+    [[ "$stage_path" == /tmp/powerforge-[0-9]*-1-example.com ]] && rm -rf -- "$stage_path"
+  done
+}
+trap cleanup EXIT
+
+mkdir -p "$fixture_root/bin" "$fixture_root/config" "$fixture_root/locks" "$fixture_root/trusted" "$fixture_root/content"
+install -m 0755 "$repo_root/Deployment/Linux/powerforge-site-deploy.sh" "$fixture_root/bin/powerforge-site-deploy"
+install -m 0755 "$repo_root/Deployment/Linux/powerforge-site-reconcile.sh" "$fixture_root/bin/powerforge-site-reconcile"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\\n" "$*" >>"$POWERFORGE_FIXTURE_CURL_LOG"' \
+  'printf "%s\\n" "{\"success\":true}"' >"$fixture_root/bin/curl"
+chmod 0755 "$fixture_root/bin/curl"
+printf '%s\n' '<!doctype html><title>PowerForge deployment fixture</title>' >"$fixture_root/content/index.html"
+tar -cf "$fixture_root/artifact.tar" -C "$fixture_root/content" .
+artifact_sha="$(sha256sum "$fixture_root/artifact.tar" | awk '{print $1}')"
+printf '%s' 'host-token' >"$fixture_root/host.token"
+chmod 0600 "$fixture_root/host.token"
+
+export PATH="$fixture_root/bin:$PATH"
+export POWERFORGE_FIXTURE_CURL_LOG="$fixture_root/curl.log"
+export POWERFORGE_SITE_CONFIG_ROOT="$fixture_root/config"
+export POWERFORGE_SITE_LOCK_ROOT="$fixture_root/locks"
+export POWERFORGE_SITE_TRUSTED_STAGE_ROOT="$fixture_root/trusted"
+export POWERFORGE_SITE_PENDING_STATE_ROOT="$fixture_root/pending"
+export POWERFORGE_SITE_DEPLOY_COMMAND="$fixture_root/bin/powerforge-site-deploy"
+deploy_command="$fixture_root/bin/powerforge-site-deploy"
+
+write_config() {
+  local credential_mode="$1"
+  local values=(
+    "SITE_ROOT=$fixture_root/site"
+    'PUBLIC_URL=https://example.com'
+    'RELEASES_TO_KEEP=5'
+    'SMOKE_PATHS="/"'
+    'CLOUDFLARE_PURGE_ENABLED=1'
+    'PENDING_TTL_SECONDS=600'
+    'PENDING_RECONCILE_REQUIRED=0'
+  )
+  if [[ "$credential_mode" == 'host' ]]; then
+    values+=(
+      'CLOUDFLARE_ZONE_ID=0123456789abcdef0123456789abcdef'
+      "CLOUDFLARE_API_TOKEN_FILE=$fixture_root/host.token"
+    )
+  fi
+  printf '%s\n' "${values[@]}" >"$fixture_root/config/example.com.env"
+}
+
+stage_release() {
+  local run_id="$1"
+  local source_sha="$2"
+  local credential_mode="$3"
+  local stage_path="/tmp/powerforge-${run_id}-1-example.com"
+  stage_paths+=("$stage_path")
+  install -d -m 0700 "$stage_path"
+  install -m 0600 "$fixture_root/artifact.tar" "$stage_path/artifact.tar"
+  printf '{"sourceSha":"%s","artifactSha256":"%s","workflowRunId":"%s","workflowRunAttempt":"1"}\n' \
+    "$source_sha" "$artifact_sha" "$run_id" >"$stage_path/deployment.json"
+  chmod 0600 "$stage_path/deployment.json"
+  if [[ "$credential_mode" == 'ephemeral' ]]; then
+    printf '%s' 'fixture-token' >"$stage_path/cloudflare-api.token"
+    printf '%s' '0123456789abcdef0123456789abcdef' >"$stage_path/cloudflare-zone-id"
+    chmod 0600 "$stage_path/cloudflare-api.token" "$stage_path/cloudflare-zone-id"
+  fi
+}
+
+promote_release() {
+  local run_id="$1"
+  local output
+  output="$($deploy_command --site example.com \
+    --archive "/tmp/powerforge-${run_id}-1-example.com/artifact.tar" \
+    --metadata "/tmp/powerforge-${run_id}-1-example.com/deployment.json" \
+    --defer-public-verification)"
+  release_id="$(sed -n 's/^POWERFORGE_RELEASE_ID=//p' <<<"$output" | tail -n 1)"
+  previous_release_id="$(sed -n 's/^POWERFORGE_PREVIOUS_RELEASE_ID=//p' <<<"$output" | tail -n 1)"
+  [[ -n "$release_id" ]]
+}
+
+write_config ephemeral
+run1="$base_run"
+stage_release "$run1" '1111111111111111111111111111111111111111' ephemeral
+promote_release "$run1"
+release1="$release_id"
+[[ -z "$previous_release_id" && -s "$fixture_root/pending/example.com/cloudflare-api.token" ]]
+$deploy_command --site example.com --expire-pending
+[[ -d "$fixture_root/pending/example.com" ]]
+$deploy_command --site example.com --finalize --release-id "$release1"
+[[ ! -e "$fixture_root/pending/example.com" ]]
+[[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
+
+run2="$((base_run + 1))"
+stage_release "$run2" '2222222222222222222222222222222222222222' ephemeral
+promote_release "$run2"
+release2="$release_id"
+[[ "$previous_release_id" == "$release1" ]]
+$deploy_command --site example.com --rollback --release-id "$release2" --previous-release-id "$release1"
+[[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$release2" ]]
+[[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
+
+run3="$((base_run + 2))"
+stage_release "$run3" '3333333333333333333333333333333333333333' ephemeral
+promote_release "$run3"
+release3="$release_id"
+sed -i '$s/.*/0/' "$fixture_root/pending/example.com/state"
+$fixture_root/bin/powerforge-site-reconcile
+[[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$release3" ]]
+[[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
+
+prepared_release="prepared-${base_run}"
+mkdir -p "$fixture_root/site/releases/$prepared_release" "$fixture_root/pending/example.com"
+printf '%s\n%s\n%s\n' "$prepared_release" "$release1" '0' >"$fixture_root/pending/example.com/state"
+printf '%s' 'fixture-token' >"$fixture_root/pending/example.com/cloudflare-api.token"
+printf '%s' '0123456789abcdef0123456789abcdef' >"$fixture_root/pending/example.com/cloudflare-zone-id"
+chmod 0700 "$fixture_root/pending/example.com"
+chmod 0600 "$fixture_root/pending/example.com/"*
+$fixture_root/bin/powerforge-site-reconcile
+[[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$prepared_release" ]]
+[[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
+
+write_config host
+run4="$((base_run + 3))"
+stage_release "$run4" '4444444444444444444444444444444444444444' host
+promote_release "$run4"
+release4="$release_id"
+[[ "$previous_release_id" == "$release1" && ! -e "$fixture_root/pending/example.com/cloudflare-api.token" ]]
+$deploy_command --site example.com --rollback --release-id "$release4" --previous-release-id "$release1"
+[[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$release4" ]]
+[[ "$(wc -l <"$fixture_root/curl.log")" -eq 8 ]]
+
+printf '%s\n' \
+  'deferred_finalize_and_rollback=passed' \
+  'expired_and_prepared_release_reconciliation=passed' \
+  'ephemeral_and_host_cache_purge=passed'

--- a/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
+++ b/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
@@ -108,6 +108,11 @@ $deploy_command --site example.com --expire-pending
 $deploy_command --site example.com --finalize --release-id "$release1"
 [[ ! -e "$fixture_root/pending/example.com" ]]
 [[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
+$deploy_command --site example.com --finalize --release-id "$release1"
+if $deploy_command --site example.com --rollback --release-id "$release1" 2>/dev/null; then
+  echo 'A live finalized release was incorrectly accepted as already rolled back.' >&2
+  exit 1
+fi
 
 run2="$((base_run + 1))"
 stage_release "$run2" '2222222222222222222222222222222222222222' ephemeral
@@ -117,6 +122,7 @@ release2="$release_id"
 $deploy_command --site example.com --rollback --release-id "$release2"
 [[ ! -e "$fixture_root/pending/example.com" && ! -e "$fixture_root/site/releases/$release2" ]]
 [[ "$(basename "$(readlink -f "$fixture_root/site/current")")" == "$release1" ]]
+$deploy_command --site example.com --rollback --release-id "$release2"
 
 run3="$((base_run + 2))"
 stage_release "$run3" '3333333333333333333333333333333333333333' ephemeral

--- a/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
+++ b/Deployment/Linux/tests/powerforge-site-deploy-fixture.sh
@@ -80,6 +80,9 @@ stage_release() {
     printf '%s' '0123456789abcdef0123456789abcdef' >"$stage_path/cloudflare-zone-id"
     chmod 0600 "$stage_path/cloudflare-api.token" "$stage_path/cloudflare-zone-id"
   fi
+  if [[ -n "${SUDO_UID:-}" ]]; then
+    chown "${SUDO_UID}:${SUDO_GID:-$SUDO_UID}" "$stage_path" "$stage_path/"*
+  fi
 }
 
 promote_release() {

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -141,7 +141,9 @@ checks that state every minute and restores an abandoned release after runner
 cancellation, timeout, or loss. Deferred promotion refuses to start when that timer is
 not active. The trusted pending state stores the exact resolved previous target, so
 rollback also preserves an existing `current` symlink outside the managed release root;
-that path is never accepted from the runner.
+that path is never accepted from the runner. Finalize and rollback acknowledge the
+same completed release idempotently, and the runner retries once when an SSH response
+is lost after the host has already reached that terminal state.
 
 On the first PowerForge deployment, an existing non-symlink `current` directory is
 moved into the release history and becomes the rollback target. This lets the shared

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -100,6 +100,20 @@ Give each repository a separate deployment key and a protected GitHub environmen
 Restrict its server account/sudo rule to the expected site argument. Do not share one
 unrestricted deployment key across every repository.
 
+The protected action uses three promoter commands: deferred promotion, finalization,
+and rollback. Allow only those exact command shapes for the repository's deployment
+account. For example:
+
+```sudoers
+powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --archive /tmp/powerforge-[0-9]+-[0-9]+-example\.com/artifact\.tar --metadata /tmp/powerforge-[0-9]+-[0-9]+-example\.com/deployment\.json --defer-public-verification$
+powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --finalize --release-id [A-Za-z0-9][A-Za-z0-9._-]*( --previous-release-id [A-Za-z0-9][A-Za-z0-9._-]*)?$
+powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --rollback --release-id [A-Za-z0-9][A-Za-z0-9._-]*( --previous-release-id [A-Za-z0-9][A-Za-z0-9._-]*)?$
+```
+
+Validate the installed file with `visudo -cf`. Sites upgrading from the earlier
+one-shot action must install these rules before repinning the action; retaining only
+the old promotion rule will reject the deferred verification protocol.
+
 The promoter rejects path traversal, links, special files, checksum mismatches,
 unconfigured site ids, mutable site configuration, and workflow staging files owned
 by another account. It atomically promotes a timestamped release, purges Cloudflare

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -119,8 +119,8 @@ account. For example:
 
 ```sudoers
 powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --archive /tmp/powerforge-[0-9]+-[0-9]+-example\.com/artifact\.tar --metadata /tmp/powerforge-[0-9]+-[0-9]+-example\.com/deployment\.json --defer-public-verification$
-powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --finalize --release-id [A-Za-z0-9][A-Za-z0-9._-]*( --previous-release-id [A-Za-z0-9][A-Za-z0-9._-]*)?$
-powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --rollback --release-id [A-Za-z0-9][A-Za-z0-9._-]*( --previous-release-id [A-Za-z0-9][A-Za-z0-9._-]*)?$
+powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --finalize --release-id [A-Za-z0-9][A-Za-z0-9._-]*$
+powerforge-example ALL=(root) NOPASSWD: /usr/local/sbin/powerforge-site-deploy ^--site example\.com --rollback --release-id [A-Za-z0-9][A-Za-z0-9._-]*$
 ```
 
 Validate the installed file with `visudo -cf`. Sites upgrading from the earlier
@@ -139,7 +139,9 @@ Release pruning happens only after the runner finalizes a verified release. Defe
 promotions create root-only pending state with a ten-minute deadline. The reconciler
 checks that state every minute and restores an abandoned release after runner
 cancellation, timeout, or loss. Deferred promotion refuses to start when that timer is
-not active.
+not active. The trusted pending state stores the exact resolved previous target, so
+rollback also preserves an existing `current` symlink outside the managed release root;
+that path is never accepted from the runner.
 
 On the first PowerForge deployment, an existing non-symlink `current` directory is
 moved into the release history and becomes the rollback target. This lets the shared

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -90,11 +90,24 @@ This two-job lane:
 7. finalizes the release, or restores the previous symlink and purges the rejected release from cache
 
 Install `Deployment/Linux/powerforge-site-deploy.sh` as
-`/usr/local/sbin/powerforge-site-deploy`. Install one root-owned configuration from
+`/usr/local/sbin/powerforge-site-deploy` and
+`Deployment/Linux/powerforge-site-reconcile.sh` as
+`/usr/local/sbin/powerforge-site-reconcile`. Install and enable the matching
+`powerforge-site-reconcile.service` and `powerforge-site-reconcile.timer` units from
+`Deployment/Linux/systemd`. Install one root-owned configuration from
 `Deployment/Linux/powerforge-site.env.example` under
 `/etc/powerforge/sites/<site>.env`. The workflow cannot provide release roots,
 Cloudflare credentials, origin addresses, or smoke policy; those remain trusted host
-configuration.
+configuration. The protected action also requires an explicit `deployment-public-url`;
+the site id is an allowlist key and is not assumed to be a public hostname.
+
+```bash
+sudo install -m 0755 Deployment/Linux/powerforge-site-reconcile.sh /usr/local/sbin/powerforge-site-reconcile
+sudo install -m 0644 Deployment/Linux/systemd/powerforge-site-reconcile.service /etc/systemd/system/powerforge-site-reconcile.service
+sudo install -m 0644 Deployment/Linux/systemd/powerforge-site-reconcile.timer /etc/systemd/system/powerforge-site-reconcile.timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now powerforge-site-reconcile.timer
+```
 
 Give each repository a separate deployment key and a protected GitHub environment.
 Restrict its server account/sudo rule to the expected site argument. Do not share one
@@ -122,7 +135,11 @@ composite action then verifies the same provenance and configured smoke paths th
 the public URL from the GitHub runner. This separation avoids treating an origin-host
 Cloudflare challenge as a broken release. A public verification failure restores the
 previous symlink remotely, removes the rejected release, and purges Cloudflare again.
-Release pruning happens only after the runner finalizes a verified release.
+Release pruning happens only after the runner finalizes a verified release. Deferred
+promotions create root-only pending state with a ten-minute deadline. The reconciler
+checks that state every minute and restores an abandoned release after runner
+cancellation, timeout, or loss. Deferred promotion refuses to start when that timer is
+not active.
 
 On the first PowerForge deployment, an existing non-symlink `current` directory is
 moved into the release history and becomes the rollback target. This lets the shared
@@ -135,8 +152,10 @@ id only inside temporary deployment staging. A least-privilege cache-purge token
 therefore does not need Zone Read. If
 the zone-id secret is absent, the action may discover exactly one active zone by
 name; that fallback also requires Zone Read and uses Cloudflare's valid page size.
-The promoter copies the credentials into root-only staging,
-purges before exact-SHA verification, and erases them on every success or failure.
+The promoter copies the credentials into root-only staging and purges before exact-SHA
+verification. During deferred verification it retains the scoped token only in the
+root-only pending directory so an abandoned release can be rolled back and purged.
+Finalization, explicit rollback, or deadline reconciliation erases that pending state.
 The normal website-pipeline Cloudflare token remains isolated to the build and is
 never reused for Linux promotion.
 This keeps Cloudflare proxying and cache analytics enabled without storing a broad

--- a/Docs/PowerForge.Web.LinuxDeployment.md
+++ b/Docs/PowerForge.Web.LinuxDeployment.md
@@ -1,6 +1,6 @@
 # PowerForge.Web Linux Deployment Pattern
 
-Last updated: 2026-07-15
+Last updated: 2026-07-16
 
 This pattern is the reusable baseline for static PowerForge.Web sites hosted on Linux with Apache or another file-based web server.
 
@@ -11,7 +11,7 @@ This pattern is the reusable baseline for static PowerForge.Web sites hosted on 
 - Publish each deploy into a timestamped release directory.
 - Promote the release by moving a `current` symlink.
 - Record the exact source commit, PowerForge commit, workflow run, and artifact checksum.
-- Roll back automatically when origin or public smoke checks fail.
+- Roll back automatically when origin or externally verified public smoke checks fail.
 - Keep generated web-server redirect artifacts in sync.
 - Keep provider-specific cache purges in environment variables, not in repo files.
 
@@ -55,6 +55,8 @@ jobs:
         with:
           artifact-name: powerforge-site-example.com
           deployment-site: example.com
+          deployment-public-url: https://example.com
+          deployment-smoke-paths: "/ /sitemap.xml"
           deployment-host: ${{ vars.POWERFORGE_WEBSITE_DEPLOY_HOST }}
           deployment-port: ${{ vars.POWERFORGE_WEBSITE_DEPLOY_PORT }}
           deployment-user: ${{ vars.POWERFORGE_WEBSITE_DEPLOY_USER }}
@@ -84,6 +86,8 @@ This two-job lane:
 3. records exact source and engine SHAs plus the artifact SHA-256
 4. transfers the artifact through a pinned SSH host key
 5. invokes the root-owned server promoter for an allowlisted site id
+6. verifies the promoted release directly at the origin and from the GitHub runner
+7. finalizes the release, or restores the previous symlink and purges the rejected release from cache
 
 Install `Deployment/Linux/powerforge-site-deploy.sh` as
 `/usr/local/sbin/powerforge-site-deploy`. Install one root-owned configuration from
@@ -99,8 +103,12 @@ unrestricted deployment key across every repository.
 The promoter rejects path traversal, links, special files, checksum mismatches,
 unconfigured site ids, mutable site configuration, and workflow staging files owned
 by another account. It atomically promotes a timestamped release, purges Cloudflare
-without disabling proxying, verifies the exact source SHA through both the origin and
-public URL, and rolls back the symlink if any check fails.
+without disabling proxying, and verifies exact provenance directly at the origin. The
+composite action then verifies the same provenance and configured smoke paths through
+the public URL from the GitHub runner. This separation avoids treating an origin-host
+Cloudflare challenge as a broken release. A public verification failure restores the
+previous symlink remotely, removes the rejected release, and purges Cloudflare again.
+Release pruning happens only after the runner finalizes a verified release.
 
 On the first PowerForge deployment, an existing non-symlink `current` directory is
 moved into the release history and becomes the rollback target. This lets the shared

--- a/PowerForge.Tests/GitHubProtectedEnvironmentDeployActionTests.cs
+++ b/PowerForge.Tests/GitHubProtectedEnvironmentDeployActionTests.cs
@@ -26,6 +26,8 @@ public sealed class GitHubProtectedEnvironmentDeployActionTests
         Assert.Contains("cloudflare-api.token", script, StringComparison.Ordinal);
         Assert.Contains("--defer-public-verification", script, StringComparison.Ordinal);
         Assert.Contains("Assert-PowerForgePublicSite", script, StringComparison.Ordinal);
+        Assert.Contains("deployment-public-url is required", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("https://$($env:POWERFORGE_DEPLOYMENT_SITE)", script, StringComparison.Ordinal);
         Assert.Contains("--finalize", script, StringComparison.Ordinal);
         Assert.Contains("--rollback", script, StringComparison.Ordinal);
         Assert.Contains("Invoke-CloudflarePurge", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubProtectedEnvironmentDeployActionTests.cs
+++ b/PowerForge.Tests/GitHubProtectedEnvironmentDeployActionTests.cs
@@ -30,6 +30,7 @@ public sealed class GitHubProtectedEnvironmentDeployActionTests
         Assert.DoesNotContain("https://$($env:POWERFORGE_DEPLOYMENT_SITE)", script, StringComparison.Ordinal);
         Assert.Contains("--finalize", script, StringComparison.Ordinal);
         Assert.Contains("--rollback", script, StringComparison.Ordinal);
+        Assert.Contains("retrying once to confirm terminal state", script, StringComparison.Ordinal);
         Assert.Contains("Invoke-CloudflarePurge", script, StringComparison.Ordinal);
         Assert.Contains("Invoke-PowerForgePublicRequest", publicVerification, StringComparison.Ordinal);
         Assert.Contains("workflowRunAttempt", publicVerification, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubProtectedEnvironmentDeployActionTests.cs
+++ b/PowerForge.Tests/GitHubProtectedEnvironmentDeployActionTests.cs
@@ -7,9 +7,12 @@ public sealed class GitHubProtectedEnvironmentDeployActionTests
     {
         var action = ReadRepoFile(".github", "actions", "powerforge-linux-site-deploy", "action.yml");
         var script = ReadRepoFile(".github", "actions", "powerforge-linux-site-deploy", "Invoke-PowerForgeLinuxSiteDeploy.ps1");
+        var publicVerification = ReadRepoFile(".github", "actions", "powerforge-linux-site-deploy", "Test-PowerForgePublicSite.ps1");
 
         Assert.Contains("using: composite", action, StringComparison.Ordinal);
         Assert.Contains("deployment-ssh-private-key", action, StringComparison.Ordinal);
+        Assert.Contains("deployment-public-url", action, StringComparison.Ordinal);
+        Assert.Contains("deployment-smoke-paths", action, StringComparison.Ordinal);
         Assert.Contains("Reject pull request deployments", action, StringComparison.Ordinal);
         Assert.DoesNotContain("github.event.pull_request.head.sha", action, StringComparison.Ordinal);
         Assert.Contains("actions/download-artifact@", action, StringComparison.Ordinal);
@@ -21,8 +24,16 @@ public sealed class GitHubProtectedEnvironmentDeployActionTests
         Assert.Contains("IdentitiesOnly=yes", script, StringComparison.Ordinal);
         Assert.Contains("StrictHostKeyChecking=yes", script, StringComparison.Ordinal);
         Assert.Contains("cloudflare-api.token", script, StringComparison.Ordinal);
+        Assert.Contains("--defer-public-verification", script, StringComparison.Ordinal);
+        Assert.Contains("Assert-PowerForgePublicSite", script, StringComparison.Ordinal);
+        Assert.Contains("--finalize", script, StringComparison.Ordinal);
+        Assert.Contains("--rollback", script, StringComparison.Ordinal);
+        Assert.Contains("Invoke-CloudflarePurge", script, StringComparison.Ordinal);
+        Assert.Contains("Invoke-PowerForgePublicRequest", publicVerification, StringComparison.Ordinal);
+        Assert.Contains("workflowRunAttempt", publicVerification, StringComparison.Ordinal);
         Assert.Contains("finally", script, StringComparison.Ordinal);
         Assert.InRange(NormalizedLineCount(script), 1, 250);
+        Assert.InRange(NormalizedLineCount(publicVerification), 1, 120);
     }
 
     [Fact]

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -63,6 +63,8 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("verify_origin_release", script, StringComparison.Ordinal);
         Assert.Contains("--defer-public-verification", script, StringComparison.Ordinal);
         Assert.Contains("finalize_deferred_release", script, StringComparison.Ordinal);
+        Assert.Contains("was already finalized", script, StringComparison.Ordinal);
+        Assert.Contains("was already rolled back", script, StringComparison.Ordinal);
         Assert.Contains("rollback_deferred_release", script, StringComparison.Ordinal);
         Assert.Contains("POWERFORGE_RELEASE_ID", script, StringComparison.Ordinal);
         Assert.Contains("POWERFORGE_PENDING_EXPIRES_AT", script, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -17,6 +17,7 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("deployment_artifact_retention_days", workflow, StringComparison.Ordinal);
         Assert.Contains("job.workflow_sha", workflow, StringComparison.Ordinal);
         Assert.Contains("uses: ./.powerforge-deployment/.github/actions/powerforge-linux-site-deploy", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment_url is required when deployment_target is linux", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("Publish and promote Linux release", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("scp @scpArgs", workflow, StringComparison.Ordinal);
         Assert.Contains("      pages: write", workflow, StringComparison.Ordinal);
@@ -51,6 +52,8 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
     public void LinuxPromoter_ShouldProtectPromotionAndRollbackContracts()
     {
         var script = ReadRepoFile("Deployment", "Linux", "powerforge-site-deploy.sh");
+        var reconciler = ReadRepoFile("Deployment", "Linux", "powerforge-site-reconcile.sh");
+        var reconcileTimer = ReadRepoFile("Deployment", "Linux", "systemd", "powerforge-site-reconcile.timer");
 
         Assert.Contains("/etc/powerforge/sites", script, StringComparison.Ordinal);
         Assert.Contains("Artifact checksum does not match", script, StringComparison.Ordinal);
@@ -62,6 +65,13 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("finalize_deferred_release", script, StringComparison.Ordinal);
         Assert.Contains("rollback_deferred_release", script, StringComparison.Ordinal);
         Assert.Contains("POWERFORGE_RELEASE_ID", script, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_PENDING_EXPIRES_AT", script, StringComparison.Ordinal);
+        Assert.Contains("--expire-pending", script, StringComparison.Ordinal);
+        Assert.Contains("PENDING_TTL_SECONDS", script, StringComparison.Ordinal);
+        Assert.Contains("ensure_pending_reconciler", script, StringComparison.Ordinal);
+        Assert.Contains("create_pending_release", script, StringComparison.Ordinal);
+        Assert.Contains("configure_pending_cloudflare", script, StringComparison.Ordinal);
+        Assert.Contains("remove_pending_release", script, StringComparison.Ordinal);
         Assert.Contains("rolling back", script, StringComparison.Ordinal);
         Assert.Contains("Migrating legacy current directory", script, StringComparison.Ordinal);
         Assert.Contains("restoring the legacy current directory", script, StringComparison.Ordinal);
@@ -91,6 +101,13 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.DoesNotContain("workflow's cloudflare_api_token secret", environmentExample, StringComparison.Ordinal);
         Assert.Contains("cloudflare-api.token", script, StringComparison.Ordinal);
         Assert.Contains("Ephemeral Cloudflare zone id does not match", script, StringComparison.Ordinal);
+        Assert.Contains("--expire-pending", reconciler, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_SITE_PENDING_STATE_ROOT", reconciler, StringComparison.Ordinal);
+        Assert.Contains("OnUnitActiveSec=1min", reconcileTimer, StringComparison.Ordinal);
+        Assert.Contains("Persistent=true", reconcileTimer, StringComparison.Ordinal);
+        Assert.Contains("sudo bash Deployment/Linux/tests/powerforge-site-deploy-fixture.sh", ReadRepoFile(".github", "workflows", "BuildModule.yml"), StringComparison.Ordinal);
+        Assert.InRange(NormalizedLineCount(script), 1, 650);
+        Assert.InRange(NormalizedLineCount(reconciler), 1, 100);
     }
 
     private static string ReadRepoFile(params string[] relativePath)
@@ -105,4 +122,7 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
 
         throw new DirectoryNotFoundException("Unable to locate repository root.");
     }
+
+    private static int NormalizedLineCount(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n').Length;
 }

--- a/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteLinuxDeployWorkflowTests.cs
@@ -15,8 +15,10 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("deployment_ssh_known_hosts", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("ssh-keyscan", workflow, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("deployment_artifact_retention_days", workflow, StringComparison.Ordinal);
-        Assert.Contains("$env:RUNNER_TEMP 'powerforge-deployment-ssh'", workflow, StringComparison.Ordinal);
-        Assert.DoesNotContain("Join-Path $HOME '.ssh'", workflow, StringComparison.Ordinal);
+        Assert.Contains("job.workflow_sha", workflow, StringComparison.Ordinal);
+        Assert.Contains("uses: ./.powerforge-deployment/.github/actions/powerforge-linux-site-deploy", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("Publish and promote Linux release", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("scp @scpArgs", workflow, StringComparison.Ordinal);
         Assert.Contains("      pages: write", workflow, StringComparison.Ordinal);
         Assert.Contains("      id-token: write", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("vars.POWERFORGE_DEPLOY_HOST", workflow, StringComparison.Ordinal);
@@ -29,19 +31,20 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
     {
         var deployWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
         var runWorkflow = ReadRepoFile(".github", "workflows", "powerforge-website-run.yml");
+        var deployAction = ReadRepoFile(".github", "actions", "powerforge-linux-site-deploy", "Invoke-PowerForgeLinuxSiteDeploy.ps1");
 
         Assert.Contains("source_ref:", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("ref: ${{ inputs.source_ref || github.event.pull_request.head.sha || github.sha }}", deployWorkflow, StringComparison.Ordinal);
         Assert.Equal(2, deployWorkflow.Split("source_ref: ${{ inputs.source_ref }}", StringSplitOptions.None).Length - 1);
-        Assert.Contains("SOURCE_SHA: ${{ needs.build.outputs.source_sha }}", deployWorkflow, StringComparison.Ordinal);
-        Assert.DoesNotContain("SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}", deployWorkflow, StringComparison.Ordinal);
+        Assert.Contains("source-sha: ${{ needs.build.outputs.source_sha }}", deployWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("source-sha: ${{ github.event.pull_request.head.sha || github.sha }}", deployWorkflow, StringComparison.Ordinal);
         Assert.Contains("--result-path", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("Resolve actual PowerForge engine provenance", runWorkflow, StringComparison.Ordinal);
         Assert.Contains("assetSha256", runWorkflow, StringComparison.Ordinal);
-        Assert.Contains("sourceSha", deployWorkflow, StringComparison.Ordinal);
-        Assert.Contains("engineSha", deployWorkflow, StringComparison.Ordinal);
-        Assert.Contains("artifactSha256", deployWorkflow, StringComparison.Ordinal);
-        Assert.Contains("workflowRunAttempt", deployWorkflow, StringComparison.Ordinal);
+        Assert.Contains("sourceSha", deployAction, StringComparison.Ordinal);
+        Assert.Contains("engineSha", deployAction, StringComparison.Ordinal);
+        Assert.Contains("artifactSha256", deployAction, StringComparison.Ordinal);
+        Assert.Contains("workflowRunAttempt", deployAction, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -53,8 +56,12 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         Assert.Contains("Artifact checksum does not match", script, StringComparison.Ordinal);
         Assert.Contains("Archive contains path traversal", script, StringComparison.Ordinal);
         Assert.Contains("purge_cloudflare", script, StringComparison.Ordinal);
-        Assert.Contains("Public endpoint did not serve", script, StringComparison.Ordinal);
-        Assert.Contains("Origin endpoint did not serve", script, StringComparison.Ordinal);
+        Assert.Contains("verify_public_release", script, StringComparison.Ordinal);
+        Assert.Contains("verify_origin_release", script, StringComparison.Ordinal);
+        Assert.Contains("--defer-public-verification", script, StringComparison.Ordinal);
+        Assert.Contains("finalize_deferred_release", script, StringComparison.Ordinal);
+        Assert.Contains("rollback_deferred_release", script, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_RELEASE_ID", script, StringComparison.Ordinal);
         Assert.Contains("rolling back", script, StringComparison.Ordinal);
         Assert.Contains("Migrating legacy current directory", script, StringComparison.Ordinal);
         Assert.Contains("restoring the legacy current directory", script, StringComparison.Ordinal);
@@ -72,10 +79,13 @@ public sealed class GitHubWebsiteLinuxDeployWorkflowTests
         string workflow = ReadRepoFile(".github", "workflows", "powerforge-website-deploy.yml");
         Assert.Contains("deployment_cloudflare_zone", workflow, StringComparison.Ordinal);
         Assert.Contains("deployment_cloudflare_api_token", workflow, StringComparison.Ordinal);
-        Assert.Contains("CLOUDFLARE_API_TOKEN: ${{ secrets.deployment_cloudflare_api_token }}", workflow, StringComparison.Ordinal);
-        Assert.DoesNotContain("CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}", workflow, StringComparison.Ordinal);
-        Assert.Contains("CLOUDFLARE_ZONE_ID", workflow, StringComparison.Ordinal);
-        Assert.Contains("per_page=5", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment-cloudflare-api-token: ${{ secrets.deployment_cloudflare_api_token }}", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("deployment-cloudflare-api-token: ${{ secrets.cloudflare_api_token }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("cloudflare-zone-id: ${{ secrets.cloudflare_zone_id }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment-public-url: ${{ inputs.deployment_url }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("deployment-smoke-paths: ${{ inputs.deployment_smoke_paths }}", workflow, StringComparison.Ordinal);
+        string deployAction = ReadRepoFile(".github", "actions", "powerforge-linux-site-deploy", "Invoke-PowerForgeLinuxSiteDeploy.ps1");
+        Assert.Contains("per_page=5", deployAction, StringComparison.Ordinal);
         string environmentExample = ReadRepoFile("Deployment", "Linux", "powerforge-site.env.example");
         Assert.Contains("deployment_cloudflare_api_token", environmentExample, StringComparison.Ordinal);
         Assert.DoesNotContain("workflow's cloudflare_api_token secret", environmentExample, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- verify exact public provenance and smoke paths from the GitHub runner after the host proves the origin
- require the public HTTPS origin explicitly instead of deriving it from the host allowlist id
- add deferred finalize/rollback operations with root-only pending state and automatic ten-minute expiry
- purge with either ephemeral deployment credentials or a persistent host token before clearing rejected state
- make the reusable all-in-one workflow delegate to the same composite action instead of duplicating SSH, SCP, metadata, and cleanup logic

## Safety and recovery

The host writes pending state before moving `current`. A generic systemd timer reconciles abandoned promotions every minute, including runner cancellation, timeout, or host restart. Finalize and rollback require the exact pending release identity. The root-owned state preserves the exact resolved previous symlink target, including targets outside the managed releases directory. Ephemeral cache-purge credentials remain root-only only until that state is finalized or rolled back.

Finalize and rollback are idempotent for the exact terminal release state. The runner retries once when SSH loses an acknowledgement after the host has already completed the operation.

Strict deployment accounts need the documented three-command sudoers allowlist for deferred promotion, finalize, and rollback.

## Validation

- 7 focused xUnit deployment contract tests
- checked-in root Linux fixture covering finalize, explicit rollback, idempotent terminal acknowledgement, deadline rollback, prepared-but-never-promoted cleanup, external rollback targets, sudo payload ownership, and both Cloudflare credential modes
- PowerShell parser, Bash syntax, ShellCheck, YAML parse, systemd unit verification, and `git diff --check`
- live public verifier accepted exact CodeGlyphX provenance and rejected an incorrect source SHA
