### PR TITLE
Fix Home Assistant release check settlement

### DIFF
--- a/.agents/skills/powerforge-homeassistant-release/SKILL.md
+++ b/.agents/skills/powerforge-homeassistant-release/SKILL.md
@@ -14,7 +14,7 @@ Use PowerForge as the release owner. A receiver repository should contain only t
    - Lovelace plugin: `package.json`, required `package-lock.json`, and `hacs.json` `filename`.
 2. Inspect the existing validation workflow and latest GitHub release. The PR head must have at least one completed successful, neutral, or skipped check run.
 3. Add only the `pull_request_target` receiver workflow documented in `Docs/PowerForge.HomeAssistantRelease.md`. Pin the reusable workflow to the full immutable SHA of a reviewed PSPublishModule release; a release tag may appear only as a maintenance comment. Keep the trigger on `closed`: the trusted default-branch workflow must handle fork and Dependabot merges without checking out or executing pull-request code with its write token.
-4. Give the job `checks: read`, `contents: write`, and `pull-requests: read`. Pass the merged PR number, merge SHA, default branch, and `github.token`.
+4. Give the job `actions: read`, `checks: read`, `contents: write`, and `pull-requests: read`. Pass the merged PR number, merge SHA, default branch, and `github.token`.
 5. Add the `release:none`, `release:patch`, `release:minor`, and `release:major` labels if the repository does not have them.
 6. Validate the receiver YAML and open a release-ready PR. Use a release label only when that onboarding PR should intentionally prove a live release.
 

--- a/.github/actions/homeassistant-release/action.yml
+++ b/.github/actions/homeassistant-release/action.yml
@@ -52,7 +52,7 @@ inputs:
   powerforge-version:
     description: Exact PowerForge.Build tool version used by the action.
     required: false
-    default: "1.0.2"
+    default: "1.0.3"
 
 outputs:
   action:

--- a/.github/workflows/powerforge-homeassistant-release.yml
+++ b/.github/workflows/powerforge-homeassistant-release.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: read
       checks: read
       contents: write
       pull-requests: read
