### PR TITLE
fix(packaging): prefer runtime-managed assemblies

### DIFF
--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -267,6 +267,19 @@ public class ModuleBootstrapperGeneratorTests
                 }
                 """);
 
+            var competingRuntimeDependencyPath = BuildFixtureProject(
+                root,
+                "NestedDependencyCompetingRuntime",
+                "NestedDependency",
+                """
+                namespace NestedDependency;
+
+                public static class Marker
+                {
+                    public static string Value => "wrong-runtime";
+                }
+                """);
+
             var modulePath = BuildFixtureProject(
                 root,
                 "DemoModule",
@@ -285,6 +298,9 @@ public class ModuleBootstrapperGeneratorTests
             var nestedDependencyPath = Path.Combine(libCore, "lib", "net8.0", "NestedDependency.dll");
             Directory.CreateDirectory(Path.GetDirectoryName(nestedDependencyPath)!);
             File.Copy(dependencyPath, nestedDependencyPath, overwrite: true);
+            var competingRuntimePath = Path.Combine(libCore, "runtimes", GetCurrentRuntimeAssetRid(), "lib", "net9.0", "NestedDependency.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(competingRuntimePath)!);
+            File.Copy(competingRuntimeDependencyPath, competingRuntimePath, overwrite: true);
             WriteDepsJson(Path.Combine(libCore, "DemoModule.deps.json"));
 
             var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
@@ -298,6 +314,7 @@ public class ModuleBootstrapperGeneratorTests
                 targetFrameworks: new[] { "net8.0" });
 
             var loaderAssembly = System.Reflection.Assembly.LoadFile(Path.Combine(libCore, "DemoModule.ModuleLoadContext.dll"));
+            var contextType = loaderAssembly.GetType("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext", throwOnError: true)!;
             var resolverType = loaderAssembly.GetType("DemoModule.ModuleLoadContext.ModuleAssemblyLoadContext+DependencyManifestResolver", throwOnError: true)!;
             var tryCreate = resolverType.GetMethod("TryCreate", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
             var resolver = tryCreate.Invoke(null, new object[] { Path.Combine(libCore, "DemoModule.dll") });
@@ -307,6 +324,14 @@ public class ModuleBootstrapperGeneratorTests
             var resolved = (string?)resolveAssembly.Invoke(resolver, new object[] { new System.Reflection.AssemblyName("NestedDependency") });
 
             Assert.Equal(nestedDependencyPath, resolved);
+
+            var loadModule = contextType.GetMethod("LoadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!;
+            var moduleAssembly = (System.Reflection.Assembly)loadModule.Invoke(null, new object?[] { Path.Combine(libCore, "DemoModule.dll"), "DemoModule" })!;
+            var value = moduleAssembly.GetType("DemoModule.Entry", throwOnError: true)!
+                .GetMethod("Read", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!
+                .Invoke(null, null);
+
+            Assert.Equal("deps", value);
         }
         finally
         {
@@ -327,9 +352,9 @@ public class ModuleBootstrapperGeneratorTests
 
         try
         {
-            var dependencyPath = BuildFixtureProject(
+            var runtimeDependencyPath = BuildFixtureProject(
                 root,
-                "NestedDependency",
+                "NestedDependencyRuntime",
                 "NestedDependency",
                 """
                 namespace NestedDependency;
@@ -337,6 +362,19 @@ public class ModuleBootstrapperGeneratorTests
                 public static class Marker
                 {
                     public static string Value => "runtime-probe";
+                }
+                """);
+
+            var facadeDependencyPath = BuildFixtureProject(
+                root,
+                "NestedDependencyFacade",
+                "NestedDependency",
+                """
+                namespace NestedDependency;
+
+                public static class Marker
+                {
+                    public static string Value => "facade";
                 }
                 """);
 
@@ -352,12 +390,13 @@ public class ModuleBootstrapperGeneratorTests
                     public static string Read() => NestedDependency.Marker.Value;
                 }
                 """,
