### PR TITLE
Remove vulnerable AngleSharp dependencies from PowerForge

### DIFF
--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -42,8 +42,8 @@
       },
       "AngleSharp": {
         "type": "Transitive",
-        "resolved": "1.4.1-beta.523",
-        "contentHash": "1HPqvhCAHu2X9umsuoy2RU7Ls6j+JIg5Enu1SgTinXqo/EVdXP5Ey/PA0vuwqVgo1x3xowXrDCgOWt2DM4vZSA=="
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Transitive",
@@ -427,6 +427,28 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       },
       "NUglify": {
         "type": "Transitive",
@@ -858,27 +880,28 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
+          "NuGet.Configuration": "[7.6.0, )",
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "NuGet.Configuration": "[7.6.0, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
       },
       "powerforge.powershell": {
         "type": "Project",
         "dependencies": {
           "Microsoft.PowerShell.SDK": "[7.4.1, )",
-          "PowerForge": "[1.0.0, )",
+          "PowerForge": "[1.0.4, )",
           "System.Security.Cryptography.Xml": "[10.0.7, )"
         }
       },
       "powerforge.web": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.5.2, )",
           "HtmlTinkerX": "[2.0.19, )",
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
-          "PowerForge": "[1.0.0, )",
+          "PowerForge": "[1.0.4, )",
           "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }
@@ -886,7 +909,7 @@
       "PowerForge.Web.Build": {
         "type": "Project",
         "dependencies": {
-          "PowerForge.Web": "[1.0.0, )"
+          "PowerForge.Web": "[1.0.4, )"
         }
       },
       "powerforgestudio.domain": {
@@ -898,36 +921,14 @@
           "HtmlForgeX": "[0.44.0, )",
           "HtmlForgeX.Markdown": "[0.20.12, )",
           "OfficeIMO.Markdown": "[0.6.29, )",
-          "PowerForge": "[1.0.0, )",
-          "PowerForge.PowerShell": "[1.0.0, )",
+          "PowerForge": "[1.0.4, )",
+          "PowerForge.PowerShell": "[1.0.4, )",
           "Spectre.Console": "[0.55.2, )",
           "Spectre.Console.Json": "[0.55.2, )",
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
-      },
-      "NuGet.Configuration": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
-        "dependencies": {
-          "NuGet.Common": "7.6.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0"
-        }
-      },
-      "NuGet.Common": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
-        "dependencies": {
-          "NuGet.Frameworks": "7.6.0"
-        }
-      },
-      "NuGet.Frameworks": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -9,8 +9,8 @@
       },
       "AngleSharp": {
         "type": "Transitive",
-        "resolved": "1.4.1-beta.523",
-        "contentHash": "1HPqvhCAHu2X9umsuoy2RU7Ls6j+JIg5Enu1SgTinXqo/EVdXP5Ey/PA0vuwqVgo1x3xowXrDCgOWt2DM4vZSA=="
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
       },
       "AngleSharp.Css": {
         "type": "Transitive",
@@ -192,10 +192,11 @@
       "powerforge.web": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[1.5.2, )",
           "HtmlTinkerX": "[2.0.19, )",
           "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
-          "PowerForge": "[1.0.1, )",
+          "PowerForge": "[1.0.4, )",
           "Scriban": "[7.2.5, )",
           "YamlDotNet": "[15.1.2, )"
         }

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="HtmlTinkerX" Version="2.0.19" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
     <PackageReference Include="OfficeIMO.Markdown" Version="0.6.13" />

