### PR TITLE
Phase systemd activation around recovery deploys

### DIFF
--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -174,11 +174,11 @@ The engine should plan and run these stages:
 3. Create service users, directories, and permissions.
 4. Configure SSH, UFW, and base security posture.
 5. Install Apache modules, vhosts, and managed includes.
-6. Install systemd services and timers and reload systemd.
+6. Install systemd services and timers and reload systemd. Units may opt into `beforeDeploy` activation when deployment requires them.
 7. Clone or update website and engine repositories.
 8. Restore or prompt for secrets.
 9. Run the site deploy script.
-10. Enable and start declared systemd units after secrets and deployment are ready.
+10. Enable and start units that declare `afterDeploy` activation after secrets and deployment are ready. Units without an activation phase retain enable-only behavior.
 11. Verify local services, origin behavior, public URLs, and certificate renewal.
 
 Stages must be resumable. A failed stage should leave a report that tells the operator what already happened and what remains.

--- a/Docs/PowerForge.Web.ServerRecovery.md
+++ b/Docs/PowerForge.Web.ServerRecovery.md
@@ -174,11 +174,12 @@ The engine should plan and run these stages:
 3. Create service users, directories, and permissions.
 4. Configure SSH, UFW, and base security posture.
 5. Install Apache modules, vhosts, and managed includes.
-6. Install systemd services and timers.
+6. Install systemd services and timers and reload systemd.
 7. Clone or update website and engine repositories.
 8. Restore or prompt for secrets.
 9. Run the site deploy script.
-10. Verify local services, origin behavior, public URLs, and certificate renewal.
+10. Enable and start declared systemd units after secrets and deployment are ready.
+11. Verify local services, origin behavior, public URLs, and certificate renewal.
 
 Stages must be resumable. A failed stage should leave a report that tells the operator what already happened and what remains.
 

--- a/PowerForge.Tests/ServerRecoveryBootstrapLinuxTests.cs
+++ b/PowerForge.Tests/ServerRecoveryBootstrapLinuxTests.cs
@@ -57,6 +57,31 @@ public sealed class ServerRecoveryBootstrapLinuxTests
     }
 
     [Fact]
+    public void BootstrapOperationLocks_CanBeReacquiredAfterCommandOwnedDeploymentOnLinux()
+    {
+        if (!OperatingSystem.IsLinux())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "powerforge-bootstrap-lock-reacquire-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var lockPath = Path.Combine(root, "operation.lock").Replace('\\', '/');
+            var acquire = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapOperationLockAcquireCommand([lockPath]);
+            var release = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapOperationLockReleaseCommand([lockPath]);
+            var script = $"set -Eeuo pipefail\ninstall -o root -g root -m 0644 /dev/null '{lockPath}'\n{acquire}\n{release}\nflock -n '{lockPath}' -c true\n{acquire}\nif flock -n '{lockPath}' -c true; then exit 71; fi\n{release}\nrm -f -- '{lockPath}'\n";
+
+            var result = RunRootBash(script);
+
+            Assert.Equal(0, result.ExitCode);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ApacheActivation_RollsBackBeforeReturningValidationFailureOnLinux()
     {
         if (!OperatingSystem.IsLinux())

--- a/PowerForge.Tests/ServerRecoveryBootstrapPlanTests.cs
+++ b/PowerForge.Tests/ServerRecoveryBootstrapPlanTests.cs
@@ -300,7 +300,7 @@ public sealed class ServerRecoveryBootstrapPlanTests
         Assert.Contains("a2disconf 'platform.conf'", activateApache.Command, StringComparison.Ordinal);
         Assert.Contains("powerforge_restore_apache_activation", activateApache.Command, StringComparison.Ordinal);
         Assert.Contains("apachectl configtest", activateApache.Command, StringComparison.Ordinal);
-        Assert.Contains("systemctl reload 'apache2'", activateApache.Command, StringComparison.Ordinal);
+        Assert.Contains("systemctl reload -- 'apache2'", activateApache.Command, StringComparison.Ordinal);
         var apacheCommands = Assert.IsType<string>(activateApache.Command).Split('\n');
         var siteSnapshot = Array.FindIndex(apacheCommands, static command =>
             command.StartsWith("if [ -e '/etc/apache2/sites-enabled/example.conf'", StringComparison.Ordinal));

--- a/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
+++ b/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
@@ -1,0 +1,75 @@
+namespace PowerForge.Tests;
+
+public sealed class ServerRecoverySystemdPlanTests
+{
+    [Fact]
+    public void BuildPlan_StartsEnabledUnitsAfterRequiredSecretsAndDeploy()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Secrets =
+            [
+                new PowerForge.Web.Cli.PowerForgeServerSecret
+                {
+                    Id = "service-token",
+                    Path = "/etc/example/service-token",
+                    RestoreMode = "file"
+                }
+            ],
+            Systemd = new PowerForge.Web.Cli.PowerForgeServerSystemd
+            {
+                Services =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "example.service",
+                        Enabled = true
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "manual.service"
+                    }
+                ],
+                Timers =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "example.timer",
+                        Enabled = true
+                    }
+                ]
+            },
+            Deploy = new PowerForge.Web.Cli.PowerForgeServerDeploy
+            {
+                Commands =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerNamedCommand
+                    {
+                        Id = "deploy-example",
+                        Command = "/usr/local/sbin/deploy-example"
+                    }
+                ]
+            }
+        };
+
+        var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []);
+        var secret = Assert.Single(steps, step => step.Title == "Confirm restored secret service-token");
+        var deploy = Assert.Single(steps, step => step.Title == "deploy-example");
+        var enableService = Assert.Single(steps, step => step.Title == "Enable example.service");
+        var enableTimer = Assert.Single(steps, step => step.Title == "Enable example.timer");
+        var startService = Assert.Single(steps, step => step.Title == "Start example.service");
+        var startTimer = Assert.Single(steps, step => step.Title == "Start example.timer");
+
+        Assert.True(secret.Order < deploy.Order);
+        Assert.True(deploy.Order < enableService.Order);
+        Assert.True(enableService.Order < startService.Order);
+        Assert.True(deploy.Order < enableTimer.Order);
+        Assert.True(enableTimer.Order < startTimer.Order);
+        Assert.Equal("systemctl enable 'example.service'", enableService.Command);
+        Assert.Equal("systemctl enable 'example.timer'", enableTimer.Command);
+        Assert.Equal("systemctl start 'example.service'", startService.Command);
+        Assert.Equal("systemctl start 'example.timer'", startTimer.Command);
+        Assert.DoesNotContain(steps, step => step.Title == "Enable manual.service");
+        Assert.DoesNotContain(steps, step => step.Title == "Start manual.service");
+    }
+}

