### PR TITLE
Fix Windows PowerShell private dependency loading

### DIFF
--- a/Module/PSPublishModule.psm1
+++ b/Module/PSPublishModule.psm1
@@ -53,6 +53,101 @@ if ($PSEdition -eq 'Core') {
     $LibFolder = $FrameworkNet
 }
 
+$UnregisterPowerForgeDesktopAssemblyResolver = $null
+if ($PSEdition -ne 'Core' -and $LibFolder) {
+    $PowerForgeDesktopAssemblyRoot = [IO.Path]::GetFullPath([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))
+    $PowerForgeDesktopAssemblyRootPrefix = $PowerForgeDesktopAssemblyRoot
+    if (-not $PowerForgeDesktopAssemblyRootPrefix.EndsWith([IO.Path]::DirectorySeparatorChar.ToString(), [StringComparison]::Ordinal)) {
+        $PowerForgeDesktopAssemblyRootPrefix += [IO.Path]::DirectorySeparatorChar
+    }
+    $PowerForgeDesktopAssemblyResolverState = [pscustomobject]@{
+        BootstrapActive = $true
+    }
+
+    $PowerForgeDesktopAssemblyResolver = [System.ResolveEventHandler] {
+        param([object] $Sender, [ResolveEventArgs] $EventArgs)
+
+        try {
+            if ($null -eq $EventArgs) {
+                return $null
+            }
+
+            # AssemblyResolve is AppDomain-wide on Windows PowerShell. During the
+            # bounded preload/import window the CLR can omit RequestingAssembly
+            # while reconciling netstandard dependency versions. Outside that
+            # window, only service requests attributable to this module's private
+            # Lib folder.
+            if ($null -eq $EventArgs.RequestingAssembly -or
+                [string]::IsNullOrWhiteSpace($EventArgs.RequestingAssembly.Location)) {
+                if (-not $PowerForgeDesktopAssemblyResolverState.BootstrapActive) {
+                    return $null
+                }
+            } else {
+                $PowerForgeRequestingAssemblyPath = [IO.Path]::GetFullPath($EventArgs.RequestingAssembly.Location)
+                if (-not $PowerForgeRequestingAssemblyPath.StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                    return $null
+                }
+            }
+
+            $PowerForgeRequestedAssemblyName = [Reflection.AssemblyName]::new($EventArgs.Name).Name
+            if ([string]::IsNullOrWhiteSpace($PowerForgeRequestedAssemblyName)) {
+                return $null
+            }
+
+            # AssemblyName.Name is expected to be a simple name. Enforce that
+            # contract before using it as a path segment, then verify the
+            # canonical candidate remains beneath the private assembly root.
+            if ($PowerForgeRequestedAssemblyName -ne [IO.Path]::GetFileName($PowerForgeRequestedAssemblyName) -or
+                $PowerForgeRequestedAssemblyName.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0) {
+                return $null
+            }
+
+            $PowerForgeAssemblyCandidate = [IO.Path]::GetFullPath(
+                [IO.Path]::Combine($PowerForgeDesktopAssemblyRoot, $PowerForgeRequestedAssemblyName + '.dll'))
+            if (-not $PowerForgeAssemblyCandidate.StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                return $null
+            }
+
+            if (-not [IO.File]::Exists($PowerForgeAssemblyCandidate)) {
+                return $null
+            }
+
+            return [Reflection.Assembly]::LoadFrom($PowerForgeAssemblyCandidate)
+        } catch {
+            return $null
+        }
+    }.GetNewClosure()
+
+    [AppDomain]::CurrentDomain.add_AssemblyResolve($PowerForgeDesktopAssemblyResolver)
+    $PowerForgeResolverForRemoval = $PowerForgeDesktopAssemblyResolver
+    $UnregisterPowerForgeDesktopAssemblyResolver = {
+        [AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)
+    }.GetNewClosure()
+
+    $PowerForgePreviousOnRemove = $ExecutionContext.SessionState.Module.OnRemove
+    $ExecutionContext.SessionState.Module.OnRemove = {
+        try {
+            & $UnregisterPowerForgeDesktopAssemblyResolver
+        } finally {
+            if ($null -ne $PowerForgePreviousOnRemove) {
+                & $PowerForgePreviousOnRemove @args
+            }
+        }
+    }.GetNewClosure()
+}
+if ($PSEdition -ne 'Core') {
+    $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'PSPublishModule.Libraries.ps1')
+    if (Test-Path -LiteralPath $LibrariesScript) {
+        try {
+            . $LibrariesScript
+        } catch {
+            if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+                & $UnregisterPowerForgeDesktopAssemblyResolver
+            }
+            throw
+        }
+    }
+}
 $PowerForgeDesktopBinaryLoaded = $false
 try {
     $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
@@ -364,6 +459,9 @@ try {
     }
 } catch {
     if ($ErrorActionPreference -eq 'Stop') {
+        if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+            & $UnregisterPowerForgeDesktopAssemblyResolver
+        }
         throw
     } else {
         Write-Warning -Message "Importing module $Library failed. Fix errors before continuing. Error: $($_.Exception.Message)"
@@ -371,13 +469,6 @@ try {
 }
 
 if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded) {
-    # Core loads dependencies through the module-scoped AssemblyLoadContext above. Dot-sourcing the libraries script
-    # there would load dependency DLLs into the default context and undo the isolation this template exists to provide.
-    $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'PSPublishModule.Libraries.ps1')
-    if (Test-Path -LiteralPath $LibrariesScript) {
-        . $LibrariesScript
-    }
-
     if ($PSEdition -ne 'Core') {
         # Desktop loads module dependencies into the default AppDomain, so expose the same configured scripting types as Core.
         $RegisterPowerForgeDesktopAssemblyTypeAccelerators = {
@@ -662,6 +753,9 @@ if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded) {
             Write-Warning -Message "Desktop type accelerator registration failed: $($_.Exception.Message)"
         }
     }