--- a/PowerForge.Web/packages.lock.json
+++ b/PowerForge.Web/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
+      },
       "HtmlTinkerX": {
         "type": "Direct",
         "requested": "[2.0.19, )",
@@ -52,11 +58,6 @@
         "type": "Transitive",
         "resolved": "1.4.0",
         "contentHash": "3M7NpnhKL//pf7HkSfLJaGQ37uksibdqfa9YuUov1VOX0QXapZeYCUpURZ9an4VMt9wJ70MU/PeAsjhw8DwtJw=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.1-beta.523",
-        "contentHash": "1HPqvhCAHu2X9umsuoy2RU7Ls6j+JIg5Enu1SgTinXqo/EVdXP5Ey/PA0vuwqVgo1x3xowXrDCgOWt2DM4vZSA=="
       },
       "AngleSharp.Css": {
         "type": "Transitive",
@@ -121,6 +122,28 @@
           "System.ComponentModel.Annotations": "5.0.0"
         }
       },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
       "NUglify": {
         "type": "Transitive",
         "resolved": "1.21.17",
@@ -166,36 +189,20 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
+          "NuGet.Configuration": "[7.6.0, )",
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "NuGet.Configuration": "[7.6.0, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
-      },
-      "NuGet.Configuration": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
-        "dependencies": {
-          "NuGet.Common": "7.6.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0"
-        }
-      },
-      "NuGet.Common": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
-        "dependencies": {
-          "NuGet.Frameworks": "7.6.0"
-        }
-      },
-      "NuGet.Frameworks": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     },
     "net8.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[1.5.2, )",
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
+      },
       "HtmlTinkerX": {
         "type": "Direct",
         "requested": "[2.0.19, )",
@@ -246,11 +253,6 @@
         "type": "Transitive",
         "resolved": "1.4.0",
         "contentHash": "3M7NpnhKL//pf7HkSfLJaGQ37uksibdqfa9YuUov1VOX0QXapZeYCUpURZ9an4VMt9wJ70MU/PeAsjhw8DwtJw=="
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "1.4.1-beta.523",
-        "contentHash": "1HPqvhCAHu2X9umsuoy2RU7Ls6j+JIg5Enu1SgTinXqo/EVdXP5Ey/PA0vuwqVgo1x3xowXrDCgOWt2DM4vZSA=="
       },
       "AngleSharp.Css": {
         "type": "Transitive",
@@ -314,6 +316,28 @@
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
         }
       },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
       "NUglify": {
         "type": "Transitive",
         "resolved": "1.21.17",
@@ -354,33 +378,11 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
+          "NuGet.Configuration": "[7.6.0, )",
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "System.Security.Cryptography.ProtectedData": "[10.0.7, )",
-          "NuGet.Configuration": "[7.6.0, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
-      },
-      "NuGet.Configuration": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
-        "dependencies": {
-          "NuGet.Common": "7.6.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0"
-        }
-      },
-      "NuGet.Common": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
-        "dependencies": {
-          "NuGet.Frameworks": "7.6.0"
-        }
-      },
-      "NuGet.Frameworks": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }

--- a/PowerForgeStudio.Wpf.Tests/packages.lock.json
+++ b/PowerForgeStudio.Wpf.Tests/packages.lock.json
@@ -37,8 +37,16 @@
       },
       "AngleSharp": {
         "type": "Transitive",
-        "resolved": "1.3.0",
-        "contentHash": "iHzfn4cK6CmhuURNdEpmSQCq5/HZFldEpkbnmqT9My8+6l2Sz3F+NxoqRA8z/jTkWB+SAu5boRdp4v/WtyjuIQ=="
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.216",
+        "contentHash": "RVt/B1pp7HREgerDw8BVZSDC+Uqh+yeL/OGtu57mLLhBBPIQ1oSYrPKOYgdt0EZEK34l7BNCjx4BaQRNRN/ZIw==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -79,46 +87,82 @@
       },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
