### PR TITLE
Render overloaded API indexers distinctly

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorMemberSignatureWarningsTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorMemberSignatureWarningsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.Json;
 using PowerForge.Web;
 using Xunit;
 
@@ -90,6 +91,169 @@ public class WebApiDocsGeneratorMemberSignatureWarningsTests
         {
             var result = WebApiDocsGenerator.Generate(options);
             Assert.DoesNotContain(result.Warnings, warning => warning.Contains("[PFWEB.APIDOCS.MEMBER.SIGNATURES]", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_RendersOverloadedIndexerParametersAsDistinctSignatures()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-indexer-signatures-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        var xmlPath = Path.Combine(root, "test.xml");
+        File.WriteAllText(xmlPath,
+            """
+            <doc>
+              <assembly><name>PowerForge.Tests</name></assembly>
+              <members>
+                <member name="T:WebApiDocsOverloadedIndexerFixture">
+                  <summary>Sample type.</summary>
+                </member>
+                <member name="P:WebApiDocsOverloadedIndexerFixture.Item(System.String)">
+                  <summary>String indexer.</summary>
+                  <param name="key">String key.</param>
+                </member>
+                <member name="P:WebApiDocsOverloadedIndexerFixture.Item(System.Int32)">
+                  <summary>Integer indexer.</summary>
+                  <param name="index">Integer index.</param>
+                </member>
+              </members>
+            </doc>
+            """);
+
+        try
+        {
+            var xmlOnlyOutputPath = Path.Combine(root, "xml-only-api");
+            var xmlOnlyResult = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                XmlPath = xmlPath,
+                OutputPath = xmlOnlyOutputPath,
+                Format = "both",
+                BaseUrl = "/api"
+            });
+            Assert.DoesNotContain(xmlOnlyResult.Warnings, warning => warning.Contains("[PFWEB.APIDOCS.MEMBER.SIGNATURES]", StringComparison.OrdinalIgnoreCase));
+            AssertIndexerProperties(
+                xmlOnlyOutputPath,
+                "WebApiDocsOverloadedIndexerFixture",
+                "this[System.String key]",
+                "System.String",
+                "this[System.Int32 index]",
+                "System.Int32");
+            var xmlOnlyHtml = string.Join(
+                Environment.NewLine,
+                Directory.GetFiles(xmlOnlyOutputPath, "*.html", SearchOption.AllDirectories)
+                    .Select(File.ReadAllText));
+            Assert.Contains("this[System.String key]", xmlOnlyHtml, StringComparison.Ordinal);
+            Assert.Contains("this[System.Int32 index]", xmlOnlyHtml, StringComparison.Ordinal);
+
+            var reflectedOutputPath = Path.Combine(root, "reflected-api");
+            var reflectedResult = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                XmlPath = xmlPath,
+                AssemblyPath = typeof(WebApiDocsOverloadedIndexerFixture).Assembly.Location,
+                OutputPath = reflectedOutputPath,
+                Format = "json",
+                BaseUrl = "/api",
+                IncludeUndocumentedTypes = false
+            });
+            Assert.DoesNotContain(reflectedResult.Warnings, warning => warning.Contains("[PFWEB.APIDOCS.MEMBER.SIGNATURES]", StringComparison.OrdinalIgnoreCase));
+            AssertIndexerProperties(
+                reflectedOutputPath,
+                "WebApiDocsOverloadedIndexerFixture",
+                "this[String key]",
+                "System.String",
+                "this[Int32 index]",
+                "System.Int32");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_PreservesIndexerOverloadsWithSimilarNormalizedTypeNames()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-case-indexers-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var xmlPath = Path.Combine(root, "fixture.xml");
+        File.WriteAllText(
+            xmlPath,
+            """
+            <?xml version="1.0"?>
+            <doc>
+              <assembly><name>PowerForge.Tests</name></assembly>
+              <members>
+                <member name="T:WebApiDocsNormalizedTypeIndexerFixture">
+                  <summary>Normalized-type indexer fixture.</summary>
+                </member>
+                <member name="P:WebApiDocsNormalizedTypeIndexerFixture.Item(IndexerKey)">
+                  <summary>Gets the global key value.</summary>
+                  <param name="value">The global key.</param>
+                </member>
+                <member name="P:WebApiDocsNormalizedTypeIndexerFixture.Item(System.IndexerKey)">
+                  <summary>Gets the System key value.</summary>
+                  <param name="value">The System key.</param>
+                </member>
+              </members>
+            </doc>
+            """);
+
+        try
+        {
+            var outputPath = Path.Combine(root, "api");
+            WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                XmlPath = xmlPath,
+                AssemblyPath = typeof(WebApiDocsNormalizedTypeIndexerFixture).Assembly.Location,
+                OutputPath = outputPath,
+                Format = "json",
+                BaseUrl = "/api",
+                IncludeUndocumentedTypes = false
+            });
+
+            var properties = ReadProperties(outputPath, "WebApiDocsNormalizedTypeIndexerFixture");
+            Assert.Equal(2, properties.Length);
+            Assert.Contains(properties, property =>
+                property.GetProperty("summary").GetString() == "Gets the global key value." &&
+                property.GetProperty("parameters")[0].GetProperty("type").GetString() == "IndexerKey");
+            Assert.Contains(properties, property =>
+                property.GetProperty("summary").GetString() == "Gets the System key value." &&
+                property.GetProperty("parameters")[0].GetProperty("type").GetString() == "System.IndexerKey");
+
+            var fallbackXmlPath = Path.Combine(root, "undocumented.xml");
+            File.WriteAllText(
+                fallbackXmlPath,
+                """
+                <?xml version="1.0"?>
+                <doc>
+                  <assembly><name>PowerForge.Tests</name></assembly>
+                  <members />
+                </doc>
+                """);
+            var fallbackOutputPath = Path.Combine(root, "reflection-fallback-api");
+            WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                XmlPath = fallbackXmlPath,
+                AssemblyPath = typeof(WebApiDocsNormalizedTypeIndexerFixture).Assembly.Location,
+                OutputPath = fallbackOutputPath,
+                Format = "json",
+                BaseUrl = "/api",
+                IncludeUndocumentedTypes = true
+            });
+
+            var fallbackProperties = ReadProperties(
+                fallbackOutputPath,
+                "WebApiDocsNormalizedTypeIndexerFixture");
+            Assert.Equal(2, fallbackProperties.Length);
+            Assert.All(fallbackProperties, property =>
+                Assert.Equal("public", property.GetProperty("access").GetString()));
         }
         finally
         {
@@ -194,6 +358,38 @@ public class WebApiDocsGeneratorMemberSignatureWarningsTests
     private static string CreatePowerShellDuplicateSyntaxHelpXml(bool includeExplicitParameterSetNames)
         => CreatePowerShellDuplicateSyntaxHelpXml(includeExplicitParameterSetNames, duplicateExplicitParameterSetName: false);
 
+    private static void AssertIndexerProperties(
+        string outputPath,
+        string fullName,
+        string firstSignature,
+        string firstParameterType,
+        string secondSignature,
+        string secondParameterType)
+    {
+        var properties = ReadProperties(outputPath, fullName);
+
+        Assert.Equal(2, properties.Length);
+        Assert.Contains(properties, property =>
+            property.GetProperty("signature").GetString()!.Contains(firstSignature, StringComparison.Ordinal) &&
+            property.GetProperty("parameters")[0].GetProperty("type").GetString() == firstParameterType);
+        Assert.Contains(properties, property =>
+            property.GetProperty("signature").GetString()!.Contains(secondSignature, StringComparison.Ordinal) &&
+            property.GetProperty("parameters")[0].GetProperty("type").GetString() == secondParameterType);
+    }
+
+    private static JsonElement[] ReadProperties(string outputPath, string fullName)
+    {
+        var typePath = Directory.GetFiles(Path.Combine(outputPath, "types"), "*.json", SearchOption.TopDirectoryOnly)
+            .Single(path => File.ReadAllText(path).Contains(
+                $"\"fullName\": \"{fullName}\"",
+                StringComparison.Ordinal));
+        using var typeDocument = JsonDocument.Parse(File.ReadAllText(typePath));
+        return typeDocument.RootElement.GetProperty("properties")
+            .EnumerateArray()
+            .Select(static property => property.Clone())
+            .ToArray();
+    }
+
     private static string CreatePowerShellDuplicateSyntaxHelpXml(bool includeExplicitParameterSetNames, bool duplicateExplicitParameterSetName)
     {
         var firstSetAttribute = includeExplicitParameterSetNames ? " parameterSetName=\"Document\"" : string.Empty;
@@ -241,5 +437,30 @@ public class WebApiDocsGeneratorMemberSignatureWarningsTests
               </command:command>
             </helpItems>
             """;
+    }
+}
+
+public sealed class WebApiDocsOverloadedIndexerFixture
+{
+    public string this[string key] => key;
+
+    public string this[int index] => index.ToString();
+}
+
+public sealed class IndexerKey
+{
+}
+
+public sealed class WebApiDocsNormalizedTypeIndexerFixture
+{
+    public string this[IndexerKey value] => value.GetType().Name;
+
+    public string this[System.IndexerKey value] => value.GetType().Name;
+}
+
+namespace System
+{
+    public sealed class IndexerKey
+    {
     }
 }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Html.TypeDetail.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Html.TypeDetail.cs
@@ -1273,6 +1273,11 @@ public static partial class WebApiDocsGenerator
         {
             return BuildPowerShellSyntaxSignature(displayName, member.Parameters, member.IncludesCommonParameters);
         }
+        if (section == "Properties" && args.Count > 0)
+        {
+            var returnType = string.IsNullOrWhiteSpace(member.ReturnType) ? string.Empty : $"{member.ReturnType} ";
+            return $"{prefix}{returnType}this[{string.Join(", ", args)}]".Trim();
+        }
 
         if (!string.IsNullOrWhiteSpace(member.ReturnType))
         {

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.Attributes.cs
@@ -217,7 +217,11 @@ public static partial class WebApiDocsGenerator
         if (property.GetMethod is not null) accessors.Add("get;");
         if (property.SetMethod is not null) accessors.Add("set;");
         var prefix = BuildPropertyPrefix(property);
-        return $"{prefix}{GetReadableTypeName(property.PropertyType)} {property.Name} {{ {string.Join(" ", accessors)} }}".Trim();
+        var parameters = property.GetIndexParameters();
+        var displayName = parameters.Length == 0
+            ? property.Name
+            : $"this[{string.Join(", ", parameters.Select(BuildParameterSignature))}]";
+        return $"{prefix}{GetReadableTypeName(property.PropertyType)} {displayName} {{ {string.Join(" ", accessors)} }}".Trim();
     }
 
     private static string BuildFieldSignature(FieldInfo field)
@@ -882,6 +886,10 @@ public static partial class WebApiDocsGenerator
             Name = name,
             Summary = GetSummary(member, memberKey, memberLookup),
             Kind = "Property",
+            DocumentationSignature = BuildDocumentationMethodSignature(
+                name,
+                parameterTypes,
+                conversionReturnType: null),
             ValueSummary = GetElement(member, "value", memberKey, memberLookup),
             Parameters = ParseParameters(member, parameterTypes, null, memberKey, memberLookup)
         };

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Reflection.cs
@@ -78,7 +78,11 @@ public static partial class WebApiDocsGenerator
                 model.Properties.Add(new ApiMemberModel
                 {
                     Name = property.Name,
-                    DisplayName = property.Name
+                    DisplayName = property.Name,
+                    DocumentationSignature = BuildDocumentationPropertySignature(property),
+                    Parameters = property.GetIndexParameters()
+                        .Select(BuildParameterModel)
+                        .ToList()
                 });
             }
 
@@ -327,20 +331,9 @@ public static partial class WebApiDocsGenerator
 
     private static ApiMemberModel? FindPropertyModel(List<ApiMemberModel> members, PropertyInfo property)
     {
-        var candidates = members
-            .Where(member => string.Equals(member.Name, property.Name, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        if (candidates.Count == 0)
-            return null;
-
-        var parameters = property.GetIndexParameters();
-        foreach (var candidate in candidates)
-        {
-            if (candidate.Parameters.Count != parameters.Length) continue;
-            if (ParamsMatch(candidate.Parameters, parameters)) return candidate;
-        }
-
-        return null;
+        var signature = BuildDocumentationPropertySignature(property);
+        return members.FirstOrDefault(candidate =>
+            string.Equals(candidate.DocumentationSignature, signature, StringComparison.Ordinal));
     }
 
     private static bool ParamsMatch(List<ApiParameterModel> parameters, ParameterInfo[] infos)
@@ -402,6 +395,16 @@ public static partial class WebApiDocsGenerator
             name,
             method.GetParameters().Select(parameter => GetDocumentationTypeName(parameter.ParameterType)).ToArray(),
             conversionReturnType);
+    }
+
+    private static string BuildDocumentationPropertySignature(PropertyInfo property)
+    {
+        return BuildDocumentationMethodSignature(
+            property.Name,
+            property.GetIndexParameters()
+                .Select(parameter => GetDocumentationTypeName(parameter.ParameterType))
+                .ToArray(),
+            conversionReturnType: null);
     }
 
     private static string BuildDocumentationMethodSignature(
@@ -608,6 +611,7 @@ public static partial class WebApiDocsGenerator
     private static void FillPropertyMember(ApiMemberModel member, PropertyInfo property, Type declaring)
     {
         member.Kind = "Property";
+        member.DocumentationSignature = BuildDocumentationPropertySignature(property);
         member.ReturnType = GetReadableTypeName(property.PropertyType);
         member.Signature = BuildPropertySignature(property);
         member.IsStatic = (property.GetMethod ?? property.SetMethod)?.IsStatic == true;
@@ -620,6 +624,20 @@ public static partial class WebApiDocsGenerator
         member.Modifiers.AddRange(GetPropertyModifiers(property));
         if (string.IsNullOrWhiteSpace(member.DisplayName))
             member.DisplayName = property.Name;
+
+        var parameters = property.GetIndexParameters();
+        if (member.Parameters.Count == 0)
+        {
+            member.Parameters = parameters.Select(BuildParameterModel).ToList();
+        }
+        else
+        {
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (i >= member.Parameters.Count) break;
+                ApplyParameterMetadata(member.Parameters[i], parameters[i]);
+            }
+        }
     }
 
     private static void FillFieldMember(ApiMemberModel member, FieldInfo field, Type declaring)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.cs
@@ -682,7 +682,9 @@ public static partial class WebApiDocsGenerator
                     ["displayName"] = p.DisplayName,
                     ["summary"] = p.Summary,
                     ["kind"] = p.Kind,
-                    ["signature"] = p.Signature,
+                    ["signature"] = string.IsNullOrWhiteSpace(p.Signature)
+                        ? BuildSignature(p, "Properties")
+                        : p.Signature,
                     ["returnType"] = p.ReturnType,
                     ["declaringType"] = p.DeclaringType,
                     ["source"] = BuildSourceJson(p.Source),
@@ -700,7 +702,19 @@ public static partial class WebApiDocsGenerator
                         ["type"] = ex.Type,
                         ["summary"] = ex.Summary
                     }).ToList(),
-                    ["seeAlso"] = p.SeeAlso
+                    ["seeAlso"] = p.SeeAlso,
+                    ["parameters"] = p.Parameters.Select(parameter => new Dictionary<string, object?>
+                    {
+                        ["name"] = parameter.Name,
+                        ["type"] = parameter.Type,
+                        ["summary"] = parameter.Summary,
+                        ["aliases"] = parameter.Aliases,
+                        ["possibleValues"] = parameter.PossibleValues,
+                        ["isOptional"] = parameter.IsOptional,
+                        ["defaultValue"] = parameter.DefaultValue,
+                        ["position"] = parameter.Position,
+                        ["pipelineInput"] = parameter.PipelineInput
+                    }).ToList()
                 }).ToList(),
                 ["fields"] = type.Fields.Select(f => new Dictionary<string, object?>
                 {


### PR DESCRIPTION
## Summary

- preserve exact XML documentation signatures for properties and reflection-fallback indexers
- render overloaded indexers as `this[...]` in XML-only HTML and JSON output
- serialize indexer parameters and enrich them without collapsing similar CLR type names
- add contract tests for XML-only, assembly-enriched, and undocumented reflection-fallback paths

## Why this matters

OfficeIMO 3.0 exposes overloaded CSV indexers. The website API-doc gate previously rendered those overloads as identical properties, causing strict duplicate-signature validation to fail. The generator now preserves and displays the real indexer contract in every supported input mode.

## Validation

- focused indexer/API signature tests: 7 passed
- broader WebApiDocsGenerator suite: 113 passed; the two remaining environment-sensitive failures reproduce unchanged on `main`
- full OfficeIMO CI website pipeline: all 36 stages passed, including eight API-doc sets, xref merge, strict verification, SEO, and audit
- independent local review of exact pushed SHA: no findings