### PR TITLE
Fix website rendering integrity and multi-API LLM context

### DIFF
--- a/PowerForge.Tests/ScribanTemplateEngineTests.cs
+++ b/PowerForge.Tests/ScribanTemplateEngineTests.cs
@@ -1,0 +1,27 @@
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public class ScribanTemplateEngineTests
+{
+    [Fact]
+    public void Render_PreservesWhitespaceInsideMultilineHtmlFragments()
+    {
+        var engine = new ScribanTemplateEngine();
+        var context = new ThemeRenderContext
+        {
+            Page = new ContentItem
+            {
+                HtmlContent = "<pre><code>first();\n\nsecond();</code></pre>"
+            }
+        };
+
+        var rendered = engine.Render(
+            "<main>\n    {{ content }}\n</main>",
+            context,
+            _ => null);
+
+        Assert.Contains("first();\n\nsecond();", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("first();\n    \n    second();", rendered, StringComparison.Ordinal);
+    }
+}

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -36,6 +36,46 @@ public class WebLlmsGeneratorTests
     }
 
     [Fact]
+    public void Generate_AggregatesMultipleApiCatalogsWithTheirPublishedRoutes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-multi-api-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var wordIndex = WriteApiIndex(root, "word", "OfficeIMO.Word", 274);
+            var excelIndex = WriteApiIndex(root, "excel", "OfficeIMO.Excel", 63);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                Name = "OfficeIMO",
+                PackageId = "OfficeIMO.Word",
+                ApiIndexPaths = new[] { wordIndex, excelIndex }
+            });
+
+            Assert.Equal(2, result.ApiCatalogCount);
+            Assert.Equal(337, result.ApiTypeCount);
+
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            Assert.Contains("- API catalogs: 2", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("[OfficeIMO.Word API index](/api/word/index.json)", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("[OfficeIMO.Excel API search](/api/excel/search.json)", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("[API index](/api/index.json)", llmsTxt, StringComparison.Ordinal);
+
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("\"apiCatalogs\"", llmsJson, StringComparison.Ordinal);
+            Assert.Contains("\"index\": \"/api/word/index.json\"", llmsJson, StringComparison.Ordinal);
+            Assert.Contains("\"type\": \"/api/excel/types/{slug}.json\"", llmsJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"api\":", llmsJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Generate_UsesProjectDescription_WhenOverviewIsNotProvided()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-project-description-" + Guid.NewGuid().ToString("N"));
@@ -149,5 +189,25 @@ public class WebLlmsGeneratorTests
         {
             // Ignore cleanup failures in tests.
         }
+    }
+
+    private static string WriteApiIndex(string root, string slug, string assemblyName, int typeCount)
+    {
+        var directory = Path.Combine(root, "api", slug);
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "index.json");
+        File.WriteAllText(path,
+            $$"""
+            {
+              "title": "{{assemblyName}} API Reference",
+              "assembly": {
+                "assemblyName": "{{assemblyName}}",
+                "assemblyVersion": "1.0.0.0"
+              },
+              "typeCount": {{typeCount}},
+              "types": []
+            }
+            """);
+        return path;
     }
 }

--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2b.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2b.cs
@@ -40,6 +40,52 @@ public partial class WebSiteAuditOptimizeBuildTests
     }
 
     [Fact]