-        "resolved": "1.0.3967.48",
-        "contentHash": "b7dZ5kZ9bfU5Yo11M8feCOoiyalXCN+2Gsw674RBDBmQ2dJV5EOXb8/ivN2LuLJ+VO2V7FmK6l6LsyfEnG1lXw=="
+        "resolved": "1.0.4078.44",
+        "contentHash": "TQkHa/aOHUqFHnJIJ/2ZmJ4nLcQJi0Pc0rj9BAs7SP5sT/KtVtb8jFp9uqQL6cKzCRSrwjS/wEPA43NWUOzU+A=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "OfficeIMO.Html": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "xBDWgQw5P9UhTksl9kDkDWCKTj+Q5tyzRgpgCGuaLQJMsry5+z+AA6wh5Umxqm8mes6F1q4PFp8VXqQf1THT1w==",
+        "dependencies": {
+          "AngleSharp": "1.5.2",
+          "AngleSharp.Css": "1.0.0-beta.216",
+          "OfficeIMO.Rtf": "0.1.10"
+        }
+      },
       "OfficeIMO.Markdown": {
         "type": "Transitive",
-        "resolved": "0.6.5",
-        "contentHash": "8tCl4cdsN/Qx+FICyFgo8tAU5nN64mQlBbROoK3gNXvD4+kfniDSwfHxYWydJMfS2BaDGMm51YZZ20FDR5loUQ=="
+        "resolved": "0.6.42",
+        "contentHash": "eApNM/lo9Sk5gET2fmNojBurTW6eRA11pJE3UGPzcBfOzOgpVHEO2PZmWPogajBjKt+YOszljcz47f5uDKaglw=="
       },
       "OfficeIMO.Markdown.Html": {
         "type": "Transitive",
-        "resolved": "0.1.5",
-        "contentHash": "z7gCXslAQLUx0bZ5JXUqvP7ZybQ94pLfYZ8PdhQ6O/qAvlYDLGtpzovCXX0yNVqTbR62pHJMiGSCBdqNMWX8iA==",
+        "resolved": "0.1.42",
+        "contentHash": "RJAwe4YPgV1EtN2NOW1c0Qx456AisIHIaKHG/+95/sxQb2iqrDz4SeIpJ8I6yHB6ifwIUXH6X6PlGfWOdgkNQw==",
         "dependencies": {
-          "AngleSharp": "1.3.0",
-          "OfficeIMO.Markdown": "0.6.5"
+          "OfficeIMO.Html": "0.1.11",
+          "OfficeIMO.Markdown": "0.6.42"
         }
       },
       "OfficeIMO.MarkdownRenderer": {
         "type": "Transitive",
-        "resolved": "0.2.5",
-        "contentHash": "vDpOtV854M3dFfNQ3tJ3r6h6MIg3l1MzVoDrYkTULkLtfgq+nJshQTUAbYwAIQVnl/XbTvoHRJNfRN7Wf3oe8g==",
+        "resolved": "0.2.42",
+        "contentHash": "sxa4hK8d/9PX98gK6UCrjFeYW0pxAjIVFXUDTlGjkmS33wDBd1/NOHb5Mmiot/qi5z5/1Ap/WfwYbiJoE/Kjow==",
         "dependencies": {
-          "OfficeIMO.Markdown": "0.6.5",
-          "OfficeIMO.Markdown.Html": "0.1.5",
-          "System.Text.Json": "[8.0.5, 9.0.0)"
+          "OfficeIMO.Markdown": "0.6.42",
+          "OfficeIMO.Markdown.Html": "0.1.42"
         }
       },
       "OfficeIMO.MarkdownRenderer.Wpf": {
         "type": "Transitive",
-        "resolved": "0.1.0",
-        "contentHash": "7ZetGNPohn2rgFXK7fqktR+oERRJUXOvuFpqCpEWLUgjXl3CBDamhQLkT8mYlidNSCCyHhuakjc6TynopGcJYg==",
+        "resolved": "0.1.37",
+        "contentHash": "pfgVr+BRU6nczUWp2VoYQ5V68jr5dSrlIuXBapn/8YVp2YVy45puQkBsMVYdeuU9BIfnU5DyY82009Rw/Ru47A==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.3856.49",
-          "OfficeIMO.MarkdownRenderer": "0.2.5"
+          "Microsoft.Web.WebView2": "1.0.3912.50",
+          "OfficeIMO.MarkdownRenderer": "0.2.42"
         }
+      },
+      "OfficeIMO.Rtf": {
+        "type": "Transitive",
+        "resolved": "0.1.10",
+        "contentHash": "ayHx70Ow1o81eHMZjy5ILfgxWs3ZSX03KFARJyYuO8YknA0wBqfqWwDHdQL5dQaKGi0kwhwbFFe8i2ZdWA2d5A=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -170,11 +214,6 @@
         "resolved": "10.0.7",
         "contentHash": "eqKW9wyPUhZi6pxy9Y0fQO/bdHROcwj0tYdmoGEPCPCtCJLFdVVAlzuuYYEnJI64HxhoXPYGhtx891g/jwN4rg=="
       },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "8.0.5",
