### PR TITLE
Fix module merging of using lines inside here-strings

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### What's Changed
+- Fixed module merging so `using` lines inside PowerShell here-strings and block comments remain in place instead of being moved into the generated module header.
 - Hardened the canonical `AsyncPSCmdlet` lifecycle with request-specific prompt and `ShouldProcess` replies while preserving PowerShell-thread execution until the first await.
 - Converted Task-backed App Store Connect and managed catalog cmdlets from sync-over-async blocking to cancellable asynchronous lifecycle hooks.
 - Added `Import-IsolatedModule` with a built-in `ExchangeOnlineManagement` profile that loads EXO binary assemblies through a module-scoped AssemblyLoadContext, allowing EXO's OData 7.22 dependency line to coexist with Az.Storage's OData 7.6 line in the same PowerShell 7 process.

--- a/PowerForge.Tests/ModuleMergeComposerTests.cs
+++ b/PowerForge.Tests/ModuleMergeComposerTests.cs
@@ -106,6 +106,48 @@ public sealed class ModuleMergeComposerTests
     }
 
     [Fact]
+    public void BuildSources_HoistsUsingAfterInlineBlockCommentWithoutDroppingComment()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMergeModule(root.FullName, moduleName);
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Private"));
+            File.WriteAllText(
+                Path.Combine(root.FullName, "Private", "Initialize-Test.ps1"),
+                "function Initialize-Test { 'first source' }");
+            File.WriteAllText(
+                Path.Combine(root.FullName, "Public", "Get-TestExample.ps1"),
+                """
+                <# license comment #> using namespace System.Text
+
+                function Get-TestExample { 'ok' }
+                """);
+
+            var sources = ModuleMergeComposer.BuildSources(
+                root.FullName,
+                moduleName,
+                information: null,
+                exports: new ExportSet(new[] { "Get-TestExample" }, Array.Empty<string>(), Array.Empty<string>()),
+                fixRelativePaths: false);
+
+            Assert.StartsWith("using namespace System.Text", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.Contains("<# license comment #>", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.True(
+                sources.MergedScriptContent.IndexOf("using namespace System.Text", StringComparison.Ordinal) <
+                sources.MergedScriptContent.IndexOf("function Initialize-Test", StringComparison.Ordinal));
+
+            Parser.ParseInput(sources.MergedScriptContent, out _, out var errors);
+            Assert.Empty(errors);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void BuildSources_RewritesLegacyPSScriptRootParentPathsByDefault()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModuleMergeComposerTests.cs
+++ b/PowerForge.Tests/ModuleMergeComposerTests.cs
@@ -63,6 +63,49 @@ public sealed class ModuleMergeComposerTests
     }
 
     [Fact]
+    public void BuildSources_PreservesUsingLinesInsideNestedPreambleBlockComments()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMergeModule(root.FullName, moduleName);
+            File.WriteAllText(
+                Path.Combine(root.FullName, "Public", "Get-TestExample.ps1"),
+                """
+                <# outer comment
+                    <# nested comment #>
+                    using namespace Missing.Namespace
+                #>
+                #requires -Version 5.1
+                using namespace System.Text
+
+                function Get-TestExample { 'ok' }
+                """);
+
+            var sources = ModuleMergeComposer.BuildSources(
+                root.FullName,
+                moduleName,
+                information: null,
+                exports: new ExportSet(new[] { "Get-TestExample" }, Array.Empty<string>(), Array.Empty<string>()),
+                fixRelativePaths: false);
+
+            Assert.StartsWith("#requires -Version 5.1" + Environment.NewLine + "using namespace System.Text", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.Contains("using namespace Missing.Namespace", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.True(
+                sources.MergedScriptContent.IndexOf("using namespace Missing.Namespace", StringComparison.Ordinal) >
+                sources.MergedScriptContent.IndexOf("using namespace System.Text", StringComparison.Ordinal));
+
+            Parser.ParseInput(sources.MergedScriptContent, out _, out var errors);
+            Assert.Empty(errors);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void BuildSources_RewritesLegacyPSScriptRootParentPathsByDefault()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge.Tests/ModuleMergeComposerTests.cs
+++ b/PowerForge.Tests/ModuleMergeComposerTests.cs
@@ -1,10 +1,67 @@
 using System;
 using System.IO;
+using System.Management.Automation.Language;
 
 namespace PowerForge.Tests;
 
 public sealed class ModuleMergeComposerTests
 {
+    [Fact]
+    public void BuildSources_PreservesUsingLinesInsidePowerShellHereStrings()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMergeModule(root.FullName, moduleName);
+            File.WriteAllText(
+                Path.Combine(root.FullName, "Public", "Get-TestExample.ps1"),
+                """
+                # module preamble
+                <#
+                using Fake.Namespace
+                #>
+                #requires -Version 5.1
+                using namespace System.Text
+
+                function Get-TestExample {
+                    Add-Type -TypeDefinition @"
+                    using System.Net;
+                    using System.Security.Cryptography.X509Certificates;
+                    public class TrustAllCertsPolicy : ICertificatePolicy {
+                        public bool CheckValidationResult(
+                            ServicePoint srvPoint, X509Certificate certificate,
+                            WebRequest request, int certificateProblem) {
+                            return true;
+                        }
+                    }
+                "@
+                }
+                """);
+
+            var sources = ModuleMergeComposer.BuildSources(
+                root.FullName,
+                moduleName,
+                information: null,
+                exports: new ExportSet(new[] { "Get-TestExample" }, Array.Empty<string>(), Array.Empty<string>()),
+                fixRelativePaths: false);
+
+            Assert.StartsWith("#requires -Version 5.1" + Environment.NewLine + "using namespace System.Text", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.Contains("using Fake.Namespace", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.Contains("using System.Net;", sources.MergedScriptContent, StringComparison.Ordinal);
+            Assert.True(
+                sources.MergedScriptContent.IndexOf("using System.Net;", StringComparison.Ordinal) >
+                sources.MergedScriptContent.IndexOf("Add-Type -TypeDefinition", StringComparison.Ordinal));
+
+            Parser.ParseInput(sources.MergedScriptContent, out _, out var errors);
+            Assert.Empty(errors);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Fact]
     public void BuildSources_RewritesLegacyPSScriptRootParentPathsByDefault()
     {

--- a/PowerForge/Services/ModuleMergeComposer.cs
+++ b/PowerForge/Services/ModuleMergeComposer.cs
@@ -200,21 +200,13 @@ internal static class ModuleMergeComposer
             }
 
             var block = new List<string>();
-            foreach (var line in lines)
+            var extractedDirectives = ExtractPreambleDirectives(lines, requires, usingLines);
+            for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
             {
-                var trimmed = line.TrimStart();
-                if (trimmed.StartsWith("#requires", System.StringComparison.OrdinalIgnoreCase))
-                {
-                    requires.Add(trimmed);
+                if (extractedDirectives.Contains(lineIndex))
                     continue;
-                }
 
-                if (trimmed.StartsWith("using ", System.StringComparison.OrdinalIgnoreCase))
-                {
-                    usingLines.Add(trimmed);
-                    continue;
-                }
-
+                var line = lines[lineIndex];
                 block.Add(fixRelativePaths ? NormalizeMergedRelativePathReferences(line) : line);
             }
 
@@ -251,6 +243,108 @@ internal static class ModuleMergeComposer
         }
 
         return merged;
+    }
+
+    private static HashSet<int> ExtractPreambleDirectives(
+        IReadOnlyList<string> lines,
+        ISet<string> requires,
+        ISet<string> usingLines)
+    {
+        // PowerShell using statements are valid only in the script preamble. Restricting extraction to that region
+        // prevents embedded languages in here-strings and block comments from being mistaken for module directives.
+        var extracted = new HashSet<int>();
+        var insideBlockComment = false;
+
+        for (var index = 0; index < lines.Count; index++)
+        {
+            var kind = ClassifyPreambleLine(lines[index], ref insideBlockComment);
+            if (kind == PreambleLineKind.Trivia)
+                continue;
+
+            if (kind == PreambleLineKind.Requires)
+            {
+                requires.Add(lines[index].TrimStart());
+                extracted.Add(index);
+                continue;
+            }
+
+            if (kind == PreambleLineKind.Using)
+            {
+                usingLines.Add(lines[index].TrimStart());
+                extracted.Add(index);
+                continue;
+            }
+
+            break;
+        }
+
+        return extracted;
+    }
+
+    private static PreambleLineKind ClassifyPreambleLine(string line, ref bool insideBlockComment)
+    {
+        var index = 0;
+        var hasLeadingBlockComment = false;
+
+        while (index < line.Length)
+        {
+            if (insideBlockComment)
+            {
+                var commentEnd = line.IndexOf("#>", index, System.StringComparison.Ordinal);
+                if (commentEnd < 0)
+                    return PreambleLineKind.Trivia;
+
+                insideBlockComment = false;
+                hasLeadingBlockComment = true;
+                index = commentEnd + 2;
+                continue;
+            }
+
+            while (index < line.Length && char.IsWhiteSpace(line[index]))
+                index++;
+
+            if (index >= line.Length)
+                return PreambleLineKind.Trivia;
+
+            if (line.IndexOf("<#", index, System.StringComparison.Ordinal) == index)
+            {
+                insideBlockComment = true;
+                hasLeadingBlockComment = true;
+                index += 2;
+                continue;
+            }
+
+            if (line[index] == '#')
+            {
+                return !hasLeadingBlockComment && StartsWithDirective(line, index, "#requires")
+                    ? PreambleLineKind.Requires
+                    : PreambleLineKind.Trivia;
+            }
+
+            if (!hasLeadingBlockComment && StartsWithDirective(line, index, "using"))
+                return PreambleLineKind.Using;
+
+            return PreambleLineKind.Code;
+        }
+
+        return PreambleLineKind.Trivia;
+    }
+
+    private static bool StartsWithDirective(string line, int index, string directive)
+    {
+        if (line.IndexOf(directive, index, System.StringComparison.OrdinalIgnoreCase) != index)
+            return false;
+
+        var boundary = index + directive.Length;
+        return boundary == line.Length || char.IsWhiteSpace(line[boundary]);
+    }
+
+    private enum PreambleLineKind
+    {
+        Trivia,
+        Requires,
+        Using,
+        Code
     }
 
     private static string NormalizeMergedRelativePathReferences(string line)

--- a/PowerForge/Services/ModuleMergeComposer.cs
+++ b/PowerForge/Services/ModuleMergeComposer.cs
@@ -253,11 +253,11 @@ internal static class ModuleMergeComposer
         // PowerShell using statements are valid only in the script preamble. Restricting extraction to that region
         // prevents embedded languages in here-strings and block comments from being mistaken for module directives.
         var extracted = new HashSet<int>();
-        var insideBlockComment = false;
+        var blockCommentDepth = 0;
 
         for (var index = 0; index < lines.Count; index++)
         {
-            var kind = ClassifyPreambleLine(lines[index], ref insideBlockComment);
+            var kind = ClassifyPreambleLine(lines[index], ref blockCommentDepth);
             if (kind == PreambleLineKind.Trivia)
                 continue;
 
@@ -281,20 +281,28 @@ internal static class ModuleMergeComposer
         return extracted;
     }
 
-    private static PreambleLineKind ClassifyPreambleLine(string line, ref bool insideBlockComment)
+    private static PreambleLineKind ClassifyPreambleLine(string line, ref int blockCommentDepth)
     {
         var index = 0;
         var hasLeadingBlockComment = false;
 
         while (index < line.Length)
         {
-            if (insideBlockComment)
+            if (blockCommentDepth > 0)
             {
+                var commentStart = line.IndexOf("<#", index, System.StringComparison.Ordinal);
                 var commentEnd = line.IndexOf("#>", index, System.StringComparison.Ordinal);
+                if (commentStart >= 0 && (commentEnd < 0 || commentStart < commentEnd))
+                {
+                    blockCommentDepth++;
+                    index = commentStart + 2;
+                    continue;
+                }
+
                 if (commentEnd < 0)
                     return PreambleLineKind.Trivia;
 
-                insideBlockComment = false;
+                blockCommentDepth--;
                 hasLeadingBlockComment = true;
                 index = commentEnd + 2;
                 continue;
@@ -308,7 +316,7 @@ internal static class ModuleMergeComposer
 
             if (line.IndexOf("<#", index, System.StringComparison.Ordinal) == index)
             {
-                insideBlockComment = true;
+                blockCommentDepth++;
                 hasLeadingBlockComment = true;
                 index += 2;
                 continue;

--- a/PowerForge/Services/ModuleMergeComposer.cs
+++ b/PowerForge/Services/ModuleMergeComposer.cs
@@ -200,13 +200,18 @@ internal static class ModuleMergeComposer
             }
 
             var block = new List<string>();
-            var extractedDirectives = ExtractPreambleDirectives(lines, requires, usingLines);
+            var directiveLineReplacements = ExtractPreambleDirectives(lines, requires, usingLines);
             for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
             {
-                if (extractedDirectives.Contains(lineIndex))
-                    continue;
-
                 var line = lines[lineIndex];
+                if (directiveLineReplacements.TryGetValue(lineIndex, out var replacement))
+                {
+                    if (replacement.Length == 0)
+                        continue;
+
+                    line = replacement;
+                }
+
                 block.Add(fixRelativePaths ? NormalizeMergedRelativePathReferences(line) : line);
             }
 
@@ -245,46 +250,49 @@ internal static class ModuleMergeComposer
         return merged;
     }
 
-    private static HashSet<int> ExtractPreambleDirectives(
+    private static Dictionary<int, string> ExtractPreambleDirectives(
         IReadOnlyList<string> lines,
         ISet<string> requires,
         ISet<string> usingLines)
     {
         // PowerShell using statements are valid only in the script preamble. Restricting extraction to that region
         // prevents embedded languages in here-strings and block comments from being mistaken for module directives.
-        var extracted = new HashSet<int>();
+        var lineReplacements = new Dictionary<int, string>();
         var blockCommentDepth = 0;
 
         for (var index = 0; index < lines.Count; index++)
         {
-            var kind = ClassifyPreambleLine(lines[index], ref blockCommentDepth);
+            var kind = ClassifyPreambleLine(lines[index], ref blockCommentDepth, out var directiveStart);
             if (kind == PreambleLineKind.Trivia)
                 continue;
 
             if (kind == PreambleLineKind.Requires)
             {
-                requires.Add(lines[index].TrimStart());
-                extracted.Add(index);
+                requires.Add(lines[index].Substring(directiveStart));
+                lineReplacements[index] = lines[index].Substring(0, directiveStart).TrimEnd();
                 continue;
             }
 
             if (kind == PreambleLineKind.Using)
             {
-                usingLines.Add(lines[index].TrimStart());
-                extracted.Add(index);
+                usingLines.Add(lines[index].Substring(directiveStart));
+                lineReplacements[index] = lines[index].Substring(0, directiveStart).TrimEnd();
                 continue;
             }
 
             break;
         }
 
-        return extracted;
+        return lineReplacements;
     }
 
-    private static PreambleLineKind ClassifyPreambleLine(string line, ref int blockCommentDepth)
+    private static PreambleLineKind ClassifyPreambleLine(
+        string line,
+        ref int blockCommentDepth,
+        out int directiveStart)
     {
         var index = 0;
-        var hasLeadingBlockComment = false;
+        directiveStart = -1;
 
         while (index < line.Length)
         {
@@ -303,7 +311,6 @@ internal static class ModuleMergeComposer
                     return PreambleLineKind.Trivia;
 
                 blockCommentDepth--;
-                hasLeadingBlockComment = true;
                 index = commentEnd + 2;
                 continue;
             }
@@ -317,20 +324,24 @@ internal static class ModuleMergeComposer
             if (line.IndexOf("<#", index, System.StringComparison.Ordinal) == index)
             {
                 blockCommentDepth++;
-                hasLeadingBlockComment = true;
                 index += 2;
                 continue;
             }
 
             if (line[index] == '#')
             {
-                return !hasLeadingBlockComment && StartsWithDirective(line, index, "#requires")
-                    ? PreambleLineKind.Requires
-                    : PreambleLineKind.Trivia;
+                if (!StartsWithDirective(line, index, "#requires"))
+                    return PreambleLineKind.Trivia;
+
+                directiveStart = index;
+                return PreambleLineKind.Requires;
             }
 
-            if (!hasLeadingBlockComment && StartsWithDirective(line, index, "using"))
+            if (StartsWithDirective(line, index, "using"))
+            {
+                directiveStart = index;
                 return PreambleLineKind.Using;
+            }
 
             return PreambleLineKind.Code;
         }


### PR DESCRIPTION
## Summary

- hoist `#requires` and PowerShell `using` statements only from each script's legal preamble
- preserve `using` text inside here-strings and block comments, including nested comments, when generating the merged `.psm1`
- hoist directives that follow leading block-comment trivia without dropping the comment prefix
- add regression coverage that validates both genuine directive hoisting and the parseability of the final merged script

## Regression

The C# merge composer scanned every trimmed source line and treated any line beginning with `using ` as a PowerShell directive. Embedded C# namespace imports were therefore removed from `Add-Type` here-strings and written at module scope. The behavior first shipped in the 3.x line with 3.0.13; the older 2.0.26 merge path did not perform this unsafe scan.

## Validation

- focused `ModuleMergeComposerTests`: 8 passed
- `PowerForge` and `PSPublishModule` `net472` Release builds: passed with no warnings
- full `PowerForge.Tests`: 4,154 passed; two unrelated timing tests passed when rerun individually
- PowerInfoblox full unsigned package build using the locally compiled fix: passed
- generated PowerInfoblox 1.0.37.1 imported in PowerShell 7 and Windows PowerShell 5.1; the embedded `TrustAllCertsPolicy` C# type compiled successfully on 5.1