+    public void OptimizeDetailed_DoesNotHashSharedAssetsForPartialHtmlScope()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-opt-partial-hash-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "docs"));
+            var firstPage = Path.Combine(root, "index.html");
+            var secondPage = Path.Combine(root, "docs", "index.html");
+            const string html = "<link rel=\"stylesheet\" href=\"/app.css\"><script src=\"/site.js\"></script>";
+            File.WriteAllText(firstPage, html);
+            File.WriteAllText(secondPage, html);
+            File.WriteAllText(Path.Combine(root, "app.css"), "body { color: red; }");
+            File.WriteAllText(Path.Combine(root, "site.js"), "console.log('ok');");
+
+            var result = WebAssetOptimizer.OptimizeDetailed(new WebAssetOptimizerOptions
+            {
+                SiteRoot = root,
+                MaxHtmlFiles = 1,
+                AssetPolicy = new AssetPolicySpec
+                {
+                    Hashing = new AssetHashSpec
+                    {
+                        Enabled = true,
+                        Extensions = new[] { ".css", ".js" }
+                    }
+                }
+            });
+
+            Assert.Equal(2, result.HtmlFileCount);
+            Assert.Equal(1, result.HtmlSelectedFileCount);
+            Assert.Equal(0, result.HashedAssetCount);
+            Assert.True(File.Exists(Path.Combine(root, "app.css")));
+            Assert.True(File.Exists(Path.Combine(root, "site.js")));
+            Assert.Equal(html, File.ReadAllText(firstPage));
+            Assert.Equal(html, File.ReadAllText(secondPage));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void OptimizeDetailed_PreservesQuotedJsonLdScriptType()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-opt-jsonld-quote-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
@@ -519,6 +519,7 @@ internal static partial class WebCliCommandHandlers
                        TryGetOptionValue(subArgs, "--path");
         var projectFile = TryGetOptionValue(subArgs, "--project");
         var apiIndex = TryGetOptionValue(subArgs, "--api-index");
+        var apiIndexes = ReadOptionList(subArgs, "--api-indexes");
         var apiBase = TryGetOptionValue(subArgs, "--api-base");
         var name = TryGetOptionValue(subArgs, "--name");
         var packageId = TryGetOptionValue(subArgs, "--package") ?? TryGetOptionValue(subArgs, "--package-id");
@@ -547,6 +548,7 @@ internal static partial class WebCliCommandHandlers
             SiteRoot = siteRoot,
             ProjectFile = projectFile,
             ApiIndexPath = apiIndex,
+            ApiIndexPaths = apiIndexes.ToArray(),
             ApiBase = apiBase ?? "/api",
             Name = name,
             PackageId = packageId,

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -122,7 +122,8 @@ internal static partial class WebCliHelpers
         Console.WriteLine("  powerforge-web links promote-404 --source <404-suggestions.json> --config <site.json> [--out <redirects.json>] [--review-csv <file>] [--enable] [--output json]");
         Console.WriteLine("  powerforge-web links ignore-404 --source <404-suggestions.json> --config <site.json> (--path <url>|--without-suggestions|--all) [--reason <text>] [--review-csv <file>] [--output json]");
         Console.WriteLine("  powerforge-web contributions validate --root <dir> [--fail-on-warnings|--strict] [--output json]");
-        Console.WriteLine("  powerforge-web llms --site-root <dir> [--project <path>] [--api-index <path>] [--api-base /api]");
+        Console.WriteLine("  powerforge-web llms --site-root <dir> [--project <path>] [--api-index <path>] [--api-indexes <path[,path...]>]");
+        Console.WriteLine("                     [--api-base /api]");
         Console.WriteLine("                     [--name <Name>] [--package <Id>] [--version <X.Y.Z>] [--quickstart <file>]");
         Console.WriteLine("                     [--overview <text>] [--license <text>] [--targets <text>] [--extra <file>]");
         Console.WriteLine("                     [--api-level none|summary|full] [--api-max-types <n>] [--api-max-members <n>]");

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
@@ -1645,11 +1645,19 @@ internal static partial class WebPipelineRunner
             throw new InvalidOperationException("llms requires siteRoot.");
 
         var apiLevelText = GetString(step, "apiLevel") ?? GetString(step, "api-level");
