### PR TITLE
Preserve first Authenticode signing failure details

### DIFF
--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -2090,6 +2090,15 @@ public sealed class ModulePipelineHostedOperationsTests
     }
 
     [Fact]
+    public void SigningScript_AllowsTheFirstFailedFileToBeRecorded()
+    {
+        var script = EmbeddedScripts.Load("Scripts/Signing/Sign-Module.ps1");
+
+        Assert.Contains("[AllowEmptyCollection()]", script, StringComparison.Ordinal);
+        Assert.Contains("Add-FailedFile -List $failedFiles", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RunTestsAfterMerge_IncludesFailedTestNamesAndMessages()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));

--- a/PowerForge/Scripts/Signing/Sign-Module.ps1
+++ b/PowerForge/Scripts/Signing/Sign-Module.ps1
@@ -86,7 +86,9 @@ function Invoke-WithFileRetry {
 
 function Add-FailedFile {
   param(
-    [Parameter(Mandatory = $true)] [System.Collections.Generic.List[string]]$List,
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
+    [System.Collections.Generic.List[string]]$List,
     [Parameter(Mandatory = $true)] [string]$FilePath,
     [string]$Message
   )


### PR DESCRIPTION
## Summary

- allow the signing pipeline's initially empty failed-file list to cross the PowerShell parameter boundary
- preserve the first real Authenticode failure, affected file, summary counts, and exit behavior
- add focused regression coverage for the embedded signing script contract

## Why

When the first file failed Authenticode signing, PowerShell rejected the empty mandatory `List<string>` before `Add-FailedFile` could record the failure. The build then reported an empty-collection binding error instead of the certificate, provider, or file-specific cause.

## Validation

- `ModulePipelineHostedOperationsTests`: 51 passed
- live binary-module signing probe now reports both failed DLL paths and the underlying SafeNet provider denial
- independent read-only review of exact SHA `fb312acd01afa5ecd5fd835453963b5205231db3`: clean
