### PR TITLE
Use a compatible PowerShell host for module releases

### DIFF
--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -115,12 +115,42 @@ public sealed class ModuleBuildHostServiceTests
         });
 
         Assert.NotNull(captured);
-        Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('Framework')", captured!.CommandText!, StringComparison.Ordinal);
+        Assert.True(captured!.PreferPwsh);
+        Assert.Equal(10, captured.RequiredRuntimeMajor);
+        Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('Framework')", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptArguments['Framework'] = 'net10.0'", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('RunMode')", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptArguments['RunMode'] = 'Publish'", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptCommand.Parameters.ContainsKey('PowerForgeReleaseStage')", captured.CommandText!, StringComparison.Ordinal);
         Assert.Contains("$buildScriptArguments['PowerForgeReleaseStage'] = $true", captured.CommandText!, StringComparison.Ordinal);
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData("net472", false, 0)]
+    [InlineData("netcoreapp3.1", true, 3)]
+    [InlineData("net8.0", true, 8)]
+    [InlineData("net10.0-windows", true, 10)]
+    [InlineData("auto", true, 8)]
+    public async Task ExecuteBuildAsync_SelectsHostCompatibleWithTargetFramework(string framework, bool modernDotNet, int requiredRuntimeMajor)
+    {
+        PowerShellRunRequest? captured = null;
+        var runner = new StubPowerShellRunner(request => {
+            captured = request;
+            return new PowerShellRunResult(0, "ok", string.Empty, "pwsh");
+        });
+        var service = new ModuleBuildHostService(runner);
+
+        var result = await service.ExecuteBuildAsync(new ModuleBuildHostBuildRequest {
+            RepositoryRoot = @"C:\repo",
+            ScriptPath = @"C:\repo\Build\Build-Module.ps1",
+            ModulePath = @"C:\repo\Module\PSPublishModule.psd1",
+            Framework = framework
+        });
+
+        Assert.NotNull(captured);
+        Assert.Equal(!FrameworkCompatibility.IsWindows() || modernDotNet, captured!.PreferPwsh);
+        Assert.Equal(requiredRuntimeMajor, captured.RequiredRuntimeMajor);
         Assert.True(result.Succeeded);
     }
 

--- a/PowerForge.Tests/PowerShellRunnerTests.cs
+++ b/PowerForge.Tests/PowerShellRunnerTests.cs
@@ -103,6 +103,106 @@ public sealed class PowerShellRunnerTests
         }
     }
 
