### PR TITLE
Add reusable Cloudflare DNS record action

### DIFF
--- a/.github/actions/powerforge-cloudflare-dns-record/Invoke-PowerForgeCloudflareDnsRecord.ps1
+++ b/.github/actions/powerforge-cloudflare-dns-record/Invoke-PowerForgeCloudflareDnsRecord.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Assert-LastExitCode {
+    param([Parameter(Mandatory)][string] $Operation)
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Operation failed with exit code $LASTEXITCODE."
+    }
+}
+
+foreach ($requiredName in @(
+        'POWERFORGE_CLOUDFLARE_API_TOKEN',
+        'POWERFORGE_CLOUDFLARE_ZONE_NAME',
+        'POWERFORGE_CLOUDFLARE_DNS_NAME',
+        'POWERFORGE_CLOUDFLARE_DNS_CONTENT')) {
+    if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($requiredName))) {
+        throw "$requiredName is required."
+    }
+}
+if ($env:POWERFORGE_CLOUDFLARE_DNS_PROXIED -notin @('true', 'false')) {
+    throw 'proxied must be true or false.'
+}
+if ($env:POWERFORGE_CLOUDFLARE_DNS_DRY_RUN -notin @('true', 'false')) {
+    throw 'dry-run must be true or false.'
+}
+
+$engineRoot = [IO.Path]::GetFullPath((Join-Path $env:GITHUB_ACTION_PATH '../../..'))
+$project = Join-Path $engineRoot 'PowerForge.Web.Cli/PowerForge.Web.Cli.csproj'
+$cli = Join-Path $engineRoot 'PowerForge.Web.Cli/bin/Release/net10.0/PowerForge.Web.Cli.dll'
+
+dotnet build $project --configuration Release --framework net10.0 --nologo --verbosity minimal
+Assert-LastExitCode -Operation 'Building PowerForge.Web CLI'
+
+$arguments = @(
+    $cli,
+    'cloudflare',
+    'dns-record',
+    'apply',
+    '--zone-name', $env:POWERFORGE_CLOUDFLARE_ZONE_NAME,
+    '--record-name', $env:POWERFORGE_CLOUDFLARE_DNS_NAME,
+    '--record-content', $env:POWERFORGE_CLOUDFLARE_DNS_CONTENT,
+    '--record-type', $env:POWERFORGE_CLOUDFLARE_DNS_TYPE,
+    '--proxied', $env:POWERFORGE_CLOUDFLARE_DNS_PROXIED,
+    '--ttl', $env:POWERFORGE_CLOUDFLARE_DNS_TTL,
+    '--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN'
+)
+if (-not [string]::IsNullOrWhiteSpace($env:POWERFORGE_CLOUDFLARE_DNS_COMMENT)) {
+    $arguments += @('--comment', $env:POWERFORGE_CLOUDFLARE_DNS_COMMENT)
+}
+if ($env:POWERFORGE_CLOUDFLARE_DNS_DRY_RUN -eq 'true') {
+    $arguments += '--dry-run'
+}
+
+dotnet @arguments
+Assert-LastExitCode -Operation 'Reconciling Cloudflare DNS record'

--- a/.github/actions/powerforge-cloudflare-dns-record/action.yml
+++ b/.github/actions/powerforge-cloudflare-dns-record/action.yml
@@ -1,0 +1,63 @@
+name: PowerForge Cloudflare DNS Record
+description: Idempotently create or update a proxied Cloudflare DNS record from a caller-owned protected environment.
+
+inputs:
+  api-token:
+    description: Protected Cloudflare API token with Zone > DNS > Edit and Zone > Zone > Read permissions for the target zone.
+    required: true
+  zone-name:
+    description: Authoritative Cloudflare zone name, for example evotec.xyz.
+    required: true
+  record-name:
+    description: Fully qualified DNS record name, for example control.evotec.xyz.
+    required: true
+  record-content:
+    description: IPv4, IPv6, or canonical target value for the record.
+    required: true
+  record-type:
+    description: Supported DNS record type (A, AAAA, or CNAME).
+    required: false
+    default: A
+  proxied:
+    description: Whether Cloudflare should proxy the record.
+    required: false
+    default: "true"
+  ttl:
+    description: DNS TTL in seconds; use 1 for automatic, which is required for proxied records.
+    required: false
+    default: "1"
+  comment:
+    description: Optional Cloudflare record comment managed by PowerForge.
+    required: false
+    default: Managed by PowerForge
+  dry-run:
+    description: Report whether the record would change without writing it.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Reject pull request DNS changes
+      if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
+      shell: pwsh
+      run: throw 'PowerForge protected Cloudflare DNS changes cannot run from pull request events.'
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+      with:
+        global-json-file: ${{ github.action_path }}/../../../global.json
+
+    - name: Reconcile Cloudflare DNS record
+      shell: pwsh
+      env:
+        POWERFORGE_CLOUDFLARE_API_TOKEN: ${{ inputs.api-token }}
+        POWERFORGE_CLOUDFLARE_DNS_COMMENT: ${{ inputs.comment }}
+        POWERFORGE_CLOUDFLARE_DNS_CONTENT: ${{ inputs.record-content }}
+        POWERFORGE_CLOUDFLARE_DNS_DRY_RUN: ${{ inputs.dry-run }}
+        POWERFORGE_CLOUDFLARE_DNS_NAME: ${{ inputs.record-name }}
+        POWERFORGE_CLOUDFLARE_DNS_PROXIED: ${{ inputs.proxied }}
+        POWERFORGE_CLOUDFLARE_DNS_TTL: ${{ inputs.ttl }}
+        POWERFORGE_CLOUDFLARE_DNS_TYPE: ${{ inputs.record-type }}
+        POWERFORGE_CLOUDFLARE_ZONE_NAME: ${{ inputs.zone-name }}
+      run: '& "$env:GITHUB_ACTION_PATH/Invoke-PowerForgeCloudflareDnsRecord.ps1"'

