### PR TITLE
Fix Home Assistant manual release dispatch

### DIFF
--- a/.agents/skills/powerforge-homeassistant-release/SKILL.md
+++ b/.agents/skills/powerforge-homeassistant-release/SKILL.md
@@ -14,7 +14,7 @@ Use PowerForge as the release owner. A receiver repository should contain only t
    - Lovelace plugin: `package.json`, required `package-lock.json`, and `hacs.json` `filename`.
 2. Inspect the existing validation workflow and latest GitHub release. The PR head must have at least one completed successful, neutral, or skipped check run.
 3. Add only the `pull_request_target` receiver workflow documented in `Docs/PowerForge.HomeAssistantRelease.md`. Pin the reusable workflow to the full immutable SHA of a reviewed PSPublishModule release; a release tag may appear only as a maintenance comment. Keep the trigger on `closed`: the trusted default-branch workflow must handle fork and Dependabot merges without checking out or executing pull-request code with its write token.
-4. Give the job `actions: read`, `checks: read`, `contents: write`, and `pull-requests: read`. Pass the merged PR number, merge SHA, default branch, and `github.token`.
+4. Give the job `actions: read`, `checks: read`, `contents: write`, and `pull-requests: read`. Keep the workflow-dispatch PR number input textual and use the canonical `format` expression when passing either event source into the reusable workflow. Pass the merge SHA, default branch, and `github.token` unchanged.
 5. Add the `release:none`, `release:patch`, `release:minor`, and `release:major` labels if the repository does not have them.
 6. Validate the receiver YAML and open a release-ready PR. Use a release label only when that onboarding PR should intentionally prove a live release.
 
@@ -35,7 +35,7 @@ Rerun the failed Actions job first. PowerForge resumes safely:
 - missing historical assets are rebuilt from a fresh read-only checkout of the exact tag commit;
 - a tag pointing at the wrong commit or a missing required asset fails verification.
 
-For a manual recovery, dispatch the receiver workflow with the original merged PR number, its merge SHA, and the same increment decision. Do not hand-edit a second version bump or manually create a competing release.
+For a manual recovery, dispatch the receiver workflow with the original merged PR number, its merge SHA, and the same increment decision. The receiver's textual PR-number contract must match the canonical example; a numeric workflow-dispatch input is not compatible with the reusable-call graph. Do not hand-edit a second version bump or manually create a competing release.
 
 ## Keep the boundary thin
 

--- a/.github/workflows/powerforge-homeassistant-release.yml
+++ b/.github/workflows/powerforge-homeassistant-release.yml
@@ -6,7 +6,7 @@ on:
       pr_number:
         description: Merged pull request number that initiated the release.
         required: true
-        type: number
+        type: string
       merge_commit_sha:
         description: Expected pull request merge commit SHA.
         required: false

--- a/Docs/PowerForge.HomeAssistantRelease.md
+++ b/Docs/PowerForge.HomeAssistantRelease.md
@@ -58,7 +58,7 @@ on:
       pr_number:
         description: Merged pull request number to release or recover
         required: true
-        type: number
+        type: string
       merge_commit_sha:
         description: Expected merge commit SHA
         required: false
@@ -79,13 +79,15 @@ jobs:
       pull-requests: read
     uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@POWERFORGE_COMMIT_SHA # PowerForge-vX.Y.Z
     with:
-      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      pr_number: ${{ format('{0}', github.event.pull_request.number || inputs.pr_number) }}
       merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}
       default_branch: ${{ github.event.repository.default_branch }}
       increment: ${{ inputs.increment || 'auto' }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+Keep the pull request number textual at the workflow boundary. Manual-dispatch inputs are strings, and `format` also converts the numeric pull-request event value to the reusable workflow's single stable input type.
 
 The reusable workflow serializes and queues releases per repository and invokes the matching action at the immutable release commit. The action installs an exact `PowerForge.Build` package version, so the workflow, action, and engine do not drift between retries.
 

--- a/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
@@ -36,6 +36,7 @@ public sealed class HomeAssistantReleaseWorkflowTests {
         var skill = File.ReadAllText(Path.Combine(root, ".agents", "skills", "powerforge-homeassistant-release", "SKILL.md"));
 
         Assert.Contains("pr_number:\n        description: Merged pull request number that initiated the release.\n        required: true\n        type: string", workflow.Replace("\r\n", "\n", StringComparison.Ordinal), StringComparison.Ordinal);
+        Assert.Contains("pr_number:\n        description: Merged pull request number to release or recover\n        required: true\n        type: string", documentation.Replace("\r\n", "\n", StringComparison.Ordinal), StringComparison.Ordinal);
         Assert.Contains("pr_number: ${{ format('{0}', github.event.pull_request.number || inputs.pr_number) }}", documentation, StringComparison.Ordinal);
         Assert.Contains("textual PR-number contract", skill, StringComparison.Ordinal);
     }

--- a/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
@@ -28,6 +28,18 @@ public sealed class HomeAssistantReleaseWorkflowTests {
         Assert.Contains("default: \"1.0.3\"", action, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void WorkflowAndReceiverTreatPullRequestNumbersAsTextualIdentifiers() {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "powerforge-homeassistant-release.yml"));
+        var documentation = File.ReadAllText(Path.Combine(root, "Docs", "PowerForge.HomeAssistantRelease.md"));
+        var skill = File.ReadAllText(Path.Combine(root, ".agents", "skills", "powerforge-homeassistant-release", "SKILL.md"));
+
+        Assert.Contains("pr_number:\n        description: Merged pull request number that initiated the release.\n        required: true\n        type: string", workflow.Replace("\r\n", "\n", StringComparison.Ordinal), StringComparison.Ordinal);
+        Assert.Contains("pr_number: ${{ format('{0}', github.event.pull_request.number || inputs.pr_number) }}", documentation, StringComparison.Ordinal);
+        Assert.Contains("textual PR-number contract", skill, StringComparison.Ordinal);
+    }
+
     private static int CountOccurrences(string value, string search) {
         var count = 0;
         var index = 0;


### PR DESCRIPTION
## Summary

- treat pull request numbers as textual identifiers at the reusable-workflow boundary
- format both merged-PR and manual-dispatch values into the same stable caller type
- update the canonical receiver documentation and maintained onboarding/recovery skill
- add contract coverage for the shared workflow and receiver example

## Why

Automatic pull_request_target releases worked, but workflow_dispatch recovery runs were rejected by GitHub before job creation because the dispatch input and reusable-call input resolved to incompatible types. Keeping the boundary textual matches GitHub's dispatch model and the composite action's existing string contract.

## Validation

- HomeAssistantReleaseWorkflowTests: 3/3 passed
- both pilot receiver workflows parse cleanly with actionlint after adopting the canonical expression
- no PowerForge package or runtime code changes; no package release is required

## Rollout

After merge, repin the two pilot receivers to this immutable workflow revision, merge them with release:none, and rerun recovery for their original release PRs.