+        var apiIndexPaths = (GetArrayOfStrings(step, "apiIndexes") ??
+                             GetArrayOfStrings(step, "api-indexes") ??
+                             Array.Empty<string>())
+            .Select(path => ResolvePath(baseDir, path))
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path!)
+            .ToArray();
         var res = WebLlmsGenerator.Generate(new WebLlmsOptions
         {
             SiteRoot = siteRoot,
             ProjectFile = ResolvePath(baseDir, GetString(step, "project")),
             ApiIndexPath = ResolvePath(baseDir, GetString(step, "apiIndex") ?? GetString(step, "api-index")),
+            ApiIndexPaths = apiIndexPaths,
             ApiBase = GetString(step, "apiBase") ?? "/api",
             Name = GetString(step, "name"),
             PackageId = GetString(step, "package") ?? GetString(step, "packageId"),

--- a/PowerForge.Web/Models/WebLlmsResult.cs
+++ b/PowerForge.Web/Models/WebLlmsResult.cs
@@ -17,6 +17,8 @@ public sealed class WebLlmsResult
     public string Version { get; set; } = "unknown";
     /// <summary>Optional count of API types included.</summary>
     public int? ApiTypeCount { get; set; }
+    /// <summary>Number of API catalogs represented in the generated files.</summary>
+    public int ApiCatalogCount { get; set; }
 }
 
 /// <summary>Result payload for sitemap generation.</summary>

--- a/PowerForge.Web/Services/ScribanTemplateEngine.cs
+++ b/PowerForge.Web/Services/ScribanTemplateEngine.cs
@@ -89,7 +89,11 @@ internal sealed class ScribanTemplateEngine : ITemplateEngine
         var templateContext = new TemplateContext
         {
             TemplateLoader = new InlineTemplateLoader(partialResolver),
-            StrictVariables = false
+            StrictVariables = false,
+            // HTML fragments such as rendered Markdown and code samples already carry
+            // intentional whitespace. Scriban's automatic indentation would otherwise
+            // inject the template line's leading spaces after every newline in a fragment.
+            AutoIndent = false
         };
         templateContext.PushGlobal(globals);
 

--- a/PowerForge.Web/Services/WebAssetOptimizer.cs
+++ b/PowerForge.Web/Services/WebAssetOptimizer.cs
@@ -169,7 +169,11 @@ public static partial class WebAssetOptimizer
 
         var hashSpec = ResolveHashSpec(options, policy);
         Dictionary<string, string>? hashMap = null;
-        if (hashSpec.Enabled)
+        // Fingerprinting moves shared assets and therefore requires every generated HTML
+        // reference to be rewritten in the same pass. A sampled/incremental HTML scope
+        // must never hash assets because untouched pages would retain broken old URLs.
+        var hasCompleteHtmlScope = htmlFiles.Length == allHtmlFiles.Length;
+        if (hashSpec.Enabled && hasCompleteHtmlScope)
         {
             hashMap = HashAssets(siteRoot, hashSpec, out var hashedAssetCount, out var hashedAssets, MarkUpdated);
             result.HashedAssetCount = hashedAssetCount;

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -14,6 +14,8 @@ public sealed class WebLlmsOptions
     public string? ProjectFile { get; set; }
     /// <summary>Optional API index path.</summary>
     public string? ApiIndexPath { get; set; }
+    /// <summary>Optional API index paths for sites that publish more than one API catalog.</summary>
+    public string[] ApiIndexPaths { get; set; } = Array.Empty<string>();
     /// <summary>Base URL for API docs.</summary>
     public string ApiBase { get; set; } = "/api";
     /// <summary>Optional project name override.</summary>
@@ -59,10 +61,10 @@ public static class WebLlmsGenerator
         var packageId = options.PackageId ?? projectInfo.PackageId ?? name;
         var version = options.Version ?? projectInfo.Version ?? "unknown";
 
-        var apiIndexPath = options.ApiIndexPath;
-        if (string.IsNullOrWhiteSpace(apiIndexPath))
-            apiIndexPath = Path.Combine(siteRoot, "api", "index.json");
-        var typeCount = ReadApiTypeCount(apiIndexPath);
+        var apiCatalogs = ResolveApiCatalogs(options, siteRoot);
+        int? typeCount = apiCatalogs.Any(catalog => catalog.TypeCount.HasValue)
+            ? apiCatalogs.Sum(catalog => catalog.TypeCount ?? 0)
+            : null;
 
         var llmsTxtPath = Path.Combine(siteRoot, "llms.txt");
         var llmsJsonPath = Path.Combine(siteRoot, "llms.json");
@@ -70,11 +72,9 @@ public static class WebLlmsGenerator
 
         var quickstart = ResolveQuickstart(options.QuickstartPath, name);
         var overview = ResolveOverview(options, projectInfo, siteRoot, name);
-        var apiBase = string.IsNullOrWhiteSpace(options.ApiBase) ? "/api" : options.ApiBase;
-
-        WriteLlmsTxt(llmsTxtPath, name, packageId, version, typeCount, apiBase, overview, quickstart);
-        WriteLlmsJson(llmsJsonPath, name, packageId, version, apiBase, quickstart);
-        WriteLlmsFull(llmsFullPath, name, packageId, version, typeCount, apiBase, overview, quickstart, options);
+        WriteLlmsTxt(llmsTxtPath, name, packageId, version, typeCount, apiCatalogs, overview, quickstart);
+        WriteLlmsJson(llmsJsonPath, name, packageId, version, typeCount, apiCatalogs, quickstart);
+        WriteLlmsFull(llmsFullPath, name, packageId, version, typeCount, apiCatalogs, overview, quickstart, options);
 
         return new WebLlmsResult
         {
@@ -84,7 +84,8 @@ public static class WebLlmsGenerator
             Name = name,
             PackageId = packageId,
             Version = version,
-            ApiTypeCount = typeCount
+            ApiTypeCount = typeCount,
+            ApiCatalogCount = apiCatalogs.Count
         };
     }
 
@@ -121,23 +122,83 @@ public static class WebLlmsGenerator
         return $"{name} documentation site and API reference.";
     }
 
