### PR TITLE
Fix module self-build path resolution in Windows PowerShell

### DIFF
--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -4,7 +4,7 @@
 
 [CmdletBinding()] param(
     [switch] $JsonOnly,
-    [string] $JsonPath = (Join-Path $PSScriptRoot '../../powerforge.json'),
+    [string] $JsonPath,
     [ValidateSet('Release', 'Debug')][string] $Configuration = 'Release',
     [ValidateSet('auto', 'net10.0', 'net8.0')][string] $Framework = 'auto',
     [switch] $NoDotnetBuild,
@@ -30,6 +30,13 @@
     [ValidateSet('Warning', 'Error')]
     [string] $FailOnDiagnosticsSeverity
 )
+
+if ([string]::IsNullOrWhiteSpace($JsonPath)) {
+    # Windows PowerShell 5.1 does not populate $PSScriptRoot while parameter
+    # default expressions are evaluated. Resolve script-relative defaults only
+    # after binding so hosted release builds work in both Windows PowerShell and pwsh.
+    $JsonPath = Join-Path $PSScriptRoot '../../powerforge.json'
+}
 
 if ($RunMode -eq 'Publish' -and -not $JsonOnly -and -not $PowerForgeReleaseStage) {
     $releaseEntryPoint = Join-Path $PSScriptRoot '../../Build/Build-Module.ps1'

--- a/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
+++ b/PowerForge.Tests/PSPublishModuleManifestContractTests.cs
@@ -1,3 +1,4 @@
+using System.Management.Automation.Language;
 using System.Text.RegularExpressions;
 using PowerForge;
 
@@ -130,6 +131,22 @@ public sealed class PSPublishModuleManifestContractTests
         Assert.Contains("function Resolve-ImportFramework", buildScript, StringComparison.Ordinal);
         Assert.Contains("$tfm = Resolve-ImportFramework -RequestedFramework $Framework", buildScript, StringComparison.Ordinal);
         Assert.Contains("\"PSPublishModule/bin/{0}/{1}/PSPublishModule.dll\" -f $Configuration, $tfm", buildScript, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_recipe_resolves_script_relative_defaults_after_parameter_binding()
+    {
+        var repoRoot = RepoRootLocator.Find();
+        var buildScriptPath = Path.Combine(repoRoot, "Module", "Build", "Build-Module.ps1");
+        var buildScript = File.ReadAllText(buildScriptPath);
+        var scriptAst = Parser.ParseFile(buildScriptPath, out _, out ParseError[] parseErrors);
+
+        Assert.Empty(parseErrors);
+
+        var jsonPathParameter = Assert.Single(scriptAst.ParamBlock!.Parameters, parameter =>
+            string.Equals(parameter.Name.VariablePath.UserPath, "JsonPath", StringComparison.OrdinalIgnoreCase));
+        Assert.Null(jsonPathParameter.DefaultValue);
+        Assert.Contains("$JsonPath = Join-Path $PSScriptRoot '../../powerforge.json'", buildScript, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- resolve the default `powerforge.json` path after parameter binding so Windows PowerShell 5.1-hosted module stages receive a populated `$PSScriptRoot`
- preserve explicit `-JsonPath` values while keeping the existing script-relative default
- add an AST-based regression test that prevents script-relative defaults from returning to the parameter block

## Validation

- completed `Module\Build\Build-Module.ps1` in Build mode with exit code 0, including package provenance checks, module validation, signing, packing, and PowerShell 7/Windows PowerShell installation
- passed 19 focused manifest and hosted-build contract tests