@@ -66,6 +67,7 @@ jobs:
           default-branch: ${{ inputs.default_branch }}
           increment: ${{ inputs.increment }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
+          powerforge-version: 1.0.3
 
   build:
     needs: prepare
@@ -99,6 +101,7 @@ jobs:
           repository-root: ${{ github.workspace }}/source
           release-version: ${{ needs.prepare.outputs.version }}
           release-commit: ${{ needs.prepare.outputs.release-commit }}
+          powerforge-version: 1.0.3
 
       - name: Transfer the single release asset to the publish job
         if: steps.build.outputs.required-asset != ''
@@ -141,3 +144,4 @@ jobs:
           required-asset: ${{ needs.build.outputs.required-asset }}
           asset-path: ${{ needs.build.outputs.required-asset != '' && format('{0}/powerforge-homeassistant-release-asset/{1}', runner.temp, needs.build.outputs.required-asset) || '' }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
+          powerforge-version: 1.0.3

--- a/Docs/PowerForge.HomeAssistantRelease.md
+++ b/Docs/PowerForge.HomeAssistantRelease.md
@@ -37,7 +37,7 @@ Use at most one release label. Conflicting labels fail the run rather than guess
 
 If the repository has no GitHub release yet, PowerForge publishes the synchronized metadata version as the initial baseline instead of incrementing past an unreleased version.
 
-Before changing anything, PowerForge confirms that the pull request is merged, its merge SHA matches the event, the checked-out default branch contains that merge, and the PR head has completed checks with accepted conclusions (`success`, `neutral`, or `skipped`).
+Before changing anything, PowerForge confirms that the pull request is merged, its merge SHA matches the event, the checked-out default branch contains that merge, and the PR head has completed checks with accepted conclusions (`success`, `neutral`, or `skipped`). PowerForge excludes the current release run from settling itself. During recovery it excludes a prior failed release check only after the Actions API proves that it came from the same trusted receiver workflow path and release event; other pending or failed checks remain blocking.
 
 The reusable workflow uses GitHub's durable `queue: max` concurrency mode. Every merged-PR trigger waits for the repository release lock instead of replacing an older pending run, so an intermediate `release:minor` or `release:major` decision is not discarded during a merge burst. Each queued trigger applies its own policy to the then-current default branch.
 
@@ -73,6 +73,7 @@ jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     permissions:
+      actions: read
       checks: read
       contents: write
       pull-requests: read

--- a/PowerForge.Blazor/PowerForge.Blazor.csproj
+++ b/PowerForge.Blazor/PowerForge.Blazor.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
 
     <!-- Package metadata -->
     <PackageId>PowerForge.Blazor</PackageId>

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge</ToolCommandName>
     <Description>PowerForge command-line interface for building and publishing PowerShell modules.</Description>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.Cli/Program.Command.HomeAssistant.cs
+++ b/PowerForge.Cli/Program.Command.HomeAssistant.cs
@@ -102,6 +102,7 @@ internal static partial class Program {
             Token = ReadToken(argv),
             PullRequestNumber = pullRequestNumber,
             MergeCommitSha = TryGetOptionValue(argv, "--merge-sha") ?? Environment.GetEnvironmentVariable("POWERFORGE_MERGE_SHA"),
+            WorkflowRunId = ParseOptionalPositiveLong(argv, "--workflow-run-id", "GITHUB_RUN_ID"),
             DefaultBranch = TryGetOptionValue(argv, "--default-branch") ?? Environment.GetEnvironmentVariable("POWERFORGE_DEFAULT_BRANCH") ?? "main",
             Increment = increment,
             Apply = argv.Any(value => value.Equals("--apply", StringComparison.OrdinalIgnoreCase)),
@@ -146,6 +147,14 @@ internal static partial class Program {
     private static int ParsePositiveInteger(string[] argv, string option, string environmentVariable) {
         var value = TryGetOptionValue(argv, option) ?? Environment.GetEnvironmentVariable(environmentVariable);
         if (!int.TryParse(value, out var parsed) || parsed <= 0)
+            throw new ArgumentException($"{option} must be a positive integer.");
+        return parsed;
+    }
+
+    private static long? ParseOptionalPositiveLong(string[] argv, string option, string environmentVariable) {
+        var value = TryGetOptionValue(argv, option) ?? Environment.GetEnvironmentVariable(environmentVariable);
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        if (!long.TryParse(value, out var parsed) || parsed <= 0)
             throw new ArgumentException($"{option} must be a positive integer.");
         return parsed;
     }

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -63,7 +63,7 @@ internal static partial class Program
                                       [--min-free-gb <N>] [--aggressive-threshold-gb <N>] [--dry-run|--apply] [--aggressive] [--allow-sudo]
                                       [--skip-diagnostics] [--skip-runner-temp] [--skip-actions-cache] [--skip-tool-cache] [--skip-dotnet-cache]
                                       [--skip-docker] [--no-docker-volumes] [--output json]
-      powerforge homeassistant release prepare --repo <owner/name> --pr-number <N> [--repository-root <path>] [--merge-sha <sha>] [--apply]
+      powerforge homeassistant release prepare --repo <owner/name> --pr-number <N> [--repository-root <path>] [--merge-sha <sha>] [--workflow-run-id <N>] [--apply]
       powerforge homeassistant release build --repository-root <path> --release-version <X.Y.Z> --release-commit <sha>
       powerforge homeassistant release publish --repo <owner/name> --pr-number <N> --release-version <X.Y.Z> --release-commit <sha>
       --verbose, -Verbose              Enable verbose diagnostics

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <PackageId>PowerForge.PowerShell</PackageId>
     <Description>PowerForge PowerShell-hosted module pipeline services.</Description>
     <AssemblyName>PowerForge.PowerShell</AssemblyName>

--- a/PowerForge.Tests/HomeAssistantGitHubClientTests.cs
+++ b/PowerForge.Tests/HomeAssistantGitHubClientTests.cs
@@ -1,0 +1,311 @@
+using System.Net;
+using System.Text;
+
+namespace PowerForge.Tests;
+
+public sealed class HomeAssistantGitHubClientTests {
+    [Fact]
+    public void GetCheckSummary_ExcludesOnlyChecksFromTheCurrentGitHubActionsRun() {
+        const long workflowRunId = 29561117925L;
+        using var httpClient = CreateHttpClient($$"""
+            {
+              "check_runs": [
+                {
+                  "name": "release / prepare",
+                  "status": "in_progress",
+                  "conclusion": null,
+                  "details_url": "https://github.com/EvotecIT/example/actions/runs/{{workflowRunId}}/job/1",
+                  "app": { "slug": "github-actions" }
+                },
+                {
+                  "name": "tests",
+                  "status": "completed",
+                  "conclusion": "success",
+                  "details_url": "https://github.com/EvotecIT/example/actions/runs/29560000000/job/2",
+                  "app": { "slug": "github-actions" }
+                }
+              ]
+            }
+            """);
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", workflowRunId);
+
+        Assert.Equal(1, summary.Total);
+        Assert.Empty(summary.BlockingChecks);
+    }
+
+    [Fact]
+    public void GetCheckSummary_KeepsPendingChecksFromOtherWorkflowRunsBlocking() {
+        const long workflowRunId = 29561117925L;
+        using var httpClient = CreateHttpClient("""
+            {
+              "check_runs": [
+                {
+                  "name": "release / prepare",
+                  "status": "in_progress",
+                  "conclusion": null,
+                  "details_url": "https://github.com/EvotecIT/example/actions/runs/29561117924/job/1",
+                  "app": { "slug": "github-actions" }
+                }
+              ]
+            }
+            """);
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", workflowRunId);
+
+        Assert.Equal(1, summary.Total);
+        Assert.Equal("release / prepare: in_progress", Assert.Single(summary.BlockingChecks));
+    }
+
+    [Fact]
+    public void GetCheckSummary_DoesNotTrustAnotherAppUsingTheCurrentWorkflowUrl() {
+        const long workflowRunId = 29561117925L;
+        using var httpClient = CreateHttpClient($$"""
+            {
+              "check_runs": [
+                {
+                  "name": "external validation",
+                  "status": "completed",
+                  "conclusion": "failure",
+                  "details_url": "https://github.com/EvotecIT/example/actions/runs/{{workflowRunId}}/job/1",
+                  "app": { "slug": "external-checks" }
+                }
+              ]
+            }
+            """);
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", workflowRunId);
+
+        Assert.Equal(1, summary.Total);
+        Assert.Equal("external validation: failure", Assert.Single(summary.BlockingChecks));
+    }
+
+    [Fact]
+    public void GetCheckSummary_KeepsNonReleaseChecksFromTheCurrentWorkflowRunBlocking() {
+        const long workflowRunId = 29561117925L;
+        using var httpClient = CreateHttpClient($$"""
+            {
+              "check_runs": [
+                {
+                  "name": "security validation",
+                  "status": "completed",
+                  "conclusion": "failure",
+                  "details_url": "https://github.com/EvotecIT/example/actions/runs/{{workflowRunId}}/job/1",
+                  "app": { "slug": "github-actions" }
+                }
+              ]
+            }
+            """);
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", workflowRunId);
+
+        Assert.Equal(1, summary.Total);
+        Assert.Equal("security validation: failure", Assert.Single(summary.BlockingChecks));
+    }
+
+    [Fact]
+    public void GetCheckSummary_LeavesNoValidationChecksWhenOnlyTheCurrentRunExists() {
+        const long workflowRunId = 29561117925L;
+        using var httpClient = CreateHttpClient($$"""
+            {
+              "check_runs": [
+                {
+                  "name": "release / prepare",
+                  "status": "in_progress",
+                  "conclusion": null,
+                  "details_url": "https://github.com/EvotecIT/example/actions/runs/{{workflowRunId}}/job/1",
+                  "app": { "slug": "github-actions" }
+                }
+              ]
+            }
+            """);
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", workflowRunId);
+
+        Assert.Equal(0, summary.Total);
+        Assert.Empty(summary.BlockingChecks);
+    }
+
+    [Fact]
+    public void GetCheckSummary_DoesNotCountCompletedFailedReleaseAttemptsAsValidation() {
+        const long currentWorkflowRunId = 29570000000L;
+        using var httpClient = CreateHttpClient(uri => uri.AbsolutePath switch {
+            "/repos/EvotecIT/example/commits/head-sha/check-runs" => """
+                {
+                  "check_runs": [
+                    {
+                      "name": "release / prepare",
+                      "status": "completed",
+                      "conclusion": "failure",
+                      "details_url": "https://github.com/EvotecIT/example/actions/runs/29561117925/job/1",
+                      "app": { "slug": "github-actions" }
+                    },
+                    {
+                      "name": "release / build",
+                      "status": "completed",
+                      "conclusion": "skipped",
+                      "details_url": "https://github.com/EvotecIT/example/actions/runs/29561117925/job/2",
+                      "app": { "slug": "github-actions" }
+                    },
+                    {
+                      "name": "release / publish",
+                      "status": "completed",
+                      "conclusion": "skipped",
+                      "details_url": "https://github.com/EvotecIT/example/actions/runs/29561117925/job/3",
+                      "app": { "slug": "github-actions" }
+                    }
+                  ]
+                }
+                """,
+            "/repos/EvotecIT/example/actions/runs/29570000000" => """
+                {
+                  "id": 29570000000,
+                  "path": ".github/workflows/release.yml",
+                  "event": "workflow_dispatch",
+                  "head_sha": "current-main-sha",
+                  "status": "in_progress",
+                  "conclusion": null
+                }
+                """,
+            "/repos/EvotecIT/example/actions/runs/29561117925" => """
+                {
+                  "id": 29561117925,
+                  "path": ".github/workflows/release.yml",
+                  "event": "pull_request_target",
+                  "head_sha": "head-sha",
+                  "status": "completed",
+                  "conclusion": "failure"
+                }
+                """,
+            _ => throw new InvalidOperationException($"Unexpected GitHub API path: {uri.AbsolutePath}")
+        });
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", currentWorkflowRunId);
+
+        Assert.Equal(0, summary.Total);
+        Assert.Empty(summary.BlockingChecks);
+    }
+
+    [Fact]
+    public void GetCheckSummary_KeepsFailedJobsFromAnInProgressReleaseWorkflowBlocking() {
+        const long currentWorkflowRunId = 29570000000L;
+        using var httpClient = CreateHttpClient(uri => uri.AbsolutePath switch {
+            "/repos/EvotecIT/example/commits/head-sha/check-runs" => """
+                {
+                  "check_runs": [
+                    {
+                      "name": "release / prepare",
+                      "status": "completed",
+                      "conclusion": "failure",
+                      "details_url": "https://github.com/EvotecIT/example/actions/runs/29561117925/job/1",
+                      "app": { "slug": "github-actions" }
+                    }
+                  ]
+                }
+                """,
+            "/repos/EvotecIT/example/actions/runs/29570000000" => """
+                {
+                  "id": 29570000000,
+                  "path": ".github/workflows/release.yml",
+                  "event": "workflow_dispatch",
+                  "head_sha": "current-main-sha",
+                  "status": "in_progress",
+                  "conclusion": null
+                }
+                """,
+            "/repos/EvotecIT/example/actions/runs/29561117925" => """
+                {
+                  "id": 29561117925,
+                  "path": ".github/workflows/release.yml",
+                  "event": "pull_request_target",
+                  "head_sha": "head-sha",
+                  "status": "in_progress",
+                  "conclusion": null
+                }
+                """,
+            _ => throw new InvalidOperationException($"Unexpected GitHub API path: {uri.AbsolutePath}")
+        });
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", currentWorkflowRunId);
+
+        Assert.Equal(1, summary.Total);
+        Assert.Equal("release / prepare: failure", Assert.Single(summary.BlockingChecks));
+    }
+
+    [Theory]
+    [InlineData(".github/workflows/security.yml", "pull_request_target", "head-sha")]
+    [InlineData(".github/workflows/release.yml", "pull_request", "head-sha")]
+    [InlineData(".github/workflows/release.yml", "pull_request_target", "different-head-sha")]
+    public void GetCheckSummary_KeepsPriorChecksBlockingWhenTrustedReleaseIdentityDoesNotMatch(
+        string candidatePath,
+        string candidateEvent,
+        string candidateHeadSha) {
+        const long currentWorkflowRunId = 29570000000L;
+        using var httpClient = CreateHttpClient(uri => uri.AbsolutePath switch {
+            "/repos/EvotecIT/example/commits/head-sha/check-runs" => """
+                {
+                  "check_runs": [
+                    {
+                      "name": "release / prepare",
+                      "status": "completed",
+                      "conclusion": "failure",
+                      "details_url": "https://github.com/EvotecIT/example/actions/runs/29561117925/job/1",
+                      "app": { "slug": "github-actions" }
+                    }
+                  ]
+                }
+                """,
+            "/repos/EvotecIT/example/actions/runs/29570000000" => """
+                {
+                  "id": 29570000000,
+                  "path": ".github/workflows/release.yml",
+                  "event": "workflow_dispatch",
+                  "head_sha": "current-main-sha"
+                }
+                """,
+            "/repos/EvotecIT/example/actions/runs/29561117925" => $$"""
+                {
+                  "id": 29561117925,
+                  "path": "{{candidatePath}}",
+                  "event": "{{candidateEvent}}",
+                  "head_sha": "{{candidateHeadSha}}",
+                  "status": "completed",
+                  "conclusion": "failure"
+                }
+                """,
+            _ => throw new InvalidOperationException($"Unexpected GitHub API path: {uri.AbsolutePath}")
+        });
+        var client = CreateClient(httpClient);
+
+        var summary = client.GetCheckSummary("head-sha", currentWorkflowRunId);
+
+        Assert.Equal(1, summary.Total);
+        Assert.Equal("release / prepare: failure", Assert.Single(summary.BlockingChecks));
+    }
+
+    private static HomeAssistantGitHubClient CreateClient(HttpClient httpClient)
+        => new("EvotecIT", "example", "token", "https://api.github.test", httpClient);
+
+    private static HttpClient CreateHttpClient(string responseBody)
+        => CreateHttpClient(_ => responseBody);
+
+    private static HttpClient CreateHttpClient(Func<Uri, string> responseFactory)
+        => new(new JsonResponseHandler(responseFactory));
+
+    private sealed class JsonResponseHandler(Func<Uri, string> responseFactory) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent(
+                    responseFactory(request.RequestUri ?? throw new InvalidOperationException("GitHub API request URI was missing.")),
+                    Encoding.UTF8,
+                    "application/json")
+            });
+    }
+}

--- a/PowerForge.Tests/HomeAssistantReleaseTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseTests.cs
@@ -216,12 +216,14 @@ public sealed class HomeAssistantReleaseTests {
             Repository = "example",
             Token = "token",
             PullRequestNumber = 42,
-            MergeCommitSha = sourceMergeSha
+            MergeCommitSha = sourceMergeSha,
+            WorkflowRunId = 29561117925L
         });
 
         Assert.Equal(HomeAssistantReleaseAction.Planned, result.Action);
         Assert.Equal(HomeAssistantVersionIncrement.Patch, result.Increment);
         Assert.Equal("0.2.7", result.ReleaseVersion);