+}
+if ($PSEdition -ne 'Core' -and $null -ne $PowerForgeDesktopAssemblyResolverState) {
+    $PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false
 }
 
 $FunctionsToExport = @()

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -30,6 +30,18 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("$LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'DemoModule.Libraries.ps1')", bootstrapper);
             Assert.Contains("$FunctionsToExport = @('Get-Demo')", bootstrapper);
             Assert.Contains("$AliasesToExport = @('gdemo')", bootstrapper);
+            Assert.Contains("[AppDomain]::CurrentDomain.add_AssemblyResolve($PowerForgeDesktopAssemblyResolver)", bootstrapper);
+            Assert.Contains("$EventArgs.RequestingAssembly.Location", bootstrapper);
+            Assert.Contains("$PowerForgeDesktopAssemblyResolverState = [pscustomobject]@{", bootstrapper);
+            Assert.Contains("if (-not $PowerForgeDesktopAssemblyResolverState.BootstrapActive)", bootstrapper);
+            Assert.Contains("$PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false", bootstrapper);
+            Assert.Contains("StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)", bootstrapper);
+            Assert.Contains("$PowerForgeRequestedAssemblyName -ne [IO.Path]::GetFileName($PowerForgeRequestedAssemblyName)", bootstrapper);
+            Assert.Contains("$PowerForgeRequestedAssemblyName.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0", bootstrapper);
+            Assert.Contains("$PowerForgeAssemblyCandidate = [IO.Path]::GetFullPath(", bootstrapper);
+            Assert.Contains("$PowerForgeAssemblyCandidate.StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)", bootstrapper);
+            Assert.Contains("[AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)", bootstrapper);
+            Assert.Contains("$ExecutionContext.SessionState.Module.OnRemove", bootstrapper);
             Assert.DoesNotContain("ProcessArchitecture", bootstrapper);
         }
         finally
@@ -62,6 +74,10 @@ public class ModuleBootstrapperGeneratorTests
             var libraries = File.ReadAllText(Path.Combine(root, "DemoModule.Libraries.ps1"));
             Assert.Contains("Lib\\Default\\DemoModule.dll", libraries);
             Assert.Contains("Lib\\Default\\Dependency.dll", libraries);