-    private static int? ReadApiTypeCount(string? apiIndexPath)
+    private static List<ApiCatalogInfo> ResolveApiCatalogs(WebLlmsOptions options, string siteRoot)
     {
-        if (string.IsNullOrWhiteSpace(apiIndexPath)) return null;
-        var full = Path.GetFullPath(apiIndexPath);
-        if (!File.Exists(full)) return null;
+        var configuredPaths = new List<string>();
+        if (!string.IsNullOrWhiteSpace(options.ApiIndexPath))
+            configuredPaths.Add(options.ApiIndexPath);
+        configuredPaths.AddRange(options.ApiIndexPaths.Where(path => !string.IsNullOrWhiteSpace(path)));
+
+        if (configuredPaths.Count == 0)
+            configuredPaths.Add(Path.Combine(siteRoot, "api", "index.json"));
+
+        var fullPaths = configuredPaths
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var multipleCatalogs = fullPaths.Length > 1;
+        var catalogs = new List<ApiCatalogInfo>(fullPaths.Length);
+        foreach (var fullPath in fullPaths)
+        {
+            var apiBase = multipleCatalogs
+                ? InferApiBase(siteRoot, fullPath)
+                : NormalizeApiBase(options.ApiBase);
+            catalogs.Add(ReadApiCatalog(fullPath, apiBase));
+        }
+
+        return catalogs;
+    }
+
+    private static ApiCatalogInfo ReadApiCatalog(string fullPath, string apiBase)
+    {
+        var catalog = new ApiCatalogInfo
+        {
+            IndexPath = fullPath,
+            ApiBase = apiBase,
+            Name = Path.GetFileName(Path.GetDirectoryName(fullPath)) ?? "API"
+        };
+        if (!File.Exists(fullPath)) return catalog;
+
         try
         {
-            using var doc = JsonDocument.Parse(File.ReadAllText(full));
+            using var doc = JsonDocument.Parse(File.ReadAllText(fullPath));
             if (doc.RootElement.TryGetProperty("typeCount", out var count) && count.TryGetInt32(out var value))
-                return value;
+                catalog.TypeCount = value;
+            if (doc.RootElement.TryGetProperty("assembly", out var assembly) &&
+                assembly.ValueKind == JsonValueKind.Object)
+            {
+                var assemblyName = ReadString(assembly, "assemblyName");
+                if (!string.IsNullOrWhiteSpace(assemblyName))
+                    catalog.Name = assemblyName;
+            }
+            else
+            {
+                var title = ReadString(doc.RootElement, "title");
+                if (!string.IsNullOrWhiteSpace(title))
+                    catalog.Name = Regex.Replace(title, @"\s+(API|Cmdlet)\s+Reference$", string.Empty, RegexOptions.IgnoreCase);
+            }
         }
         catch
         {
-            return null;
+            // Keep the catalog link even when optional metadata cannot be read.
         }
 
-        return null;
+        return catalog;
+    }
+
+    private static string InferApiBase(string siteRoot, string apiIndexPath)
+    {
+        var directory = Path.GetDirectoryName(apiIndexPath) ?? siteRoot;
+        var relative = Path.GetRelativePath(siteRoot, directory).Replace('\\', '/').Trim('/');
+        if (string.IsNullOrWhiteSpace(relative) || relative.StartsWith("..", StringComparison.Ordinal))
+            return "/api";
+        return "/" + relative;
+    }
+
+    private static string NormalizeApiBase(string? apiBase)
+    {
+        var normalized = string.IsNullOrWhiteSpace(apiBase) ? "/api" : apiBase.Trim();
+        return normalized.Length > 1 ? normalized.TrimEnd('/') : normalized;
     }
 
     private static string MatchValue(string content, string name)