+    [Fact]
+    public void Run_CompatibleRequest_RejectsIncompatibleExecutableOverride()
+    {
+        var executablePath = CreateStubExecutablePath();
+        var requests = new List<ProcessRunRequest>();
+        var processRunner = new StubProcessRunner(request => {
+            requests.Add(request);
+            return new ProcessRunResult(0, "Core|7", string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+        });
+        var runner = new PowerShellRunner(processRunner);
+
+        var result = runner.Run(PowerShellRunRequest.ForCompatibleCommand(
+            commandText: "Get-ChildItem",
+            timeout: TimeSpan.FromMinutes(1),
+            requiredRuntimeMajor: 8,
+            executableOverride: executablePath));
+
+        Assert.Equal(127, result.ExitCode);
+        Assert.Empty(result.Executable);
+        Assert.Contains("requires PowerShell Core running on .NET 8 or later", result.StdErr, StringComparison.Ordinal);
+        Assert.Single(requests);
+        Assert.Contains("$PSVersionTable.PSEdition", requests[0].Arguments[^1], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Run_CompatibleRequest_DoesNotFallBackToWindowsPowerShell()
+    {
+        using var directory = new TemporaryDirectory();
+        var executableName = Path.DirectorySeparatorChar == '\\' ? "powershell.exe" : "powershell";
+        File.WriteAllText(Path.Combine(directory.Path, executableName), string.Empty);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", directory.Path);
+            var processRunner = new StubProcessRunner(request =>
+                throw new InvalidOperationException($"Unexpected process invocation: {request.FileName}"));
+            var runner = new PowerShellRunner(processRunner);
+
+            var result = runner.Run(PowerShellRunRequest.ForCompatibleCommand(
+                commandText: "Get-ChildItem",
+                timeout: TimeSpan.FromMinutes(1),
+                requiredRuntimeMajor: 8));
+
+            Assert.Equal(127, result.ExitCode);
+            Assert.Empty(result.Executable);
+            Assert.Contains("No compatible pwsh executable was found", result.StdErr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    [Fact]
+    public void Run_CompatibleRequest_SkipsOlderRuntimeAndUsesCompatiblePwsh()
+    {
+        using var directory = new TemporaryDirectory();
+        var firstDirectory = Directory.CreateDirectory(Path.Combine(directory.Path, "pwsh-8"));
+        var secondDirectory = Directory.CreateDirectory(Path.Combine(directory.Path, "pwsh-10"));
+        var executableName = Path.DirectorySeparatorChar == '\\' ? "pwsh.exe" : "pwsh";
+        var firstExecutable = Path.Combine(firstDirectory.FullName, executableName);
+        var secondExecutable = Path.Combine(secondDirectory.FullName, executableName);
+        File.WriteAllText(firstExecutable, string.Empty);
+        File.WriteAllText(secondExecutable, string.Empty);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", string.Join(Path.PathSeparator, firstDirectory.FullName, secondDirectory.FullName));
+            var requests = new List<ProcessRunRequest>();
+            var processRunner = new StubProcessRunner(request => {
+                requests.Add(request);
+                var isProbe = request.Arguments[^1].Contains("$PSVersionTable.PSEdition", StringComparison.Ordinal);
+                var output = isProbe
+                    ? (string.Equals(request.FileName, firstExecutable, StringComparison.OrdinalIgnoreCase) ? "Core|8" : "Core|10")
+                    : "ok";
+                return new ProcessRunResult(0, output, string.Empty, request.FileName, TimeSpan.Zero, timedOut: false);
+            });
+            var runner = new PowerShellRunner(processRunner);
+
+            var result = runner.Run(PowerShellRunRequest.ForCompatibleCommand(
+                commandText: "Get-ChildItem",
+                timeout: TimeSpan.FromMinutes(1),
+                requiredRuntimeMajor: 10));
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(secondExecutable, result.Executable);
+            Assert.Collection(
+                requests,
+                request => Assert.Equal(firstExecutable, request.FileName),
+                request => Assert.Equal(secondExecutable, request.FileName),
+                request => Assert.Equal(secondExecutable, request.FileName));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
     private static string CreateStubExecutablePath()
     {
         var path = Path.Combine(Path.GetTempPath(), "powerforge-pwsh-stub.exe");

--- a/PowerForge/Abstractions/IPowerShellRunner.cs
+++ b/PowerForge/Abstractions/IPowerShellRunner.cs
@@ -36,6 +36,11 @@ public sealed class PowerShellRunRequest
     public TimeSpan Timeout { get; }
     /// <summary>When true, prefer <c>pwsh</c>; otherwise use Windows PowerShell first on Windows.</summary>
     public bool PreferPwsh { get; }
+    /// <summary>
+    /// Minimum .NET runtime major version required from a PowerShell Core host.
+    /// A value of zero allows the normal preferred-host fallback behavior.
+    /// </summary>
+    public int RequiredRuntimeMajor { get; }
     /// <summary>Optional working directory for the PowerShell process.</summary>
     public string? WorkingDirectory { get; }
     /// <summary>Optional environment variable overrides for the PowerShell process.</summary>
@@ -73,6 +78,7 @@ public sealed class PowerShellRunRequest
         CaptureOutput = captureOutput;
         CaptureError = captureError;
         InvocationMode = PowerShellInvocationMode.File;
+        RequiredRuntimeMajor = 0;
     }
 
     /// <summary>
@@ -111,6 +117,49 @@ public sealed class PowerShellRunRequest
             executableOverride: executableOverride,
             captureOutput: captureOutput,
             captureError: captureError,
+            requiredRuntimeMajor: 0,
+            invocationMode: PowerShellInvocationMode.Command);
+    }
+
+    /// <summary>
+    /// Creates a command request that requires a compatible PowerShell Core host.
+    /// </summary>
+    /// <param name="commandText">Inline PowerShell text to execute with <c>-Command</c>.</param>
+    /// <param name="timeout">Maximum allowed execution time before killing the process.</param>
+    /// <param name="requiredRuntimeMajor">Minimum .NET runtime major version required from <c>pwsh</c>.</param>
+    /// <param name="workingDirectory">Optional working directory for the PowerShell process.</param>
+    /// <param name="environmentVariables">Optional environment variable overrides.</param>
+    /// <param name="executableOverride">Optional explicit executable name or path.</param>
+    /// <param name="captureOutput">When true, capture standard output.</param>
+    /// <param name="captureError">When true, capture standard error.</param>
+    /// <returns>PowerShell command request.</returns>
+    public static PowerShellRunRequest ForCompatibleCommand(
+        string commandText,
+        TimeSpan timeout,
+        int requiredRuntimeMajor,
+        string? workingDirectory = null,
+        IReadOnlyDictionary<string, string?>? environmentVariables = null,
+        string? executableOverride = null,
+        bool captureOutput = true,
+        bool captureError = true)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+            throw new ArgumentException("Command text is required.", nameof(commandText));
+        if (requiredRuntimeMajor <= 0)
+            throw new ArgumentOutOfRangeException(nameof(requiredRuntimeMajor), "Required runtime major must be greater than zero.");
+
+        return new PowerShellRunRequest(
+            scriptPath: null,
+            commandText: commandText,
+            arguments: Array.Empty<string>(),
+            timeout: timeout,
+            preferPwsh: true,
+            workingDirectory: workingDirectory,
+            environmentVariables: environmentVariables,
+            executableOverride: executableOverride,
+            captureOutput: captureOutput,
+            captureError: captureError,
+            requiredRuntimeMajor: requiredRuntimeMajor,
             invocationMode: PowerShellInvocationMode.Command);
     }
 
@@ -125,6 +174,7 @@ public sealed class PowerShellRunRequest
         string? executableOverride,
         bool captureOutput,
         bool captureError,
+        int requiredRuntimeMajor,
         PowerShellInvocationMode invocationMode)
     {
         ScriptPath = scriptPath;
@@ -137,6 +187,7 @@ public sealed class PowerShellRunRequest
         ExecutableOverride = executableOverride;
         CaptureOutput = captureOutput;
         CaptureError = captureError;
+        RequiredRuntimeMajor = requiredRuntimeMajor;
         InvocationMode = invocationMode;
     }
 }
@@ -188,10 +239,14 @@ public sealed class PowerShellRunner : IPowerShellRunner
     /// <inheritdoc />
     public PowerShellRunResult Run(PowerShellRunRequest request)
     {
-        var exe = ResolveExecutable(request.PreferPwsh, request.ExecutableOverride);
+        string? resolutionError = null;
+        var exe = request.RequiredRuntimeMajor > 0
+            ? ResolveCompatiblePwsh(request, out resolutionError)
+            : ResolveExecutable(request.PreferPwsh, request.ExecutableOverride);
         if (exe is null)
         {
-            return new PowerShellRunResult(127, string.Empty, "No PowerShell executable found (pwsh or powershell.exe).", string.Empty);
+            var error = resolutionError ?? "No PowerShell executable found (pwsh or powershell.exe).";
+            return new PowerShellRunResult(127, string.Empty, error, string.Empty);
         }
 
         var arguments = BuildArguments(request);
@@ -206,6 +261,81 @@ public sealed class PowerShellRunner : IPowerShellRunner
                 request.CaptureError)).GetAwaiter().GetResult();
 
         return new PowerShellRunResult(processResult.ExitCode, processResult.StdOut, processResult.StdErr, exe);
