### PR TITLE
Add credential-free server recovery PR validation

### DIFF
--- a/.github/actions/powerforge-server-recovery-validate/Invoke-PowerForgeServerRecoveryValidation.ps1
+++ b/.github/actions/powerforge-server-recovery-validate/Invoke-PowerForgeServerRecoveryValidation.ps1
@@ -16,6 +16,24 @@ function Assert-ProcessSucceeded {
     }
 }
 
+function Assert-PathHasNoSymbolicLink {
+    param(
+        [Parameter(Mandatory)][string] $Root,
+        [Parameter(Mandatory)][string] $Path
+    )
+
+    $relativePath = [IO.Path]::GetRelativePath($Root, $Path)
+    $currentPath = $Root
+    foreach ($segment in $relativePath.Split([IO.Path]::DirectorySeparatorChar, [StringSplitOptions]::RemoveEmptyEntries)) {
+        $currentPath = Join-Path $currentPath $segment
+        $item = Get-Item -LiteralPath $currentPath -Force
+        if ($item.LinkType -eq 'SymbolicLink' -or
+            ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw 'manifest-path and its parent directories must not be symbolic links.'
+        }
+    }
+}
+
 function Invoke-ProcessCapture {
     param(
         [Parameter(Mandatory)][string] $FileName,
@@ -107,10 +125,7 @@ if (-not $manifestPath.StartsWith($workspacePrefix, [StringComparison]::Ordinal)
     -not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
     throw 'manifest-path must identify a file inside the caller repository.'
 }
-$manifestItem = Get-Item -LiteralPath $manifestPath -Force
-if ($manifestItem.LinkType -eq 'SymbolicLink') {
-    throw 'manifest-path must not be a symbolic link.'
-}
+Assert-PathHasNoSymbolicLink -Root $workspace -Path $manifestPath
 
 $engineRoot = [IO.Path]::GetFullPath((Join-Path $env:GITHUB_ACTION_PATH '../../..'))
 $runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP).TrimEnd([IO.Path]::DirectorySeparatorChar)

--- a/.github/actions/powerforge-server-recovery-validate/Invoke-PowerForgeServerRecoveryValidation.ps1
+++ b/.github/actions/powerforge-server-recovery-validate/Invoke-PowerForgeServerRecoveryValidation.ps1
@@ -1,0 +1,226 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'GitHub Actions workflow commands require host output.')]
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Assert-ProcessSucceeded {
+    param(
+        [Parameter(Mandatory)][pscustomobject] $Result,
+        [Parameter(Mandatory)][string] $Operation
+    )
+
+    if ($Result.ExitCode -ne 0) {
+        throw "$Operation failed with exit code $($Result.ExitCode). Run the pinned PowerForge CLI locally for detailed diagnostics."
+    }
+}
+
+function Invoke-ProcessCapture {
+    param(
+        [Parameter(Mandatory)][string] $FileName,
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new($FileName)
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $Arguments) {
+        [void] $startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        [void] $process.Start()
+        $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        [pscustomobject]@{
+            ExitCode = $process.ExitCode
+            Stdout   = $stdoutTask.GetAwaiter().GetResult()
+            Stderr   = $stderrTask.GetAwaiter().GetResult()
+        }
+    } finally {
+        $process.Dispose()
+    }
+}
+
+function Invoke-PowerForgeJson {
+    param(
+        [Parameter(Mandatory)][string] $CliPath,
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [Parameter(Mandatory)][string] $Operation
+    )
+
+    $result = Invoke-ProcessCapture -FileName 'dotnet' -Arguments (@($CliPath) + $Arguments)
+    Assert-ProcessSucceeded -Result $result -Operation $Operation
+    try {
+        $envelope = $result.Stdout | ConvertFrom-Json -Depth 100
+    } catch {
+        throw "$Operation did not return a valid PowerForge JSON envelope."
+    }
+    if (-not $envelope.success) {
+        throw "$Operation reported failure. Run the pinned PowerForge CLI locally for detailed diagnostics."
+    }
+    $envelope
+}
+
+function Write-ActionOutput {
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Value
+    )
+
+    "$Name=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}
+
+function Write-ActionWarning {
+    param([Parameter(Mandatory)][string] $Message)
+
+    $escaped = $Message.Replace('%', '%25').Replace("`r", '%0D').Replace("`n", '%0A')
+    Write-Host "::warning::$escaped"
+}
+
+if ($env:RUNNER_OS -ne 'Linux') {
+    throw 'PowerForge server recovery validation requires a Linux runner so generated scripts can be checked with Bash and ShellCheck.'
+}
+if ($env:POWERFORGE_FAIL_ON_WARNINGS -notin @('true', 'false')) {
+    throw 'fail-on-warnings must be true or false.'
+}
+if ($env:POWERFORGE_ENGINE_REF -notmatch '^[a-fA-F0-9]{40}$') {
+    throw 'The PowerForge recovery validation action must be pinned to an exact 40-character commit.'
+}
+if ($env:POWERFORGE_ENGINE_REPOSITORY -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+    throw 'The action repository must resolve to an owner/repository name.'
+}
+
+$workspace = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE).TrimEnd([IO.Path]::DirectorySeparatorChar)
+$workspacePrefix = $workspace + [IO.Path]::DirectorySeparatorChar
+if ([IO.Path]::IsPathRooted($env:POWERFORGE_MANIFEST_PATH)) {
+    throw 'manifest-path must be repository-relative.'
+}
+$manifestPath = [IO.Path]::GetFullPath((Join-Path $workspace $env:POWERFORGE_MANIFEST_PATH))
+if (-not $manifestPath.StartsWith($workspacePrefix, [StringComparison]::Ordinal) -or
+    -not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw 'manifest-path must identify a file inside the caller repository.'
+}
+$manifestItem = Get-Item -LiteralPath $manifestPath -Force
+if ($manifestItem.LinkType -eq 'SymbolicLink') {
+    throw 'manifest-path must not be a symbolic link.'
+}
+
+$engineRoot = [IO.Path]::GetFullPath((Join-Path $env:GITHUB_ACTION_PATH '../../..'))
+$runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP).TrimEnd([IO.Path]::DirectorySeparatorChar)
+$runnerTempPrefix = $runnerTemp + [IO.Path]::DirectorySeparatorChar
+$validationRoot = [IO.Path]::GetFullPath((Join-Path $runnerTemp ('powerforge-server-recovery-validate-' + [Guid]::NewGuid().ToString('N'))))
+if (-not $validationRoot.StartsWith($runnerTempPrefix, [StringComparison]::Ordinal)) {
+    throw 'Validation output escaped the runner temporary directory.'
+}
+
+try {
+    New-Item -ItemType Directory -Path $validationRoot | Out-Null
+    $artifactsRoot = Join-Path $validationRoot 'artifacts'
+    $bootstrapRoot = Join-Path $validationRoot 'bootstrap'
+    $restoreRoot = Join-Path $validationRoot 'restore-secrets'
+
+    $project = Join-Path $engineRoot 'PowerForge.Web.Cli/PowerForge.Web.Cli.csproj'
+    $build = Invoke-ProcessCapture -FileName 'dotnet' -Arguments @(
+        'build', $project, '-c', 'Release', '-f', 'net10.0', '--nologo', '--artifacts-path', $artifactsRoot
+    )
+    Assert-ProcessSucceeded -Result $build -Operation 'Building the pinned PowerForge recovery CLI'
+    $cli = Join-Path $artifactsRoot 'bin/PowerForge.Web.Cli/release/PowerForge.Web.Cli.dll'
+    if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) {
+        throw "PowerForge recovery CLI was not produced: $cli"
+    }
+
+    $manifestJson = Get-Content -LiteralPath $manifestPath -Raw
+    $schemaPath = Join-Path $engineRoot 'Schemas/powerforge.web.serverrecovery.schema.json'
+    try {
+        $schemaValid = $manifestJson | Test-Json -SchemaFile $schemaPath -ErrorAction Stop
+    } catch {
+        throw 'The recovery manifest does not satisfy the pinned PowerForge server recovery schema.'
+    }
+    if (-not $schemaValid) {
+        throw 'The recovery manifest does not satisfy the pinned PowerForge server recovery schema.'
+    }
+    $manifest = $manifestJson | ConvertFrom-Json -Depth 100
+    $expectedSchemaUrl = "https://raw.githubusercontent.com/$($env:POWERFORGE_ENGINE_REPOSITORY)/$($env:POWERFORGE_ENGINE_REF)/Schemas/powerforge.web.serverrecovery.schema.json"
+    if (-not [string]::Equals([string]$manifest.'$schema', $expectedSchemaUrl, [StringComparison]::Ordinal)) {
+        throw 'The recovery manifest schema URL must match the exact repository and commit pinned by this action.'
+    }
+    $bootstrap = Invoke-PowerForgeJson -CliPath $cli -Operation 'Generating the bootstrap plan' -Arguments @(
+        'server', 'bootstrap-plan', '--manifest', $manifestPath, '--out', $bootstrapRoot, '--output', 'json'
+    )
+    $bootstrapScript = Join-Path $bootstrapRoot 'bootstrap-plan.sh'
+    $bashResult = Invoke-ProcessCapture -FileName 'bash' -Arguments @('-n', '--', $bootstrapScript)
+    Assert-ProcessSucceeded -Result $bashResult -Operation 'Parsing the generated bootstrap script with Bash'
+    $shellCheckResult = Invoke-ProcessCapture -FileName 'shellcheck' -Arguments @('-S', 'warning', '--', $bootstrapScript)
+    Assert-ProcessSucceeded -Result $shellCheckResult -Operation 'Checking the generated bootstrap script with ShellCheck'
+
+    $warnings = [Collections.Generic.List[string]]::new()
+    foreach ($warning in @($bootstrap.result.warnings)) {
+        if (-not [string]::IsNullOrWhiteSpace([string]$warning)) {
+            $warnings.Add([string]$warning)
+        }
+    }
+
+    $secretCount = @($manifest.secrets).Count
+    $encryptedCaptureCount = @($manifest.capture.encryptedFiles).Count
+    if ($secretCount -gt 0 -or $encryptedCaptureCount -gt 0) {
+        $restore = Invoke-PowerForgeJson -CliPath $cli -Operation 'Generating the secret-restore plan' -Arguments @(
+            'server', 'restore-secrets-plan', '--manifest', $manifestPath, '--out', $restoreRoot,
+            '--archive', 'encrypted-secrets.tar.gz.age', '--output', 'json'
+        )
+        $restoreScript = Join-Path $restoreRoot 'restore-secrets.sh'
+        $bashResult = Invoke-ProcessCapture -FileName 'bash' -Arguments @('-n', '--', $restoreScript)
+        Assert-ProcessSucceeded -Result $bashResult -Operation 'Parsing the generated secret-restore script with Bash'
+        $shellCheckResult = Invoke-ProcessCapture -FileName 'shellcheck' -Arguments @('-S', 'warning', '--', $restoreScript)
+        Assert-ProcessSucceeded -Result $shellCheckResult -Operation 'Checking the generated secret-restore script with ShellCheck'
+        foreach ($warning in @($restore.result.warnings)) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$warning)) {
+                $warnings.Add([string]$warning)
+            }
+        }
+    }
+
+    foreach ($warning in $warnings) {
+        Write-ActionWarning -Message $warning
+    }
+    if ($warnings.Count -gt 0 -and $env:POWERFORGE_FAIL_ON_WARNINGS -eq 'true') {
+        throw "Recovery plan generation emitted $($warnings.Count) warning(s)."
+    }
+
+    $bootstrapStepCount = @($bootstrap.result.steps).Count
+    $managedSourceCount = @(
+        @($manifest.paths)
+        @($manifest.apache.sites)
+        @($manifest.apache.conf)
+        @($manifest.systemd.services)
+        @($manifest.systemd.timers)
+    ).Where({ -not [string]::IsNullOrWhiteSpace([string]$_.source) }).Count
+    Write-ActionOutput -Name 'bootstrap-step-count' -Value ([string]$bootstrapStepCount)
+    Write-ActionOutput -Name 'managed-source-count' -Value ([string]$managedSourceCount)
+    Write-ActionOutput -Name 'secret-count' -Value ([string]$secretCount)
+    Write-ActionOutput -Name 'warning-count' -Value ([string]$warnings.Count)
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        @"
+## PowerForge server recovery validation
+
+- Bootstrap steps: $bootstrapStepCount
+- Managed repository sources: $managedSourceCount
+- Declared secrets: $secretCount
+- Generation warnings: $($warnings.Count)
+
+Generated shell plans were parsed by Bash and checked by ShellCheck. No generated command was executed.
+"@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+    }
+} finally {
+    if ($validationRoot.StartsWith($runnerTempPrefix, [StringComparison]::Ordinal) -and
+        (Test-Path -LiteralPath $validationRoot)) {
+        Remove-Item -LiteralPath $validationRoot -Recurse -Force
+    }
+}