-        "contentHash": "0f1B50Ss7rqxXiaBJyzUu9bWFOO2/zSlifZ/UNMdiIpDYe4cY4LQQicP4nirK1OS31I43rn062UIJ1Q9bpmHpg=="
-      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -221,7 +260,7 @@
       "dbaclientx.sqlite": {
         "type": "Project",
         "dependencies": {
-          "DBAClientX.Core": "[0.11.0, )",
+          "DBAClientX.Core": "[0.10.0, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "SQLitePCLRaw.core": "[3.0.3, )"
@@ -230,6 +269,7 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
+          "NuGet.Configuration": "[7.6.0, )",
           "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
@@ -241,10 +281,10 @@
       "powerforgestudio.orchestrator": {
         "type": "Project",
         "dependencies": {
-          "DBAClientX.Core": "[0.11.0, )",
-          "DBAClientX.SQLite": "[0.10.0, )",
+          "DBAClientX.Core": "[0.10.0, )",
+          "DBAClientX.SQLite": "[0.9.0, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",
-          "PowerForge": "[1.0.0, )",
+          "PowerForge": "[1.0.4, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
       },
@@ -252,7 +292,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.Web.WebView2": "[1.0.*, )",
-          "OfficeIMO.MarkdownRenderer.Wpf": "[0.1.0, )",
+          "OfficeIMO.MarkdownRenderer.Wpf": "[0.1.37, )",
           "PowerForgeStudio.Domain": "[1.0.0, )",
           "PowerForgeStudio.Orchestrator": "[1.0.0, )"
         }

--- a/PowerForgeStudio.Wpf/PowerForgeStudio.Wpf.csproj
+++ b/PowerForgeStudio.Wpf/PowerForgeStudio.Wpf.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OfficeIMO.MarkdownRenderer.Wpf" Version="0.1.0"
+    <PackageReference Include="OfficeIMO.MarkdownRenderer.Wpf" Version="0.1.37"
                       Condition="!Exists('$(OfficeImoMarkdownRendererWpfProject)')" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.*" />
   </ItemGroup>

--- a/PowerForgeStudio.Wpf/packages.lock.json
+++ b/PowerForgeStudio.Wpf/packages.lock.json
@@ -5,23 +5,31 @@
       "Microsoft.Web.WebView2": {
         "type": "Direct",
         "requested": "[1.0.*, )",
-        "resolved": "1.0.3967.48",
-        "contentHash": "b7dZ5kZ9bfU5Yo11M8feCOoiyalXCN+2Gsw674RBDBmQ2dJV5EOXb8/ivN2LuLJ+VO2V7FmK6l6LsyfEnG1lXw=="
+        "resolved": "1.0.4078.44",
+        "contentHash": "TQkHa/aOHUqFHnJIJ/2ZmJ4nLcQJi0Pc0rj9BAs7SP5sT/KtVtb8jFp9uqQL6cKzCRSrwjS/wEPA43NWUOzU+A=="
       },
       "OfficeIMO.MarkdownRenderer.Wpf": {
         "type": "Direct",
-        "requested": "[0.1.0, )",
-        "resolved": "0.1.0",
-        "contentHash": "7ZetGNPohn2rgFXK7fqktR+oERRJUXOvuFpqCpEWLUgjXl3CBDamhQLkT8mYlidNSCCyHhuakjc6TynopGcJYg==",
+        "requested": "[0.1.37, )",
+        "resolved": "0.1.37",
+        "contentHash": "pfgVr+BRU6nczUWp2VoYQ5V68jr5dSrlIuXBapn/8YVp2YVy45puQkBsMVYdeuU9BIfnU5DyY82009Rw/Ru47A==",
         "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.3856.49",
-          "OfficeIMO.MarkdownRenderer": "0.2.5"
+          "Microsoft.Web.WebView2": "1.0.3912.50",
+          "OfficeIMO.MarkdownRenderer": "0.2.42"
         }
       },
       "AngleSharp": {
         "type": "Transitive",
-        "resolved": "1.3.0",
-        "contentHash": "iHzfn4cK6CmhuURNdEpmSQCq5/HZFldEpkbnmqT9My8+6l2Sz3F+NxoqRA8z/jTkWB+SAu5boRdp4v/WtyjuIQ=="
+        "resolved": "1.5.2",
+        "contentHash": "LVZ7rrr6GHbhERhTgVDarVygl1e6KwE96pronA90LBOMacDhxR4lB+xYLjn/vlnUu+xbOB2RM9fuCPEx5bdyWA=="
+      },
+      "AngleSharp.Css": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.216",
+        "contentHash": "RVt/B1pp7HREgerDw8BVZSDC+Uqh+yeL/OGtu57mLLhBBPIQ1oSYrPKOYgdt0EZEK34l7BNCjx4BaQRNRN/ZIw==",
+        "dependencies": {
+          "AngleSharp": "[1.0.0, 2.0.0)"
+        }
       },
       "Microsoft.Data.Sqlite": {
         "type": "Transitive",
@@ -41,29 +49,64 @@
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "OfficeIMO.Html": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "xBDWgQw5P9UhTksl9kDkDWCKTj+Q5tyzRgpgCGuaLQJMsry5+z+AA6wh5Umxqm8mes6F1q4PFp8VXqQf1THT1w==",
+        "dependencies": {
+          "AngleSharp": "1.5.2",
+          "AngleSharp.Css": "1.0.0-beta.216",
+          "OfficeIMO.Rtf": "0.1.10"
+        }
+      },
       "OfficeIMO.Markdown": {
         "type": "Transitive",
-        "resolved": "0.6.5",
-        "contentHash": "8tCl4cdsN/Qx+FICyFgo8tAU5nN64mQlBbROoK3gNXvD4+kfniDSwfHxYWydJMfS2BaDGMm51YZZ20FDR5loUQ=="
+        "resolved": "0.6.42",
+        "contentHash": "eApNM/lo9Sk5gET2fmNojBurTW6eRA11pJE3UGPzcBfOzOgpVHEO2PZmWPogajBjKt+YOszljcz47f5uDKaglw=="
       },
       "OfficeIMO.Markdown.Html": {
         "type": "Transitive",
-        "resolved": "0.1.5",
-        "contentHash": "z7gCXslAQLUx0bZ5JXUqvP7ZybQ94pLfYZ8PdhQ6O/qAvlYDLGtpzovCXX0yNVqTbR62pHJMiGSCBdqNMWX8iA==",
+        "resolved": "0.1.42",
+        "contentHash": "RJAwe4YPgV1EtN2NOW1c0Qx456AisIHIaKHG/+95/sxQb2iqrDz4SeIpJ8I6yHB6ifwIUXH6X6PlGfWOdgkNQw==",
         "dependencies": {
-          "AngleSharp": "1.3.0",
-          "OfficeIMO.Markdown": "0.6.5"
+          "OfficeIMO.Html": "0.1.11",
+          "OfficeIMO.Markdown": "0.6.42"
         }
       },
       "OfficeIMO.MarkdownRenderer": {
         "type": "Transitive",
-        "resolved": "0.2.5",
-        "contentHash": "vDpOtV854M3dFfNQ3tJ3r6h6MIg3l1MzVoDrYkTULkLtfgq+nJshQTUAbYwAIQVnl/XbTvoHRJNfRN7Wf3oe8g==",
+        "resolved": "0.2.42",
+        "contentHash": "sxa4hK8d/9PX98gK6UCrjFeYW0pxAjIVFXUDTlGjkmS33wDBd1/NOHb5Mmiot/qi5z5/1Ap/WfwYbiJoE/Kjow==",
         "dependencies": {
-          "OfficeIMO.Markdown": "0.6.5",
-          "OfficeIMO.Markdown.Html": "0.1.5",
-          "System.Text.Json": "[8.0.5, 9.0.0)"
+          "OfficeIMO.Markdown": "0.6.42",
+          "OfficeIMO.Markdown.Html": "0.1.42"
         }
+      },
+      "OfficeIMO.Rtf": {
+        "type": "Transitive",
+        "resolved": "0.1.10",
+        "contentHash": "ayHx70Ow1o81eHMZjy5ILfgxWs3ZSX03KFARJyYuO8YknA0wBqfqWwDHdQL5dQaKGi0kwhwbFFe8i2ZdWA2d5A=="
       },
       "SourceGear.sqlite3": {
         "type": "Transitive",
@@ -100,15 +143,20 @@
           "SQLitePCLRaw.core": "3.0.3"
         }
       },
