### PR TITLE
Unify generated API navigation and footer markup

### DIFF
--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -432,7 +432,8 @@ Docs templates (`template: docs`):
 Header/footer fragments can use nav tokens when `nav` is provided:
 - `{{SITE_NAME}}`, `{{BRAND_NAME}}`, `{{BRAND_URL}}`, `{{BRAND_ICON}}`
 - `{{NAV_LINKS}}`, `{{NAV_ACTIONS}}`
-- `{{FOOTER_PRODUCT}}`, `{{FOOTER_RESOURCES}}`, `{{FOOTER_COMPANY}}`
+- `{{FOOTER_PRODUCT}}`, `{{FOOTER_RESOURCES}}`, `{{FOOTER_COMPANY}}` for the legacy three-column footer contract
+- every exported footer menu also receives a deterministic token derived from its menu name: uppercase letters and digits with other characters normalized to `_` (for example, `footer-products` becomes `{{FOOTER_PRODUCTS}}` and `footer-community` becomes `{{FOOTER_COMMUNITY}}`)
 - `{{YEAR}}`
 
 Project.json example (metadata you can reuse across repos):

--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -433,7 +433,8 @@ Header/footer fragments can use nav tokens when `nav` is provided:
 - `{{SITE_NAME}}`, `{{BRAND_NAME}}`, `{{BRAND_URL}}`, `{{BRAND_ICON}}`
 - `{{NAV_LINKS}}`, `{{NAV_ACTIONS}}`
 - `{{FOOTER_PRODUCT}}`, `{{FOOTER_RESOURCES}}`, `{{FOOTER_COMPANY}}` for the legacy three-column footer contract
-- every exported footer menu also receives a deterministic token derived from its menu name: uppercase letters and digits with other characters normalized to `_` (for example, `footer-products` becomes `{{FOOTER_PRODUCTS}}` and `footer-community` becomes `{{FOOTER_COMMUNITY}}`)
+- every exported footer menu also receives deterministic tokens derived from its menu name: uppercase letters and digits with other characters normalized to `_` (for example, `footer-products` becomes `{{FOOTER_PRODUCTS}}` and `{{FOOTER_PRODUCTS_LIST_ITEMS}}`)
+- use the base named token when a fragment needs bare links; use its `_LIST_ITEMS` form inside a semantic `<ul>` or `<ol>` so generated API footers can share the exact markup and spacing of the main site footer
 - `{{YEAR}}`
 
 Project.json example (metadata you can reuse across repos):

--- a/Docs/PowerForge.Web.Pipeline.md
+++ b/Docs/PowerForge.Web.Pipeline.md
@@ -435,6 +435,9 @@ Header/footer fragments can use nav tokens when `nav` is provided:
 - `{{FOOTER_PRODUCT}}`, `{{FOOTER_RESOURCES}}`, `{{FOOTER_COMPANY}}` for the legacy three-column footer contract
 - every exported footer menu also receives deterministic tokens derived from its menu name: uppercase letters and digits with other characters normalized to `_` (for example, `footer-products` becomes `{{FOOTER_PRODUCTS}}` and `{{FOOTER_PRODUCTS_LIST_ITEMS}}`)
 - use the base named token when a fragment needs bare links; use its `_LIST_ITEMS` form inside a semantic `<ul>` or `<ol>` so generated API footers can share the exact markup and spacing of the main site footer
+- configured empty footer menus still resolve both named tokens to an empty string, so temporary navigation changes cannot leak unresolved placeholders
+- menu names must remain distinct after normalization; collisions emit a generator warning and therefore fail pipelines that enable `failOnWarnings`
+- a footer placeholder supplied explicitly through `templateTokens` is treated as caller-owned and does not require a navigation file
 - `{{YEAR}}`
 
 Project.json example (metadata you can reuse across repos):

