### PR TITLE
Add reusable GitHub Sponsors content generation

### DIFF
--- a/.github/actions/github-content/action.yml
+++ b/.github/actions/github-content/action.yml
@@ -55,7 +55,7 @@ runs:
           throw "GitHub content config not found: $configPath"
         }
 
-        $jsonLines = & dotnet run --project $project -c Release --no-build --framework net10.0 -- github content sync --config $configPath --restrict-output-root $workspace --output json
+        $jsonLines = & dotnet run --project $project -c Release --no-build --framework net10.0 -- github content sync --config $configPath --token-env GITHUB_TOKEN --restrict-output-root $workspace --output json
         $exitCode = $LASTEXITCODE
         $json = $jsonLines -join [Environment]::NewLine
         if ([string]::IsNullOrWhiteSpace($json)) {

--- a/.github/actions/github-content/action.yml
+++ b/.github/actions/github-content/action.yml
@@ -1,0 +1,89 @@
+name: PowerForge GitHub Content
+description: Generate managed repository content such as GitHub Sponsors rosters using PowerForge.Cli.
+
+inputs:
+  config-path:
+    description: Path to the GitHub content config inside the checked-out repository.
+    required: false
+    default: ".powerforge/github-content.json"
+  github-token:
+    description: Token used for GitHub GraphQL requests.
+    required: true
+
+outputs:
+  changed:
+    description: Whether any configured document changed.
+    value: ${{ steps.content.outputs.changed }}
+  changed-paths-json:
+    description: JSON array of changed paths relative to the caller workspace.
+    value: ${{ steps.content.outputs.changed-paths-json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      with:
+        global-json-file: ${{ github.action_path }}/../../../global.json
+
+    - name: Build PowerForge CLI
+      shell: pwsh
+      run: |
+        $repoRoot = (Resolve-Path (Join-Path $env:GITHUB_ACTION_PATH "../../..")).Path
+        $project = Join-Path $repoRoot "PowerForge.Cli/PowerForge.Cli.csproj"
+        dotnet build $project -c Release --framework net10.0
+      env:
+        DOTNET_NOLOGO: true
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+    - name: Generate repository content
+      id: content
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $repoRoot = (Resolve-Path (Join-Path $env:GITHUB_ACTION_PATH "../../..")).Path
+        $project = Join-Path $repoRoot "PowerForge.Cli/PowerForge.Cli.csproj"
+        $workspace = (Resolve-Path $env:GITHUB_WORKSPACE).Path
+        $configPath = [string]$env:INPUT_CONFIG_PATH
+        if ([string]::IsNullOrWhiteSpace($configPath)) {
+          throw 'GitHub content config path is required.'
+        }
+        if (-not [System.IO.Path]::IsPathRooted($configPath)) {
+          $configPath = Join-Path $workspace $configPath
+        }
+        if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+          throw "GitHub content config not found: $configPath"
+        }
+
+        $jsonLines = & dotnet run --project $project -c Release --no-build --framework net10.0 -- github content sync --config $configPath --restrict-output-root $workspace --output json
+        $exitCode = $LASTEXITCODE
+        $json = $jsonLines -join [Environment]::NewLine
+        if ([string]::IsNullOrWhiteSpace($json)) {
+          throw "PowerForge returned no JSON result (exit code $exitCode)."
+        }
+        $payload = $json | ConvertFrom-Json -Depth 100
+        if ($exitCode -ne 0 -or -not $payload.success) {
+          throw ([string]$payload.error)
+        }
+
+        $workspacePrefix = $workspace.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+        $paths = [System.Collections.Generic.List[string]]::new()
+        foreach ($document in @($payload.result.documents)) {
+          if (-not $document.changed) { continue }
+          $fullPath = [System.IO.Path]::GetFullPath([string]$document.path)
+          if (-not $fullPath.StartsWith($workspacePrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Generated document is outside the caller workspace: $fullPath"
+          }
+          $relativePath = [System.IO.Path]::GetRelativePath($workspace, $fullPath).Replace('\', '/')
+          $paths.Add($relativePath)
+        }
+
+        $changed = $paths.Count -gt 0
+        "changed=$($changed.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        $pathsJson = ConvertTo-Json -InputObject $paths -Compress
+        "changed-paths-json=$pathsJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      env:
+        DOTNET_NOLOGO: true
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
+        INPUT_CONFIG_PATH: ${{ inputs['config-path'] }}
+        GITHUB_TOKEN: ${{ inputs['github-token'] }}

--- a/.github/workflows/powerforge-github-content.yml
+++ b/.github/workflows/powerforge-github-content.yml
@@ -90,6 +90,9 @@ jobs:
           if ($paths.Count -eq 0) {
             throw 'PowerForge reported changes without any changed document paths.'
           }
+          if ([string]::IsNullOrWhiteSpace($env:COMMIT_MESSAGE)) {
+            throw 'A non-empty commit message is required when commit_changes is enabled.'
+          }
           foreach ($path in $paths) {
             git --literal-pathspecs add -- $path
           }
@@ -105,4 +108,7 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit -m $env:COMMIT_MESSAGE
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           git push

--- a/.github/workflows/powerforge-github-content.yml
+++ b/.github/workflows/powerforge-github-content.yml
@@ -41,6 +41,10 @@ jobs:
     steps:
       - name: Checkout caller repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Resolve the branch when this serialized job actually starts. The event SHA
+          # may predate a generated-content commit pushed by an earlier queued run.
+          ref: ${{ github.ref }}
 
       - name: Resolve shared workflow source
         id: workflow_source

--- a/.github/workflows/powerforge-github-content.yml
+++ b/.github/workflows/powerforge-github-content.yml
@@ -91,7 +91,7 @@ jobs:
             throw 'PowerForge reported changes without any changed document paths.'
           }
           foreach ($path in $paths) {
-            git add -- $path
+            git --literal-pathspecs add -- $path
           }
           git diff --cached --quiet
           if ($LASTEXITCODE -eq 0) {

--- a/.github/workflows/powerforge-github-content.yml
+++ b/.github/workflows/powerforge-github-content.yml
@@ -1,0 +1,104 @@
+name: PowerForge GitHub Content
+
+on:
+  workflow_call:
+    inputs:
+      config_path:
+        description: Path to the GitHub content config in the caller repository.
+        required: false
+        default: ".powerforge/github-content.json"
+        type: string
+      powerforge_ref:
+        description: Optional PSPublishModule ref override. By default the exact reusable-workflow commit is used.
+        required: false
+        default: ""
+        type: string
+      commit_changes:
+        description: Commit and push generated document changes to the checked-out branch.
+        required: false
+        default: true
+        type: boolean
+      commit_message:
+        description: Commit message used when generated content changes.
+        required: false
+        default: "docs: update GitHub sponsors"
+        type: string
+    secrets:
+      github_token:
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  content:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Resolve shared workflow source
+        id: workflow_source
+        shell: pwsh
+        run: |
+          $repository = [string]'${{ job.workflow_repository }}'
+          $ref = [string]'${{ inputs.powerforge_ref }}'
+          $workflowSha = [string]'${{ job.workflow_sha }}'
+
+          if ([string]::IsNullOrWhiteSpace($repository)) {
+            $repository = 'EvotecIT/PSPublishModule'
+          }
+          if ([string]::IsNullOrWhiteSpace($ref)) {
+            $ref = $workflowSha
+          }
+          if ([string]::IsNullOrWhiteSpace($ref)) {
+            throw 'Unable to resolve the exact shared workflow commit from job.workflow_sha. Pass powerforge_ref explicitly.'
+          }
+
+          Write-Host "Using GitHub content engine $repository@$ref"
+          "repository=$repository" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "ref=$ref" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Checkout PowerForge
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: ${{ steps.workflow_source.outputs.repository }}
+          ref: ${{ steps.workflow_source.outputs.ref }}
+          path: .powerforge-runtime/pspublishmodule
+
+      - name: Generate GitHub repository content
+        id: content
+        uses: ./.powerforge-runtime/pspublishmodule/.github/actions/github-content
+        with:
+          config-path: ${{ inputs.config_path }}
+          github-token: ${{ secrets.github_token != '' && secrets.github_token || github.token }}
+
+      - name: Commit generated content
+        if: inputs.commit_changes && steps.content.outputs.changed == 'true'
+        shell: pwsh
+        env:
+          CHANGED_PATHS_JSON: ${{ steps.content.outputs.changed-paths-json }}
+          COMMIT_MESSAGE: ${{ inputs.commit_message }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $paths = @($env:CHANGED_PATHS_JSON | ConvertFrom-Json)
+          if ($paths.Count -eq 0) {
+            throw 'PowerForge reported changes without any changed document paths.'
+          }
+          foreach ($path in $paths) {
+            git add -- $path
+          }
+          git diff --cached --quiet
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host 'Generated content is already current.'
+            exit 0
+          }
+          if ($LASTEXITCODE -ne 1) {
+            exit $LASTEXITCODE
+          }
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m $env:COMMIT_MESSAGE
+          git push

--- a/.github/workflows/powerforge-github-content.yml
+++ b/.github/workflows/powerforge-github-content.yml
@@ -39,6 +39,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Validate caller ref
+        if: inputs.commit_changes
+        shell: pwsh
+        env:
+          CALLER_REF: ${{ github.ref }}
+        run: |
+          if (-not $env:CALLER_REF.StartsWith('refs/heads/', [System.StringComparison]::Ordinal)) {
+            throw "commit_changes requires a branch ref, but the caller ref is '$env:CALLER_REF'. Set commit_changes to false for tag or pull request refs."
+          }
+
       - name: Checkout caller repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -49,10 +59,14 @@ jobs:
       - name: Resolve shared workflow source
         id: workflow_source
         shell: pwsh
+        env:
+          POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+          WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          WORKFLOW_SHA: ${{ job.workflow_sha }}
         run: |
-          $repository = [string]'${{ job.workflow_repository }}'
-          $ref = [string]'${{ inputs.powerforge_ref }}'
-          $workflowSha = [string]'${{ job.workflow_sha }}'
+          $repository = [string]$env:WORKFLOW_REPOSITORY
+          $ref = [string]$env:POWERFORGE_REF
+          $workflowSha = [string]$env:WORKFLOW_SHA
 
           if ([string]::IsNullOrWhiteSpace($repository)) {
             $repository = 'EvotecIT/PSPublishModule'
@@ -62,6 +76,9 @@ jobs:
           }
           if ([string]::IsNullOrWhiteSpace($ref)) {
             throw 'Unable to resolve the exact shared workflow commit from job.workflow_sha. Pass powerforge_ref explicitly.'
+          }
+          if ($ref.IndexOfAny([char[]]"`r`n") -ge 0) {
+            throw 'powerforge_ref must be a single-line Git ref or commit SHA.'
           }
 
           Write-Host "Using GitHub content engine $repository@$ref"

--- a/.github/workflows/powerforge-github-content.yml
+++ b/.github/workflows/powerforge-github-content.yml
@@ -30,6 +30,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: powerforge-github-content-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   content:
     runs-on: ubuntu-latest

--- a/Docs/PowerForge.GitHubContent.md
+++ b/Docs/PowerForge.GitHubContent.md
@@ -70,11 +70,11 @@ $env:GITHUB_TOKEN = '<token>'
 powerforge github content sync --config .\.powerforge\github-content.json
 ```
 
-Use `--output json` when another tool needs the changed paths and normalized sponsor records. Automation should also pass `--restrict-output-root <repository-root>`; PowerForge then rejects outside paths and symlink/reparse-point traversal before it writes any configured output. The reusable action supplies this restriction automatically.
+Use `--output json` when another tool needs the changed paths and normalized sponsor records. When multiple configured paths already identify the same physical file, including hard-link or symbolic-link aliases, PowerForge projects their marker updates into one write so no block is lost. Automation should also pass `--restrict-output-root <repository-root>`; PowerForge then rejects outside paths and symlink/reparse-point traversal before it writes any configured output. The reusable action supplies this restriction automatically.
 
 ## Automate updates
 
-The reusable workflow can run on a schedule or on demand. It stages only document paths returned by PowerForge.
+The reusable workflow can run on a schedule or on demand. Runs are serialized per caller branch, and a queued run resolves the branch again when it starts so it does not regenerate content from an older event commit. The workflow stages only document paths returned by PowerForge.
 
 ```yaml
 name: Update sponsors

--- a/Docs/PowerForge.GitHubContent.md
+++ b/Docs/PowerForge.GitHubContent.md
@@ -1,0 +1,115 @@
+# Generated GitHub Repository Content
+
+PowerForge can keep sponsor recognition in a repository up to date without replacing the rest of a README or `SPONSORS.md`. The first provider reads public GitHub Sponsors data; the config and managed Markdown layer are designed to accept other repository content providers later.
+
+The command is opt-in. It writes only configured marker blocks, fails before writing when GitHub cannot be queried, and rejects missing or duplicate markers unless the config explicitly allows a new file or appended block.
+
+## Configure sponsor recognition
+
+Copy [`Examples/GitHubContent/github-content.json`](../Examples/GitHubContent/github-content.json) to `.powerforge/github-content.json`, then set `sponsorableLogin` and remove the example override and company.
+
+Tier recognition is disabled unless `tierRecognition.enabled` is `true`. With `useDefaultTiers` enabled, PowerForge maps the selected GitHub monthly funding tier into these public recognition bands:
+
+| Recognition tier | Minimum monthly tier |
+| --- | ---: |
+| Principal | $1,000 |
+| Platinum | $100 |
+| Gold | $30 |
+| Silver | $10 |
+| Bronze | $5 |
+| Sponsors | Custom, unavailable, or below a configured band |
+
+Funding amounts and GitHub funding-tier names are not rendered or returned in JSON results. They remain internal to one tier-enabled run and only decide where a current sponsor appears. When tier recognition is disabled, PowerForge does not request funding-tier prices at all.
+
+Enabling tier recognition still reveals an approximate funding band that GitHub does not publish to every viewer by default. Turn it on only when tier-based public recognition is part of the sponsor reward and the displayed bands match that policy. Leave it disabled for an ungrouped roster.
+
+To place an account in a different public recognition tier, add an override. Overrides take precedence over the GitHub tier:
+
+```json
+{
+  "login": "some-account",
+  "recognitionTierKey": "Gold"
+}
+```
+
+Manual entries use the same renderer and tier keys. They are intended for companies or people whose support is tracked outside GitHub:
+
+```json
+{
+  "key": "example-company",
+  "displayName": "Example Company",
+  "profileUrl": "https://example.com",
+  "avatarUrl": "https://example.com/logo.png",
+  "recognitionTierKey": "Platinum"
+}
+```
+
+If `tiers` contains custom definitions, those definitions replace the defaults. `unmappedTierKey` must name one of the configured tiers.
+
+## Choose the output
+
+An output can create a full `SPONSORS.md`, update an existing block, or add a compact avatar row to a README. Output paths are relative to the repository root.
+
+New files require `createIfMissing: true`. Existing files require markers such as:
+
+```markdown
+<!-- POWERFORGE:sponsors-readme:START -->
+<!-- POWERFORGE:sponsors-readme:END -->
+```
+
+Set `missingBlockBehavior` to `Append` only when the generator should add a missing block to an existing document. The default, `Fail`, protects hand-written content from accidental placement changes.
+
+`Full` output groups current sponsors by recognition tier and keeps former public sponsors in a separate, untiered list. `Compact` output shows current sponsor avatars and can link to the full roster.
+
+## Run locally
+
+Provide an authenticated GitHub token through the configured environment variable. Do not store the token in the JSON file.
+
+```powershell
+$env:GITHUB_TOKEN = '<token>'
+powerforge github content sync --config .\.powerforge\github-content.json
+```
+
+Use `--output json` when another tool needs the changed paths and normalized sponsor records. Automation should also pass `--restrict-output-root <repository-root>`; PowerForge then rejects outside paths and symlink/reparse-point traversal before it writes any configured output. The reusable action supplies this restriction automatically.
+
+## Automate updates
+
+The reusable workflow can run on a schedule or on demand. It stages only document paths returned by PowerForge.
+
+```yaml
+name: Update sponsors
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * 1"
+
+permissions:
+  contents: write
+
+jobs:
+  sponsors:
+    # Pin a released tag or immutable commit SHA.
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@<commit-sha>
+    with:
+      config_path: .powerforge/github-content.json
+```
+
+The reusable workflow resolves its engine checkout from the exact commit that contains the called workflow. An explicit `powerforge_ref` override is available for controlled testing, but the default never follows a mutable branch.
+
+Set `commit_changes: false` to generate and validate content without pushing a commit. A caller may also pass a maintainer-authorized user token when accurate GitHub tier mapping is required:
+
+```yaml
+    secrets:
+      github_token: ${{ secrets.SPONSORS_TOKEN }}
+```
+
+GitHub does not expose a public sponsorship's selected tier to every viewer. The repository `GITHUB_TOKEN` is sufficient for the public roster, but it may return no tier for every sponsor. In that case all accounts use `unmappedTierKey`; no amount is guessed. Store a suitable user token as `SPONSORS_TOKEN` (or another repository or organization secret) when tier grouping must reflect the selected GitHub tier.
+
+Set `requireFundingTierData` to `true` for that case. If GitHub withholds every current sponsor's tier, PowerForge then fails before writing instead of silently moving the whole roster into the fallback tier. Individual custom sponsorships can still use the fallback while other sponsors retain their mapped tiers.
+
+## Public data and former sponsors
+
+PowerForge always queries GitHub with `includePrivate: false`; private sponsorships are not requested or rendered. Current sponsorships and all public sponsorships are queried separately so former public sponsors can be recognized without requesting sponsorship IDs or private metadata. Custom GraphQL endpoints must use HTTPS because every request carries a bearer token.
+
+An account that stopped and later resumed sponsorship is treated as current. Former sponsors are not assigned a historical recognition tier because GitHub’s public connection does not provide a reliable status-and-tier history for that purpose.

--- a/Docs/PowerForge.GitHubContent.md
+++ b/Docs/PowerForge.GitHubContent.md
@@ -97,7 +97,7 @@ jobs:
 
 The reusable workflow resolves its engine checkout from the exact commit that contains the called workflow. An explicit `powerforge_ref` override is available for controlled testing, but the default never follows a mutable branch.
 
-Set `commit_changes: false` to generate and validate content without pushing a commit. A caller may also pass a maintainer-authorized user token when accurate GitHub tier mapping is required:
+With the default `commit_changes: true`, the caller must run on a branch ref because the workflow commits back to that branch. Set `commit_changes: false` to generate and validate content from a tag, pull request ref, or another non-branch ref without pushing a commit. A caller may also pass a maintainer-authorized user token when accurate GitHub tier mapping is required:
 
 ```yaml
     secrets:
@@ -106,7 +106,7 @@ Set `commit_changes: false` to generate and validate content without pushing a c
 
 GitHub does not expose a public sponsorship's selected tier to every viewer. The repository `GITHUB_TOKEN` is sufficient for the public roster, but it may return no tier for every sponsor. In that case all accounts use `unmappedTierKey`; no amount is guessed. Store a suitable user token as `SPONSORS_TOKEN` (or another repository or organization secret) when tier grouping must reflect the selected GitHub tier.
 
-Set `requireFundingTierData` to `true` for that case. If GitHub withholds every current sponsor's tier, PowerForge then fails before writing instead of silently moving the whole roster into the fallback tier. Individual custom sponsorships can still use the fallback while other sponsors retain their mapped tiers.
+The starter config leaves `requireFundingTierData` set to `false`, so it works with the normal workflow token and uses the fallback tier when GitHub withholds tier metadata. Set it to `true` only when the workflow receives a suitable token and accurate GitHub tier mapping is required. If GitHub then withholds every current sponsor's tier, PowerForge fails before writing instead of silently moving the whole roster into the fallback tier. Individual custom sponsorships can still use the fallback while other sponsors retain their mapped tiers.
 
 ## Public data and former sponsors
 

--- a/Examples/GitHubContent/github-content.json
+++ b/Examples/GitHubContent/github-content.json
@@ -6,7 +6,7 @@
     "sponsorableLogin": "your-github-login",
     "includeFormer": true,
     "failOnEmpty": true,
-    "requireFundingTierData": true,
+    "requireFundingTierData": false,
     "tierRecognition": {
       "enabled": true,
       "useDefaultTiers": true,

--- a/Examples/GitHubContent/github-content.json
+++ b/Examples/GitHubContent/github-content.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/github.content.schema.json",
+  "tokenEnvName": "GITHUB_TOKEN",
+  "sponsors": {
+    "enabled": true,
+    "sponsorableLogin": "your-github-login",
+    "includeFormer": true,
+    "failOnEmpty": true,
+    "requireFundingTierData": true,
+    "tierRecognition": {
+      "enabled": true,
+      "useDefaultTiers": true,
+      "unmappedTierKey": "Sponsors"
+    },
+    "overrides": [
+      {
+        "login": "account-to-recognize-differently",
+        "recognitionTierKey": "Gold"
+      }
+    ],
+    "manualEntries": [
+      {
+        "key": "example-company",
+        "displayName": "Example Company",
+        "profileUrl": "https://example.com",
+        "avatarUrl": "https://example.com/logo.png",
+        "recognitionTierKey": "Platinum"
+      }
+    ],
+    "outputs": [
+      {
+        "path": "SPONSORS.md",
+        "blockId": "sponsors",
+        "layout": "Full",
+        "title": "Sponsors",
+        "introduction": "Thank you to everyone who supports this project.",
+        "includeFormer": true,
+        "createIfMissing": true
+      },
+      {
+        "path": "README.md",
+        "blockId": "sponsors-readme",
+        "layout": "Compact",
+        "includeFormer": false,
+        "createIfMissing": false,
+        "missingBlockBehavior": "Fail",
+        "avatarSize": 48,
+        "maxEntries": 12,
+        "moreLink": "SPONSORS.md"
+      }
+    ]
+  }
+}

--- a/PowerForge.Cli/PowerForgeCliJsonContext.cs
+++ b/PowerForge.Cli/PowerForgeCliJsonContext.cs
@@ -74,6 +74,8 @@ namespace PowerForge.Cli;
 [JsonSerializable(typeof(WorkspaceValidationResult))]
 [JsonSerializable(typeof(GitHubHousekeepingSpec))]
 [JsonSerializable(typeof(GitHubHousekeepingResult))]
+[JsonSerializable(typeof(GitHubRepositoryContentSpec))]
+[JsonSerializable(typeof(GitHubRepositoryContentResult))]
 [JsonSerializable(typeof(GitHubArtifactCleanupResult))]
 [JsonSerializable(typeof(GitHubActionsCacheCleanupResult))]
 [JsonSerializable(typeof(RunnerHousekeepingResult))]

--- a/PowerForge.Cli/Program.Command.GitHub.Content.cs
+++ b/PowerForge.Cli/Program.Command.GitHub.Content.cs
@@ -1,0 +1,175 @@
+using PowerForge;
+using PowerForge.Cli;
+
+internal static partial class Program
+{
+    private static int CommandGitHubContent(string[] argv, CliOptions cli, ILogger logger)
+    {
+        if (argv.Length == 0 || IsHelpArg(argv[0]) || !argv[0].Equals("sync", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine(GitHubContentSyncUsage);
+            return 2;
+        }
+
+        var syncArgs = argv.Skip(1).ToArray();
+        var outputJson = IsJsonOutput(syncArgs);
+        GitHubRepositoryContentSpec spec;
+        string configPath;
+        string? restrictedOutputRoot;
+        try
+        {
+            (spec, configPath, restrictedOutputRoot) = ParseGitHubContentSyncArgs(syncArgs);
+        }
+        catch (Exception ex)
+        {
+            return WriteGitHubCommandArgumentError(outputJson, "github.content.sync", ex.Message, GitHubContentSyncUsage, logger);
+        }
+
+        try
+        {
+            var (cmdLogger, logBuffer) = CreateCommandLogger(outputJson, cli, logger);
+            var service = new GitHubRepositoryContentService(cmdLogger);
+            var baseDirectory = FindGitRepositoryRoot(configPath);
+            var result = RunWithStatus(
+                outputJson,
+                cli,
+                "Synchronizing GitHub repository content",
+                () => service.Sync(spec, baseDirectory, restrictedOutputRoot));
+            var exitCode = result.Success ? 0 : 1;
+
+            if (outputJson)
+            {
+                WriteJson(new CliJsonEnvelope
+                {
+                    SchemaVersion = OutputSchemaVersion,
+                    Command = "github.content.sync",
+                    Success = result.Success,
+                    ExitCode = exitCode,
+                    Result = CliJson.SerializeToElement(result, CliJson.Context.GitHubRepositoryContentResult),
+                    Logs = LogsToJsonElement(logBuffer)
+                });
+                return exitCode;
+            }
+
+            logger.Info($"Sponsors: {result.CurrentSponsors.Length} current, {result.FormerSponsors.Length} former.");
+            foreach (var document in result.Documents)
+            {
+                var state = document.Created ? "created" : document.Appended ? "appended" : document.Changed ? "updated" : "unchanged";
+                logger.Info($"{document.Path}: {state}");
+            }
+            return exitCode;
+        }
+        catch (Exception ex)
+        {
+            return WriteGitHubCommandFailure(outputJson, "github.content.sync", ex.Message, logger);
+        }
+    }
+
+    private static (GitHubRepositoryContentSpec Spec, string ConfigPath, string? RestrictedOutputRoot) ParseGitHubContentSyncArgs(string[] argv)
+    {
+        var configPath = TryGetOptionValue(argv, "--config");
+        if (string.IsNullOrWhiteSpace(configPath))
+            configPath = FindDefaultGitHubContentConfig(Directory.GetCurrentDirectory());
+        if (string.IsNullOrWhiteSpace(configPath))
+            throw new InvalidOperationException("GitHub content config file not found. Provide --config or add .powerforge/github-content.json.");
+
+        var (spec, fullConfigPath) = LoadGitHubRepositoryContentSpecWithPath(configPath!);
+        spec.Sponsors ??= new GitHubSponsorsContentSpec();
+        string? restrictedOutputRoot = null;
+
+        for (var index = 0; index < argv.Length; index++)
+        {
+            var arg = argv[index];
+            switch (arg.ToLowerInvariant())
+            {
+                case "--config":
+                    index++;
+                    break;
+                case "--login":
+                case "--sponsorable":
+                    spec.Sponsors.SponsorableLogin = ReadRequiredValue(argv, ref index, arg);
+                    break;
+                case "--graphql-endpoint":
+                case "--api-url":
+                    spec.GraphQlEndpoint = ReadRequiredValue(argv, ref index, arg);
+                    break;
+                case "--token":
+                    spec.Token = ReadRequiredValue(argv, ref index, arg);
+                    break;
+                case "--token-env":
+                    spec.TokenEnvName = ReadRequiredValue(argv, ref index, arg);
+                    break;
+                case "--restrict-output-root":
+                    restrictedOutputRoot = Path.GetFullPath(ReadRequiredValue(argv, ref index, arg));
+                    break;
+                case "--output":
+                    index++;
+                    break;
+                case "--output-json":
+                case "--json":
+                    break;
+                default:
+                    ThrowOnUnknownOption(arg);
+                    break;
+            }
+        }
+
+        return (spec, fullConfigPath, restrictedOutputRoot);
+    }
+
+    private static string? FindDefaultGitHubContentConfig(string baseDirectory)
+    {
+        var candidates = new[]
+        {
+            "github-content.json",
+            Path.Combine(".powerforge", "github-content.json"),
+            Path.Combine(".github", "powerforge", "github-content.json")
+        };
+
+        foreach (var directory in EnumerateSelfAndParents(baseDirectory))
+        {
+            foreach (var relativePath in candidates)
+            {
+                try
+                {
+                    var fullPath = Path.GetFullPath(Path.Combine(directory, relativePath));
+                    if (File.Exists(fullPath))
+                        return fullPath;
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+
+        return null;
+    }
+
+    private static string ReadRequiredValue(string[] argv, ref int index, string optionName)
+    {
+        if (++index >= argv.Length || string.IsNullOrWhiteSpace(argv[index]))
+            throw new InvalidOperationException($"{optionName} requires a value.");
+        return argv[index];
+    }
+
+    private static (GitHubRepositoryContentSpec Value, string FullPath) LoadGitHubRepositoryContentSpecWithPath(string path)
+    {
+        var fullPath = ResolveExistingFilePath(path);
+        var json = File.ReadAllText(fullPath);
+        var spec = CliJson.DeserializeOrThrow(json, CliJson.Context.GitHubRepositoryContentSpec, fullPath);
+        return (spec, fullPath);
+    }
+
+    private static string FindGitRepositoryRoot(string configPath)
+    {
+        var current = new DirectoryInfo(Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            var marker = Path.Combine(current.FullName, ".git");
+            if (Directory.Exists(marker) || File.Exists(marker))
+                return current.FullName;
+            current = current.Parent;
+        }
+
+        return Path.GetDirectoryName(configPath) ?? Directory.GetCurrentDirectory();
+    }
+}

--- a/PowerForge.Cli/Program.Command.GitHub.cs
+++ b/PowerForge.Cli/Program.Command.GitHub.cs
@@ -9,6 +9,7 @@ internal static partial class Program
 {
     private const string GitHubArtifactsPruneUsage = "Usage: powerforge github artifacts prune [--repo <owner/repo>] [--api-base-url <Url>] [--token-env <ENV>] [--token <TOKEN>] [--name <pattern[,pattern...]>] [--exclude <pattern[,pattern...]>] [--keep <N>] [--max-age-days <N>] [--max-delete <N>] [--dry-run|--apply] [--fail-on-delete-error] [--output json]";
     private const string GitHubCachesPruneUsage = "Usage: powerforge github caches prune [--repo <owner/repo>] [--api-base-url <Url>] [--token-env <ENV>] [--token <TOKEN>] [--key <pattern[,pattern...]>] [--exclude <pattern[,pattern...]>] [--keep <N>] [--max-age-days <N>] [--max-delete <N>] [--dry-run|--apply] [--fail-on-delete-error] [--output json]";
+    private const string GitHubContentSyncUsage = "Usage: powerforge github content sync [--config <file>] [--login <LOGIN>] [--graphql-endpoint <URL>] [--token-env <ENV>] [--token <TOKEN>] [--restrict-output-root <path>] [--output json]";
     private const string GitHubHousekeepingUsage = "Usage: powerforge github housekeeping [--config <file>] [--repo <owner/repo>] [--api-base-url <Url>] [--token-env <ENV>] [--token <TOKEN>] [--runner-min-free-gb <N>] [--dry-run|--apply] [--output json]";
     private const string GitHubRunnerCleanupUsage = "Usage: powerforge github runner cleanup [--runner-temp <path>] [--work-root <path>] [--runner-root <path>] [--diag-root <path>] [--tool-cache <path>] [--min-free-gb <N>] [--aggressive-threshold-gb <N>] [--diag-retention-days <N>] [--actions-retention-days <N>] [--workspaces-retention-days|--workspace-retention-days <N>] [--tool-cache-retention-days <N>] [--dry-run|--apply] [--aggressive] [--allow-sudo] [--clean-workspaces] [--skip-diagnostics] [--skip-runner-temp] [--skip-actions-cache] [--skip-workspaces] [--skip-tool-cache] [--skip-dotnet-cache] [--skip-docker] [--no-docker-volumes] [--output json] (when conflicting cleanup/skip flags are provided, the later flag wins)";
 
@@ -19,6 +20,7 @@ internal static partial class Program
         {
             Console.WriteLine(GitHubArtifactsPruneUsage);
             Console.WriteLine(GitHubCachesPruneUsage);
+            Console.WriteLine(GitHubContentSyncUsage);
             Console.WriteLine(GitHubHousekeepingUsage);
             Console.WriteLine(GitHubRunnerCleanupUsage);
             return 2;
@@ -28,6 +30,7 @@ internal static partial class Program
         {
             "artifacts" => CommandGitHubArtifacts(argv.Skip(1).ToArray(), cli, logger),
             "caches" => CommandGitHubCaches(argv.Skip(1).ToArray(), cli, logger),
+            "content" => CommandGitHubContent(argv.Skip(1).ToArray(), cli, logger),
             "housekeeping" => CommandGitHubHousekeeping(argv.Skip(1).ToArray(), cli, logger),
             "runner" => CommandGitHubRunner(argv.Skip(1).ToArray(), cli, logger),
             _ => UnknownGitHubCommand()
@@ -317,6 +320,7 @@ internal static partial class Program
     {
         Console.WriteLine(GitHubArtifactsPruneUsage);
         Console.WriteLine(GitHubCachesPruneUsage);
+        Console.WriteLine(GitHubContentSyncUsage);
         Console.WriteLine(GitHubHousekeepingUsage);
         Console.WriteLine(GitHubRunnerCleanupUsage);
         return 2;

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PowerForge.Tests;
+
+public sealed class GitHubContentActionTests
+{
+    [Fact]
+    public void ExampleConfig_DeserializesToOptInTieredOutputs()
+    {
+        var repoRoot = FindRepoRoot();
+        var configPath = Path.Combine(repoRoot, "Examples", "GitHubContent", "github-content.json");
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+
+        var spec = JsonSerializer.Deserialize<GitHubRepositoryContentSpec>(File.ReadAllText(configPath), options);
+
+        Assert.NotNull(spec);
+        Assert.True(spec.Sponsors.Enabled);
+        Assert.True(spec.Sponsors.TierRecognition.Enabled);
+        Assert.Equal(2, spec.Sponsors.Outputs.Length);
+        Assert.Contains(spec.Sponsors.Outputs, output => output.Layout == GitHubSponsorsMarkdownLayout.Full && output.CreateIfMissing);
+        Assert.Contains(spec.Sponsors.Outputs, output => output.Layout == GitHubSponsorsMarkdownLayout.Compact && !output.CreateIfMissing);
+    }
+
+    [Fact]
+    public void CompositeAction_ReportsOnlyChangedDocumentsInsideCallerWorkspace()
+    {
+        var repoRoot = FindRepoRoot();
+        var action = File.ReadAllText(Path.Combine(repoRoot, ".github", "actions", "github-content", "action.yml"));
+
+        Assert.Contains("github content sync", action, StringComparison.Ordinal);
+        var client = File.ReadAllText(Path.Combine(repoRoot, "PowerForge", "Services", "GitHubSponsorsClient.cs"));
+        Assert.Contains("includePrivate", client, StringComparison.Ordinal);
+        Assert.Contains("repositoryOwner(login: $login)", client, StringComparison.Ordinal);
+        Assert.Contains("Generated document is outside the caller workspace", action, StringComparison.Ordinal);
+        Assert.Contains("--restrict-output-root $workspace", action, StringComparison.Ordinal);
+        Assert.Contains("changed-paths-json", action, StringComparison.Ordinal);
+        Assert.Contains("GITHUB_TOKEN: ${{ inputs['github-token'] }}", action, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReusableWorkflow_StagesReportedPathsInsteadOfTheRuntimeCheckout()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "powerforge-github-content.yml"));
+
+        Assert.Contains("permissions:\n  contents: write", Normalize(workflow), StringComparison.Ordinal);
+        Assert.Contains("if: inputs.commit_changes && steps.content.outputs.changed == 'true'", workflow, StringComparison.Ordinal);
+        Assert.Contains("git add -- $path", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("git add --all", workflow, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("git add .", workflow, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(".powerforge-runtime/pspublishmodule", workflow, StringComparison.Ordinal);
+        Assert.Contains("job.workflow_repository", workflow, StringComparison.Ordinal);
+        Assert.Contains("job.workflow_sha", workflow, StringComparison.Ordinal);
+        Assert.Contains("default: \"\"", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("default: \"main\"", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PublicDocumentation_LinksTheConfigAndReusableWorkflow()
+    {
+        var repoRoot = FindRepoRoot();
+        var docs = File.ReadAllText(Path.Combine(repoRoot, "Docs", "PowerForge.GitHubContent.md"));
+        var readme = File.ReadAllText(Path.Combine(repoRoot, "README.md"));
+
+        Assert.Contains("tierRecognition.enabled", docs, StringComparison.Ordinal);
+        Assert.Contains("includePrivate: false", docs, StringComparison.Ordinal);
+        Assert.Contains("powerforge-github-content.yml", docs, StringComparison.Ordinal);
+        Assert.Contains("Docs/PowerForge.GitHubContent.md", readme, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var index = 0; index < 12 && current is not null; index++)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return current.FullName;
+            current = current.Parent;
+        }
+        throw new DirectoryNotFoundException("Unable to locate the PowerForge repository root.");
+    }
+
+    private static string Normalize(string value)
+        => value.Replace("\r\n", "\n").Replace('\r', '\n');
+}

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -58,6 +58,7 @@ public sealed class GitHubContentActionTests
         Assert.Contains("includePrivate", client, StringComparison.Ordinal);
         Assert.Contains("repositoryOwner(login: $login)", client, StringComparison.Ordinal);
         Assert.Contains("Generated document is outside the caller workspace", action, StringComparison.Ordinal);
+        Assert.Contains("--token-env GITHUB_TOKEN", action, StringComparison.Ordinal);
         Assert.Contains("--restrict-output-root $workspace", action, StringComparison.Ordinal);
         Assert.Contains("changed-paths-json", action, StringComparison.Ordinal);
         Assert.Contains("GITHUB_TOKEN: ${{ inputs['github-token'] }}", action, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -83,6 +83,14 @@ public sealed class GitHubContentActionTests
         Assert.Contains("cancel-in-progress: false", workflow, StringComparison.Ordinal);
         Assert.Contains("default: \"\"", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("default: \"main\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("[string]::IsNullOrWhiteSpace($env:COMMIT_MESSAGE)", workflow, StringComparison.Ordinal);
+
+        var commitIndex = workflow.IndexOf("git commit -m $env:COMMIT_MESSAGE", StringComparison.Ordinal);
+        Assert.True(commitIndex >= 0, "The reusable workflow must commit the generated changes.");
+        var exitCodeCheckIndex = workflow.IndexOf("if ($LASTEXITCODE -ne 0)", commitIndex, StringComparison.Ordinal);
+        var pushIndex = workflow.IndexOf("git push", commitIndex, StringComparison.Ordinal);
+        Assert.True(exitCodeCheckIndex > commitIndex, "The reusable workflow must inspect the commit exit code.");
+        Assert.True(pushIndex > exitCodeCheckIndex, "The reusable workflow must fail a bad commit before pushing.");
     }
 
     [Fact]
@@ -90,7 +98,7 @@ public sealed class GitHubContentActionTests
     {
         var repoRoot = FindRepoRoot();
         var docs = File.ReadAllText(Path.Combine(repoRoot, "Docs", "PowerForge.GitHubContent.md"));
-        var readme = File.ReadAllText(Path.Combine(repoRoot, "README.md"));
+        var readme = File.ReadAllText(Path.Combine(repoRoot, "README.MD"));
 
         Assert.Contains("tierRecognition.enabled", docs, StringComparison.Ordinal);
         Assert.Contains("includePrivate: false", docs, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -72,7 +72,8 @@ public sealed class GitHubContentActionTests
 
         Assert.Contains("permissions:\n  contents: write", Normalize(workflow), StringComparison.Ordinal);
         Assert.Contains("if: inputs.commit_changes && steps.content.outputs.changed == 'true'", workflow, StringComparison.Ordinal);
-        Assert.Contains("git add -- $path", workflow, StringComparison.Ordinal);
+        Assert.Contains("git --literal-pathspecs add -- $path", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("git add -- $path", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("git add --all", workflow, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("git add .", workflow, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(".powerforge-runtime/pspublishmodule", workflow, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -23,9 +23,34 @@ public sealed class GitHubContentActionTests
         Assert.NotNull(spec);
         Assert.True(spec.Sponsors.Enabled);
         Assert.True(spec.Sponsors.TierRecognition.Enabled);
+        Assert.False(spec.Sponsors.RequireFundingTierData);
         Assert.Equal(2, spec.Sponsors.Outputs.Length);
         Assert.Contains(spec.Sponsors.Outputs, output => output.Layout == GitHubSponsorsMarkdownLayout.Full && output.CreateIfMissing);
         Assert.Contains(spec.Sponsors.Outputs, output => output.Layout == GitHubSponsorsMarkdownLayout.Compact && !output.CreateIfMissing);
+    }
+
+    [Fact]
+    public void ReusableWorkflow_RejectsCommitFromNonBranchRef()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "powerforge-github-content.yml"));
+
+        Assert.Contains("if: inputs.commit_changes", workflow, StringComparison.Ordinal);
+        Assert.Contains("CALLER_REF: ${{ github.ref }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("$env:CALLER_REF.StartsWith('refs/heads/'", workflow, StringComparison.Ordinal);
+        Assert.Contains("Set commit_changes to false for tag or pull request refs", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReusableWorkflow_PassesCustomEngineRefAsData()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "powerforge-github-content.yml"));
+
+        Assert.Contains("POWERFORGE_REF: ${{ inputs.powerforge_ref }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("$ref = [string]$env:POWERFORGE_REF", workflow, StringComparison.Ordinal);
+        Assert.Contains("powerforge_ref must be a single-line Git ref or commit SHA", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("'${{ inputs.powerforge_ref }}'", workflow, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -69,7 +94,9 @@ public sealed class GitHubContentActionTests
     {
         var repoRoot = FindRepoRoot();
         var workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "powerforge-github-content.yml"));
+        var parsedWorkflow = new YamlDotNet.Serialization.DeserializerBuilder().Build().Deserialize<object>(workflow);
 
+        Assert.NotNull(parsedWorkflow);
         Assert.Contains("permissions:\n  contents: write", Normalize(workflow), StringComparison.Ordinal);
         Assert.Contains("if: inputs.commit_changes && steps.content.outputs.changed == 'true'", workflow, StringComparison.Ordinal);
         Assert.Contains("git --literal-pathspecs add -- $path", workflow, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -77,6 +77,8 @@ public sealed class GitHubContentActionTests
         Assert.Contains(".powerforge-runtime/pspublishmodule", workflow, StringComparison.Ordinal);
         Assert.Contains("job.workflow_repository", workflow, StringComparison.Ordinal);
         Assert.Contains("job.workflow_sha", workflow, StringComparison.Ordinal);
+        Assert.Contains("group: powerforge-github-content-${{ github.repository }}-${{ github.ref }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("cancel-in-progress: false", workflow, StringComparison.Ordinal);
         Assert.Contains("default: \"\"", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("default: \"main\"", workflow, StringComparison.Ordinal);
     }

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -81,6 +81,11 @@ public sealed class GitHubContentActionTests
         Assert.Contains("job.workflow_sha", workflow, StringComparison.Ordinal);
         Assert.Contains("group: powerforge-github-content-${{ github.repository }}-${{ github.ref }}", workflow, StringComparison.Ordinal);
         Assert.Contains("cancel-in-progress: false", workflow, StringComparison.Ordinal);
+        Assert.Contains(
+            "- name: Checkout caller repository\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n        with:\n          # Resolve the branch when this serialized job actually starts.",
+            Normalize(workflow),
+            StringComparison.Ordinal);
+        Assert.Contains("ref: ${{ github.ref }}", workflow, StringComparison.Ordinal);
         Assert.Contains("default: \"\"", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("default: \"main\"", workflow, StringComparison.Ordinal);
         Assert.Contains("[string]::IsNullOrWhiteSpace($env:COMMIT_MESSAGE)", workflow, StringComparison.Ordinal);

--- a/PowerForge.Tests/GitHubContentActionTests.cs
+++ b/PowerForge.Tests/GitHubContentActionTests.cs
@@ -29,6 +29,25 @@ public sealed class GitHubContentActionTests
     }
 
     [Fact]
+    public void Schema_AllowsEnvironmentBasedSponsorableLoginFallback()
+    {
+        var repoRoot = FindRepoRoot();
+        var schemaPath = Path.Combine(repoRoot, "Schemas", "github.content.schema.json");
+        using var schema = JsonDocument.Parse(File.ReadAllText(schemaPath));
+        var required = schema.RootElement
+            .GetProperty("definitions")
+            .GetProperty("sponsors")
+            .GetProperty("required")
+            .EnumerateArray()
+            .Select(value => value.GetString())
+            .ToArray();
+
+        Assert.DoesNotContain("sponsorableLogin", required);
+        Assert.Contains("enabled", required);
+        Assert.Contains("outputs", required);
+    }
+
+    [Fact]
     public void CompositeAction_ReportsOnlyChangedDocumentsInsideCallerWorkspace()
     {
         var repoRoot = FindRepoRoot();

--- a/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
+++ b/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
@@ -184,6 +184,66 @@ public sealed class GitHubRepositoryContentServiceTests
         Assert.Equal(original, File.ReadAllText(first));
     }
 
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public void Sync_RejectsOverlappingBlocksBeforeWritingAnyFile(bool outerFirst, bool appendInner)
+    {
+        var root = CreateTempRoot();
+        var first = Path.Combine(root, "SPONSORS.md");
+        const string firstOriginal = "<!-- POWERFORGE:sponsors:START -->\nold\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(first, firstOriginal);
+        var readme = Path.Combine(root, "README.md");
+        const string readmeOriginal =
+            "<!-- POWERFORGE:outer:START -->\n" +
+            "before\n" +
+            "<!-- POWERFORGE:inner:START -->\ninner\n<!-- POWERFORGE:inner:END -->\n" +
+            "after\n" +
+            "<!-- POWERFORGE:outer:END -->\n";
+        File.WriteAllText(readme, readmeOriginal);
+        var outer = new GitHubSponsorsOutputSpec { Path = "README.md", BlockId = "outer" };
+        var inner = new GitHubSponsorsOutputSpec
+        {
+            Path = "README.md",
+            BlockId = "inner",
+            MissingBlockBehavior = appendInner
+                ? ManagedMarkdownMissingBlockBehavior.Append
+                : ManagedMarkdownMissingBlockBehavior.Fail
+        };
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = outerFirst
+                    ? new[]
+                    {
+                        new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors" },
+                        outer,
+                        inner
+                    }
+                    : new[]
+                    {
+                        new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors" },
+                        inner,
+                        outer
+                    }
+            }
+        }, root));
+
+        Assert.Contains("overlap", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(firstOriginal, File.ReadAllText(first));
+        Assert.Equal(readmeOriginal, File.ReadAllText(readme));
+    }
+
     [Fact]
     public void Sync_RejectsMultipleBlocksForSameMissingDocumentBeforeWriting()
     {
@@ -317,6 +377,79 @@ public sealed class GitHubRepositoryContentServiceTests
 
         Assert.Contains("symbolic link or reparse point", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.False(File.Exists(Path.Combine(outsideRoot, "SPONSORS.md")));
+    }
+
+    [Fact]
+    public void Sync_RejectsRestrictedOutputRootThatIsSymlink()
+    {
+        var holder = CreateTempRoot();
+        var outsideRoot = CreateTempRoot();
+        var linkedRoot = Path.Combine(holder, "linked-root");
+        try
+        {
+            Directory.CreateSymbolicLink(linkedRoot, outsideRoot);
+        }
+        catch (Exception linkException) when (linkException is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors", CreateIfMissing = true }
+                }
+            }
+        }, linkedRoot, restrictedOutputRoot: linkedRoot));
+
+        Assert.Contains("symbolic link or reparse point", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(outsideRoot, "SPONSORS.md")));
+    }
+
+    [Fact]
+    public void Sync_RejectsRestrictedOutputRootWithSymlinkedAncestor()
+    {
+        var holder = CreateTempRoot();
+        var outsideRoot = CreateTempRoot();
+        var linkedAncestor = Path.Combine(holder, "linked-ancestor");
+        try
+        {
+            Directory.CreateSymbolicLink(linkedAncestor, outsideRoot);
+        }
+        catch (Exception linkException) when (linkException is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        var restrictedRoot = Path.Combine(linkedAncestor, "nested");
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors", CreateIfMissing = true }
+                }
+            }
+        }, restrictedRoot, restrictedOutputRoot: restrictedRoot));
+
+        Assert.Contains("symbolic link or reparse point", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(outsideRoot, "nested", "SPONSORS.md")));
     }
 
     [Fact]

--- a/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
+++ b/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
@@ -1,0 +1,384 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed class GitHubRepositoryContentServiceTests
+{
+    [Fact]
+    public void Sync_CreatesFullRosterAndUpdatesCompactReadmeBlock()
+    {
+        var root = CreateTempRoot();
+        var readme = Path.Combine(root, "README.md");
+        File.WriteAllText(readme, "# Demo\n\n<!-- POWERFORGE:sponsors:START -->\nold\n<!-- POWERFORGE:sponsors:END -->\n");
+        using var httpClient = new HttpClient(new SponsorsHandler(activeOnly => activeOnly
+            ? Response(Node("alice", "Alice", 30) + "," + Node("custom", "Custom", null))
+            : Response(Node("alice", "Alice", 30) + "," + Node("custom", "Custom", null) + "," + Node("former", "Former", 5))));
+        var service = new GitHubRepositoryContentService(
+            sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var result = service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = true },
+                Overrides = new[] { new GitHubSponsorOverrideSpec { Login = "custom", RecognitionTierKey = "Platinum" } },
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = "SPONSORS.md",
+                        BlockId = "sponsors",
+                        CreateIfMissing = true,
+                        Introduction = "Thank you for supporting this project."
+                    },
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = "README.md",
+                        BlockId = "sponsors",
+                        Layout = GitHubSponsorsMarkdownLayout.Compact,
+                        MoreLink = "SPONSORS.md"
+                    }
+                }
+            }
+        }, root);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.CurrentSponsors.Length);
+        Assert.Single(result.FormerSponsors);
+        Assert.Equal(2, result.Documents.Length);
+        var sponsors = File.ReadAllText(Path.Combine(root, "SPONSORS.md"));
+        Assert.Contains("# Sponsors", sponsors, StringComparison.Ordinal);
+        Assert.Contains("## Platinum Sponsors", sponsors, StringComparison.Ordinal);
+        Assert.Contains("## Gold Sponsors", sponsors, StringComparison.Ordinal);
+        Assert.Contains("## Past Sponsors", sponsors, StringComparison.Ordinal);
+        var readmeText = File.ReadAllText(readme);
+        Assert.DoesNotContain("old", readmeText, StringComparison.Ordinal);
+        Assert.Contains("[See all sponsors](SPONSORS.md)", readmeText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sync_DoesNotModifyDocumentsWhenGitHubReturnsNoCurrentSponsors()
+    {
+        var root = CreateTempRoot();
+        var readme = Path.Combine(root, "README.md");
+        const string original = "<!-- POWERFORGE:sponsors:START -->\nkeep\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(readme, original);
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(string.Empty)));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                Outputs = new[] { new GitHubSponsorsOutputSpec { Path = "README.md", BlockId = "sponsors" } }
+            }
+        }, root));
+
+        Assert.Contains("no public current sponsors", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(readme));
+    }
+
+    [Fact]
+    public void Sync_PreflightsEveryDestinationBeforeWritingAnyFile()
+    {
+        var root = CreateTempRoot();
+        var first = Path.Combine(root, "SPONSORS.md");
+        File.WriteAllText(first, "<!-- POWERFORGE:sponsors:START -->\nold\n<!-- POWERFORGE:sponsors:END -->\n");
+        var invalidReadme = Path.Combine(root, "README.md");
+        File.WriteAllText(invalidReadme, "# Missing marker\n");
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors" },
+                    new GitHubSponsorsOutputSpec { Path = "README.md", BlockId = "sponsors" }
+                }
+            }
+        }, root));
+
+        Assert.Contains("old", File.ReadAllText(first), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sync_RefusesToCollapseTieredRosterWhenAllFundingTiersAreWithheld()
+    {
+        var root = CreateTempRoot();
+        var readme = Path.Combine(root, "README.md");
+        const string original = "<!-- POWERFORGE:sponsors:START -->\nkeep\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(readme, original);
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("custom", "Custom", null))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                RequireFundingTierData = true,
+                TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = true },
+                Outputs = new[] { new GitHubSponsorsOutputSpec { Path = "README.md", BlockId = "sponsors" } }
+            }
+        }, root));
+
+        Assert.Contains("withheld funding-tier data", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(readme));
+    }
+
+    [Fact]
+    public void Sync_RejectsOutsideOutputBeforeWritingAnyRestrictedDocument()
+    {
+        var root = CreateTempRoot();
+        var outsideRoot = CreateTempRoot();
+        var first = Path.Combine(root, "SPONSORS.md");
+        const string original = "<!-- POWERFORGE:sponsors:START -->\nold\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(first, original);
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors" },
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = Path.Combine(outsideRoot, "OUTSIDE.md"),
+                        BlockId = "sponsors",
+                        CreateIfMissing = true
+                    }
+                }
+            }
+        }, root, restrictedOutputRoot: root));
+
+        Assert.Contains("outside the restricted output root", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(first));
+        Assert.False(File.Exists(Path.Combine(outsideRoot, "OUTSIDE.md")));
+    }
+
+    [Fact]
+    public void Sync_RejectsOutputThroughSymlinkInsideRestrictedRoot()
+    {
+        var root = CreateTempRoot();
+        var outsideRoot = CreateTempRoot();
+        var link = Path.Combine(root, "linked-output");
+        try
+        {
+            Directory.CreateSymbolicLink(link, outsideRoot);
+        }
+        catch (Exception linkException) when (linkException is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = Path.Combine("linked-output", "SPONSORS.md"),
+                        BlockId = "sponsors",
+                        CreateIfMissing = true
+                    }
+                }
+            }
+        }, root, restrictedOutputRoot: root));
+
+        Assert.Contains("symbolic link or reparse point", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(Path.Combine(outsideRoot, "SPONSORS.md")));
+    }
+
+    [Fact]
+    public void Sync_RejectsDanglingFileSymlinkInsideRestrictedRoot()
+    {
+        var root = CreateTempRoot();
+        var outsideRoot = CreateTempRoot();
+        var outsideTarget = Path.Combine(outsideRoot, "SPONSORS.md");
+        var link = Path.Combine(root, "SPONSORS.md");
+        try
+        {
+            File.CreateSymbolicLink(link, outsideTarget);
+        }
+        catch (Exception linkException) when (linkException is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        Assert.False(File.Exists(outsideTarget));
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = "SPONSORS.md",
+                        BlockId = "sponsors",
+                        CreateIfMissing = true
+                    }
+                }
+            }
+        }, root, restrictedOutputRoot: root));
+
+        Assert.Contains("symbolic link or reparse point", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(outsideTarget));
+    }
+
+    [Fact]
+    public void Sync_RejectsCaseVariantDanglingSymlinkConservatively()
+    {
+        var root = CreateTempRoot();
+        var outsideRoot = CreateTempRoot();
+        var outsideTarget = Path.Combine(outsideRoot, "SPONSORS.md");
+        var link = Path.Combine(root, "SPONSORS.md");
+        try
+        {
+            File.CreateSymbolicLink(link, outsideTarget);
+        }
+        catch (Exception linkException) when (linkException is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = "sponsors.md",
+                        BlockId = "sponsors",
+                        CreateIfMissing = true
+                    }
+                }
+            }
+        }, root, restrictedOutputRoot: root));
+
+        Assert.Contains("symbolic link or reparse point", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(outsideTarget));
+    }
+
+    [Fact]
+    public void Sync_PrefersExactDanglingSymlinkOverCaseCollidingRegularFile()
+    {
+        var root = CreateTempRoot();
+        var outsideRoot = CreateTempRoot();
+        var outsideTarget = Path.Combine(outsideRoot, "SPONSORS.md");
+        File.WriteAllText(Path.Combine(root, "SPONSORS.md"), "regular file with different casing");
+        var exactLink = Path.Combine(root, "sponsors.md");
+        try
+        {
+            File.CreateSymbolicLink(exactLink, outsideTarget);
+        }
+        catch (Exception linkException) when (linkException is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = "sponsors.md",
+                        BlockId = "sponsors",
+                        CreateIfMissing = true
+                    }
+                }
+            }
+        }, root, restrictedOutputRoot: root));
+
+        Assert.Contains("symbolic link or reparse point", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(outsideTarget));
+    }
+
+    private static string Node(string login, string name, int? amount)
+    {
+        var tier = amount is null ? "null" : $"{{\"name\":\"Tier\",\"monthlyPriceInDollars\":{amount.Value}}}";
+        return $"{{\"sponsorEntity\":{{\"__typename\":\"User\",\"login\":\"{login}\",\"name\":\"{name}\",\"avatarUrl\":\"https://avatars.example/{login}\",\"url\":\"https://github.com/{login}\"}},\"tier\":{tier}}}";
+    }
+
+    private static string Response(string nodes)
+        => "{\"data\":{\"owner\":{\"__typename\":\"User\",\"sponsorshipsAsMaintainer\":{\"nodes\":[" + nodes + "],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}";
+
+    private static string CreateTempRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class SponsorsHandler(Func<bool, string> responseFactory) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            using var document = JsonDocument.Parse(body);
+            var activeOnly = document.RootElement.GetProperty("variables").GetProperty("activeOnly").GetBoolean();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseFactory(activeOnly), Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
+++ b/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
@@ -117,6 +117,74 @@ public sealed class GitHubRepositoryContentServiceTests
     }
 
     [Fact]
+    public void Sync_RejectsDirectoryDestinationBeforeWritingAnyFile()
+    {
+        var root = CreateTempRoot();
+        var first = Path.Combine(root, "SPONSORS.md");
+        const string original = "<!-- POWERFORGE:sponsors:START -->\nold\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(first, original);
+        var directoryDestination = Path.Combine(root, "README.md");
+        Directory.CreateDirectory(directoryDestination);
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<IOException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors" },
+                    new GitHubSponsorsOutputSpec { Path = "README.md", BlockId = "sponsors", CreateIfMissing = true }
+                }
+            }
+        }, root));
+
+        Assert.Contains("existing directory", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(first));
+    }
+
+    [Fact]
+    public void Sync_RejectsFileAncestorBeforeWritingAnyFile()
+    {
+        var root = CreateTempRoot();
+        var first = Path.Combine(root, "SPONSORS.md");
+        const string original = "<!-- POWERFORGE:sponsors:START -->\nold\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(first, original);
+        File.WriteAllText(Path.Combine(root, "occupied"), "not a directory");
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<IOException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "sponsors" },
+                    new GitHubSponsorsOutputSpec
+                    {
+                        Path = Path.Combine("occupied", "README.md"),
+                        BlockId = "sponsors",
+                        CreateIfMissing = true
+                    }
+                }
+            }
+        }, root));
+
+        Assert.Contains("existing file ancestor", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(first));
+    }
+
+    [Fact]
     public void Sync_RejectsMultipleBlocksForSameMissingDocumentBeforeWriting()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
+++ b/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
@@ -310,6 +310,37 @@ public sealed class GitHubRepositoryContentServiceTests
     }
 
     [Fact]
+    public void Sync_EvaluatesRequiredFundingDataAfterSponsorExclusions()
+    {
+        var root = CreateTempRoot();
+        var readme = Path.Combine(root, "README.md");
+        const string original = "<!-- POWERFORGE:sponsors:START -->\nkeep\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(readme, original);
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(
+            Node("tiered", "Tiered", 30) + "," +
+            Node("withheld", "Withheld", null))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                RequireFundingTierData = true,
+                TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = true },
+                Overrides = new[] { new GitHubSponsorOverrideSpec { Login = "tiered", Exclude = true } },
+                Outputs = new[] { new GitHubSponsorsOutputSpec { Path = "README.md", BlockId = "sponsors" } }
+            }
+        }, root));
+
+        Assert.Contains("withheld funding-tier data", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(readme));
+    }
+
+    [Fact]
     public void Sync_RejectsOutsideOutputBeforeWritingAnyRestrictedDocument()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
+++ b/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
@@ -78,6 +78,15 @@ public sealed class GitHubRepositoryContentServiceTests
             {
                 Enabled = true,
                 SponsorableLogin = "owner",
+                ManualEntries = new[]
+                {
+                    new GitHubManualSponsorSpec
+                    {
+                        Key = "manual-company",
+                        DisplayName = "Manual Company",
+                        RecognitionTierKey = "Sponsors"
+                    }
+                },
                 Outputs = new[] { new GitHubSponsorsOutputSpec { Path = "README.md", BlockId = "sponsors" } }
             }
         }, root));

--- a/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
+++ b/PowerForge.Tests/GitHubRepositoryContentServiceTests.cs
@@ -117,6 +117,34 @@ public sealed class GitHubRepositoryContentServiceTests
     }
 
     [Fact]
+    public void Sync_RejectsMultipleBlocksForSameMissingDocumentBeforeWriting()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "SPONSORS.md");
+        using var httpClient = new HttpClient(new SponsorsHandler(_ => Response(Node("alice", "Alice", 5))));
+        var service = new GitHubRepositoryContentService(sponsorsClient: new GitHubSponsorsClient(httpClient));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => service.Sync(new GitHubRepositoryContentSpec
+        {
+            Token = "token",
+            Sponsors = new GitHubSponsorsContentSpec
+            {
+                Enabled = true,
+                SponsorableLogin = "owner",
+                IncludeFormer = false,
+                Outputs = new[]
+                {
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "full", CreateIfMissing = true },
+                    new GitHubSponsorsOutputSpec { Path = "SPONSORS.md", BlockId = "compact", CreateIfMissing = true }
+                }
+            }
+        }, root));
+
+        Assert.Contains("Multiple managed blocks target missing document", exception.Message, StringComparison.Ordinal);
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
     public void Sync_RefusesToCollapseTieredRosterWhenAllFundingTiersAreWithheld()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/GitHubSponsorRecognitionServiceTests.cs
+++ b/PowerForge.Tests/GitHubSponsorRecognitionServiceTests.cs
@@ -1,0 +1,145 @@
+namespace PowerForge.Tests;
+
+public sealed class GitHubSponsorRecognitionServiceTests
+{
+    [Fact]
+    public void Prepare_UsesOptInBandsAndLetsManualOverridesWin()
+    {
+        var source = new[]
+        {
+            Sponsor("platinum", 100),
+            Sponsor("gold", 30),
+            Sponsor("bronze", 5),
+            Sponsor("custom", null),
+            Sponsor("hidden", 100)
+        };
+        var spec = new GitHubSponsorsContentSpec
+        {
+            TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = true },
+            Overrides = new[]
+            {
+                new GitHubSponsorOverrideSpec { Login = "bronze", RecognitionTierKey = "Gold" },
+                new GitHubSponsorOverrideSpec { Login = "custom", RecognitionTierKey = "Platinum", DisplayName = "Custom Company" },
+                new GitHubSponsorOverrideSpec { Login = "hidden", Exclude = true }
+            },
+            ManualEntries = new[]
+            {
+                new GitHubManualSponsorSpec
+                {
+                    Key = "invoice-company",
+                    DisplayName = "Invoice Company",
+                    ProfileUrl = "https://example.com",
+                    RecognitionTierKey = "Principal"
+                }
+            }
+        };
+
+        var result = new GitHubSponsorRecognitionService().Prepare(source, spec);
+
+        Assert.True(result.TierRecognitionEnabled);
+        Assert.Equal("Platinum", Assert.Single(result.Sponsors, item => item.Key == "platinum").RecognitionTierKey);
+        Assert.Equal("Gold", Assert.Single(result.Sponsors, item => item.Key == "gold").RecognitionTierKey);
+        Assert.Equal("Gold", Assert.Single(result.Sponsors, item => item.Key == "bronze").RecognitionTierKey);
+        var custom = Assert.Single(result.Sponsors, item => item.Key == "custom");
+        Assert.Equal("Platinum", custom.RecognitionTierKey);
+        Assert.Equal("Custom Company", custom.DisplayName);
+        Assert.Equal("Principal", Assert.Single(result.Sponsors, item => item.Key == "invoice-company").RecognitionTierKey);
+        Assert.DoesNotContain(result.Sponsors, item => item.Key == "hidden");
+    }
+
+    [Fact]
+    public void Prepare_LeavesFundingTierPrivateFromRecognitionWhenTieringIsDisabled()
+    {
+        var result = new GitHubSponsorRecognitionService().Prepare(new[] { Sponsor("gold", 30) }, new GitHubSponsorsContentSpec
+        {
+            TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = false },
+            Overrides = new[] { new GitHubSponsorOverrideSpec { Login = "gold", RecognitionTierKey = "Principal" } }
+        });
+
+        Assert.False(result.TierRecognitionEnabled);
+        Assert.Null(Assert.Single(result.Sponsors).RecognitionTierKey);
+    }
+
+    [Fact]
+    public void Prepare_RejectsUnknownExplicitRecognitionTier()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => new GitHubSponsorRecognitionService().Prepare(
+            new[] { Sponsor("alice", 5) },
+            new GitHubSponsorsContentSpec
+            {
+                TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = true },
+                Overrides = new[] { new GitHubSponsorOverrideSpec { Login = "alice", RecognitionTierKey = "Diamond" } }
+            }));
+
+        Assert.Contains("Diamond", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Prepare_MapsUnknownGitHubTierToNeutralFallback()
+    {
+        var result = new GitHubSponsorRecognitionService().Prepare(new[] { Sponsor("custom", null) }, new GitHubSponsorsContentSpec
+        {
+            TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = true }
+        });
+
+        Assert.Equal("Sponsors", Assert.Single(result.Sponsors).RecognitionTierKey);
+    }
+
+    [Fact]
+    public void Prepare_DoesNotPublishHistoricalTierClassificationForFormerSponsors()
+    {
+        var former = Sponsor("former", 100);
+        former.Sponsor.Status = GitHubSponsorStatus.Former;
+
+        var result = new GitHubSponsorRecognitionService().Prepare(new[] { former }, new GitHubSponsorsContentSpec
+        {
+            TierRecognition = new GitHubSponsorTierRecognitionSpec { Enabled = true }
+        });
+
+        Assert.Null(Assert.Single(result.Sponsors).RecognitionTierKey);
+    }
+
+    [Fact]
+    public void Prepare_RejectsManualLoginThatDuplicatesGitHubOrAnotherManualIdentity()
+    {
+        var service = new GitHubSponsorRecognitionService();
+        var githubCollision = Assert.Throws<InvalidOperationException>(() => service.Prepare(
+            new[] { Sponsor("alice", 5) },
+            new GitHubSponsorsContentSpec
+            {
+                ManualEntries = new[]
+                {
+                    new GitHubManualSponsorSpec { Key = "invoice-alice", Login = "alice", DisplayName = "Alice" }
+                }
+            }));
+        Assert.Contains("duplicates an existing sponsor", githubCollision.Message, StringComparison.OrdinalIgnoreCase);
+
+        var manualCollision = Assert.Throws<InvalidOperationException>(() => service.Prepare(
+            Array.Empty<GitHubSponsorSourceRecord>(),
+            new GitHubSponsorsContentSpec
+            {
+                ManualEntries = new[]
+                {
+                    new GitHubManualSponsorSpec { Key = "company-one", Login = "same-login", DisplayName = "One" },
+                    new GitHubManualSponsorSpec { Key = "same-login", DisplayName = "Two" }
+                }
+            }));
+        Assert.Contains("configured more than once", manualCollision.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static GitHubSponsorSourceRecord Sponsor(string login, int? amount)
+        => new()
+        {
+            Sponsor = new GitHubSponsorRecord
+            {
+                Key = login,
+                Login = login,
+                DisplayName = login,
+                ProfileUrl = $"https://github.com/{login}",
+                AvatarUrl = $"https://github.com/{login}.png",
+                Status = GitHubSponsorStatus.Current,
+                EntityType = GitHubSponsorEntityType.User
+            },
+            FundingTierMonthlyDollars = amount
+        };
+}

--- a/PowerForge.Tests/GitHubSponsorsClientTests.cs
+++ b/PowerForge.Tests/GitHubSponsorsClientTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed class GitHubSponsorsClientTests
+{
+    [Fact]
+    public void GetSponsors_PaginatesAndSeparatesCurrentFromFormerWithoutPrivateData()
+    {
+        var handler = new SponsorsHandler((activeOnly, cursor) =>
+        {
+            if (activeOnly && cursor is null)
+                return ConnectionResponse(UserNode("alice", "Alice", "User", "Gold", 30), hasNextPage: true, "current-1");
+            if (activeOnly)
+                return ConnectionResponse(UserNode("acme", "Acme Ltd", "Organization", null, null), hasNextPage: false, null);
+
+            return ConnectionResponse(string.Join(',',
+                UserNode("alice", "Alice", "User", "Gold", 30),
+                UserNode("acme", "Acme Ltd", "Organization", null, null),
+                UserNode("former", "Former Friend", "User", "Bronze", 5)), hasNextPage: false, null);
+        });
+        using var client = new HttpClient(handler);
+
+        var records = new GitHubSponsorsClient(client).GetSponsors(new GitHubSponsorsQuery
+        {
+            SponsorableLogin = "owner",
+            Token = "secret-token",
+            IncludeFormer = true,
+            PageSize = 1
+        });
+
+        Assert.Equal(3, records.Length);
+        Assert.Equal(2, records.Count(record => record.Status == GitHubSponsorStatus.Current));
+        var former = Assert.Single(records, record => record.Status == GitHubSponsorStatus.Former);
+        Assert.Equal("former", former.Login);
+        Assert.Equal(GitHubSponsorEntityType.Organization, Assert.Single(records, record => record.Login == "acme").EntityType);
+        Assert.Equal(3, handler.RequestBodies.Count);
+        Assert.All(handler.RequestBodies, body => Assert.Contains("includePrivate: false", body, StringComparison.Ordinal));
+        Assert.All(handler.RequestBodies, body => Assert.DoesNotContain("monthlyPriceInDollars", body, StringComparison.Ordinal));
+        Assert.All(handler.AuthorizationHeaders, header => Assert.Equal("Bearer secret-token", header));
+        var publicJson = JsonSerializer.Serialize(records);
+        Assert.DoesNotContain("FundingTier", publicJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Gold\"", publicJson, StringComparison.Ordinal);
+        Assert.DoesNotContain(":30", publicJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetSponsorSources_RetainsFundingOnlyForInternalOptInRecognition()
+    {
+        var handler = new SponsorsHandler((_, _) => ConnectionResponse(UserNode("alice", "Alice", "User", "Gold", 30), false, null));
+        using var client = new HttpClient(handler);
+
+        var records = new GitHubSponsorsClient(client).GetSponsorSources(new GitHubSponsorsQuery
+        {
+            SponsorableLogin = "owner",
+            Token = "token",
+            IncludeFormer = false
+        }, includeFundingTierData: true);
+
+        Assert.Equal(30, Assert.Single(records).FundingTierMonthlyDollars);
+        Assert.Contains("monthlyPriceInDollars", Assert.Single(handler.RequestBodies), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetSponsors_RejectsHttpEndpointBeforeSendingBearerToken()
+    {
+        var handler = new SponsorsHandler((_, _) => throw new InvalidOperationException("HTTP handler must not be reached."));
+        using var client = new HttpClient(handler);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new GitHubSponsorsClient(client).GetSponsors(new GitHubSponsorsQuery
+        {
+            SponsorableLogin = "owner",
+            Token = "secret-token",
+            GraphQlEndpoint = "http://example.test/graphql",
+            IncludeFormer = false
+        }));
+
+        Assert.Contains("must use HTTPS", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(handler.AuthorizationHeaders);
+    }
+
+    [Fact]
+    public void GetSponsors_SurfacesGraphQlErrors()
+    {
+        var handler = new SponsorsHandler((_, _) => """{"errors":[{"message":"Resource not accessible"}]}""");
+        using var client = new HttpClient(handler);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new GitHubSponsorsClient(client).GetSponsors(new GitHubSponsorsQuery
+        {
+            SponsorableLogin = "owner",
+            Token = "token",
+            IncludeFormer = false
+        }));
+
+        Assert.Contains("Resource not accessible", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static string UserNode(string login, string name, string type, string? tierName, int? amount)
+    {
+        var tier = amount is null
+            ? "null"
+            : $"{{\"name\":{JsonSerializer.Serialize(tierName)},\"monthlyPriceInDollars\":{amount.Value}}}";
+        return $"{{\"sponsorEntity\":{{\"__typename\":\"{type}\",\"login\":\"{login}\",\"name\":\"{name}\",\"avatarUrl\":\"https://avatars.example/{login}\",\"url\":\"https://github.com/{login}\"}},\"tier\":{tier}}}";
+    }
+
+    private static string ConnectionResponse(string nodes, bool hasNextPage, string? endCursor)
+    {
+        var cursor = endCursor is null ? "null" : JsonSerializer.Serialize(endCursor);
+        return "{\"data\":{\"owner\":{\"__typename\":\"User\",\"sponsorshipsAsMaintainer\":{\"nodes\":[" + nodes +
+               "],\"pageInfo\":{\"hasNextPage\":" + hasNextPage.ToString().ToLowerInvariant() +
+               ",\"endCursor\":" + cursor + "}}}}}";
+    }
+
+    private sealed class SponsorsHandler(Func<bool, string?, string> responseFactory) : HttpMessageHandler
+    {
+        internal List<string> RequestBodies { get; } = new();
+        internal List<string> AuthorizationHeaders { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+            RequestBodies.Add(body);
+            AuthorizationHeaders.Add(request.Headers.Authorization?.ToString() ?? string.Empty);
+            using var document = JsonDocument.Parse(body);
+            var variables = document.RootElement.GetProperty("variables");
+            var activeOnly = variables.GetProperty("activeOnly").GetBoolean();
+            var after = variables.GetProperty("after");
+            var cursor = after.ValueKind == JsonValueKind.String ? after.GetString() : null;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseFactory(activeOnly, cursor), Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/PowerForge.Tests/GitHubSponsorsClientTests.cs
+++ b/PowerForge.Tests/GitHubSponsorsClientTests.cs
@@ -64,6 +64,30 @@ public sealed class GitHubSponsorsClientTests
     }
 
     [Fact]
+    public void GetSponsorSources_DoesNotRequestFundingTiersForFormerConnection()
+    {
+        var handler = new SponsorsHandler((activeOnly, _) => activeOnly
+            ? ConnectionResponse(UserNode("alice", "Alice", "User", "Gold", 30), false, null)
+            : ConnectionResponse(string.Join(',',
+                UserNode("alice", "Alice", "User", "Gold", 30),
+                UserNode("former", "Former Friend", "User", "Bronze", 5)), false, null));
+        using var client = new HttpClient(handler);
+
+        var records = new GitHubSponsorsClient(client).GetSponsorSources(new GitHubSponsorsQuery
+        {
+            SponsorableLogin = "owner",
+            Token = "token",
+            IncludeFormer = true
+        }, includeFundingTierData: true);
+
+        Assert.Equal(2, handler.RequestBodies.Count);
+        Assert.Contains("monthlyPriceInDollars", handler.RequestBodies[0], StringComparison.Ordinal);
+        Assert.DoesNotContain("monthlyPriceInDollars", handler.RequestBodies[1], StringComparison.Ordinal);
+        Assert.Equal(30, Assert.Single(records, record => record.Sponsor.Status == GitHubSponsorStatus.Current).FundingTierMonthlyDollars);
+        Assert.Null(Assert.Single(records, record => record.Sponsor.Status == GitHubSponsorStatus.Former).FundingTierMonthlyDollars);
+    }
+
+    [Fact]
     public void GetSponsors_RejectsHttpEndpointBeforeSendingBearerToken()
     {
         var handler = new SponsorsHandler((_, _) => throw new InvalidOperationException("HTTP handler must not be reached."));

--- a/PowerForge.Tests/GitHubSponsorsClientTests.cs
+++ b/PowerForge.Tests/GitHubSponsorsClientTests.cs
@@ -121,6 +121,28 @@ public sealed class GitHubSponsorsClientTests
         Assert.Contains("Resource not accessible", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void GetSponsors_RejectsRepeatedPaginationCursor()
+    {
+        var handler = new SponsorsHandler((_, cursor) => cursor switch
+        {
+            null => ConnectionResponse(UserNode("first", "First", "User", null, null), true, "cursor-a"),
+            "cursor-a" => ConnectionResponse(UserNode("second", "Second", "User", null, null), true, "cursor-b"),
+            _ => ConnectionResponse(UserNode("third", "Third", "User", null, null), true, "cursor-a")
+        });
+        using var client = new HttpClient(handler);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new GitHubSponsorsClient(client).GetSponsors(new GitHubSponsorsQuery
+        {
+            SponsorableLogin = "owner",
+            Token = "token",
+            IncludeFormer = false
+        }));
+
+        Assert.Contains("repeated an earlier end cursor", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(3, handler.RequestBodies.Count);
+    }
+
     private static string UserNode(string login, string name, string type, string? tierName, int? amount)
     {
         var tier = amount is null

--- a/PowerForge.Tests/GitHubSponsorsMarkdownRendererTests.cs
+++ b/PowerForge.Tests/GitHubSponsorsMarkdownRendererTests.cs
@@ -1,0 +1,105 @@
+namespace PowerForge.Tests;
+
+public sealed class GitHubSponsorsMarkdownRendererTests
+{
+    [Fact]
+    public void RenderFull_GroupsCurrentSponsorsAndListsFormerSponsorsWithoutFundingAmounts()
+    {
+        var recognition = new GitHubSponsorRecognitionResult
+        {
+            TierRecognitionEnabled = true,
+            Tiers = new[]
+            {
+                new GitHubSponsorRecognitionTierSpec { Key = "Gold", Heading = "Gold Sponsors", Order = 10, AvatarSize = 80 },
+                new GitHubSponsorRecognitionTierSpec { Key = "Sponsors", Heading = "Sponsors", Order = 20, AvatarSize = 64 }
+            },
+            Sponsors = new[]
+            {
+                Sponsor("alice", "Alice <Admin>", GitHubSponsorStatus.Current, "Gold", "https://example.com/alice"),
+                Sponsor("former", "Former [Friend]", GitHubSponsorStatus.Former, "Sponsors", "https://example.com/former")
+            }
+        };
+
+        var markdown = new GitHubSponsorsMarkdownRenderer().Render(recognition, new GitHubSponsorsOutputSpec
+        {
+            Layout = GitHubSponsorsMarkdownLayout.Full,
+            Introduction = "Thank you for supporting the project."
+        });
+
+        Assert.Contains("## Gold Sponsors", markdown, StringComparison.Ordinal);
+        Assert.Contains("Alice &lt;Admin&gt;", markdown, StringComparison.Ordinal);
+        Assert.Contains("width=\"80\"", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Past Sponsors", markdown, StringComparison.Ordinal);
+        Assert.Contains("<a href=\"https://example.com/former\">Former [Friend]</a>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("$", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderCompact_LimitsEntriesAndAddsRosterLink()
+    {
+        var recognition = new GitHubSponsorRecognitionResult
+        {
+            Sponsors = new[]
+            {
+                Sponsor("alice", "Alice", GitHubSponsorStatus.Current, null, "https://example.com/alice"),
+                Sponsor("bob", "Bob", GitHubSponsorStatus.Current, null, "https://example.com/bob")
+            }
+        };
+
+        var markdown = new GitHubSponsorsMarkdownRenderer().Render(recognition, new GitHubSponsorsOutputSpec
+        {
+            Layout = GitHubSponsorsMarkdownLayout.Compact,
+            MaxEntries = 1,
+            MoreLink = "SPONSORS.md"
+        });
+
+        Assert.Contains("Alice", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("Bob", markdown, StringComparison.Ordinal);
+        Assert.Contains("[See all sponsors](SPONSORS.md)", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderFull_DropsUnsafeRemoteUrls()
+    {
+        var recognition = new GitHubSponsorRecognitionResult
+        {
+            Sponsors = new[] { Sponsor("bad", "Bad", GitHubSponsorStatus.Current, null, "javascript:alert(1)") }
+        };
+
+        var markdown = new GitHubSponsorsMarkdownRenderer().Render(recognition, new GitHubSponsorsOutputSpec());
+
+        Assert.DoesNotContain("javascript", markdown, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Bad", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderFull_EncodesFormerSponsorNamesInsideSafeHtmlList()
+    {
+        var recognition = new GitHubSponsorRecognitionResult
+        {
+            Sponsors = new[]
+            {
+                Sponsor("former", "<script>*bold*</script>", GitHubSponsorStatus.Former, null, "https://example.com/former")
+            }
+        };
+
+        var markdown = new GitHubSponsorsMarkdownRenderer().Render(recognition, new GitHubSponsorsOutputSpec());
+
+        Assert.Contains("<ul>", markdown, StringComparison.Ordinal);
+        Assert.Contains("&lt;script&gt;*bold*&lt;/script&gt;", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("<script>", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static GitHubSponsorRecord Sponsor(string key, string name, GitHubSponsorStatus status, string? tier, string profile)
+        => new()
+        {
+            Key = key,
+            Login = key,
+            DisplayName = name,
+            ProfileUrl = profile,
+            AvatarUrl = $"https://avatars.example/{key}",
+            Status = status,
+            EntityType = GitHubSponsorEntityType.User,
+            RecognitionTierKey = tier
+        };
+}

--- a/PowerForge.Tests/GitHubSponsorsMarkdownRendererTests.cs
+++ b/PowerForge.Tests/GitHubSponsorsMarkdownRendererTests.cs
@@ -73,6 +73,18 @@ public sealed class GitHubSponsorsMarkdownRendererTests
     }
 
     [Fact]
+    public void RenderFull_ShowsEmptyStateWhenTierRecognitionIsEnabled()
+    {
+        var markdown = new GitHubSponsorsMarkdownRenderer().Render(new GitHubSponsorRecognitionResult
+        {
+            TierRecognitionEnabled = true,
+            Tiers = new[] { new GitHubSponsorRecognitionTierSpec { Key = "Sponsors", Heading = "Sponsors" } }
+        }, new GitHubSponsorsOutputSpec());
+
+        Assert.Equal("No public sponsors are currently listed.", markdown);
+    }
+
+    [Fact]
     public void RenderFull_EncodesFormerSponsorNamesInsideSafeHtmlList()
     {
         var recognition = new GitHubSponsorRecognitionResult

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -218,17 +218,26 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
 
         var results = new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
         {
-            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "new sponsors" },
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "old sponsors" },
             new ManagedMarkdownUpdateRequest { Path = alias, BlockId = "stats", Markdown = "new stats" }
         });
 
         Assert.Equal(2, results.Length);
+        Assert.All(results, result => Assert.True(result.Changed));
         var text = File.ReadAllText(path);
-        Assert.Contains("new sponsors", text, StringComparison.Ordinal);
+        Assert.Contains("old sponsors", text, StringComparison.Ordinal);
         Assert.Contains("new stats", text, StringComparison.Ordinal);
-        Assert.DoesNotContain("old sponsors", text, StringComparison.Ordinal);
         Assert.DoesNotContain("old stats", text, StringComparison.Ordinal);
         Assert.Equal(text, File.ReadAllText(alias));
+    }
+
+    [Fact]
+    public void WindowsFileIdentity_PreservesAll128IdentifierBits()
+    {
+        var first = ExistingFilePathIdentityResolver.FormatWindowsFileIdentity(1, 2, 3);
+        var differentUpperHalf = ExistingFilePathIdentityResolver.FormatWindowsFileIdentity(1, 2, 4);
+
+        Assert.NotEqual(first, differentUpperHalf);
     }
 
     [Fact]

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -205,6 +205,33 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
     }
 
     [Fact]
+    public void UpdateMany_CoalescesHardLinkAliasBeforeWritingFinalDocument()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        var alias = Path.Combine(root, "README-hardlink.md");
+        File.WriteAllText(
+            path,
+            "<!-- POWERFORGE:sponsors:START -->\nold sponsors\n<!-- POWERFORGE:sponsors:END -->\n" +
+            "<!-- POWERFORGE:stats:START -->\nold stats\n<!-- POWERFORGE:stats:END -->\n");
+        CreateHardLink(alias, path);
+
+        var results = new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
+        {
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "new sponsors" },
+            new ManagedMarkdownUpdateRequest { Path = alias, BlockId = "stats", Markdown = "new stats" }
+        });
+
+        Assert.Equal(2, results.Length);
+        var text = File.ReadAllText(path);
+        Assert.Contains("new sponsors", text, StringComparison.Ordinal);
+        Assert.Contains("new stats", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old sponsors", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old stats", text, StringComparison.Ordinal);
+        Assert.Equal(text, File.ReadAllText(alias));
+    }
+
+    [Fact]
     public void UpdateMany_RejectsDuplicateLogicalTargetWithoutWriting()
     {
         var root = CreateTempRoot();
@@ -355,6 +382,29 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
         Buffer.BlockCopy(content, 0, bytes, 3, content.Length);
         File.WriteAllBytes(path, bytes);
     }
+
+    private static void CreateHardLink(string linkPath, string existingPath)
+    {
+        var succeeded = Path.DirectorySeparatorChar == '\\'
+            ? CreateHardLinkWindows(linkPath, existingPath, IntPtr.Zero)
+            : CreateHardLinkUnix(existingPath, linkPath) == 0;
+        if (!succeeded)
+        {
+            var error = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+            throw new IOException($"Unable to create hard-link test artifact: {new System.ComponentModel.Win32Exception(error).Message}");
+        }
+    }
+
+    [System.Runtime.InteropServices.DllImport(
+        "kernel32.dll",
+        EntryPoint = "CreateHardLinkW",
+        CharSet = System.Runtime.InteropServices.CharSet.Unicode,
+        SetLastError = true)]
+    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+    private static extern bool CreateHardLinkWindows(string fileName, string existingFileName, IntPtr securityAttributes);
+
+    [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "link", SetLastError = true)]
+    private static extern int CreateHardLinkUnix(string existingPath, string newPath);
 
     private static string CreateTempRoot()
     {

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -171,6 +171,40 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
     }
 
     [Fact]
+    public void UpdateMany_CoalescesFileSymlinkAliasBeforeWritingFinalDocument()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        var alias = Path.Combine(root, "README-alias.md");
+        File.WriteAllText(
+            path,
+            "<!-- POWERFORGE:sponsors:START -->\nold sponsors\n<!-- POWERFORGE:sponsors:END -->\n" +
+            "<!-- POWERFORGE:stats:START -->\nold stats\n<!-- POWERFORGE:stats:END -->\n");
+        try
+        {
+            File.CreateSymbolicLink(alias, path);
+        }
+        catch (Exception exception) when (
+            exception is UnauthorizedAccessException or IOException or NotSupportedException or PlatformNotSupportedException)
+        {
+            return;
+        }
+
+        var results = new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
+        {
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "new sponsors" },
+            new ManagedMarkdownUpdateRequest { Path = alias, BlockId = "stats", Markdown = "new stats" }
+        });
+
+        Assert.Equal(2, results.Length);
+        var text = File.ReadAllText(path);
+        Assert.Contains("new sponsors", text, StringComparison.Ordinal);
+        Assert.Contains("new stats", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old sponsors", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old stats", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void UpdateMany_RejectsDuplicateLogicalTargetWithoutWriting()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -240,6 +240,29 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
         Assert.NotEqual(first, differentUpperHalf);
     }
 
+    [Theory]
+    [InlineData("NTFS", true)]
+    [InlineData("FAT32", true)]
+    [InlineData("ReFS", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void LegacyWindowsFileIdentity_RejectsReFsAndUnknownFileSystems(string? fileSystemName, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            ExistingFilePathIdentityResolver.IsLegacyWindowsFileIdentitySafe(
+                fileSystemName,
+                volumeInformationApiUnavailable: false));
+    }
+
+    [Fact]
+    public void LegacyWindowsFileIdentity_AllowsSystemsThatPredateReFs()
+    {
+        Assert.True(ExistingFilePathIdentityResolver.IsLegacyWindowsFileIdentitySafe(
+            fileSystemName: null,
+            volumeInformationApiUnavailable: true));
+    }
+
     [Fact]
     public void UpdateMany_RejectsDuplicateLogicalTargetWithoutWriting()
     {

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -1,0 +1,128 @@
+namespace PowerForge.Tests;
+
+public sealed class ManagedMarkdownDocumentUpdaterTests
+{
+    [Fact]
+    public void Update_CreatesManagedDocumentWhenExplicitlyAllowed()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "SPONSORS.md");
+
+        var result = new ManagedMarkdownDocumentUpdater().Update(new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "sponsors",
+            Markdown = "Generated roster",
+            CreateIfMissing = true,
+            NewDocumentTitle = "Sponsors"
+        });
+
+        Assert.True(result.Changed);
+        Assert.True(result.Created);
+        Assert.False(result.Appended);
+        Assert.Equal("# Sponsors\n\n<!-- POWERFORGE:sponsors:START -->\nGenerated roster\n<!-- POWERFORGE:sponsors:END -->\n", Normalize(File.ReadAllText(path)));
+    }
+
+    [Fact]
+    public void Update_AppendsOnlyWhenExplicitlyConfigured()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        File.WriteAllText(path, "# Project\n\nExisting content.\n");
+
+        var result = new ManagedMarkdownDocumentUpdater().Update(new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "sponsors",
+            Markdown = "Generated roster",
+            MissingBlockBehavior = ManagedMarkdownMissingBlockBehavior.Append
+        });
+
+        Assert.True(result.Appended);
+        var text = Normalize(File.ReadAllText(path));
+        Assert.StartsWith("# Project\n\nExisting content.\n\n", text, StringComparison.Ordinal);
+        Assert.Contains("<!-- POWERFORGE:sponsors:START -->", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Update_RejectsDuplicateMarkersWithoutChangingDocument()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        var original = "<!-- POWERFORGE:sponsors:START -->\none\n<!-- POWERFORGE:sponsors:START -->\ntwo\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(path, original);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new ManagedMarkdownDocumentUpdater().Update(new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "sponsors",
+            Markdown = "replacement"
+        }));
+
+        Assert.Contains("duplicate", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void Update_PreservesCrlfAndLegacyBenchmarkMarkers()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        File.WriteAllText(path, "Before\r\n<!-- BENCHMARK:demo:START -->\r\nold\r\n<!-- BENCHMARK:demo:END -->\r\nAfter\r\n");
+
+        var result = new BenchmarkDocumentUpdater().UpdateBlock(path, "demo", "new\nvalue");
+
+        Assert.True(result.Changed);
+        var bytes = File.ReadAllBytes(path);
+        var text = System.Text.Encoding.UTF8.GetString(bytes);
+        Assert.Contains("\r\nnew\r\nvalue\r\n", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\nold\n", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Update_PreservesUtf8BomAndEveryByteOutsideMixedEndingBlock()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        const string original = "Before\r\nKeep\n<!-- POWERFORGE:sponsors:START -->\r\nold\ncontent\r\n<!-- POWERFORGE:sponsors:END -->\nAfter\rTail";
+        WriteUtf8Bom(path, original);
+
+        var result = new ManagedMarkdownDocumentUpdater().Update(new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "sponsors",
+            Markdown = "new\nvalue"
+        });
+
+        Assert.True(result.Changed);
+        const string expected = "Before\r\nKeep\n<!-- POWERFORGE:sponsors:START -->\r\nnew\r\nvalue\r\n<!-- POWERFORGE:sponsors:END -->\nAfter\rTail";
+        var expectedContent = System.Text.Encoding.UTF8.GetBytes(expected);
+        var expectedBytes = new byte[3 + expectedContent.Length];
+        expectedBytes[0] = 0xEF;
+        expectedBytes[1] = 0xBB;
+        expectedBytes[2] = 0xBF;
+        Buffer.BlockCopy(expectedContent, 0, expectedBytes, 3, expectedContent.Length);
+        Assert.Equal(expectedBytes, File.ReadAllBytes(path));
+    }
+
+    private static void WriteUtf8Bom(string path, string value)
+    {
+        var content = System.Text.Encoding.UTF8.GetBytes(value);
+        var bytes = new byte[3 + content.Length];
+        bytes[0] = 0xEF;
+        bytes[1] = 0xBB;
+        bytes[2] = 0xBF;
+        Buffer.BlockCopy(content, 0, bytes, 3, content.Length);
+        File.WriteAllBytes(path, bytes);
+    }
+
+    private static string CreateTempRoot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string Normalize(string value)
+        => value.Replace("\r\n", "\n").Replace('\r', '\n');
+}

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -3,6 +3,16 @@ namespace PowerForge.Tests;
 public sealed class ManagedMarkdownDocumentUpdaterTests
 {
     [Fact]
+    public void ValidateBlock_PreservesTwoArgumentPublicSignature()
+    {
+        var method = typeof(ManagedMarkdownDocumentUpdater).GetMethod(
+            nameof(ManagedMarkdownDocumentUpdater.ValidateBlock),
+            new[] { typeof(string), typeof(string) });
+
+        Assert.NotNull(method);
+    }
+
+    [Fact]
     public void Update_CreatesManagedDocumentWhenExplicitlyAllowed()
     {
         var root = CreateTempRoot();
@@ -60,6 +70,25 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
         }));
 
         Assert.Contains("duplicate", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void Update_DoesNotMatchDifferentMarkerNamespaceWithSameBlockId()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        const string original = "<!-- BENCHMARK:sponsors:START -->\nbenchmark data\n<!-- BENCHMARK:sponsors:END -->\n";
+        File.WriteAllText(path, original);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new ManagedMarkdownDocumentUpdater().Update(new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "sponsors",
+            Markdown = "replacement"
+        }));
+
+        Assert.Contains("was not found", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(original, File.ReadAllText(path));
     }
 

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -109,6 +109,42 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
     }
 
     [Fact]
+    public void Update_PreservesDocumentedTwoPartBenchmarkMarkers()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        const string original = "Before\n<!-- managed-module-benchmark-table:start -->\nold\n<!-- managed-module-benchmark-table:end -->\nAfter\n";
+        File.WriteAllText(path, original);
+
+        var updater = new BenchmarkDocumentUpdater();
+        updater.ValidateBlock(path, "managed-module-benchmark-table");
+        var result = updater.UpdateBlock(path, "managed-module-benchmark-table", "new\nvalue");
+
+        Assert.True(result.Changed);
+        Assert.Equal(
+            "Before\n<!-- managed-module-benchmark-table:start -->\nnew\nvalue\n<!-- managed-module-benchmark-table:end -->\nAfter\n",
+            Normalize(File.ReadAllText(path)));
+    }
+
+    [Fact]
+    public void ValidateUpdate_RejectsExistingDirectoryEvenWhenCreationIsAllowed()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "SPONSORS.md");
+        Directory.CreateDirectory(path);
+
+        var exception = Assert.Throws<IOException>(() => new ManagedMarkdownDocumentUpdater().ValidateUpdate(new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "sponsors",
+            Markdown = "replacement",
+            CreateIfMissing = true
+        }));
+
+        Assert.Contains("existing directory", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Update_PreservesUtf8BomAndEveryByteOutsideMixedEndingBlock()
     {
         var root = CreateTempRoot();

--- a/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
+++ b/PowerForge.Tests/ManagedMarkdownDocumentUpdaterTests.cs
@@ -145,6 +145,147 @@ public sealed class ManagedMarkdownDocumentUpdaterTests
     }
 
     [Fact]
+    public void UpdateMany_ProjectsDisjointBlocksBeforeWritingFinalDocument()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        File.WriteAllText(
+            path,
+            "<!-- POWERFORGE:sponsors:START -->\nold sponsors\n<!-- POWERFORGE:sponsors:END -->\n" +
+            "Between\n" +
+            "<!-- POWERFORGE:stats:START -->\nold stats\n<!-- POWERFORGE:stats:END -->\n");
+
+        var results = new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
+        {
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "new sponsors" },
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "stats", Markdown = "new stats" }
+        });
+
+        Assert.Equal(2, results.Length);
+        Assert.All(results, result => Assert.True(result.Changed));
+        var text = Normalize(File.ReadAllText(path));
+        Assert.Contains("<!-- POWERFORGE:sponsors:START -->\nnew sponsors\n<!-- POWERFORGE:sponsors:END -->", text, StringComparison.Ordinal);
+        Assert.Contains("<!-- POWERFORGE:stats:START -->\nnew stats\n<!-- POWERFORGE:stats:END -->", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old sponsors", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old stats", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdateMany_RejectsDuplicateLogicalTargetWithoutWriting()
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        const string original = "<!-- POWERFORGE:sponsors:START -->\nold\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(path, original);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
+        {
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "new" },
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "old" }
+        }));
+
+        Assert.Contains("targeted more than once", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void UpdateMany_KeepsCaseDistinctFilesSeparateOnCaseSensitiveFileSystem()
+    {
+        var root = CreateTempRoot();
+        var upperPath = Path.Combine(root, "A.md");
+        var lowerPath = Path.Combine(root, "a.md");
+        const string upperOriginal = "<!-- POWERFORGE:sponsors:START -->\nupper old\n<!-- POWERFORGE:sponsors:END -->\n";
+        const string lowerOriginal = "<!-- POWERFORGE:sponsors:START -->\nlower old\n<!-- POWERFORGE:sponsors:END -->\n";
+        File.WriteAllText(upperPath, upperOriginal);
+        File.WriteAllText(lowerPath, lowerOriginal);
+        if (string.Equals(File.ReadAllText(upperPath), File.ReadAllText(lowerPath), StringComparison.Ordinal))
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
+            {
+                new ManagedMarkdownUpdateRequest { Path = upperPath, BlockId = "sponsors", Markdown = "upper new" },
+                new ManagedMarkdownUpdateRequest { Path = lowerPath, BlockId = "sponsors", Markdown = "lower new" }
+            }));
+            Assert.Contains("targeted more than once", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("lower old", File.ReadAllText(upperPath), StringComparison.Ordinal);
+            return;
+        }
+
+        var results = new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
+        {
+            new ManagedMarkdownUpdateRequest { Path = upperPath, BlockId = "sponsors", Markdown = "upper new" },
+            new ManagedMarkdownUpdateRequest { Path = lowerPath, BlockId = "sponsors", Markdown = "lower new" }
+        });
+
+        Assert.Equal(2, results.Length);
+        Assert.Contains("upper new", File.ReadAllText(upperPath), StringComparison.Ordinal);
+        Assert.DoesNotContain("lower new", File.ReadAllText(upperPath), StringComparison.Ordinal);
+        Assert.Contains("lower new", File.ReadAllText(lowerPath), StringComparison.Ordinal);
+        Assert.DoesNotContain("upper new", File.ReadAllText(lowerPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdateMany_CoalescesWindowsDriveRootCasingAliases()
+    {
+        if (Path.DirectorySeparatorChar != '\\')
+            return;
+
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        const string original =
+            "<!-- POWERFORGE:sponsors:START -->\nold sponsors\n<!-- POWERFORGE:sponsors:END -->\n" +
+            "<!-- POWERFORGE:stats:START -->\nold stats\n<!-- POWERFORGE:stats:END -->\n";
+        File.WriteAllText(path, original);
+        var alias = char.ToLowerInvariant(path[0]) + path.Substring(1);
+
+        var results = new ManagedMarkdownDocumentUpdater().UpdateMany(new[]
+        {
+            new ManagedMarkdownUpdateRequest { Path = path, BlockId = "sponsors", Markdown = "new sponsors" },
+            new ManagedMarkdownUpdateRequest { Path = alias, BlockId = "stats", Markdown = "new stats" }
+        });
+
+        Assert.Equal(2, results.Length);
+        var text = File.ReadAllText(path);
+        Assert.Contains("new sponsors", text, StringComparison.Ordinal);
+        Assert.Contains("new stats", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old sponsors", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("old stats", text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UpdateMany_RejectsReplacementThatIntroducesRequestedNestedBlockWithoutWriting(bool outerFirst)
+    {
+        var root = CreateTempRoot();
+        var path = Path.Combine(root, "README.md");
+        const string original = "<!-- POWERFORGE:outer:START -->\nold\n<!-- POWERFORGE:outer:END -->\n";
+        File.WriteAllText(path, original);
+        var outer = new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "outer",
+            Markdown = "before\n<!-- POWERFORGE:inner:START -->\nintroduced\n<!-- POWERFORGE:inner:END -->\nafter"
+        };
+        var inner = new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = "inner",
+            Markdown = "inner replacement",
+            MissingBlockBehavior = ManagedMarkdownMissingBlockBehavior.Append
+        };
+        var requests = outerFirst ? new[] { outer, inner } : new[] { inner, outer };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new ManagedMarkdownDocumentUpdater().UpdateMany(requests));
+
+        Assert.True(
+            exception.Message.Contains("overlap", StringComparison.OrdinalIgnoreCase) ||
+            exception.Message.Contains("duplic", StringComparison.OrdinalIgnoreCase),
+            exception.Message);
+        Assert.Equal(original, File.ReadAllText(path));
+    }
+
+    [Fact]
     public void Update_PreservesUtf8BomAndEveryByteOutsideMixedEndingBlock()
     {
         var root = CreateTempRoot();

--- a/PowerForge/Models/GitHubRepositoryContent.cs
+++ b/PowerForge/Models/GitHubRepositoryContent.cs
@@ -1,0 +1,349 @@
+namespace PowerForge;
+
+/// <summary>
+/// Source or manually assigned status of a sponsor.
+/// </summary>
+public enum GitHubSponsorStatus
+{
+    /// <summary>The sponsor is currently active.</summary>
+    Current,
+
+    /// <summary>The sponsor is no longer active.</summary>
+    Former
+}
+
+/// <summary>
+/// Entity type represented by a sponsor record.
+/// </summary>
+public enum GitHubSponsorEntityType
+{
+    /// <summary>A GitHub user account.</summary>
+    User,
+
+    /// <summary>A GitHub organization account.</summary>
+    Organization,
+
+    /// <summary>A sponsor supplied only through local configuration.</summary>
+    Manual
+}
+
+/// <summary>
+/// Markdown layout used for a generated Sponsors block.
+/// </summary>
+public enum GitHubSponsorsMarkdownLayout
+{
+    /// <summary>Tiered roster with optional former-sponsor recognition.</summary>
+    Full,
+
+    /// <summary>Compact avatar row suitable for a project README.</summary>
+    Compact
+}
+
+/// <summary>
+/// Top-level configuration for generated GitHub repository content.
+/// </summary>
+public sealed class GitHubRepositoryContentSpec
+{
+    /// <summary>Optional GitHub GraphQL endpoint.</summary>
+    public string? GraphQlEndpoint { get; set; }
+
+    /// <summary>Optional GitHub token. Prefer <see cref="TokenEnvName"/> in checked-in configuration.</summary>
+    public string? Token { get; set; }
+
+    /// <summary>Environment variable used to resolve the token when <see cref="Token"/> is empty.</summary>
+    public string TokenEnvName { get; set; } = "GITHUB_TOKEN";
+
+    /// <summary>GitHub Sponsors content settings.</summary>
+    public GitHubSponsorsContentSpec Sponsors { get; set; } = new();
+}
+
+/// <summary>
+/// Query used to retrieve public current and former GitHub sponsors.
+/// </summary>
+public sealed class GitHubSponsorsQuery
+{
+    /// <summary>GitHub user or organization login receiving sponsorships.</summary>
+    public string SponsorableLogin { get; set; } = string.Empty;
+
+    /// <summary>GitHub token used for GraphQL requests.</summary>
+    public string Token { get; set; } = string.Empty;
+
+    /// <summary>Optional GitHub GraphQL endpoint.</summary>
+    public string? GraphQlEndpoint { get; set; }
+
+    /// <summary>Whether public former sponsors should also be retrieved.</summary>
+    public bool IncludeFormer { get; set; } = true;
+
+    /// <summary>GraphQL records requested per page.</summary>
+    public int PageSize { get; set; } = 100;
+}
+
+/// <summary>
+/// Configuration for GitHub Sponsors retrieval, recognition, and document output.
+/// </summary>
+public sealed class GitHubSponsorsContentSpec
+{
+    /// <summary>Whether Sponsors content generation is enabled.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>GitHub user or organization login receiving sponsorships.</summary>
+    public string SponsorableLogin { get; set; } = string.Empty;
+
+    /// <summary>Whether public former sponsors should also be retrieved.</summary>
+    public bool IncludeFormer { get; set; } = true;
+
+    /// <summary>Whether generation fails when no current sponsors are returned.</summary>
+    public bool FailOnEmpty { get; set; } = true;
+
+    /// <summary>Whether tiered generation fails when GitHub withholds funding-tier data for every current GitHub sponsor.</summary>
+    public bool RequireFundingTierData { get; set; }
+
+    /// <summary>GraphQL records requested per page.</summary>
+    public int PageSize { get; set; } = 100;
+
+    /// <summary>Opt-in recognition-tier settings.</summary>
+    public GitHubSponsorTierRecognitionSpec TierRecognition { get; set; } = new();
+
+    /// <summary>Per-account recognition and presentation overrides.</summary>
+    public GitHubSponsorOverrideSpec[] Overrides { get; set; } = Array.Empty<GitHubSponsorOverrideSpec>();
+
+    /// <summary>Manually maintained sponsors, including non-GitHub people or companies.</summary>
+    public GitHubManualSponsorSpec[] ManualEntries { get; set; } = Array.Empty<GitHubManualSponsorSpec>();
+
+    /// <summary>Markdown documents or blocks produced by the run.</summary>
+    public GitHubSponsorsOutputSpec[] Outputs { get; set; } = Array.Empty<GitHubSponsorsOutputSpec>();
+}
+
+/// <summary>
+/// Opt-in mapping from GitHub funding tiers to public recognition tiers.
+/// </summary>
+public sealed class GitHubSponsorTierRecognitionSpec
+{
+    /// <summary>Whether public output is grouped by recognition tier.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Whether the standard Principal/Platinum/Gold/Silver/Bronze bands are used when <see cref="Tiers"/> is empty.</summary>
+    public bool UseDefaultTiers { get; set; } = true;
+
+    /// <summary>Recognition tier used when GitHub does not expose a selected tier or no band matches.</summary>
+    public string UnmappedTierKey { get; set; } = "Sponsors";
+
+    /// <summary>Custom recognition tier bands. Higher minimum amounts are matched first.</summary>
+    public GitHubSponsorRecognitionTierSpec[] Tiers { get; set; } = Array.Empty<GitHubSponsorRecognitionTierSpec>();
+}
+
+/// <summary>
+/// One public sponsor-recognition tier.
+/// </summary>
+public sealed class GitHubSponsorRecognitionTierSpec
+{
+    /// <summary>Stable key referenced by overrides and result records.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Heading shown in a full Sponsors roster.</summary>
+    public string Heading { get; set; } = string.Empty;
+
+    /// <summary>Minimum GitHub monthly tier price mapped to this recognition tier.</summary>
+    public int? MinimumMonthlyDollars { get; set; }
+
+    /// <summary>Sort order in generated output. Lower values appear first.</summary>
+    public int Order { get; set; }
+
+    /// <summary>Avatar size in pixels for this recognition tier.</summary>
+    public int AvatarSize { get; set; } = 64;
+}
+
+/// <summary>
+/// Per-account override applied after GitHub data is retrieved.
+/// </summary>
+public sealed class GitHubSponsorOverrideSpec
+{
+    /// <summary>GitHub login or manual-entry key matched case-insensitively.</summary>
+    public string Login { get; set; } = string.Empty;
+
+    /// <summary>Optional recognition tier key. This always overrides the GitHub funding tier mapping.</summary>
+    public string? RecognitionTierKey { get; set; }
+
+    /// <summary>Optional public display name.</summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>Optional public profile or company URL.</summary>
+    public string? ProfileUrl { get; set; }
+
+    /// <summary>Optional avatar or logo URL.</summary>
+    public string? AvatarUrl { get; set; }
+
+    /// <summary>Whether the matched sponsor is omitted from generated content.</summary>
+    public bool Exclude { get; set; }
+}
+
+/// <summary>
+/// Manually maintained sponsor used for companies, external funding, or explicit recognition.
+/// </summary>
+public sealed class GitHubManualSponsorSpec
+{
+    /// <summary>Stable key used for sorting and overrides.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Public display name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Optional GitHub login. When present, GitHub profile and avatar defaults can be derived.</summary>
+    public string? Login { get; set; }
+
+    /// <summary>Optional public profile or company URL.</summary>
+    public string? ProfileUrl { get; set; }
+
+    /// <summary>Optional avatar or logo URL.</summary>
+    public string? AvatarUrl { get; set; }
+
+    /// <summary>Optional recognition tier key.</summary>
+    public string? RecognitionTierKey { get; set; }
+
+    /// <summary>Whether the manual entry is a former sponsor.</summary>
+    public bool Former { get; set; }
+}
+
+/// <summary>
+/// One generated Sponsors Markdown destination.
+/// </summary>
+public sealed class GitHubSponsorsOutputSpec
+{
+    /// <summary>Destination Markdown path, relative to the repository root unless absolute.</summary>
+    public string Path { get; set; } = "SPONSORS.md";
+
+    /// <summary>Marker block identifier.</summary>
+    public string BlockId { get; set; } = "sponsors";
+
+    /// <summary>Generated layout.</summary>
+    public GitHubSponsorsMarkdownLayout Layout { get; set; } = GitHubSponsorsMarkdownLayout.Full;
+
+    /// <summary>Heading used when creating a new document.</summary>
+    public string Title { get; set; } = "Sponsors";
+
+    /// <summary>Optional Markdown placed before generated sponsor groups.</summary>
+    public string? Introduction { get; set; }
+
+    /// <summary>Optional Markdown placed after generated sponsor groups.</summary>
+    public string? Closing { get; set; }
+
+    /// <summary>Whether former sponsors are included in this output.</summary>
+    public bool IncludeFormer { get; set; } = true;
+
+    /// <summary>Whether a missing destination document may be created.</summary>
+    public bool CreateIfMissing { get; set; }
+
+    /// <summary>Behavior when the document exists but the marker block is missing.</summary>
+    public ManagedMarkdownMissingBlockBehavior MissingBlockBehavior { get; set; } = ManagedMarkdownMissingBlockBehavior.Fail;
+
+    /// <summary>Default avatar size in pixels when recognition tiers do not provide one.</summary>
+    public int AvatarSize { get; set; } = 64;
+
+    /// <summary>Maximum current sponsors shown by a compact output. Zero includes all.</summary>
+    public int MaxEntries { get; set; }
+
+    /// <summary>Optional link added after a compact output, such as <c>SPONSORS.md</c>.</summary>
+    public string? MoreLink { get; set; }
+}
+
+/// <summary>
+/// Normalized public sponsor record used for results and rendering.
+/// </summary>
+public sealed class GitHubSponsorRecord
+{
+    /// <summary>GitHub login or manual-entry key.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>GitHub login when available.</summary>
+    public string? Login { get; set; }
+
+    /// <summary>Public display name.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Public profile or company URL.</summary>
+    public string? ProfileUrl { get; set; }
+
+    /// <summary>Avatar or logo URL.</summary>
+    public string? AvatarUrl { get; set; }
+
+    /// <summary>Current or former status.</summary>
+    public GitHubSponsorStatus Status { get; set; }
+
+    /// <summary>GitHub user, organization, or manual entity type.</summary>
+    public GitHubSponsorEntityType EntityType { get; set; }
+
+    /// <summary>Public recognition tier after mapping and manual overrides.</summary>
+    public string? RecognitionTierKey { get; set; }
+}
+
+/// <summary>
+/// Internal sponsor source data. Funding amounts are used only for opt-in recognition mapping and are never exposed in public results.
+/// </summary>
+internal sealed class GitHubSponsorSourceRecord
+{
+    internal GitHubSponsorRecord Sponsor { get; set; } = new();
+    internal int? FundingTierMonthlyDollars { get; set; }
+}
+
+/// <summary>
+/// Sponsors and recognition tiers prepared for deterministic rendering.
+/// </summary>
+public sealed class GitHubSponsorRecognitionResult
+{
+    /// <summary>Whether tier grouping is enabled.</summary>
+    public bool TierRecognitionEnabled { get; set; }
+
+    /// <summary>Normalized tiers in display order.</summary>
+    public GitHubSponsorRecognitionTierSpec[] Tiers { get; set; } = Array.Empty<GitHubSponsorRecognitionTierSpec>();
+
+    /// <summary>Normalized, overridden, and sorted sponsor records.</summary>
+    public GitHubSponsorRecord[] Sponsors { get; set; } = Array.Empty<GitHubSponsorRecord>();
+}
+
+/// <summary>
+/// Summary of one generated Sponsors document update.
+/// </summary>
+public sealed class GitHubSponsorsDocumentResult
+{
+    /// <summary>Absolute output path.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Managed block identifier.</summary>
+    public string BlockId { get; set; } = string.Empty;
+
+    /// <summary>Generated layout.</summary>
+    public GitHubSponsorsMarkdownLayout Layout { get; set; }
+
+    /// <summary>Whether the file content changed.</summary>
+    public bool Changed { get; set; }
+
+    /// <summary>Whether a new file was created.</summary>
+    public bool Created { get; set; }
+
+    /// <summary>Whether a new managed block was appended.</summary>
+    public bool Appended { get; set; }
+}
+
+/// <summary>
+/// Result of a GitHub repository-content synchronization run.
+/// </summary>
+public sealed class GitHubRepositoryContentResult
+{
+    /// <summary>Whether all requested content was generated successfully.</summary>
+    public bool Success { get; set; }
+
+    /// <summary>Sponsorable account used for the run.</summary>
+    public string SponsorableLogin { get; set; } = string.Empty;
+
+    /// <summary>Normalized current sponsors.</summary>
+    public GitHubSponsorRecord[] CurrentSponsors { get; set; } = Array.Empty<GitHubSponsorRecord>();
+
+    /// <summary>Normalized former sponsors.</summary>
+    public GitHubSponsorRecord[] FormerSponsors { get; set; } = Array.Empty<GitHubSponsorRecord>();
+
+    /// <summary>Generated document updates.</summary>
+    public GitHubSponsorsDocumentResult[] Documents { get; set; } = Array.Empty<GitHubSponsorsDocumentResult>();
+
+    /// <summary>Optional warning or failure message.</summary>
+    public string? Message { get; set; }
+}

--- a/PowerForge/Models/GitHubRepositoryContent.cs
+++ b/PowerForge/Models/GitHubRepositoryContent.cs
@@ -298,6 +298,10 @@ public sealed class GitHubSponsorRecognitionResult
 
     /// <summary>Normalized, overridden, and sorted sponsor records.</summary>
     public GitHubSponsorRecord[] Sponsors { get; set; } = Array.Empty<GitHubSponsorRecord>();
+
+    internal bool HasRenderedCurrentGitHubSponsors { get; set; }
+
+    internal bool HasFundingTierDataForRenderedCurrentGitHubSponsors { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/ManagedMarkdown.cs
+++ b/PowerForge/Models/ManagedMarkdown.cs
@@ -1,0 +1,58 @@
+namespace PowerForge;
+
+/// <summary>
+/// Behavior used when a managed block is missing from an existing Markdown document.
+/// </summary>
+public enum ManagedMarkdownMissingBlockBehavior
+{
+    /// <summary>Fail without modifying the document.</summary>
+    Fail,
+
+    /// <summary>Append a new marker-delimited block to the document.</summary>
+    Append
+}
+
+/// <summary>
+/// Request for creating or updating a marker-delimited Markdown block.
+/// </summary>
+public sealed class ManagedMarkdownUpdateRequest
+{
+    /// <summary>Markdown document path.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Stable identifier used in the managed block markers.</summary>
+    public string BlockId { get; set; } = string.Empty;
+
+    /// <summary>Markdown written between the managed block markers.</summary>
+    public string Markdown { get; set; } = string.Empty;
+
+    /// <summary>Whether a missing document may be created.</summary>
+    public bool CreateIfMissing { get; set; }
+
+    /// <summary>Behavior used when the document exists but the managed block does not.</summary>
+    public ManagedMarkdownMissingBlockBehavior MissingBlockBehavior { get; set; } = ManagedMarkdownMissingBlockBehavior.Fail;
+
+    /// <summary>Optional level-one heading added when a new document is created.</summary>
+    public string? NewDocumentTitle { get; set; }
+}
+
+/// <summary>
+/// Result of a managed Markdown block update.
+/// </summary>
+public sealed class ManagedMarkdownUpdateResult
+{
+    /// <summary>Absolute document path.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Updated block identifier.</summary>
+    public string BlockId { get; set; } = string.Empty;
+
+    /// <summary>Whether the file content changed.</summary>
+    public bool Changed { get; set; }
+
+    /// <summary>Whether a new document was created.</summary>
+    public bool Created { get; set; }
+
+    /// <summary>Whether a new block was appended to an existing document.</summary>
+    public bool Appended { get; set; }
+}

--- a/PowerForge/Models/ManagedMarkdown.cs
+++ b/PowerForge/Models/ManagedMarkdown.cs
@@ -13,12 +13,30 @@ public enum ManagedMarkdownMissingBlockBehavior
 }
 
 /// <summary>
+/// Marker syntax accepted by a managed Markdown update.
+/// </summary>
+public enum ManagedMarkdownMarkerFormat
+{
+    /// <summary>Require namespaced markers such as <c>POWERFORGE:sponsors:START</c>.</summary>
+    Namespaced,
+
+    /// <summary>Require legacy two-part markers such as <c>sponsors:start</c>.</summary>
+    LegacyBlockId,
+
+    /// <summary>Accept either namespaced or legacy markers, but never both for the same block.</summary>
+    NamespacedOrLegacyBlockId
+}
+
+/// <summary>
 /// Request for creating or updating a marker-delimited Markdown block.
 /// </summary>
 public sealed class ManagedMarkdownUpdateRequest
 {
     /// <summary>Marker namespace used before the block identifier.</summary>
     public string MarkerNamespace { get; set; } = "POWERFORGE";
+
+    /// <summary>Marker syntax accepted for this update. Namespaced markers are required by default.</summary>
+    public ManagedMarkdownMarkerFormat MarkerFormat { get; set; } = ManagedMarkdownMarkerFormat.Namespaced;
 
     /// <summary>Markdown document path.</summary>
     public string Path { get; set; } = string.Empty;

--- a/PowerForge/Models/ManagedMarkdown.cs
+++ b/PowerForge/Models/ManagedMarkdown.cs
@@ -17,6 +17,9 @@ public enum ManagedMarkdownMissingBlockBehavior
 /// </summary>
 public sealed class ManagedMarkdownUpdateRequest
 {
+    /// <summary>Marker namespace used before the block identifier.</summary>
+    public string MarkerNamespace { get; set; } = "POWERFORGE";
+
     /// <summary>Markdown document path.</summary>
     public string Path { get; set; } = string.Empty;
 

--- a/PowerForge/Services/Benchmarks/BenchmarkDocumentUpdater.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkDocumentUpdater.cs
@@ -19,6 +19,7 @@ public sealed class BenchmarkDocumentUpdater
         var result = _updater.Update(new ManagedMarkdownUpdateRequest
         {
             MarkerNamespace = "BENCHMARK",
+            MarkerFormat = ManagedMarkdownMarkerFormat.NamespacedOrLegacyBlockId,
             Path = path,
             BlockId = blockId,
             Markdown = markdown,
@@ -40,5 +41,9 @@ public sealed class BenchmarkDocumentUpdater
     /// <param name="path">Markdown document path.</param>
     /// <param name="blockId">Block identifier.</param>
     public void ValidateBlock(string path, string blockId)
-        => _updater.ValidateBlock(path, blockId, "BENCHMARK");
+        => _updater.ValidateBlock(
+            path,
+            blockId,
+            "BENCHMARK",
+            ManagedMarkdownMarkerFormat.NamespacedOrLegacyBlockId);
 }

--- a/PowerForge/Services/Benchmarks/BenchmarkDocumentUpdater.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkDocumentUpdater.cs
@@ -18,6 +18,7 @@ public sealed class BenchmarkDocumentUpdater
     {
         var result = _updater.Update(new ManagedMarkdownUpdateRequest
         {
+            MarkerNamespace = "BENCHMARK",
             Path = path,
             BlockId = blockId,
             Markdown = markdown,
@@ -39,5 +40,5 @@ public sealed class BenchmarkDocumentUpdater
     /// <param name="path">Markdown document path.</param>
     /// <param name="blockId">Block identifier.</param>
     public void ValidateBlock(string path, string blockId)
-        => _updater.ValidateBlock(path, blockId);
+        => _updater.ValidateBlock(path, blockId, "BENCHMARK");
 }

--- a/PowerForge/Services/Benchmarks/BenchmarkDocumentUpdater.cs
+++ b/PowerForge/Services/Benchmarks/BenchmarkDocumentUpdater.cs
@@ -1,6 +1,3 @@
-using System.Text;
-using System.Text.RegularExpressions;
-
 namespace PowerForge;
 
 /// <summary>
@@ -8,6 +5,8 @@ namespace PowerForge;
 /// </summary>
 public sealed class BenchmarkDocumentUpdater
 {
+    private readonly ManagedMarkdownDocumentUpdater _updater = new();
+
     /// <summary>
     /// Replaces a benchmark block in a document.
     /// </summary>
@@ -17,28 +16,20 @@ public sealed class BenchmarkDocumentUpdater
     /// <returns>Update result.</returns>
     public BenchmarkDocumentUpdateResult UpdateBlock(string path, string blockId, string markdown)
     {
-        var block = ReadBlock(path, blockId);
-
-        var replacement = (markdown ?? string.Empty).Replace("\r\n", "\n").Replace('\r', '\n').TrimEnd();
-        var updatedLines = new List<string>();
-        updatedLines.AddRange(block.Lines.Take(block.Start + 1));
-        if (replacement.Length > 0)
-            updatedLines.AddRange(replacement.Split('\n'));
-        updatedLines.AddRange(block.Lines.Skip(block.End));
-
-        var updated = string.Join("\n", updatedLines);
-        if (block.Original.Contains("\r\n", StringComparison.Ordinal))
-            updated = updated.Replace("\n", "\r\n");
-
-        var changed = !string.Equals(block.Original, updated, StringComparison.Ordinal);
-        if (changed)
-            File.WriteAllText(path, updated, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        var result = _updater.Update(new ManagedMarkdownUpdateRequest
+        {
+            Path = path,
+            BlockId = blockId,
+            Markdown = markdown,
+            CreateIfMissing = false,
+            MissingBlockBehavior = ManagedMarkdownMissingBlockBehavior.Fail
+        });
 
         return new BenchmarkDocumentUpdateResult
         {
-            Path = Path.GetFullPath(path),
-            BlockId = blockId,
-            Changed = changed
+            Path = result.Path,
+            BlockId = result.BlockId,
+            Changed = result.Changed
         };
     }
 
@@ -48,70 +39,5 @@ public sealed class BenchmarkDocumentUpdater
     /// <param name="path">Markdown document path.</param>
     /// <param name="blockId">Block identifier.</param>
     public void ValidateBlock(string path, string blockId)
-        => _ = ReadBlock(path, blockId);
-
-    private static BenchmarkBlockLocation ReadBlock(string path, string blockId)
-    {
-        if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Document path is required.", nameof(path));
-        if (string.IsNullOrWhiteSpace(blockId)) throw new ArgumentException("Block id is required.", nameof(blockId));
-        if (!File.Exists(path)) throw new FileNotFoundException($"Benchmark document was not found: {path}", path);
-
-        var original = File.ReadAllText(path);
-        var normalized = original.Replace("\r\n", "\n").Replace('\r', '\n');
-        var lines = normalized.Split('\n');
-        var start = -1;
-        var end = -1;
-
-        for (var i = 0; i < lines.Length; i++)
-        {
-            if (start < 0 && IsMarker(lines[i], blockId, "START"))
-            {
-                start = i;
-                continue;
-            }
-
-            if (start >= 0 && IsMarker(lines[i], blockId, "END"))
-            {
-                end = i;
-                break;
-            }
-        }
-
-        if (start < 0 || end < 0 || end <= start)
-            throw new InvalidOperationException($"Benchmark block '{blockId}' was not found in '{path}'.");
-
-        return new BenchmarkBlockLocation(original, lines, start, end);
-    }
-
-    private static bool IsMarker(string line, string blockId, string side)
-    {
-        var text = (line ?? string.Empty).Trim();
-        if (!text.StartsWith("<!--", StringComparison.Ordinal) || !text.EndsWith("-->", StringComparison.Ordinal))
-            return false;
-
-        var body = text.Substring(4, text.Length - 7).Trim();
-        var escaped = Regex.Escape(blockId.Trim());
-        var sidePattern = Regex.Escape(side.Trim());
-        return Regex.IsMatch(body, $"(^|:)({escaped})(:|$).*(:{sidePattern}$|^{sidePattern}$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)
-               || Regex.IsMatch(body, $"(^|:){escaped}:{sidePattern}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    }
-
-    private sealed class BenchmarkBlockLocation
-    {
-        internal BenchmarkBlockLocation(string original, string[] lines, int start, int end)
-        {
-            Original = original;
-            Lines = lines;
-            Start = start;
-            End = end;
-        }
-
-        internal string Original { get; }
-
-        internal string[] Lines { get; }
-
-        internal int Start { get; }
-
-        internal int End { get; }
-    }
+        => _updater.ValidateBlock(path, blockId);
 }

--- a/PowerForge/Services/ExistingFilePathIdentityResolver.cs
+++ b/PowerForge/Services/ExistingFilePathIdentityResolver.cs
@@ -1,6 +1,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace PowerForge;
 
@@ -35,17 +36,26 @@ internal static class ExistingFilePathIdentityResolver
 
     private static string ReadWindowsFileIdentity(SafeFileHandle handle)
     {
-        if (!GetFileInformationByHandleEx(
+        if (GetFileInformationByHandleEx(
                 handle,
                 WindowsFileInfoByHandleClass.FileIdInfo,
                 out var information,
                 checked((uint)Marshal.SizeOf<WindowsFileIdInfo>())))
+        {
+            return FormatWindowsFileIdentity(
+                information.VolumeSerialNumber,
+                information.FileId.Part0,
+                information.FileId.Part1);
+        }
+
+        var extendedIdentityError = Marshal.GetLastWin32Error();
+        if (!CanUseLegacyWindowsFileIdentity(handle))
+            throw new Win32Exception(extendedIdentityError);
+        if (!GetFileInformationByHandle(handle, out var legacyInformation))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
-        return FormatWindowsFileIdentity(
-            information.VolumeSerialNumber,
-            information.FileId.Part0,
-            information.FileId.Part1);
+        return $"windows-legacy:{legacyInformation.VolumeSerialNumber:X8}:" +
+               $"{legacyInformation.FileIndexHigh:X8}{legacyInformation.FileIndexLow:X8}";
     }
 
     /// <summary>
@@ -53,6 +63,41 @@ internal static class ExistingFilePathIdentityResolver
     /// </summary>
     internal static string FormatWindowsFileIdentity(ulong volumeSerialNumber, ulong identifierPart0, ulong identifierPart1)
         => $"windows:{volumeSerialNumber:X16}:{identifierPart0:X16}{identifierPart1:X16}";
+
+    private static bool CanUseLegacyWindowsFileIdentity(SafeFileHandle handle)
+    {
+        try
+        {
+            var fileSystemName = new StringBuilder(32);
+            if (!GetVolumeInformationByHandle(
+                    handle,
+                    null,
+                    0,
+                    out _,
+                    out _,
+                    out _,
+                    fileSystemName,
+                    checked((uint)fileSystemName.Capacity)))
+            {
+                return false;
+            }
+
+            return IsLegacyWindowsFileIdentitySafe(fileSystemName.ToString(), volumeInformationApiUnavailable: false);
+        }
+        catch (EntryPointNotFoundException)
+        {
+            // GetVolumeInformationByHandleW and ReFS both begin with Windows 8 / Server 2012.
+            return IsLegacyWindowsFileIdentitySafe(null, volumeInformationApiUnavailable: true);
+        }
+    }
+
+    /// <summary>
+    /// Limits the legacy 64-bit Windows file identifier to systems and filesystems where ReFS collisions cannot occur.
+    /// </summary>
+    internal static bool IsLegacyWindowsFileIdentitySafe(string? fileSystemName, bool volumeInformationApiUnavailable)
+        => volumeInformationApiUnavailable ||
+           (!string.IsNullOrWhiteSpace(fileSystemName) &&
+            !string.Equals(fileSystemName, "ReFS", StringComparison.OrdinalIgnoreCase));
 
 #if NET8_0_OR_GREATER
     private static string ReadUnixFileIdentity(SafeFileHandle handle)
@@ -76,6 +121,28 @@ internal static class ExistingFilePathIdentityResolver
     {
         internal ulong VolumeSerialNumber;
         internal WindowsFileId128 FileId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WindowsFileTime
+    {
+        internal uint LowDateTime;
+        internal uint HighDateTime;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WindowsFileInformation
+    {
+        internal uint FileAttributes;
+        internal WindowsFileTime CreationTime;
+        internal WindowsFileTime LastAccessTime;
+        internal WindowsFileTime LastWriteTime;
+        internal uint VolumeSerialNumber;
+        internal uint FileSizeHigh;
+        internal uint FileSizeLow;
+        internal uint NumberOfLinks;
+        internal uint FileIndexHigh;
+        internal uint FileIndexLow;
     }
 
     private enum WindowsFileInfoByHandleClass
@@ -116,6 +183,24 @@ internal static class ExistingFilePathIdentityResolver
         WindowsFileInfoByHandleClass fileInformationClass,
         out WindowsFileIdInfo information,
         uint bufferSize);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle file,
+        out WindowsFileInformation information);
+
+    [DllImport("kernel32.dll", EntryPoint = "GetVolumeInformationByHandleW", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetVolumeInformationByHandle(
+        SafeFileHandle file,
+        StringBuilder? volumeName,
+        uint volumeNameSize,
+        out uint volumeSerialNumber,
+        out uint maximumComponentLength,
+        out uint fileSystemFlags,
+        StringBuilder fileSystemName,
+        uint fileSystemNameSize);
 
 #if NET8_0_OR_GREATER
     [DllImport("System.Native", EntryPoint = "SystemNative_FStat", SetLastError = true)]

--- a/PowerForge/Services/ExistingFilePathIdentityResolver.cs
+++ b/PowerForge/Services/ExistingFilePathIdentityResolver.cs
@@ -35,11 +35,24 @@ internal static class ExistingFilePathIdentityResolver
 
     private static string ReadWindowsFileIdentity(SafeFileHandle handle)
     {
-        if (!GetFileInformationByHandle(handle, out var information))
+        if (!GetFileInformationByHandleEx(
+                handle,
+                WindowsFileInfoByHandleClass.FileIdInfo,
+                out var information,
+                checked((uint)Marshal.SizeOf<WindowsFileIdInfo>())))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
-        return $"windows:{information.VolumeSerialNumber:X8}:{information.FileIndexHigh:X8}{information.FileIndexLow:X8}";
+        return FormatWindowsFileIdentity(
+            information.VolumeSerialNumber,
+            information.FileId.Part0,
+            information.FileId.Part1);
     }
+
+    /// <summary>
+    /// Formats the volume-qualified 128-bit Windows file identifier without discarding ReFS identity bits.
+    /// </summary>
+    internal static string FormatWindowsFileIdentity(ulong volumeSerialNumber, ulong identifierPart0, ulong identifierPart1)
+        => $"windows:{volumeSerialNumber:X16}:{identifierPart0:X16}{identifierPart1:X16}";
 
 #if NET8_0_OR_GREATER
     private static string ReadUnixFileIdentity(SafeFileHandle handle)
@@ -52,25 +65,22 @@ internal static class ExistingFilePathIdentityResolver
 #endif
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct WindowsFileTime
+    private struct WindowsFileId128
     {
-        internal uint LowDateTime;
-        internal uint HighDateTime;
+        internal ulong Part0;
+        internal ulong Part1;
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct WindowsFileInformation
+    private struct WindowsFileIdInfo
     {
-        internal uint FileAttributes;
-        internal WindowsFileTime CreationTime;
-        internal WindowsFileTime LastAccessTime;
-        internal WindowsFileTime LastWriteTime;
-        internal uint VolumeSerialNumber;
-        internal uint FileSizeHigh;
-        internal uint FileSizeLow;
-        internal uint NumberOfLinks;
-        internal uint FileIndexHigh;
-        internal uint FileIndexLow;
+        internal ulong VolumeSerialNumber;
+        internal WindowsFileId128 FileId;
+    }
+
+    private enum WindowsFileInfoByHandleClass
+    {
+        FileIdInfo = 18
     }
 
 #if NET8_0_OR_GREATER
@@ -99,11 +109,13 @@ internal static class ExistingFilePathIdentityResolver
     }
 #endif
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool GetFileInformationByHandle(
+    private static extern bool GetFileInformationByHandleEx(
         SafeFileHandle file,
-        out WindowsFileInformation information);
+        WindowsFileInfoByHandleClass fileInformationClass,
+        out WindowsFileIdInfo information,
+        uint bufferSize);
 
 #if NET8_0_OR_GREATER
     [DllImport("System.Native", EntryPoint = "SystemNative_FStat", SetLastError = true)]

--- a/PowerForge/Services/ExistingFilePathIdentityResolver.cs
+++ b/PowerForge/Services/ExistingFilePathIdentityResolver.cs
@@ -86,7 +86,7 @@ internal static class ExistingFilePathIdentityResolver
         }
         catch (EntryPointNotFoundException)
         {
-            // GetVolumeInformationByHandleW and ReFS both begin with Windows 8 / Server 2012.
+            // An unavailable volume-handle API implies an OS old enough to predate ReFS.
             return IsLegacyWindowsFileIdentitySafe(null, volumeInformationApiUnavailable: true);
         }
     }

--- a/PowerForge/Services/ExistingFilePathIdentityResolver.cs
+++ b/PowerForge/Services/ExistingFilePathIdentityResolver.cs
@@ -1,0 +1,119 @@
+#if NETFRAMEWORK
+using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+#endif
+
+namespace PowerForge;
+
+/// <summary>
+/// Resolves an existing file to a stable physical identity so aliases are projected and written once.
+/// </summary>
+internal static class ExistingFilePathIdentityResolver
+{
+    internal static string Resolve(string path)
+    {
+        var fullPath = System.IO.Path.GetFullPath(path);
+#if NET8_0_OR_GREATER
+        return ResolveModern(fullPath);
+#else
+        return ResolveWindowsFinalPath(fullPath);
+#endif
+    }
+
+#if NET8_0_OR_GREATER
+    private static string ResolveModern(string fullPath)
+    {
+        var root = System.IO.Path.GetPathRoot(fullPath);
+        if (string.IsNullOrWhiteSpace(root))
+            throw new IOException($"Existing file path has no filesystem root: {fullPath}");
+
+        var current = root!;
+        var relative = fullPath.Substring(root!.Length);
+        var separators = System.IO.Path.DirectorySeparatorChar == System.IO.Path.AltDirectorySeparatorChar
+            ? new[] { System.IO.Path.DirectorySeparatorChar }
+            : new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
+
+        foreach (var segment in relative.Split(separators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var entry = FindExistingEntry(current, segment);
+            FileSystemInfo info = Directory.Exists(entry)
+                ? new DirectoryInfo(entry)
+                : new FileInfo(entry);
+            var target = info.ResolveLinkTarget(returnFinalTarget: true);
+            current = target is null ? entry : System.IO.Path.GetFullPath(target.FullName);
+        }
+
+        return System.IO.Path.GetFullPath(current);
+    }
+
+    private static string FindExistingEntry(string parent, string segment)
+    {
+        string? exact = null;
+        var aliases = new List<string>();
+        foreach (var entry in Directory.EnumerateFileSystemEntries(parent))
+        {
+            var name = System.IO.Path.GetFileName(entry);
+            if (string.Equals(name, segment, StringComparison.Ordinal))
+            {
+                exact = entry;
+                break;
+            }
+            if (string.Equals(name, segment, StringComparison.OrdinalIgnoreCase))
+                aliases.Add(entry);
+        }
+
+        if (exact is not null)
+            return exact;
+        if (aliases.Count == 1)
+            return aliases[0];
+        if (aliases.Count > 1)
+            throw new IOException($"Existing path has ambiguous case aliases: {System.IO.Path.Combine(parent, segment)}");
+        throw new FileNotFoundException("Existing path entry disappeared while resolving its identity.", System.IO.Path.Combine(parent, segment));
+    }
+#else
+    private static string ResolveWindowsFinalPath(string fullPath)
+    {
+        using var stream = new FileStream(
+            fullPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        return ReadFinalPath(stream.SafeFileHandle);
+    }
+
+    private static string ReadFinalPath(SafeFileHandle handle)
+    {
+        var capacity = 512;
+        while (true)
+        {
+            var builder = new StringBuilder(capacity);
+            var length = GetFinalPathNameByHandle(handle, builder, (uint)builder.Capacity, 0);
+            if (length == 0)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            if (length < builder.Capacity)
+                return NormalizeWindowsDevicePath(builder.ToString());
+            capacity = checked((int)length + 1);
+        }
+    }
+
+    private static string NormalizeWindowsDevicePath(string path)
+    {
+        const string uncPrefix = @"\\?\UNC\";
+        const string devicePrefix = @"\\?\";
+        if (path.StartsWith(uncPrefix, StringComparison.OrdinalIgnoreCase))
+            return @"\\" + path.Substring(uncPrefix.Length);
+        return path.StartsWith(devicePrefix, StringComparison.OrdinalIgnoreCase)
+            ? path.Substring(devicePrefix.Length)
+            : path;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern uint GetFinalPathNameByHandle(
+        SafeFileHandle file,
+        StringBuilder filePath,
+        uint filePathLength,
+        uint flags);
+#endif
+}

--- a/PowerForge/Services/ExistingFilePathIdentityResolver.cs
+++ b/PowerForge/Services/ExistingFilePathIdentityResolver.cs
@@ -1,9 +1,6 @@
-#if NETFRAMEWORK
 using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Text;
-#endif
 
 namespace PowerForge;
 
@@ -12,108 +9,106 @@ namespace PowerForge;
 /// </summary>
 internal static class ExistingFilePathIdentityResolver
 {
+    /// <summary>
+    /// Returns an operating-system file identity that is shared by every symbolic-link or hard-link alias.
+    /// </summary>
+    /// <param name="path">Existing file whose identity should be resolved.</param>
+    /// <returns>A volume/device-qualified file identifier suitable for in-process equality checks.</returns>
     internal static string Resolve(string path)
     {
         var fullPath = System.IO.Path.GetFullPath(path);
-#if NET8_0_OR_GREATER
-        return ResolveModern(fullPath);
-#else
-        return ResolveWindowsFinalPath(fullPath);
-#endif
-    }
-
-#if NET8_0_OR_GREATER
-    private static string ResolveModern(string fullPath)
-    {
-        var root = System.IO.Path.GetPathRoot(fullPath);
-        if (string.IsNullOrWhiteSpace(root))
-            throw new IOException($"Existing file path has no filesystem root: {fullPath}");
-
-        var current = root!;
-        var relative = fullPath.Substring(root!.Length);
-        var separators = System.IO.Path.DirectorySeparatorChar == System.IO.Path.AltDirectorySeparatorChar
-            ? new[] { System.IO.Path.DirectorySeparatorChar }
-            : new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
-
-        foreach (var segment in relative.Split(separators, StringSplitOptions.RemoveEmptyEntries))
-        {
-            var entry = FindExistingEntry(current, segment);
-            FileSystemInfo info = Directory.Exists(entry)
-                ? new DirectoryInfo(entry)
-                : new FileInfo(entry);
-            var target = info.ResolveLinkTarget(returnFinalTarget: true);
-            current = target is null ? entry : System.IO.Path.GetFullPath(target.FullName);
-        }
-
-        return System.IO.Path.GetFullPath(current);
-    }
-
-    private static string FindExistingEntry(string parent, string segment)
-    {
-        string? exact = null;
-        var aliases = new List<string>();
-        foreach (var entry in Directory.EnumerateFileSystemEntries(parent))
-        {
-            var name = System.IO.Path.GetFileName(entry);
-            if (string.Equals(name, segment, StringComparison.Ordinal))
-            {
-                exact = entry;
-                break;
-            }
-            if (string.Equals(name, segment, StringComparison.OrdinalIgnoreCase))
-                aliases.Add(entry);
-        }
-
-        if (exact is not null)
-            return exact;
-        if (aliases.Count == 1)
-            return aliases[0];
-        if (aliases.Count > 1)
-            throw new IOException($"Existing path has ambiguous case aliases: {System.IO.Path.Combine(parent, segment)}");
-        throw new FileNotFoundException("Existing path entry disappeared while resolving its identity.", System.IO.Path.Combine(parent, segment));
-    }
-#else
-    private static string ResolveWindowsFinalPath(string fullPath)
-    {
         using var stream = new FileStream(
             fullPath,
             FileMode.Open,
             FileAccess.Read,
             FileShare.ReadWrite | FileShare.Delete);
-        return ReadFinalPath(stream.SafeFileHandle);
+
+        if (System.IO.Path.DirectorySeparatorChar == '\\')
+            return ReadWindowsFileIdentity(stream.SafeFileHandle);
+
+#if NET8_0_OR_GREATER
+        return ReadUnixFileIdentity(stream.SafeFileHandle);
+#else
+        throw new PlatformNotSupportedException("Physical file identity is not available for this runtime and operating system.");
+#endif
     }
 
-    private static string ReadFinalPath(SafeFileHandle handle)
+    private static string ReadWindowsFileIdentity(SafeFileHandle handle)
     {
-        var capacity = 512;
-        while (true)
-        {
-            var builder = new StringBuilder(capacity);
-            var length = GetFinalPathNameByHandle(handle, builder, (uint)builder.Capacity, 0);
-            if (length == 0)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            if (length < builder.Capacity)
-                return NormalizeWindowsDevicePath(builder.ToString());
-            capacity = checked((int)length + 1);
-        }
+        if (!GetFileInformationByHandle(handle, out var information))
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+
+        return $"windows:{information.VolumeSerialNumber:X8}:{information.FileIndexHigh:X8}{information.FileIndexLow:X8}";
     }
 
-    private static string NormalizeWindowsDevicePath(string path)
+#if NET8_0_OR_GREATER
+    private static string ReadUnixFileIdentity(SafeFileHandle handle)
     {
-        const string uncPrefix = @"\\?\UNC\";
-        const string devicePrefix = @"\\?\";
-        if (path.StartsWith(uncPrefix, StringComparison.OrdinalIgnoreCase))
-            return @"\\" + path.Substring(uncPrefix.Length);
-        return path.StartsWith(devicePrefix, StringComparison.OrdinalIgnoreCase)
-            ? path.Substring(devicePrefix.Length)
-            : path;
+        if (SystemNativeFStat(handle, out var status) != 0)
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+
+        return $"unix:{unchecked((ulong)status.Device):X16}:{unchecked((ulong)status.Inode):X16}";
     }
+#endif
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WindowsFileTime
+    {
+        internal uint LowDateTime;
+        internal uint HighDateTime;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WindowsFileInformation
+    {
+        internal uint FileAttributes;
+        internal WindowsFileTime CreationTime;
+        internal WindowsFileTime LastAccessTime;
+        internal WindowsFileTime LastWriteTime;
+        internal uint VolumeSerialNumber;
+        internal uint FileSizeHigh;
+        internal uint FileSizeLow;
+        internal uint NumberOfLinks;
+        internal uint FileIndexHigh;
+        internal uint FileIndexLow;
+    }
+
+#if NET8_0_OR_GREATER
+    // System.Native exposes one normalized FileStatus ABI across .NET's supported Unix platforms.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UnixFileStatus
+    {
+        internal int Flags;
+        internal int Mode;
+        internal uint UserId;
+        internal uint GroupId;
+        internal long Size;
+        internal long AccessTime;
+        internal long AccessTimeNanoseconds;
+        internal long ModificationTime;
+        internal long ModificationTimeNanoseconds;
+        internal long ChangeTime;
+        internal long ChangeTimeNanoseconds;
+        internal long BirthTime;
+        internal long BirthTimeNanoseconds;
+        internal long Device;
+        internal long RawDevice;
+        internal long Inode;
+        internal uint UserFlags;
+        internal int HardLinkCount;
+    }
+#endif
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern uint GetFinalPathNameByHandle(
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
         SafeFileHandle file,
-        StringBuilder filePath,
-        uint filePathLength,
-        uint flags);
+        out WindowsFileInformation information);
+
+#if NET8_0_OR_GREATER
+    [DllImport("System.Native", EntryPoint = "SystemNative_FStat", SetLastError = true)]
+    private static extern int SystemNativeFStat(
+        SafeFileHandle file,
+        out UnixFileStatus status);
 #endif
 }

--- a/PowerForge/Services/GitHubRepositoryContentService.cs
+++ b/PowerForge/Services/GitHubRepositoryContentService.cs
@@ -85,6 +85,7 @@ public sealed class GitHubRepositoryContentService
 
         var basePath = ResolveBaseDirectory(baseDirectory);
         var planned = BuildPlans(outputs, recognition, basePath, restrictedOutputRoot);
+        ValidatePlanSet(planned);
         foreach (var plan in planned)
             _documentUpdater.ValidateUpdate(plan.Request);
 
@@ -148,6 +149,29 @@ public sealed class GitHubRepositoryContentService
             }));
         }
         return plans;
+    }
+
+    private static void ValidatePlanSet(List<OutputPlan> plans)
+    {
+        var byPath = new Dictionary<string, List<OutputPlan>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var plan in plans)
+        {
+            if (!byPath.TryGetValue(plan.Request.Path, out var matching))
+            {
+                matching = new List<OutputPlan>();
+                byPath.Add(plan.Request.Path, matching);
+            }
+            matching.Add(plan);
+        }
+
+        foreach (var pair in byPath)
+        {
+            if (pair.Value.Count > 1 && !File.Exists(pair.Key))
+            {
+                throw new InvalidOperationException(
+                    $"Multiple managed blocks target missing document '{pair.Key}'. Create the document with all markers first or configure one output per new file. No documents were modified.");
+            }
+        }
     }
 
     private static string ResolveSponsorableLogin(string? configured)

--- a/PowerForge/Services/GitHubRepositoryContentService.cs
+++ b/PowerForge/Services/GitHubRepositoryContentService.cs
@@ -69,6 +69,8 @@ public sealed class GitHubRepositoryContentService
         }, includeFundingTierData: tierRecognitionEnabled);
 
         var currentGitHubSponsors = source.Where(sponsor => sponsor.Sponsor.Status == GitHubSponsorStatus.Current).ToArray();
+        if (sponsorsSpec.FailOnEmpty && currentGitHubSponsors.Length == 0)
+            throw new InvalidOperationException("GitHub Sponsors returned no public current sponsors. No documents were modified.");
         if (tierRecognitionEnabled && sponsorsSpec.RequireFundingTierData &&
             currentGitHubSponsors.Length > 0 && currentGitHubSponsors.All(sponsor => sponsor.FundingTierMonthlyDollars is null))
         {
@@ -80,8 +82,6 @@ public sealed class GitHubRepositoryContentService
         var recognition = _recognitionService.Prepare(source, sponsorsSpec);
         var current = recognition.Sponsors.Where(sponsor => sponsor.Status == GitHubSponsorStatus.Current).ToArray();
         var former = recognition.Sponsors.Where(sponsor => sponsor.Status == GitHubSponsorStatus.Former).ToArray();
-        if (sponsorsSpec.FailOnEmpty && current.Length == 0)
-            throw new InvalidOperationException("GitHub Sponsors returned no public current sponsors. No documents were modified.");
 
         var basePath = ResolveBaseDirectory(baseDirectory);
         var planned = BuildPlans(outputs, recognition, basePath, restrictedOutputRoot);

--- a/PowerForge/Services/GitHubRepositoryContentService.cs
+++ b/PowerForge/Services/GitHubRepositoryContentService.cs
@@ -86,13 +86,13 @@ public sealed class GitHubRepositoryContentService
         var basePath = ResolveBaseDirectory(baseDirectory);
         var planned = BuildPlans(outputs, recognition, basePath, restrictedOutputRoot);
         ValidatePlanSet(planned);
-        foreach (var plan in planned)
-            _documentUpdater.ValidateUpdate(plan.Request);
+        var updates = _documentUpdater.UpdateMany(planned.Select(plan => plan.Request));
 
         var documentResults = new List<GitHubSponsorsDocumentResult>();
-        foreach (var plan in planned)
+        for (var index = 0; index < planned.Count; index++)
         {
-            var update = _documentUpdater.Update(plan.Request);
+            var plan = planned[index];
+            var update = updates[index];
             documentResults.Add(new GitHubSponsorsDocumentResult
             {
                 Path = update.Path,
@@ -122,7 +122,7 @@ public sealed class GitHubRepositoryContentService
         string? restrictedOutputRoot)
     {
         var plans = new List<OutputPlan>();
-        var destinations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var destinations = new HashSet<string>(StringComparer.Ordinal);
         foreach (var output in outputs)
         {
             if (output is null) throw new InvalidOperationException("Sponsors outputs cannot contain null entries.");
@@ -153,7 +153,7 @@ public sealed class GitHubRepositoryContentService
 
     private static void ValidatePlanSet(List<OutputPlan> plans)
     {
-        var byPath = new Dictionary<string, List<OutputPlan>>(StringComparer.OrdinalIgnoreCase);
+        var byPath = new Dictionary<string, List<OutputPlan>>(StringComparer.Ordinal);
         foreach (var plan in plans)
         {
             if (!byPath.TryGetValue(plan.Request.Path, out var matching))
@@ -221,34 +221,50 @@ public sealed class GitHubRepositoryContentService
         if (!outputPath.Equals(root, comparison) && !outputPath.StartsWith(rootPrefix, comparison))
             throw new InvalidOperationException($"Managed output is outside the restricted output root: {outputPath}");
 
-        if (outputPath.Equals(root, comparison))
-            return;
+        ValidateNoReparsePoints(root);
+        if (!outputPath.Equals(root, comparison))
+            ValidateNoReparsePoints(outputPath);
+    }
 
-        var relative = outputPath.Substring(rootPrefix.Length);
-        var current = root;
-        foreach (var segment in relative.Split(new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries))
+    private static void ValidateNoReparsePoints(string path)
+    {
+        var fullPath = System.IO.Path.GetFullPath(path);
+        var volumeRoot = System.IO.Path.GetPathRoot(fullPath) ?? string.Empty;
+        var current = volumeRoot;
+        if (!string.IsNullOrWhiteSpace(current))
+            ValidateExistingPathEntry(current);
+
+        var relative = fullPath.Substring(volumeRoot.Length);
+        foreach (var segment in relative.Split(
+                     new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar },
+                     StringSplitOptions.RemoveEmptyEntries))
         {
             current = System.IO.Path.Combine(current, segment);
-            var existingEntry = FindPathEntryWithoutFollowing(current);
-            if (existingEntry is null)
-                continue;
+            ValidateExistingPathEntry(current);
+        }
+    }
 
-            FileAttributes attributes;
-            try
-            {
-                attributes = File.GetAttributes(existingEntry);
-            }
-            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or NotSupportedException)
-            {
-                throw new InvalidOperationException(
-                    $"Managed output path contains an existing entry that cannot be safely inspected: {existingEntry}",
-                    exception);
-            }
-            if ((attributes & FileAttributes.ReparsePoint) != 0)
-            {
-                throw new InvalidOperationException(
-                    $"Managed output path traverses a symbolic link or reparse point and cannot be safely restricted: {existingEntry}");
-            }
+    private static void ValidateExistingPathEntry(string path)
+    {
+        var existingEntry = FindPathEntryWithoutFollowing(path);
+        if (existingEntry is null)
+            return;
+
+        FileAttributes attributes;
+        try
+        {
+            attributes = File.GetAttributes(existingEntry);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                $"Managed output path contains an existing entry that cannot be safely inspected: {existingEntry}",
+                exception);
+        }
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new InvalidOperationException(
+                $"Managed output path traverses a symbolic link or reparse point and cannot be safely restricted: {existingEntry}");
         }
     }
 

--- a/PowerForge/Services/GitHubRepositoryContentService.cs
+++ b/PowerForge/Services/GitHubRepositoryContentService.cs
@@ -1,0 +1,274 @@
+namespace PowerForge;
+
+/// <summary>
+/// Orchestrates config-driven GitHub repository content generation.
+/// </summary>
+public sealed class GitHubRepositoryContentService
+{
+    private readonly ILogger _logger;
+    private readonly GitHubSponsorsClient _sponsorsClient;
+    private readonly GitHubSponsorRecognitionService _recognitionService;
+    private readonly GitHubSponsorsMarkdownRenderer _renderer;
+    private readonly ManagedMarkdownDocumentUpdater _documentUpdater;
+
+    /// <summary>
+    /// Creates a repository-content service.
+    /// </summary>
+    /// <param name="logger">Optional progress logger.</param>
+    /// <param name="sponsorsClient">Optional Sponsors API client.</param>
+    /// <param name="recognitionService">Optional recognition service.</param>
+    /// <param name="renderer">Optional Markdown renderer.</param>
+    /// <param name="documentUpdater">Optional managed-document updater.</param>
+    public GitHubRepositoryContentService(
+        ILogger? logger = null,
+        GitHubSponsorsClient? sponsorsClient = null,
+        GitHubSponsorRecognitionService? recognitionService = null,
+        GitHubSponsorsMarkdownRenderer? renderer = null,
+        ManagedMarkdownDocumentUpdater? documentUpdater = null)
+    {
+        _logger = logger ?? new NullLogger();
+        _sponsorsClient = sponsorsClient ?? new GitHubSponsorsClient();
+        _recognitionService = recognitionService ?? new GitHubSponsorRecognitionService();
+        _renderer = renderer ?? new GitHubSponsorsMarkdownRenderer();
+        _documentUpdater = documentUpdater ?? new ManagedMarkdownDocumentUpdater();
+    }
+
+    /// <summary>
+    /// Synchronizes all enabled repository-content sections.
+    /// </summary>
+    /// <param name="spec">Repository-content specification.</param>
+    /// <param name="baseDirectory">Base directory used for relative output paths.</param>
+    /// <param name="restrictedOutputRoot">Optional root that every output must remain within. Reparse-point output paths are rejected.</param>
+    /// <returns>Synchronization result.</returns>
+    public GitHubRepositoryContentResult Sync(
+        GitHubRepositoryContentSpec spec,
+        string? baseDirectory = null,
+        string? restrictedOutputRoot = null)
+    {
+        if (spec is null) throw new ArgumentNullException(nameof(spec));
+        var sponsorsSpec = spec.Sponsors ?? throw new InvalidOperationException("Sponsors configuration is required.");
+        if (!sponsorsSpec.Enabled)
+            throw new InvalidOperationException("No GitHub repository-content sections are enabled. Set sponsors.enabled to true.");
+
+        var login = ResolveSponsorableLogin(sponsorsSpec.SponsorableLogin);
+        var token = ResolveToken(spec.Token, spec.TokenEnvName);
+        var outputs = sponsorsSpec.Outputs ?? Array.Empty<GitHubSponsorsOutputSpec>();
+        if (outputs.Length == 0)
+            throw new InvalidOperationException("At least one Sponsors output is required.");
+
+        var includeFormer = sponsorsSpec.IncludeFormer && outputs.Any(output => output.IncludeFormer);
+        _logger.Info($"Retrieving public GitHub Sponsors for {login}.");
+        var tierRecognitionEnabled = sponsorsSpec.TierRecognition?.Enabled ?? false;
+        var source = _sponsorsClient.GetSponsorSources(new GitHubSponsorsQuery
+        {
+            SponsorableLogin = login,
+            Token = token,
+            GraphQlEndpoint = spec.GraphQlEndpoint,
+            IncludeFormer = includeFormer,
+            PageSize = sponsorsSpec.PageSize
+        }, includeFundingTierData: tierRecognitionEnabled);
+
+        var currentGitHubSponsors = source.Where(sponsor => sponsor.Sponsor.Status == GitHubSponsorStatus.Current).ToArray();
+        if (tierRecognitionEnabled && sponsorsSpec.RequireFundingTierData &&
+            currentGitHubSponsors.Length > 0 && currentGitHubSponsors.All(sponsor => sponsor.FundingTierMonthlyDollars is null))
+        {
+            throw new InvalidOperationException(
+                "GitHub withheld funding-tier data for every current sponsor. No documents were modified. " +
+                "Use a maintainer-authorized token or disable sponsors.requireFundingTierData.");
+        }
+
+        var recognition = _recognitionService.Prepare(source, sponsorsSpec);
+        var current = recognition.Sponsors.Where(sponsor => sponsor.Status == GitHubSponsorStatus.Current).ToArray();
+        var former = recognition.Sponsors.Where(sponsor => sponsor.Status == GitHubSponsorStatus.Former).ToArray();
+        if (sponsorsSpec.FailOnEmpty && current.Length == 0)
+            throw new InvalidOperationException("GitHub Sponsors returned no public current sponsors. No documents were modified.");
+
+        var basePath = ResolveBaseDirectory(baseDirectory);
+        var planned = BuildPlans(outputs, recognition, basePath, restrictedOutputRoot);
+        foreach (var plan in planned)
+            _documentUpdater.ValidateUpdate(plan.Request);
+
+        var documentResults = new List<GitHubSponsorsDocumentResult>();
+        foreach (var plan in planned)
+        {
+            var update = _documentUpdater.Update(plan.Request);
+            documentResults.Add(new GitHubSponsorsDocumentResult
+            {
+                Path = update.Path,
+                BlockId = update.BlockId,
+                Layout = plan.Output.Layout,
+                Changed = update.Changed,
+                Created = update.Created,
+                Appended = update.Appended
+            });
+        }
+
+        _logger.Info($"Generated {documentResults.Count} Sponsors output(s): {current.Length} current, {former.Length} former.");
+        return new GitHubRepositoryContentResult
+        {
+            Success = true,
+            SponsorableLogin = login,
+            CurrentSponsors = current,
+            FormerSponsors = former,
+            Documents = documentResults.ToArray()
+        };
+    }
+
+    private List<OutputPlan> BuildPlans(
+        GitHubSponsorsOutputSpec[] outputs,
+        GitHubSponsorRecognitionResult recognition,
+        string basePath,
+        string? restrictedOutputRoot)
+    {
+        var plans = new List<OutputPlan>();
+        var destinations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var output in outputs)
+        {
+            if (output is null) throw new InvalidOperationException("Sponsors outputs cannot contain null entries.");
+            if (string.IsNullOrWhiteSpace(output.Path)) throw new InvalidOperationException("Sponsors output path is required.");
+            if (string.IsNullOrWhiteSpace(output.BlockId)) throw new InvalidOperationException("Sponsors output block id is required.");
+
+            var path = System.IO.Path.IsPathRooted(output.Path)
+                ? System.IO.Path.GetFullPath(output.Path)
+                : System.IO.Path.GetFullPath(System.IO.Path.Combine(basePath, output.Path));
+            ValidateRestrictedOutputPath(path, restrictedOutputRoot);
+            var destinationKey = path + "|" + output.BlockId.Trim();
+            if (!destinations.Add(destinationKey))
+                throw new InvalidOperationException($"Sponsors output '{output.BlockId}' is configured more than once for '{path}'.");
+
+            var markdown = _renderer.Render(recognition, output);
+            plans.Add(new OutputPlan(output, new ManagedMarkdownUpdateRequest
+            {
+                Path = path,
+                BlockId = output.BlockId,
+                Markdown = markdown,
+                CreateIfMissing = output.CreateIfMissing,
+                MissingBlockBehavior = output.MissingBlockBehavior,
+                NewDocumentTitle = output.Title
+            }));
+        }
+        return plans;
+    }
+
+    private static string ResolveSponsorableLogin(string? configured)
+    {
+        var login = string.IsNullOrWhiteSpace(configured)
+            ? Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_OWNER")
+            : configured;
+        if (string.IsNullOrWhiteSpace(login))
+            throw new InvalidOperationException("Sponsorable login is required. Configure sponsors.sponsorableLogin or set GITHUB_REPOSITORY_OWNER.");
+        return login!.Trim();
+    }
+
+    private static string ResolveToken(string? configured, string? tokenEnvironmentName)
+    {
+        if (!string.IsNullOrWhiteSpace(configured))
+            return configured!.Trim();
+        var environmentName = string.IsNullOrWhiteSpace(tokenEnvironmentName) ? "GITHUB_TOKEN" : tokenEnvironmentName!.Trim();
+        var token = Environment.GetEnvironmentVariable(environmentName);
+        if (string.IsNullOrWhiteSpace(token))
+            throw new InvalidOperationException($"GitHub token is required. Set {environmentName} or provide a token at runtime.");
+        return token!.Trim();
+    }
+
+    private static string ResolveBaseDirectory(string? baseDirectory)
+    {
+        var value = string.IsNullOrWhiteSpace(baseDirectory) ? Directory.GetCurrentDirectory() : baseDirectory!;
+        return System.IO.Path.GetFullPath(value);
+    }
+
+    private static void ValidateRestrictedOutputPath(string outputPath, string? restrictedOutputRoot)
+    {
+        if (string.IsNullOrWhiteSpace(restrictedOutputRoot))
+            return;
+
+        var fullRoot = System.IO.Path.GetFullPath(restrictedOutputRoot!.Trim().Trim('"'));
+        var volumeRoot = System.IO.Path.GetPathRoot(fullRoot) ?? string.Empty;
+        var root = fullRoot.Length > volumeRoot.Length
+            ? fullRoot.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar)
+            : fullRoot;
+        var comparison = System.IO.Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var rootPrefix = root.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+                         root.EndsWith(System.IO.Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? root
+            : root + System.IO.Path.DirectorySeparatorChar;
+        if (!outputPath.Equals(root, comparison) && !outputPath.StartsWith(rootPrefix, comparison))
+            throw new InvalidOperationException($"Managed output is outside the restricted output root: {outputPath}");
+
+        if (outputPath.Equals(root, comparison))
+            return;
+
+        var relative = outputPath.Substring(rootPrefix.Length);
+        var current = root;
+        foreach (var segment in relative.Split(new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = System.IO.Path.Combine(current, segment);
+            var existingEntry = FindPathEntryWithoutFollowing(current);
+            if (existingEntry is null)
+                continue;
+
+            FileAttributes attributes;
+            try
+            {
+                attributes = File.GetAttributes(existingEntry);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or NotSupportedException)
+            {
+                throw new InvalidOperationException(
+                    $"Managed output path contains an existing entry that cannot be safely inspected: {existingEntry}",
+                    exception);
+            }
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Managed output path traverses a symbolic link or reparse point and cannot be safely restricted: {existingEntry}");
+            }
+        }
+    }
+
+    private static string? FindPathEntryWithoutFollowing(string path)
+    {
+        if (File.Exists(path) || Directory.Exists(path))
+            return path;
+
+        var parent = System.IO.Path.GetDirectoryName(path);
+        if (string.IsNullOrWhiteSpace(parent) || !Directory.Exists(parent))
+            return null;
+
+        string? exact = null;
+        var aliases = new List<string>();
+        foreach (var entry in Directory.EnumerateFileSystemEntries(parent))
+        {
+            var candidate = System.IO.Path.GetFullPath(entry);
+            if (candidate.Equals(path, StringComparison.Ordinal))
+                exact = candidate;
+            else if (candidate.Equals(path, StringComparison.OrdinalIgnoreCase))
+                aliases.Add(candidate);
+        }
+
+        if (exact is not null)
+            return exact;
+        if (aliases.Count == 1)
+            return aliases[0];
+        if (aliases.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"Managed output path has ambiguous case-colliding filesystem entries and cannot be safely restricted: {path}");
+        }
+        return null;
+    }
+
+    private sealed class OutputPlan
+    {
+        internal OutputPlan(GitHubSponsorsOutputSpec output, ManagedMarkdownUpdateRequest request)
+        {
+            Output = output;
+            Request = request;
+        }
+
+        internal GitHubSponsorsOutputSpec Output { get; }
+        internal ManagedMarkdownUpdateRequest Request { get; }
+    }
+}

--- a/PowerForge/Services/GitHubRepositoryContentService.cs
+++ b/PowerForge/Services/GitHubRepositoryContentService.cs
@@ -71,15 +71,16 @@ public sealed class GitHubRepositoryContentService
         var currentGitHubSponsors = source.Where(sponsor => sponsor.Sponsor.Status == GitHubSponsorStatus.Current).ToArray();
         if (sponsorsSpec.FailOnEmpty && currentGitHubSponsors.Length == 0)
             throw new InvalidOperationException("GitHub Sponsors returned no public current sponsors. No documents were modified.");
-        if (tierRecognitionEnabled && sponsorsSpec.RequireFundingTierData &&
-            currentGitHubSponsors.Length > 0 && currentGitHubSponsors.All(sponsor => sponsor.FundingTierMonthlyDollars is null))
-        {
-            throw new InvalidOperationException(
-                "GitHub withheld funding-tier data for every current sponsor. No documents were modified. " +
-                "Use a maintainer-authorized token or disable sponsors.requireFundingTierData.");
-        }
 
         var recognition = _recognitionService.Prepare(source, sponsorsSpec);
+        if (tierRecognitionEnabled && sponsorsSpec.RequireFundingTierData &&
+            recognition.HasRenderedCurrentGitHubSponsors &&
+            !recognition.HasFundingTierDataForRenderedCurrentGitHubSponsors)
+        {
+            throw new InvalidOperationException(
+                "GitHub withheld funding-tier data for every rendered current GitHub sponsor. No documents were modified. " +
+                "Use a maintainer-authorized token, adjust exclusions, or disable sponsors.requireFundingTierData.");
+        }
         var current = recognition.Sponsors.Where(sponsor => sponsor.Status == GitHubSponsorStatus.Current).ToArray();
         var former = recognition.Sponsors.Where(sponsor => sponsor.Status == GitHubSponsorStatus.Former).ToArray();
 

--- a/PowerForge/Services/GitHubSponsorRecognitionService.cs
+++ b/PowerForge/Services/GitHubSponsorRecognitionService.cs
@@ -1,0 +1,232 @@
+namespace PowerForge;
+
+/// <summary>
+/// Applies manual entries, presentation overrides, and opt-in recognition tiers to GitHub Sponsors data.
+/// </summary>
+public sealed class GitHubSponsorRecognitionService
+{
+    private static readonly GitHubSponsorRecognitionTierSpec[] DefaultTiers =
+    {
+        new() { Key = "Principal", Heading = "Principal Sponsors", MinimumMonthlyDollars = 1000, Order = 10, AvatarSize = 112 },
+        new() { Key = "Platinum", Heading = "Platinum Sponsors", MinimumMonthlyDollars = 100, Order = 20, AvatarSize = 96 },
+        new() { Key = "Gold", Heading = "Gold Sponsors", MinimumMonthlyDollars = 30, Order = 30, AvatarSize = 80 },
+        new() { Key = "Silver", Heading = "Silver Sponsors", MinimumMonthlyDollars = 10, Order = 40, AvatarSize = 72 },
+        new() { Key = "Bronze", Heading = "Bronze Sponsors", MinimumMonthlyDollars = 5, Order = 50, AvatarSize = 64 },
+        new() { Key = "Sponsors", Heading = "Sponsors", MinimumMonthlyDollars = null, Order = 60, AvatarSize = 64 }
+    };
+
+    /// <summary>
+    /// Prepares sponsor records for rendering.
+    /// </summary>
+    /// <param name="source">Public sponsors returned by GitHub.</param>
+    /// <param name="spec">Sponsors content specification.</param>
+    /// <returns>Normalized recognition result.</returns>
+    public GitHubSponsorRecognitionResult Prepare(IEnumerable<GitHubSponsorRecord> source, GitHubSponsorsContentSpec spec)
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        return Prepare(source.Select(item => new GitHubSponsorSourceRecord { Sponsor = item }), spec);
+    }
+
+    /// <summary>
+    /// Prepares sponsor records using private in-process funding data when tier recognition is enabled.
+    /// </summary>
+    internal GitHubSponsorRecognitionResult Prepare(IEnumerable<GitHubSponsorSourceRecord> source, GitHubSponsorsContentSpec spec)
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (spec is null) throw new ArgumentNullException(nameof(spec));
+
+        var records = source.Select(Clone).ToList();
+        AddManualEntries(records, spec.ManualEntries);
+        ApplyOverrides(records, spec.Overrides);
+        records.RemoveAll(record => record.Excluded);
+
+        var recognition = spec.TierRecognition ?? new GitHubSponsorTierRecognitionSpec();
+        var tiers = recognition.Enabled ? NormalizeTiers(recognition) : Array.Empty<GitHubSponsorRecognitionTierSpec>();
+        if (recognition.Enabled)
+            AssignRecognitionTiers(records, tiers, NormalizeRequired(recognition.UnmappedTierKey, "Unmapped recognition tier key is required."));
+        else
+            records.ForEach(record => record.Value.RecognitionTierKey = null);
+
+        return new GitHubSponsorRecognitionResult
+        {
+            TierRecognitionEnabled = recognition.Enabled,
+            Tiers = tiers,
+            Sponsors = records
+                .Select(record => record.Value)
+                .OrderBy(record => record.Status)
+                .ThenBy(record => TierOrder(record.RecognitionTierKey, tiers))
+                .ThenBy(record => record.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(record => record.Key, StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+        };
+    }
+
+    private static void AddManualEntries(List<MutableSponsor> records, GitHubManualSponsorSpec[]? manualEntries)
+    {
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var record in records)
+        {
+            existing.Add(record.Value.Key);
+            if (!string.IsNullOrWhiteSpace(record.Value.Login)) existing.Add(record.Value.Login!);
+        }
+        var manualIdentities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in manualEntries ?? Array.Empty<GitHubManualSponsorSpec>())
+        {
+            var key = NormalizeRequired(entry.Key, "Manual sponsor key is required.");
+            var login = NormalizeOptional(entry.Login);
+            var identities = new[] { key, login }.Where(value => value is not null).Distinct(StringComparer.OrdinalIgnoreCase).Cast<string>().ToArray();
+            foreach (var identity in identities)
+            {
+                if (!manualIdentities.Add(identity))
+                    throw new InvalidOperationException($"Manual sponsor identity '{identity}' is configured more than once.");
+                if (existing.Contains(identity))
+                    throw new InvalidOperationException($"Manual sponsor identity '{identity}' duplicates an existing sponsor. Use an override instead.");
+            }
+
+            var displayName = NormalizeOptional(entry.DisplayName) ?? login ?? key;
+            records.Add(new MutableSponsor(new GitHubSponsorRecord
+            {
+                Key = key,
+                Login = login,
+                DisplayName = displayName,
+                ProfileUrl = NormalizeOptional(entry.ProfileUrl) ?? (login is null ? null : $"https://github.com/{login}"),
+                AvatarUrl = NormalizeOptional(entry.AvatarUrl) ?? (login is null ? null : $"https://github.com/{login}.png"),
+                Status = entry.Former ? GitHubSponsorStatus.Former : GitHubSponsorStatus.Current,
+                EntityType = GitHubSponsorEntityType.Manual,
+                RecognitionTierKey = NormalizeOptional(entry.RecognitionTierKey)
+            }, explicitTier: !string.IsNullOrWhiteSpace(entry.RecognitionTierKey)));
+            foreach (var identity in identities) existing.Add(identity);
+        }
+    }
+
+    private static void ApplyOverrides(List<MutableSponsor> records, GitHubSponsorOverrideSpec[]? overrides)
+    {
+        var configured = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in overrides ?? Array.Empty<GitHubSponsorOverrideSpec>())
+        {
+            var login = NormalizeRequired(item.Login, "Sponsor override login is required.");
+            if (!configured.Add(login))
+                throw new InvalidOperationException($"Sponsor override '{login}' is configured more than once.");
+
+            var record = records.FirstOrDefault(candidate =>
+                string.Equals(candidate.Value.Key, login, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(candidate.Value.Login, login, StringComparison.OrdinalIgnoreCase));
+            if (record is null)
+                continue;
+
+            record.Excluded = item.Exclude;
+            record.Value.DisplayName = NormalizeOptional(item.DisplayName) ?? record.Value.DisplayName;
+            record.Value.ProfileUrl = NormalizeOptional(item.ProfileUrl) ?? record.Value.ProfileUrl;
+            record.Value.AvatarUrl = NormalizeOptional(item.AvatarUrl) ?? record.Value.AvatarUrl;
+            if (!string.IsNullOrWhiteSpace(item.RecognitionTierKey))
+            {
+                record.Value.RecognitionTierKey = item.RecognitionTierKey!.Trim();
+                record.ExplicitTier = true;
+            }
+        }
+    }
+
+    private static GitHubSponsorRecognitionTierSpec[] NormalizeTiers(GitHubSponsorTierRecognitionSpec recognition)
+    {
+        var configured = recognition.Tiers ?? Array.Empty<GitHubSponsorRecognitionTierSpec>();
+        var source = configured.Length == 0 && recognition.UseDefaultTiers ? DefaultTiers : configured;
+        if (source.Length == 0)
+            throw new InvalidOperationException("Tier recognition is enabled but no recognition tiers are configured.");
+
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var tiers = source.Select(item =>
+        {
+            var key = NormalizeRequired(item.Key, "Recognition tier key is required.");
+            if (!keys.Add(key))
+                throw new InvalidOperationException($"Recognition tier key '{key}' is configured more than once.");
+            if (item.MinimumMonthlyDollars is < 0)
+                throw new InvalidOperationException($"Recognition tier '{key}' cannot have a negative minimum monthly amount.");
+
+            return new GitHubSponsorRecognitionTierSpec
+            {
+                Key = key,
+                Heading = NormalizeOptional(item.Heading) ?? key,
+                MinimumMonthlyDollars = item.MinimumMonthlyDollars,
+                Order = item.Order,
+                AvatarSize = Math.Max(24, Math.Min(256, item.AvatarSize))
+            };
+        }).OrderBy(item => item.Order).ThenBy(item => item.Key, StringComparer.OrdinalIgnoreCase).ToArray();
+
+        var fallback = NormalizeRequired(recognition.UnmappedTierKey, "Unmapped recognition tier key is required.");
+        if (!keys.Contains(fallback))
+            throw new InvalidOperationException($"Unmapped recognition tier '{fallback}' is not present in the configured tiers.");
+        return tiers;
+    }
+
+    private static void AssignRecognitionTiers(List<MutableSponsor> records, GitHubSponsorRecognitionTierSpec[] tiers, string unmappedTierKey)
+    {
+        var fallback = tiers.First(tier => string.Equals(tier.Key, unmappedTierKey.Trim(), StringComparison.OrdinalIgnoreCase)).Key;
+        var pricedTiers = tiers
+            .Where(tier => tier.MinimumMonthlyDollars is not null)
+            .OrderByDescending(tier => tier.MinimumMonthlyDollars)
+            .ThenBy(tier => tier.Order)
+            .ToArray();
+
+        foreach (var record in records)
+        {
+            if (record.Value.Status == GitHubSponsorStatus.Former)
+            {
+                record.Value.RecognitionTierKey = null;
+                continue;
+            }
+
+            if (record.ExplicitTier)
+            {
+                var explicitKey = record.Value.RecognitionTierKey ?? string.Empty;
+                var configured = tiers.FirstOrDefault(tier => string.Equals(tier.Key, explicitKey, StringComparison.OrdinalIgnoreCase));
+                if (configured is null)
+                    throw new InvalidOperationException($"Sponsor '{record.Value.Key}' references unknown recognition tier '{explicitKey}'.");
+                record.Value.RecognitionTierKey = configured.Key;
+                continue;
+            }
+
+            var amount = record.FundingTierMonthlyDollars;
+            record.Value.RecognitionTierKey = amount is null
+                ? fallback
+                : pricedTiers.FirstOrDefault(tier => amount.Value >= tier.MinimumMonthlyDollars!.Value)?.Key ?? fallback;
+        }
+    }
+
+    private static int TierOrder(string? key, GitHubSponsorRecognitionTierSpec[] tiers)
+        => tiers.FirstOrDefault(tier => string.Equals(tier.Key, key, StringComparison.OrdinalIgnoreCase))?.Order ?? int.MaxValue;
+
+    private static MutableSponsor Clone(GitHubSponsorSourceRecord source)
+        => new(new GitHubSponsorRecord
+        {
+            Key = source.Sponsor.Key,
+            Login = source.Sponsor.Login,
+            DisplayName = source.Sponsor.DisplayName,
+            ProfileUrl = source.Sponsor.ProfileUrl,
+            AvatarUrl = source.Sponsor.AvatarUrl,
+            Status = source.Sponsor.Status,
+            EntityType = source.Sponsor.EntityType,
+            RecognitionTierKey = source.Sponsor.RecognitionTierKey
+        }, explicitTier: !string.IsNullOrWhiteSpace(source.Sponsor.RecognitionTierKey), source.FundingTierMonthlyDollars);
+
+    private static string NormalizeRequired(string? value, string message)
+        => NormalizeOptional(value) ?? throw new InvalidOperationException(message);
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
+
+    private sealed class MutableSponsor
+    {
+        internal MutableSponsor(GitHubSponsorRecord value, bool explicitTier, int? fundingTierMonthlyDollars = null)
+        {
+            Value = value;
+            ExplicitTier = explicitTier;
+            FundingTierMonthlyDollars = fundingTierMonthlyDollars;
+        }
+
+        internal GitHubSponsorRecord Value { get; }
+        internal int? FundingTierMonthlyDollars { get; }
+        internal bool ExplicitTier { get; set; }
+        internal bool Excluded { get; set; }
+    }
+}

--- a/PowerForge/Services/GitHubSponsorRecognitionService.cs
+++ b/PowerForge/Services/GitHubSponsorRecognitionService.cs
@@ -47,10 +47,18 @@ public sealed class GitHubSponsorRecognitionService
         else
             records.ForEach(record => record.Value.RecognitionTierKey = null);
 
+        var renderedCurrentGitHubSponsors = records
+            .Where(record =>
+                record.Value.Status == GitHubSponsorStatus.Current &&
+                record.Value.EntityType != GitHubSponsorEntityType.Manual)
+            .ToArray();
         return new GitHubSponsorRecognitionResult
         {
             TierRecognitionEnabled = recognition.Enabled,
             Tiers = tiers,
+            HasRenderedCurrentGitHubSponsors = renderedCurrentGitHubSponsors.Length > 0,
+            HasFundingTierDataForRenderedCurrentGitHubSponsors =
+                renderedCurrentGitHubSponsors.Any(record => record.FundingTierMonthlyDollars is not null),
             Sponsors = records
                 .Select(record => record.Value)
                 .OrderBy(record => record.Status)

--- a/PowerForge/Services/GitHubSponsorsClient.cs
+++ b/PowerForge/Services/GitHubSponsorsClient.cs
@@ -124,7 +124,10 @@ public sealed class GitHubSponsorsClient
 
         if (query.IncludeFormer)
         {
-            var allPublic = GetConnection(endpoint, token, login, activeOnly: false, pageSize, includeFundingTierData);
+            // Historical tier prices are not needed: current sponsors already carry the
+            // optional tier data from the active-only query, while former sponsors are
+            // deliberately recognized without a historical tier classification.
+            var allPublic = GetConnection(endpoint, token, login, activeOnly: false, pageSize, includeFundingTierData: false);
             records.AddRange(allPublic
                 .Where(item => !currentKeys.Contains(item.Sponsor.Key))
                 .GroupBy(item => item.Sponsor.Key, StringComparer.OrdinalIgnoreCase)

--- a/PowerForge/Services/GitHubSponsorsClient.cs
+++ b/PowerForge/Services/GitHubSponsorsClient.cs
@@ -155,6 +155,7 @@ public sealed class GitHubSponsorsClient
         bool includeFundingTierData)
     {
         var records = new List<GitHubSponsorSourceRecord>();
+        var seenCursors = new HashSet<string>(StringComparer.Ordinal);
         string? cursor = null;
 
         while (true)
@@ -194,14 +195,17 @@ public sealed class GitHubSponsorsClient
                 break;
 
             var hasNextPage = pageInfo.TryGetProperty("hasNextPage", out var hasNext) && hasNext.ValueKind == JsonValueKind.True;
-            cursor = pageInfo.TryGetProperty("endCursor", out var endCursor) && endCursor.ValueKind == JsonValueKind.String
+            var nextCursor = pageInfo.TryGetProperty("endCursor", out var endCursor) && endCursor.ValueKind == JsonValueKind.String
                 ? endCursor.GetString()
                 : null;
 
             if (!hasNextPage)
                 break;
-            if (string.IsNullOrWhiteSpace(cursor))
+            if (string.IsNullOrWhiteSpace(nextCursor))
                 throw new InvalidOperationException("GitHub Sponsors pagination reported another page without an end cursor.");
+            if (!seenCursors.Add(nextCursor!))
+                throw new InvalidOperationException("GitHub Sponsors pagination repeated an earlier end cursor.");
+            cursor = nextCursor;
         }
 
         return records;

--- a/PowerForge/Services/GitHubSponsorsClient.cs
+++ b/PowerForge/Services/GitHubSponsorsClient.cs
@@ -1,0 +1,336 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace PowerForge;
+
+/// <summary>
+/// Retrieves public GitHub Sponsors records through the GitHub GraphQL API.
+/// </summary>
+public sealed class GitHubSponsorsClient
+{
+    private const string SponsorsQueryWithoutFundingTier = """
+        query($login: String!, $first: Int!, $after: String, $activeOnly: Boolean!) {
+          owner: repositoryOwner(login: $login) {
+            __typename
+            ... on User {
+              sponsorshipsAsMaintainer(first: $first, after: $after, includePrivate: false, activeOnly: $activeOnly) {
+                nodes {
+                  sponsorEntity {
+                    __typename
+                    ... on User { login name avatarUrl url }
+                    ... on Organization { login name avatarUrl url }
+                  }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+            ... on Organization {
+              sponsorshipsAsMaintainer(first: $first, after: $after, includePrivate: false, activeOnly: $activeOnly) {
+                nodes {
+                  sponsorEntity {
+                    __typename
+                    ... on User { login name avatarUrl url }
+                    ... on Organization { login name avatarUrl url }
+                  }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+        """;
+
+    private const string SponsorsQueryWithFundingTier = """
+        query($login: String!, $first: Int!, $after: String, $activeOnly: Boolean!) {
+          owner: repositoryOwner(login: $login) {
+            __typename
+            ... on User {
+              sponsorshipsAsMaintainer(first: $first, after: $after, includePrivate: false, activeOnly: $activeOnly) {
+                nodes {
+                  sponsorEntity {
+                    __typename
+                    ... on User { login name avatarUrl url }
+                    ... on Organization { login name avatarUrl url }
+                  }
+                  tier { monthlyPriceInDollars }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+            ... on Organization {
+              sponsorshipsAsMaintainer(first: $first, after: $after, includePrivate: false, activeOnly: $activeOnly) {
+                nodes {
+                  sponsorEntity {
+                    __typename
+                    ... on User { login name avatarUrl url }
+                    ... on Organization { login name avatarUrl url }
+                  }
+                  tier { monthlyPriceInDollars }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+        """;
+
+    private static readonly HttpClient SharedClient = CreateSharedClient();
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Creates a GitHub Sponsors client.
+    /// </summary>
+    /// <param name="client">Optional HTTP client for custom transports and tests.</param>
+    public GitHubSponsorsClient(HttpClient? client = null)
+    {
+        _client = client ?? SharedClient;
+    }
+
+    /// <summary>
+    /// Retrieves public current sponsors and, when requested, public former sponsors.
+    /// Private sponsorships are never requested.
+    /// </summary>
+    /// <param name="query">Sponsors query.</param>
+    /// <returns>Normalized public sponsor records.</returns>
+    public GitHubSponsorRecord[] GetSponsors(GitHubSponsorsQuery query)
+        => GetSponsorSources(query, includeFundingTierData: false)
+            .Select(item => ClonePublicRecord(item.Sponsor))
+            .ToArray();
+
+    /// <summary>
+    /// Retrieves sponsor identities and optionally retains funding amounts for in-process recognition mapping.
+    /// Funding amounts must never cross the public result boundary.
+    /// </summary>
+    internal GitHubSponsorSourceRecord[] GetSponsorSources(GitHubSponsorsQuery query, bool includeFundingTierData)
+    {
+        if (query is null) throw new ArgumentNullException(nameof(query));
+
+        var login = (query.SponsorableLogin ?? string.Empty).Trim();
+        var token = (query.Token ?? string.Empty).Trim();
+        if (login.Length == 0) throw new InvalidOperationException("Sponsorable login is required.");
+        if (token.Length == 0) throw new InvalidOperationException("GitHub token is required.");
+
+        var endpoint = NormalizeEndpoint(query.GraphQlEndpoint);
+        var pageSize = Math.Max(1, Math.Min(100, query.PageSize));
+        var current = GetConnection(endpoint, token, login, activeOnly: true, pageSize, includeFundingTierData);
+        var currentKeys = new HashSet<string>(current.Select(item => item.Sponsor.Key), StringComparer.OrdinalIgnoreCase);
+
+        var records = current
+            .GroupBy(item => item.Sponsor.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToList();
+
+        if (query.IncludeFormer)
+        {
+            var allPublic = GetConnection(endpoint, token, login, activeOnly: false, pageSize, includeFundingTierData);
+            records.AddRange(allPublic
+                .Where(item => !currentKeys.Contains(item.Sponsor.Key))
+                .GroupBy(item => item.Sponsor.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(group =>
+                {
+                    var item = group.First();
+                    item.Sponsor.Status = GitHubSponsorStatus.Former;
+                    return item;
+                }));
+        }
+
+        return records
+            .OrderBy(item => item.Sponsor.Status)
+            .ThenBy(item => item.Sponsor.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.Sponsor.Key, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private List<GitHubSponsorSourceRecord> GetConnection(
+        Uri endpoint,
+        string token,
+        string login,
+        bool activeOnly,
+        int pageSize,
+        bool includeFundingTierData)
+    {
+        var records = new List<GitHubSponsorSourceRecord>();
+        string? cursor = null;
+
+        while (true)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+            request.Content = new StringContent(
+                CreateRequestBody(login, pageSize, cursor, activeOnly, includeFundingTierData),
+                Encoding.UTF8,
+                "application/json");
+
+            using var response = _client.SendAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
+            var body = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            if (!response.IsSuccessStatusCode)
+                throw new InvalidOperationException($"GitHub GraphQL request failed with HTTP {(int)response.StatusCode}: {TrimForMessage(body)}");
+
+            using var document = JsonDocument.Parse(body);
+            ThrowOnGraphQlErrors(document.RootElement);
+            var connection = GetSponsorConnection(document.RootElement, login);
+
+            if (connection.TryGetProperty("nodes", out var nodes) && nodes.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var node in nodes.EnumerateArray())
+                {
+                    var parsed = ParseSponsor(
+                        node,
+                        activeOnly ? GitHubSponsorStatus.Current : GitHubSponsorStatus.Former,
+                        includeFundingTierData);
+                    if (parsed is not null)
+                        records.Add(parsed);
+                }
+            }
+
+            if (!connection.TryGetProperty("pageInfo", out var pageInfo) || pageInfo.ValueKind != JsonValueKind.Object)
+                break;
+
+            var hasNextPage = pageInfo.TryGetProperty("hasNextPage", out var hasNext) && hasNext.ValueKind == JsonValueKind.True;
+            cursor = pageInfo.TryGetProperty("endCursor", out var endCursor) && endCursor.ValueKind == JsonValueKind.String
+                ? endCursor.GetString()
+                : null;
+
+            if (!hasNextPage)
+                break;
+            if (string.IsNullOrWhiteSpace(cursor))
+                throw new InvalidOperationException("GitHub Sponsors pagination reported another page without an end cursor.");
+        }
+
+        return records;
+    }
+
+    private static JsonElement GetSponsorConnection(JsonElement root, string login)
+    {
+        if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
+            throw new InvalidOperationException("GitHub GraphQL response did not contain a data object.");
+
+        if (data.TryGetProperty("owner", out var owner) && owner.ValueKind == JsonValueKind.Object &&
+            owner.TryGetProperty("sponsorshipsAsMaintainer", out var connection) && connection.ValueKind == JsonValueKind.Object)
+            return connection;
+
+        throw new InvalidOperationException($"GitHub sponsorable account '{login}' was not found or its public sponsorships are unavailable.");
+    }
+
+    private static GitHubSponsorSourceRecord? ParseSponsor(
+        JsonElement node,
+        GitHubSponsorStatus status,
+        bool includeFundingTierData)
+    {
+        if (!node.TryGetProperty("sponsorEntity", out var sponsor) || sponsor.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var login = ReadString(sponsor, "login");
+        if (string.IsNullOrWhiteSpace(login))
+            return null;
+
+        var typeName = ReadString(sponsor, "__typename");
+        var name = ReadString(sponsor, "name");
+        int? monthlyPrice = null;
+        if (includeFundingTierData && node.TryGetProperty("tier", out var tier) && tier.ValueKind == JsonValueKind.Object)
+        {
+            if (tier.TryGetProperty("monthlyPriceInDollars", out var price) && price.ValueKind == JsonValueKind.Number && price.TryGetInt32(out var parsedPrice))
+                monthlyPrice = parsedPrice;
+        }
+
+        return new GitHubSponsorSourceRecord
+        {
+            Sponsor = new GitHubSponsorRecord
+            {
+                Key = login!,
+                Login = login,
+                DisplayName = string.IsNullOrWhiteSpace(name) ? login! : name!.Trim(),
+                ProfileUrl = ReadString(sponsor, "url"),
+                AvatarUrl = ReadString(sponsor, "avatarUrl"),
+                Status = status,
+                EntityType = string.Equals(typeName, "Organization", StringComparison.OrdinalIgnoreCase)
+                    ? GitHubSponsorEntityType.Organization
+                    : GitHubSponsorEntityType.User
+            },
+            FundingTierMonthlyDollars = monthlyPrice
+        };
+    }
+
+    private static string CreateRequestBody(
+        string login,
+        int pageSize,
+        string? cursor,
+        bool activeOnly,
+        bool includeFundingTierData)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("query", includeFundingTierData ? SponsorsQueryWithFundingTier : SponsorsQueryWithoutFundingTier);
+            writer.WritePropertyName("variables");
+            writer.WriteStartObject();
+            writer.WriteString("login", login);
+            writer.WriteNumber("first", pageSize);
+            if (cursor is null) writer.WriteNull("after"); else writer.WriteString("after", cursor);
+            writer.WriteBoolean("activeOnly", activeOnly);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static void ThrowOnGraphQlErrors(JsonElement root)
+    {
+        if (!root.TryGetProperty("errors", out var errors) || errors.ValueKind != JsonValueKind.Array || errors.GetArrayLength() == 0)
+            return;
+
+        var messages = errors.EnumerateArray()
+            .Select(error => ReadString(error, "message"))
+            .Where(message => !string.IsNullOrWhiteSpace(message))
+            .ToArray();
+        var detail = messages.Length == 0 ? "Unknown GraphQL error." : string.Join(" ", messages);
+        throw new InvalidOperationException($"GitHub GraphQL returned an error: {TrimForMessage(detail)}");
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static Uri NormalizeEndpoint(string? endpoint)
+    {
+        var value = string.IsNullOrWhiteSpace(endpoint) ? "https://api.github.com/graphql" : endpoint!.Trim();
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+            throw new InvalidOperationException($"Invalid GitHub GraphQL endpoint: {endpoint}");
+        if (!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("GitHub GraphQL endpoint must use HTTPS because the request carries a bearer token.");
+        return uri;
+    }
+
+    private static GitHubSponsorRecord ClonePublicRecord(GitHubSponsorRecord source)
+        => new()
+        {
+            Key = source.Key,
+            Login = source.Login,
+            DisplayName = source.DisplayName,
+            ProfileUrl = source.ProfileUrl,
+            AvatarUrl = source.AvatarUrl,
+            Status = source.Status,
+            EntityType = source.EntityType,
+            RecognitionTierKey = source.RecognitionTierKey
+        };
+
+    private static string TrimForMessage(string? text)
+    {
+        var value = (text ?? string.Empty).Trim();
+        return value.Length <= 2000 ? value : value.Substring(0, 2000) + "...";
+    }
+
+    private static HttpClient CreateSharedClient()
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("PowerForge-GitHubSponsors/1.0");
+        return client;
+    }
+}

--- a/PowerForge/Services/GitHubSponsorsMarkdownRenderer.cs
+++ b/PowerForge/Services/GitHubSponsorsMarkdownRenderer.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Text;
+
+namespace PowerForge;
+
+/// <summary>
+/// Renders normalized Sponsors data as deterministic Markdown and safe inline HTML.
+/// </summary>
+public sealed class GitHubSponsorsMarkdownRenderer
+{
+    /// <summary>
+    /// Renders one Sponsors output block.
+    /// </summary>
+    /// <param name="recognition">Prepared sponsor records and recognition tiers.</param>
+    /// <param name="output">Output layout settings.</param>
+    /// <returns>Generated Markdown.</returns>
+    public string Render(GitHubSponsorRecognitionResult recognition, GitHubSponsorsOutputSpec output)
+    {
+        if (recognition is null) throw new ArgumentNullException(nameof(recognition));
+        if (output is null) throw new ArgumentNullException(nameof(output));
+
+        var current = (recognition.Sponsors ?? Array.Empty<GitHubSponsorRecord>())
+            .Where(sponsor => sponsor.Status == GitHubSponsorStatus.Current)
+            .ToArray();
+        var former = (recognition.Sponsors ?? Array.Empty<GitHubSponsorRecord>())
+            .Where(sponsor => sponsor.Status == GitHubSponsorStatus.Former)
+            .ToArray();
+
+        return output.Layout switch
+        {
+            GitHubSponsorsMarkdownLayout.Compact => RenderCompact(current, output),
+            _ => RenderFull(current, former, recognition, output)
+        };
+    }
+
+    private static string RenderFull(
+        GitHubSponsorRecord[] current,
+        GitHubSponsorRecord[] former,
+        GitHubSponsorRecognitionResult recognition,
+        GitHubSponsorsOutputSpec output)
+    {
+        var builder = new StringBuilder();
+        AppendOptionalMarkdown(builder, output.Introduction);
+
+        if (recognition.TierRecognitionEnabled)
+        {
+            foreach (var tier in recognition.Tiers ?? Array.Empty<GitHubSponsorRecognitionTierSpec>())
+            {
+                var members = current
+                    .Where(sponsor => string.Equals(sponsor.RecognitionTierKey, tier.Key, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+                if (members.Length == 0)
+                    continue;
+
+                AppendSectionHeading(builder, tier.Heading);
+                AppendSponsorRow(builder, members, tier.AvatarSize);
+            }
+        }
+        else if (current.Length > 0)
+        {
+            AppendSectionHeading(builder, "Current Sponsors");
+            AppendSponsorRow(builder, current, output.AvatarSize);
+        }
+        else
+        {
+            builder.AppendLine("No public sponsors are currently listed.");
+            builder.AppendLine();
+        }
+
+        if (output.IncludeFormer && former.Length > 0)
+        {
+            AppendSectionHeading(builder, "Past Sponsors");
+            builder.AppendLine("We are grateful to everyone who has supported this work.");
+            builder.AppendLine();
+            builder.AppendLine("<ul>");
+            foreach (var sponsor in former)
+            {
+                var name = WebUtility.HtmlEncode((sponsor.DisplayName ?? sponsor.Key).Replace('\r', ' ').Replace('\n', ' ').Trim());
+                var profile = NormalizeAbsoluteUrl(sponsor.ProfileUrl);
+                builder.Append("  <li>");
+                if (profile is null)
+                    builder.Append(name);
+                else
+                    builder.Append("<a href=\"").Append(WebUtility.HtmlEncode(profile)).Append("\">").Append(name).Append("</a>");
+                builder.AppendLine("</li>");
+            }
+            builder.AppendLine("</ul>");
+            builder.AppendLine();
+        }
+
+        AppendOptionalMarkdown(builder, output.Closing);
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string RenderCompact(GitHubSponsorRecord[] current, GitHubSponsorsOutputSpec output)
+    {
+        var builder = new StringBuilder();
+        AppendOptionalMarkdown(builder, output.Introduction);
+
+        var maximum = Math.Max(0, output.MaxEntries);
+        var members = maximum == 0 ? current : current.Take(maximum).ToArray();
+        if (members.Length > 0)
+            AppendSponsorRow(builder, members, output.AvatarSize);
+        else
+        {
+            builder.AppendLine("No public sponsors are currently listed.");
+            builder.AppendLine();
+        }
+
+        var moreLink = NormalizeRelativeOrAbsoluteUrl(output.MoreLink);
+        if (moreLink is not null)
+        {
+            builder.Append("[See all sponsors](").Append(EscapeMarkdownUrl(moreLink)).AppendLine(")");
+            builder.AppendLine();
+        }
+
+        AppendOptionalMarkdown(builder, output.Closing);
+        return builder.ToString().TrimEnd();
+    }
+
+    private static void AppendSponsorRow(StringBuilder builder, GitHubSponsorRecord[] sponsors, int requestedAvatarSize)
+    {
+        var avatarSize = Math.Max(24, Math.Min(256, requestedAvatarSize));
+        builder.AppendLine("<p>");
+        foreach (var sponsor in sponsors)
+        {
+            var displayName = WebUtility.HtmlEncode(sponsor.DisplayName ?? sponsor.Key);
+            var profileUrl = NormalizeAbsoluteUrl(sponsor.ProfileUrl);
+            var avatarUrl = NormalizeAbsoluteUrl(sponsor.AvatarUrl);
+
+            if (avatarUrl is not null)
+            {
+                if (profileUrl is not null)
+                    builder.Append("  <a href=\"").Append(WebUtility.HtmlEncode(profileUrl)).Append("\" title=\"").Append(displayName).Append("\">");
+                else
+                    builder.Append("  ");
+
+                builder.Append("<img src=\"").Append(WebUtility.HtmlEncode(avatarUrl))
+                    .Append("\" width=\"").Append(avatarSize)
+                    .Append("\" height=\"").Append(avatarSize)
+                    .Append("\" alt=\"").Append(displayName).Append("\" />");
+                if (profileUrl is not null)
+                    builder.Append("</a>");
+                builder.AppendLine();
+                continue;
+            }
+
+            builder.Append("  ");
+            if (profileUrl is null) builder.Append(displayName); else builder.Append("<a href=\"").Append(WebUtility.HtmlEncode(profileUrl)).Append("\">").Append(displayName).Append("</a>");
+            builder.AppendLine("<br />");
+        }
+        builder.AppendLine("</p>");
+        builder.AppendLine();
+    }
+
+    private static void AppendSectionHeading(StringBuilder builder, string? heading)
+    {
+        var normalized = (heading ?? string.Empty).Replace('\r', ' ').Replace('\n', ' ').Trim();
+        builder.Append("## ").AppendLine(normalized.Length == 0 ? "Sponsors" : normalized);
+        builder.AppendLine();
+    }
+
+    private static void AppendOptionalMarkdown(StringBuilder builder, string? markdown)
+    {
+        if (string.IsNullOrWhiteSpace(markdown))
+            return;
+        builder.AppendLine(markdown!.Replace("\r\n", "\n").Replace('\r', '\n').Trim());
+        builder.AppendLine();
+    }
+
+    private static string EscapeMarkdownUrl(string value)
+        => value.Replace(" ", "%20").Replace("(", "%28").Replace(")", "%29");
+
+    private static string? NormalizeAbsoluteUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !Uri.TryCreate(value!.Trim(), UriKind.Absolute, out var uri))
+            return null;
+        return uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) || uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            ? uri.AbsoluteUri
+            : null;
+    }
+
+    private static string? NormalizeRelativeOrAbsoluteUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var trimmed = value!.Trim();
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+            return NormalizeAbsoluteUrl(trimmed);
+        if (trimmed.StartsWith("#", StringComparison.Ordinal) || trimmed.StartsWith("/", StringComparison.Ordinal) || !trimmed.Contains(':'))
+            return trimmed;
+        return null;
+    }
+}

--- a/PowerForge/Services/GitHubSponsorsMarkdownRenderer.cs
+++ b/PowerForge/Services/GitHubSponsorsMarkdownRenderer.cs
@@ -42,7 +42,12 @@ public sealed class GitHubSponsorsMarkdownRenderer
         var builder = new StringBuilder();
         AppendOptionalMarkdown(builder, output.Introduction);
 
-        if (recognition.TierRecognitionEnabled)
+        if (current.Length == 0)
+        {
+            builder.AppendLine("No public sponsors are currently listed.");
+            builder.AppendLine();
+        }
+        else if (recognition.TierRecognitionEnabled)
         {
             foreach (var tier in recognition.Tiers ?? Array.Empty<GitHubSponsorRecognitionTierSpec>())
             {
@@ -56,15 +61,10 @@ public sealed class GitHubSponsorsMarkdownRenderer
                 AppendSponsorRow(builder, members, tier.AvatarSize);
             }
         }
-        else if (current.Length > 0)
+        else
         {
             AppendSectionHeading(builder, "Current Sponsors");
             AppendSponsorRow(builder, current, output.AvatarSize);
-        }
-        else
-        {
-            builder.AppendLine("No public sponsors are currently listed.");
-            builder.AppendLine();
         }
 
         if (output.IncludeFormer && former.Length > 0)

--- a/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
+++ b/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
@@ -14,22 +14,7 @@ public sealed class ManagedMarkdownDocumentUpdater
     public void ValidateUpdate(ManagedMarkdownUpdateRequest request)
     {
         if (request is null) throw new ArgumentNullException(nameof(request));
-        var path = NormalizePath(request.Path);
-        var markerNamespace = NormalizeMarkerNamespace(request.MarkerNamespace);
-        var blockId = NormalizeBlockId(request.BlockId);
-        var markerFormat = NormalizeMarkerFormat(request.MarkerFormat);
-        ValidateDestinationPath(path);
-        if (!File.Exists(path))
-        {
-            if (!request.CreateIfMissing)
-                throw new FileNotFoundException($"Managed Markdown document was not found: {path}", path);
-            return;
-        }
-
-        var document = ReadDocument(path);
-        var location = FindBlock(document.Text, markerNamespace, blockId, markerFormat);
-        if (location is null && request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
-            throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
+        PrepareUpdates(new[] { request });
     }
 
     /// <summary>
@@ -40,65 +25,261 @@ public sealed class ManagedMarkdownDocumentUpdater
     public ManagedMarkdownUpdateResult Update(ManagedMarkdownUpdateRequest request)
     {
         if (request is null) throw new ArgumentNullException(nameof(request));
+        return UpdateMany(new[] { request })[0];
+    }
 
-        var path = NormalizePath(request.Path);
-        var markerNamespace = NormalizeMarkerNamespace(request.MarkerNamespace);
-        var blockId = NormalizeBlockId(request.BlockId);
-        var markerFormat = NormalizeMarkerFormat(request.MarkerFormat);
-        var replacement = NormalizeMarkdown(request.Markdown);
-        ValidateDestinationPath(path);
-        var exists = File.Exists(path);
-
-        DocumentText document;
-        string updated;
-        var created = false;
-        var appended = false;
-
-        if (!exists)
+    /// <summary>
+    /// Projects a batch of managed-block updates in memory, validates the final documents, and writes only after every update is valid.
+    /// Documents targeted more than once are written once with their final projected content.
+    /// </summary>
+    /// <param name="requests">Managed document update requests.</param>
+    /// <returns>One update result per request, in input order.</returns>
+    public ManagedMarkdownUpdateResult[] UpdateMany(IEnumerable<ManagedMarkdownUpdateRequest> requests)
+    {
+        if (requests is null) throw new ArgumentNullException(nameof(requests));
+        var batch = PrepareUpdates(requests);
+        foreach (var document in batch.Documents)
         {
-            if (!request.CreateIfMissing)
-                throw new FileNotFoundException($"Managed Markdown document was not found: {path}", path);
+            if (!document.Changed)
+                continue;
 
-            document = DocumentText.NewUtf8();
-            updated = CreateDocument(markerNamespace, blockId, replacement, request.NewDocumentTitle, Environment.NewLine, markerFormat);
-            created = true;
+            var directory = System.IO.Path.GetDirectoryName(document.Path);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+            WriteDocument(document.Path, document.Document, document.Text);
         }
-        else
+        return batch.Results;
+    }
+
+    private static PreparedBatch PrepareUpdates(IEnumerable<ManagedMarkdownUpdateRequest> requests)
+    {
+        var source = requests.ToArray();
+        var documents = new Dictionary<string, PreparedDocument>(GetPathIdentityComparer());
+        var orderedDocuments = new List<PreparedDocument>();
+        var results = new ManagedMarkdownUpdateResult[source.Length];
+
+        for (var index = 0; index < source.Length; index++)
         {
-            document = ReadDocument(path);
-            var location = FindBlock(document.Text, markerNamespace, blockId, markerFormat);
+            var request = source[index] ?? throw new ArgumentException("Managed Markdown update requests cannot contain null entries.", nameof(requests));
+            var normalized = NormalizeRequest(request);
+            ValidateDestinationPath(normalized.Path);
+            var identity = ResolvePathIdentity(normalized.Path);
 
-            if (location is null)
+            if (!documents.TryGetValue(identity.Key, out var document))
             {
-                if (request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
-                    throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
+                var ambiguousAlias = orderedDocuments.FirstOrDefault(existing =>
+                    string.Equals(existing.Path, normalized.Path, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(existing.IdentityKey, identity.Key, StringComparison.Ordinal) &&
+                    (!existing.IdentityWasResolved || !identity.WasResolved));
+                if (ambiguousAlias is not null)
+                {
+                    throw new InvalidOperationException(
+                        $"Managed Markdown paths '{ambiguousAlias.Path}' and '{normalized.Path}' may refer to the same destination. " +
+                        "Use one canonical path casing for a batch that creates a new document.");
+                }
 
-                updated = AppendBlock(document.Text, markerNamespace, blockId, replacement, DetectPreferredLineEnding(document.Text), markerFormat);
-                appended = true;
+                var exists = File.Exists(normalized.Path);
+                document = new PreparedDocument(
+                    normalized.Path,
+                    identity.Key,
+                    identity.WasResolved,
+                    exists ? ReadDocument(normalized.Path) : DocumentText.NewUtf8(),
+                    exists);
+                documents.Add(identity.Key, document);
+                orderedDocuments.Add(document);
+            }
+
+            normalized.OriginalLocation = document.Exists
+                ? FindBlock(
+                    document.Document.Text,
+                    normalized.MarkerNamespace,
+                    normalized.BlockId,
+                    normalized.MarkerFormat)
+                : null;
+            foreach (var prior in document.Requests)
+            {
+                if (TargetsCanMatchSameMarker(prior, normalized))
+                {
+                    throw new InvalidOperationException(
+                        $"Managed block '{normalized.BlockId}' is targeted more than once in '{document.Path}'.");
+                }
+                if (prior.OriginalLocation is not null && normalized.OriginalLocation is not null &&
+                    BlocksOverlap(prior.OriginalLocation, normalized.OriginalLocation))
+                {
+                    throw new InvalidOperationException(
+                        $"Managed blocks '{prior.BlockId}' and '{normalized.BlockId}' overlap in '{document.Path}'.");
+                }
+            }
+
+            var before = document.Text;
+            string updated;
+            var created = false;
+            var appended = false;
+
+            if (!document.Exists)
+            {
+                if (!normalized.CreateIfMissing)
+                    throw new FileNotFoundException($"Managed Markdown document was not found: {normalized.Path}", normalized.Path);
+
+                updated = CreateDocument(
+                    normalized.MarkerNamespace,
+                    normalized.BlockId,
+                    normalized.Markdown,
+                    normalized.NewDocumentTitle,
+                    Environment.NewLine,
+                    normalized.MarkerFormat);
+                created = true;
             }
             else
             {
-                updated = ReplaceBlock(document.Text, location, replacement);
+                var location = FindBlock(
+                    document.Text,
+                    normalized.MarkerNamespace,
+                    normalized.BlockId,
+                    normalized.MarkerFormat);
+                if (location is null)
+                {
+                    if (normalized.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
+                        throw new InvalidOperationException($"Managed block '{normalized.BlockId}' was not found in '{normalized.Path}'.");
+
+                    updated = AppendBlock(
+                        document.Text,
+                        normalized.MarkerNamespace,
+                        normalized.BlockId,
+                        normalized.Markdown,
+                        DetectPreferredLineEnding(document.Text),
+                        normalized.MarkerFormat);
+                    appended = true;
+                }
+                else
+                {
+                    updated = ReplaceBlock(document.Text, location, normalized.Markdown);
+                }
+            }
+
+            document.Text = updated;
+            document.Exists = true;
+            document.Requests.Add(normalized);
+            results[index] = new ManagedMarkdownUpdateResult
+            {
+                Path = normalized.Path,
+                BlockId = normalized.BlockId,
+                Changed = !string.Equals(before, updated, StringComparison.Ordinal),
+                Created = created,
+                Appended = appended
+            };
+        }
+
+        foreach (var document in orderedDocuments)
+        {
+            var finalLocations = new List<(NormalizedUpdateRequest Request, BlockLocation Location)>();
+            foreach (var request in document.Requests)
+            {
+                var location = FindBlock(document.Text, request.MarkerNamespace, request.BlockId, request.MarkerFormat);
+                if (location is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Managed Markdown batch update did not preserve block '{request.BlockId}' in '{document.Path}'. " +
+                        "Managed blocks in the same document cannot overlap.");
+                }
+                foreach (var prior in finalLocations)
+                {
+                    if (BlocksOverlap(prior.Location, location))
+                    {
+                        throw new InvalidOperationException(
+                            $"Managed Markdown batch update produced overlapping blocks '{prior.Request.BlockId}' and " +
+                            $"'{request.BlockId}' in '{document.Path}'.");
+                    }
+                }
+                finalLocations.Add((request, location));
+            }
+            document.Changed = !string.Equals(document.Document.Text, document.Text, StringComparison.Ordinal);
+        }
+
+        return new PreparedBatch(orderedDocuments.ToArray(), results);
+    }
+
+    private static NormalizedUpdateRequest NormalizeRequest(ManagedMarkdownUpdateRequest request)
+        => new(
+            NormalizePath(request.Path),
+            NormalizeMarkerNamespace(request.MarkerNamespace),
+            NormalizeBlockId(request.BlockId),
+            NormalizeMarkerFormat(request.MarkerFormat),
+            NormalizeMarkdown(request.Markdown),
+            request.CreateIfMissing,
+            request.MissingBlockBehavior,
+            request.NewDocumentTitle);
+
+    private static bool TargetsCanMatchSameMarker(NormalizedUpdateRequest first, NormalizedUpdateRequest second)
+    {
+        if (!string.Equals(first.BlockId, second.BlockId, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var shareLegacy = first.MarkerFormat != ManagedMarkdownMarkerFormat.Namespaced &&
+                          second.MarkerFormat != ManagedMarkdownMarkerFormat.Namespaced;
+        var shareNamespaced = first.MarkerFormat != ManagedMarkdownMarkerFormat.LegacyBlockId &&
+                              second.MarkerFormat != ManagedMarkdownMarkerFormat.LegacyBlockId &&
+                              string.Equals(first.MarkerNamespace, second.MarkerNamespace, StringComparison.OrdinalIgnoreCase);
+        return shareLegacy || shareNamespaced;
+    }
+
+    private static bool BlocksOverlap(BlockLocation first, BlockLocation second)
+        => first.StartLine.Start < second.EndLine.End && second.StartLine.Start < first.EndLine.End;
+
+    private static StringComparer GetPathIdentityComparer()
+        => System.IO.Path.DirectorySeparatorChar == '\\'
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
+    private static PathIdentity ResolvePathIdentity(string path)
+    {
+        if (!File.Exists(path))
+            return new PathIdentity(path, wasResolved: false);
+
+        var fullPath = System.IO.Path.GetFullPath(path);
+        var root = System.IO.Path.GetPathRoot(fullPath);
+        if (string.IsNullOrWhiteSpace(root))
+            return new PathIdentity(fullPath, wasResolved: false);
+
+        var current = root!;
+        var relative = fullPath.Substring(root!.Length);
+        var separators = System.IO.Path.DirectorySeparatorChar == System.IO.Path.AltDirectorySeparatorChar
+            ? new[] { System.IO.Path.DirectorySeparatorChar }
+            : new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
+        var segments = relative.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+        try
+        {
+            foreach (var segment in segments)
+            {
+                if (!Directory.Exists(current))
+                    return new PathIdentity(fullPath, wasResolved: false);
+
+                string? exact = null;
+                string? caseInsensitive = null;
+                foreach (var entry in Directory.EnumerateFileSystemEntries(current))
+                {
+                    var name = System.IO.Path.GetFileName(entry);
+                    if (string.Equals(name, segment, StringComparison.Ordinal))
+                    {
+                        exact = entry;
+                        break;
+                    }
+                    if (caseInsensitive is null && string.Equals(name, segment, StringComparison.OrdinalIgnoreCase))
+                        caseInsensitive = entry;
+                }
+
+                var match = exact ?? caseInsensitive;
+                if (match is null)
+                    return new PathIdentity(fullPath, wasResolved: false);
+                current = match;
             }
         }
-
-        var changed = !string.Equals(document.Text, updated, StringComparison.Ordinal);
-        if (changed)
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
-            var directory = System.IO.Path.GetDirectoryName(path);
-            if (!string.IsNullOrWhiteSpace(directory))
-                Directory.CreateDirectory(directory);
-            WriteDocument(path, document, updated);
+            return new PathIdentity(fullPath, wasResolved: false);
         }
 
-        return new ManagedMarkdownUpdateResult
-        {
-            Path = path,
-            BlockId = blockId,
-            Changed = changed,
-            Created = created,
-            Appended = appended
-        };
+        return new PathIdentity(System.IO.Path.GetFullPath(current), wasResolved: true);
     }
 
     /// <summary>
@@ -464,6 +645,85 @@ public sealed class ManagedMarkdownDocumentUpdater
 
         internal static DocumentText NewUtf8()
             => new(string.Empty, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), Array.Empty<byte>());
+    }
+
+    private sealed class NormalizedUpdateRequest
+    {
+        internal NormalizedUpdateRequest(
+            string path,
+            string markerNamespace,
+            string blockId,
+            ManagedMarkdownMarkerFormat markerFormat,
+            string markdown,
+            bool createIfMissing,
+            ManagedMarkdownMissingBlockBehavior missingBlockBehavior,
+            string? newDocumentTitle)
+        {
+            Path = path;
+            MarkerNamespace = markerNamespace;
+            BlockId = blockId;
+            MarkerFormat = markerFormat;
+            Markdown = markdown;
+            CreateIfMissing = createIfMissing;
+            MissingBlockBehavior = missingBlockBehavior;
+            NewDocumentTitle = newDocumentTitle;
+        }
+
+        internal string Path { get; }
+        internal string MarkerNamespace { get; }
+        internal string BlockId { get; }
+        internal ManagedMarkdownMarkerFormat MarkerFormat { get; }
+        internal string Markdown { get; }
+        internal bool CreateIfMissing { get; }
+        internal ManagedMarkdownMissingBlockBehavior MissingBlockBehavior { get; }
+        internal string? NewDocumentTitle { get; }
+        internal BlockLocation? OriginalLocation { get; set; }
+    }
+
+    private sealed class PreparedDocument
+    {
+        internal PreparedDocument(string path, string identityKey, bool identityWasResolved, DocumentText document, bool exists)
+        {
+            Path = path;
+            IdentityKey = identityKey;
+            IdentityWasResolved = identityWasResolved;
+            Document = document;
+            Text = document.Text;
+            Exists = exists;
+        }
+
+        internal string Path { get; }
+        internal string IdentityKey { get; }
+        internal bool IdentityWasResolved { get; }
+        internal DocumentText Document { get; }
+        internal List<NormalizedUpdateRequest> Requests { get; } = new();
+        internal string Text { get; set; }
+        internal bool Exists { get; set; }
+        internal bool Changed { get; set; }
+    }
+
+    private readonly struct PathIdentity
+    {
+        internal PathIdentity(string key, bool wasResolved)
+        {
+            Key = key;
+            WasResolved = wasResolved;
+        }
+
+        internal string Key { get; }
+        internal bool WasResolved { get; }
+    }
+
+    private sealed class PreparedBatch
+    {
+        internal PreparedBatch(PreparedDocument[] documents, ManagedMarkdownUpdateResult[] results)
+        {
+            Documents = documents;
+            Results = results;
+        }
+
+        internal PreparedDocument[] Documents { get; }
+        internal ManagedMarkdownUpdateResult[] Results { get; }
     }
 
     private sealed class LineLocation

--- a/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
+++ b/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
@@ -1,0 +1,366 @@
+using System.Text;
+
+namespace PowerForge;
+
+/// <summary>
+/// Creates and updates marker-delimited blocks in Markdown documents.
+/// </summary>
+public sealed class ManagedMarkdownDocumentUpdater
+{
+    /// <summary>
+    /// Validates whether an update can be applied without writing the document.
+    /// </summary>
+    /// <param name="request">Managed document update request.</param>
+    public void ValidateUpdate(ManagedMarkdownUpdateRequest request)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+        var path = NormalizePath(request.Path);
+        var blockId = NormalizeBlockId(request.BlockId);
+        if (!File.Exists(path))
+        {
+            if (!request.CreateIfMissing)
+                throw new FileNotFoundException($"Managed Markdown document was not found: {path}", path);
+            return;
+        }
+
+        var document = ReadDocument(path);
+        var location = FindBlock(document.Text, blockId);
+        if (location is null && request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
+            throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
+    }
+
+    /// <summary>
+    /// Creates or updates one managed block.
+    /// </summary>
+    /// <param name="request">Managed document update request.</param>
+    /// <returns>Update result.</returns>
+    public ManagedMarkdownUpdateResult Update(ManagedMarkdownUpdateRequest request)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+
+        var path = NormalizePath(request.Path);
+        var blockId = NormalizeBlockId(request.BlockId);
+        var replacement = NormalizeMarkdown(request.Markdown);
+        var exists = File.Exists(path);
+
+        DocumentText document;
+        string updated;
+        var created = false;
+        var appended = false;
+
+        if (!exists)
+        {
+            if (!request.CreateIfMissing)
+                throw new FileNotFoundException($"Managed Markdown document was not found: {path}", path);
+
+            document = DocumentText.NewUtf8();
+            updated = CreateDocument(blockId, replacement, request.NewDocumentTitle, Environment.NewLine);
+            created = true;
+        }
+        else
+        {
+            document = ReadDocument(path);
+            var location = FindBlock(document.Text, blockId);
+
+            if (location is null)
+            {
+                if (request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
+                    throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
+
+                updated = AppendBlock(document.Text, blockId, replacement, DetectPreferredLineEnding(document.Text));
+                appended = true;
+            }
+            else
+            {
+                updated = ReplaceBlock(document.Text, location, replacement);
+            }
+        }
+
+        var changed = !string.Equals(document.Text, updated, StringComparison.Ordinal);
+        if (changed)
+        {
+            var directory = System.IO.Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+            WriteDocument(path, document, updated);
+        }
+
+        return new ManagedMarkdownUpdateResult
+        {
+            Path = path,
+            BlockId = blockId,
+            Changed = changed,
+            Created = created,
+            Appended = appended
+        };
+    }
+
+    /// <summary>
+    /// Validates that a managed block exists without modifying the document.
+    /// </summary>
+    /// <param name="path">Markdown document path.</param>
+    /// <param name="blockId">Managed block identifier.</param>
+    public void ValidateBlock(string path, string blockId)
+    {
+        var fullPath = NormalizePath(path);
+        var normalizedBlockId = NormalizeBlockId(blockId);
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException($"Managed Markdown document was not found: {fullPath}", fullPath);
+
+        var content = ReadDocument(fullPath).Text;
+        if (FindBlock(content, normalizedBlockId) is null)
+            throw new InvalidOperationException($"Managed block '{normalizedBlockId}' was not found in '{fullPath}'.");
+    }
+
+    private static string CreateDocument(string blockId, string markdown, string? title, string newline)
+    {
+        var builder = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(title))
+        {
+            builder.Append("# ").Append(title!.Trim()).Append(newline).Append(newline);
+        }
+
+        AppendManagedBlock(builder, blockId, markdown, newline);
+        return builder.ToString();
+    }
+
+    private static string AppendBlock(string original, string blockId, string markdown, string newline)
+    {
+        var builder = new StringBuilder(original);
+        if (builder.Length > 0)
+        {
+            if (!EndsWithLineEnding(original))
+                builder.Append(newline);
+            builder.Append(newline);
+        }
+        AppendManagedBlock(builder, blockId, markdown, newline);
+        return builder.ToString();
+    }
+
+    private static void AppendManagedBlock(StringBuilder builder, string blockId, string markdown, string newline)
+    {
+        builder.Append("<!-- POWERFORGE:").Append(blockId).Append(":START -->").Append(newline);
+        if (markdown.Length > 0)
+            builder.Append(ConvertLineEndings(markdown, newline)).Append(newline);
+        builder.Append("<!-- POWERFORGE:").Append(blockId).Append(":END -->").Append(newline);
+    }
+
+    private static string ReplaceBlock(string original, BlockLocation block, string replacement)
+    {
+        var newline = block.StartLine.LineEnding.Length > 0
+            ? block.StartLine.LineEnding
+            : DetectPreferredLineEnding(original);
+        var prefix = original.Substring(0, block.StartLine.End);
+        var suffix = original.Substring(block.EndLine.Start);
+        if (replacement.Length == 0)
+            return prefix + suffix;
+        return prefix + ConvertLineEndings(replacement, newline) + newline + suffix;
+    }
+
+    private static BlockLocation? FindBlock(string content, string blockId)
+    {
+        var starts = new List<LineLocation>();
+        var ends = new List<LineLocation>();
+        foreach (var line in EnumerateLines(content))
+        {
+            var value = content.Substring(line.Start, line.ContentEnd - line.Start);
+            if (IsMarker(value, blockId, "START")) starts.Add(line);
+            if (IsMarker(value, blockId, "END")) ends.Add(line);
+        }
+
+        if (starts.Count == 0 && ends.Count == 0)
+            return null;
+        if (starts.Count != 1 || ends.Count != 1 || ends[0].Start <= starts[0].Start)
+            throw new InvalidOperationException($"Managed block '{blockId}' has missing, duplicate, or out-of-order markers.");
+
+        return new BlockLocation(starts[0], ends[0]);
+    }
+
+    private static IEnumerable<LineLocation> EnumerateLines(string content)
+    {
+        var index = 0;
+        while (index < content.Length)
+        {
+            var start = index;
+            while (index < content.Length && content[index] != '\r' && content[index] != '\n')
+                index++;
+            var contentEnd = index;
+            var lineEndingStart = index;
+            if (index < content.Length && content[index] == '\r')
+            {
+                index++;
+                if (index < content.Length && content[index] == '\n') index++;
+            }
+            else if (index < content.Length)
+            {
+                index++;
+            }
+            yield return new LineLocation(start, contentEnd, index, content.Substring(lineEndingStart, index - lineEndingStart));
+        }
+    }
+
+    private static bool IsMarker(string? line, string blockId, string side)
+    {
+        var text = (line ?? string.Empty).Trim();
+        if (!text.StartsWith("<!--", StringComparison.Ordinal) || !text.EndsWith("-->", StringComparison.Ordinal))
+            return false;
+
+        var body = text.Substring(4, text.Length - 7).Trim();
+        var parts = body.Split(':').Select(part => part.Trim()).ToArray();
+        return parts.Length >= 2
+               && string.Equals(parts[parts.Length - 2], blockId, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(parts[parts.Length - 1], side, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static DocumentText ReadDocument(string path)
+    {
+        var bytes = File.ReadAllBytes(path);
+        var encoding = DetectEncoding(bytes, out var preambleLength);
+        var text = encoding.GetString(bytes, preambleLength, bytes.Length - preambleLength);
+        var preamble = new byte[preambleLength];
+        if (preambleLength > 0)
+            Buffer.BlockCopy(bytes, 0, preamble, 0, preambleLength);
+        return new DocumentText(text, encoding, preamble);
+    }
+
+    private static void WriteDocument(string path, DocumentText document, string text)
+    {
+        var content = document.Encoding.GetBytes(text);
+        if (document.Preamble.Length == 0)
+        {
+            File.WriteAllBytes(path, content);
+            return;
+        }
+
+        var bytes = new byte[document.Preamble.Length + content.Length];
+        Buffer.BlockCopy(document.Preamble, 0, bytes, 0, document.Preamble.Length);
+        Buffer.BlockCopy(content, 0, bytes, document.Preamble.Length, content.Length);
+        File.WriteAllBytes(path, bytes);
+    }
+
+    private static Encoding DetectEncoding(byte[] bytes, out int preambleLength)
+    {
+        if (StartsWith(bytes, 0x00, 0x00, 0xFE, 0xFF))
+        {
+            preambleLength = 4;
+            return new UTF32Encoding(bigEndian: true, byteOrderMark: false, throwOnInvalidCharacters: true);
+        }
+        if (StartsWith(bytes, 0xFF, 0xFE, 0x00, 0x00))
+        {
+            preambleLength = 4;
+            return new UTF32Encoding(bigEndian: false, byteOrderMark: false, throwOnInvalidCharacters: true);
+        }
+        if (StartsWith(bytes, 0xEF, 0xBB, 0xBF))
+        {
+            preambleLength = 3;
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+        }
+        if (StartsWith(bytes, 0xFE, 0xFF))
+        {
+            preambleLength = 2;
+            return new UnicodeEncoding(bigEndian: true, byteOrderMark: false, throwOnInvalidBytes: true);
+        }
+        if (StartsWith(bytes, 0xFF, 0xFE))
+        {
+            preambleLength = 2;
+            return new UnicodeEncoding(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: true);
+        }
+
+        preambleLength = 0;
+        return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    }
+
+    private static bool StartsWith(byte[] bytes, params byte[] prefix)
+    {
+        if (bytes.Length < prefix.Length) return false;
+        for (var index = 0; index < prefix.Length; index++)
+        {
+            if (bytes[index] != prefix[index]) return false;
+        }
+        return true;
+    }
+
+    private static string DetectPreferredLineEnding(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (value[index] == '\r')
+                return index + 1 < value.Length && value[index + 1] == '\n' ? "\r\n" : "\r";
+            if (value[index] == '\n')
+                return "\n";
+        }
+        return Environment.NewLine;
+    }
+
+    private static bool EndsWithLineEnding(string value)
+        => value.EndsWith("\n", StringComparison.Ordinal) || value.EndsWith("\r", StringComparison.Ordinal);
+
+    private static string ConvertLineEndings(string value, string newline)
+        => NormalizeLineEndings(value).Replace("\n", newline);
+
+    private static string NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Document path is required.", nameof(path));
+        return System.IO.Path.GetFullPath(path!.Trim().Trim('"'));
+    }
+
+    private static string NormalizeBlockId(string? blockId)
+    {
+        if (string.IsNullOrWhiteSpace(blockId)) throw new ArgumentException("Block id is required.", nameof(blockId));
+        var normalized = blockId!.Trim();
+        if (normalized.Contains(':') || normalized.Contains('\r') || normalized.Contains('\n') || normalized.Contains("-->", StringComparison.Ordinal))
+            throw new ArgumentException("Block id cannot contain colons, line breaks, or an HTML comment terminator.", nameof(blockId));
+        return normalized;
+    }
+
+    private static string NormalizeMarkdown(string? markdown)
+        => NormalizeLineEndings(markdown ?? string.Empty).TrimEnd('\n');
+
+    private static string NormalizeLineEndings(string value)
+        => value.Replace("\r\n", "\n").Replace('\r', '\n');
+
+    private sealed class DocumentText
+    {
+        internal DocumentText(string text, Encoding encoding, byte[] preamble)
+        {
+            Text = text;
+            Encoding = encoding;
+            Preamble = preamble;
+        }
+
+        internal string Text { get; }
+        internal Encoding Encoding { get; }
+        internal byte[] Preamble { get; }
+
+        internal static DocumentText NewUtf8()
+            => new(string.Empty, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), Array.Empty<byte>());
+    }
+
+    private sealed class LineLocation
+    {
+        internal LineLocation(int start, int contentEnd, int end, string lineEnding)
+        {
+            Start = start;
+            ContentEnd = contentEnd;
+            End = end;
+            LineEnding = lineEnding;
+        }
+
+        internal int Start { get; }
+        internal int ContentEnd { get; }
+        internal int End { get; }
+        internal string LineEnding { get; }
+    }
+
+    private sealed class BlockLocation
+    {
+        internal BlockLocation(LineLocation startLine, LineLocation endLine)
+        {
+            StartLine = startLine;
+            EndLine = endLine;
+        }
+
+        internal LineLocation StartLine { get; }
+        internal LineLocation EndLine { get; }
+    }
+}

--- a/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
+++ b/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
@@ -15,6 +15,7 @@ public sealed class ManagedMarkdownDocumentUpdater
     {
         if (request is null) throw new ArgumentNullException(nameof(request));
         var path = NormalizePath(request.Path);
+        var markerNamespace = NormalizeMarkerNamespace(request.MarkerNamespace);
         var blockId = NormalizeBlockId(request.BlockId);
         if (!File.Exists(path))
         {
@@ -24,7 +25,7 @@ public sealed class ManagedMarkdownDocumentUpdater
         }
 
         var document = ReadDocument(path);
-        var location = FindBlock(document.Text, blockId);
+        var location = FindBlock(document.Text, markerNamespace, blockId);
         if (location is null && request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
             throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
     }
@@ -39,6 +40,7 @@ public sealed class ManagedMarkdownDocumentUpdater
         if (request is null) throw new ArgumentNullException(nameof(request));
 
         var path = NormalizePath(request.Path);
+        var markerNamespace = NormalizeMarkerNamespace(request.MarkerNamespace);
         var blockId = NormalizeBlockId(request.BlockId);
         var replacement = NormalizeMarkdown(request.Markdown);
         var exists = File.Exists(path);
@@ -54,20 +56,20 @@ public sealed class ManagedMarkdownDocumentUpdater
                 throw new FileNotFoundException($"Managed Markdown document was not found: {path}", path);
 
             document = DocumentText.NewUtf8();
-            updated = CreateDocument(blockId, replacement, request.NewDocumentTitle, Environment.NewLine);
+            updated = CreateDocument(markerNamespace, blockId, replacement, request.NewDocumentTitle, Environment.NewLine);
             created = true;
         }
         else
         {
             document = ReadDocument(path);
-            var location = FindBlock(document.Text, blockId);
+            var location = FindBlock(document.Text, markerNamespace, blockId);
 
             if (location is null)
             {
                 if (request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
                     throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
 
-                updated = AppendBlock(document.Text, blockId, replacement, DetectPreferredLineEnding(document.Text));
+                updated = AppendBlock(document.Text, markerNamespace, blockId, replacement, DetectPreferredLineEnding(document.Text));
                 appended = true;
             }
             else
@@ -101,18 +103,28 @@ public sealed class ManagedMarkdownDocumentUpdater
     /// <param name="path">Markdown document path.</param>
     /// <param name="blockId">Managed block identifier.</param>
     public void ValidateBlock(string path, string blockId)
+        => ValidateBlock(path, blockId, "POWERFORGE");
+
+    /// <summary>
+    /// Validates that a managed block with the specified marker namespace exists without modifying the document.
+    /// </summary>
+    /// <param name="path">Markdown document path.</param>
+    /// <param name="blockId">Managed block identifier.</param>
+    /// <param name="markerNamespace">Expected marker namespace.</param>
+    public void ValidateBlock(string path, string blockId, string markerNamespace)
     {
         var fullPath = NormalizePath(path);
+        var normalizedMarkerNamespace = NormalizeMarkerNamespace(markerNamespace);
         var normalizedBlockId = NormalizeBlockId(blockId);
         if (!File.Exists(fullPath))
             throw new FileNotFoundException($"Managed Markdown document was not found: {fullPath}", fullPath);
 
         var content = ReadDocument(fullPath).Text;
-        if (FindBlock(content, normalizedBlockId) is null)
+        if (FindBlock(content, normalizedMarkerNamespace, normalizedBlockId) is null)
             throw new InvalidOperationException($"Managed block '{normalizedBlockId}' was not found in '{fullPath}'.");
     }
 
-    private static string CreateDocument(string blockId, string markdown, string? title, string newline)
+    private static string CreateDocument(string markerNamespace, string blockId, string markdown, string? title, string newline)
     {
         var builder = new StringBuilder();
         if (!string.IsNullOrWhiteSpace(title))
@@ -120,11 +132,11 @@ public sealed class ManagedMarkdownDocumentUpdater
             builder.Append("# ").Append(title!.Trim()).Append(newline).Append(newline);
         }
 
-        AppendManagedBlock(builder, blockId, markdown, newline);
+        AppendManagedBlock(builder, markerNamespace, blockId, markdown, newline);
         return builder.ToString();
     }
 
-    private static string AppendBlock(string original, string blockId, string markdown, string newline)
+    private static string AppendBlock(string original, string markerNamespace, string blockId, string markdown, string newline)
     {
         var builder = new StringBuilder(original);
         if (builder.Length > 0)
@@ -133,16 +145,16 @@ public sealed class ManagedMarkdownDocumentUpdater
                 builder.Append(newline);
             builder.Append(newline);
         }
-        AppendManagedBlock(builder, blockId, markdown, newline);
+        AppendManagedBlock(builder, markerNamespace, blockId, markdown, newline);
         return builder.ToString();
     }
 
-    private static void AppendManagedBlock(StringBuilder builder, string blockId, string markdown, string newline)
+    private static void AppendManagedBlock(StringBuilder builder, string markerNamespace, string blockId, string markdown, string newline)
     {
-        builder.Append("<!-- POWERFORGE:").Append(blockId).Append(":START -->").Append(newline);
+        builder.Append("<!-- ").Append(markerNamespace).Append(':').Append(blockId).Append(":START -->").Append(newline);
         if (markdown.Length > 0)
             builder.Append(ConvertLineEndings(markdown, newline)).Append(newline);
-        builder.Append("<!-- POWERFORGE:").Append(blockId).Append(":END -->").Append(newline);
+        builder.Append("<!-- ").Append(markerNamespace).Append(':').Append(blockId).Append(":END -->").Append(newline);
     }
 
     private static string ReplaceBlock(string original, BlockLocation block, string replacement)
@@ -157,15 +169,15 @@ public sealed class ManagedMarkdownDocumentUpdater
         return prefix + ConvertLineEndings(replacement, newline) + newline + suffix;
     }
 
-    private static BlockLocation? FindBlock(string content, string blockId)
+    private static BlockLocation? FindBlock(string content, string markerNamespace, string blockId)
     {
         var starts = new List<LineLocation>();
         var ends = new List<LineLocation>();
         foreach (var line in EnumerateLines(content))
         {
             var value = content.Substring(line.Start, line.ContentEnd - line.Start);
-            if (IsMarker(value, blockId, "START")) starts.Add(line);
-            if (IsMarker(value, blockId, "END")) ends.Add(line);
+            if (IsMarker(value, markerNamespace, blockId, "START")) starts.Add(line);
+            if (IsMarker(value, markerNamespace, blockId, "END")) ends.Add(line);
         }
 
         if (starts.Count == 0 && ends.Count == 0)
@@ -199,7 +211,7 @@ public sealed class ManagedMarkdownDocumentUpdater
         }
     }
 
-    private static bool IsMarker(string? line, string blockId, string side)
+    private static bool IsMarker(string? line, string markerNamespace, string blockId, string side)
     {
         var text = (line ?? string.Empty).Trim();
         if (!text.StartsWith("<!--", StringComparison.Ordinal) || !text.EndsWith("-->", StringComparison.Ordinal))
@@ -207,9 +219,10 @@ public sealed class ManagedMarkdownDocumentUpdater
 
         var body = text.Substring(4, text.Length - 7).Trim();
         var parts = body.Split(':').Select(part => part.Trim()).ToArray();
-        return parts.Length >= 2
-               && string.Equals(parts[parts.Length - 2], blockId, StringComparison.OrdinalIgnoreCase)
-               && string.Equals(parts[parts.Length - 1], side, StringComparison.OrdinalIgnoreCase);
+        return parts.Length == 3
+               && string.Equals(parts[0], markerNamespace, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(parts[1], blockId, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(parts[2], side, StringComparison.OrdinalIgnoreCase);
     }
 
     private static DocumentText ReadDocument(string path)
@@ -310,6 +323,15 @@ public sealed class ManagedMarkdownDocumentUpdater
         var normalized = blockId!.Trim();
         if (normalized.Contains(':') || normalized.Contains('\r') || normalized.Contains('\n') || normalized.Contains("-->", StringComparison.Ordinal))
             throw new ArgumentException("Block id cannot contain colons, line breaks, or an HTML comment terminator.", nameof(blockId));
+        return normalized;
+    }
+
+    private static string NormalizeMarkerNamespace(string? markerNamespace)
+    {
+        if (string.IsNullOrWhiteSpace(markerNamespace)) throw new ArgumentException("Marker namespace is required.", nameof(markerNamespace));
+        var normalized = markerNamespace!.Trim();
+        if (normalized.Contains(':') || normalized.Contains('\r') || normalized.Contains('\n') || normalized.Contains("-->", StringComparison.Ordinal))
+            throw new ArgumentException("Marker namespace cannot contain colons, line breaks, or an HTML comment terminator.", nameof(markerNamespace));
         return normalized;
     }
 

--- a/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
+++ b/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
@@ -17,6 +17,8 @@ public sealed class ManagedMarkdownDocumentUpdater
         var path = NormalizePath(request.Path);
         var markerNamespace = NormalizeMarkerNamespace(request.MarkerNamespace);
         var blockId = NormalizeBlockId(request.BlockId);
+        var markerFormat = NormalizeMarkerFormat(request.MarkerFormat);
+        ValidateDestinationPath(path);
         if (!File.Exists(path))
         {
             if (!request.CreateIfMissing)
@@ -25,7 +27,7 @@ public sealed class ManagedMarkdownDocumentUpdater
         }
 
         var document = ReadDocument(path);
-        var location = FindBlock(document.Text, markerNamespace, blockId);
+        var location = FindBlock(document.Text, markerNamespace, blockId, markerFormat);
         if (location is null && request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
             throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
     }
@@ -42,7 +44,9 @@ public sealed class ManagedMarkdownDocumentUpdater
         var path = NormalizePath(request.Path);
         var markerNamespace = NormalizeMarkerNamespace(request.MarkerNamespace);
         var blockId = NormalizeBlockId(request.BlockId);
+        var markerFormat = NormalizeMarkerFormat(request.MarkerFormat);
         var replacement = NormalizeMarkdown(request.Markdown);
+        ValidateDestinationPath(path);
         var exists = File.Exists(path);
 
         DocumentText document;
@@ -56,20 +60,20 @@ public sealed class ManagedMarkdownDocumentUpdater
                 throw new FileNotFoundException($"Managed Markdown document was not found: {path}", path);
 
             document = DocumentText.NewUtf8();
-            updated = CreateDocument(markerNamespace, blockId, replacement, request.NewDocumentTitle, Environment.NewLine);
+            updated = CreateDocument(markerNamespace, blockId, replacement, request.NewDocumentTitle, Environment.NewLine, markerFormat);
             created = true;
         }
         else
         {
             document = ReadDocument(path);
-            var location = FindBlock(document.Text, markerNamespace, blockId);
+            var location = FindBlock(document.Text, markerNamespace, blockId, markerFormat);
 
             if (location is null)
             {
                 if (request.MissingBlockBehavior != ManagedMarkdownMissingBlockBehavior.Append)
                     throw new InvalidOperationException($"Managed block '{blockId}' was not found in '{path}'.");
 
-                updated = AppendBlock(document.Text, markerNamespace, blockId, replacement, DetectPreferredLineEnding(document.Text));
+                updated = AppendBlock(document.Text, markerNamespace, blockId, replacement, DetectPreferredLineEnding(document.Text), markerFormat);
                 appended = true;
             }
             else
@@ -112,19 +116,41 @@ public sealed class ManagedMarkdownDocumentUpdater
     /// <param name="blockId">Managed block identifier.</param>
     /// <param name="markerNamespace">Expected marker namespace.</param>
     public void ValidateBlock(string path, string blockId, string markerNamespace)
+        => ValidateBlock(path, blockId, markerNamespace, ManagedMarkdownMarkerFormat.Namespaced);
+
+    /// <summary>
+    /// Validates that a managed block with the specified namespace and marker format exists without modifying the document.
+    /// </summary>
+    /// <param name="path">Markdown document path.</param>
+    /// <param name="blockId">Managed block identifier.</param>
+    /// <param name="markerNamespace">Expected marker namespace.</param>
+    /// <param name="markerFormat">Accepted marker syntax.</param>
+    public void ValidateBlock(
+        string path,
+        string blockId,
+        string markerNamespace,
+        ManagedMarkdownMarkerFormat markerFormat)
     {
         var fullPath = NormalizePath(path);
         var normalizedMarkerNamespace = NormalizeMarkerNamespace(markerNamespace);
         var normalizedBlockId = NormalizeBlockId(blockId);
+        var normalizedMarkerFormat = NormalizeMarkerFormat(markerFormat);
+        ValidateDestinationPath(fullPath);
         if (!File.Exists(fullPath))
             throw new FileNotFoundException($"Managed Markdown document was not found: {fullPath}", fullPath);
 
         var content = ReadDocument(fullPath).Text;
-        if (FindBlock(content, normalizedMarkerNamespace, normalizedBlockId) is null)
+        if (FindBlock(content, normalizedMarkerNamespace, normalizedBlockId, normalizedMarkerFormat) is null)
             throw new InvalidOperationException($"Managed block '{normalizedBlockId}' was not found in '{fullPath}'.");
     }
 
-    private static string CreateDocument(string markerNamespace, string blockId, string markdown, string? title, string newline)
+    private static string CreateDocument(
+        string markerNamespace,
+        string blockId,
+        string markdown,
+        string? title,
+        string newline,
+        ManagedMarkdownMarkerFormat markerFormat)
     {
         var builder = new StringBuilder();
         if (!string.IsNullOrWhiteSpace(title))
@@ -132,11 +158,17 @@ public sealed class ManagedMarkdownDocumentUpdater
             builder.Append("# ").Append(title!.Trim()).Append(newline).Append(newline);
         }
 
-        AppendManagedBlock(builder, markerNamespace, blockId, markdown, newline);
+        AppendManagedBlock(builder, markerNamespace, blockId, markdown, newline, markerFormat);
         return builder.ToString();
     }
 
-    private static string AppendBlock(string original, string markerNamespace, string blockId, string markdown, string newline)
+    private static string AppendBlock(
+        string original,
+        string markerNamespace,
+        string blockId,
+        string markdown,
+        string newline,
+        ManagedMarkdownMarkerFormat markerFormat)
     {
         var builder = new StringBuilder(original);
         if (builder.Length > 0)
@@ -145,16 +177,39 @@ public sealed class ManagedMarkdownDocumentUpdater
                 builder.Append(newline);
             builder.Append(newline);
         }
-        AppendManagedBlock(builder, markerNamespace, blockId, markdown, newline);
+        AppendManagedBlock(builder, markerNamespace, blockId, markdown, newline, markerFormat);
         return builder.ToString();
     }
 
-    private static void AppendManagedBlock(StringBuilder builder, string markerNamespace, string blockId, string markdown, string newline)
+    private static void AppendManagedBlock(
+        StringBuilder builder,
+        string markerNamespace,
+        string blockId,
+        string markdown,
+        string newline,
+        ManagedMarkdownMarkerFormat markerFormat)
     {
-        builder.Append("<!-- ").Append(markerNamespace).Append(':').Append(blockId).Append(":START -->").Append(newline);
+        var writeFormat = markerFormat == ManagedMarkdownMarkerFormat.LegacyBlockId
+            ? ManagedMarkdownMarkerFormat.LegacyBlockId
+            : ManagedMarkdownMarkerFormat.Namespaced;
+        AppendMarker(builder, markerNamespace, blockId, "START", newline, writeFormat);
         if (markdown.Length > 0)
             builder.Append(ConvertLineEndings(markdown, newline)).Append(newline);
-        builder.Append("<!-- ").Append(markerNamespace).Append(':').Append(blockId).Append(":END -->").Append(newline);
+        AppendMarker(builder, markerNamespace, blockId, "END", newline, writeFormat);
+    }
+
+    private static void AppendMarker(
+        StringBuilder builder,
+        string markerNamespace,
+        string blockId,
+        string side,
+        string newline,
+        ManagedMarkdownMarkerFormat markerFormat)
+    {
+        builder.Append("<!-- ");
+        if (markerFormat == ManagedMarkdownMarkerFormat.Namespaced)
+            builder.Append(markerNamespace).Append(':');
+        builder.Append(blockId).Append(':').Append(side).Append(" -->").Append(newline);
     }
 
     private static string ReplaceBlock(string original, BlockLocation block, string replacement)
@@ -169,15 +224,31 @@ public sealed class ManagedMarkdownDocumentUpdater
         return prefix + ConvertLineEndings(replacement, newline) + newline + suffix;
     }
 
-    private static BlockLocation? FindBlock(string content, string markerNamespace, string blockId)
+    private static BlockLocation? FindBlock(
+        string content,
+        string markerNamespace,
+        string blockId,
+        ManagedMarkdownMarkerFormat markerFormat)
+    {
+        if (markerFormat != ManagedMarkdownMarkerFormat.NamespacedOrLegacyBlockId)
+            return FindBlock(content, markerNamespace, blockId, markerFormat == ManagedMarkdownMarkerFormat.LegacyBlockId);
+
+        var namespaced = FindBlock(content, markerNamespace, blockId, legacy: false);
+        var legacy = FindBlock(content, markerNamespace, blockId, legacy: true);
+        if (namespaced is not null && legacy is not null)
+            throw new InvalidOperationException($"Managed block '{blockId}' has both namespaced and legacy markers.");
+        return namespaced ?? legacy;
+    }
+
+    private static BlockLocation? FindBlock(string content, string markerNamespace, string blockId, bool legacy)
     {
         var starts = new List<LineLocation>();
         var ends = new List<LineLocation>();
         foreach (var line in EnumerateLines(content))
         {
             var value = content.Substring(line.Start, line.ContentEnd - line.Start);
-            if (IsMarker(value, markerNamespace, blockId, "START")) starts.Add(line);
-            if (IsMarker(value, markerNamespace, blockId, "END")) ends.Add(line);
+            if (IsMarker(value, markerNamespace, blockId, "START", legacy)) starts.Add(line);
+            if (IsMarker(value, markerNamespace, blockId, "END", legacy)) ends.Add(line);
         }
 
         if (starts.Count == 0 && ends.Count == 0)
@@ -211,7 +282,7 @@ public sealed class ManagedMarkdownDocumentUpdater
         }
     }
 
-    private static bool IsMarker(string? line, string markerNamespace, string blockId, string side)
+    private static bool IsMarker(string? line, string markerNamespace, string blockId, string side, bool legacy)
     {
         var text = (line ?? string.Empty).Trim();
         if (!text.StartsWith("<!--", StringComparison.Ordinal) || !text.EndsWith("-->", StringComparison.Ordinal))
@@ -219,6 +290,13 @@ public sealed class ManagedMarkdownDocumentUpdater
 
         var body = text.Substring(4, text.Length - 7).Trim();
         var parts = body.Split(':').Select(part => part.Trim()).ToArray();
+        if (legacy)
+        {
+            return parts.Length == 2
+                   && string.Equals(parts[0], blockId, StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(parts[1], side, StringComparison.OrdinalIgnoreCase);
+        }
+
         return parts.Length == 3
                && string.Equals(parts[0], markerNamespace, StringComparison.OrdinalIgnoreCase)
                && string.Equals(parts[1], blockId, StringComparison.OrdinalIgnoreCase)
@@ -333,6 +411,36 @@ public sealed class ManagedMarkdownDocumentUpdater
         if (normalized.Contains(':') || normalized.Contains('\r') || normalized.Contains('\n') || normalized.Contains("-->", StringComparison.Ordinal))
             throw new ArgumentException("Marker namespace cannot contain colons, line breaks, or an HTML comment terminator.", nameof(markerNamespace));
         return normalized;
+    }
+
+    private static ManagedMarkdownMarkerFormat NormalizeMarkerFormat(ManagedMarkdownMarkerFormat markerFormat)
+    {
+        if (!Enum.IsDefined(typeof(ManagedMarkdownMarkerFormat), markerFormat))
+            throw new ArgumentOutOfRangeException(nameof(markerFormat), markerFormat, "Unsupported managed Markdown marker format.");
+        return markerFormat;
+    }
+
+    private static void ValidateDestinationPath(string path)
+    {
+        if (Directory.Exists(path))
+            throw new IOException($"Managed Markdown document path is an existing directory: {path}");
+
+        var parent = System.IO.Path.GetDirectoryName(path);
+        while (!string.IsNullOrWhiteSpace(parent))
+        {
+            if (File.Exists(parent))
+            {
+                throw new IOException(
+                    $"Managed Markdown document path has an existing file ancestor '{parent}': {path}");
+            }
+            if (Directory.Exists(parent))
+                return;
+
+            var next = System.IO.Path.GetDirectoryName(parent);
+            if (string.Equals(next, parent, StringComparison.Ordinal))
+                return;
+            parent = next;
+        }
     }
 
     private static string NormalizeMarkdown(string? markdown)

--- a/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
+++ b/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
@@ -168,6 +168,7 @@ public sealed class ManagedMarkdownDocumentUpdater
                 Created = created,
                 Appended = appended
             };
+            document.ResultIndexes.Add(index);
         }
 
         foreach (var document in orderedDocuments)
@@ -194,6 +195,8 @@ public sealed class ManagedMarkdownDocumentUpdater
                 finalLocations.Add((request, location));
             }
             document.Changed = !string.Equals(document.Document.Text, document.Text, StringComparison.Ordinal);
+            foreach (var resultIndex in document.ResultIndexes)
+                results[resultIndex].Changed = document.Changed;
         }
 
         return new PreparedBatch(orderedDocuments.ToArray(), results);
@@ -664,6 +667,7 @@ public sealed class ManagedMarkdownDocumentUpdater
         internal bool IdentityWasResolved { get; }
         internal DocumentText Document { get; }
         internal List<NormalizedUpdateRequest> Requests { get; } = new();
+        internal List<int> ResultIndexes { get; } = new();
         internal string Text { get; set; }
         internal bool Exists { get; set; }
         internal bool Changed { get; set; }

--- a/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
+++ b/PowerForge/Services/ManagedMarkdownDocumentUpdater.cs
@@ -236,50 +236,17 @@ public sealed class ManagedMarkdownDocumentUpdater
         if (!File.Exists(path))
             return new PathIdentity(path, wasResolved: false);
 
-        var fullPath = System.IO.Path.GetFullPath(path);
-        var root = System.IO.Path.GetPathRoot(fullPath);
-        if (string.IsNullOrWhiteSpace(root))
-            return new PathIdentity(fullPath, wasResolved: false);
-
-        var current = root!;
-        var relative = fullPath.Substring(root!.Length);
-        var separators = System.IO.Path.DirectorySeparatorChar == System.IO.Path.AltDirectorySeparatorChar
-            ? new[] { System.IO.Path.DirectorySeparatorChar }
-            : new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar };
-        var segments = relative.Split(separators, StringSplitOptions.RemoveEmptyEntries);
         try
         {
-            foreach (var segment in segments)
-            {
-                if (!Directory.Exists(current))
-                    return new PathIdentity(fullPath, wasResolved: false);
-
-                string? exact = null;
-                string? caseInsensitive = null;
-                foreach (var entry in Directory.EnumerateFileSystemEntries(current))
-                {
-                    var name = System.IO.Path.GetFileName(entry);
-                    if (string.Equals(name, segment, StringComparison.Ordinal))
-                    {
-                        exact = entry;
-                        break;
-                    }
-                    if (caseInsensitive is null && string.Equals(name, segment, StringComparison.OrdinalIgnoreCase))
-                        caseInsensitive = entry;
-                }
-
-                var match = exact ?? caseInsensitive;
-                if (match is null)
-                    return new PathIdentity(fullPath, wasResolved: false);
-                current = match;
-            }
+            return new PathIdentity(ExistingFilePathIdentityResolver.Resolve(path), wasResolved: true);
         }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or NotSupportedException or PlatformNotSupportedException)
         {
-            return new PathIdentity(fullPath, wasResolved: false);
+            throw new InvalidOperationException(
+                $"Managed Markdown document identity could not be resolved safely: {path}",
+                exception);
         }
-
-        return new PathIdentity(System.IO.Path.GetFullPath(current), wasResolved: true);
     }
 
     /// <summary>

--- a/README.MD
+++ b/README.MD
@@ -57,6 +57,7 @@ The same contracts are available from PowerShell cmdlets, JSON files, and CLI co
 | .NET publish and packaging | Builds publish matrices for apps, services, tools, bundles, plugins, MSI, MSIX, Microsoft Store packages, appinstaller files, signing, checksums, and manifests. | `New-DotNetPublishConfig`, `Invoke-DotNetPublish`, `Invoke-PowerForgeBundlePostProcess`, `Invoke-PowerForgePluginExport`, `Invoke-PowerForgePluginPack` |
 | Unified release | Coordinates module artifacts, NuGet packages, tool binaries, installers, GitHub releases, staging folders, checksums, Winget manifests/submission, and release manifests from one release config. | `New-PowerForgeReleaseConfig`, `Invoke-PowerForgeRelease`, `Invoke-ProjectRelease`, `Invoke-ProjectBuild`, `powerforge release` |
 | GitHub housekeeping | Prunes Actions artifacts and caches, performs runner cleanup, and provides reusable workflows/actions for cross-repo maintenance. | `powerforge github housekeeping`, `.github/workflows/powerforge-github-housekeeping.yml` |
+| GitHub repository content | Generates managed Sponsors rosters from public GitHub data with optional recognition tiers, manual overrides, and reusable automation. | `powerforge github content sync`, `.github/workflows/powerforge-github-content.yml` |
 | Home Assistant and HACS releases | Applies PR-driven semantic version policy, keeps integration/plugin metadata aligned, builds HACS assets, publishes verified GitHub releases, and resumes failed runs. | `powerforge homeassistant release`, `.github/workflows/powerforge-homeassistant-release.yml` |
 | Static websites and API docs | Builds PowerForge.Web sites, docs, blogs, search indexes, API docs, project hubs, SEO assets, sitemaps, quality gates, audits, and deployment artifacts. | `powerforge-web build`, `powerforge-web pipeline`, `powerforge-web verify`, `powerforge-web audit`, `powerforge-web scaffold` |
 | Project hygiene | Checks or fixes line endings/encoding, removes comments or project files, reads versions, and summarizes test failures. | `Get-ProjectConsistency`, `Convert-ProjectConsistency`, `Get-ProjectVersion`, `Set-ProjectVersion`, `Get-ModuleTestFailures` |
@@ -524,6 +525,16 @@ Recommended site contracts include:
 - a theme manifest with feature contracts.
 
 See [Docs/PowerForge.Web.WebsiteStarter.md](Docs/PowerForge.Web.WebsiteStarter.md), [Docs/PowerForge.Web.QualityGates.md](Docs/PowerForge.Web.QualityGates.md), and [Docs/PowerForge.Web.Roadmap.md](Docs/PowerForge.Web.Roadmap.md).
+
+## GitHub Repository Content
+
+Generate a full `SPONSORS.md` and an optional compact README block from public GitHub Sponsors data:
+
+```powershell
+powerforge github content sync --config .\.powerforge\github-content.json
+```
+
+Recognition tiers are opt-in, per-account overrides win over GitHub tier mapping, and manual entries cover companies or support received outside GitHub. See [Generated GitHub Repository Content](Docs/PowerForge.GitHubContent.md) for the config, markers, privacy behavior, and reusable workflow.
 
 ## GitHub Housekeeping
 

--- a/Schemas/github.content.schema.json
+++ b/Schemas/github.content.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PowerForge GitHub Repository Content",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["sponsors"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "graphQlEndpoint": { "type": ["string", "null"], "format": "uri", "pattern": "^https://" },
+    "token": { "type": ["string", "null"] },
+    "tokenEnvName": { "type": "string", "default": "GITHUB_TOKEN" },
+    "sponsors": { "$ref": "#/definitions/sponsors" }
+  },
+  "definitions": {
+    "sponsors": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "sponsorableLogin", "outputs"],
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "sponsorableLogin": { "type": "string", "minLength": 1 },
+        "includeFormer": { "type": "boolean", "default": true },
+        "failOnEmpty": { "type": "boolean", "default": true },
+        "requireFundingTierData": { "type": "boolean", "default": false },
+        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100, "default": 100 },
+        "tierRecognition": { "$ref": "#/definitions/tierRecognition" },
+        "overrides": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/override" }
+        },
+        "manualEntries": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/manualEntry" }
+        },
+        "outputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/output" }
+        }
+      }
+    },
+    "tierRecognition": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "useDefaultTiers": { "type": "boolean", "default": true },
+        "unmappedTierKey": { "type": "string", "default": "Sponsors" },
+        "tiers": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/tier" }
+        }
+      }
+    },
+    "tier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "heading"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "heading": { "type": "string", "minLength": 1 },
+        "minimumMonthlyDollars": { "type": ["integer", "null"], "minimum": 0 },
+        "order": { "type": "integer", "default": 0 },
+        "avatarSize": { "type": "integer", "minimum": 24, "maximum": 256, "default": 64 }
+      }
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["login"],
+      "properties": {
+        "login": { "type": "string", "minLength": 1 },
+        "recognitionTierKey": { "type": ["string", "null"] },
+        "displayName": { "type": ["string", "null"] },
+        "profileUrl": { "type": ["string", "null"] },
+        "avatarUrl": { "type": ["string", "null"] },
+        "exclude": { "type": "boolean", "default": false }
+      }
+    },
+    "manualEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "displayName"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "displayName": { "type": "string", "minLength": 1 },
+        "login": { "type": ["string", "null"] },
+        "profileUrl": { "type": ["string", "null"] },
+        "avatarUrl": { "type": ["string", "null"] },
+        "recognitionTierKey": { "type": ["string", "null"] },
+        "former": { "type": "boolean", "default": false }
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "blockId"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "blockId": { "type": "string", "minLength": 1, "pattern": "^[^:\\r\\n]+$" },
+        "layout": { "type": "string", "enum": ["Full", "Compact"], "default": "Full" },
+        "title": { "type": "string", "default": "Sponsors" },
+        "introduction": { "type": ["string", "null"] },
+        "closing": { "type": ["string", "null"] },
+        "includeFormer": { "type": "boolean", "default": true },
+        "createIfMissing": { "type": "boolean", "default": false },
+        "missingBlockBehavior": { "type": "string", "enum": ["Fail", "Append"], "default": "Fail" },
+        "avatarSize": { "type": "integer", "minimum": 24, "maximum": 256, "default": 64 },
+        "maxEntries": { "type": "integer", "minimum": 0, "default": 0 },
+        "moreLink": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/Schemas/github.content.schema.json
+++ b/Schemas/github.content.schema.json
@@ -15,7 +15,7 @@
     "sponsors": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["enabled", "sponsorableLogin", "outputs"],
+      "required": ["enabled", "outputs"],
       "properties": {
         "enabled": { "type": "boolean", "default": false },
         "sponsorableLogin": { "type": "string", "minLength": 1 },


### PR DESCRIPTION
## Summary

- add a config-driven GitHub repository-content engine and `powerforge github content sync` CLI, with managed Markdown blocks reusable by future providers such as repository statistics
- generate current and former GitHub Sponsors in full or compact layouts, with opt-in default/custom recognition tiers, per-sponsor tier and presentation overrides, exclusions, and manual people/company entries
- add a reusable composite action and workflow whose engine defaults to the exact called-workflow commit rather than a mutable branch; serialized runs resolve the live caller branch when they start, commit-enabled runs require a branch ref, and custom engine refs are passed as data
- preserve hand-written Markdown bytes outside generated blocks, coalesce physical file aliases into one projected write, and stage every changed alias together
- reject missing/duplicate markers, outside-workspace outputs, symlink/reparse escapes, insecure GraphQL endpoints, repeated pagination cursors, empty sponsor results, and unavailable tier data when configured as required
- keep GitHub funding amounts internal to tier mapping; public results and JSON expose only the chosen recognition label
- let the starter work with the repository token by falling back when GitHub withholds tier metadata, while keeping strict tier-data enforcement available for maintainer-token automation

## Usage

Copy `Examples/GitHubContent/github-content.json` to `.powerforge/github-content.json`, customize the sponsorable account and outputs, then run:

```powershell
powerforge github content sync --config .\.powerforge\github-content.json
```

Tier grouping stays disabled unless `tierRecognition.enabled` is set. Manual entries and overrides can place a sponsor in any configured recognition tier regardless of the GitHub tier. See `Docs/PowerForge.GitHubContent.md` for token and workflow setup.