+            Assert.True(
+                libraries.IndexOf("Lib\\Default\\Dependency.dll", StringComparison.Ordinal) <
+                libraries.IndexOf("Lib\\Default\\DemoModule.dll", StringComparison.Ordinal),
+                "Private dependencies must be preloaded before the exported module assembly on Desktop PowerShell.");
             Assert.DoesNotContain("libgcc_s_seh-1.dll", libraries);
         }
         finally
@@ -176,7 +192,13 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("Falling back to direct Import-Module", bootstrapper);
             Assert.Contains("will load from the default context", bootstrapper);
             Assert.Contains("$PSEdition -ne 'Core'", bootstrapper);
+            Assert.Contains("[AppDomain]::CurrentDomain.add_AssemblyResolve($PowerForgeDesktopAssemblyResolver)", bootstrapper);
+            Assert.Contains("[AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)", bootstrapper);
             Assert.Contains("$LibrariesScript = [IO.Path]::Combine($PSScriptRoot, 'DemoModule.Libraries.ps1')", bootstrapper);
+            Assert.True(
+                bootstrapper.IndexOf(". $LibrariesScript", StringComparison.Ordinal) <
+                bootstrapper.IndexOf("& $ImportModule $ModuleAssemblyPath", StringComparison.Ordinal),
+                "Desktop dependencies must load before the exported binary module.");
 
             Assert.True(File.Exists(Path.Combine(root, "Lib", "Core", "DemoModule.ModuleLoadContext.dll")));
             Assert.False(File.Exists(Path.Combine(root, "Lib", "Default", "DemoModule.ModuleLoadContext.dll")));

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -50,7 +50,20 @@ if ($PSEdition -eq 'Core') {
     $LibFolder = $FrameworkNet
 }
 
-{{RuntimeHandlerBlock}}$PowerForgeDesktopBinaryLoaded = $false
+{{DesktopAssemblyResolverBlock}}{{RuntimeHandlerBlock}}if ($PSEdition -ne 'Core') {
+    $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, '{{ModuleName}}.Libraries.ps1')
+    if (Test-Path -LiteralPath $LibrariesScript) {
+        try {
+            . $LibrariesScript
+        } catch {
+            if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+                & $UnregisterPowerForgeDesktopAssemblyResolver
+            }
+            throw
+        }
+    }
+}
+$PowerForgeDesktopBinaryLoaded = $false
 try {
     $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
     $ModuleAssemblyPath = [IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder, $Library)
@@ -118,6 +131,9 @@ try {
     }
 } catch {
     if ($ErrorActionPreference -eq 'Stop') {
+        if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+            & $UnregisterPowerForgeDesktopAssemblyResolver
+        }
         throw
     } else {
         Write-Warning -Message "Importing module $Library failed. Fix errors before continuing. Error: $($_.Exception.Message)"
@@ -125,12 +141,8 @@ try {
 }
 
 if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded) {
-    # Core loads dependencies through the module-scoped AssemblyLoadContext above. Dot-sourcing the libraries script
-    # there would load dependency DLLs into the default context and undo the isolation this template exists to provide.
-    $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, '{{ModuleName}}.Libraries.ps1')
-    if (Test-Path -LiteralPath $LibrariesScript) {
-        . $LibrariesScript
-    }
-
 {{DesktopTypeAcceleratorBlock}}
+}
+if ($PSEdition -ne 'Core' -and $null -ne $PowerForgeDesktopAssemblyResolverState) {
+    $PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false
 }

--- a/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
@@ -50,7 +50,22 @@ if ($PSEdition -eq 'Core') {
     $LibFolder = $FrameworkNet
 }
 
