### PR TITLE
Hide non-public symbols from generated API documentation

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
@@ -20,11 +20,17 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
                   <assembly><name>PowerForge.Tests</name></assembly>
                   <members>
                     <member name="T:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture"><summary>Public fixture.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.#ctor"><summary>Public constructor.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.#ctor(System.Int32)"><summary>Internal constructor.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.PublicMethod"><summary>Public method.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.InternalMethod"><summary>Internal method.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Overloaded(System.String)"><summary>Public overload.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Overloaded(System.Int32)"><summary>Internal overload.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Addition(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture,PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)"><summary>Public operator.</summary></member>
                     <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.PublicProperty"><summary>Public property.</summary></member>
                     <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.InternalProperty"><summary>Internal property.</summary></member>
+                    <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Item(System.String)"><summary>Public indexer.</summary></member>
+                    <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Item(System.Int32)"><summary>Internal indexer.</summary></member>
                     <member name="T:PowerForge.Tests.WebApiDocsInternalAccessibilityFixture"><summary>Internal fixture.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsInternalAccessibilityFixture.LooksPublic"><summary>Public method on an internal type.</summary></member>
                   </members>
@@ -32,12 +38,32 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
                 """);
 
             var outputPath = Path.Combine(root, "api");
+            const string internalTypeSlug = "powerforge-tests-webapidocsinternalaccessibilityfixture";
+            var internalJsonPath = Path.Combine(outputPath, "types", internalTypeSlug + ".json");
+            var internalRoutePath = Path.Combine(outputPath, internalTypeSlug, "index.html");
+            var internalAliasPath = Path.Combine(outputPath, internalTypeSlug + ".html");
+
+            var xmlOnlyResult = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                XmlPath = xmlPath,
+                OutputPath = outputPath,
+                Format = "both",
+                Template = "docs",
+                BaseUrl = "/api",
+                IncludeUndocumentedTypes = false
+            });
+            Assert.Equal(2, xmlOnlyResult.TypeCount);
+            Assert.True(File.Exists(internalJsonPath));
+            Assert.True(File.Exists(internalRoutePath));
+            Assert.True(File.Exists(internalAliasPath));
+
             var result = WebApiDocsGenerator.Generate(new WebApiDocsOptions
             {
                 XmlPath = xmlPath,
                 AssemblyPath = typeof(WebApiDocsGeneratorAccessibilityTests).Assembly.Location,
                 OutputPath = outputPath,
-                Format = "json",
+                Format = "both",
+                Template = "docs",
                 BaseUrl = "/api",
                 IncludeUndocumentedTypes = false
             });
@@ -53,17 +79,64 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
             Assert.Contains("PublicMethod", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("op_Addition", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("PublicProperty", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Public constructor.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Public overload.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Public operator.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Public indexer.", publicTypeJson, StringComparison.Ordinal);
             Assert.DoesNotContain("InternalMethod", publicTypeJson, StringComparison.Ordinal);
             Assert.DoesNotContain("InternalProperty", publicTypeJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("Internal constructor.", publicTypeJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("Internal overload.", publicTypeJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("Internal indexer.", publicTypeJson, StringComparison.Ordinal);
 
-            Assert.False(File.Exists(Path.Combine(
-                outputPath,
-                "types",
-                "powerforge-tests-webapidocsinternalaccessibilityfixture.json")));
+            Assert.False(File.Exists(internalJsonPath));
+            Assert.False(File.Exists(internalRoutePath));
+            Assert.False(File.Exists(internalAliasPath));
 
             var xref = File.ReadAllText(Path.Combine(outputPath, "xrefmap.json"));
             Assert.DoesNotContain("InternalMethod", xref, StringComparison.Ordinal);
             Assert.DoesNotContain("InternalAccessibilityFixture", xref, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Generate_WithUninspectableRequestedAssembly_FailsClosed()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-fail-closed-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "test.xml");
+            File.WriteAllText(xmlPath,
+                """
+                <doc>
+                  <assembly><name>Broken</name></assembly>
+                  <members>
+                    <member name="T:Broken.InternalType"><summary>Must not be emitted.</summary></member>
+                  </members>
+                </doc>
+                """);
+            var assemblyPath = Path.Combine(root, "broken.dll");
+            File.WriteAllText(assemblyPath, "not an assembly");
+            var outputPath = Path.Combine(root, "api");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                WebApiDocsGenerator.Generate(new WebApiDocsOptions
+                {
+                    XmlPath = xmlPath,
+                    AssemblyPath = assemblyPath,
+                    OutputPath = outputPath,
+                    Format = "json"
+                }));
+
+            Assert.Contains("could not be inspected", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(Path.Combine(outputPath, "index.json")));
         }
         finally
         {
@@ -119,6 +192,17 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
 
 public sealed class WebApiDocsPublicAccessibilityFixture
 {
+    /// <summary>Visible constructor used by API documentation visibility tests.</summary>
+    public WebApiDocsPublicAccessibilityFixture()
+    {
+    }
+
+    /// <summary>Hidden constructor used by API documentation visibility tests.</summary>
+    internal WebApiDocsPublicAccessibilityFixture(int value)
+    {
+        _ = value;
+    }
+
     /// <summary>Visible member used by API documentation visibility tests.</summary>
     public void PublicMethod()
     {
@@ -128,6 +212,18 @@ public sealed class WebApiDocsPublicAccessibilityFixture
     public static WebApiDocsPublicAccessibilityFixture operator +(
         WebApiDocsPublicAccessibilityFixture left,
         WebApiDocsPublicAccessibilityFixture right) => left;
+
+    /// <summary>Visible overload used by API documentation visibility tests.</summary>
+    public void Overloaded(string value)
+    {
+        _ = value;
+    }
+
+    /// <summary>Hidden overload used by API documentation visibility tests.</summary>
+    internal void Overloaded(int value)
+    {
+        _ = value;
+    }
 
     /// <summary>Hidden member used by API documentation visibility tests.</summary>
     internal void InternalMethod()
@@ -139,6 +235,12 @@ public sealed class WebApiDocsPublicAccessibilityFixture
 
     /// <summary>Hidden property used by API documentation visibility tests.</summary>
     internal string InternalProperty { get; } = string.Empty;
+
+    /// <summary>Visible indexer used by API documentation visibility tests.</summary>
+    public string this[string key] => key;
+
+    /// <summary>Hidden indexer used by API documentation visibility tests.</summary>
+    internal string this[int index] => index.ToString();
 }
 
 internal sealed class WebApiDocsInternalAccessibilityFixture

--- a/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
@@ -29,6 +29,8 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Addition(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture,PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)"><summary>Public operator.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Implicit(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)~System.String"><summary>String conversion.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Implicit(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)~System.Int32"><summary>Integer conversion.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_CheckedExplicit(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)~System.Int64"><summary>Checked long conversion.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_CheckedExplicit(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)~System.Int16"><summary>Checked short conversion.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Generic``1(System.String)"><summary>Single generic parameter.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Generic``2(System.String)"><summary>Two generic parameters.</summary></member>
                     <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.PublicProperty"><summary>Public property.</summary></member>
@@ -88,6 +90,8 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
             Assert.Contains("Public operator.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("String conversion.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("Integer conversion.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Checked long conversion.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Checked short conversion.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("Single generic parameter.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("Two generic parameters.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("Public indexer.", publicTypeJson, StringComparison.Ordinal);
@@ -227,6 +231,18 @@ public sealed class WebApiDocsPublicAccessibilityFixture
 
     /// <summary>Visible conversion used by API documentation visibility tests.</summary>
     public static implicit operator int(WebApiDocsPublicAccessibilityFixture value) => 0;
+
+    /// <summary>Visible conversion required by the checked conversion pair.</summary>
+    public static explicit operator long(WebApiDocsPublicAccessibilityFixture value) => 0L;
+
+    /// <summary>Visible checked conversion used by API documentation visibility tests.</summary>
+    public static explicit operator checked long(WebApiDocsPublicAccessibilityFixture value) => 0L;
+
+    /// <summary>Visible conversion required by the checked conversion pair.</summary>
+    public static explicit operator short(WebApiDocsPublicAccessibilityFixture value) => 0;
+
+    /// <summary>Visible checked conversion used by API documentation visibility tests.</summary>
+    public static explicit operator checked short(WebApiDocsPublicAccessibilityFixture value) => 0;
 
     /// <summary>Visible generic overload used by API documentation visibility tests.</summary>
     public string Generic<T>(string value) => value;

--- a/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
@@ -27,6 +27,10 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Overloaded(System.String)"><summary>Public overload.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Overloaded(System.Int32)"><summary>Internal overload.</summary></member>
                     <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Addition(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture,PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)"><summary>Public operator.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Implicit(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)~System.String"><summary>String conversion.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Implicit(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)~System.Int32"><summary>Integer conversion.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Generic``1(System.String)"><summary>Single generic parameter.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Generic``2(System.String)"><summary>Two generic parameters.</summary></member>
                     <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.PublicProperty"><summary>Public property.</summary></member>
                     <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.InternalProperty"><summary>Internal property.</summary></member>
                     <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.Item(System.String)"><summary>Public indexer.</summary></member>
@@ -82,6 +86,10 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
             Assert.Contains("Public constructor.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("Public overload.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("Public operator.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("String conversion.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Integer conversion.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Single generic parameter.", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("Two generic parameters.", publicTypeJson, StringComparison.Ordinal);
             Assert.Contains("Public indexer.", publicTypeJson, StringComparison.Ordinal);
             Assert.DoesNotContain("InternalMethod", publicTypeJson, StringComparison.Ordinal);
             Assert.DoesNotContain("InternalProperty", publicTypeJson, StringComparison.Ordinal);
@@ -212,6 +220,19 @@ public sealed class WebApiDocsPublicAccessibilityFixture
     public static WebApiDocsPublicAccessibilityFixture operator +(
         WebApiDocsPublicAccessibilityFixture left,
         WebApiDocsPublicAccessibilityFixture right) => left;
+
+    /// <summary>Visible conversion used by API documentation visibility tests.</summary>
+    public static implicit operator string(WebApiDocsPublicAccessibilityFixture value) =>
+        value.ToString() ?? string.Empty;
+
+    /// <summary>Visible conversion used by API documentation visibility tests.</summary>
+    public static implicit operator int(WebApiDocsPublicAccessibilityFixture value) => 0;
+
+    /// <summary>Visible generic overload used by API documentation visibility tests.</summary>
+    public string Generic<T>(string value) => value;
+
+    /// <summary>Visible generic overload used by API documentation visibility tests.</summary>
+    public string Generic<TFirst, TSecond>(string value) => value;
 
     /// <summary>Visible overload used by API documentation visibility tests.</summary>
     public void Overloaded(string value)

--- a/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorAccessibilityTests.cs
@@ -6,6 +6,73 @@ namespace PowerForge.Tests;
 public sealed class WebApiDocsGeneratorAccessibilityTests
 {
     [Fact]
+    public void Generate_WithAssembly_OmitsInternalXmlTypesAndMembers()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-public-surface-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "test.xml");
+            File.WriteAllText(xmlPath,
+                """
+                <doc>
+                  <assembly><name>PowerForge.Tests</name></assembly>
+                  <members>
+                    <member name="T:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture"><summary>Public fixture.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.PublicMethod"><summary>Public method.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.InternalMethod"><summary>Internal method.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.op_Addition(PowerForge.Tests.WebApiDocsPublicAccessibilityFixture,PowerForge.Tests.WebApiDocsPublicAccessibilityFixture)"><summary>Public operator.</summary></member>
+                    <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.PublicProperty"><summary>Public property.</summary></member>
+                    <member name="P:PowerForge.Tests.WebApiDocsPublicAccessibilityFixture.InternalProperty"><summary>Internal property.</summary></member>
+                    <member name="T:PowerForge.Tests.WebApiDocsInternalAccessibilityFixture"><summary>Internal fixture.</summary></member>
+                    <member name="M:PowerForge.Tests.WebApiDocsInternalAccessibilityFixture.LooksPublic"><summary>Public method on an internal type.</summary></member>
+                  </members>
+                </doc>
+                """);
+
+            var outputPath = Path.Combine(root, "api");
+            var result = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                XmlPath = xmlPath,
+                AssemblyPath = typeof(WebApiDocsGeneratorAccessibilityTests).Assembly.Location,
+                OutputPath = outputPath,
+                Format = "json",
+                BaseUrl = "/api",
+                IncludeUndocumentedTypes = false
+            });
+
+            Assert.Equal(1, result.TypeCount);
+
+            var publicTypePath = Path.Combine(
+                outputPath,
+                "types",
+                "powerforge-tests-webapidocspublicaccessibilityfixture.json");
+            Assert.True(File.Exists(publicTypePath), "Expected the exported fixture type to be documented.");
+            var publicTypeJson = File.ReadAllText(publicTypePath);
+            Assert.Contains("PublicMethod", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("op_Addition", publicTypeJson, StringComparison.Ordinal);
+            Assert.Contains("PublicProperty", publicTypeJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("InternalMethod", publicTypeJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("InternalProperty", publicTypeJson, StringComparison.Ordinal);
+
+            Assert.False(File.Exists(Path.Combine(
+                outputPath,
+                "types",
+                "powerforge-tests-webapidocsinternalaccessibilityfixture.json")));
+
+            var xref = File.ReadAllText(Path.Combine(outputPath, "xrefmap.json"));
+            Assert.DoesNotContain("InternalMethod", xref, StringComparison.Ordinal);
+            Assert.DoesNotContain("InternalAccessibilityFixture", xref, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Generate_AssignsUniqueIdsToCaseDistinctNamespaces()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-namespace-ids-" + Guid.NewGuid().ToString("N"));
@@ -47,5 +114,37 @@ public sealed class WebApiDocsGeneratorAccessibilityTests
             if (Directory.Exists(root))
                 Directory.Delete(root, recursive: true);
         }
+    }
+}
+
+public sealed class WebApiDocsPublicAccessibilityFixture
+{
+    /// <summary>Visible member used by API documentation visibility tests.</summary>
+    public void PublicMethod()
+    {
+    }
+
+    /// <summary>Visible operator used by API documentation visibility tests.</summary>
+    public static WebApiDocsPublicAccessibilityFixture operator +(
+        WebApiDocsPublicAccessibilityFixture left,
+        WebApiDocsPublicAccessibilityFixture right) => left;
+
+    /// <summary>Hidden member used by API documentation visibility tests.</summary>
+    internal void InternalMethod()
+    {
+    }
+
+    /// <summary>Visible property used by API documentation visibility tests.</summary>
+    public string PublicProperty { get; } = string.Empty;
+
+    /// <summary>Hidden property used by API documentation visibility tests.</summary>
+    internal string InternalProperty { get; } = string.Empty;
+}
+
+internal sealed class WebApiDocsInternalAccessibilityFixture
+{
+    /// <summary>Looks public in XML, but its declaring type is not exported.</summary>
+    public void LooksPublic()
+    {
     }
 }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
@@ -84,6 +84,7 @@ public static partial class WebApiDocsGenerator
         public string? ValueSummary { get; set; }
         public bool IsConstructor { get; set; }
         public bool IsExtension { get; set; }
+        internal string? DocumentationSignature { get; set; }
         public List<string> Attributes { get; } = new();
         public List<ApiTypeParameterModel> TypeParameters { get; } = new();
         public List<ApiExampleModel> Examples { get; } = new();

--- a/PowerForge.Web/Services/WebApiDocsGenerator.OutputCleanup.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.OutputCleanup.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace PowerForge.Web;
+
+public static partial class WebApiDocsGenerator
+{
+    private static readonly Regex GeneratedApiTypeSlugRegex = new(
+        "^[a-z0-9][a-z0-9-]*$",
+        RegexOptions.CultureInvariant);
+
+    private static HashSet<string> ReadExistingApiTypeSlugs(string outputPath)
+    {
+        var indexPath = Path.Combine(outputPath, "index.json");
+        if (!File.Exists(indexPath))
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(indexPath));
+            if (!document.RootElement.TryGetProperty("types", out var types) ||
+                types.ValueKind != JsonValueKind.Array)
+            {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            return types
+                .EnumerateArray()
+                .Where(static type => type.ValueKind == JsonValueKind.Object)
+                .Select(static type =>
+                    type.TryGetProperty("slug", out var slug) && slug.ValueKind == JsonValueKind.String
+                        ? slug.GetString()
+                        : null)
+                .Where(static slug => IsSafeGeneratedApiTypeSlug(slug))
+                .Select(static slug => slug!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+        catch (JsonException)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+        catch (IOException)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private static void RemoveStaleApiTypeArtifacts(
+        string outputPath,
+        IReadOnlySet<string> previousTypeSlugs,
+        IReadOnlyList<ApiTypeModel> currentTypes)
+    {
+        if (previousTypeSlugs.Count == 0)
+            return;
+
+        var currentTypeSlugs = currentTypes
+            .Select(static type => type.Slug)
+            .Where(static slug => IsSafeGeneratedApiTypeSlug(slug))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var typesPath = Path.Combine(outputPath, "types");
+
+        foreach (var staleSlug in previousTypeSlugs.Where(slug => !currentTypeSlugs.Contains(slug)))
+        {
+            DeleteGeneratedApiFile(Path.Combine(typesPath, staleSlug + ".json"));
+            DeleteGeneratedApiFile(Path.Combine(typesPath, staleSlug + ".html"));
+            DeleteGeneratedApiFile(Path.Combine(outputPath, staleSlug + ".html"));
+
+            var routePath = Path.Combine(outputPath, staleSlug);
+            if (Directory.Exists(routePath))
+                Directory.Delete(routePath, recursive: true);
+        }
+    }
+
+    private static bool IsSafeGeneratedApiTypeSlug(string? slug) =>
+        !string.IsNullOrWhiteSpace(slug) &&
+        GeneratedApiTypeSlugRegex.IsMatch(slug);
+
+    private static void DeleteGeneratedApiFile(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+}

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
@@ -101,6 +101,7 @@ public static partial class WebApiDocsGenerator
             Returns = source.Returns,
             Value = source.Value,
             ValueSummary = source.ValueSummary,
+            DocumentationSignature = source.DocumentationSignature,
             Source = source.Source is null
                 ? null
                 : new ApiSourceLink { Path = source.Source.Path, Line = source.Source.Line, Url = source.Source.Url }
@@ -835,6 +836,7 @@ public static partial class WebApiDocsGenerator
         var parameterTypes = ParseParameterTypes(fullName);
         var parameterNames = TryResolveParameterNames(assembly, typeName, name, parameterTypes);
         var parameters = ParseParameters(member, parameterTypes, parameterNames, memberKey, memberLookup);
+        var conversionReturnType = ParseDocumentationConversionReturnType(fullName);
 
         var isCtor = IsConstructorName(name);
         var displayName = isCtor ? GetShortTypeName(typeName) : name;
@@ -846,7 +848,10 @@ public static partial class WebApiDocsGenerator
             Kind = isCtor ? "Constructor" : "Method",
             Parameters = parameters,
             Returns = GetElement(member, "returns", memberKey, memberLookup),
-            IsConstructor = isCtor
+            IsConstructor = isCtor,
+            DocumentationSignature = isCtor
+                ? null
+                : BuildDocumentationMethodSignature(name, parameterTypes, conversionReturnType)
         };
         model.TypeParameters.AddRange(GetTypeParameters(member, memberKey, memberLookup));
         model.Examples.AddRange(GetExamples(member, memberKey, memberLookup));

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
@@ -871,12 +871,14 @@ public static partial class WebApiDocsGenerator
         var name = ExtractMemberName(fullName);
         if (string.IsNullOrWhiteSpace(name)) return;
 
+        var parameterTypes = ParseParameterTypes(fullName);
         var model = new ApiMemberModel
         {
             Name = name,
             Summary = GetSummary(member, memberKey, memberLookup),
             Kind = "Property",
-            ValueSummary = GetElement(member, "value", memberKey, memberLookup)
+            ValueSummary = GetElement(member, "value", memberKey, memberLookup),
+            Parameters = ParseParameters(member, parameterTypes, null, memberKey, memberLookup)
         };
         model.Examples.AddRange(GetExamples(member, memberKey, memberLookup));
         model.Exceptions.AddRange(GetExceptions(member, memberKey, memberLookup));

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
@@ -395,7 +395,7 @@ public static partial class WebApiDocsGenerator
             name += "``" + method.GetGenericArguments().Length;
 
         var conversionReturnType =
-            method.Name is "op_Implicit" or "op_Explicit"
+            IsConversionOperator(method.Name)
                 ? GetDocumentationTypeName(method.ReturnType)
                 : null;
         return BuildDocumentationMethodSignature(
@@ -416,6 +416,12 @@ public static partial class WebApiDocsGenerator
             ? signature
             : signature + "~" + conversionReturnType;
     }
+
+    private static bool IsConversionOperator(string name) =>
+        name is "op_Implicit" or
+            "op_Explicit" or
+            "op_CheckedImplicit" or
+            "op_CheckedExplicit";
 
     private static string? ParseDocumentationConversionReturnType(string fullName)
     {

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
@@ -48,6 +48,7 @@ public static partial class WebApiDocsGenerator
                 {
                     Name = method.Name,
                     DisplayName = method.Name,
+                    DocumentationSignature = BuildDocumentationMethodSignature(method),
                     Parameters = method.GetParameters().Select(p => new ApiParameterModel
                     {
                         Name = p.Name ?? string.Empty,
@@ -302,19 +303,9 @@ public static partial class WebApiDocsGenerator
 
     private static ApiMemberModel? FindMethodModel(List<ApiMemberModel> members, MethodInfo method)
     {
-        var candidates = members
-            .Where(m => string.Equals(m.Name, method.Name, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        if (candidates.Count == 0) return null;
-
-        var parameters = method.GetParameters();
-        foreach (var candidate in candidates)
-        {
-            if (candidate.Parameters.Count != parameters.Length) continue;
-            if (ParamsMatch(candidate.Parameters, parameters)) return candidate;
-        }
-
-        return null;
+        var signature = BuildDocumentationMethodSignature(method);
+        return members.FirstOrDefault(candidate =>
+            string.Equals(candidate.DocumentationSignature, signature, StringComparison.Ordinal));
     }
 
     private static ApiMemberModel? FindConstructorModel(List<ApiMemberModel> members, ConstructorInfo ctor)
@@ -395,6 +386,49 @@ public static partial class WebApiDocsGenerator
         }
 
         return (type.FullName ?? type.Name).Replace('+', '.');
+    }
+
+    private static string BuildDocumentationMethodSignature(MethodInfo method)
+    {
+        var name = method.Name;
+        if (method.IsGenericMethod)
+            name += "``" + method.GetGenericArguments().Length;
+
+        var conversionReturnType =
+            method.Name is "op_Implicit" or "op_Explicit"
+                ? GetDocumentationTypeName(method.ReturnType)
+                : null;
+        return BuildDocumentationMethodSignature(
+            name,
+            method.GetParameters().Select(parameter => GetDocumentationTypeName(parameter.ParameterType)).ToArray(),
+            conversionReturnType);
+    }
+
+    private static string BuildDocumentationMethodSignature(
+        string name,
+        IReadOnlyList<string> parameterTypes,
+        string? conversionReturnType)
+    {
+        var signature = parameterTypes.Count == 0
+            ? name
+            : name + "(" + string.Join(",", parameterTypes) + ")";
+        return string.IsNullOrWhiteSpace(conversionReturnType)
+            ? signature
+            : signature + "~" + conversionReturnType;
+    }
+
+    private static string? ParseDocumentationConversionReturnType(string fullName)
+    {
+        var parametersEnd = fullName.LastIndexOf(')');
+        if (parametersEnd < 0 ||
+            parametersEnd + 1 >= fullName.Length ||
+            fullName[parametersEnd + 1] != '~')
+        {
+            return null;
+        }
+
+        var returnType = fullName.Substring(parametersEnd + 2).Trim();
+        return returnType.Length == 0 ? null : returnType;
     }
 
     private static string NormalizeTypeName(string? value)
@@ -508,6 +542,7 @@ public static partial class WebApiDocsGenerator
     private static void FillMethodMember(ApiMemberModel member, MethodInfo method, Type declaring)
     {
         member.Kind = "Method";
+        member.DocumentationSignature = BuildDocumentationMethodSignature(method);
         member.ReturnType = GetReadableTypeName(method.ReturnType);
         member.Signature = BuildMethodSignature(method);
         member.IsStatic = method.IsStatic;

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
@@ -199,7 +199,7 @@ public static partial class WebApiDocsGenerator
 
             foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
             {
-                var member = FindNamedMember(model.Properties, property.Name);
+                var member = FindPropertyModel(model.Properties, property);
                 if (member is null)
                 {
                     member = new ApiMemberModel
@@ -314,7 +314,7 @@ public static partial class WebApiDocsGenerator
             if (ParamsMatch(candidate.Parameters, parameters)) return candidate;
         }
 
-        return candidates.FirstOrDefault(c => c.Parameters.Count == parameters.Length) ?? candidates.First();
+        return null;
     }
 
     private static ApiMemberModel? FindConstructorModel(List<ApiMemberModel> members, ConstructorInfo ctor)
@@ -331,7 +331,25 @@ public static partial class WebApiDocsGenerator
             if (ParamsMatch(candidate.Parameters, parameters)) return candidate;
         }
 
-        return candidates.FirstOrDefault(c => c.Parameters.Count == parameters.Length) ?? candidates.First();
+        return null;
+    }
+
+    private static ApiMemberModel? FindPropertyModel(List<ApiMemberModel> members, PropertyInfo property)
+    {
+        var candidates = members
+            .Where(member => string.Equals(member.Name, property.Name, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (candidates.Count == 0)
+            return null;
+
+        var parameters = property.GetIndexParameters();
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Parameters.Count != parameters.Length) continue;
+            if (ParamsMatch(candidate.Parameters, parameters)) return candidate;
+        }
+
+        return null;
     }
 
     private static bool ParamsMatch(List<ApiParameterModel> parameters, ParameterInfo[] infos)
@@ -340,11 +358,43 @@ public static partial class WebApiDocsGenerator
         for (var i = 0; i < parameters.Count; i++)
         {
             var left = NormalizeTypeName(parameters[i].Type);
-            var right = NormalizeTypeName(GetReadableTypeName(infos[i].ParameterType));
+            var right = NormalizeTypeName(GetDocumentationTypeName(infos[i].ParameterType));
             if (!string.Equals(left, right, StringComparison.OrdinalIgnoreCase))
                 return false;
         }
         return true;
+    }
+
+    private static string GetDocumentationTypeName(Type type)
+    {
+        if (type.IsByRef)
+            return GetDocumentationTypeName(type.GetElementType() ?? type) + "@";
+        if (type.IsPointer)
+            return GetDocumentationTypeName(type.GetElementType() ?? type) + "*";
+        if (type.IsArray)
+        {
+            var elementType = GetDocumentationTypeName(type.GetElementType() ?? typeof(object));
+            if (type.GetArrayRank() == 1)
+                return elementType + "[]";
+
+            return elementType + "[" + string.Join(",", Enumerable.Repeat("0:", type.GetArrayRank())) + "]";
+        }
+        if (type.IsGenericParameter)
+        {
+            var prefix = type.DeclaringMethod is null ? "`" : "``";
+            return prefix + type.GenericParameterPosition;
+        }
+        if (type.IsGenericType)
+        {
+            var definition = type.GetGenericTypeDefinition();
+            var definitionName = GenericArityRegex
+                .Replace(definition.FullName ?? definition.Name, string.Empty)
+                .Replace('+', '.');
+            var arguments = type.GetGenericArguments().Select(GetDocumentationTypeName);
+            return definitionName + "{" + string.Join(",", arguments) + "}";
+        }
+
+        return (type.FullName ?? type.Name).Replace('+', '.');
     }
 
     private static string NormalizeTypeName(string? value)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
@@ -43,7 +43,7 @@ public static partial class WebApiDocsGenerator
 
             foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
             {
-                if (method.IsSpecialName) continue;
+                if (!ShouldIncludeReflectedMethod(method)) continue;
                 model.Methods.Add(new ApiMemberModel
                 {
                     Name = method.Name,
@@ -140,7 +140,7 @@ public static partial class WebApiDocsGenerator
 
             foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
             {
-                if (method.IsSpecialName) continue;
+                if (!ShouldIncludeReflectedMethod(method)) continue;
                 var member = FindMethodModel(model.Methods, method);
                 if (member is null)
                 {
@@ -266,6 +266,34 @@ public static partial class WebApiDocsGenerator
             }
         }
     }
+
+    private static void RestrictToPublicAssemblySurface(ApiDocModel doc, Assembly assembly)
+    {
+        var exportedTypes = GetExportedTypesSafe(assembly)
+            .Where(static type => type is not null)
+            .Select(static type => (type!.FullName ?? type.Name).Replace('+', '.'))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var typeName in doc.Types.Keys.Where(typeName => !exportedTypes.Contains(typeName)).ToArray())
+            doc.Types.Remove(typeName);
+
+        foreach (var type in doc.Types.Values)
+        {
+            type.Methods.RemoveAll(static member => !IsPublicAssemblyMember(member));
+            type.Constructors.RemoveAll(static member => !IsPublicAssemblyMember(member));
+            type.Properties.RemoveAll(static member => !IsPublicAssemblyMember(member));
+            type.Fields.RemoveAll(static member => !IsPublicAssemblyMember(member));
+            type.Events.RemoveAll(static member => !IsPublicAssemblyMember(member));
+            type.ExtensionMethods.RemoveAll(static member => !IsPublicAssemblyMember(member));
+        }
+    }
+
+    private static bool IsPublicAssemblyMember(ApiMemberModel member) =>
+        string.Equals(member.Access, "public", StringComparison.Ordinal);
+
+    private static bool ShouldIncludeReflectedMethod(MethodInfo method) =>
+        !method.IsSpecialName ||
+        method.Name.StartsWith("op_", StringComparison.Ordinal);
 
     private static ApiMemberModel? FindNamedMember(List<ApiMemberModel> members, string name)
     {

--- a/PowerForge.Web/Services/WebApiDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.cs
@@ -397,6 +397,7 @@ public static partial class WebApiDocsGenerator
             : string.Empty;
         var outputPath = Path.GetFullPath(options.OutputPath);
         Directory.CreateDirectory(outputPath);
+        var previousTypeSlugs = ReadExistingApiTypeSlugs(outputPath);
 
         var warnings = new List<string>();
         if (options.Type == ApiDocsType.CSharp && !File.Exists(xmlPath))
@@ -405,13 +406,18 @@ public static partial class WebApiDocsGenerator
             warnings.Add($"PowerShell help not found: {helpPath}");
 
         Assembly? assembly = null;
-        if (options.Type == ApiDocsType.CSharp && !string.IsNullOrWhiteSpace(options.AssemblyPath) && File.Exists(options.AssemblyPath))
+        if (options.Type == ApiDocsType.CSharp && !string.IsNullOrWhiteSpace(options.AssemblyPath))
         {
-            assembly = TryLoadAssembly(Path.GetFullPath(options.AssemblyPath), warnings);
-        }
-        else if (options.Type == ApiDocsType.CSharp && !string.IsNullOrWhiteSpace(options.AssemblyPath))
-        {
-            warnings.Add($"Assembly not found: {options.AssemblyPath}");
+            var requestedAssemblyPath = Path.GetFullPath(options.AssemblyPath);
+            if (!File.Exists(requestedAssemblyPath))
+                throw new FileNotFoundException(
+                    $"Configured API documentation assembly was not found: {requestedAssemblyPath}",
+                    requestedAssemblyPath);
+
+            assembly = TryLoadAssembly(requestedAssemblyPath, warnings);
+            if (assembly is null)
+                throw new InvalidOperationException(
+                    $"Configured API documentation assembly could not be inspected: {requestedAssemblyPath}");
         }
 
         var apiDoc = options.Type == ApiDocsType.PowerShell
@@ -460,6 +466,7 @@ public static partial class WebApiDocsGenerator
             .Where(t => ShouldIncludeType(t, options))
             .OrderBy(t => t.FullName, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        RemoveStaleApiTypeArtifacts(outputPath, previousTypeSlugs, types);
         var typeDisplayNames = BuildTypeDisplayNameMap(types, options, warnings);
         var typeAliasMap = BuildTypeAliasMap(types, typeDisplayNames);
         var typeUsageMap = BuildTypeUsageMap(types);

--- a/PowerForge.Web/Services/WebApiDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.cs
@@ -434,6 +434,7 @@ public static partial class WebApiDocsGenerator
         if (options.Type == ApiDocsType.CSharp && assembly is not null)
         {
             EnrichFromAssembly(apiDoc, assembly, options, warnings);
+            RestrictToPublicAssemblySurface(apiDoc, assembly);
         }
         var assemblyName = apiDoc.AssemblyName;
         var assemblyVersion = apiDoc.AssemblyVersion;


### PR DESCRIPTION
## Summary

- constrain assembly-backed C# API documentation to exported types and public members
- match overloads, indexers, generic methods, and conversion operators by their complete XML documentation identity
- remove stale generated type routes during incremental regeneration and fail closed when an explicitly configured assembly cannot be inspected
- cover visibility boundaries and regeneration behavior with focused contract tests

## Why it matters

XML documentation can contain entries for non-public implementation details. Assembly-backed generation now treats the compiled public surface as authoritative, preventing internal APIs from appearing as supported documentation while retaining legitimate overloads and operators.

## Compatibility

XML-only generation remains available when no assembly is configured. When an assembly path is explicitly configured, a missing or uninspectable assembly is now an error instead of silently publishing an unverified surface.