--- a/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
+++ b/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
@@ -3,10 +3,11 @@ namespace PowerForge.Tests;
 public sealed class ServerRecoverySystemdPlanTests
 {
     [Fact]
-    public void BuildPlan_StartsEnabledUnitsAfterRequiredSecretsAndDeploy()
+    public void BuildPlan_ReacquiresCommandOwnedLocksForAfterDeployActivation()
     {
         var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
         {
+            OperationLocks = ["/var/lock/powerforge-example.lock"],
             Secrets =
             [
                 new PowerForge.Web.Cli.PowerForgeServerSecret
@@ -23,19 +24,67 @@ public sealed class ServerRecoverySystemdPlanTests
                     new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
                     {
                         Name = "example.service",
-                        Enabled = true
-                    },
-                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
-                    {
-                        Name = "manual.service"
+                        Enabled = true,
+                        Activation = PowerForge.Web.Cli.PowerForgeServerSystemdActivation.AfterDeploy
                     }
-                ],
+                ]
+            },
+            Deploy = new PowerForge.Web.Cli.PowerForgeServerDeploy
+            {
+                OperationLockOwner = "command",
+                Commands =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerNamedCommand
+                    {
+                        Id = "deploy-example",
+                        Command = "/usr/local/sbin/deploy-example",
+                        Required = true
+                    }
+                ]
+            }
+        };
+
+        var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []);
+        var secret = Assert.Single(steps, step => step.Title == "Confirm restored secret service-token");
+        var release = Assert.Single(steps, step => step.Title == "Release shared operation locks for command-owned deployment");
+        var deploy = Assert.Single(steps, step => step.Title == "deploy-example");
+        var reacquire = Assert.Single(steps, step => step.Title == "Reacquire shared operation locks after command-owned deployment");
+        var enable = Assert.Single(steps, step => step.Title == "Enable example.service");
+        var start = Assert.Single(steps, step => step.Title == "Start example.service");
+
+        Assert.True(secret.Order < release.Order);
+        Assert.True(release.Order < deploy.Order);
+        Assert.True(deploy.Order < reacquire.Order);
+        Assert.True(reacquire.Order < enable.Order);
+        Assert.True(enable.Order < start.Order);
+        Assert.Contains("flock -n \"$powerforge_operation_lock_fd_1\"", reacquire.Command, StringComparison.Ordinal);
+        Assert.Equal("systemctl enable 'example.service'", enable.Command);
+        Assert.Equal("systemctl start 'example.service'", start.Command);
+    }
+
+    [Fact]
+    public void BuildPlan_ActivatesBeforeDeployPrerequisitesAfterSecrets()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Secrets =
+            [
+                new PowerForge.Web.Cli.PowerForgeServerSecret
+                {
+                    Id = "timer-token",
+                    Path = "/etc/example/timer-token",
+                    RestoreMode = "file"
+                }
+            ],
+            Systemd = new PowerForge.Web.Cli.PowerForgeServerSystemd
+            {
                 Timers =
                 [
                     new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
                     {
                         Name = "example.timer",
-                        Enabled = true
+                        Enabled = true,
+                        Activation = PowerForge.Web.Cli.PowerForgeServerSystemdActivation.BeforeDeploy
                     }
                 ]
             },
@@ -53,23 +102,120 @@ public sealed class ServerRecoverySystemdPlanTests
         };
 
         var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []);
-        var secret = Assert.Single(steps, step => step.Title == "Confirm restored secret service-token");
+        var secret = Assert.Single(steps, step => step.Title == "Confirm restored secret timer-token");
+        var enable = Assert.Single(steps, step => step.Title == "Enable example.timer");
+        var start = Assert.Single(steps, step => step.Title == "Start example.timer");
         var deploy = Assert.Single(steps, step => step.Title == "deploy-example");
-        var enableService = Assert.Single(steps, step => step.Title == "Enable example.service");
-        var enableTimer = Assert.Single(steps, step => step.Title == "Enable example.timer");
-        var startService = Assert.Single(steps, step => step.Title == "Start example.service");
-        var startTimer = Assert.Single(steps, step => step.Title == "Start example.timer");
 
-        Assert.True(secret.Order < deploy.Order);
-        Assert.True(deploy.Order < enableService.Order);
-        Assert.True(enableService.Order < startService.Order);
-        Assert.True(deploy.Order < enableTimer.Order);
-        Assert.True(enableTimer.Order < startTimer.Order);
-        Assert.Equal("systemctl enable 'example.service'", enableService.Command);
-        Assert.Equal("systemctl enable 'example.timer'", enableTimer.Command);
-        Assert.Equal("systemctl start 'example.service'", startService.Command);
-        Assert.Equal("systemctl start 'example.timer'", startTimer.Command);
-        Assert.DoesNotContain(steps, step => step.Title == "Enable manual.service");
-        Assert.DoesNotContain(steps, step => step.Title == "Start manual.service");
+        Assert.True(secret.Order < enable.Order);
+        Assert.True(enable.Order < start.Order);
+        Assert.True(start.Order < deploy.Order);
+    }
+
+    [Fact]
+    public void BuildPlan_PreservesLegacyEnableOnlyBehaviorWithoutActivation()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Systemd = new PowerForge.Web.Cli.PowerForgeServerSystemd
+            {
+                Timers =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "legacy.timer",
+                        Enabled = true
+                    }
+                ]
+            }
+        };
+
+        var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []);
+
+        Assert.Single(steps, step => step.Title == "Enable legacy.timer");
+        Assert.DoesNotContain(steps, step => step.Title == "Start legacy.timer");
+    }
+
+    [Fact]
+    public void BootstrapScript_FailsClosedBeforeActivationForRequiredSensitiveDeploy()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Systemd = new PowerForge.Web.Cli.PowerForgeServerSystemd
+            {
+                Services =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "example.service",
+                        Enabled = true,
+                        Activation = PowerForge.Web.Cli.PowerForgeServerSystemdActivation.AfterDeploy
+                    }
+                ]
+            },
+            Deploy = new PowerForge.Web.Cli.PowerForgeServerDeploy
+            {
+                Commands =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerNamedCommand
+                    {
+                        Id = "sensitive-deploy",
+                        Command = "/usr/local/sbin/deploy-example --token secret-env-reference",
+                        Required = true,
+                        Sensitive = true
+                    }
+                ]
+            }
+        };
+        var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []);
+        var deploy = Assert.Single(steps, step => step.Title == "sensitive-deploy");
+        var scriptPath = Path.GetTempFileName();
+        try
+        {
+            PowerForge.Web.Cli.WebCliCommandHandlers.WriteBootstrapPlanScript(scriptPath, steps);
+            var script = File.ReadAllText(scriptPath);
+            var manualStop = script.IndexOf("Manual bootstrap step required: sensitive-deploy", StringComparison.Ordinal);
+            var activation = script.IndexOf("systemctl start 'example.service'", StringComparison.Ordinal);
+
+            Assert.True(deploy.Manual);
+            Assert.True(manualStop >= 0);
+            Assert.True(activation > manualStop);
+            Assert.Contains("exit 3", script[manualStop..activation], StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(scriptPath);
+        }
+    }
+
+    [Fact]
+    public void Validation_RejectsUnsupportedOrNonEnabledActivation()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Target = new PowerForge.Web.Cli.PowerForgeServerTarget { Host = "example.test" },
+            Systemd = new PowerForge.Web.Cli.PowerForgeServerSystemd
+            {
+                Services =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "invalid.service",
+                        Enabled = true,
+                        Activation = "duringDeploy"
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "disabled.service",
+                        Activation = PowerForge.Web.Cli.PowerForgeServerSystemdActivation.AfterDeploy
+                    }
+                ]
+            }
+        };
+
+        var errors = PowerForge.Web.Cli.WebCliCommandHandlers.ValidateServerRecoveryManifest(manifest);
+
+        Assert.Contains(errors, error => error.Contains("unsupported activation phase 'duringDeploy'", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("'disabled.service' must be enabled", StringComparison.Ordinal));
     }
 }