-{{RuntimeHandlerBlock}}try {
+{{DesktopAssemblyResolverBlock}}{{RuntimeHandlerBlock}}$PowerForgeDesktopLibrariesLoaded = $false
+if ($PSEdition -ne 'Core') {
+    $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, '{{ModuleName}}.Libraries.ps1')
+    if (Test-Path -LiteralPath $LibrariesScript) {
+        try {
+            . $LibrariesScript
+            $PowerForgeDesktopLibrariesLoaded = $true
+        } catch {
+            if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+                & $UnregisterPowerForgeDesktopAssemblyResolver
+            }
+            throw
+        }
+    }
+}
+try {
     $ImportModule = Get-Command -Name Import-Module -Module Microsoft.PowerShell.Core
 
     if (-not ($Class -as [type])) {
@@ -61,6 +76,9 @@ if ($PSEdition -eq 'Core') {
     }
 } catch {
     if ($ErrorActionPreference -eq 'Stop') {
+        if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+            & $UnregisterPowerForgeDesktopAssemblyResolver
+        }
         throw
     } else {
         Write-Warning -Message "Importing module $Library failed. Fix errors before continuing. Error: $($_.Exception.Message)"
@@ -69,6 +87,16 @@ if ($PSEdition -eq 'Core') {
 
 # Dot source all libraries by loading external file
 $LibrariesScript = [IO.Path]::Combine($PSScriptRoot, '{{ModuleName}}.Libraries.ps1')
-if (Test-Path -LiteralPath $LibrariesScript) {
-    . $LibrariesScript
+if (-not $PowerForgeDesktopLibrariesLoaded -and (Test-Path -LiteralPath $LibrariesScript)) {
+    try {
+        . $LibrariesScript
+    } catch {
+        if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+            & $UnregisterPowerForgeDesktopAssemblyResolver
+        }
+        throw
+    }
+}
+if ($PSEdition -ne 'Core' -and $null -ne $PowerForgeDesktopAssemblyResolverState) {
+    $PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false
 }

--- a/PowerForge/Scripts/ModuleBootstrapper/DesktopAssemblyResolver.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/DesktopAssemblyResolver.Template.ps1
@@ -1,0 +1,82 @@
+$UnregisterPowerForgeDesktopAssemblyResolver = $null
+if ($PSEdition -ne 'Core' -and $LibFolder) {
+    $PowerForgeDesktopAssemblyRoot = [IO.Path]::GetFullPath([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))
+    $PowerForgeDesktopAssemblyRootPrefix = $PowerForgeDesktopAssemblyRoot
+    if (-not $PowerForgeDesktopAssemblyRootPrefix.EndsWith([IO.Path]::DirectorySeparatorChar.ToString(), [StringComparison]::Ordinal)) {
+        $PowerForgeDesktopAssemblyRootPrefix += [IO.Path]::DirectorySeparatorChar
+    }
+    $PowerForgeDesktopAssemblyResolverState = [pscustomobject]@{
+        BootstrapActive = $true
+    }
+
+    $PowerForgeDesktopAssemblyResolver = [System.ResolveEventHandler] {
+        param([object] $Sender, [ResolveEventArgs] $EventArgs)
+
+        try {
+            if ($null -eq $EventArgs) {
+                return $null
+            }
+
+            # AssemblyResolve is AppDomain-wide on Windows PowerShell. During the
+            # bounded preload/import window the CLR can omit RequestingAssembly
+            # while reconciling netstandard dependency versions. Outside that
+            # window, only service requests attributable to this module's private
+            # Lib folder.
+            if ($null -eq $EventArgs.RequestingAssembly -or
+                [string]::IsNullOrWhiteSpace($EventArgs.RequestingAssembly.Location)) {
+                if (-not $PowerForgeDesktopAssemblyResolverState.BootstrapActive) {
+                    return $null
+                }
+            } else {
+                $PowerForgeRequestingAssemblyPath = [IO.Path]::GetFullPath($EventArgs.RequestingAssembly.Location)
+                if (-not $PowerForgeRequestingAssemblyPath.StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                    return $null
+                }
+            }
+
+            $PowerForgeRequestedAssemblyName = [Reflection.AssemblyName]::new($EventArgs.Name).Name
+            if ([string]::IsNullOrWhiteSpace($PowerForgeRequestedAssemblyName)) {
+                return $null
+            }
+
+            # AssemblyName.Name is expected to be a simple name. Enforce that
+            # contract before using it as a path segment, then verify the
+            # canonical candidate remains beneath the private assembly root.
+            if ($PowerForgeRequestedAssemblyName -ne [IO.Path]::GetFileName($PowerForgeRequestedAssemblyName) -or
+                $PowerForgeRequestedAssemblyName.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0) {
+                return $null
+            }
+
+            $PowerForgeAssemblyCandidate = [IO.Path]::GetFullPath(
+                [IO.Path]::Combine($PowerForgeDesktopAssemblyRoot, $PowerForgeRequestedAssemblyName + '.dll'))
+            if (-not $PowerForgeAssemblyCandidate.StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                return $null
+            }
+
+            if (-not [IO.File]::Exists($PowerForgeAssemblyCandidate)) {
+                return $null
+            }
+
+            return [Reflection.Assembly]::LoadFrom($PowerForgeAssemblyCandidate)
+        } catch {
+            return $null
+        }
+    }.GetNewClosure()
+
+    [AppDomain]::CurrentDomain.add_AssemblyResolve($PowerForgeDesktopAssemblyResolver)
+    $PowerForgeResolverForRemoval = $PowerForgeDesktopAssemblyResolver
+    $UnregisterPowerForgeDesktopAssemblyResolver = {
+        [AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)
+    }.GetNewClosure()
+
+    $PowerForgePreviousOnRemove = $ExecutionContext.SessionState.Module.OnRemove
+    $ExecutionContext.SessionState.Module.OnRemove = {
+        try {
+            & $UnregisterPowerForgeDesktopAssemblyResolver
+        } finally {
+            if ($null -ne $PowerForgePreviousOnRemove) {
+                & $PowerForgePreviousOnRemove @args
+            }
+        }
+    }.GetNewClosure()
+}

--- a/PowerForge/Services/ModuleBootstrapperGenerator.LibraryOrdering.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.LibraryOrdering.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace PowerForge;
+
+internal static partial class ModuleBootstrapperGenerator
+{
+    private static IReadOnlyList<string> OrderManagedLibrariesForDesktopPreload(
+        string directory,
+        IReadOnlyCollection<string> fileNames,
+        ISet<string> excluded,
+        ISet<string> exportAssemblies)
+    {
+        string[] candidates = fileNames
+            .Where(name => !excluded.Contains(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var assemblyFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var references = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (string fileName in candidates)
+        {
+            if (!TryReadAssemblyMetadata(Path.Combine(directory, fileName), out string? assemblyName, out string[] assemblyReferences))
+            {
+                references[fileName] = Array.Empty<string>();
+                continue;
+            }
+
+            assemblyFiles[assemblyName!] = fileName;
+            references[fileName] = assemblyReferences;
+        }
+
+        var remaining = new HashSet<string>(candidates, StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<string>(candidates.Length);
+        while (remaining.Count > 0)
+        {
+            string? next = remaining
+                .Where(fileName => references.TryGetValue(fileName, out string[]? required) &&
+                    required.All(reference => !assemblyFiles.TryGetValue(reference, out string? dependencyFile) ||
+                                              !remaining.Contains(dependencyFile)))
+                .OrderBy(fileName => exportAssemblies.Contains(fileName) ? 1 : 0)
+                .ThenBy(fileName => fileName, StringComparer.OrdinalIgnoreCase)
+                .FirstOrDefault();
+
+            // Cycles are unusual for managed assemblies. Keep generation deterministic and let the
+            // module-scoped resolver service any cycle edge whose requesting assembly is already owned.
+            next ??= remaining
+                .OrderBy(fileName => exportAssemblies.Contains(fileName) ? 1 : 0)
+                .ThenBy(fileName => fileName, StringComparer.OrdinalIgnoreCase)
+                .First();
+            remaining.Remove(next);
+            ordered.Add(next);
+        }
+
+        return ordered;
+    }
+
+    private static bool TryReadAssemblyMetadata(string path, out string? assemblyName, out string[] references)
+    {
+        assemblyName = null;
+        references = Array.Empty<string>();
+        try
+        {
+            using FileStream stream = File.OpenRead(path);
+            using var reader = new PEReader(stream);
+            if (!reader.HasMetadata) return false;
+            MetadataReader metadata = reader.GetMetadataReader();
+            if (!metadata.IsAssembly) return false;
+            assemblyName = metadata.GetString(metadata.GetAssemblyDefinition().Name);
+            references = metadata.AssemblyReferences
+                .Select(handle => metadata.GetString(metadata.GetAssemblyReference(handle).Name))
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            return !string.IsNullOrWhiteSpace(assemblyName);
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+}

--- a/PowerForge/Services/ModuleBootstrapperGenerator.cs
+++ b/PowerForge/Services/ModuleBootstrapperGenerator.cs
@@ -211,21 +211,9 @@ internal static partial class ModuleBootstrapperGenerator
         foreach (var ignored in ignoredLibraryFileNames)
             excluded.Add(ignored);
 
-        var exportFirst = new HashSet<string>(exportAssemblyFileNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
-        foreach (var name in exportAssemblyFileNames ?? Array.Empty<string>())
-        {
-            if (string.IsNullOrWhiteSpace(name)) continue;
-            if (excluded.Contains(name)) continue;
-            if (!dllFiles.Contains(name, StringComparer.OrdinalIgnoreCase)) continue;
+        var exportLast = new HashSet<string>(exportAssemblyFileNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        foreach (var name in OrderManagedLibrariesForDesktopPreload(dir, dllFiles, excluded, exportLast))
             list.Add(RelativeLibPath(folderName, name));
-        }
-
-        foreach (var name in dllFiles.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
-        {
-            if (excluded.Contains(name)) continue;
-            if (exportFirst.Contains(name)) continue;
-            list.Add(RelativeLibPath(folderName, name));
-        }
 
         return list;
 
@@ -287,6 +275,7 @@ internal static partial class ModuleBootstrapperGenerator
                     ["ModuleName"] = EscapePsSingleQuoted(moduleName),
                     ["LoaderAssemblyName"] = EscapePsSingleQuoted(loaderIdentity?.AssemblyName ?? string.Empty),
                     ["LoaderTypeName"] = loaderIdentity?.TypeName ?? string.Empty,
+                    ["DesktopAssemblyResolverBlock"] = BuildDesktopAssemblyResolverBlock(),
                     ["RuntimeHandlerBlock"] = handleRuntimes ? BuildRuntimeHandlerBlock() : string.Empty,
                     ["TypeAcceleratorBlock"] = BuildTypeAcceleratorBlock(
                         assemblyTypeAcceleratorMode,
@@ -1153,6 +1142,14 @@ public sealed class ModuleAssemblyLoadContext : AssemblyLoadContext
                        "}",
                        string.Empty
                    });
+    }
+
+    private static string BuildDesktopAssemblyResolverBlock()
+    {
+        return RenderModuleBootstrapperTemplate(
+            "DesktopAssemblyResolver",
+            "Scripts/ModuleBootstrapper/DesktopAssemblyResolver.Template.ps1",
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
     }
 
     internal static string BuildTypeAcceleratorBlock(


### PR DESCRIPTION
## Summary

- preload Desktop dependencies in metadata-derived dependency order before importing exported binary modules
- scope Windows PowerShell `AssemblyResolve` handling to the module's private `Lib` tree, with a bounded bootstrap window for CLR requests that omit the requesting assembly
- unregister the resolver on module removal and on terminal import failures
- keep PowerShell Core on the existing isolated AssemblyLoadContext path

## Why this matters

Windows PowerShell 5.1 can request a compatible private dependency without identifying the requesting assembly while a netstandard dependency graph is loading. A global resolver is unsafe, while refusing every ownerless request prevents otherwise valid packaged modules from importing. This change supports only the short preload/import phase, validates canonical candidate paths, and then returns to requester-owned resolution.

## Validation

- `ModuleBootstrapperGeneratorTests`: 23/23 on net10.0
- PowerForge, PowerForge.PowerShell, and PSPublishModule: Release/net472 builds with zero warnings and errors
- PSPublishModule self-build imported from the installed artifact in PowerShell 7 and Windows PowerShell 5.1
- the resulting installed builder packaged ComputerX and TestimoX; both packages imported in PowerShell 7 and Windows PowerShell 5.1