### PR TITLE
Harden Home Assistant release workflow trust

### DIFF
--- a/.agents/skills/powerforge-homeassistant-release/SKILL.md
+++ b/.agents/skills/powerforge-homeassistant-release/SKILL.md
@@ -13,7 +13,7 @@ Use PowerForge as the release owner. A receiver repository should contain only t
    - integration: one `custom_components/<domain>/manifest.json`, with an optional matching `[project] version` in `pyproject.toml`;
    - Lovelace plugin: `package.json`, required `package-lock.json`, and `hacs.json` `filename`.
 2. Inspect the existing validation workflow and latest GitHub release. The PR head must have at least one completed successful, neutral, or skipped check run.
-3. Add only the `pull_request_target` receiver workflow documented in `Docs/PowerForge.HomeAssistantRelease.md`. Pin the reusable workflow to a reviewed PSPublishModule commit or release ref. Keep the trigger on `closed`: the trusted default-branch workflow must handle fork and Dependabot merges without checking out or executing pull-request code with its write token.
+3. Add only the `pull_request_target` receiver workflow documented in `Docs/PowerForge.HomeAssistantRelease.md`. Pin the reusable workflow to the full immutable SHA of a reviewed PSPublishModule release; a release tag may appear only as a maintenance comment. Keep the trigger on `closed`: the trusted default-branch workflow must handle fork and Dependabot merges without checking out or executing pull-request code with its write token.
 4. Give the job `checks: read`, `contents: write`, and `pull-requests: read`. Pass the merged PR number, merge SHA, default branch, and `github.token`.
 5. Add the `release:none`, `release:patch`, `release:minor`, and `release:major` labels if the repository does not have them.
 6. Validate the receiver YAML and open a release-ready PR. Use a release label only when that onboarding PR should intentionally prove a live release.

--- a/.agents/skills/powerforge-homeassistant-release/SKILL.md
+++ b/.agents/skills/powerforge-homeassistant-release/SKILL.md
@@ -13,7 +13,7 @@ Use PowerForge as the release owner. A receiver repository should contain only t
    - integration: one `custom_components/<domain>/manifest.json`, with an optional matching `[project] version` in `pyproject.toml`;
    - Lovelace plugin: `package.json`, required `package-lock.json`, and `hacs.json` `filename`.
 2. Inspect the existing validation workflow and latest GitHub release. The PR head must have at least one completed successful, neutral, or skipped check run.
-3. Add only the receiver workflow documented in `Docs/PowerForge.HomeAssistantRelease.md`. Pin the reusable workflow to a reviewed PSPublishModule commit or release ref.
+3. Add only the `pull_request_target` receiver workflow documented in `Docs/PowerForge.HomeAssistantRelease.md`. Pin the reusable workflow to a reviewed PSPublishModule commit or release ref. Keep the trigger on `closed`: the trusted default-branch workflow must handle fork and Dependabot merges without checking out or executing pull-request code with its write token.
 4. Give the job `checks: read`, `contents: write`, and `pull-requests: read`. Pass the merged PR number, merge SHA, default branch, and `github.token`.
 5. Add the `release:none`, `release:patch`, `release:minor`, and `release:major` labels if the repository does not have them.
 6. Validate the receiver YAML and open a release-ready PR. Use a release label only when that onboarding PR should intentionally prove a live release.

--- a/.github/workflows/powerforge-homeassistant-release.yml
+++ b/.github/workflows/powerforge-homeassistant-release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Prepare immutable release commit
         id: prepare
-        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@PowerForge-v1.0.2
+        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@8976b47713d00778aa798f4d4e292eaeb89b5b81
         with:
           stage: prepare
           repository-root: ${{ github.workspace }}/source
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build without GitHub write credentials
         id: build
-        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@PowerForge-v1.0.2
+        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@8976b47713d00778aa798f4d4e292eaeb89b5b81
         with:
           stage: build
           repository-root: ${{ github.workspace }}/source
@@ -130,7 +130,7 @@ jobs:
 
       - name: Publish and verify without receiver source code
         id: publish
-        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@PowerForge-v1.0.2
+        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@8976b47713d00778aa798f4d4e292eaeb89b5b81
         with:
           stage: publish
           repository: ${{ github.repository }}

--- a/Docs/PowerForge.HomeAssistantRelease.md
+++ b/Docs/PowerForge.HomeAssistantRelease.md
@@ -43,7 +43,7 @@ The reusable workflow uses GitHub's durable `queue: max` concurrency mode. Every
 
 ## Thin receiver workflow
 
-Pin `POWERFORGE_REF` below to a reviewed PSPublishModule commit or release ref. The receiver contains no release implementation:
+Replace `POWERFORGE_COMMIT_SHA` below with the full commit SHA of a reviewed PSPublishModule release. Keep a release-name comment beside the pin when it helps maintenance. Do not grant a movable tag a cross-repository write token. The receiver contains no release implementation:
 
 The receiver intentionally uses `pull_request_target` for the `closed` event. GitHub otherwise downgrades `GITHUB_TOKEN` to read-only when a merged pull request came from a fork or Dependabot. The trusted default-branch receiver only passes merge metadata into PowerForge: privileged prepare and publish jobs never execute receiver code, and the credential-free build job checks out the already-merged release commit.
 
@@ -76,7 +76,7 @@ jobs:
       checks: read
       contents: write
       pull-requests: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@POWERFORGE_REF
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@POWERFORGE_COMMIT_SHA # PowerForge-vX.Y.Z
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}

--- a/Docs/PowerForge.HomeAssistantRelease.md
+++ b/Docs/PowerForge.HomeAssistantRelease.md
@@ -86,7 +86,7 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-The reusable workflow serializes and queues releases per repository and invokes the matching tagged action. The action installs an exact `PowerForge.Build` package version, so the workflow, action, and engine do not drift between retries.
+The reusable workflow serializes and queues releases per repository and invokes the matching action at the immutable release commit. The action installs an exact `PowerForge.Build` package version, so the workflow, action, and engine do not drift between retries.
 
 The shared workflow deliberately uses three jobs with different permissions:
 

--- a/Docs/PowerForge.HomeAssistantRelease.md
+++ b/Docs/PowerForge.HomeAssistantRelease.md
@@ -45,11 +45,13 @@ The reusable workflow uses GitHub's durable `queue: max` concurrency mode. Every
 
 Pin `POWERFORGE_REF` below to a reviewed PSPublishModule commit or release ref. The receiver contains no release implementation:
 
+The receiver intentionally uses `pull_request_target` for the `closed` event. GitHub otherwise downgrades `GITHUB_TOKEN` to read-only when a merged pull request came from a fork or Dependabot. The trusted default-branch receiver only passes merge metadata into PowerForge: privileged prepare and publish jobs never execute receiver code, and the credential-free build job checks out the already-merged release commit.
+
 ```yaml
 name: Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

- use `pull_request_target` for the canonical closed-PR receiver so fork and Dependabot merges retain the required write token
- pin the reusable workflow's composite action to the immutable PowerForge 1.0.2 release commit
- require full commit-SHA pins in the receiver documentation and repository skill
- document why the trusted trigger remains isolated from pull-request-controlled code

`PowerForge.Build 1.0.2` is unchanged; this hardens the GitHub Actions trust boundary around it.