--- a/.github/actions/powerforge-server-recovery-validate/action.yml
+++ b/.github/actions/powerforge-server-recovery-validate/action.yml
@@ -1,0 +1,49 @@
+name: PowerForge Server Recovery Validate
+description: Validate a server recovery manifest and its generated shell plans without credentials or host access.
+
+inputs:
+  manifest-path:
+    description: Repository-relative PowerForge server recovery manifest.
+    required: true
+  fail-on-warnings:
+    description: Fail when bootstrap or secret-restore plan generation emits warnings.
+    required: false
+    default: 'true'
+
+outputs:
+  bootstrap-step-count:
+    description: Number of generated bootstrap plan steps.
+    value: ${{ steps.validate.outputs.bootstrap-step-count }}
+  managed-source-count:
+    description: Number of repository-backed managed file declarations.
+    value: ${{ steps.validate.outputs.managed-source-count }}
+  secret-count:
+    description: Number of declared recovery secrets.
+    value: ${{ steps.validate.outputs.secret-count }}
+  warning-count:
+    description: Number of bootstrap and secret-restore generation warnings.
+    value: ${{ steps.validate.outputs.warning-count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout caller repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        token: ${{ github.token }}
+        ref: ${{ github.sha }}
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+      with:
+        global-json-file: ${{ github.action_path }}/../../../global.json
+
+    - name: Validate recovery manifest and generated plans
+      id: validate
+      shell: pwsh
+      env:
+        POWERFORGE_ENGINE_REF: ${{ github.action_ref }}
+        POWERFORGE_ENGINE_REPOSITORY: ${{ github.action_repository }}
+        POWERFORGE_FAIL_ON_WARNINGS: ${{ inputs.fail-on-warnings }}
+        POWERFORGE_MANIFEST_PATH: ${{ inputs.manifest-path }}
+      run: '& "$env:GITHUB_ACTION_PATH/Invoke-PowerForgeServerRecoveryValidation.ps1"'

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -81,6 +81,25 @@ The generated runtime commands follow the supported package-manager paths docume
 
 `server restore-secrets-plan` generates a markdown plan, JSON plan, and LF-normalized `restore-secrets.sh` draft for an encrypted secret bundle. The script requires `age` and `python3`, decrypts into a mode-700 temporary directory, validates every archive member against exact encrypted capture roots, rejects traversal, duplicate paths, hard links, unsafe symlinks, special files, and extraction through existing symlink parents, then refuses to restore unless it runs as root with `POWERFORGE_RESTORE_SECRETS_CONFIRM=YES`. Declared owner, group, and mode values replace filename-based permission guesses. For a directory secret, owner and group apply to its restored archive members through descriptor-relative no-follow traversal; the declared mode applies with `fchmod` to restored directories and derives a non-executable regular-file mode from the same read/write bits (for example, `0750` directories and `0640` files). Symbolic links and unrelated pre-existing descendants are not modified, numeric UID/GID declarations remain supported, and overlapping secret roots are applied from parent to child so the most-specific metadata wins.
 
+## Pull Request Validation
+
+Use the credential-free recovery validation action in pull requests. It validates the manifest against the schema from the exact action commit, requires the manifest schema URL and action pin to match, generates bootstrap and secret-restore plans in runner-temporary storage, parses the generated scripts with Bash, and checks them with ShellCheck. It does not execute generated commands, contact the target host, capture state, restore secrets, deploy, or accept credential inputs.
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  recovery-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-recovery-validate@<exact-commit>
+        with:
+          manifest-path: deploy/linux/example.serverrecovery.json
+```
+
+Keep `fail-on-warnings` at its default `true` for migration and maintenance pull requests. The protected backup action remains a separate environment-gated workflow because it needs SSH and backup-repository identities; PR validation must not receive those credentials.
+
 Proposed PowerShell shape:
 
 ```powershell

--- a/PowerForge.Tests/GitHubServerRecoveryValidationActionTests.cs
+++ b/PowerForge.Tests/GitHubServerRecoveryValidationActionTests.cs
@@ -1,0 +1,86 @@
+namespace PowerForge.Tests;
+
+public sealed class GitHubServerRecoveryValidationActionTests
+{
+    [Fact]
+    public void Action_ShouldBeCredentialFreeAndUsePinnedDependencies()
+    {
+        var action = ReadRepoFile(".github", "actions", "powerforge-server-recovery-validate", "action.yml");
+
+        Assert.Contains("manifest-path:", action, StringComparison.Ordinal);
+        Assert.Contains("fail-on-warnings:", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("private-key", action, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("known-hosts", action, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("${{ secrets.", action, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", action, StringComparison.Ordinal);
+        Assert.Contains("actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7", action, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_ENGINE_REF: ${{ github.action_ref }}", action, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_ENGINE_REPOSITORY: ${{ github.action_repository }}", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("run: |", action, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ShouldGenerateAndLintPlansWithoutExecutingRecoveryCommands()
+    {
+        var script = ReadRepoFile(".github", "actions", "powerforge-server-recovery-validate", "Invoke-PowerForgeServerRecoveryValidation.ps1");
+
+        Assert.Contains("server', 'bootstrap-plan", script, StringComparison.Ordinal);
+        Assert.Contains("server', 'restore-secrets-plan", script, StringComparison.Ordinal);
+        Assert.Contains("'-n', '--', $bootstrapScript", script, StringComparison.Ordinal);
+        Assert.Contains("'-S', 'warning', '--', $bootstrapScript", script, StringComparison.Ordinal);
+        Assert.Contains("No generated command was executed", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("server', 'capture", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("server', 'deploy", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("server', 'verify", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("server', 'inspect", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssh ", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Invoke-WebRequest", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Invoke-RestMethod", script, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Script_ShouldPinEngineAndBoundCallerAndTemporaryPaths()
+    {
+        var script = ReadRepoFile(".github", "actions", "powerforge-server-recovery-validate", "Invoke-PowerForgeServerRecoveryValidation.ps1");
+
+        Assert.Contains("POWERFORGE_ENGINE_REF -notmatch '^[a-fA-F0-9]{40}$'", script, StringComparison.Ordinal);
+        Assert.Contains("Test-Json -SchemaFile $schemaPath -ErrorAction Stop", script, StringComparison.Ordinal);
+        Assert.Contains("$manifest.'$schema'", script, StringComparison.Ordinal);
+        Assert.Contains("POWERFORGE_ENGINE_REPOSITORY)/$($env:POWERFORGE_ENGINE_REF)", script, StringComparison.Ordinal);
+        Assert.Contains("IsPathRooted($env:POWERFORGE_MANIFEST_PATH)", script, StringComparison.Ordinal);
+        Assert.Contains("manifestPath.StartsWith($workspacePrefix", script, StringComparison.Ordinal);
+        Assert.Contains("$manifestItem.LinkType -eq 'SymbolicLink'", script, StringComparison.Ordinal);
+        Assert.Contains("validationRoot.StartsWith($runnerTempPrefix", script, StringComparison.Ordinal);
+        Assert.Contains("[Guid]::NewGuid().ToString('N')", script, StringComparison.Ordinal);
+        Assert.Contains("'--artifacts-path', $artifactsRoot", script, StringComparison.Ordinal);
+        Assert.Contains("$artifactsRoot 'bin/PowerForge.Web.Cli/release/PowerForge.Web.Cli.dll'", script, StringComparison.Ordinal);
+        Assert.Contains("Remove-Item -LiteralPath $validationRoot -Recurse -Force", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Script_ShouldNotPrintManifestOrCliDiagnostics()
+    {
+        var script = ReadRepoFile(".github", "actions", "powerforge-server-recovery-validate", "Invoke-PowerForgeServerRecoveryValidation.ps1");
+
+        Assert.DoesNotContain("Write-Host $manifest", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Write-Host $result.Stdout", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Write-Host $result.Stderr", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Run the pinned PowerForge CLI locally for detailed diagnostics", script, StringComparison.Ordinal);
+    }
+
+    private static string ReadRepoFile(params string[] relativePath)
+        => File.ReadAllText(GetRepoPath(relativePath));
+
+    private static string GetRepoPath(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && current is not null; i++)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return Path.Combine([current.FullName, .. relativePath]);
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+}

--- a/PowerForge.Tests/GitHubServerRecoveryValidationActionTests.cs
+++ b/PowerForge.Tests/GitHubServerRecoveryValidationActionTests.cs
@@ -49,7 +49,10 @@ public sealed class GitHubServerRecoveryValidationActionTests
         Assert.Contains("POWERFORGE_ENGINE_REPOSITORY)/$($env:POWERFORGE_ENGINE_REF)", script, StringComparison.Ordinal);
         Assert.Contains("IsPathRooted($env:POWERFORGE_MANIFEST_PATH)", script, StringComparison.Ordinal);
         Assert.Contains("manifestPath.StartsWith($workspacePrefix", script, StringComparison.Ordinal);
-        Assert.Contains("$manifestItem.LinkType -eq 'SymbolicLink'", script, StringComparison.Ordinal);
+        Assert.Contains("[IO.Path]::GetRelativePath($Root, $Path)", script, StringComparison.Ordinal);
+        Assert.Contains("$item.LinkType -eq 'SymbolicLink'", script, StringComparison.Ordinal);
+        Assert.Contains("[IO.FileAttributes]::ReparsePoint", script, StringComparison.Ordinal);
+        Assert.Contains("Assert-PathHasNoSymbolicLink -Root $workspace -Path $manifestPath", script, StringComparison.Ordinal);
         Assert.Contains("validationRoot.StartsWith($runnerTempPrefix", script, StringComparison.Ordinal);
         Assert.Contains("[Guid]::NewGuid().ToString('N')", script, StringComparison.Ordinal);
         Assert.Contains("'--artifacts-path', $artifactsRoot", script, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- add a credential-free composite action for pull-request validation of server recovery manifests
- validate against the schema from the exact action commit and require the manifest schema URL to use the same repository and commit
- reject manifests reached through symlinked repository paths and isolate all generated build/plan data under runner-temporary storage
- generate bootstrap and secret-restore plans, parse them with Bash, and check them with ShellCheck without executing recovery commands
- document the thin consumer workflow and keep protected backup credentials in the separate environment-gated action

## Consumer shape

```yaml
- uses: EvotecIT/PSPublishModule/.github/actions/powerforge-server-recovery-validate@<exact-commit>
  with:
    manifest-path: deploy/linux/example.serverrecovery.json
```

The action accepts no credential input and performs no SSH, host inspection, capture, restore, deploy, or Cloudflare operation.