+        Assert.Equal(29561117925L, github.ExcludedWorkflowRunId);
     }
 
     [Fact]
@@ -687,9 +689,13 @@ public sealed class HomeAssistantReleaseTests {
         internal HomeAssistantGitHubRelease? LatestRelease { get; set; }
         internal HomeAssistantGitHubRelease? TagRelease { get; set; }
         internal string? TagCommitSha { get; set; }
+        internal long? ExcludedWorkflowRunId { get; private set; }
 
         public HomeAssistantPullRequest GetPullRequest(int number) => PullRequest;
-        public HomeAssistantCheckSummary GetCheckSummary(string commitSha) => new() { Total = 1 };
+        public HomeAssistantCheckSummary GetCheckSummary(string commitSha, long? excludedWorkflowRunId) {
+            ExcludedWorkflowRunId = excludedWorkflowRunId;
+            return new HomeAssistantCheckSummary { Total = 1 };
+        }
         public HomeAssistantGitHubRelease? GetLatestRelease() => LatestRelease;
         public HomeAssistantGitHubRelease? FindReleaseByMarker(string marker) => MarkerRelease;
         public HomeAssistantGitHubRelease? GetReleaseByTag(string tagName) => TagRelease ?? MarkerRelease;

--- a/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
@@ -14,4 +14,28 @@ public sealed class HomeAssistantReleaseWorkflowTests {
         Assert.Contains("path: ${{ steps.build.outputs.asset-path }}", uploadStep, StringComparison.Ordinal);
         Assert.Contains("include-hidden-files: true", uploadStep, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void WorkflowPinsTheReleasedEngineVersionForEveryStage() {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "powerforge-homeassistant-release.yml"));
+        var action = File.ReadAllText(Path.Combine(root, ".github", "actions", "homeassistant-release", "action.yml"));
+        var skill = File.ReadAllText(Path.Combine(root, ".agents", "skills", "powerforge-homeassistant-release", "SKILL.md"));
+
+        Assert.Equal(3, CountOccurrences(workflow, "powerforge-version: 1.0.3"));
+        Assert.Contains("actions: read", workflow, StringComparison.Ordinal);
+        Assert.Contains("`actions: read`", skill, StringComparison.Ordinal);
+        Assert.Contains("default: \"1.0.3\"", action, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string value, string search) {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(search, index, StringComparison.Ordinal)) >= 0) {
+            count++;
+            index += search.Length;
+        }
+
+        return count;
+    }
 }