@@ -253,11 +314,10 @@ public static class WebLlmsGenerator
         string packageId,
         string version,
         int? typeCount,
-        string apiBase,
+        IReadOnlyList<ApiCatalogInfo> apiCatalogs,
         string overview,
         string[] quickstart)
     {
-        var normalizedApiBase = apiBase.TrimEnd('/');
         var lines = new List<string>
         {
             $"# {name}",
@@ -269,6 +329,7 @@ public static class WebLlmsGenerator
             $"- Package: {packageId}"
         };
         if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
+        if (apiCatalogs.Count > 1) lines.Add($"- API catalogs: {apiCatalogs.Count}");
         lines.Add(string.Empty);
         lines.Add("## Install");
         lines.Add($"- dotnet add package {packageId}");
@@ -279,9 +340,7 @@ public static class WebLlmsGenerator
         lines.Add("```");
         lines.Add(string.Empty);
         lines.Add("## Machine-friendly API data");
-        lines.Add($"- [API index]({normalizedApiBase}/index.json): Type and package metadata.");
-        lines.Add($"- [API search]({normalizedApiBase}/search.json): Searchable API data.");
-        lines.Add($"- [API type template]({normalizedApiBase}/types/{{slug}}.json): Per-type API details.");
+        AppendApiResourceLinks(lines, apiCatalogs);
         lines.Add(string.Empty);
         lines.Add("Slug rule: lower-case, dots/symbols -> dashes.");
 
@@ -293,7 +352,8 @@ public static class WebLlmsGenerator
         string name,
         string packageId,
         string version,
-        string apiBase,
+        int? typeCount,
+        IReadOnlyList<ApiCatalogInfo> apiCatalogs,
         string[] quickstart)
     {
         var payload = new Dictionary<string, object?>
@@ -303,14 +363,17 @@ public static class WebLlmsGenerator
             ["package"] = packageId,
             ["install"] = new[] { $"dotnet add package {packageId}" },
             ["quickstart"] = quickstart.Where(l => l != null).ToArray(),
-            ["api"] = new Dictionary<string, object?>
-            {
-                ["index"] = $"{apiBase.TrimEnd('/')}/index.json",
-                ["search"] = $"{apiBase.TrimEnd('/')}/search.json",
-                ["type"] = $"{apiBase.TrimEnd('/')}/types/{{slug}}.json",
-                ["slugRule"] = "lower-case, dots/symbols -> dashes"
-            }
+            ["apiTypeCount"] = typeCount
         };