-                new[] { dependencyPath });
+                new[] { facadeDependencyPath });
 
             File.Copy(modulePath, Path.Combine(libCore, "DemoModule.dll"), overwrite: true);
+            File.Copy(facadeDependencyPath, Path.Combine(libCore, "NestedDependency.dll"), overwrite: true);
             var nestedDependencyPath = Path.Combine(libCore, "runtimes", GetCurrentRuntimeAssetRid(), "lib", "net8.0", "NestedDependency.dll");
             Directory.CreateDirectory(Path.GetDirectoryName(nestedDependencyPath)!);
-            File.Copy(dependencyPath, nestedDependencyPath, overwrite: true);
+            File.Copy(runtimeDependencyPath, nestedDependencyPath, overwrite: true);
 
             var exports = new ExportSet(Array.Empty<string>(), new[] { "Get-Demo" }, Array.Empty<string>());
             ModuleBootstrapperGenerator.Generate(

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -648,17 +648,28 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
 
         var resolvedPath = _resolver?.ResolveAssemblyToPath(assemblyName);
         if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
+        {{
+            // A package can place a compile-time facade beside the module and the real
+            // implementation under runtimes/<rid>/lib. Replace only that adjacent
+            // facade; preserve every non-adjacent path selected by the dependency resolver.
+            var runtimePath = IsAdjacentAssemblyPath(resolvedPath, assemblyName.Name)
+                ? ResolvePackagedRuntimeAssembly(assemblyName.Name)
+                : null;
+            if (!string.IsNullOrWhiteSpace(runtimePath) && File.Exists(runtimePath))
+                return LoadFromAssemblyPath(runtimePath);
+
             return LoadFromAssemblyPath(resolvedPath);
+        }}
 
         resolvedPath = _manifestResolver?.ResolveAssemblyToPath(assemblyName);
         if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
             return LoadFromAssemblyPath(resolvedPath);
 
-        resolvedPath = ResolvePackagedRuntimeAssembly(assemblyName.Name);
-        if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
-            return LoadFromAssemblyPath(resolvedPath);
-
         var assemblyPath = Path.Combine(_assemblyDirectory, assemblyName.Name + "".dll"");
+        var packagedRuntimePath = ResolvePackagedRuntimeAssembly(assemblyName.Name);
+        if (!string.IsNullOrWhiteSpace(packagedRuntimePath) && File.Exists(packagedRuntimePath))
+            return LoadFromAssemblyPath(packagedRuntimePath);
+
         return File.Exists(assemblyPath) ? LoadFromAssemblyPath(assemblyPath) : null;
     }}
 
@@ -946,6 +957,18 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
         }}
 
         return null;
+    }}
+
+    private bool IsAdjacentAssemblyPath(string resolvedPath, string assemblyName)
+    {{
+        if (string.IsNullOrWhiteSpace(resolvedPath) || string.IsNullOrWhiteSpace(assemblyName))
+            return false;
+
+        var adjacentPath = Path.Combine(_assemblyDirectory, assemblyName + "".dll"");
+        return string.Equals(
+            Path.GetFullPath(resolvedPath),
+            Path.GetFullPath(adjacentPath),
+            StringComparison.OrdinalIgnoreCase);
     }}
 
     private IntPtr LoadPackagedNativeLibrary(string unmanagedDllName)


### PR DESCRIPTION
## Summary

- prefer RID-specific runtime implementations when the adjacent published file is only a compile-time facade
- preserve an already selected non-adjacent dependency instead of overriding the resolver's package decision
- cover competing same-name runtime assets so module packages remain deterministic

## Why this matters

PowerShell modules can otherwise package a reference facade beside the module even when the dependency graph contains the correct runtime-managed assembly. The generated bootstrapper now uses the executable runtime asset without replacing unrelated resolver decisions.

## Validation

- `ModuleBootstrapperGeneratorTests`: 23 passed
- `ModuleBuilderDependencyCopyTests`: 8 passed