### PR TITLE
Preserve executable permissions in native CLI archives

### DIFF
--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ToolArchives.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ToolArchives.cs
@@ -1,0 +1,52 @@
+using System.IO.Compression;
+
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    [Fact]
+    public void ToolArchive_UnixExecutablesPreserveLaunchPermissions()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var outputRoot = Path.Combine(root, "output");
+            Directory.CreateDirectory(outputRoot);
+
+            var executablePath = Path.Combine(outputRoot, "PowerForgeWeb");
+            var aliasPath = Path.Combine(outputRoot, "powerforge-web");
+            File.WriteAllText(executablePath, "main");
+            File.WriteAllText(aliasPath, "alias");
+
+            var archivePath = Path.Combine(root, "PowerForgeWeb-osx-arm64.zip");
+            ZipFile.CreateFromDirectory(outputRoot, archivePath);
+
+            PowerForgeToolReleaseService.ApplyArchiveExecutablePermissions(
+                "osx-arm64",
+                outputRoot,
+                archivePath,
+                executablePath,
+                aliasPath);
+
+            using (var archive = ZipFile.OpenRead(archivePath))
+            {
+                Assert.Equal(unchecked((int)0x81ED0000u), archive.GetEntry("PowerForgeWeb")!.ExternalAttributes);
+                Assert.Equal(unchecked((int)0x81ED0000u), archive.GetEntry("powerforge-web")!.ExternalAttributes);
+            }
+
+            var extractRoot = Path.Combine(root, "extracted");
+            ZipFile.ExtractToDirectory(archivePath, extractRoot);
+            if (!OperatingSystem.IsWindows())
+            {
+                var executableMode = File.GetUnixFileMode(Path.Combine(extractRoot, "PowerForgeWeb"));
+                var aliasMode = File.GetUnixFileMode(Path.Combine(extractRoot, "powerforge-web"));
+                Assert.True(executableMode.HasFlag(UnixFileMode.UserExecute));
+                Assert.True(aliasMode.HasFlag(UnixFileMode.UserExecute));
+            }
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+}

--- a/PowerForge/Services/PowerForgeToolReleaseService.cs
+++ b/PowerForge/Services/PowerForgeToolReleaseService.cs
@@ -10,6 +10,9 @@ namespace PowerForge;
 /// </summary>
 internal sealed class PowerForgeToolReleaseService
 {
+    // ZIP stores the Unix file type and mode in the upper 16 bits: regular file + 0755.
+    private const int UnixExecutableExternalAttributes = unchecked((int)0x81ED0000u);
+
     private readonly ILogger _logger;
     private readonly Func<ProcessStartInfo, ProcessExecutionResult> _runProcess;
 
@@ -282,6 +285,14 @@ internal sealed class PowerForgeToolReleaseService
                 if (File.Exists(combination.ZipPath!))
                     File.Delete(combination.ZipPath!);
                 ZipFile.CreateFromDirectory(combination.OutputPath, combination.ZipPath!);
+                ApplyArchiveExecutablePermissions(
+                    combination.Runtime,
+                    combination.OutputPath,
+                    combination.ZipPath!,
+                    finalExecutablePath,
+                    string.Equals(aliasPath, finalExecutablePath, StringComparison.OrdinalIgnoreCase)
+                        ? null
+                        : aliasPath);
                 zipPath = combination.ZipPath;
             }
 
@@ -315,6 +326,30 @@ internal sealed class PowerForgeToolReleaseService
                     // best effort
                 }
             }
+        }
+    }
+
+    internal static void ApplyArchiveExecutablePermissions(
+        string runtime,
+        string outputRoot,
+        string archivePath,
+        params string?[] executablePaths)
+    {
+        if (runtime.StartsWith("win-", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var entryNames = executablePaths
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => FrameworkCompatibility.GetRelativePath(outputRoot, path!).Replace('\\', '/'))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Update);
+        foreach (var entryName in entryNames)
+        {
+            var entry = archive.GetEntry(entryName)
+                ?? throw new InvalidOperationException($"Executable '{entryName}' was not found in archive '{archivePath}'.");
+            entry.ExternalAttributes = UnixExecutableExternalAttributes;
         }
     }
 


### PR DESCRIPTION
## Summary

- preserve Unix executable metadata for native tool binaries and command aliases in generated ZIP archives
- keep Windows archive behavior unchanged
- add an artifact-level regression test that extracts the ZIP and verifies the binary remains launchable

## Why

PowerForge 1.0.5 macOS and Linux archives contain the correct binaries, but extraction removes their executable permission. Users must run `chmod` before the standalone CLI can start. This fixes the shared release engine so consumer projects do not need local workarounds.

## Validation

- focused archive permission regression test
- ZIP metadata and extracted Unix file mode verified
- PowerForge builds for net472, net8.0, and net10.0