### PR TITLE
Prepare PowerForge 1.0.1 packages

### DIFF
--- a/PowerForge.Blazor/PowerForge.Blazor.csproj
+++ b/PowerForge.Blazor/PowerForge.Blazor.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
 
     <!-- Package metadata -->
     <PackageId>PowerForge.Blazor</PackageId>

--- a/PowerForge.Blazor/packages.lock.json
+++ b/PowerForge.Blazor/packages.lock.json
@@ -99,6 +99,28 @@
         "resolved": "8.0.11",
         "contentHash": "UYSbAkNGTWVUne3I04/9IRQel3Bt1Ww6Y5cjvZEZ89rWhBD1yWu7YDotvQS62V6mgSfFaXXPGrCUm1VG824QXw=="
       },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
       "System.Collections.Immutable": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -139,6 +161,7 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
+          "NuGet.Configuration": "[7.6.0, )",
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )"

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge</ToolCommandName>
     <Description>PowerForge command-line interface for building and publishing PowerShell modules.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageId>PowerForge.PowerShell</PackageId>
     <Description>PowerForge PowerShell-hosted module pipeline services.</Description>
     <AssemblyName>PowerForge.PowerShell</AssemblyName>

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
@@ -117,6 +118,42 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.False(result.Success);
             Assert.Contains("already exists", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Sample.Package version 1.2.3", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void PublishPreflight_RejectsPackageAboveNuGetOrgLimitBeforeUpload()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var packagePath = Path.Combine(root.FullName, "Sample.Package.1.2.3.nupkg");
+            using (var stream = new FileStream(packagePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                stream.SetLength(DotNetRepositoryReleaseService.NuGetOrgPackageSizeLimitBytes + 1);
+
+            var project = new DotNetRepositoryProjectResult
+            {
+                ProjectName = "Sample.Package",
+                PackageId = "Sample.Package",
+                NewVersion = "1.2.3"
+            };
+            project.Packages.Add(packagePath);
+
+            var preflight = new DotNetRepositoryReleaseService(new NullLogger()).ValidatePublishPreflight(
+                new[] { project },
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    PublishSource = "https://api.nuget.org/v3/index.json"
+                });
+
+            Assert.False(preflight.Success);
+            Assert.Contains("exceeds the nuget.org package limit", preflight.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(Path.GetFileName(packagePath), preflight.ErrorMessage, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -658,6 +695,75 @@ public sealed class DotNetRepositoryReleaseServiceTests
             Assert.True(File.Exists(project.Packages[0]));
             Assert.True(File.Exists(project.SymbolPackages[0]));
             Assert.True(File.Exists(project.ReleaseZipPath));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Theory]
+    [InlineData(DotNetRepositoryPackStrategy.PerProject)]
+    [InlineData(DotNetRepositoryPackStrategy.MSBuild)]
+    public void Execute_WithAssemblySigning_PreservesSignedPackToolAssembly(DotNetRepositoryPackStrategy packStrategy)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var projectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Sample.Tool"));
+            var projectPath = Path.Combine(projectDirectory.FullName, "Sample.Tool.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>net8.0</TargetFramework>
+                    <PackageId>Sample.Tool</PackageId>
+                    <VersionPrefix>1.0.0</VersionPrefix>
+                    <PackAsTool>true</PackAsTool>
+                    <ToolCommandName>sample-tool</ToolCommandName>
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(projectDirectory.FullName, "Program.cs"), "System.Console.WriteLine(\"sample\");");
+
+            var marker = new byte[] { 0x49, 0x58, 0x53, 0x49, 0x47 };
+            string[] signedPaths = Array.Empty<string>();
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    Configuration = "Release",
+                    OutputPath = Path.Combine(root.FullName, "packages"),
+                    Pack = true,
+                    PackStrategy = packStrategy,
+                    Publish = false,
+                    UpdateVersions = false,
+                    CreateReleaseZip = false,
+                    CertificateThumbprint = "ABC123",
+                    SignAssemblies = true,
+                    SignPackages = false
+                },
+                request =>
+                {
+                    signedPaths = Assert.IsType<string[]>(request.FilePaths);
+                    foreach (var path in signedPaths.Where(path => path.EndsWith("Sample.Tool.dll", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.None);
+                        stream.Write(marker, 0, marker.Length);
+                    }
+                },
+                _ => { });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Contains(signedPaths, path => path.EndsWith(Path.Combine("obj", "Release", "net8.0", "Sample.Tool.dll"), StringComparison.OrdinalIgnoreCase));
+
+            var package = Assert.Single(Assert.Single(result.Projects, project => project.IsPackable).Packages);
+            using var archive = ZipFile.OpenRead(package);
+            var entry = Assert.Single(archive.Entries, item => string.Equals(item.FullName, "tools/net8.0/any/Sample.Tool.dll", StringComparison.OrdinalIgnoreCase));
+            using var entryStream = entry.Open();
+            using var packagedAssembly = new MemoryStream();
+            entryStream.CopyTo(packagedAssembly);
+            Assert.Equal(marker, packagedAssembly.ToArray().TakeLast(marker.Length).ToArray());
         }
         finally
         {

--- a/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseServiceTests.cs
@@ -161,6 +161,46 @@ public sealed class DotNetRepositoryReleaseServiceTests
         }
     }
 
