### PR TITLE
Render deferred recovery fallback as valid shell

### DIFF
--- a/PowerForge.Tests/ServerRecoveryDeferredSecretRenderingTests.cs
+++ b/PowerForge.Tests/ServerRecoveryDeferredSecretRenderingTests.cs
@@ -1,0 +1,23 @@
+namespace PowerForge.Tests;
+
+public sealed class ServerRecoveryDeferredSecretRenderingTests
+{
+    [Fact]
+    public void DeferredSecretInstall_RendersNestedFallbackOnANewLine()
+    {
+        var command = PowerForge.Web.Cli.WebCliCommandHandlers.BuildDeferredSecretInstallCommand(
+            new PowerForge.Web.Cli.PowerForgeServerSecret
+            {
+                Id = "repository-secret",
+                Path = "/srv/example/.secret",
+                Owner = "root",
+                Group = "root",
+                Mode = "0600"
+            },
+            "/var/lib/powerforge/restore-secrets/example",
+            "/srv/example");
+
+        Assert.Contains("; else\nif [ -e '/srv/example/.secret' ]", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("; else if [", command, StringComparison.Ordinal);
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Coherence.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Coherence.cs
@@ -102,7 +102,7 @@ internal static partial class WebCliCommandHandlers
             $"test -f {quotedStaged} && test ! -L {quotedStaged} || {{ echo {ShellQuote($"Staged repository secret is unsafe: {secret.Id}")} >&2; exit 3; }}; " +
             $"{BuildExistingRegularFileTargetGuard(target)}; " +
             $"install -T -o {ShellQuote(owner)} -g {ShellQuote(group)} -m {ShellQuote(mode)} {quotedStaged} {quotedTarget}; " +
-            $"rm -f -- {quotedStaged}; else {BuildExistingRegularFileTargetGuard(target)}; fi",
+            $"rm -f -- {quotedStaged}; else\n{BuildExistingRegularFileTargetGuard(target)}; fi",
             validateTarget);
     }
 


### PR DESCRIPTION
## Summary
- render deferred repository-secret fallback checks as valid nested shell blocks
- preserve the existing staged-secret install and rerunnable target validation behavior
- add focused regression coverage for the generated shell shape

## Why
Generated bootstrap plans with repository-overlapping secrets could pass Bash parsing but fail the recovery action's ShellCheck gate because a nested `if` followed `else` on the same line.