### PR TITLE
Preserve receiver JSON text in Home Assistant releases

### DIFF
--- a/.github/actions/homeassistant-release/action.yml
+++ b/.github/actions/homeassistant-release/action.yml
@@ -52,7 +52,7 @@ inputs:
   powerforge-version:
     description: Exact PowerForge.Build tool version used by the action.
     required: false
-    default: "1.0.3"
+    default: "1.0.4"
 
 outputs:
   action:

--- a/.github/workflows/powerforge-homeassistant-release.yml
+++ b/.github/workflows/powerforge-homeassistant-release.yml
@@ -67,7 +67,7 @@ jobs:
           default-branch: ${{ inputs.default_branch }}
           increment: ${{ inputs.increment }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
-          powerforge-version: 1.0.3
+          powerforge-version: 1.0.4
 
   build:
     needs: prepare
@@ -101,7 +101,7 @@ jobs:
           repository-root: ${{ github.workspace }}/source
           release-version: ${{ needs.prepare.outputs.version }}
           release-commit: ${{ needs.prepare.outputs.release-commit }}
-          powerforge-version: 1.0.3
+          powerforge-version: 1.0.4
 
       - name: Transfer the single release asset to the publish job
         if: steps.build.outputs.required-asset != ''
@@ -144,4 +144,4 @@ jobs:
           required-asset: ${{ needs.build.outputs.required-asset }}
           asset-path: ${{ needs.build.outputs.required-asset != '' && format('{0}/powerforge-homeassistant-release-asset/{1}', runner.temp, needs.build.outputs.required-asset) || '' }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
-          powerforge-version: 1.0.3
+          powerforge-version: 1.0.4

--- a/PowerForge.Blazor/PowerForge.Blazor.csproj
+++ b/PowerForge.Blazor/PowerForge.Blazor.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
 
     <!-- Package metadata -->
     <PackageId>PowerForge.Blazor</PackageId>

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge</ToolCommandName>
     <Description>PowerForge command-line interface for building and publishing PowerShell modules.</Description>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.PowerShell/PowerForge.PowerShell.csproj
+++ b/PowerForge.PowerShell/PowerForge.PowerShell.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <PackageId>PowerForge.PowerShell</PackageId>
     <Description>PowerForge PowerShell-hosted module pipeline services.</Description>
     <AssemblyName>PowerForge.PowerShell</AssemblyName>

--- a/PowerForge.Tests/HomeAssistantReleaseTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseTests.cs
@@ -1,5 +1,6 @@
 using PowerForge;
 using System.IO.Compression;
+using System.Text;
 using System.Text.Json.Nodes;
 
 namespace PowerForge.Tests;
@@ -75,6 +76,23 @@ public sealed class HomeAssistantReleaseTests {
     }
 
     [Fact]
+    public void RepositoryService_PreservesIntegrationManifestFormatting() {
+        using var fixture = HomeAssistantFixture.CreateIntegration("0.2.6");
+        var path = Path.Combine(fixture.Root, "custom_components", "example", "manifest.json");
+        const string before = "{\r\n  \"domain\": \"example\",\r\n  \"codeowners\": [\"@EvotecIT\", \"@Example\"],\r\n  \"version\": \"0.2.6\"\r\n}\r\n";
+        File.WriteAllText(path, before, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+        var service = new HomeAssistantRepositoryService();
+
+        service.UpdateVersion(service.Inspect(fixture.Root), fixture.Root, "0.2.10");
+
+        var bytes = File.ReadAllBytes(path);
+        Assert.Equal(0xEF, bytes[0]);
+        Assert.Equal(0xBB, bytes[1]);
+        Assert.Equal(0xBF, bytes[2]);
+        Assert.Equal(before.Replace("\"0.2.6\"", "\"0.2.10\"", StringComparison.Ordinal), Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3));
+    }
+
+    [Fact]
     public void RepositoryService_SynchronizesPluginPackageAndLockMetadata() {
         using var fixture = HomeAssistantFixture.CreatePlugin("0.1.10");
         var service = new HomeAssistantRepositoryService();
@@ -88,6 +106,23 @@ public sealed class HomeAssistantReleaseTests {
         var packageLock = JsonNode.Parse(File.ReadAllText(Path.Combine(fixture.Root, "package-lock.json")))!.AsObject();
         Assert.Equal("0.1.11", packageLock["version"]!.GetValue<string>());
         Assert.Equal("0.1.11", packageLock["packages"]![""]!["version"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void RepositoryService_PreservesUnrelatedPluginJsonText() {
+        using var fixture = HomeAssistantFixture.CreatePlugin("0.9.9");
+        var packagePath = Path.Combine(fixture.Root, "package.json");
+        var lockPath = Path.Combine(fixture.Root, "package-lock.json");
+        const string packageBefore = "{\n  \"name\": \"example\",\n  \"version\": \"0.9.9\",\n  \"scripts\": { \"pack\": \"npm run build && node pack.mjs\" },\n  \"repository\": \"git+https://example.test/repo.git\"\n}\n";
+        const string lockBefore = "{\n  \"name\": \"example\",\n  \"version\": \"0.9.9\",\n  \"lockfileVersion\": 3,\n  \"packages\": {\n    \"\": { \"name\": \"example\", \"version\": \"0.9.9\" },\n    \"node_modules/tool\": { \"version\": \"1.0.0\", \"integrity\": \"sha512-a+b/c==\", \"engines\": { \"node\": \">=18\" } }\n  }\n}\n";
+        File.WriteAllText(packagePath, packageBefore);
+        File.WriteAllText(lockPath, lockBefore);
+        var service = new HomeAssistantRepositoryService();
+
+        service.UpdateVersion(service.Inspect(fixture.Root), fixture.Root, "0.10.0");
+
+        Assert.Equal(packageBefore.Replace("\"0.9.9\"", "\"0.10.0\"", StringComparison.Ordinal), File.ReadAllText(packagePath));
+        Assert.Equal(lockBefore.Replace("\"0.9.9\"", "\"0.10.0\"", StringComparison.Ordinal), File.ReadAllText(lockPath));
     }
 
     [Fact]

--- a/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
@@ -22,10 +22,10 @@ public sealed class HomeAssistantReleaseWorkflowTests {
         var action = File.ReadAllText(Path.Combine(root, ".github", "actions", "homeassistant-release", "action.yml"));
         var skill = File.ReadAllText(Path.Combine(root, ".agents", "skills", "powerforge-homeassistant-release", "SKILL.md"));
 
-        Assert.Equal(3, CountOccurrences(workflow, "powerforge-version: 1.0.3"));
+        Assert.Equal(3, CountOccurrences(workflow, "powerforge-version: 1.0.4"));
         Assert.Contains("actions: read", workflow, StringComparison.Ordinal);
         Assert.Contains("`actions: read`", skill, StringComparison.Ordinal);
-        Assert.Contains("default: \"1.0.3\"", action, StringComparison.Ordinal);
+        Assert.Contains("default: \"1.0.4\"", action, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
+++ b/PowerForge.Web.Cli/PowerForge.Web.Cli.csproj
@@ -11,7 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>powerforge-web</ToolCommandName>
     <Description>PowerForge.Web command-line interface for building and serving static sites.</Description>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Przemyslaw Klys</Authors>
     <Company>Evotec Services sp. z o.o.</Company>

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <PackageId>PowerForge.Web</PackageId>
     <RootNamespace>PowerForge.Web</RootNamespace>
     <Description>PowerForge.Web static-site engine and reusable website build components.</Description>

--- a/PowerForge/PowerForge.csproj
+++ b/PowerForge/PowerForge.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>CS1591</WarningsAsErrors>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <PackageId>PowerForge</PackageId>
     <Description>PowerForge core library: reusable engine for building, formatting, packaging and publishing PowerShell modules.</Description>
     <AssemblyName>PowerForge</AssemblyName>

--- a/PowerForge/Services/HomeAssistantRepositoryService.cs
+++ b/PowerForge/Services/HomeAssistantRepositoryService.cs
@@ -10,7 +10,6 @@ using System.Text.RegularExpressions;
 namespace PowerForge;
 
 internal sealed class HomeAssistantRepositoryService {
-    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
     private readonly IProcessRunner _processRunner;
 
@@ -223,19 +222,15 @@ internal sealed class HomeAssistantRepositoryService {
     }
 
     private static void UpdateJsonVersion(string path, string version) {
-        var value = ReadJsonObject(path);
-        value["version"] = version;
-        WriteJson(path, value);
+        UpdateJsonStringValues(path, version, new[] { "version" });
     }
 
     private static void UpdatePackageLockVersion(string path, string version) {
-        var value = ReadJsonObject(path);
-        value["version"] = version;
-        if (value["packages"] is JsonObject packages && packages[""] is JsonObject rootPackage)
-            rootPackage["version"] = version;
-        else
-            throw new InvalidOperationException($"'{path}' does not contain packages[''] metadata.");
-        WriteJson(path, value);
+        UpdateJsonStringValues(
+            path,
+            version,
+            new[] { "version" },
+            new[] { "packages", string.Empty, "version" });
     }
 
     private static void ValidatePackageLockVersion(string path, string expectedVersion) {
@@ -251,8 +246,95 @@ internal sealed class HomeAssistantRepositoryService {
         }
     }
 
-    private static void WriteJson(string path, JsonObject value)
-        => File.WriteAllText(path, value.ToJsonString(JsonOptions) + Environment.NewLine, Utf8NoBom);
+    private static void UpdateJsonStringValues(string path, string value, params string[][] targetPaths) {
+        var bytes = File.ReadAllBytes(path);
+        var bomLength = bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF ? 3 : 0;
+        var reader = new Utf8JsonReader(new ReadOnlySpan<byte>(bytes, bomLength, bytes.Length - bomLength));
+        var containerPath = new List<string>();
+        var containerSegments = new Stack<bool>();
+        var replacements = new List<(int Start, int End)>();
+        var updatedPaths = new bool[targetPaths.Length];
+        string? pendingProperty = null;
+
+        while (reader.Read()) {
+            switch (reader.TokenType) {
+                case JsonTokenType.PropertyName:
+                    pendingProperty = reader.GetString()
+                                      ?? throw new InvalidOperationException($"'{path}' contains a null JSON property name.");
+                    break;
+                case JsonTokenType.StartObject:
+                case JsonTokenType.StartArray:
+                    var pushedSegment = pendingProperty is not null;
+                    if (pushedSegment) containerPath.Add(pendingProperty!);
+                    containerSegments.Push(pushedSegment);
+                    pendingProperty = null;
+                    break;
+                case JsonTokenType.EndObject:
+                case JsonTokenType.EndArray:
+                    if (containerSegments.Count == 0)
+                        throw new InvalidOperationException($"'{path}' contains unbalanced JSON containers.");
+                    if (containerSegments.Pop()) containerPath.RemoveAt(containerPath.Count - 1);
+                    pendingProperty = null;
+                    break;
+                case JsonTokenType.String:
+                    if (pendingProperty is not null) {
+                        var targetIndex = FindTargetPath(containerPath, pendingProperty, targetPaths);
+                        if (targetIndex >= 0) {
+                            if (updatedPaths[targetIndex])
+                                throw new InvalidOperationException($"'{path}' contains duplicate JSON metadata at '{string.Join("/", targetPaths[targetIndex])}'.");
+                            updatedPaths[targetIndex] = true;
+                            replacements.Add((
+                                checked(bomLength + (int)reader.TokenStartIndex),
+                                checked(bomLength + (int)reader.BytesConsumed)));
+                        }
+                    }
+                    pendingProperty = null;
+                    break;
+                case JsonTokenType.Number:
+                case JsonTokenType.True:
+                case JsonTokenType.False:
+                case JsonTokenType.Null:
+                    pendingProperty = null;
+                    break;
+            }
+        }
+
+        for (var i = 0; i < updatedPaths.Length; i++) {
+            if (!updatedPaths[i])
+                throw new InvalidOperationException($"'{path}' does not contain string JSON metadata at '{string.Join("/", targetPaths[i])}'.");
+        }
+
+        var replacement = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value));
+        using var output = new MemoryStream(bytes.Length + replacements.Count * replacement.Length);
+        var cursor = 0;
+        foreach (var range in replacements) {
+            output.Write(bytes, cursor, range.Start - cursor);
+            output.Write(replacement, 0, replacement.Length);
+            cursor = range.End;
+        }
+        output.Write(bytes, cursor, bytes.Length - cursor);
+        File.WriteAllBytes(path, output.ToArray());
+    }
+
+    private static int FindTargetPath(IReadOnlyList<string> containerPath, string propertyName, IReadOnlyList<string[]> targetPaths) {
+        for (var targetIndex = 0; targetIndex < targetPaths.Count; targetIndex++) {
+            var targetPath = targetPaths[targetIndex];
+            if (targetPath.Length != containerPath.Count + 1 ||
+                !string.Equals(targetPath[targetPath.Length - 1], propertyName, StringComparison.Ordinal)) {
+                continue;
+            }
+
+            var matches = true;
+            for (var segmentIndex = 0; segmentIndex < containerPath.Count; segmentIndex++) {
+                if (string.Equals(targetPath[segmentIndex], containerPath[segmentIndex], StringComparison.Ordinal)) continue;
+                matches = false;
+                break;
+            }
+            if (matches) return targetIndex;
+        }
+
+        return -1;
+    }
 
     private static string ReadPyProjectVersion(string path) {
         var text = File.ReadAllText(path);


### PR DESCRIPTION
## What changed

- replace only the selected JSON version string tokens instead of serializing whole receiver files
- preserve UTF-8 BOMs, whitespace, line endings, property layout, integrity strings, script operators, and unrelated package-lock metadata
- cover integration metadata plus both plugin package-lock version paths, including variable-length replacements
- advance all six PowerForge packages and the Home Assistant action/workflow tool pins to 1.0.4

## Why

The first live receiver releases were correct, but their version commits also normalized unrelated JSON text such as `&&`, `+`, `>=`, arrays, and indentation. Keeping that noise out of receiver history makes the shared automation genuinely thin and reduces future review/token cost.

## Rollout

After merge, publish and verify PowerForge 1.0.4, then pin both receivers to this immutable reusable-workflow revision. The already-published receiver releases remain valid.