### PR TITLE
Resolve central MSBuild package versions during release

### DIFF
--- a/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetRepositoryReleaseCentralVersionTests
+{
+    [Fact]
+    public void Execute_UpdateVersionsDisabled_UsesEvaluatedPackageVersionForMsBuildBatchCollection()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <ProductVersion>1.2.3</ProductVersion>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.CentralVersion"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.CentralVersion.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.CentralVersion</PackageId>
+                    <VersionPrefix>$(ProductVersion)</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var outputPath = Path.Combine(root.FullName, "packages");
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = outputPath,
+                Pack = true,
+                PackStrategy = DotNetRepositoryPackStrategy.MSBuild,
+                Publish = false,
+                UpdateVersions = false,
+                SignAssemblies = false,
+                SignPackages = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("1.2.3", result.ResolvedVersionsByProject["Sample.CentralVersion"]);
+            var project = Assert.Single(result.Projects, candidate => candidate.IsPackable);
+            Assert.Equal("1.2.3", project.OldVersion);
+            Assert.Equal("1.2.3", project.NewVersion);
+            var package = Assert.Single(project.Packages);
+            Assert.Equal("Sample.CentralVersion.1.2.3.nupkg", Path.GetFileName(package));
+            Assert.True(File.Exists(package));
+            Assert.DoesNotContain("$(ProductVersion)", result.ResolvedVersionsByProject.Values);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
@@ -8,6 +8,55 @@ namespace PowerForge.Tests;
 public sealed class DotNetRepositoryReleaseCentralVersionTests
 {
     [Fact]
+    public void Execute_NoExpectedVersion_PreservesCentralVersionReference()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <ProductVersion>1.2.3</ProductVersion>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.CentralVersion"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.CentralVersion.csproj");
+            const string projectSource = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.CentralVersion</PackageId>
+                    <VersionPrefix>$(ProductVersion)</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            File.WriteAllText(projectPath, projectSource);
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                Pack = false,
+                Publish = false,
+                UpdateVersions = true,
+                SignAssemblies = false,
+                SignPackages = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("1.2.3", result.ResolvedVersionsByProject["Sample.CentralVersion"]);
+            Assert.Equal(projectSource, File.ReadAllText(projectPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Execute_UpdateVersionsDisabled_UsesEvaluatedPackageVersionForMsBuildBatchCollection()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
@@ -171,4 +171,45 @@ public sealed class DotNetRepositoryReleaseCentralVersionTests
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
     }
+
+    [Fact]
+    public void Execute_WhatIf_PreservesDeclaredReferenceWithoutEvaluatingMsBuild()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.WhatIf"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.WhatIf.csproj");
+            const string projectSource = """
+                <Project Sdk="Intentionally.Missing.Sdk/999.0.0">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.WhatIf</PackageId>
+                    <VersionPrefix>$(ProductVersion)</VersionPrefix>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            File.WriteAllText(projectPath, projectSource);
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Pack = false,
+                Publish = false,
+                UpdateVersions = false,
+                WhatIf = true,
+                SignAssemblies = false,
+                SignPackages = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("$(ProductVersion)", result.ResolvedVersionsByProject["Sample.WhatIf"]);
+            Assert.Equal(projectSource, File.ReadAllText(projectPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseCentralVersionTests.cs
@@ -112,4 +112,63 @@ public sealed class DotNetRepositoryReleaseCentralVersionTests
             try { root.Delete(recursive: true); } catch { /* best effort */ }
         }
     }
+
+    [Fact]
+    public void Execute_UpdateVersionsDisabled_PrefersImportedPackageVersionOverLiteralProjectVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <ProductVersion>2.3.4</ProductVersion>
+                    <PackageVersion>$(ProductVersion)</PackageVersion>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.ImportedPackageVersion"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.ImportedPackageVersion.csproj");
+            const string projectSource = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.ImportedPackageVersion</PackageId>
+                    <Version>1.0.0</Version>
+                    <IsPackable>true</IsPackable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            File.WriteAllText(projectPath, projectSource);
+
+            var outputPath = Path.Combine(root.FullName, "packages");
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(new DotNetRepositoryReleaseSpec
+            {
+                RootPath = root.FullName,
+                Configuration = "Release",
+                OutputPath = outputPath,
+                Pack = true,
+                PackStrategy = DotNetRepositoryPackStrategy.MSBuild,
+                Publish = false,
+                UpdateVersions = false,
+                SignAssemblies = false,
+                SignPackages = false
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("2.3.4", result.ResolvedVersionsByProject["Sample.ImportedPackageVersion"]);
+            var project = Assert.Single(result.Projects, candidate => candidate.IsPackable);
+            Assert.Equal("1.0.0", project.OldVersion);
+            Assert.Equal("2.3.4", project.NewVersion);
+            var package = Assert.Single(project.Packages);
+            Assert.Equal("Sample.ImportedPackageVersion.2.3.4.nupkg", Path.GetFileName(package));
+            Assert.True(File.Exists(package));
+            Assert.Equal(projectSource, File.ReadAllText(projectPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -297,8 +297,19 @@ public sealed partial class DotNetRepositoryReleaseService
 
                 result.ResolvedVersionsByProject[project.ProjectName] = resolvedVersion;
 
-                if (CsprojVersionEditor.TryGetVersion(project.CsprojPath, out var oldV))
+                if (CsprojVersionEditor.TryGetVersion(project.CsprojPath, out var oldV) &&
+                    PackageVersionUtility.TryNormalizeExact(oldV, out var normalizedOldVersion))
+                {
+                    project.OldVersion = normalizedOldVersion;
+                }
+                else if (!spec.UpdateVersions)
+                {
+                    project.OldVersion = resolvedVersion;
+                }
+                else if (!string.IsNullOrWhiteSpace(oldV))
+                {
                     project.OldVersion = oldV;
+                }
 
                 project.NewVersion = resolvedVersion;
                 if (spec.WhatIf || !spec.UpdateVersions) continue;

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -296,13 +296,15 @@ public sealed partial class DotNetRepositoryReleaseService
                     _logger.Warn($"{project.ProjectName}: {resolutionWarning}");
 
                 result.ResolvedVersionsByProject[project.ProjectName] = resolvedVersion;
+                var shouldUpdateProjectVersion = spec.UpdateVersions &&
+                    (alignedVersions.ContainsKey(project.ProjectName) || !string.IsNullOrWhiteSpace(expectedVersion));
 
                 if (CsprojVersionEditor.TryGetVersion(project.CsprojPath, out var oldV) &&
                     PackageVersionUtility.TryNormalizeExact(oldV, out var normalizedOldVersion))
                 {
                     project.OldVersion = normalizedOldVersion;
                 }
-                else if (!spec.UpdateVersions)
+                else if (!shouldUpdateProjectVersion)
                 {
                     project.OldVersion = resolvedVersion;
                 }
@@ -312,7 +314,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 }
 
                 project.NewVersion = resolvedVersion;
-                if (spec.WhatIf || !spec.UpdateVersions) continue;
+                if (spec.WhatIf || !shouldUpdateProjectVersion) continue;
 
                 var content = File.ReadAllText(project.CsprojPath);
                 var updated = CsprojVersionEditor.UpdateVersionText(content, resolvedVersion, out _);

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -57,6 +57,15 @@ public sealed partial class DotNetRepositoryReleaseService
                 declaredExactVersion = exact;
         }
 
+        if (spec.WhatIf)
+        {
+            if (!string.IsNullOrWhiteSpace(declaredVersion))
+                return declaredVersion!;
+
+            warning = "WhatIf cannot resolve a project version without evaluating MSBuild because no version tag was declared.";
+            return string.Empty;
+        }
+
         var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? spec.RootPath;
         var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
         var exitCode = RunDotnetMsBuildGetProperty(

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -49,11 +49,12 @@ public sealed partial class DotNetRepositoryReleaseService
     {
         warning = null;
         string? declaredVersion = null;
+        string? declaredExactVersion = null;
         if (CsprojVersionEditor.TryGetVersion(project.CsprojPath, out var candidate))
         {
             declaredVersion = candidate;
             if (PackageVersionUtility.TryNormalizeExact(candidate, out var exact))
-                return exact;
+                declaredExactVersion = exact;
         }
 
         var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? spec.RootPath;
@@ -81,22 +82,28 @@ public sealed partial class DotNetRepositoryReleaseService
         if (exitCode != 0)
         {
             var detail = SummarizeProcessFailureOutput(stdErr, stdOut);
-            warning = string.IsNullOrWhiteSpace(declaredVersion)
-                ? $"No literal project version was found and MSBuild PackageVersion evaluation failed. {detail}".Trim()
-                : $"Project version '{declaredVersion}' requires MSBuild evaluation, but PackageVersion evaluation failed. {detail}".Trim();
+            warning = !string.IsNullOrWhiteSpace(declaredExactVersion)
+                ? $"MSBuild PackageVersion evaluation failed; using declared project version '{declaredExactVersion}'. {detail}".Trim()
+                : string.IsNullOrWhiteSpace(declaredVersion)
+                    ? $"No literal project version was found and MSBuild PackageVersion evaluation failed. {detail}".Trim()
+                    : $"Project version '{declaredVersion}' requires MSBuild evaluation, but PackageVersion evaluation failed. {detail}".Trim();
         }
         else if (!string.IsNullOrWhiteSpace(evaluatedVersion))
         {
-            warning = $"MSBuild evaluated PackageVersion to unsupported value '{evaluatedVersion}'.";
+            warning = !string.IsNullOrWhiteSpace(declaredExactVersion)
+                ? $"MSBuild evaluated PackageVersion to unsupported value '{evaluatedVersion}'; using declared project version '{declaredExactVersion}'."
+                : $"MSBuild evaluated PackageVersion to unsupported value '{evaluatedVersion}'.";
         }
         else
         {
-            warning = string.IsNullOrWhiteSpace(declaredVersion)
-                ? "No project version was found after evaluating MSBuild PackageVersion."
-                : $"Project version '{declaredVersion}' did not evaluate to a package version.";
+            warning = !string.IsNullOrWhiteSpace(declaredExactVersion)
+                ? $"MSBuild did not evaluate PackageVersion; using declared project version '{declaredExactVersion}'."
+                : string.IsNullOrWhiteSpace(declaredVersion)
+                    ? "No project version was found after evaluating MSBuild PackageVersion."
+                    : $"Project version '{declaredVersion}' did not evaluate to a package version.";
         }
 
-        return string.Empty;
+        return declaredExactVersion ?? string.Empty;
     }
 
     private static DotNetPackResult PackProject(

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -21,20 +21,10 @@ public sealed partial class DotNetRepositoryReleaseService
         warning = null;
 
         if (!spec.UpdateVersions)
-        {
-            if (CsprojVersionEditor.TryGetVersion(project.CsprojPath, out var v))
-                return v;
-            warning = "UpdateVersions is disabled and no version tags were found in the project file.";
-            return string.Empty;
-        }
+            return ResolveCurrentProjectVersion(project, spec, out warning);
 
         if (string.IsNullOrWhiteSpace(expectedVersion))
-        {
-            if (CsprojVersionEditor.TryGetVersion(project.CsprojPath, out var v))
-                return v;
-            warning = "No expected version provided and no version tags were found in the project file.";
-            return string.Empty;
-        }
+            return ResolveCurrentProjectVersion(project, spec, out warning);
 
         if (PackageVersionUtility.TryNormalizeExact(expectedVersion, out var exact))
             return exact;
@@ -50,6 +40,63 @@ public sealed partial class DotNetRepositoryReleaseService
             warning = $"No current package version found; using 0 baseline for '{expectedVersion}'.";
 
         return VersionPatternStepper.Step(expectedVersion!, current);
+    }
+
+    private string ResolveCurrentProjectVersion(
+        DotNetRepositoryProjectResult project,
+        DotNetRepositoryReleaseSpec spec,
+        out string? warning)
+    {
+        warning = null;
+        string? declaredVersion = null;
+        if (CsprojVersionEditor.TryGetVersion(project.CsprojPath, out var candidate))
+        {
+            declaredVersion = candidate;
+            if (PackageVersionUtility.TryNormalizeExact(candidate, out var exact))
+                return exact;
+        }
+
+        var projectDirectory = Path.GetDirectoryName(project.CsprojPath) ?? spec.RootPath;
+        var configuration = string.IsNullOrWhiteSpace(spec.Configuration) ? "Release" : spec.Configuration.Trim();
+        var exitCode = RunDotnetMsBuildGetProperty(
+            project.CsprojPath,
+            projectDirectory,
+            configuration,
+            targetFramework: null,
+            propertyName: "PackageVersion",
+            project.ProjectName,
+            _logger,
+            out var evaluatedVersion,
+            out var stdErr,
+            out var stdOut,
+            out _);
+
+        if (exitCode == 0 &&
+            !string.IsNullOrWhiteSpace(evaluatedVersion) &&
+            PackageVersionUtility.TryNormalizeExact(evaluatedVersion, out var evaluatedExact))
+        {
+            return evaluatedExact;
+        }
+
+        if (exitCode != 0)
+        {
+            var detail = SummarizeProcessFailureOutput(stdErr, stdOut);
+            warning = string.IsNullOrWhiteSpace(declaredVersion)
+                ? $"No literal project version was found and MSBuild PackageVersion evaluation failed. {detail}".Trim()
+                : $"Project version '{declaredVersion}' requires MSBuild evaluation, but PackageVersion evaluation failed. {detail}".Trim();
+        }
+        else if (!string.IsNullOrWhiteSpace(evaluatedVersion))
+        {
+            warning = $"MSBuild evaluated PackageVersion to unsupported value '{evaluatedVersion}'.";
+        }
+        else
+        {
+            warning = string.IsNullOrWhiteSpace(declaredVersion)
+                ? "No project version was found after evaluating MSBuild PackageVersion."
+                : $"Project version '{declaredVersion}' did not evaluate to a package version.";
+        }
+
+        return string.Empty;
     }
 
     private static DotNetPackResult PackProject(


### PR DESCRIPTION
## Summary

- evaluate the effective MSBuild `PackageVersion` when a project version is imported or references another property
- keep `UpdateVersions = false` releases on the evaluated version so batch package collection matches the files MSBuild actually produced
- keep WhatIf previews free of MSBuild/dotnet evaluation while real releases use the effective package version
- report normalized old/new versions and cover the central-property batch-pack contract with focused regression tests

## Why

ChartForgeX centralizes its six package versions through `ChartForgeXProductVersion`. PowerForge successfully rebuilt and signed those packages, but then searched for the literal `$(ChartForgeXProductVersion)` and rejected the real `1.0.1` artifacts. Version evaluation belongs in the shared release engine, not in a consumer-specific wrapper.

## Validation

- `dotnet test PowerForge.Tests/PowerForge.Tests.csproj -c Release --filter "FullyQualifiedName~DotNetRepositoryRelease"` (100/100)
- `dotnet test PSPublishModule.sln -c Release` (PowerForge 4147/4147, Studio 147 passed with one explicit local-smoke skip, net472 smoke 4/4)
- real ChartForgeX merged-source release run through the fixed local module: six 1.0.1 packages collected, fresh-build payload provenance verified, release zips created, and all packages signed

