### PR TITLE
Pin Home Assistant release action to PowerForge 1.0.3

### DIFF
--- a/.github/workflows/powerforge-homeassistant-release.yml
+++ b/.github/workflows/powerforge-homeassistant-release.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Prepare immutable release commit
         id: prepare
-        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@8976b47713d00778aa798f4d4e292eaeb89b5b81
+        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@068a5d464b82b5d50ef3a1f44e8dc8f3bdfc4b8f
         with:
           stage: prepare
           repository-root: ${{ github.workspace }}/source
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build without GitHub write credentials
         id: build
-        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@8976b47713d00778aa798f4d4e292eaeb89b5b81
+        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@068a5d464b82b5d50ef3a1f44e8dc8f3bdfc4b8f
         with:
           stage: build
           repository-root: ${{ github.workspace }}/source
@@ -133,7 +133,7 @@ jobs:
 
       - name: Publish and verify without receiver source code
         id: publish
-        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@8976b47713d00778aa798f4d4e292eaeb89b5b81
+        uses: EvotecIT/PSPublishModule/.github/actions/homeassistant-release@068a5d464b82b5d50ef3a1f44e8dc8f3bdfc4b8f
         with:
           stage: publish
           repository: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- pin all three Home Assistant reusable-workflow stages to the immutable PowerForge 1.0.3 release commit
- keep the nested action source aligned with the explicit 1.0.3 tool version
- preserve the receiver contract as a single thin reusable-workflow call

## Validation

- HomeAssistantReleaseWorkflowTests: 2/2 passed
- fresh exact-head local review: no actionable findings
- all six PowerForge 1.0.3 packages are public on NuGet.org
- PowerForge.Build 1.0.3 installs from a NuGet.org-only configuration and exposes the Home Assistant release command

## Rollout

After merge, the two pilot repositories will be repinned to this workflow revision and their original release runs recovered.