### PR TITLE
Drain Git sync output before reading buffers

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerGitProcessTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerGitProcessTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using PowerForge.Web.Cli;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class WebPipelineRunnerGitProcessTests
+{
+    [Fact]
+    public void RunGitCommand_DrainsHighVolumeOutputBeforeReturning()
+    {
+        if (!IsGitAvailable())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-git-output-drain-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var scriptPath = Path.Combine(root, "emit-output.sh");
+            File.WriteAllText(scriptPath,
+                """
+                #!/bin/sh
+                i=0
+                while [ "$i" -lt 10000 ]; do
+                  printf 'stdout-%05d\n' "$i"
+                  printf 'stderr-%05d\n' "$i" >&2
+                  i=$((i + 1))
+                done
+                printf 'stdout-complete\n'
+                printf 'stderr-complete\n' >&2
+                """);
+
+            var portableScriptPath = scriptPath.Replace('\\', '/');
+            var result = WebPipelineRunner.RunGitCommand(
+                root,
+                new[]
+                {
+                    "-c",
+                    $"alias.powerforge-output=!sh \"{portableScriptPath}\"",
+                    "powerforge-output"
+                },
+                authHeader: null,
+                timeoutSeconds: 60);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(10001, result.Output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length);
+            Assert.Equal(10001, result.Error.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Length);
+            Assert.EndsWith("stdout-complete", result.Output, StringComparison.Ordinal);
+            Assert.EndsWith("stderr-complete", result.Error, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup for transient test files.
+            }
+        }
+    }
+
+    private static bool IsGitAvailable()
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo("git", "--version")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
+            if (process is null)
+                return false;
+
+            process.WaitForExit(5000);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.GitSync.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.GitSync.cs
@@ -1194,7 +1194,7 @@ internal static partial class WebPipelineRunner
         };
     }
 
-    private static (int ExitCode, string Output, string Error) RunGitCommand(
+    internal static (int ExitCode, string Output, string Error) RunGitCommand(
         string workingDirectory,
         IReadOnlyList<string> args,
         string? authHeader,
@@ -1265,6 +1265,9 @@ internal static partial class WebPipelineRunner
 
             throw new InvalidOperationException($"git-sync timed out after {timeoutSeconds}s.");
         }
+
+        // Timed waits do not drain asynchronous output handlers before returning.
+        process.WaitForExit();
 
         return (process.ExitCode, stdout.ToString().Trim(), stderr.ToString().Trim());
     }


### PR DESCRIPTION
## Summary
- drain asynchronous Git stdout and stderr handlers before reading captured buffers
- keep the existing timeout boundary unchanged
- cover high-volume stdout and stderr capture with a dedicated cross-platform regression test

## Why
`sources-sync` intermittently failed after a successful Git process exit with an `ArgumentOutOfRangeException` for `chunkLength`. The timed process wait could return before asynchronous output callbacks completed, allowing a callback to mutate a `StringBuilder` while its result was being read.

This change keeps the fix in the shared Git-sync owner, so website workflows remain thin and require no retry or shell workaround.