### PR TITLE
Preserve shared runtime dependencies in module packages

### DIFF
--- a/PowerForge.Tests/ModuleBuilderDependencyCopyTests.cs
+++ b/PowerForge.Tests/ModuleBuilderDependencyCopyTests.cs
@@ -279,6 +279,121 @@ public sealed class ModuleBuilderDependencyCopyTests
     }
 
     [Fact]
+    public void CopyPublishOutputBinaries_PreservesDependencySharedWithExcludedPowerShellClosure()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var publishDir = Path.Combine(root, "publish");
+        var targetDir = Path.Combine(root, "target");
+
+        Directory.CreateDirectory(publishDir);
+        Directory.CreateDirectory(targetDir);
+
+        try
+        {
+            foreach (var fileName in new[]
+            {
+                "TestModule.dll",
+                "ADPlayground.dll",
+                "System.ServiceModel.NetTcp.dll",
+                "System.ServiceModel.Primitives.dll",
+                "System.Private.ServiceModel.dll"
+            })
+            {
+                File.WriteAllText(Path.Combine(publishDir, fileName), fileName);
+            }
+
+            var depsPath = Path.Combine(publishDir, "TestModule.deps.json");
+            File.WriteAllText(depsPath, """
+                                        {
+                                          "targets": {
+                                            ".NETCoreApp,Version=v8.0": {
+                                              "TestModule/1.0.0": {
+                                                "dependencies": {
+                                                  "ADPlayground": "1.0.0",
+                                                  "Microsoft.PowerShell.SDK": "7.4.6"
+                                                },
+                                                "runtime": {
+                                                  "TestModule.dll": {}
+                                                }
+                                              },
+                                              "ADPlayground/1.0.0": {
+                                                "dependencies": {
+                                                  "System.ServiceModel.NetTcp": "4.10.3"
+                                                },
+                                                "runtime": {
+                                                  "ADPlayground.dll": {}
+                                                }
+                                              },
+                                              "Microsoft.PowerShell.SDK/7.4.6": {
+                                                "dependencies": {
+                                                  "System.Private.ServiceModel": "4.10.3",
+                                                  "System.ServiceModel.NetTcp": "4.10.3",
+                                                  "System.ServiceModel.Primitives": "4.10.3"
+                                                }
+                                              },
+                                              "System.ServiceModel.NetTcp/4.10.3": {
+                                                "dependencies": {
+                                                  "System.Private.ServiceModel": "4.10.3",
+                                                  "System.ServiceModel.Primitives": "4.10.3"
+                                                },
+                                                "runtime": {
+                                                  "lib/net6.0/System.ServiceModel.NetTcp.dll": {}
+                                                }
+                                              },
+                                              "System.ServiceModel.Primitives/4.10.3": {
+                                                "dependencies": {
+                                                  "System.Private.ServiceModel": "4.10.3"
+                                                },
+                                                "runtime": {
+                                                  "lib/net6.0/System.ServiceModel.Primitives.dll": {}
+                                                }
+                                              },
+                                              "System.Private.ServiceModel/4.10.3": {
+                                                "runtime": {
+                                                  "lib/netstandard2.0/System.Private.ServiceModel.dll": {}
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                        """);
+
+            var builder = ModuleBuilderTestDependencies.Create();
+            var copyMethod = typeof(ModuleBuilder).GetMethod(
+                "CopyPublishOutputBinaries",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(copyMethod);
+
+            copyMethod!.Invoke(builder, new object[]
+            {
+                publishDir,
+                targetDir,
+                "net8.0",
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                null!
+            });
+
+            Assert.True(File.Exists(Path.Combine(targetDir, "TestModule.dll")));
+            Assert.True(File.Exists(Path.Combine(targetDir, "ADPlayground.dll")));
+            Assert.True(File.Exists(Path.Combine(targetDir, "System.ServiceModel.NetTcp.dll")));
+            Assert.True(File.Exists(Path.Combine(targetDir, "System.ServiceModel.Primitives.dll")));
+            Assert.True(File.Exists(Path.Combine(targetDir, "System.Private.ServiceModel.dll")));
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+    }
+
+    [Fact]
     public void BuildInPlace_WarnsWhenUsingExistingLibPayloadWithoutCsproj()
     {
         var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -1046,7 +1046,7 @@ public sealed class ModuleBuilder
             if (!root.TryGetProperty("targets", out var targets) || targets.ValueKind != JsonValueKind.Object)
                 return plan;
 
-            var appAssemblyName = Path.GetFileNameWithoutExtension(depsPath);
+            var appAssemblyName = GetDepsApplicationAssemblyName(depsPath);
             var excluded = ComputeExcludedLibraries(targets, appAssemblyName, options.ExcludeLibraryFilters);
 
             foreach (var target in targets.EnumerateObject())
@@ -1081,6 +1081,15 @@ public sealed class ModuleBuilder
             _logger.Warn($"Failed to parse deps.json for {tfm} ({depsPath}): {ex.Message}. Falling back to copying top-level binaries.");
             return null;
         }
+    }
+
+    private static string GetDepsApplicationAssemblyName(string depsPath)
+    {
+        var fileName = Path.GetFileName(depsPath);
+        const string suffix = ".deps.json";
+        return fileName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            ? fileName.Substring(0, fileName.Length - suffix.Length)
+            : Path.GetFileNameWithoutExtension(fileName);
     }
 
     private static bool IsPowerShellRuntimeLibraryId(string id)

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -1034,6 +1034,7 @@ public sealed class ModuleBuilder
         }
         catch { /* ignore */ }
 
+        if (depsPath is null) return null;
         if (string.IsNullOrWhiteSpace(depsPath) || !File.Exists(depsPath)) return null;
 
         try


### PR DESCRIPTION
## Summary

- identify application roots by stripping the complete `.deps.json` suffix
- preserve runtime dependencies that are reachable from the application graph even when they also appear in the excluded PowerShell runtime closure
- add a regression test covering the shared `System.Private.ServiceModel` dependency path

## Why this matters

PowerForge could derive `TestModule.deps` instead of `TestModule` from `TestModule.deps.json`. That prevented the application root from being found and could remove a runtime dependency needed by the packaged module. The fix remains generic in PowerForge and requires no consumer-specific workaround.

## Validation

- dependency-copy test suite passes (8/8)
- a real TestimoX module package that previously failed preflight now builds successfully and imports in PowerShell 7 and Windows PowerShell 5.1
- independent local packaging review found no actionable issues

The broader PowerForge test project passed 4,931 of 4,932 tests locally; the remaining Apple release test requires App Store Connect credentials and is unrelated to this change.