--- a/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
+++ b/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
@@ -58,8 +58,8 @@ public sealed class ServerRecoverySystemdPlanTests
         Assert.True(reacquire.Order < enable.Order);
         Assert.True(enable.Order < start.Order);
         Assert.Contains("flock -n \"$powerforge_operation_lock_fd_1\"", reacquire.Command, StringComparison.Ordinal);
-        Assert.Equal("systemctl enable 'example.service'", enable.Command);
-        Assert.Equal("systemctl start 'example.service'", start.Command);
+        Assert.Equal("systemctl enable -- 'example.service'", enable.Command);
+        Assert.Equal("systemctl start -- 'example.service'", start.Command);
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public sealed class ServerRecoverySystemdPlanTests
             PowerForge.Web.Cli.WebCliCommandHandlers.WriteBootstrapPlanScript(scriptPath, steps);
             var script = File.ReadAllText(scriptPath);
             var manualStop = script.IndexOf("Manual bootstrap step required: sensitive-deploy", StringComparison.Ordinal);
-            var activation = script.IndexOf("systemctl start 'example.service'", StringComparison.Ordinal);
+            var activation = script.IndexOf("systemctl start -- 'example.service'", StringComparison.Ordinal);
 
             Assert.True(deploy.Manual);
             Assert.True(manualStop >= 0);
@@ -208,6 +208,26 @@ public sealed class ServerRecoverySystemdPlanTests
                     {
                         Name = "disabled.service",
                         Activation = PowerForge.Web.Cli.PowerForgeServerSystemdActivation.AfterDeploy
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "--help.service"
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "wrong.timer"
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "transient.service",
+                        ExpectedState = PowerForge.Web.Cli.PowerForgeServerSystemdState.Active
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
+                        Name = "unknown-state.service",
+                        Enabled = true,
+                        Activation = PowerForge.Web.Cli.PowerForgeServerSystemdActivation.AfterDeploy,
+                        ExpectedState = "failed"
                     }
                 ]
             }
@@ -217,5 +237,68 @@ public sealed class ServerRecoverySystemdPlanTests
 
         Assert.Contains(errors, error => error.Contains("unsupported activation phase 'duringDeploy'", StringComparison.Ordinal));
         Assert.Contains(errors, error => error.Contains("'disabled.service' must be enabled", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("safe .service unit name", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("'transient.service' must declare activation", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("unsupported expected state 'failed'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validation_RejectsWhitespaceCommandsAndPlannerFailsClosed()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Target = new PowerForge.Web.Cli.PowerForgeServerTarget { Host = "example.test" },
+            Deploy = new PowerForge.Web.Cli.PowerForgeServerDeploy
+            {
+                Commands =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerNamedCommand
+                    {
+                        Id = "missing-deploy",
+                        Command = "   ",
+                        Required = true,
+                        Sensitive = true
+                    }
+                ]
+            }
+        };
+
+        var errors = PowerForge.Web.Cli.WebCliCommandHandlers.ValidateServerRecoveryManifest(manifest);
+
+        Assert.Contains(errors, error => error.Contains("deploy.commands[0].command must contain a non-whitespace command", StringComparison.Ordinal));
+        Assert.Throws<InvalidOperationException>(() =>
+            PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []));
+    }
+
+    [Fact]
+    public void BuildPlan_DoesNotDeduplicateRequiredSensitiveBarrier()
+    {
+        var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
+        {
+            Deploy = new PowerForge.Web.Cli.PowerForgeServerDeploy
+            {
+                Commands =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerNamedCommand
+                    {
+                        Id = "preflight",
+                        Command = "/usr/local/sbin/deploy-example"
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerNamedCommand
+                    {
+                        Id = "operator-deploy",
+                        Command = "/usr/local/sbin/deploy-example",
+                        Required = true,
+                        Sensitive = true
+                    }
+                ]
+            }
+        };
+
+        var steps = PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []);
+
+        Assert.Single(steps, step => step.Title == "preflight");
+        var barrier = Assert.Single(steps, step => step.Title == "operator-deploy");
+        Assert.True(barrier.Manual);
     }
 }

--- a/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
+++ b/PowerForge.Tests/ServerRecoverySystemdPlanTests.cs
@@ -211,6 +211,12 @@ public sealed class ServerRecoverySystemdPlanTests
                     },
                     new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
                     {
+                        Name = "blank-activation.service",
+                        Enabled = true,
+                        Activation = " "
+                    },
+                    new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
+                    {
                         Name = "--help.service"
                     },
                     new PowerForge.Web.Cli.PowerForgeServerSystemdUnit