--- a/PowerForge.Tests/CloudflareDnsRecordTests.cs
+++ b/PowerForge.Tests/CloudflareDnsRecordTests.cs
@@ -1,0 +1,310 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed class CloudflareDnsRecordTests
+{
+    private const string ZoneId = "0123456789abcdef0123456789abcdef";
+
+    [Fact]
+    public void Apply_ShouldCreateMissingRecord()
+    {
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { Zone() })),
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray())),
+            JsonResponse(HttpStatusCode.OK, Envelope(Record("record-created", "141.94.123.4", proxied: true))));
+        using var client = NewClient(handler);
+
+        var result = CloudflareDnsRecordManager.Apply(
+            "evotec.xyz",
+            "secret-token",
+            "A",
+            "control.evotec.xyz",
+            "141.94.123.4",
+            proxied: true,
+            ttl: 1,
+            comment: "Managed by PowerForge",
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.True(result.Changed);
+        Assert.Equal("created", result.Action);
+        Assert.Equal("record-created", result.RecordId);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal(HttpMethod.Post, handler.Requests[2].Method);
+        Assert.EndsWith($"zones/{ZoneId}/dns_records", handler.Requests[2].PathAndQuery, StringComparison.Ordinal);
+        Assert.Contains("\"content\":\"141.94.123.4\"", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.Contains("\"proxied\":true", handler.Requests[2].Body, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-token", string.Join('\n', handler.Requests.Select(request => request.Body)), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Apply_ShouldUpdateDriftedRecord()
+    {
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { Zone() })),
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { Record("record-existing", "192.0.2.10", proxied: false) })),
+            JsonResponse(HttpStatusCode.OK, Envelope(Record("record-existing", "141.94.123.4", proxied: true))));
+        using var client = NewClient(handler);
+
+        var result = Apply(client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.True(result.ChangesRequired);
+        Assert.True(result.Changed);
+        Assert.Equal("updated", result.Action);
+        Assert.Equal(HttpMethod.Patch, handler.Requests[2].Method);
+        Assert.EndsWith($"zones/{ZoneId}/dns_records/record-existing", handler.Requests[2].PathAndQuery, StringComparison.Ordinal);
+        Assert.DoesNotContain("tags", handler.Requests[2].Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Apply_ShouldRemainIdempotentWhenRecordMatches()
+    {
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { Zone() })),
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { Record("record-existing", "141.94.123.4", proxied: true) })));
+        using var client = NewClient(handler);
+
+        var result = Apply(client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.False(result.ChangesRequired);
+        Assert.False(result.Changed);
+        Assert.Equal("unchanged", result.Action);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public void Apply_DryRunShouldReportCreationWithoutMutation()
+    {
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { Zone() })),
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray())));
+        using var client = NewClient(handler);
+
+        var result = CloudflareDnsRecordManager.Apply(
+            "evotec.xyz",
+            "secret-token",
+            "A",
+            "control.evotec.xyz",
+            "141.94.123.4",
+            proxied: true,
+            ttl: 1,
+            comment: "Managed by PowerForge",
+            dryRun: true,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.True(result.DryRun);
+        Assert.True(result.ChangesRequired);
+        Assert.False(result.Changed);
+        Assert.Equal("would-create", result.Action);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public void Apply_ShouldRefuseAmbiguousRecords()
+    {
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { Zone() })),
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray
+            {
+                Record("record-one", "141.94.123.4", proxied: true),
+                Record("record-two", "141.94.123.4", proxied: true)
+            })));
+        using var client = NewClient(handler);
+
+        var result = Apply(client);
+
+        Assert.False(result.Success);
+        Assert.Contains("multiple", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public void Apply_ShouldNormalizeInternationalizedNamesToPunycode()
+    {
+        const string internationalZoneId = "abcdef0123456789abcdef0123456789";
+        var existing = new JsonObject
+        {
+            ["id"] = "record-idn",
+            ["type"] = "CNAME",
+            ["name"] = "control.xn--tst-qla.example",
+            ["content"] = "target.xn--tst-qla.example",
+            ["proxied"] = true,
+            ["ttl"] = 1,
+            ["comment"] = "Managed by PowerForge"
+        };
+        var handler = new SequenceHandler(
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray
+            {
+                new JsonObject { ["id"] = internationalZoneId, ["name"] = "xn--tst-qla.example", ["status"] = "active" }
+            })),
+            JsonResponse(HttpStatusCode.OK, Envelope(new JsonArray { existing })));
+        using var client = NewClient(handler);
+
+        var result = CloudflareDnsRecordManager.Apply(
+            "täst.example",
+            "secret-token",
+            "CNAME",
+            "control.täst.example",
+            "target.täst.example",
+            proxied: true,
+            ttl: 1,
+            comment: "Managed by PowerForge",
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Equal("unchanged", result.Action);
+        Assert.Equal("control.xn--tst-qla.example", result.RecordName);
+        Assert.Equal("target.xn--tst-qla.example", result.RecordContent);
+        Assert.Contains("name=xn--tst-qla.example", handler.Requests[0].PathAndQuery, StringComparison.Ordinal);
+        Assert.Contains("name=control.xn--tst-qla.example", handler.Requests[1].PathAndQuery, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("other.example", "recordName 'other.example' must belong to zone 'evotec.xyz'.")]
+    [InlineData("control.evotec.xyz", "recordContent must be a valid IPv4 address for an A record.", "2001:db8::1")]
+    public void Apply_ShouldValidateScopeAndContentBeforeCallingCloudflare(string recordName, string expectedMessage, string content = "141.94.123.4")
+    {
+        var handler = new SequenceHandler();
+        using var client = NewClient(handler);
+
+        var result = CloudflareDnsRecordManager.Apply(
+            "evotec.xyz",
+            "secret-token",
+            "A",
+            recordName,
+            content,
+            proxied: true,
+            ttl: 1,
+            comment: null,
+            dryRun: false,
+            logger: null,
+            client);
+
+        Assert.False(result.Success);
+        Assert.Equal(expectedMessage, result.Message);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
+    public void CompositeAction_ShouldKeepTokenOutOfArgumentsAndRejectPullRequests()
+    {
+        var action = ReadRepoFile(".github", "actions", "powerforge-cloudflare-dns-record", "action.yml");
+        var script = ReadRepoFile(".github", "actions", "powerforge-cloudflare-dns-record", "Invoke-PowerForgeCloudflareDnsRecord.ps1");
+
+        Assert.Contains("Reject pull request DNS changes", action, StringComparison.Ordinal);
+        Assert.Contains("Zone > DNS > Edit and Zone > Zone > Read", action, StringComparison.Ordinal);
+        Assert.Contains("actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7", action, StringComparison.Ordinal);
+        Assert.Contains("Invoke-PowerForgeCloudflareDnsRecord.ps1", action, StringComparison.Ordinal);
+        Assert.Contains("--token-env', 'POWERFORGE_CLOUDFLARE_API_TOKEN'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("--token', $env:POWERFORGE_CLOUDFLARE_API_TOKEN", script, StringComparison.Ordinal);
+        Assert.Contains("'dns-record'", script, StringComparison.Ordinal);
+        Assert.True(script.Split('\n').Length < 100, "The action entrypoint should remain a bounded adapter over the CLI.");
+    }
+
+    [Fact]
+    public void Command_ShouldRejectUnknownDnsWriteArgumentsBeforeUsingDefaults()
+    {
+        var exitCode = WebCliCommandHandlers.HandleSubCommand(
+            "cloudflare",
+            ["dns-record", "apply", "--proxie", "false"],
+            outputJson: false,
+            new WebConsoleLogger(),
+            outputSchemaVersion: 1);
+
+        Assert.Equal(2, exitCode);
+    }
+
+    private static CloudflareDnsRecordApplyResult Apply(HttpClient client) => CloudflareDnsRecordManager.Apply(
+        "evotec.xyz",
+        "secret-token",
+        "A",
+        "control.evotec.xyz",
+        "141.94.123.4",
+        proxied: true,
+        ttl: 1,
+        comment: "Managed by PowerForge",
+        dryRun: false,
+        logger: null,
+        client);
+
+    private static JsonObject Zone() => new()
+    {
+        ["id"] = ZoneId,
+        ["name"] = "evotec.xyz",
+        ["status"] = "active"
+    };
+
+    private static JsonObject Record(string id, string content, bool proxied) => new()
+    {
+        ["id"] = id,
+        ["type"] = "A",
+        ["name"] = "control.evotec.xyz",
+        ["content"] = content,
+        ["proxied"] = proxied,
+        ["ttl"] = 1,
+        ["comment"] = "Managed by PowerForge",
+        ["tags"] = new JsonArray("manual-metadata")
+    };
+
+    private static string Envelope(JsonNode result) => new JsonObject
+    {
+        ["success"] = true,
+        ["result"] = result
+    }.ToJsonString();
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string body) => new(statusCode)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json")
+    };
+
+    private static HttpClient NewClient(HttpMessageHandler handler) => new(handler)
+    {
+        BaseAddress = new Uri("https://api.cloudflare.test/client/v4/")
+    };
+
+    private static string ReadRepoFile(params string[] segments)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "PSPublishModule.sln")))
+            current = current.Parent;
+        Assert.NotNull(current);
+        return File.ReadAllText(Path.Combine([current!.FullName, .. segments]));
+    }
+
+    private sealed class SequenceHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        internal List<CapturedRequest> Requests { get; } = [];
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            CaptureAndRespond(request);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(CaptureAndRespond(request));
+
+        private HttpResponseMessage CaptureAndRespond(HttpRequestMessage request)
+        {
+            var body = request.Content?.ReadAsStringAsync().GetAwaiter().GetResult() ?? string.Empty;
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri!.PathAndQuery.TrimStart('/'), body));
+            if (_responses.Count == 0)
+                throw new InvalidOperationException("Unexpected HTTP request.");
+            return _responses.Dequeue();
+        }
+    }
+
+    private sealed record CapturedRequest(HttpMethod Method, string PathAndQuery, string Body);
+}