+    [Theory]
+    [InlineData("nuget.org")]
+    [InlineData("PublicPackages")]
+    public void PublishPreflight_RejectsPackageAboveNuGetOrgLimitForNamedSource(string sourceName)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(root.FullName, "NuGet.config"),
+                $"<configuration><packageSources><clear /><add key=\"{sourceName}\" value=\"https://api.nuget.org/v3/index.json\" /></packageSources></configuration>");
+            var packagePath = Path.Combine(root.FullName, "Sample.Package.1.2.3.nupkg");
+            using (var stream = new FileStream(packagePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                stream.SetLength(DotNetRepositoryReleaseService.NuGetOrgPackageSizeLimitBytes + 1);
+
+            var project = new DotNetRepositoryProjectResult
+            {
+                ProjectName = "Sample.Package",
+                PackageId = "Sample.Package",
+                NewVersion = "1.2.3"
+            };
+            project.Packages.Add(packagePath);
+
+            var preflight = new DotNetRepositoryReleaseService(new NullLogger()).ValidatePublishPreflight(
+                new[] { project },
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    PublishSource = sourceName
+                });
+
+            Assert.False(preflight.Success);
+            Assert.Contains("exceeds the nuget.org package limit", preflight.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Fact]
     public void Execute_IgnoresNestedGitWorktreeRoots_DuringProjectDiscovery()
     {

--- a/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+++ b/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>PowerForge.Web.Cli</AssemblyName>
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge-web</ToolCommandName>
     <Description>PowerForge.Web command-line interface for building and serving static sites.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>
@@ -20,6 +20,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/EvotecIT/PSPublishModule</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <!-- Playwright ships runtime helper scripts inside the dotnet-tool payload; they are not NuGet install/init scripts. -->
+    <NoWarn>$(NoWarn);NU5111</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -101,6 +101,28 @@
           "System.ComponentModel.Annotations": "5.0.0"
         }
       },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
       "NUglify": {
         "type": "Transitive",
         "resolved": "1.21.17",
@@ -161,10 +183,10 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
+          "NuGet.Configuration": "[7.6.0, )",
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "NuGet.Configuration": "[7.6.0, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
       },
       "powerforge.web": {
@@ -173,226 +195,10 @@
           "HtmlTinkerX": "[2.0.19, )",
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
-          "PowerForge": "[1.0.0, )",
+          "PowerForge": "[1.0.1, )",
           "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }
-      },
-      "NuGet.Configuration": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
-        "dependencies": {
-          "NuGet.Common": "7.6.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0"
-        }
-      },
-      "NuGet.Common": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
-        "dependencies": {
-          "NuGet.Frameworks": "7.6.0"
-        }
-      },
-      "NuGet.Frameworks": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
-      }
-    },
-    "net8.0": {
-      "Acornima": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "3M7NpnhKL//pf7HkSfLJaGQ37uksibdqfa9YuUov1VOX0QXapZeYCUpURZ9an4VMt9wJ70MU/PeAsjhw8DwtJw=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.1-beta.523",
-        "contentHash": "1HPqvhCAHu2X9umsuoy2RU7Ls6j+JIg5Enu1SgTinXqo/EVdXP5Ey/PA0vuwqVgo1x3xowXrDCgOWt2DM4vZSA=="
-      },
-      "AngleSharp.Css": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.213",
-        "contentHash": "R6Fn8GnapJi0uqJODCDUM0aYftaomcWhrk1Ty+U8E4zsTd+So4ZyDHS6J9Nni9b8WMCCp+pnMAehmVwbsgYMeQ==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)"
-        }
-      },
-      "AngleSharp.Diffing": {
-        "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "Uzz5895TpRyMA4t8GExmq4TxXqi3+bZTgb3kJgH+tdwrSuo9CO6Dlmv+Oqyhb2pNRfbnReLUzhlHAuT7c+3jSg==",
-        "dependencies": {
-          "AngleSharp": "1.1.2",
-          "AngleSharp.Css": "1.0.0-beta.144"
-        }
-      },
-      "AngleSharp.Js": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta.47",
-        "contentHash": "zSBLEBwoSBwU0JKtHX6DF5X4CDML/Sn92LrAlpy+XbI8wOCkZ8DVqh5mLlHXq8s6cVaOX2PzhPV5m7wv/6MT3A==",
-        "dependencies": {
-          "AngleSharp": "[1.0.0, 2.0.0)",
-          "Jint": "[4.0.0, 5.0.0)"
-        }
-      },
-      "ChartForgeX": {
-        "type": "Transitive",
-        "resolved": "0.1.6",
-        "contentHash": "KkhZMruv/Fhe5LSXD22KEl/T/HimNqB450NI9rKklyPewrYmU8rWnCOG5kbhzN3zHwXnmTdq1qJn2J9kw/N51w=="
-      },
-      "HtmlAgilityPack": {
-        "type": "Transitive",
-        "resolved": "1.12.4",
-        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
-      },
-      "HtmlTinkerX": {
-        "type": "Transitive",
-        "resolved": "2.0.19",
-        "contentHash": "aN1x0cqwonG/JNSYxCBtqTTCq1nyaEYiX6WdQvvkGpfYlLKuFjKD+4HfXSfBl1KZqC6SdIUZz3oXAib5AyB8vQ==",
-        "dependencies": {
-          "AngleSharp": "1.4.1-beta.523",
-          "AngleSharp.Css": "1.0.0-beta.213",
-          "AngleSharp.Diffing": "1.1.1",
-          "AngleSharp.Js": "1.0.0-beta.47",
-          "ChartForgeX": "0.1.6",
-          "HtmlAgilityPack": "1.12.4",
-          "Jint": "4.8.0",
-          "Microsoft.Playwright": "1.59.0",
-          "NUglify": "1.21.17",
-          "OfficeIMO.Markdown.Html": "0.1.13",
-          "PreMailer.Net": "2.7.2"
-        }
-      },
-      "Jint": {
-        "type": "Transitive",
-        "resolved": "4.8.0",
-        "contentHash": "JlXh13WDivP2izPgS9jeUlzyP//hsHUGhGb33EQHLuRiLhdwJ0ajaYjVETnqnkIQay/qP6NHglxx/40bL0/ihQ==",
-        "dependencies": {
-          "Acornima": "1.4.0"
-        }
-      },
-      "Magick.NET-Q8-AnyCPU": {
-        "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
-        "dependencies": {
-          "Magick.NET.Core": "14.14.0"
-        }
-      },
-      "Magick.NET.Core": {
-        "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
-      },
-      "Microsoft.Playwright": {
-        "type": "Transitive",
-        "resolved": "1.59.0",
-        "contentHash": "igqHbZMmXI6cYNPg1X1o5/51U3CQp83lvvov/d/zmus2wlG1LjvpEL6i1Jx51pRahPtSyppvwq+ZoBfxeSjiew==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
-        }
-      },
-      "NUglify": {
-        "type": "Transitive",
-        "resolved": "1.21.17",
-        "contentHash": "K2ywYpoPEvU3+Ooq6wxz+FJOkmbDeoE41q/sJZWv9tI7qbTmH2A5R0E4hWzruvl/9pnUhqwbu1mxT06C45D0ZQ=="
-      },
-      "OfficeIMO.Markdown": {
-        "type": "Transitive",
-        "resolved": "0.6.13",
-        "contentHash": "G32iOoUiPRfsyWoNiq9sS3Q3oN60jQFKOn6VLpvoemtzq7oXc7oECKw0W+BS7oUds+uKpsNHsfPDAfUUhTY8hg=="
-      },
-      "OfficeIMO.Markdown.Html": {
-        "type": "Transitive",
-        "resolved": "0.1.13",
-        "contentHash": "9f4V0tM164RcwKGyf681aj2NKc4zk7xMWu1pW23idj9sllazRmZ/Vma++//QSMShbDGsGQPPWU+rX1gT7280xg==",
-        "dependencies": {
-          "AngleSharp": "1.3.0",
-          "OfficeIMO.Markdown": "0.6.13"
-        }
-      },
-      "PreMailer.Net": {
-        "type": "Transitive",
-        "resolved": "2.7.2",
-        "contentHash": "OeN00ZA9ycJSSD4ZcjbWn5aJpJ+OfrAM3ti+9VI9Mc+o90QnWayPCU7PszopLa91lxKrL9ZnIcG33AAd5dypLA==",
-        "dependencies": {
-          "AngleSharp": "1.1.0"
-        }
-      },
-      "Scriban": {
-        "type": "Transitive",
-        "resolved": "7.2.5",
-        "contentHash": "6HDyv0P6PVdx/prWM3Aw0QHAT/DCpkBxOovZ2iPIH4L4ZvJ13JNYJgyUI+xJ5K2agXreYTBe23AL5ZQNTqJQvA=="
-      },
-      "System.IO.Packaging": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "qvYn5etKp2m3p05CCvw48OXf0mbD57g0gq/dCjQvq2ZgXYtjB3CV6rwzO7QprxMHnkZFhJ0StrB0thrVzpF49Q=="
-      },
-      "System.Reflection.MetadataLoadContext": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ=="
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "eqKW9wyPUhZi6pxy9Y0fQO/bdHROcwj0tYdmoGEPCPCtCJLFdVVAlzuuYYEnJI64HxhoXPYGhtx891g/jwN4rg=="
-      },
-      "YamlDotNet": {
-        "type": "Transitive",
-        "resolved": "15.1.2",
-        "contentHash": "qeX0XhzOIcQEvnI5JxnPaIwcINwyY4Qy/LXhSfsdHkFrl9F41AT52UFfy2nIE7kgrhMg+cP7xuS+GtPJhmHmTA=="
-      },
-      "powerforge": {
-        "type": "Project",
-        "dependencies": {
-          "System.IO.Packaging": "[10.0.7, )",
-          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "NuGet.Configuration": "[7.6.0, )"
-        }
-      },
-      "powerforge.web": {
-        "type": "Project",
-        "dependencies": {
-          "HtmlTinkerX": "[2.0.19, )",
-          "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
-          "OfficeIMO.Markdown": "[0.6.13, )",
-          "PowerForge": "[1.0.0, )",
-          "Scriban": "[7.2.5, )",
-          "YamlDotNet": "[15.1.2, )"
-        }
-      },
-      "NuGet.Configuration": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
-        "dependencies": {
-          "NuGet.Common": "7.6.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0"
-        }
-      },
-      "NuGet.Common": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
-        "dependencies": {
-          "NuGet.Frameworks": "7.6.0"
-        }
-      },
-      "NuGet.Frameworks": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageId>PowerForge.Web</PackageId>
     <RootNamespace>PowerForge.Web</RootNamespace>
     <Description>PowerForge.Web static-site engine and reusable website build components.</Description>

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <PackageId>PowerForge</PackageId>
     <Description>PowerForge core library: reusable engine for building, formatting, packaging and publishing PowerShell modules.</Description>
     <AssemblyName>PowerForge</AssemblyName>