+        if (apiCatalogs.Count == 1)
+            payload["api"] = CreateApiResourcePayload(apiCatalogs[0]);
+        else
+            payload["apiCatalogs"] = apiCatalogs.Select(catalog => new Dictionary<string, object?>
+            {
+                ["name"] = catalog.Name,
+                ["typeCount"] = catalog.TypeCount,
+                ["resources"] = CreateApiResourcePayload(catalog)
+            }).ToArray();
 
         var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
         File.WriteAllText(path, json, Encoding.UTF8);
@@ -322,7 +385,7 @@ public static class WebLlmsGenerator
         string packageId,
         string version,
         int? typeCount,
-        string apiBase,
+        IReadOnlyList<ApiCatalogInfo> apiCatalogs,
         string overview,
         string[] quickstart,
         WebLlmsOptions options)
@@ -337,6 +400,7 @@ public static class WebLlmsGenerator
             $"- Version: {version}"
         };
         if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
+        if (apiCatalogs.Count > 1) lines.Add($"- API catalogs: {apiCatalogs.Count}");
         if (!string.IsNullOrWhiteSpace(options.License)) lines.Add($"- License: {options.License}");
         if (!string.IsNullOrWhiteSpace(options.Targets)) lines.Add($"- Targets: {options.Targets}");
 
@@ -352,11 +416,9 @@ public static class WebLlmsGenerator
         lines.Add("```");
         lines.Add(string.Empty);
         lines.Add("## API Resources");
-        lines.Add($"- [API index]({apiBase.TrimEnd('/')}/index.json): Type and package metadata.");
-        lines.Add($"- [API search]({apiBase.TrimEnd('/')}/search.json): Searchable API data.");
-        lines.Add($"- [API type template]({apiBase.TrimEnd('/')}/types/{{slug}}.json): Per-type API details.");
+        AppendApiResourceLinks(lines, apiCatalogs);
 
-        AppendApiDetails(lines, options, apiBase);
+        AppendApiDetails(lines, options, apiCatalogs);
 
         if (!string.IsNullOrWhiteSpace(options.ExtraContentPath))
         {
@@ -371,34 +433,59 @@ public static class WebLlmsGenerator
         File.WriteAllText(path, string.Join(Environment.NewLine, lines), Encoding.UTF8);
     }
 