--- a/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
@@ -600,11 +600,31 @@ public class WebApiDocsGeneratorContractTests
                   ],
                   "actions": [
                     { "text": "Install", "href": "https://example.test/install", "external": true }
-                  ]
+                  ],
+                  "footer": {
+                    "footer-products": [
+                      { "text": "Word", "href": "/products/word/" }
+                    ],
+                    "footer-docs": [
+                      { "text": "Getting Started", "href": "/docs/getting-started/" }
+                    ],
+                    "footer-resources": [
+                      { "text": "Benchmarks", "href": "/benchmarks/" }
+                    ],
+                    "footer-community": [
+                      { "text": "GitHub", "href": "https://example.test/repository", "external": true }
+                    ]
+                  }
                 }
               }
             }
             """);
+
+        var headerPath = Path.Combine(root, "api-header.html");
+        File.WriteAllText(headerPath, "<header>{{NAV_LINKS}}{{NAV_ACTIONS}}</header>");
+        var footerPath = Path.Combine(root, "api-footer.html");
+        File.WriteAllText(footerPath,
+            "<footer>{{FOOTER_PRODUCTS}}{{FOOTER_DOCS}}{{FOOTER_RESOURCES}}{{FOOTER_COMMUNITY}}</footer>");
 
         var xmlPath = Path.Combine(root, "test.xml");
         File.WriteAllText(xmlPath,
@@ -628,7 +648,9 @@ public class WebApiDocsGeneratorContractTests
             Template = "docs",
             BaseUrl = "/api",
             NavJsonPath = navJsonPath,
-            NavContextPath = "/api/"
+            NavContextPath = "/api/",
+            HeaderHtmlPath = headerPath,
+            FooterHtmlPath = footerPath
         };
 
         try
@@ -643,6 +665,11 @@ public class WebApiDocsGeneratorContractTests
             Assert.Contains("href=\"/api/\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("href=\"/docs/\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("href=\"https://example.test/install\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"/products/word/\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"/docs/getting-started/\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"/benchmarks/\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("href=\"https://example.test/repository\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("{{FOOTER_", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(">Home<", html, StringComparison.OrdinalIgnoreCase);
         }
         finally

--- a/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
@@ -624,7 +624,7 @@ public class WebApiDocsGeneratorContractTests
         File.WriteAllText(headerPath, "<header>{{NAV_LINKS}}{{NAV_ACTIONS}}</header>");
         var footerPath = Path.Combine(root, "api-footer.html");
         File.WriteAllText(footerPath,
-            "<footer>{{FOOTER_PRODUCTS}}{{FOOTER_DOCS}}{{FOOTER_RESOURCES}}{{FOOTER_COMMUNITY}}</footer>");
+            "<footer><ul>{{FOOTER_PRODUCTS_LIST_ITEMS}}</ul><ul>{{FOOTER_DOCS_LIST_ITEMS}}</ul><ul>{{FOOTER_RESOURCES_LIST_ITEMS}}</ul><ul>{{FOOTER_COMMUNITY_LIST_ITEMS}}</ul></footer>");
 
         var xmlPath = Path.Combine(root, "test.xml");
         File.WriteAllText(xmlPath,
@@ -669,6 +669,8 @@ public class WebApiDocsGeneratorContractTests
             Assert.Contains("href=\"/docs/getting-started/\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("href=\"/benchmarks/\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("href=\"https://example.test/repository\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<li><a href=\"/products/word/\">Word</a></li>", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<li><a href=\"/docs/getting-started/\">Getting Started</a></li>", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("{{FOOTER_", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain(">Home<", html, StringComparison.OrdinalIgnoreCase);
         }

--- a/PowerForge.Tests/WebApiDocsGeneratorFooterTokenContractTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorFooterTokenContractTests.cs
@@ -1,0 +1,125 @@
+using PowerForge.Web;
+
+public sealed class WebApiDocsGeneratorFooterTokenContractTests
+{
+    [Fact]
+    public void CustomFooterToken_DoesNotRequireNavigationWhenCallerProvidesValue()
+    {
+        var generated = Generate(
+            "<footer>{{FOOTER_LEGAL}}</footer>",
+            navJson: null,
+            options => options.TemplateTokens["FOOTER_LEGAL"] = "<a href=\"/legal/\">Legal</a>");
+
+        Assert.DoesNotContain(generated.Result.Warnings, warning =>
+            warning.Contains("NAV.REQUIRED", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("<a href=\"/legal/\">Legal</a>", generated.Html, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{FOOTER_LEGAL}}", generated.Html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmptyConfiguredFooterMenu_ReplacesNamedTokensWithEmptyContent()
+    {
+        const string navJson = """
+            {
+              "generated": true,
+              "surfaces": {
+                "apidocs": {
+                  "primary": [ { "text": "API", "href": "/api/" } ],
+                  "footer": { "footer-community": [] }
+                }
+              }
+            }
+            """;
+
+        var generated = Generate(
+            "<footer>{{FOOTER_COMMUNITY}}|{{FOOTER_COMMUNITY_LIST_ITEMS}}</footer>",
+            navJson);
+
+        Assert.Contains("<footer", generated.Html, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("|", generated.Html, StringComparison.Ordinal);
+        Assert.DoesNotContain("{{FOOTER_", generated.Html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CollidingFooterMenuNames_EmitWarningAndKeepFirstMenuDeterministically()
+    {
+        const string navJson = """
+            {
+              "generated": true,
+              "surfaces": {
+                "apidocs": {
+                  "primary": [ { "text": "API", "href": "/api/" } ],
+                  "footer": {
+                    "footer-products": [ { "text": "First", "href": "/first/" } ],
+                    "footer_products": [ { "text": "Second", "href": "/second/" } ]
+                  }
+                }
+              }
+            }
+            """;
+
+        var generated = Generate("<footer>{{FOOTER_PRODUCTS}}</footer>", navJson);
+
+        Assert.Contains(generated.Result.Warnings, warning =>
+            warning.Contains("both map", StringComparison.OrdinalIgnoreCase) &&
+            warning.Contains("FOOTER_PRODUCTS", StringComparison.Ordinal));
+        Assert.Contains("href=\"/first/\"", generated.Html, StringComparison.Ordinal);
+        Assert.DoesNotContain("href=\"/second/\"", generated.Html, StringComparison.Ordinal);
+    }
+
+    private static (WebApiDocsResult Result, string Html) Generate(
+        string footerHtml,
+        string? navJson,
+        Action<WebApiDocsOptions>? configure = null)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-footer-token-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "test.xml");
+            File.WriteAllText(xmlPath,
+                """
+                <doc>
+                  <assembly><name>Test</name></assembly>
+                  <members>
+                    <member name="T:MyNamespace.Sample"><summary>Sample.</summary></member>
+                  </members>
+                </doc>
+                """);
+
+            var footerPath = Path.Combine(root, "api-footer.html");
+            File.WriteAllText(footerPath, footerHtml);
+
+            string? navPath = null;
+            if (navJson is not null)
+            {
+                navPath = Path.Combine(root, "site-nav.json");
+                File.WriteAllText(navPath, navJson);
+            }
+
+            var outputPath = Path.Combine(root, "api");
+            var options = new WebApiDocsOptions
+            {
+                XmlPath = xmlPath,
+                OutputPath = outputPath,
+                Format = "html",
+                Template = "docs",
+                BaseUrl = "/api",
+                NavJsonPath = navPath,
+                NavSurfaceName = "apidocs",
+                FooterHtmlPath = footerPath
+            };
+            configure?.Invoke(options);
+
+            WebApiDocsResult result = WebApiDocsGenerator.Generate(options);
+            string html = File.ReadAllText(Path.Combine(outputPath, "index.html"));
+            return (result, html);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/PowerForge.Tests/WebApiDocsGeneratorSourceAndCssTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorSourceAndCssTests.cs
@@ -152,6 +152,8 @@ public class WebApiDocsGeneratorSourceAndCssTests
             Assert.Contains("id=\"api-namespace\"", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("initNamespaceCombobox", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("initNavDropdowns", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("!sidebar.classList.contains('sidebar-open')", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("if (toggle) toggle.focus();", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("PowerForge API docs first-paint control stability", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("body.pf-api-docs .namespace-select", html, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("<style>body.pf-api-docs", html, StringComparison.OrdinalIgnoreCase);

--- a/PowerForge.Web/Assets/ApiDocs/docs.js
+++ b/PowerForge.Web/Assets/ApiDocs/docs.js
@@ -56,6 +56,12 @@
     });
   }
 
+  document.addEventListener('keydown', function(event) {
+    if (event.key !== 'Escape' || !sidebar || !sidebar.classList.contains('sidebar-open')) return;
+    setSidebar(false);
+    if (toggle) toggle.focus();
+  });
+
   function initNavDropdowns() {
     var dropdowns = Array.prototype.slice.call(document.querySelectorAll('.nav-dropdown'));
     if (!dropdowns.length) return;

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.Models.cs
@@ -665,6 +665,7 @@ public static partial class WebApiDocsGenerator
         public List<NavItem> FooterProduct { get; set; } = new();
         public List<NavItem> FooterResources { get; set; } = new();
         public List<NavItem> FooterCompany { get; set; } = new();
+        public Dictionary<string, List<NavItem>> FooterMenus { get; } = new(StringComparer.OrdinalIgnoreCase);
     }
 
     private readonly record struct ApiSocialProfile(

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
@@ -92,7 +92,10 @@ public static partial class WebApiDocsGenerator
         {
             var tokenName = BuildFooterMenuTokenName(footerMenu.Key);
             if (!string.IsNullOrWhiteSpace(tokenName))
+            {
                 tokens[tokenName] = BuildLinkHtml(footerMenu.Value);
+                tokens[tokenName + "_LIST_ITEMS"] = BuildListItemHtml(footerMenu.Value);
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(header))
@@ -147,6 +150,22 @@ public static partial class WebApiDocsGenerator
             return string.Empty;
 
         return string.Concat(items.Select(BuildNavItemHtml));
+    }
+
+    private static string BuildListItemHtml(IReadOnlyList<NavItem> items)
+    {
+        if (items.Count == 0)
+            return string.Empty;
+
+        var fragments = new List<string>(items.Count);
+        foreach (var item in items)
+        {
+            var itemHtml = BuildNavItemHtml(item);
+            if (!string.IsNullOrWhiteSpace(itemHtml))
+                fragments.Add("<li>" + itemHtml + "</li>");
+        }
+
+        return string.Concat(fragments);
     }
 
     private static string BuildNavItemHtml(NavItem item)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
@@ -26,13 +26,15 @@ public static partial class WebApiDocsGenerator
         // Fail-fast (in CI via apidocs failOnWarnings): if fragments expect nav injection but the step
         // forgot to provide navJsonPath, we should emit a deterministic warning instead of silently
         // producing API pages without navigation.
-        var needsNavTokens =
-            ContainsTemplateToken(header, "NAV_LINKS") ||
-            ContainsTemplateToken(header, "NAV_ACTIONS") ||
-            ContainsTemplateToken(footer, "NAV_LINKS") ||
-            ContainsTemplateToken(footer, "NAV_ACTIONS") ||
-            ContainsTemplateTokenPrefix(header, "FOOTER_") ||
-            ContainsTemplateTokenPrefix(footer, "FOOTER_");
+        var headerNeedsNavTokens =
+            ContainsUnprovidedTemplateToken(header, "NAV_LINKS", tokens) ||
+            ContainsUnprovidedTemplateToken(header, "NAV_ACTIONS", tokens) ||
+            ContainsUnprovidedTemplateTokenPrefix(header, "FOOTER_", tokens);
+        var footerNeedsNavTokens =
+            ContainsUnprovidedTemplateToken(footer, "NAV_LINKS", tokens) ||
+            ContainsUnprovidedTemplateToken(footer, "NAV_ACTIONS", tokens) ||
+            ContainsUnprovidedTemplateTokenPrefix(footer, "FOOTER_", tokens);
+        var needsNavTokens = headerNeedsNavTokens || footerNeedsNavTokens;
         if (needsNavTokens && string.IsNullOrWhiteSpace(options.NavJsonPath))
         {
             warnings?.Add("API docs nav required: header/footer fragments contain {{NAV_*}} or {{FOOTER_*}} placeholders but NavJsonPath is not set. Set apidocs.nav (or apidocs.config) so navigation can be injected.");
@@ -63,7 +65,10 @@ public static partial class WebApiDocsGenerator
         {
             // If the site provides custom header/footer fragments but forgets to include navigation placeholders,
             // nav injection will be a no-op and API pages may render without expected site navigation.
-            if (!needsNavTokens)
+            var customFragmentMissingNavTokens =
+                (!string.IsNullOrWhiteSpace(options.HeaderHtmlPath) && !headerNeedsNavTokens) ||
+                (!string.IsNullOrWhiteSpace(options.FooterHtmlPath) && !footerNeedsNavTokens);
+            if (customFragmentMissingNavTokens)
             {
                 warnings?.Add("API docs nav: header/footer fragments do not contain {{NAV_LINKS}} or {{NAV_ACTIONS}} placeholders; nav injection may be empty.");
             }
@@ -88,13 +93,35 @@ public static partial class WebApiDocsGenerator
         tokens["FOOTER_PRODUCT"] = BuildLinkHtml(nav.FooterProduct);
         tokens["FOOTER_RESOURCES"] = BuildLinkHtml(nav.FooterResources);
         tokens["FOOTER_COMPANY"] = BuildLinkHtml(nav.FooterCompany);
+        var footerTokenOwners = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var footerMenu in nav.FooterMenus)
         {
             var tokenName = BuildFooterMenuTokenName(footerMenu.Key);
             if (!string.IsNullOrWhiteSpace(tokenName))
             {
+                var listTokenName = tokenName + "_LIST_ITEMS";
+                string? conflictingToken = null;
+                string? conflictingMenu = null;
+                foreach (var candidate in new[] { tokenName, listTokenName })
+                {
+                    if (footerTokenOwners.TryGetValue(candidate, out var owner))
+                    {
+                        conflictingToken = candidate;
+                        conflictingMenu = owner;
+                        break;
+                    }
+                }
+
+                if (conflictingToken is not null)
+                {
+                    warnings?.Add($"API docs nav: footer menu names '{conflictingMenu}' and '{footerMenu.Key}' both map to the generated token '{conflictingToken}'. Rename one menu so every footer token is unambiguous.");
+                    continue;
+                }
+
+                footerTokenOwners[tokenName] = footerMenu.Key;
+                footerTokenOwners[listTokenName] = footerMenu.Key;
                 tokens[tokenName] = BuildLinkHtml(footerMenu.Value);
-                tokens[tokenName + "_LIST_ITEMS"] = BuildListItemHtml(footerMenu.Value);
+                tokens[listTokenName] = BuildListItemHtml(footerMenu.Value);
             }
         }
 
@@ -112,11 +139,41 @@ public static partial class WebApiDocsGenerator
         return html.IndexOf("{{" + token + "}}", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
-    private static bool ContainsTemplateTokenPrefix(string html, string prefix)
+    private static bool ContainsUnprovidedTemplateToken(
+        string html,
+        string token,
+        IReadOnlyDictionary<string, string?> providedTokens)
+    {
+        return !providedTokens.ContainsKey(token) && ContainsTemplateToken(html, token);
+    }
+
+    private static bool ContainsUnprovidedTemplateTokenPrefix(
+        string html,
+        string prefix,
+        IReadOnlyDictionary<string, string?> providedTokens)
     {
         if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(prefix))
             return false;
-        return html.IndexOf("{{" + prefix, StringComparison.OrdinalIgnoreCase) >= 0;
+
+        var searchStart = 0;
+        while (searchStart < html.Length)
+        {
+            var open = html.IndexOf("{{", searchStart, StringComparison.Ordinal);
+            if (open < 0)
+                return false;
+
+            var close = html.IndexOf("}}", open + 2, StringComparison.Ordinal);
+            if (close < 0)
+                return false;
+
+            var token = html.Substring(open + 2, close - open - 2).Trim();
+            if (token.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && !providedTokens.ContainsKey(token))
+                return true;
+
+            searchStart = close + 2;
+        }
+
+        return false;
     }
 
     private static string BuildFooterMenuTokenName(string menuName)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace PowerForge.Web;
 
@@ -29,10 +30,12 @@ public static partial class WebApiDocsGenerator
             ContainsTemplateToken(header, "NAV_LINKS") ||
             ContainsTemplateToken(header, "NAV_ACTIONS") ||
             ContainsTemplateToken(footer, "NAV_LINKS") ||
-            ContainsTemplateToken(footer, "NAV_ACTIONS");
+            ContainsTemplateToken(footer, "NAV_ACTIONS") ||
+            ContainsTemplateTokenPrefix(header, "FOOTER_") ||
+            ContainsTemplateTokenPrefix(footer, "FOOTER_");
         if (needsNavTokens && string.IsNullOrWhiteSpace(options.NavJsonPath))
         {
-            warnings?.Add("API docs nav required: header/footer fragments contain {{NAV_*}} placeholders but NavJsonPath is not set. Set apidocs.nav (or apidocs.config) so navigation can be injected.");
+            warnings?.Add("API docs nav required: header/footer fragments contain {{NAV_*}} or {{FOOTER_*}} placeholders but NavJsonPath is not set. Set apidocs.nav (or apidocs.config) so navigation can be injected.");
             if (!string.IsNullOrWhiteSpace(header))
                 header = ApplyTemplate(header, tokens);
             if (!string.IsNullOrWhiteSpace(footer))
@@ -85,6 +88,12 @@ public static partial class WebApiDocsGenerator
         tokens["FOOTER_PRODUCT"] = BuildLinkHtml(nav.FooterProduct);
         tokens["FOOTER_RESOURCES"] = BuildLinkHtml(nav.FooterResources);
         tokens["FOOTER_COMPANY"] = BuildLinkHtml(nav.FooterCompany);
+        foreach (var footerMenu in nav.FooterMenus)
+        {
+            var tokenName = BuildFooterMenuTokenName(footerMenu.Key);
+            if (!string.IsNullOrWhiteSpace(tokenName))
+                tokens[tokenName] = BuildLinkHtml(footerMenu.Value);
+        }
 
         if (!string.IsNullOrWhiteSpace(header))
             header = ApplyTemplate(header, tokens);
@@ -98,6 +107,38 @@ public static partial class WebApiDocsGenerator
             return false;
         // Tokens are case-insensitive and appear as {{TOKEN}} in fragments.
         return html.IndexOf("{{" + token + "}}", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static bool ContainsTemplateTokenPrefix(string html, string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(prefix))
+            return false;
+        return html.IndexOf("{{" + prefix, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string BuildFooterMenuTokenName(string menuName)
+    {
+        if (string.IsNullOrWhiteSpace(menuName))
+            return string.Empty;
+
+        var builder = new StringBuilder(menuName.Length);
+        var separatorPending = false;
+        foreach (var character in menuName.Trim())
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                if (separatorPending && builder.Length > 0)
+                    builder.Append('_');
+                builder.Append(char.ToUpperInvariant(character));
+                separatorPending = false;
+            }
+            else
+            {
+                separatorPending = true;
+            }
+        }
+
+        return builder.ToString();
     }
 
     private static string BuildLinkHtml(IReadOnlyList<NavItem> items)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TemplatesAndNav.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TemplatesAndNav.cs
@@ -412,8 +412,7 @@ public static partial class WebApiDocsGenerator
             return;
 
         foreach (var footer in menuMap.Where(kvp =>
-                     kvp.Key.StartsWith("footer", StringComparison.OrdinalIgnoreCase) &&
-                     kvp.Value.Count > 0))
+                     kvp.Key.StartsWith("footer", StringComparison.OrdinalIgnoreCase)))
         {
             nav.FooterMenus[footer.Key] = footer.Value;
         }
@@ -824,7 +823,7 @@ public static partial class WebApiDocsGenerator
         {
             var name = kvp.Key ?? string.Empty;
             var items = kvp.Value ?? new List<NavItem>();
-            if (name.StartsWith("footer", StringComparison.OrdinalIgnoreCase) && items.Count > 0)
+            if (name.StartsWith("footer", StringComparison.OrdinalIgnoreCase))
                 nav.FooterMenus[name] = items;
 
             if (name.Equals("footer-product", StringComparison.OrdinalIgnoreCase))

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TemplatesAndNav.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.TemplatesAndNav.cs
@@ -264,11 +264,20 @@ public static partial class WebApiDocsGenerator
         if (root.TryGetProperty("footer", out var footerProp) && footerProp.ValueKind == JsonValueKind.Object)
         {
             if (footerProp.TryGetProperty("product", out var productProp) && productProp.ValueKind == JsonValueKind.Array)
+            {
                 nav.FooterProduct = ParseNavItems(productProp);
+                nav.FooterMenus["footer-product"] = nav.FooterProduct;
+            }
             if (footerProp.TryGetProperty("resources", out var resourcesProp) && resourcesProp.ValueKind == JsonValueKind.Array)
+            {
                 nav.FooterResources = ParseNavItems(resourcesProp);
+                nav.FooterMenus["footer-resources"] = nav.FooterResources;
+            }
             if (footerProp.TryGetProperty("company", out var companyProp) && companyProp.ValueKind == JsonValueKind.Array)
+            {
                 nav.FooterCompany = ParseNavItems(companyProp);
+                nav.FooterMenus["footer-company"] = nav.FooterCompany;
+            }
         }
 
         if (root.TryGetProperty("actions", out var actionsProp) && actionsProp.ValueKind == JsonValueKind.Array)
@@ -401,6 +410,13 @@ public static partial class WebApiDocsGenerator
     {
         if (nav is null || menuMap is null || menuMap.Count == 0)
             return;
+
+        foreach (var footer in menuMap.Where(kvp =>
+                     kvp.Key.StartsWith("footer", StringComparison.OrdinalIgnoreCase) &&
+                     kvp.Value.Count > 0))
+        {
+            nav.FooterMenus[footer.Key] = footer.Value;
+        }
 
         if (menuMap.TryGetValue("footer-product", out var footerProduct) && footerProduct.Count > 0)
             nav.FooterProduct = footerProduct;
@@ -808,6 +824,9 @@ public static partial class WebApiDocsGenerator
         {
             var name = kvp.Key ?? string.Empty;
             var items = kvp.Value ?? new List<NavItem>();
+            if (name.StartsWith("footer", StringComparison.OrdinalIgnoreCase) && items.Count > 0)
+                nav.FooterMenus[name] = items;
+
             if (name.Equals("footer-product", StringComparison.OrdinalIgnoreCase))
                 nav.FooterProduct = items;
             else if (name.Equals("footer-resources", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Summary

- Expose every exported footer menu as a deterministic API template token, such as `footer-products` to `FOOTER_PRODUCTS`.
- Expose matching `_LIST_ITEMS` tokens so generated pages can reuse semantic `ul` or `ol` footer markup instead of reconstructing lists locally.
- Keep the existing three legacy footer tokens unchanged for compatibility.
- Preserve empty configured menus as empty tokens, treat caller-supplied template tokens as satisfied without navigation, and emit fail-on-warning diagnostics for normalized token-name collisions.
- Detect missing navigation per custom fragment instead of allowing an unrelated fallback fragment to hide the warning.
- Close generated API mobile navigation on Escape and return focus to its toggle.

## Why it matters

Generated API pages can now consume the same footer groups, semantic structure, and keyboard behavior as the surrounding website. Sites with more than three footer columns keep one navigation source of truth and one visual contract instead of copying links or adding consumer-specific CSS and JavaScript.

## Validation

- The complete API generator/footer/source/CSS contract set passes: 34/34.
- Focused coverage includes custom caller tokens, empty menus, normalized-name collisions, named footer surfaces, missing navigation, theme assets, and source behavior.
- The OfficeIMO production pipeline consumes this exact commit to generate all 13 API catalogs, 3,515 audited pages, and the shared responsive footer/navigation without local generator workarounds.