--- a/PowerForge.Web.Cli/CloudflareDnsRecordManager.cs
+++ b/PowerForge.Web.Cli/CloudflareDnsRecordManager.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace PowerForge.Web.Cli;
+
+internal sealed class CloudflareDnsRecordApplyResult
+{
+    public bool Success { get; init; }
+    public bool DryRun { get; init; }
+    public bool ChangesRequired { get; init; }
+    public bool Changed { get; init; }
+    public string Action { get; init; } = string.Empty;
+    public string ZoneId { get; init; } = string.Empty;
+    public string RecordId { get; init; } = string.Empty;
+    public string RecordType { get; init; } = string.Empty;
+    public string RecordName { get; init; } = string.Empty;
+    public string RecordContent { get; init; } = string.Empty;
+    public bool Proxied { get; init; }
+    public int Ttl { get; init; }
+    public string Message { get; init; } = string.Empty;
+}
+
+internal static class CloudflareDnsRecordManager
+{
+    internal static CloudflareDnsRecordApplyResult Apply(
+        string zoneName,
+        string apiToken,
+        string recordType,
+        string recordName,
+        string recordContent,
+        bool proxied,
+        int ttl,
+        string? comment,
+        bool dryRun,
+        WebConsoleLogger? logger,
+        HttpClient? httpClient = null)
+    {
+        if (string.IsNullOrWhiteSpace(apiToken))
+            return Failure("Missing apiToken.", recordType, recordName, recordContent, proxied, ttl, dryRun);
+
+        string normalizedZone;
+        string normalizedType;
+        string normalizedName;
+        string normalizedContent;
+        try
+        {
+            normalizedZone = NormalizeDomain(zoneName, "zoneName");
+            normalizedType = NormalizeRecordType(recordType);
+            normalizedName = NormalizeDomain(recordName, "recordName");
+            normalizedContent = NormalizeRecordContent(normalizedType, recordContent);
+            ValidateRecordScope(normalizedZone, normalizedName);
+            ValidateTtl(proxied, ttl);
+        }
+        catch (ArgumentException ex)
+        {
+            return Failure(ex.Message, recordType, recordName, recordContent, proxied, ttl, dryRun);
+        }
+
+        var normalizedComment = string.IsNullOrWhiteSpace(comment) ? null : comment.Trim();
+        var ownsHttpClient = httpClient is null;
+        httpClient ??= new HttpClient { BaseAddress = new Uri("https://api.cloudflare.com/client/v4/") };
+
+        try
+        {
+            var zoneResponse = CloudflareApiClient.Send(
+                httpClient,
+                HttpMethod.Get,
+                $"zones?name={Uri.EscapeDataString(normalizedZone)}&status=active&per_page=50",
+                apiToken,
+                body: null);
+            if (!zoneResponse.Success)
+                return Failure(zoneResponse.ErrorMessage, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun);
+            if (!TryReadArray(zoneResponse.Result, out var zones))
+                return Failure("Cloudflare zone lookup returned a malformed result.", normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun);
+            if (zones.Count == 0)
+                return Failure($"Cloudflare active zone '{normalizedZone}' was not found.", normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun);
+            if (zones.Count != 1 || zones[0] is not JsonObject zone || !TryReadString(zone, "id", out var zoneId))
+                return Failure($"Cloudflare zone lookup for '{normalizedZone}' was ambiguous or malformed.", normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun);
+
+            var recordResponse = CloudflareApiClient.Send(
+                httpClient,
+                HttpMethod.Get,
+                $"zones/{Uri.EscapeDataString(zoneId)}/dns_records?type={Uri.EscapeDataString(normalizedType)}&name={Uri.EscapeDataString(normalizedName)}&per_page=50",
+                apiToken,
+                body: null);
+            if (!recordResponse.Success)
+                return Failure(recordResponse.ErrorMessage, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun, zoneId);
+            if (!TryReadArray(recordResponse.Result, out var records))
+                return Failure("Cloudflare DNS record lookup returned a malformed result.", normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun, zoneId);
+            if (records.Count > 1)
+                return Failure($"Cloudflare returned multiple {normalizedType} records named '{normalizedName}'; refusing to choose one.", normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun, zoneId);
+
+            var desired = BuildDesiredRecord(normalizedType, normalizedName, normalizedContent, proxied, ttl, normalizedComment);
+            if (records.Count == 0)
+            {
+                if (dryRun)
+                {
+                    var preview = $"Cloudflare DNS record {normalizedType} {normalizedName} would be created with content {normalizedContent}.";
+                    logger?.Info(preview);
+                    return Success("would-create", zoneId, string.Empty, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun: true, changesRequired: true, changed: false, preview);
+                }
+
+                var createResponse = CloudflareApiClient.Send(
+                    httpClient,
+                    HttpMethod.Post,
+                    $"zones/{Uri.EscapeDataString(zoneId)}/dns_records",
+                    apiToken,
+                    desired);
+                if (!createResponse.Success)
+                    return Failure(createResponse.ErrorMessage, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun, zoneId);
+
+                var createdId = TryReadResultId(createResponse.Result);
+                var created = $"Created Cloudflare DNS record {normalizedType} {normalizedName} with content {normalizedContent}.";
+                logger?.Info(created);
+                return Success("created", zoneId, createdId, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun: false, changesRequired: true, changed: true, created);
+            }
+
+            if (records[0] is not JsonObject existing || !TryReadString(existing, "id", out var recordId))
+                return Failure("Cloudflare DNS record lookup returned a malformed record.", normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun, zoneId);
+
+            if (RecordMatches(existing, desired))
+            {
+                var current = $"Cloudflare DNS record {normalizedType} {normalizedName} is already current.";
+                logger?.Info(current);
+                return Success("unchanged", zoneId, recordId, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun, changesRequired: false, changed: false, current);
+            }
+
+            if (dryRun)
+            {
+                var preview = $"Cloudflare DNS record {normalizedType} {normalizedName} would be updated to content {normalizedContent}.";
+                logger?.Info(preview);
+                return Success("would-update", zoneId, recordId, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun: true, changesRequired: true, changed: false, preview);
+            }
+
+            var updateResponse = CloudflareApiClient.Send(
+                httpClient,
+                HttpMethod.Patch,
+                $"zones/{Uri.EscapeDataString(zoneId)}/dns_records/{Uri.EscapeDataString(recordId)}",
+                apiToken,
+                desired);
+            if (!updateResponse.Success)
+                return Failure(updateResponse.ErrorMessage, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun, zoneId, recordId);
+
+            var updated = $"Updated Cloudflare DNS record {normalizedType} {normalizedName} to content {normalizedContent}.";
+            logger?.Info(updated);
+            return Success("updated", zoneId, recordId, normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun: false, changesRequired: true, changed: true, updated);
+        }
+        catch (Exception ex)
+        {
+            return Failure($"Cloudflare DNS record reconciliation failed: {ex.GetType().Name}: {ex.Message}", normalizedType, normalizedName, normalizedContent, proxied, ttl, dryRun);
+        }
+        finally
+        {
+            if (ownsHttpClient)
+                httpClient.Dispose();
+        }
+    }
+
+    private static string NormalizeDomain(string value, string parameterName)
+    {
+        var unicodeName = (value ?? string.Empty).Trim().TrimEnd('.');
+        string normalized;
+        try
+        {
+            normalized = new IdnMapping().GetAscii(unicodeName).ToLowerInvariant();
+        }
+        catch (ArgumentException)
+        {
+            throw new ArgumentException($"{parameterName} must be a valid DNS name.");
+        }
+        if (string.IsNullOrWhiteSpace(normalized) || Uri.CheckHostName(normalized) != UriHostNameType.Dns)
+            throw new ArgumentException($"{parameterName} must be a valid DNS name.");
+        return normalized;
+    }
+
+    private static string NormalizeRecordType(string value)
+    {
+        var normalized = (value ?? string.Empty).Trim().ToUpperInvariant();
+        if (normalized is not ("A" or "AAAA" or "CNAME"))
+            throw new ArgumentException("recordType must be A, AAAA, or CNAME.");
+        return normalized;
+    }
+
+    private static string NormalizeRecordContent(string recordType, string value)
+    {
+        var normalized = (value ?? string.Empty).Trim();
+        if (recordType == "CNAME")
+            return NormalizeDomain(normalized, "recordContent");
+
+        if (!IPAddress.TryParse(normalized, out var address))
+            throw new ArgumentException($"recordContent must be a valid {recordType} address.");
+        if (recordType == "A" && address.AddressFamily != AddressFamily.InterNetwork)
+            throw new ArgumentException("recordContent must be a valid IPv4 address for an A record.");
+        if (recordType == "AAAA" && address.AddressFamily != AddressFamily.InterNetworkV6)
+            throw new ArgumentException("recordContent must be a valid IPv6 address for an AAAA record.");
+        return address.ToString();
+    }
+
+    private static void ValidateRecordScope(string zoneName, string recordName)
+    {
+        if (!recordName.Equals(zoneName, StringComparison.Ordinal) &&
+            !recordName.EndsWith('.' + zoneName, StringComparison.Ordinal))
+            throw new ArgumentException($"recordName '{recordName}' must belong to zone '{zoneName}'.");
+    }
+
+    private static void ValidateTtl(bool proxied, int ttl)
+    {
+        if (ttl != 1 && (ttl < 60 || ttl > 86400))
+            throw new ArgumentException("ttl must be 1 (automatic) or between 60 and 86400 seconds.");
+        if (proxied && ttl != 1)
+            throw new ArgumentException("ttl must be 1 (automatic) when proxied is true.");
+    }
+
+    private static JsonObject BuildDesiredRecord(
+        string recordType,
+        string recordName,
+        string recordContent,
+        bool proxied,
+        int ttl,
+        string? comment)
+    {
+        var desired = new JsonObject
+        {
+            ["type"] = recordType,
+            ["name"] = recordName,
+            ["content"] = recordContent,
+            ["proxied"] = proxied,
+            ["ttl"] = ttl
+        };
+        if (comment is not null)
+            desired["comment"] = comment;
+        return desired;
+    }
+
+    private static bool RecordMatches(JsonObject existing, JsonObject desired)
+    {
+        foreach (var propertyName in new[] { "type", "name", "content", "proxied", "ttl", "comment" })
+        {
+            if (desired[propertyName] is null)
+                continue;
+            if (!JsonNode.DeepEquals(existing[propertyName], desired[propertyName]))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool TryReadArray(JsonElement? result, out JsonArray values)
+    {
+        values = new JsonArray();
+        if (result is null || result.Value.ValueKind != JsonValueKind.Array)
+            return false;
+        values = JsonNode.Parse(result.Value.GetRawText()) as JsonArray ?? new JsonArray();
+        return true;
+    }
+
+    private static bool TryReadString(JsonObject value, string propertyName, out string result)
+    {
+        result = value[propertyName]?.GetValue<string>() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(result);
+    }
+
+    private static string TryReadResultId(JsonElement? result)
+    {
+        if (result is null || result.Value.ValueKind != JsonValueKind.Object ||
+            !result.Value.TryGetProperty("id", out var id) || id.ValueKind != JsonValueKind.String)
+            return string.Empty;
+        return id.GetString() ?? string.Empty;
+    }
+
+    private static CloudflareDnsRecordApplyResult Failure(
+        string message,
+        string recordType,
+        string recordName,
+        string recordContent,
+        bool proxied,
+        int ttl,
+        bool dryRun,
+        string zoneId = "",
+        string recordId = "") => new()
+    {
+        Success = false,
+        DryRun = dryRun,
+        Action = "failed",
+        ZoneId = zoneId,
+        RecordId = recordId,
+        RecordType = recordType ?? string.Empty,
+        RecordName = recordName ?? string.Empty,
+        RecordContent = recordContent ?? string.Empty,
+        Proxied = proxied,
+        Ttl = ttl,
+        Message = message
+    };
+
+    private static CloudflareDnsRecordApplyResult Success(
+        string action,
+        string zoneId,
+        string recordId,
+        string recordType,
+        string recordName,
+        string recordContent,
+        bool proxied,
+        int ttl,
+        bool dryRun,
+        bool changesRequired,
+        bool changed,
+        string message) => new()
+    {
+        Success = true,
+        DryRun = dryRun,
+        ChangesRequired = changesRequired,
+        Changed = changed,
+        Action = action,
+        ZoneId = zoneId,
+        RecordId = recordId,
+        RecordType = recordType,
+        RecordName = recordName,
+        RecordContent = recordContent,
+        Proxied = proxied,
+        Ttl = ttl,
+        Message = message
+    };
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Cloudflare.cs
@@ -27,6 +27,19 @@ internal static partial class WebCliCommandHandlers
         if (verb.Equals("verify", StringComparison.OrdinalIgnoreCase))
             return HandleCloudflareVerify(subArgs, outputJson, logger, outputSchemaVersion);
 
+        if (verb.Equals("dns-record", StringComparison.OrdinalIgnoreCase) ||
+            verb.Equals("dns", StringComparison.OrdinalIgnoreCase))
+        {
+            if (subArgs.Length > 0 && !subArgs[0].StartsWith("-", StringComparison.Ordinal))
+            {
+                if (!subArgs[0].Equals("apply", StringComparison.OrdinalIgnoreCase))
+                    return Fail($"Unknown cloudflare dns-record verb '{subArgs[0]}'. Supported: apply.", outputJson, logger, "web.cloudflare.dns-record");
+                subArgs = subArgs.Skip(1).ToArray();
+            }
+
+            return HandleCloudflareDnsRecord(subArgs, outputJson, logger, outputSchemaVersion);
+        }
+
         if (verb.Equals("cache-policy", StringComparison.OrdinalIgnoreCase) ||
             verb.Equals("policy", StringComparison.OrdinalIgnoreCase) ||
             verb.Equals("rules", StringComparison.OrdinalIgnoreCase))
@@ -41,7 +54,143 @@ internal static partial class WebCliCommandHandlers
             return HandleCloudflareCachePolicy(subArgs, outputJson, logger, outputSchemaVersion);
         }
 
-        return Fail($"Unknown cloudflare verb '{verb}'. Supported: purge, verify, cache-policy.", outputJson, logger, "web.cloudflare");
+        return Fail($"Unknown cloudflare verb '{verb}'. Supported: purge, verify, cache-policy, dns-record.", outputJson, logger, "web.cloudflare");
+    }
+
+    private static int HandleCloudflareDnsRecord(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)
+    {
+        const string command = "web.cloudflare.dns-record.apply";
+        if (!TryValidateCloudflareDnsRecordArguments(subArgs, out var argumentError))
+            return Fail(argumentError, outputJson, logger, command);
+
+        var zoneName = TryGetOptionValue(subArgs, "--zone-name") ??
+                       TryGetOptionValue(subArgs, "--zoneName") ??
+                       TryGetOptionValue(subArgs, "--zone");
+        if (string.IsNullOrWhiteSpace(zoneName))
+            return Fail("Missing required --zone-name.", outputJson, logger, command);
+
+        var recordName = TryGetOptionValue(subArgs, "--record-name") ??
+                         TryGetOptionValue(subArgs, "--recordName") ??
+                         TryGetOptionValue(subArgs, "--name");
+        if (string.IsNullOrWhiteSpace(recordName))
+            return Fail("Missing required --record-name.", outputJson, logger, command);
+
+        var recordContent = TryGetOptionValue(subArgs, "--record-content") ??
+                            TryGetOptionValue(subArgs, "--recordContent") ??
+                            TryGetOptionValue(subArgs, "--content");
+        if (string.IsNullOrWhiteSpace(recordContent))
+            return Fail("Missing required --record-content.", outputJson, logger, command);
+
+        var token = TryGetOptionValue(subArgs, "--token") ??
+                    TryGetOptionValue(subArgs, "--api-token") ??
+                    TryGetOptionValue(subArgs, "--apiToken");
+        var tokenEnv = TryGetOptionValue(subArgs, "--token-env") ??
+                       TryGetOptionValue(subArgs, "--api-token-env") ??
+                       TryGetOptionValue(subArgs, "--apiTokenEnv") ??
+                       "CLOUDFLARE_API_TOKEN";
+        if (string.IsNullOrWhiteSpace(token))
+            token = Environment.GetEnvironmentVariable(tokenEnv);
+        if (string.IsNullOrWhiteSpace(token))
+            return Fail($"Missing Cloudflare API token. Provide --token or set env var '{tokenEnv}'.", outputJson, logger, command);
+
+        var recordType = TryGetOptionValue(subArgs, "--record-type") ??
+                         TryGetOptionValue(subArgs, "--recordType") ??
+                         TryGetOptionValue(subArgs, "--type") ??
+                         "A";
+        var proxiedValue = TryGetOptionValue(subArgs, "--proxied") ?? "true";
+        if (!bool.TryParse(proxiedValue, out var proxied))
+            return Fail("--proxied must be true or false.", outputJson, logger, command);
+
+        var ttlValue = TryGetOptionValue(subArgs, "--ttl") ?? "1";
+        if (!int.TryParse(ttlValue, out var ttl))
+            return Fail("--ttl must be an integer.", outputJson, logger, command);
+
+        var comment = TryGetOptionValue(subArgs, "--comment");
+        var dryRun = HasOption(subArgs, "--dry-run") || HasOption(subArgs, "--dryRun");
+        var result = CloudflareDnsRecordManager.Apply(
+            zoneName,
+            token,
+            recordType,
+            recordName,
+            recordContent,
+            proxied,
+            ttl,
+            comment,
+            dryRun,
+            logger);
+
+        if (outputJson)
+        {
+            var element = JsonSerializer.SerializeToElement(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["zoneId"] = result.ZoneId,
+                ["recordId"] = result.RecordId,
+                ["recordType"] = result.RecordType,
+                ["recordName"] = result.RecordName,
+                ["recordContent"] = result.RecordContent,
+                ["proxied"] = result.Proxied,
+                ["ttl"] = result.Ttl,
+                ["dryRun"] = result.DryRun,
+                ["changesRequired"] = result.ChangesRequired,
+                ["changed"] = result.Changed,
+                ["action"] = result.Action,
+                ["message"] = result.Message
+            }, WebCliJson.Options);
+
+            WebCliJsonWriter.Write(new WebCliJsonEnvelope
+            {
+                SchemaVersion = outputSchemaVersion,
+                Command = command,
+                Success = result.Success,
+                ExitCode = result.Success ? 0 : 1,
+                Result = element,
+                Error = result.Success ? null : result.Message
+            });
+            return result.Success ? 0 : 1;
+        }
+
+        if (result.Success) logger.Success(result.Message);
+        else logger.Error(result.Message);
+        return result.Success ? 0 : 1;
+    }
+
+    private static bool TryValidateCloudflareDnsRecordArguments(string[] args, out string error)
+    {
+        var valueOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "--zone-name", "--zoneName", "--zone",
+            "--record-name", "--recordName", "--name",
+            "--record-content", "--recordContent", "--content",
+            "--token", "--api-token", "--apiToken",
+            "--token-env", "--api-token-env", "--apiTokenEnv",
+            "--record-type", "--recordType", "--type",
+            "--proxied", "--ttl", "--comment", "--output"
+        };
+        var flagOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "--dry-run", "--dryRun", "--output-json", "--json"
+        };
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (flagOptions.Contains(argument))
+                continue;
+            if (!valueOptions.Contains(argument))
+            {
+                error = $"Unknown cloudflare dns-record argument '{argument}'.";
+                return false;
+            }
+            if (index + 1 >= args.Length || args[index + 1].StartsWith("--", StringComparison.Ordinal))
+            {
+                error = $"Missing value for cloudflare dns-record option '{argument}'.";
+                return false;
+            }
+            index++;
+        }
+
+        error = string.Empty;
+        return true;
     }
 
     private static int HandleCloudflareCachePolicy(string[] subArgs, bool outputJson, WebConsoleLogger logger, int outputSchemaVersion)