-    private static void AppendApiDetails(List<string> lines, WebLlmsOptions options, string apiBase)
+    private static void AppendApiResourceLinks(List<string> lines, IReadOnlyList<ApiCatalogInfo> apiCatalogs)
+    {
+        foreach (var catalog in apiCatalogs)
+        {
+            var label = apiCatalogs.Count > 1 ? $"{catalog.Name} " : string.Empty;
+            lines.Add($"- [{label}API index]({catalog.ApiBase}/index.json): Type and package metadata.");
+            lines.Add($"- [{label}API search]({catalog.ApiBase}/search.json): Searchable API data.");
+            lines.Add($"- [{label}API type template]({catalog.ApiBase}/types/{{slug}}.json): Per-type API details.");
+        }
+    }
+
+    private static Dictionary<string, object?> CreateApiResourcePayload(ApiCatalogInfo catalog)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["index"] = $"{catalog.ApiBase}/index.json",
+            ["search"] = $"{catalog.ApiBase}/search.json",
+            ["type"] = $"{catalog.ApiBase}/types/{{slug}}.json",
+            ["slugRule"] = "lower-case, dots/symbols -> dashes"
+        };
+    }
+
+    private static void AppendApiDetails(List<string> lines, WebLlmsOptions options, IReadOnlyList<ApiCatalogInfo> apiCatalogs)
     {
         if (options.ApiDetailLevel == WebApiDetailLevel.None)
             return;
 
-        var indexPath = options.ApiIndexPath;
-        if (string.IsNullOrWhiteSpace(indexPath))
-            indexPath = Path.Combine(options.SiteRoot, "api", "index.json");
-        var fullIndexPath = Path.GetFullPath(indexPath);
-        if (!File.Exists(fullIndexPath))
+        var catalogEntries = apiCatalogs
+            .Select(catalog => (Catalog: catalog, Entries: ReadApiIndex(catalog.IndexPath)))
+            .Where(item => item.Entries.Count > 0)
+            .ToArray();
+        if (catalogEntries.Length == 0)
             return;
 
-        var entries = ReadApiIndex(fullIndexPath);
-        if (entries.Count == 0)
-            return;
-
-        var maxTypes = options.ApiMaxTypes <= 0 ? entries.Count : Math.Min(options.ApiMaxTypes, entries.Count);
+        var remainingTypes = options.ApiMaxTypes <= 0 ? int.MaxValue : options.ApiMaxTypes;
         var maxMembers = options.ApiMaxMembers <= 0 ? int.MaxValue : options.ApiMaxMembers;
-        var typesDir = Path.Combine(Path.GetDirectoryName(fullIndexPath) ?? ".", "types");
+        var selectedEntries = new List<(ApiCatalogInfo Catalog, ApiIndexEntry Entry)>();
 
         lines.Add(string.Empty);
         lines.Add("## API Summary");
-
-        for (var i = 0; i < maxTypes; i++)
+        foreach (var (catalog, entries) in catalogEntries)
         {
-            var entry = entries[i];
-            var summary = string.IsNullOrWhiteSpace(entry.Summary) ? string.Empty : $" — {entry.Summary}";
-            lines.Add($"- {entry.FullName}{summary}");
+            if (remainingTypes <= 0) break;
+            if (catalogEntries.Length > 1)
+                lines.Add($"### {catalog.Name}");
+            foreach (var entry in entries.Take(remainingTypes))
+            {
+                var summary = string.IsNullOrWhiteSpace(entry.Summary) ? string.Empty : $" — {entry.Summary}";
+                lines.Add($"- {entry.FullName}{summary}");
+                selectedEntries.Add((catalog, entry));
+                remainingTypes--;
+                if (remainingTypes <= 0) break;
+            }
         }
 
         if (options.ApiDetailLevel != WebApiDetailLevel.Full)
@@ -406,9 +493,10 @@ public static class WebLlmsGenerator
 
         lines.Add(string.Empty);
         lines.Add("## API Members");
-        foreach (var entry in entries.Take(maxTypes))
+        foreach (var (catalog, entry) in selectedEntries)
         {
             if (maxMembers <= 0) break;
+            var typesDir = Path.Combine(Path.GetDirectoryName(catalog.IndexPath) ?? ".", "types");
             var typePath = Path.Combine(typesDir, $"{entry.Slug}.json");
             if (!File.Exists(typePath)) continue;
 
@@ -523,6 +611,14 @@ public static class WebLlmsGenerator
         public string Summary { get; set; } = string.Empty;
         public string Kind { get; set; } = string.Empty;
         public string Slug { get; set; } = string.Empty;
+    }
+
+    private sealed class ApiCatalogInfo
+    {
+        public string IndexPath { get; set; } = string.Empty;
+        public string ApiBase { get; set; } = "/api";
+        public string Name { get; set; } = "API";
+        public int? TypeCount { get; set; }
     }
 
     private sealed class ApiTypeDetail


### PR DESCRIPTION
## Summary

- preserve authored whitespace in Scriban-rendered HTML and code fragments
- avoid shared-asset hashing when optimization is scoped to only part of a site
- support multiple API indexes in llms.txt, llms.json, and llms-full.txt, using each catalog's real published route
- expose the multi-catalog option through the PowerForge pipeline and CLI

## Validation

- focused rendering, optimizer, and LLM tests: 7 passed
- OfficeIMO CI-equivalent website pipeline against this branch: passed (17 API catalogs, 58,263 xrefs, 3,659 routes, full optimize/SEO/audit)
- full PowerForge test assembly: 4,956 passed; 3 unrelated existing/environmental failures (WindowsApps PowerShell launch path, Apple release credential expectation, async fanout timeout)