@@ -236,6 +242,7 @@ public sealed class ServerRecoverySystemdPlanTests
         var errors = PowerForge.Web.Cli.WebCliCommandHandlers.ValidateServerRecoveryManifest(manifest);
 
         Assert.Contains(errors, error => error.Contains("unsupported activation phase 'duringDeploy'", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("unsupported activation phase ' '", StringComparison.Ordinal));
         Assert.Contains(errors, error => error.Contains("'disabled.service' must be enabled", StringComparison.Ordinal));
         Assert.Contains(errors, error => error.Contains("safe .service unit name", StringComparison.Ordinal));
         Assert.Contains(errors, error => error.Contains("'transient.service' must declare activation", StringComparison.Ordinal));
@@ -248,6 +255,17 @@ public sealed class ServerRecoverySystemdPlanTests
         var manifest = new PowerForge.Web.Cli.PowerForgeServerRecoveryManifest
         {
             Target = new PowerForge.Web.Cli.PowerForgeServerTarget { Host = "example.test" },
+            Bootstrap = new PowerForge.Web.Cli.PowerForgeServerCommandGroup
+            {
+                Commands =
+                [
+                    new PowerForge.Web.Cli.PowerForgeServerNamedCommand
+                    {
+                        Id = "missing-bootstrap",
+                        Command = "  "
+                    }
+                ]
+            },
             Deploy = new PowerForge.Web.Cli.PowerForgeServerDeploy
             {
                 Commands =
@@ -265,6 +283,7 @@ public sealed class ServerRecoverySystemdPlanTests
 
         var errors = PowerForge.Web.Cli.WebCliCommandHandlers.ValidateServerRecoveryManifest(manifest);
 
+        Assert.Contains(errors, error => error.Contains("bootstrap.commands[0].command must contain a non-whitespace command", StringComparison.Ordinal));
         Assert.Contains(errors, error => error.Contains("deploy.commands[0].command must contain a non-whitespace command", StringComparison.Ordinal));
         Assert.Throws<InvalidOperationException>(() =>
             PowerForge.Web.Cli.WebCliCommandHandlers.BuildBootstrapPlanSteps(manifest, []));

--- a/PowerForge.Tests/ServerScaffoldTests.cs
+++ b/PowerForge.Tests/ServerScaffoldTests.cs
@@ -422,6 +422,14 @@ public sealed class ServerScaffoldTests
         invalidSystemdName["systemd"]!["timers"]![0]!["name"] = "--help.timer";
         Assert.False(EvaluateSchema(schema, invalidSystemdName));
 
+        var serviceWithTimerSuffix = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
+        serviceWithTimerSuffix["systemd"]!["services"]![0]!["name"] = "cleanup.timer";
+        Assert.False(EvaluateSchema(schema, serviceWithTimerSuffix));
+
+        var timerWithServiceSuffix = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
+        timerWithServiceSuffix["systemd"]!["timers"]![0]!["name"] = "cleanup.service";
+        Assert.False(EvaluateSchema(schema, timerWithServiceSuffix));
+
         var whitespaceCommand = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
         whitespaceCommand["deploy"]!["commands"]![0]!["command"] = "   ";
         Assert.False(EvaluateSchema(schema, whitespaceCommand));

--- a/PowerForge.Tests/ServerScaffoldTests.cs
+++ b/PowerForge.Tests/ServerScaffoldTests.cs
@@ -75,6 +75,7 @@ public sealed class ServerScaffoldTests
         Assert.True(manifestNode["apache"]!["sites"]![0]!["enabled"]!.GetValue<bool>());
         Assert.Null(manifestNode["apache"]!["sites"]![1]!["enabled"]);
         Assert.Equal("beforeDeploy", manifestNode["systemd"]!["timers"]![0]!["activation"]!.GetValue<string>());
+        Assert.Equal("active", manifestNode["systemd"]!["timers"]![0]!["expectedState"]!.GetValue<string>());
         Assert.DoesNotContain(manifestNode["deploy"]!["commands"]!.AsArray(), command =>
             command!["command"]!.GetValue<string>().Contains("systemctl", StringComparison.Ordinal));
         Assert.Null(manifestNode["certificates"]![0]!["dryRunCommand"]);
@@ -406,6 +407,24 @@ public sealed class ServerScaffoldTests
         Assert.True(EvaluateSchema(schema, apacheActivation));
         apacheActivation["apache"]!["sites"]![0]!["enabled"] = "yes";
         Assert.False(EvaluateSchema(schema, apacheActivation));
+
+        var systemdActivation = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
+        var systemdTimer = systemdActivation["systemd"]!["timers"]![0]!;
+        systemdTimer["enabled"] = false;
+        Assert.False(EvaluateSchema(schema, systemdActivation));
+
+        var systemdExpectedState = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
+        var stateTimer = systemdExpectedState["systemd"]!["timers"]![0]!;
+        stateTimer.AsObject().Remove("activation");
+        Assert.False(EvaluateSchema(schema, systemdExpectedState));
+
+        var invalidSystemdName = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
+        invalidSystemdName["systemd"]!["timers"]![0]!["name"] = "--help.timer";
+        Assert.False(EvaluateSchema(schema, invalidSystemdName));
+
+        var whitespaceCommand = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
+        whitespaceCommand["deploy"]!["commands"]![0]!["command"] = "   ";
+        Assert.False(EvaluateSchema(schema, whitespaceCommand));
 
         var oversizedApacheName = JsonNode.Parse(files["deploy/linux/example.serverrecovery.json"])!.AsObject();
         oversizedApacheName["apache"]!["sites"]![0]!["target"] =

--- a/PowerForge.Tests/ServerScaffoldTests.cs
+++ b/PowerForge.Tests/ServerScaffoldTests.cs
@@ -74,6 +74,9 @@ public sealed class ServerScaffoldTests
         Assert.Equal($"/var/lock/powerforge-site-{options.SiteId}.lock", manifestNode["operationLocks"]![0]!.GetValue<string>());
         Assert.True(manifestNode["apache"]!["sites"]![0]!["enabled"]!.GetValue<bool>());
         Assert.Null(manifestNode["apache"]!["sites"]![1]!["enabled"]);
+        Assert.Equal("beforeDeploy", manifestNode["systemd"]!["timers"]![0]!["activation"]!.GetValue<string>());
+        Assert.DoesNotContain(manifestNode["deploy"]!["commands"]!.AsArray(), command =>
+            command!["command"]!.GetValue<string>().Contains("systemctl", StringComparison.Ordinal));
         Assert.Null(manifestNode["certificates"]![0]!["dryRunCommand"]);
         Assert.DoesNotContain(manifestNode["verify"]!["commands"]!.AsArray(), command =>
             command!["id"]!.GetValue<string>().Contains("certbot", StringComparison.Ordinal));

--- a/PowerForge.Web.Cli/ServerRecoveryModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryModels.cs
@@ -122,6 +122,7 @@ internal sealed class PowerForgeServerSystemdUnit
     public string? Target { get; set; }
     public bool Enabled { get; set; }
     public string? Activation { get; set; }
+    public string? ExpectedState { get; set; }
     public bool Required { get; set; }
 }
 
@@ -129,6 +130,12 @@ internal static class PowerForgeServerSystemdActivation
 {
     public const string BeforeDeploy = "beforeDeploy";
     public const string AfterDeploy = "afterDeploy";
+}
+
+internal static class PowerForgeServerSystemdState
+{
+    public const string Active = "active";
+    public const string Inactive = "inactive";
 }
 
 internal sealed class PowerForgeServerCertificate

--- a/PowerForge.Web.Cli/ServerRecoveryModels.cs
+++ b/PowerForge.Web.Cli/ServerRecoveryModels.cs
@@ -121,7 +121,14 @@ internal sealed class PowerForgeServerSystemdUnit
     public string? Source { get; set; }
     public string? Target { get; set; }
     public bool Enabled { get; set; }
+    public string? Activation { get; set; }
     public bool Required { get; set; }
+}
+
+internal static class PowerForgeServerSystemdActivation
+{
+    public const string BeforeDeploy = "beforeDeploy";
+    public const string AfterDeploy = "afterDeploy";
 }
 
 internal sealed class PowerForgeServerCertificate

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Coherence.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Coherence.cs
@@ -143,7 +143,7 @@ internal static partial class WebCliCommandHandlers
             commands.Add(
                 $"  if [ -f \"$powerforge_apache_state/{index}.enabled\" ]; then {entry.Enable} {ShellQuote(entry.Name)} >/dev/null; else {entry.Disable} {ShellQuote(entry.Name)} >/dev/null; fi");
         }
-        commands.Add($"  if {validateCommand}; then systemctl reload {ShellQuote(service)} || true; fi");
+        commands.Add($"  if {validateCommand}; then systemctl reload -- {ShellQuote(service)} || true; fi");
         commands.Add("  rm -rf -- \"$powerforge_apache_state\"");
         commands.Add("  exit \"$powerforge_apache_status\"");
         commands.Add("}");
@@ -164,7 +164,7 @@ internal static partial class WebCliCommandHandlers
             commands.Add($"{(entry.Enabled ? entry.Enable : entry.Disable)} {ShellQuote(entry.Name)}");
         }
         commands.Add(validateCommand);