--- a/PowerForge.Web.Cli/WebCliHelpers.Help.ServerCloudflare.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.Help.ServerCloudflare.cs
@@ -22,5 +22,8 @@ internal static partial class WebCliHelpers
         Console.WriteLine("  powerforge-web cloudflare cache-policy apply --zone-id <id> [--token <token> | --token-env <env>]");
         Console.WriteLine("                     [--site-config <site.json> | --hostname <host>] [--base-path <path>] [--policy-name <name>]");
         Console.WriteLine("                     [--html-path <p[,p...]>] [--dry-run]");
+        Console.WriteLine("  powerforge-web cloudflare dns-record apply --zone-name <zone> --record-name <name> --record-content <value>");
+        Console.WriteLine("                     [--record-type <A|AAAA|CNAME>] [--proxied <true|false>] [--ttl <seconds>] [--comment <text>]");
+        Console.WriteLine("                     [--token <token> | --token-env <env>] [--dry-run]");
     }
 }


### PR DESCRIPTION
## Summary

- add an idempotent PowerForge Cloudflare DNS reconciler for A, AAAA, and CNAME records
- expose it through a thin composite action for protected deployment environments
- preserve unmanaged Cloudflare metadata with PATCH updates, normalize internationalized names, and reject unknown write arguments
- keep API tokens in environment variables and block DNS mutations from pull request events

## Operational contract

The token needs Zone DNS Edit and Zone Read permission for the target zone. Proxied records use Cloudflare automatic TTL.

## Validation

- Cloudflare-focused tests: 31 passed
- independent read-only candidate review and targeted confirmation completed on the exact pushed SHA