+      "System.IO.Packaging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qvYn5etKp2m3p05CCvw48OXf0mbD57g0gq/dCjQvq2ZgXYtjB3CV6rwzO7QprxMHnkZFhJ0StrB0thrVzpF49Q=="
+      },
       "System.Reflection.MetadataLoadContext": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ=="
       },
-      "System.Text.Json": {
+      "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "8.0.5",
-        "contentHash": "0f1B50Ss7rqxXiaBJyzUu9bWFOO2/zSlifZ/UNMdiIpDYe4cY4LQQicP4nirK1OS31I43rn062UIJ1Q9bpmHpg=="
+        "resolved": "10.0.7",
+        "contentHash": "eqKW9wyPUhZi6pxy9Y0fQO/bdHROcwj0tYdmoGEPCPCtCJLFdVVAlzuuYYEnJI64HxhoXPYGhtx891g/jwN4rg=="
       },
       "dbaclientx.core": {
         "type": "Project"
@@ -116,7 +164,7 @@
       "dbaclientx.sqlite": {
         "type": "Project",
         "dependencies": {
-          "DBAClientX.Core": "[0.11.0, )",
+          "DBAClientX.Core": "[0.10.0, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",
           "SQLitePCLRaw.bundle_e_sqlite3": "[3.0.3, )",
           "SQLitePCLRaw.core": "[3.0.3, )"
@@ -125,8 +173,10 @@
       "powerforge": {
         "type": "Project",
         "dependencies": {
+          "NuGet.Configuration": "[7.6.0, )",
+          "System.IO.Packaging": "[10.0.7, )",
           "System.Reflection.MetadataLoadContext": "[8.0.0, )",
-          "NuGet.Configuration": "[7.6.0, )"
+          "System.Security.Cryptography.ProtectedData": "[10.0.7, )"
         }
       },
       "powerforgestudio.domain": {
@@ -135,33 +185,12 @@
       "powerforgestudio.orchestrator": {
         "type": "Project",
         "dependencies": {
-          "DBAClientX.Core": "[0.11.0, )",
-          "DBAClientX.SQLite": "[0.10.0, )",
+          "DBAClientX.Core": "[0.10.0, )",
+          "DBAClientX.SQLite": "[0.9.0, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",
-          "PowerForge": "[1.0.0, )",
+          "PowerForge": "[1.0.4, )",
           "PowerForgeStudio.Domain": "[1.0.0, )"
         }
-      },
-      "NuGet.Configuration": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
-        "dependencies": {
-          "NuGet.Common": "7.6.0"
-        }
-      },
-      "NuGet.Common": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
-        "dependencies": {
-          "NuGet.Frameworks": "7.6.0"
-        }
-      },
-      "NuGet.Frameworks": {
-        "type": "Transitive",
-        "resolved": "7.6.0",
-        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
       }
     }
   }


### PR DESCRIPTION
## Summary

- Declare AngleSharp 1.5.2 as a direct PowerForge.Web dependency because the website engine uses AngleSharp APIs directly.
- Update the WPF Markdown renderer within its existing 0.1.x release line so the remaining solution lock graphs also resolve AngleSharp 1.5.2.
- Refresh Web, CLI, test, and WPF locks to remove vulnerable AngleSharp 1.3.x/1.4.x resolutions.

## Context

The newly published GHSA-pgww-w46g-26qg advisory affects AngleSharp versions below 1.5.0. PowerForge's reusable source-mode website workflow treats NuGet audit warnings as errors, which blocked downstream website CI even when the consumer change was unrelated.

## Compatibility

The website workflow and public PowerForge surfaces are unchanged. The WPF project continues to use the public OfficeIMO.MarkdownRenderer.Wpf 0.1.x line and compiles against version 0.1.37.

## Validation

- Solution-wide transitive vulnerability audit reports no vulnerable packages.
- PowerForge.Web builds warning-free for .NET 8 and .NET 10.
- PowerForge.Web.Cli and the WPF/test projects build warning-free.
- A full 36-step OfficeIMO website CI pipeline completes through the locally built shared engine.