--- a/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
@@ -252,7 +252,10 @@ public sealed partial class DotNetRepositoryReleaseService
                 var csprojDir = Path.GetDirectoryName(project.CsprojPath) ?? string.Empty;
                 var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
                 var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
-                var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                var signingPlan = BuildAssemblySigningPlan(
+                    outputDirectories,
+                    includePatterns,
+                    ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
                 if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
                 {
                     var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
@@ -260,7 +263,10 @@ public sealed partial class DotNetRepositoryReleaseService
                     {
                         includePatterns = evaluatedIncludePatterns;
                         outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
-                        signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                        signingPlan = BuildAssemblySigningPlan(
+                            outputDirectories,
+                            includePatterns,
+                            ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
                     }
                 }
                 logger.Info($"{project.ProjectName}: assembly signing include pattern(s): {string.Join(", ", includePatterns)}.");

--- a/PowerForge/Services/DotNetRepositoryReleaseService.NuGetSources.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.NuGetSources.cs
@@ -14,6 +14,42 @@ public sealed partial class DotNetRepositoryReleaseService
         out string resolvedSource)
     {
         resolvedSource = string.Empty;
+        if (!TryResolveNamedPublishSource(sourceName, searchRoot, out var configuredSource))
+            return false;
+
+        try
+        {
+            if (Uri.TryCreate(configuredSource, UriKind.Absolute, out var configuredUri))
+            {
+                if (!configuredUri.IsFile)
+                    return false;
+
+                resolvedSource = Path.GetFullPath(configuredUri.LocalPath);
+                return true;
+            }
+
+            var normalized = PathValueResolver.NormalizeSeparators(configuredSource);
+            var settingsRoot = Path.GetFullPath(searchRoot);
+            if (!Directory.Exists(settingsRoot))
+                settingsRoot = Path.GetDirectoryName(settingsRoot) ?? settingsRoot;
+            resolvedSource = Path.IsPathRooted(normalized)
+                ? Path.GetFullPath(normalized)
+                : PathValueResolver.Resolve(settingsRoot, normalized);
+            return true;
+        }
+        catch
+        {
+            // dotnet nuget push reports malformed or inaccessible configuration itself.
+            return false;
+        }
+    }
+
+    private static bool TryResolveNamedPublishSource(
+        string sourceName,
+        string searchRoot,
+        out string configuredSource)
+    {
+        configuredSource = string.Empty;
         if (string.IsNullOrWhiteSpace(sourceName) || string.IsNullOrWhiteSpace(searchRoot))
             return false;
 
@@ -24,31 +60,14 @@ public sealed partial class DotNetRepositoryReleaseService
                 settingsRoot = Path.GetDirectoryName(settingsRoot) ?? settingsRoot;
 
             var settings = Settings.LoadDefaultSettings(settingsRoot);
-            var configuredSource = new PackageSourceProvider(settings)
+            configuredSource = new PackageSourceProvider(settings)
                 .LoadPackageSources()
                 .FirstOrDefault(source => string.Equals(
                     source.Name,
                     sourceName,
                     StringComparison.OrdinalIgnoreCase))
-                ?.Source;
-            if (string.IsNullOrWhiteSpace(configuredSource))
-                return false;
-            var configuredSourceValue = configuredSource!;
-
-            if (Uri.TryCreate(configuredSourceValue, UriKind.Absolute, out var configuredUri))
-            {
-                if (!configuredUri.IsFile)
-                    return false;
-
-                resolvedSource = Path.GetFullPath(configuredUri.LocalPath);
-                return true;
-            }
-
-            var normalized = PathValueResolver.NormalizeSeparators(configuredSourceValue);
-            resolvedSource = Path.IsPathRooted(normalized)
-                ? Path.GetFullPath(normalized)
-                : PathValueResolver.Resolve(settingsRoot, normalized);
-            return true;
+                ?.Source ?? string.Empty;
+            return !string.IsNullOrWhiteSpace(configuredSource);
         }
         catch
         {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.PackageProvenance.cs
@@ -117,7 +117,14 @@ public sealed partial class DotNetRepositoryReleaseService
             project.ProjectName,
             logger,
             payloadNames.ToArray());
-        var outputHashes = BuildOutputHashLookup(outputDirectories, payloadNames);
+        var packToolIntermediateAssemblies = ResolvePackToolIntermediateAssemblyPaths(
+            project.CsprojPath,
+            projectDirectory,
+            configuration,
+            project.ProjectName,
+            logger,
+            payloadNames.ToArray());
+        var outputHashes = BuildOutputHashLookup(outputDirectories, payloadNames, packToolIntermediateAssemblies);
 
         foreach (var packagePath in packagesWithPayloads)
         {
@@ -207,7 +214,8 @@ public sealed partial class DotNetRepositoryReleaseService
 
     private static Dictionary<string, HashSet<string>> BuildOutputHashLookup(
         IEnumerable<string> outputDirectories,
-        HashSet<string> payloadNames)
+        HashSet<string> payloadNames,
+        IEnumerable<string>? additionalFiles = null)
     {
         var hashes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         foreach (var directory in outputDirectories
@@ -217,22 +225,36 @@ public sealed partial class DotNetRepositoryReleaseService
         {
             foreach (var path in Directory.EnumerateFiles(directory, "*", SearchOption.TopDirectoryOnly))
             {
-                var fileName = Path.GetFileName(path);
-                if (!payloadNames.Contains(fileName))
-                    continue;
-
-                if (!hashes.TryGetValue(fileName, out var fileHashes))
-                {
-                    fileHashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    hashes[fileName] = fileHashes;
-                }
-
-                using var stream = File.OpenRead(path);
-                fileHashes.Add(ComputePackagePayloadSha256(stream));
+                AddBuildOutputHash(hashes, payloadNames, path);
             }
         }
 
+        if (additionalFiles is not null)
+        {
+            foreach (var path in additionalFiles.Where(File.Exists).Distinct(StringComparer.OrdinalIgnoreCase))
+                AddBuildOutputHash(hashes, payloadNames, path);
+        }
+
         return hashes;
+    }
+
+    private static void AddBuildOutputHash(
+        IDictionary<string, HashSet<string>> hashes,
+        HashSet<string> payloadNames,
+        string path)
+    {
+        var fileName = Path.GetFileName(path);
+        if (!payloadNames.Contains(fileName))
+            return;
+
+        if (!hashes.TryGetValue(fileName, out var fileHashes))
+        {
+            fileHashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            hashes[fileName] = fileHashes;
+        }
+
+        using var stream = File.OpenRead(path);
+        fileHashes.Add(ComputePackagePayloadSha256(stream));
     }
 
     private static string?[] ResolveConfiguredTargetFrameworks(

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
@@ -50,6 +50,8 @@ public sealed partial class DotNetRepositoryReleaseService
         DotNetRepositoryReleaseSpec spec)
     {
         var versionSources = GetPublishPreflightVersionSources(spec);
+        var enforceNuGetOrgPackageSize = !spec.WhatIf &&
+                                            IsNuGetOrgPublishSource(spec.PublishSource, spec.RootPath);
 
         foreach (var project in projects)
         {
@@ -67,9 +69,7 @@ public sealed partial class DotNetRepositoryReleaseService
                 if (!spec.WhatIf && !File.Exists(pkg))
                     return (false, $"Publish preflight failed: package not found: {pkg}");
 
-                var packageLength = spec.WhatIf || !IsNuGetOrgPublishSource(spec.PublishSource)
-                    ? 0
-                    : new FileInfo(pkg).Length;
+                var packageLength = enforceNuGetOrgPackageSize ? new FileInfo(pkg).Length : 0;
                 if (packageLength > NuGetOrgPackageSizeLimitBytes)
                 {
                     return (false,
@@ -98,15 +98,29 @@ public sealed partial class DotNetRepositoryReleaseService
         return (true, null);
     }
 
-    private static bool IsNuGetOrgPublishSource(string? source)
+    private static bool IsNuGetOrgPublishSource(string? source, string? searchRoot)
     {
         if (string.IsNullOrWhiteSpace(source))
             return true;
 
-        return Uri.TryCreate(source!.Trim(), UriKind.Absolute, out var uri) &&
+        var trimmed = source!.Trim();
+        if (IsNuGetOrgEndpoint(trimmed))
+            return true;
+
+        if (!string.IsNullOrWhiteSpace(searchRoot) &&
+            TryResolveNamedPublishSource(trimmed, searchRoot!, out var configuredSource))
+        {
+            return IsNuGetOrgEndpoint(configuredSource);
+        }
+
+        // Keep the conventional key safe even when no NuGet.config is available locally.
+        return string.Equals(trimmed, "nuget.org", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsNuGetOrgEndpoint(string source)
+        => Uri.TryCreate(source, UriKind.Absolute, out var uri) &&
                (string.Equals(uri.Host, "nuget.org", StringComparison.OrdinalIgnoreCase) ||
                 uri.Host.EndsWith(".nuget.org", StringComparison.OrdinalIgnoreCase));
-    }
 
     private static IReadOnlyList<string>? GetPublishPreflightVersionSources(DotNetRepositoryReleaseSpec spec)
     {

--- a/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.ValidationAndSort.cs
@@ -12,6 +12,9 @@ namespace PowerForge;
 
 public sealed partial class DotNetRepositoryReleaseService
 {
+    // nuget.org documents an approximate 250 MB upload limit.
+    internal const long NuGetOrgPackageSizeLimitBytes = 250L * 1024L * 1024L;
+
     private static HashSet<string> BuildNameSet(IEnumerable<string>? items)
     {
         var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -42,7 +45,7 @@ public sealed partial class DotNetRepositoryReleaseService
         return set.ToArray();
     }
 
-    private (bool Success, string? ErrorMessage) ValidatePublishPreflight(
+    internal (bool Success, string? ErrorMessage) ValidatePublishPreflight(
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         DotNetRepositoryReleaseSpec spec)
     {
@@ -63,6 +66,16 @@ public sealed partial class DotNetRepositoryReleaseService
             {
                 if (!spec.WhatIf && !File.Exists(pkg))
                     return (false, $"Publish preflight failed: package not found: {pkg}");
+
+                var packageLength = spec.WhatIf || !IsNuGetOrgPublishSource(spec.PublishSource)
+                    ? 0
+                    : new FileInfo(pkg).Length;
+                if (packageLength > NuGetOrgPackageSizeLimitBytes)
+                {
+                    return (false,
+                        $"Publish preflight failed: {Path.GetFileName(pkg)} is {FormatBytes(packageLength)}, " +
+                        $"which exceeds the nuget.org package limit of about {FormatBytes(NuGetOrgPackageSizeLimitBytes)}.");
+                }
             }
 
             if (!PackageVersionUtility.TryNormalizeExact(project.NewVersion, out var target))
@@ -83,6 +96,16 @@ public sealed partial class DotNetRepositoryReleaseService
         }
 
         return (true, null);
+    }
+
+    private static bool IsNuGetOrgPublishSource(string? source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            return true;
+
+        return Uri.TryCreate(source!.Trim(), UriKind.Absolute, out var uri) &&
+               (string.Equals(uri.Host, "nuget.org", StringComparison.OrdinalIgnoreCase) ||
+                uri.Host.EndsWith(".nuget.org", StringComparison.OrdinalIgnoreCase));
     }
 
     private static IReadOnlyList<string>? GetPublishPreflightVersionSources(DotNetRepositoryReleaseSpec spec)

--- a/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.VersionAndPacking.cs
@@ -153,7 +153,10 @@ public sealed partial class DotNetRepositoryReleaseService
                 var includePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
                 var resolveOutputWatch = Stopwatch.StartNew();
                 var outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
-                var signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                var signingPlan = BuildAssemblySigningPlan(
+                    outputDirectories,
+                    includePatterns,
+                    ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
                 if (signingPlan.Files.Length == 0 && !spec.SignDependencyAssemblies)
                 {
                     var evaluatedIncludePatterns = ResolveAssemblySigningIncludePatterns(project, spec, csprojDir, configuration, logger);
@@ -161,7 +164,10 @@ public sealed partial class DotNetRepositoryReleaseService
                     {
                         includePatterns = evaluatedIncludePatterns;
                         outputDirectories = ResolveBuildOutputDirectories(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns);
-                        signingPlan = BuildAssemblySigningPlan(outputDirectories, includePatterns);
+                        signingPlan = BuildAssemblySigningPlan(
+                            outputDirectories,
+                            includePatterns,
+                            ResolvePackToolIntermediateAssemblyPaths(project.CsprojPath, csprojDir, configuration, project.ProjectName, logger, includePatterns));
                     }
                 }
                 resolveOutputWatch.Stop();
@@ -456,6 +462,67 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
         });
     }
 
+    private static string[] ResolvePackToolIntermediateAssemblyPaths(
+        string csproj,
+        string workingDirectory,
+        string configuration,
+        string projectName,
+        ILogger logger,
+        IReadOnlyList<string> includePatterns)
+    {
+        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var targetFramework in ResolveConfiguredTargetFrameworks(csproj, workingDirectory, configuration, projectName, logger))
+        {
+            var packAsToolExitCode = RunDotnetMsBuildGetProperty(
+                csproj,
+                workingDirectory,
+                configuration,
+                targetFramework,
+                "PackAsTool",
+                projectName,
+                logger,
+                out var packAsToolValue,
+                out _,
+                out _,
+                out _);
+            if (packAsToolExitCode != 0 || !bool.TryParse(packAsToolValue?.Trim(), out var packAsTool) || !packAsTool)
+                continue;
+
+            var intermediateExitCode = RunDotnetMsBuildGetProperty(
+                csproj,
+                workingDirectory,
+                configuration,
+                targetFramework,
+                "IntermediateOutputPath",
+                projectName,
+                logger,
+                out var intermediateOutputPath,
+                out var stdErr,
+                out var stdOut,
+                out var duration);
+            if (intermediateExitCode != 0 || string.IsNullOrWhiteSpace(intermediateOutputPath))
+            {
+                logger.Verbose($"{projectName}: unable to resolve the pack-tool intermediate output in {FormatDuration(duration)}. {SummarizeProcessFailureOutput(stdErr, stdOut)}");
+                continue;
+            }
+
+            var normalizedIntermediateOutputPath = intermediateOutputPath!.Trim().Trim('"');
+            var resolvedDirectory = Path.IsPathRooted(normalizedIntermediateOutputPath)
+                ? Path.GetFullPath(normalizedIntermediateOutputPath)
+                : Path.GetFullPath(Path.Combine(workingDirectory, normalizedIntermediateOutputPath));
+            if (!Directory.Exists(resolvedDirectory))
+                continue;
+
+            foreach (var includePattern in includePatterns.Where(static pattern => !string.IsNullOrWhiteSpace(pattern)))
+            {
+                foreach (var path in Directory.EnumerateFiles(resolvedDirectory, includePattern, SearchOption.TopDirectoryOnly))
+                    files.Add(Path.GetFullPath(path));
+            }
+        }
+
+        return files.ToArray();
+    }
+
     private static string[] ResolveConventionalBuildOutputDirectories(
         string csproj,
         string workingDirectory,
@@ -536,7 +603,8 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
 
     private static AssemblySigningPlan BuildAssemblySigningPlan(
         IReadOnlyList<string> outputDirectories,
-        IReadOnlyList<string> includePatterns)
+        IReadOnlyList<string> includePatterns,
+        IReadOnlyList<string>? additionalFiles = null)
     {
         var files = new List<string>();
         var outputDirectoryCount = 0;
@@ -556,6 +624,12 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
             }
         }
 
+        if (additionalFiles is not null)
+        {
+            foreach (var path in additionalFiles.Where(File.Exists))
+                files.Add(path);
+        }
+
         return new AssemblySigningPlan
         {
             IncludePatterns = includePatterns.ToArray(),
@@ -563,7 +637,12 @@ private static string? ResolvePackagePath(DotNetRepositoryReleaseSpec spec, DotN
                 .Select(Path.GetFullPath)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray(),
-            OutputDirectoryCount = outputDirectoryCount
+            OutputDirectoryCount = outputDirectoryCount + (additionalFiles ?? Array.Empty<string>())
+                .Where(File.Exists)
+                .Select(Path.GetDirectoryName)
+                .Where(static directory => !string.IsNullOrWhiteSpace(directory))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count()
         };
     }
 


### PR DESCRIPTION
## Summary

- align the six PowerForge packages on version 1.0.1
- preserve Authenticode signing for assemblies packed through `PackAsTool`, including MSBuild batch packing
- validate tool package payloads against the exact fresh intermediate assemblies consumed by the SDK pack target
- keep the PowerForge web tool publishable by targeting .NET 10 once instead of duplicating Playwright and ImageMagick payloads for .NET 8 and .NET 10
- reject packages above the documented nuget.org upload limit during publish preflight, including named NuGet.config sources

## Breaking change

`PowerForge.Web.Build` now requires the .NET 10 runtime. The reusable `PowerForge.Web` library remains multi-targeted for .NET 8 and .NET 10.

## Validation

- complete signed six-package release rehearsal succeeded without publishing
- all six 1.0.1 NuGet author signatures verified
- tool entry assemblies verified with valid Authenticode signatures
- `PowerForge.Web.Build` reduced from 286.81 MiB to 143.48 MiB
- focused repository release suite: 105 passed
- .NET Framework 4.7.2 build: clean
- net472 smoke: 4 passed
- Studio: 147 passed, 1 documented local smoke skip
- full PowerForge run reached 4,132 passes before one unrelated load-sensitive fan-out timeout; that exact test passed twice in isolation
- Windows, Linux, macOS, dependency-audit, and focused publish checks passed on the final head