--- a/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+++ b/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge-web</ToolCommandName>
     <Description>PowerForge.Web command-line interface for building and serving static sites.</Description>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <PackageId>PowerForge.Web</PackageId>
     <RootNamespace>PowerForge.Web</RootNamespace>
     <Description>PowerForge.Web static-site engine and reusable website build components.</Description>

--- a/PowerForge/Models/HomeAssistantReleaseModels.cs
+++ b/PowerForge/Models/HomeAssistantReleaseModels.cs
@@ -80,6 +80,9 @@ public sealed class HomeAssistantReleasePrepareSpec {
     /// <summary>Expected merge commit SHA supplied by the workflow event.</summary>
     public string? MergeCommitSha { get; set; }
 
+    /// <summary>Current GitHub Actions workflow run used to identify trusted release checks.</summary>
+    public long? WorkflowRunId { get; set; }
+
     /// <summary>Default branch to receive the version-only release commit.</summary>
     public string DefaultBranch { get; set; } = "main";
 

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <PackageId>PowerForge</PackageId>
     <Description>PowerForge core library: reusable engine for building, formatting, packaging and publishing PowerShell modules.</Description>
     <AssemblyName>PowerForge</AssemblyName>

--- a/PowerForge/Services/HomeAssistantGitHubClient.cs
+++ b/PowerForge/Services/HomeAssistantGitHubClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -60,19 +61,36 @@ internal sealed class HomeAssistantGitHubClient : IHomeAssistantGitHubClient {
         return result;
     }
 
-    public HomeAssistantCheckSummary GetCheckSummary(string commitSha) {
+    public HomeAssistantCheckSummary GetCheckSummary(string commitSha, long? excludedWorkflowRunId) {
         if (string.IsNullOrWhiteSpace(commitSha)) throw new ArgumentException("Commit SHA is required.", nameof(commitSha));
         var result = new HomeAssistantCheckSummary();
+        var workflowRuns = new Dictionary<long, HomeAssistantWorkflowRun>();
         for (var page = 1; page <= 10; page++) {
             var value = GetObject($"/repos/{_owner}/{_repository}/commits/{commitSha}/check-runs?per_page=100&filter=latest&page={page}");
             if (value["check_runs"] is not JsonArray runs) return result;
 
             foreach (var run in runs.OfType<JsonObject>()) {
-                result.Total++;
                 var name = GetString(run, "name");
                 var status = GetString(run, "status");
                 var conclusion = GetString(run, "conclusion");
-                if (!string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase) || !IsAcceptedConclusion(conclusion))
+                var completed = string.Equals(status, "completed", StringComparison.OrdinalIgnoreCase);
+                var accepted = completed && IsAcceptedConclusion(conclusion);
+                var blocking = !accepted;
+                var workflowRunId = GetGitHubActionsWorkflowRunId(run);
+                if (excludedWorkflowRunId.HasValue && workflowRunId.HasValue) {
+                    if (workflowRunId.Value == excludedWorkflowRunId.Value && IsReleaseCheckName(name))
+                        continue;
+                    if (IsReleaseCheckName(name) && IsCompletedFailedReleaseWorkflow(
+                            excludedWorkflowRunId.Value,
+                            workflowRunId.Value,
+                            commitSha,
+                            workflowRuns)) {
+                        continue;
+                    }
+                }
+
+                result.Total++;
+                if (blocking)
                     result.BlockingChecks.Add($"{name}: {(string.IsNullOrWhiteSpace(conclusion) ? status : conclusion)}");
             }
 
@@ -184,6 +202,63 @@ internal sealed class HomeAssistantGitHubClient : IHomeAssistantGitHubClient {
         => conclusion.Equals("success", StringComparison.OrdinalIgnoreCase) ||
            conclusion.Equals("neutral", StringComparison.OrdinalIgnoreCase) ||
            conclusion.Equals("skipped", StringComparison.OrdinalIgnoreCase);
+
+    private static long? GetGitHubActionsWorkflowRunId(JsonObject run) {
+        if (!string.Equals(GetString(run["app"] as JsonObject, "slug"), "github-actions", StringComparison.OrdinalIgnoreCase))
+            return null;
+        var detailsUrl = GetString(run, "details_url");
+        if (!Uri.TryCreate(detailsUrl, UriKind.Absolute, out var uri)) return null;
+        var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        for (var index = 0; index + 2 < segments.Length; index++) {
+            if (string.Equals(segments[index], "actions", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(segments[index + 1], "runs", StringComparison.OrdinalIgnoreCase) &&
+                long.TryParse(segments[index + 2], out var workflowRunId) && workflowRunId > 0) {
+                return workflowRunId;
+            }
+        }
+
+        return null;
+    }
+
+    private bool IsCompletedFailedReleaseWorkflow(
+        long currentWorkflowRunId,
+        long candidateWorkflowRunId,
+        string commitSha,
+        IDictionary<long, HomeAssistantWorkflowRun> cache) {
+        var current = GetWorkflowRun(currentWorkflowRunId, cache);
+        var candidate = GetWorkflowRun(candidateWorkflowRunId, cache);
+        return !string.IsNullOrWhiteSpace(current.Path) &&
+               string.Equals(current.Path, candidate.Path, StringComparison.OrdinalIgnoreCase) &&
+               IsReleaseEvent(current.Event) &&
+               IsReleaseEvent(candidate.Event) &&
+               string.Equals(candidate.HeadSha, commitSha, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(candidate.Status, "completed", StringComparison.OrdinalIgnoreCase) &&
+               !IsAcceptedConclusion(candidate.Conclusion);
+    }
+
+    private HomeAssistantWorkflowRun GetWorkflowRun(long workflowRunId, IDictionary<long, HomeAssistantWorkflowRun> cache) {
+        if (cache.TryGetValue(workflowRunId, out var cached)) return cached;
+        var value = GetObject($"/repos/{_owner}/{_repository}/actions/runs/{workflowRunId}");
+        var result = new HomeAssistantWorkflowRun {
+            Id = value["id"]?.GetValue<long>() ?? workflowRunId,
+            Path = GetString(value, "path"),
+            Event = GetString(value, "event"),
+            HeadSha = GetString(value, "head_sha"),
+            Status = GetString(value, "status"),
+            Conclusion = GetString(value, "conclusion")
+        };
+        cache[workflowRunId] = result;
+        return result;
+    }
+
+    private static bool IsReleaseCheckName(string name)
+        => string.Equals(name, "release / prepare", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(name, "release / build", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(name, "release / publish", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsReleaseEvent(string eventName)
+        => string.Equals(eventName, "pull_request_target", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(eventName, "workflow_dispatch", StringComparison.OrdinalIgnoreCase);
 
     private static string Trim(string value) {
         var normalized = (value ?? string.Empty).Replace('\r', ' ').Replace('\n', ' ').Trim();

--- a/PowerForge/Services/HomeAssistantReleaseContracts.cs
+++ b/PowerForge/Services/HomeAssistantReleaseContracts.cs
@@ -19,6 +19,15 @@ internal sealed class HomeAssistantCheckSummary {
     internal List<string> BlockingChecks { get; } = new();
 }
 
+internal sealed class HomeAssistantWorkflowRun {
+    internal long Id { get; set; }
+    internal string Path { get; set; } = string.Empty;
+    internal string Event { get; set; } = string.Empty;
+    internal string HeadSha { get; set; } = string.Empty;
+    internal string Status { get; set; } = string.Empty;
+    internal string Conclusion { get; set; } = string.Empty;
+}
+
 internal sealed class HomeAssistantGitHubRelease {
     internal long Id { get; set; }
     internal string TagName { get; set; } = string.Empty;
@@ -52,7 +61,7 @@ internal sealed class HomeAssistantRepositorySnapshot {
 
 internal interface IHomeAssistantGitHubClient {
     HomeAssistantPullRequest GetPullRequest(int number);
-    HomeAssistantCheckSummary GetCheckSummary(string commitSha);
+    HomeAssistantCheckSummary GetCheckSummary(string commitSha, long? excludedWorkflowRunId);
     HomeAssistantGitHubRelease? GetLatestRelease();
     HomeAssistantGitHubRelease? FindReleaseByMarker(string marker);
     HomeAssistantGitHubRelease? GetReleaseByTag(string tagName);

--- a/PowerForge/Services/HomeAssistantReleaseService.cs
+++ b/PowerForge/Services/HomeAssistantReleaseService.cs
@@ -70,7 +70,7 @@ public sealed class HomeAssistantReleaseService {
             }
         }
 
-        ValidateChecks(github, pullRequest);
+        ValidateChecks(github, pullRequest, spec.WorkflowRunId);
         _git.EnsureContainsMerge(root, mergeCommitSha);
         var preparedReleaseCommit = _git.FindPreparedReleaseCommit(
             root,
@@ -312,8 +312,11 @@ public sealed class HomeAssistantReleaseService {
         return pullRequest;
     }
 
-    private static void ValidateChecks(IHomeAssistantGitHubClient github, HomeAssistantPullRequest pullRequest) {
-        var checks = github.GetCheckSummary(pullRequest.HeadSha);
+    private static void ValidateChecks(
+        IHomeAssistantGitHubClient github,
+        HomeAssistantPullRequest pullRequest,
+        long? excludedWorkflowRunId) {
+        var checks = github.GetCheckSummary(pullRequest.HeadSha, excludedWorkflowRunId);
         if (checks.Total == 0)
             throw new InvalidOperationException($"No check runs were found for pull request head {pullRequest.HeadSha}; refusing an unvalidated release.");
         if (checks.BlockingChecks.Count > 0)
@@ -348,6 +351,8 @@ public sealed class HomeAssistantReleaseService {
         if (spec is null) throw new ArgumentNullException(nameof(spec));
         if (string.IsNullOrWhiteSpace(spec.RepositoryRoot)) throw new ArgumentException("RepositoryRoot is required.", nameof(spec));
         ValidateGitHubIdentity(spec.Owner, spec.Repository, spec.Token, spec.PullRequestNumber);
+        if (spec.WorkflowRunId.HasValue && spec.WorkflowRunId.Value <= 0)
+            throw new ArgumentException("WorkflowRunId must be positive when supplied.", nameof(spec));
         if (string.IsNullOrWhiteSpace(spec.DefaultBranch)) throw new ArgumentException("DefaultBranch is required.", nameof(spec));
         if (string.IsNullOrWhiteSpace(spec.ServerUrl)) throw new ArgumentException("ServerUrl is required.", nameof(spec));
     }


### PR DESCRIPTION
## Summary

- prevent Home Assistant release workflows from treating their own checks as pull-request validation or blockers
- allow recovery only for completed failed release attempts proven to use the same trusted receiver workflow path, approved event, and original PR head
- keep unrelated, pending, or identity-mismatched checks fail-closed
- add the required `actions: read` contract to the reusable workflow, receiver documentation, and maintained onboarding skill
- bump the aligned PowerForge package/action/workflow version to 1.0.3

## Coverage

Regression coverage includes current-run isolation, co-located security jobs, completed failed attempts with skipped sibling jobs, pending attempts, and workflow path/event/head mismatches. The six-package 1.0.3 release set builds and `PowerForge.Build 1.0.3` installs from the generated package.

## Rollout

After merge, publish PowerForge 1.0.3, update the reusable workflow's nested action SHA to the immutable 1.0.3 release commit, then repin and recover the two pilot repositories.