+    }
+
+    private string? ResolveCompatiblePwsh(PowerShellRunRequest request, out string? error)
+    {
+        var requiredRuntimeMajor = request.RequiredRuntimeMajor;
+        IReadOnlyList<string> candidates;
+        if (!string.IsNullOrWhiteSpace(request.ExecutableOverride))
+        {
+            candidates = ResolveExecutableCandidates(request.ExecutableOverride!);
+            if (candidates.Count == 0)
+            {
+                error = $"PowerShell executable override '{request.ExecutableOverride}' was not found. "
+                        + $"The requested command requires pwsh running on .NET {requiredRuntimeMajor} or later.";
+                return null;
+            }
+        }
+        else
+        {
+            var pwshName = Path.DirectorySeparatorChar == '\\' ? "pwsh.exe" : "pwsh";
+            candidates = ResolveExecutableCandidates(pwshName);
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (IsCompatiblePwsh(candidate, request, requiredRuntimeMajor))
+            {
+                error = null;
+                return candidate;
+            }
+        }
+
+        var overrideDescription = string.IsNullOrWhiteSpace(request.ExecutableOverride)
+            ? "No compatible pwsh executable was found"
+            : $"PowerShell executable override '{request.ExecutableOverride}' is not compatible";
+        error = $"{overrideDescription}. The requested command requires PowerShell Core running on .NET {requiredRuntimeMajor} or later.";
+        return null;
+    }
+
+    private bool IsCompatiblePwsh(string executable, PowerShellRunRequest request, int requiredRuntimeMajor)
+    {
+        var probeArguments = new[] {
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "'{0}|{1}' -f $PSVersionTable.PSEdition, [Environment]::Version.Major"
+        };
+        var probeResult = _processRunner.RunAsync(
+            new ProcessRunRequest(
+                executable,
+                request.WorkingDirectory ?? Environment.CurrentDirectory,
+                probeArguments,
+                TimeSpan.FromSeconds(15),
+                request.EnvironmentVariables,
+                captureOutput: true,
+                captureError: true)).GetAwaiter().GetResult();
+
+        if (!probeResult.Succeeded)
+            return false;
+
+        var lines = probeResult.StdOut.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var line in lines)
+        {
+            var parts = line.Trim().Split('|');
+            if (parts.Length == 2
+                && string.Equals(parts[0], "Core", StringComparison.OrdinalIgnoreCase)
+                && int.TryParse(parts[1], out var runtimeMajor)
+                && runtimeMajor >= requiredRuntimeMajor)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -264,18 +394,34 @@ public sealed class PowerShellRunner : IPowerShellRunner
     /// </summary>
     private static string? ResolveOnPath(string fileName)
     {
+        var candidates = ResolveExecutableCandidates(fileName);
+        return candidates.Count > 0 ? candidates[0] : null;
+    }
+
+    private static IReadOnlyList<string> ResolveExecutableCandidates(string fileName)
+    {
+        var candidates = new List<string>();
+        if (Path.IsPathRooted(fileName) || fileName.IndexOf(Path.DirectorySeparatorChar) >= 0 || fileName.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+        {
+            if (File.Exists(fileName))
+                candidates.Add(fileName);
+            return candidates;
+        }
+
         var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
         foreach (var dir in path.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
         {
             try
             {
                 var candidate = Path.Combine(dir, fileName);
-                if (File.Exists(candidate))
-                    return candidate;
+                if (File.Exists(candidate) && !candidates.Contains(candidate, StringComparer.OrdinalIgnoreCase))
+                    candidates.Add(candidate);
             }
             catch { /* ignore */ }
         }
-        return null;
+        if (candidates.Count == 0 && File.Exists(fileName))
+            candidates.Add(fileName);
+        return candidates;
     }
 
 }

--- a/PowerForge/Services/ModuleBuildHostService.cs
+++ b/PowerForge/Services/ModuleBuildHostService.cs
@@ -35,7 +35,13 @@ public sealed class ModuleBuildHostService
         ValidateRequiredPath(request.OutputPath, nameof(request.OutputPath));
 
         var script = BuildExportScript(request.RepositoryRoot, request.ScriptPath, request.OutputPath, request.ModulePath);
-        return RunCommandAsync(request.RepositoryRoot, script, TimeSpan.FromMinutes(15), cancellationToken);
+        return RunCommandAsync(
+            request.RepositoryRoot,
+            script,
+            TimeSpan.FromMinutes(15),
+            preferPwsh: !FrameworkCompatibility.IsWindows(),
+            requiredRuntimeMajor: 0,
+            cancellationToken);
     }
 
     /// <summary>
@@ -50,22 +56,40 @@ public sealed class ModuleBuildHostService
 
         var script = BuildBuildScript(request.RepositoryRoot, request.ScriptPath, request.ModulePath, request);
         var timeout = request.Timeout <= TimeSpan.Zero ? TimeSpan.FromHours(2) : request.Timeout;
-        return RunCommandAsync(request.RepositoryRoot, script, timeout, cancellationToken);
+        var hostRequirements = ResolveHostRequirements(request.Framework);
+        return RunCommandAsync(
+            request.RepositoryRoot,
+            script,
+            timeout,
+            preferPwsh: hostRequirements.PreferPwsh,
+            requiredRuntimeMajor: hostRequirements.RequiredRuntimeMajor,
+            cancellationToken);
     }
 
     private async Task<ModuleBuildHostExecutionResult> RunCommandAsync(
         string workingDirectory,
         string script,
         TimeSpan timeout,
+        bool preferPwsh,
+        int requiredRuntimeMajor,
         CancellationToken cancellationToken)
     {
         var startedAt = Stopwatch.StartNew();
-        var result = await Task.Run(() => _powerShellRunner.Run(PowerShellRunRequest.ForCommand(
-            commandText: script,
-            timeout: timeout,
-            preferPwsh: !FrameworkCompatibility.IsWindows(),
-            workingDirectory: workingDirectory,
-            executableOverride: Environment.GetEnvironmentVariable("RELEASE_OPS_STUDIO_POWERSHELL_EXE"))), cancellationToken).ConfigureAwait(false);
+        var executableOverride = Environment.GetEnvironmentVariable("RELEASE_OPS_STUDIO_POWERSHELL_EXE");
+        var runRequest = requiredRuntimeMajor > 0
+            ? PowerShellRunRequest.ForCompatibleCommand(
+                commandText: script,
+                timeout: timeout,
+                requiredRuntimeMajor: requiredRuntimeMajor,
+                workingDirectory: workingDirectory,
+                executableOverride: executableOverride)
+            : PowerShellRunRequest.ForCommand(
+                commandText: script,
+                timeout: timeout,
+                preferPwsh: preferPwsh,
+                workingDirectory: workingDirectory,
+                executableOverride: executableOverride);
+        var result = await Task.Run(() => _powerShellRunner.Run(runRequest), cancellationToken).ConfigureAwait(false);
         startedAt.Stop();
 
         return new ModuleBuildHostExecutionResult {
@@ -75,6 +99,59 @@ public sealed class ModuleBuildHostService
             StandardError = result.StdErr,
             Executable = result.Executable
         };
+    }
+
+    private static PowerShellHostRequirements ResolveHostRequirements(string? framework)
+    {
+        var defaultPreference = !FrameworkCompatibility.IsWindows();
+
+        if (string.IsNullOrWhiteSpace(framework))
+            return new PowerShellHostRequirements(defaultPreference, 0);
+
+        var targetFramework = framework!.Trim();
+        if (string.Equals(targetFramework, "auto", StringComparison.OrdinalIgnoreCase))
+            return new PowerShellHostRequirements(preferPwsh: true, requiredRuntimeMajor: 8);
+
+        if (targetFramework.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase))
+        {
+            var coreVersionText = targetFramework.Substring("netcoreapp".Length);
+            return Version.TryParse(coreVersionText, out var coreVersion)
+                ? new PowerShellHostRequirements(preferPwsh: true, requiredRuntimeMajor: coreVersion.Major)
+                : new PowerShellHostRequirements(preferPwsh: true, requiredRuntimeMajor: 0);
+        }
+
+        if (!targetFramework.StartsWith("net", StringComparison.OrdinalIgnoreCase))
+            return new PowerShellHostRequirements(defaultPreference, 0);
+
+        var versionText = targetFramework.Substring(3);
+        var platformSeparator = versionText.IndexOf('-');
+        if (platformSeparator >= 0)
+            versionText = versionText.Substring(0, platformSeparator);
+
+        // Compact TFMs such as net472 target .NET Framework. Modern .NET TFMs
+        // use a dotted version (net8.0, net10.0) and require pwsh on Windows.
+        // This also prevents self-release from preloading an installed net472
+        // PSPublishModule assembly that cannot be unloaded before the local build.
+        if (versionText.IndexOf('.') >= 0
+            && Version.TryParse(versionText, out var version)
+            && version.Major >= 5)
+        {
+            return new PowerShellHostRequirements(preferPwsh: true, requiredRuntimeMajor: version.Major);
+        }
+
+        return new PowerShellHostRequirements(defaultPreference, 0);
+    }
+
+    private sealed class PowerShellHostRequirements
+    {
+        public PowerShellHostRequirements(bool preferPwsh, int requiredRuntimeMajor)
+        {
+            PreferPwsh = preferPwsh;
+            RequiredRuntimeMajor = requiredRuntimeMajor;
+        }
+
+        public bool PreferPwsh { get; }
+        public int RequiredRuntimeMajor { get; }
     }
 
     private static string BuildExportScript(string repositoryRoot, string scriptPath, string outputPath, string modulePath)


### PR DESCRIPTION
## Summary

- require a compatible PowerShell Core host for modern .NET module release targets
- resolve `auto` through `pwsh` on .NET 8 or later and probe candidate runtimes before executing the build script
- reject incompatible host overrides with a clear error instead of falling back to Windows PowerShell
- preserve the existing Windows PowerShell preference for legacy .NET Framework targets

## Why

The unified module release path could start Windows PowerShell after the modern binaries were built. That preloaded the installed `net472` PSPublishModule assembly, which cannot be unloaded before the repository script imports the local module and ultimately caused the misleading `Illegal characters in path` failure.