-        commands.Add($"systemctl reload {ShellQuote(service)}");
+        commands.Add($"systemctl reload -- {ShellQuote(service)}");
         commands.Add("trap - EXIT HUP INT TERM");
         commands.Add("rm -rf -- \"$powerforge_apache_state\"");
         return string.Join('\n', commands);

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Systemd.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Systemd.cs
@@ -16,8 +16,8 @@ internal static partial class WebCliCommandHandlers
                      string.Equals(unit.Activation, activation, StringComparison.Ordinal) &&
                      !string.IsNullOrWhiteSpace(unit.Name)))
         {
-            AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
-            AddStep(steps, ref order, "systemd", $"Start {unit.Name}", $"systemctl start {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+            AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable -- {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+            AddStep(steps, ref order, "systemd", $"Start {unit.Name}", $"systemctl start -- {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
         }
     }
 }

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Systemd.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.Systemd.cs
@@ -1,0 +1,23 @@
+using static PowerForge.Web.Cli.WebCliHelpers;
+
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static void AddSystemdActivationSteps(
+        ICollection<PowerForgeServerBootstrapPlanStep> steps,
+        ref int order,
+        IEnumerable<PowerForgeServerSystemdUnit> units,
+        string activation,
+        ISet<string> plannedCommands)
+    {
+        foreach (var unit in units.Where(unit =>
+                     unit.Enabled &&
+                     string.Equals(unit.Activation, activation, StringComparison.Ordinal) &&
+                     !string.IsNullOrWhiteSpace(unit.Name)))
+        {
+            AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+            AddStep(steps, ref order, "systemd", $"Start {unit.Name}", $"systemctl start {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
@@ -95,6 +95,9 @@ internal static partial class WebCliCommandHandlers
         }
 
         var operationLocks = manifest.OperationLocks ?? Array.Empty<string>();
+        var systemdUnits = (manifest.Systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
+            .Concat(manifest.Systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>())
+            .ToArray();
         foreach (var operationLock in operationLocks)
         {
             AddStep(steps, ref order, "locking", $"Prepare shared operation lock {operationLock}",
@@ -283,8 +286,7 @@ internal static partial class WebCliCommandHandlers
                 BuildApacheActivationCommand(manifest.Apache!), plannedCommands: plannedCommands);
         }
 
-        foreach (var unit in (manifest.Systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
-                 .Concat(manifest.Systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>()))
+        foreach (var unit in systemdUnits)
         {
             if (!string.IsNullOrWhiteSpace(unit.Source) && !string.IsNullOrWhiteSpace(unit.Target))
             {
@@ -300,6 +302,14 @@ internal static partial class WebCliCommandHandlers
         if (manifest.Systemd is not null)
         {
             AddStep(steps, ref order, "systemd", "Reload systemd units", "systemctl daemon-reload", plannedCommands: plannedCommands);
+
+            foreach (var unit in systemdUnits.Where(static unit =>
+                         unit.Enabled &&
+                         string.IsNullOrWhiteSpace(unit.Activation) &&
+                         !string.IsNullOrWhiteSpace(unit.Name)))
+            {
+                AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+            }
         }
 
         if (manifest.Firewall is not null)
@@ -337,6 +347,13 @@ internal static partial class WebCliCommandHandlers
             AddStep(steps, ref order, "secrets", $"Confirm restored secret {secret.Id}", guard, plannedCommands: plannedCommands);
         }
 
+        AddSystemdActivationSteps(
+            steps,
+            ref order,
+            systemdUnits,
+            PowerForgeServerSystemdActivation.BeforeDeploy,
+            plannedCommands);
+
         var deployCommands = manifest.Deploy?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>();
         if (operationLocks.Length > 0 &&
             string.Equals(manifest.Deploy?.OperationLockOwner, "command", StringComparison.Ordinal))
@@ -351,16 +368,38 @@ internal static partial class WebCliCommandHandlers
             var shell = string.IsNullOrWhiteSpace(command.WorkingDirectory)
                 ? command.Command
                 : $"cd {ShellQuote(command.WorkingDirectory)} && {command.Command}";
-            AddStep(steps, ref order, "deploy", command.Id ?? "deploy command", shell, command.Sensitive, plannedCommands: plannedCommands);
+            AddStep(
+                steps,
+                ref order,
+                "deploy",
+                command.Id ?? "deploy command",
+                shell,
+                command.Sensitive,
+                manual: command.Sensitive && command.Required,
+                plannedCommands: plannedCommands);
         }
 
-        foreach (var unit in (manifest.Systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
-                 .Concat(manifest.Systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>())
-                 .Where(static unit => unit.Enabled && !string.IsNullOrWhiteSpace(unit.Name)))
+        var hasAfterDeployActivation = systemdUnits.Any(static unit =>
+            unit.Enabled &&
+            string.Equals(unit.Activation, PowerForgeServerSystemdActivation.AfterDeploy, StringComparison.Ordinal) &&
+            !string.IsNullOrWhiteSpace(unit.Name));
+        if (hasAfterDeployActivation &&
+            operationLocks.Length > 0 &&
+            string.Equals(manifest.Deploy?.OperationLockOwner, "command", StringComparison.Ordinal))
         {
-            AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
-            AddStep(steps, ref order, "systemd", $"Start {unit.Name}", $"systemctl start {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+            AddStep(
+                steps,
+                ref order,
+                "locking",
+                "Reacquire shared operation locks after command-owned deployment",
+                BuildBootstrapOperationLockAcquireCommand(operationLocks));
         }
+        AddSystemdActivationSteps(
+            steps,
+            ref order,
+            systemdUnits,
+            PowerForgeServerSystemdActivation.AfterDeploy,
+            plannedCommands);
 
         AddStep(steps, ref order, "verify", "Run PowerForge server verify", "# Run from an operator workstation: powerforge-web server verify --manifest <manifest> --fail-on-failure", manual: true, plannedCommands: plannedCommands);
         return steps;

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
@@ -308,7 +308,7 @@ internal static partial class WebCliCommandHandlers
                          string.IsNullOrWhiteSpace(unit.Activation) &&
                          !string.IsNullOrWhiteSpace(unit.Name)))
             {
-                AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+                AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable -- {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
             }
         }
 
@@ -364,7 +364,8 @@ internal static partial class WebCliCommandHandlers
 
         foreach (var command in deployCommands)
         {
-            if (string.IsNullOrWhiteSpace(command.Command)) continue;
+            if (string.IsNullOrWhiteSpace(command.Command))
+                throw new InvalidOperationException($"Deploy command '{command.Id}' must contain a non-whitespace command.");
             var shell = string.IsNullOrWhiteSpace(command.WorkingDirectory)
                 ? command.Command
                 : $"cd {ShellQuote(command.WorkingDirectory)} && {command.Command}";
@@ -679,7 +680,8 @@ internal static partial class WebCliCommandHandlers
         bool manual = false,
         ISet<string>? plannedCommands = null)
     {
-        if (!string.IsNullOrWhiteSpace(command) &&
+        if (!manual &&
+            !string.IsNullOrWhiteSpace(command) &&
             plannedCommands is not null &&
             !command.TrimStart().StartsWith("#", StringComparison.Ordinal) &&
             !plannedCommands.Add(command))

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
@@ -300,13 +300,6 @@ internal static partial class WebCliCommandHandlers
         if (manifest.Systemd is not null)
         {
             AddStep(steps, ref order, "systemd", "Reload systemd units", "systemctl daemon-reload", plannedCommands: plannedCommands);
-
-            foreach (var unit in (manifest.Systemd.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
-                     .Concat(manifest.Systemd.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>())
-                     .Where(static unit => unit.Enabled && !string.IsNullOrWhiteSpace(unit.Name)))
-            {
-                AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
-            }
         }
 
         if (manifest.Firewall is not null)
@@ -359,6 +352,14 @@ internal static partial class WebCliCommandHandlers
                 ? command.Command
                 : $"cd {ShellQuote(command.WorkingDirectory)} && {command.Command}";
             AddStep(steps, ref order, "deploy", command.Id ?? "deploy command", shell, command.Sensitive, plannedCommands: plannedCommands);
+        }
+
+        foreach (var unit in (manifest.Systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
+                 .Concat(manifest.Systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>())
+                 .Where(static unit => unit.Enabled && !string.IsNullOrWhiteSpace(unit.Name)))
+        {
+            AddStep(steps, ref order, "systemd", $"Enable {unit.Name}", $"systemctl enable {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
+            AddStep(steps, ref order, "systemd", $"Start {unit.Name}", $"systemctl start {ShellQuote(unit.Name!)}", plannedCommands: plannedCommands);
         }
 
         AddStep(steps, ref order, "verify", "Run PowerForge server verify", "# Run from an operator workstation: powerforge-web server verify --manifest <manifest> --fail-on-failure", manual: true, plannedCommands: plannedCommands);

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.BootstrapPlan.cs
@@ -256,7 +256,8 @@ internal static partial class WebCliCommandHandlers
 
         foreach (var command in manifest.Bootstrap?.Commands ?? Array.Empty<PowerForgeServerNamedCommand>())
         {
-            if (string.IsNullOrWhiteSpace(command.Command)) continue;
+            if (string.IsNullOrWhiteSpace(command.Command))
+                throw new InvalidOperationException($"Bootstrap command '{command.Id}' must contain a non-whitespace command.");
             AddStep(steps, ref order, "bootstrap", command.Id ?? "bootstrap command", command.Command, command.Sensitive, plannedCommands: plannedCommands);
         }
 

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
@@ -437,7 +437,7 @@ internal static partial class WebCliCommandHandlers
         foreach (var unit in units ?? Array.Empty<PowerForgeServerSystemdUnit>())
         {
             if (string.IsNullOrWhiteSpace(unit.Name)) continue;
-            var exists = ExecuteRemote(sshCommand, target, $"systemctl cat {ShellQuote(unit.Name)} >/dev/null");
+            var exists = ExecuteRemote(sshCommand, target, $"systemctl cat -- {ShellQuote(unit.Name)} >/dev/null");
             AddBooleanCheck(checks, $"systemd.{kind}.{unit.Name}.exists", "systemd", $"systemd {kind} exists: {unit.Name}",
                 exists.Success,
                 "unit exists",
@@ -453,16 +453,16 @@ internal static partial class WebCliCommandHandlers
             }
 
             if (!unit.Enabled) continue;
-            var enabled = ExecuteRemote(sshCommand, target, $"systemctl is-enabled {ShellQuote(unit.Name)}");
+            var enabled = ExecuteRemote(sshCommand, target, $"systemctl is-enabled -- {ShellQuote(unit.Name)}");
             AddBooleanCheck(checks, $"systemd.{kind}.{unit.Name}.enabled", "systemd", $"systemd {kind} is enabled: {unit.Name}",
                 enabled.Stdout.Trim().Equals("enabled", StringComparison.OrdinalIgnoreCase),
                 "enabled",
                 enabled.Stdout.Trim());
-            if (string.IsNullOrWhiteSpace(unit.Activation)) continue;
-            var active = ExecuteRemote(sshCommand, target, $"systemctl is-active {ShellQuote(unit.Name)}");
-            AddBooleanCheck(checks, $"systemd.{kind}.{unit.Name}.active", "systemd", $"systemd {kind} is active: {unit.Name}",
-                active.Stdout.Trim().Equals("active", StringComparison.OrdinalIgnoreCase),
-                "active",
+            if (string.IsNullOrWhiteSpace(unit.ExpectedState)) continue;
+            var active = ExecuteRemote(sshCommand, target, $"systemctl is-active -- {ShellQuote(unit.Name)}");
+            AddBooleanCheck(checks, $"systemd.{kind}.{unit.Name}.state", "systemd", $"systemd {kind} state matches: {unit.Name}",
+                active.Stdout.Trim().Equals(unit.ExpectedState, StringComparison.OrdinalIgnoreCase),
+                unit.ExpectedState,
                 active.Stdout.Trim());
         }
     }

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Inspect.cs
@@ -458,6 +458,12 @@ internal static partial class WebCliCommandHandlers
                 enabled.Stdout.Trim().Equals("enabled", StringComparison.OrdinalIgnoreCase),
                 "enabled",
                 enabled.Stdout.Trim());
+            if (string.IsNullOrWhiteSpace(unit.Activation)) continue;
+            var active = ExecuteRemote(sshCommand, target, $"systemctl is-active {ShellQuote(unit.Name)}");
+            AddBooleanCheck(checks, $"systemd.{kind}.{unit.Name}.active", "systemd", $"systemd {kind} is active: {unit.Name}",
+                active.Stdout.Trim().Equals("active", StringComparison.OrdinalIgnoreCase),
+                "active",
+                active.Stdout.Trim());
         }
     }
 

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Scaffold.Templates.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Scaffold.Templates.cs
@@ -144,7 +144,7 @@ internal static partial class WebCliCommandHandlers
         var verifyCommands = new List<PowerForgeServerNamedCommand>
         {
             Command("apache-config", "sudo -n apachectl configtest", required: true),
-            Command("static-deployment-reconciler", "test -x /usr/local/sbin/powerforge-site-reconcile && systemctl is-enabled --quiet powerforge-site-reconcile.timer && systemctl is-active --quiet powerforge-site-reconcile.timer", required: true),
+            Command("static-deployment-reconciler", "test -x /usr/local/sbin/powerforge-site-reconcile && systemctl is-enabled --quiet -- powerforge-site-reconcile.timer && systemctl is-active --quiet -- powerforge-site-reconcile.timer", required: true),
             Command("deployment-account", $"id -u {deploymentUser} >/dev/null && sudo -n grep -q '^restrict ' /home/{deploymentUser}/.ssh/authorized_keys && sudo -n visudo -cf /etc/sudoers.d/{deploymentUser}", required: true),
             Command("backup-account", $"id -u {backupUser} >/dev/null && sudo -n grep -q '^restrict ' /var/lib/{backupUser}/.ssh/authorized_keys && sudo -n visudo -cf /etc/sudoers.d/{backupUser}", required: true),
             Command("repository-identity", repositoryVerification, required: true),
@@ -219,7 +219,7 @@ internal static partial class WebCliCommandHandlers
             Systemd = new PowerForgeServerSystemd
             {
                 Services = [new PowerForgeServerSystemdUnit { Name = "powerforge-site-reconcile.service", Source = $"{enginePath}/Deployment/Linux/systemd/powerforge-site-reconcile.service", Target = "/etc/systemd/system/powerforge-site-reconcile.service", Required = true }],
-                Timers = [new PowerForgeServerSystemdUnit { Name = "powerforge-site-reconcile.timer", Source = $"{enginePath}/Deployment/Linux/systemd/powerforge-site-reconcile.timer", Target = "/etc/systemd/system/powerforge-site-reconcile.timer", Enabled = true, Activation = PowerForgeServerSystemdActivation.BeforeDeploy, Required = true }]
+                Timers = [new PowerForgeServerSystemdUnit { Name = "powerforge-site-reconcile.timer", Source = $"{enginePath}/Deployment/Linux/systemd/powerforge-site-reconcile.timer", Target = "/etc/systemd/system/powerforge-site-reconcile.timer", Enabled = true, Activation = PowerForgeServerSystemdActivation.BeforeDeploy, ExpectedState = PowerForgeServerSystemdState.Active, Required = true }]
             },
             Secrets = secrets.ToArray(),
             Capture = new PowerForgeServerCapture

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Scaffold.Templates.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Scaffold.Templates.cs
@@ -219,7 +219,7 @@ internal static partial class WebCliCommandHandlers
             Systemd = new PowerForgeServerSystemd
             {
                 Services = [new PowerForgeServerSystemdUnit { Name = "powerforge-site-reconcile.service", Source = $"{enginePath}/Deployment/Linux/systemd/powerforge-site-reconcile.service", Target = "/etc/systemd/system/powerforge-site-reconcile.service", Required = true }],
-                Timers = [new PowerForgeServerSystemdUnit { Name = "powerforge-site-reconcile.timer", Source = $"{enginePath}/Deployment/Linux/systemd/powerforge-site-reconcile.timer", Target = "/etc/systemd/system/powerforge-site-reconcile.timer", Enabled = true, Required = true }]
+                Timers = [new PowerForgeServerSystemdUnit { Name = "powerforge-site-reconcile.timer", Source = $"{enginePath}/Deployment/Linux/systemd/powerforge-site-reconcile.timer", Target = "/etc/systemd/system/powerforge-site-reconcile.timer", Enabled = true, Activation = PowerForgeServerSystemdActivation.BeforeDeploy, Required = true }]
             },
             Secrets = secrets.ToArray(),
             Capture = new PowerForgeServerCapture
@@ -240,8 +240,6 @@ internal static partial class WebCliCommandHandlers
             {
                 Commands =
                 [
-                    Command("reload-systemd", "sudo -n systemctl daemon-reload", required: true),
-                    Command("enable-static-deployment-reconciler", "sudo -n systemctl enable --now powerforge-site-reconcile.timer", required: true),
                     Command("enable-apache-sites", $"sudo -n /usr/local/sbin/powerforge-apache-site-enable --http-site {domainFile}.conf --https-site {domainFile}-le-ssl.conf --certificate-name {options.Domain}", required: true)
                 ]
             },

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.Systemd.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.Systemd.cs
@@ -1,0 +1,22 @@
+namespace PowerForge.Web.Cli;
+
+internal static partial class WebCliCommandHandlers
+{
+    private static void ValidateSystemdActivation(
+        PowerForgeServerSystemd? systemd,
+        ICollection<string> errors)
+    {
+        var units = (systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
+            .Concat(systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>());
+        foreach (var unit in units)
+        {
+            if (string.IsNullOrWhiteSpace(unit.Activation))
+                continue;
+
+            if (unit.Activation is not (PowerForgeServerSystemdActivation.BeforeDeploy or PowerForgeServerSystemdActivation.AfterDeploy))
+                errors.Add($"Systemd unit '{unit.Name}' has unsupported activation phase '{unit.Activation}'.");
+            if (!unit.Enabled)
+                errors.Add($"Systemd unit '{unit.Name}' must be enabled when activation is declared.");
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.Systemd.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.Systemd.cs
@@ -25,7 +25,7 @@ internal static partial class WebCliCommandHandlers
             if (!IsValidSystemdUnitName(unit.Name, requiredSuffix))
                 errors.Add($"{path}[{index}].name must be a safe {requiredSuffix} unit name.");
 
-            if (!string.IsNullOrWhiteSpace(unit.Activation))
+            if (unit.Activation is not null)
             {
                 if (unit.Activation is not (PowerForgeServerSystemdActivation.BeforeDeploy or PowerForgeServerSystemdActivation.AfterDeploy))
                     errors.Add($"Systemd unit '{unit.Name}' has unsupported activation phase '{unit.Activation}'.");

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.Systemd.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.Systemd.cs
@@ -2,21 +2,67 @@ namespace PowerForge.Web.Cli;
 
 internal static partial class WebCliCommandHandlers
 {
+    private static readonly char[] AllowedSystemdUnitNameCharacters =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:_.@-".ToCharArray();
+
     private static void ValidateSystemdActivation(
         PowerForgeServerSystemd? systemd,
         ICollection<string> errors)
     {
-        var units = (systemd?.Services ?? Array.Empty<PowerForgeServerSystemdUnit>())
-            .Concat(systemd?.Timers ?? Array.Empty<PowerForgeServerSystemdUnit>());
-        foreach (var unit in units)
-        {
-            if (string.IsNullOrWhiteSpace(unit.Activation))
-                continue;
+        ValidateSystemdUnits(systemd?.Services, ".service", "systemd.services", errors);
+        ValidateSystemdUnits(systemd?.Timers, ".timer", "systemd.timers", errors);
+    }
 
-            if (unit.Activation is not (PowerForgeServerSystemdActivation.BeforeDeploy or PowerForgeServerSystemdActivation.AfterDeploy))
-                errors.Add($"Systemd unit '{unit.Name}' has unsupported activation phase '{unit.Activation}'.");
-            if (!unit.Enabled)
-                errors.Add($"Systemd unit '{unit.Name}' must be enabled when activation is declared.");
+    private static void ValidateSystemdUnits(
+        IEnumerable<PowerForgeServerSystemdUnit>? units,
+        string requiredSuffix,
+        string path,
+        ICollection<string> errors)
+    {
+        var index = 0;
+        foreach (var unit in units ?? Array.Empty<PowerForgeServerSystemdUnit>())
+        {
+            if (!IsValidSystemdUnitName(unit.Name, requiredSuffix))
+                errors.Add($"{path}[{index}].name must be a safe {requiredSuffix} unit name.");
+
+            if (!string.IsNullOrWhiteSpace(unit.Activation))
+            {
+                if (unit.Activation is not (PowerForgeServerSystemdActivation.BeforeDeploy or PowerForgeServerSystemdActivation.AfterDeploy))
+                    errors.Add($"Systemd unit '{unit.Name}' has unsupported activation phase '{unit.Activation}'.");
+                if (!unit.Enabled)
+                    errors.Add($"Systemd unit '{unit.Name}' must be enabled when activation is declared.");
+            }
+
+            if (unit.ExpectedState is not null)
+            {
+                if (unit.ExpectedState is not (PowerForgeServerSystemdState.Active or PowerForgeServerSystemdState.Inactive))
+                    errors.Add($"Systemd unit '{unit.Name}' has unsupported expected state '{unit.ExpectedState}'.");
+                if (string.IsNullOrWhiteSpace(unit.Activation))
+                    errors.Add($"Systemd unit '{unit.Name}' must declare activation when expectedState is declared.");
+            }
+
+            index++;
+        }
+    }
+
+    private static bool IsValidSystemdUnitName(string? name, string requiredSuffix)
+        => !string.IsNullOrWhiteSpace(name) &&
+           name.Length <= 255 &&
+           name.EndsWith(requiredSuffix, StringComparison.Ordinal) &&
+           IsAsciiLetterOrDigit(name[0]) &&
+           name.All(character => Array.IndexOf(AllowedSystemdUnitNameCharacters, character) >= 0);
+
+    private static void ValidateNamedCommandText(
+        IEnumerable<PowerForgeServerNamedCommand>? commands,
+        string path,
+        ICollection<string> errors)
+    {
+        var index = 0;
+        foreach (var command in commands ?? Array.Empty<PowerForgeServerNamedCommand>())
+        {
+            if (string.IsNullOrWhiteSpace(command.Command))
+                errors.Add($"{path}[{index}].command must contain a non-whitespace command.");
+            index++;
         }
     }
 }

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
@@ -15,6 +15,7 @@ internal static partial class WebCliCommandHandlers
         ValidateHostAndPackages(manifest, errors);
         ValidateOperationLocks(manifest, errors);
         ValidateSystemdActivation(manifest.Systemd, errors);
+        ValidateNamedCommandText(manifest.Bootstrap?.Commands, "bootstrap.commands", errors);
         ValidateNamedCommandText(manifest.Capture?.Commands, "capture.commands", errors);
         ValidateNamedCommandText(manifest.Deploy?.Commands, "deploy.commands", errors);
         ValidateNamedCommandText(manifest.Verify?.Commands, "verify.commands", errors);

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
@@ -15,6 +15,9 @@ internal static partial class WebCliCommandHandlers
         ValidateHostAndPackages(manifest, errors);
         ValidateOperationLocks(manifest, errors);
         ValidateSystemdActivation(manifest.Systemd, errors);
+        ValidateNamedCommandText(manifest.Capture?.Commands, "capture.commands", errors);
+        ValidateNamedCommandText(manifest.Deploy?.Commands, "deploy.commands", errors);
+        ValidateNamedCommandText(manifest.Verify?.Commands, "verify.commands", errors);
 
         var plainFiles = manifest.Capture?.PlainFiles ?? Array.Empty<PowerForgeServerManagedFile>();
         var encryptedFiles = manifest.Capture?.EncryptedFiles ?? Array.Empty<PowerForgeServerManagedFile>();

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.Validation.cs
@@ -14,6 +14,7 @@ internal static partial class WebCliCommandHandlers
 
         ValidateHostAndPackages(manifest, errors);
         ValidateOperationLocks(manifest, errors);
+        ValidateSystemdActivation(manifest.Systemd, errors);
 
         var plainFiles = manifest.Capture?.PlainFiles ?? Array.Empty<PowerForgeServerManagedFile>();
         var encryptedFiles = manifest.Capture?.EncryptedFiles ?? Array.Empty<PowerForgeServerManagedFile>();

--- a/Schemas/powerforge.web.serverrecovery.schema.json
+++ b/Schemas/powerforge.web.serverrecovery.schema.json
@@ -373,7 +373,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9:_.@-]{0,246}\\.(service|timer)$"
+        },
         "source": { "$ref": "#/$defs/AbsoluteUnixExactPath" },
         "target": {
           "allOf": [
@@ -387,9 +390,27 @@
           "enum": ["beforeDeploy", "afterDeploy"],
           "description": "Optionally start an enabled unit before or after declared deploy commands. Omit for legacy enable-only behavior."
         },
+        "expectedState": {
+          "type": "string",
+          "enum": ["active", "inactive"],
+          "description": "Optionally require the activated unit to settle in this systemctl is-active state during inspection. Omit for transient oneshot units whose steady state is not asserted."
+        },
         "required": { "type": "boolean" }
       },
-      "required": ["name"]
+      "required": ["name"],
+      "allOf": [
+        {
+          "if": { "required": ["activation"] },
+          "then": {
+            "required": ["enabled"],
+            "properties": { "enabled": { "enum": [true] } }
+          }
+        },
+        {
+          "if": { "required": ["expectedState"] },
+          "then": { "required": ["activation"] }
+        }
+      ]
     },
     "Secret": {
       "type": "object",
@@ -473,7 +494,7 @@
       "additionalProperties": false,
       "properties": {
         "id": { "type": "string", "minLength": 1 },
-        "command": { "type": "string", "minLength": 1 },
+        "command": { "type": "string", "minLength": 1, "pattern": "\\S" },
         "workingDirectory": { "type": "string" },
         "sensitive": { "type": "boolean" },
         "required": { "type": "boolean" }

--- a/Schemas/powerforge.web.serverrecovery.schema.json
+++ b/Schemas/powerforge.web.serverrecovery.schema.json
@@ -382,6 +382,11 @@
           ]
         },
         "enabled": { "type": "boolean" },
+        "activation": {
+          "type": "string",
+          "enum": ["beforeDeploy", "afterDeploy"],
+          "description": "Optionally start an enabled unit before or after declared deploy commands. Omit for legacy enable-only behavior."
+        },
         "required": { "type": "boolean" }
       },
       "required": ["name"]

--- a/Schemas/powerforge.web.serverrecovery.schema.json
+++ b/Schemas/powerforge.web.serverrecovery.schema.json
@@ -361,11 +361,21 @@
       "properties": {
         "services": {
           "type": "array",
-          "items": { "$ref": "#/$defs/SystemdUnit" }
+          "items": {
+            "allOf": [
+              { "$ref": "#/$defs/SystemdUnit" },
+              { "properties": { "name": { "pattern": "\\.service$" } } }
+            ]
+          }
         },
         "timers": {
           "type": "array",
-          "items": { "$ref": "#/$defs/SystemdUnit" }
+          "items": {
+            "allOf": [
+              { "$ref": "#/$defs/SystemdUnit" },
+              { "properties": { "name": { "pattern": "\\.timer$" } } }
+            ]
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- model explicit `beforeDeploy` and `afterDeploy` activation for enabled recovery-managed systemd units while preserving legacy enable-only manifests
- keep command-owned deployment locking coherent by reacquiring shared locks before post-deploy activation and fail closed on required sensitive deploy steps
- make steady-state inspection explicit with optional `expectedState`, so transient oneshot services are not treated as drift
- align schema/runtime validation for activation, unit collection suffixes, safe names, and non-whitespace commands
- keep generated consumers thin by declaring reconcile activation in the shared scaffold instead of duplicating `systemctl` deploy commands

## Compatibility

Existing enabled units without `activation` keep their previous enable-only behavior. Consumers opt into start timing and steady-state inspection declaratively.

## Validation

- recovery/action/scaffold/capture tests: 283 passed on Windows; 280 non-root Linux tests plus 3 privileged lock tests passed under an isolated root process
- DotNetPublish tests: 179 passed
- exact Evotec recovery action proof: 63 bootstrap steps, 15 managed sources, 7 secrets, 0 warnings
- warning-as-errors build, schema parsing, Bash/ShellCheck generation, diff hygiene, and independent local review passed