### PR TITLE
Harden server backup and API-doc recovery paths

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
@@ -246,6 +246,8 @@ public class WebApiDocsGeneratorContractTests
             HeaderHtmlPath = headerPath,
             FooterHtmlPath = footerPath
         };
+        options.TemplateTokens["NAV_LINKS"] = "<a href=\"/provided/\">Provided</a>";
+        options.TemplateTokens["NAV_ACTIONS"] = string.Empty;
 
         try
         {

--- a/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorContractTests.cs
@@ -198,6 +198,80 @@ public class WebApiDocsGeneratorContractTests
     }
 
     [Fact]
+    public void GenerateDocsHtml_AllowsNavigationTokensInOnlyOneCustomFragment()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-nav-split-fragments-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        var siteJsonPath = Path.Combine(root, "site.json");
+        File.WriteAllText(siteJsonPath,
+            """
+            {
+              "Name": "TestSite",
+              "Navigation": {
+                "Menus": [
+                  { "Name": "main", "Items": [ { "Title": "Docs", "Url": "/docs/" } ] }
+                ]
+              }
+            }
+            """);
+
+        var xmlPath = Path.Combine(root, "test.xml");
+        File.WriteAllText(xmlPath,
+            """
+            <doc>
+              <assembly><name>Test</name></assembly>
+              <members>
+                <member name="T:MyNamespace.Sample">
+                  <summary>Sample.</summary>
+                </member>
+              </members>
+            </doc>
+            """);
+
+        var headerPath = Path.Combine(root, "api-header.html");
+        var footerPath = Path.Combine(root, "api-footer.html");
+        File.WriteAllText(headerPath, "<header>{{NAV_LINKS}}{{NAV_ACTIONS}}</header>");
+        File.WriteAllText(footerPath, "<footer>Footer</footer>");
+
+        var outputPath = Path.Combine(root, "api");
+        var options = new WebApiDocsOptions
+        {
+            XmlPath = xmlPath,
+            OutputPath = outputPath,
+            Format = "html",
+            Template = "docs",
+            BaseUrl = "/api",
+            NavJsonPath = siteJsonPath,
+            HeaderHtmlPath = headerPath,
+            FooterHtmlPath = footerPath
+        };
+
+        try
+        {
+            var result = WebApiDocsGenerator.Generate(options);
+            Assert.DoesNotContain(result.Warnings, warning =>
+                warning.Contains("nav injection may be empty", StringComparison.OrdinalIgnoreCase));
+
+            var html = File.ReadAllText(Path.Combine(outputPath, "index.html"));
+            Assert.Contains("href=\"/docs/\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<footer>Footer</footer>", html, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, true);
+            }
+            catch
+            {
+                // ignore cleanup failures in tests
+            }
+        }
+    }
+
+    [Fact]
     public void GenerateDocsHtml_WarnsWhenNavTokensPresentButNavJsonPathNotSet()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-nav-required-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebCliServerCaptureTests.cs
+++ b/PowerForge.Tests/WebCliServerCaptureTests.cs
@@ -292,14 +292,17 @@ public sealed class WebCliServerCaptureTests
     {
         var command = WebCliCommandHandlers.BuildRemoteOperationLockCommand(
             ["/var/lock/powerforge-site-example.lock"],
-            waitSeconds: 900);
+            waitSecondsPerLock: 900);
 
         Assert.Contains("flock -w 900 '/var/lock/powerforge-site-example.lock'", command, StringComparison.Ordinal);
         Assert.DoesNotContain("flock -n", command, StringComparison.Ordinal);
+        Assert.Equal(
+            TimeSpan.FromSeconds(1830),
+            WebCliCommandHandlers.GetRemoteOperationLockMarkerTimeout(lockCount: 2, waitSecondsPerLock: 900));
         Assert.Throws<InvalidOperationException>(() =>
             WebCliCommandHandlers.BuildRemoteOperationLockCommand(
                 ["/var/lock/powerforge-site-example.lock"],
-                waitSeconds: 3601));
+                waitSecondsPerLock: 3601));
     }
 
     [Fact]

--- a/PowerForge.Tests/WebCliServerCaptureTests.cs
+++ b/PowerForge.Tests/WebCliServerCaptureTests.cs
@@ -288,6 +288,21 @@ public sealed class WebCliServerCaptureTests
     }
 
     [Fact]
+    public void BuildRemoteOperationLockCommand_CanWaitForAConcurrentHostOperation()
+    {
+        var command = WebCliCommandHandlers.BuildRemoteOperationLockCommand(
+            ["/var/lock/powerforge-site-example.lock"],
+            waitSeconds: 900);
+
+        Assert.Contains("flock -w 900 '/var/lock/powerforge-site-example.lock'", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("flock -n", command, StringComparison.Ordinal);
+        Assert.Throws<InvalidOperationException>(() =>
+            WebCliCommandHandlers.BuildRemoteOperationLockCommand(
+                ["/var/lock/powerforge-site-example.lock"],
+                waitSeconds: 3601));
+    }
+
+    [Fact]
     public void RemoteOperationLock_ReportsADeadSessionBeforeWorkCanContinue()
     {
         var startInfo = new ProcessStartInfo(OperatingSystem.IsWindows() ? "cmd.exe" : "sh")

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.OperationLocks.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.OperationLocks.cs
@@ -5,17 +5,23 @@ namespace PowerForge.Web.Cli;
 
 internal static partial class WebCliCommandHandlers
 {
-    internal static string BuildRemoteOperationLockCommand(IEnumerable<string> paths)
+    internal static string BuildRemoteOperationLockCommand(IEnumerable<string> paths, int waitSeconds = 0)
     {
         var locks = GetRemoteOperationLocks(paths);
         if (locks.Length == 0)
             throw new InvalidOperationException("At least one operation lock is required.");
+        if (waitSeconds is < 0 or > 3600)
+            throw new InvalidOperationException("Operation lock wait must be from 0 through 3600 seconds.");
 
         var builder = new StringBuilder("set -e; ");
         foreach (var path in locks)
             builder.Append(BuildOperationLockPostcondition(path)).Append("; ");
         foreach (var path in locks)
-            builder.Append("flock -n ").Append(ShellQuote(path)).Append(' ');
+        {
+            builder.Append(waitSeconds > 0 ? $"flock -w {waitSeconds} " : "flock -n ")
+                .Append(ShellQuote(path))
+                .Append(' ');
+        }
         builder.Append("sh -c ").Append(ShellQuote("printf 'POWERFORGE_OPERATION_LOCKED\\n'; cat >/dev/null"));
         return builder.ToString();
     }
@@ -23,13 +29,16 @@ internal static partial class WebCliCommandHandlers
     private static RemoteOperationLock? AcquireRemoteOperationLocks(
         string sshCommand,
         string target,
-        IEnumerable<string> paths)
+        IEnumerable<string> paths,
+        int waitSeconds = 0)
     {
         var locks = GetRemoteOperationLocks(paths);
         if (locks.Length == 0)
             return null;
 
-        var process = CreateProcess(sshCommand, BuildSshArguments(target, BuildRemoteOperationLockCommand(locks)));
+        var process = CreateProcess(
+            sshCommand,
+            BuildSshArguments(target, BuildRemoteOperationLockCommand(locks, waitSeconds)));
         process.StartInfo.RedirectStandardInput = true;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
@@ -40,7 +49,7 @@ internal static partial class WebCliCommandHandlers
         bool markerReady;
         try
         {
-            markerReady = markerTask.Wait(TimeSpan.FromSeconds(30));
+            markerReady = markerTask.Wait(TimeSpan.FromSeconds(Math.Max(30, waitSeconds + 30)));
         }
         catch (Exception exception)
         {

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.OperationLocks.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.OperationLocks.cs
@@ -5,20 +5,20 @@ namespace PowerForge.Web.Cli;
 
 internal static partial class WebCliCommandHandlers
 {
-    internal static string BuildRemoteOperationLockCommand(IEnumerable<string> paths, int waitSeconds = 0)
+    internal static string BuildRemoteOperationLockCommand(IEnumerable<string> paths, int waitSecondsPerLock = 0)
     {
         var locks = GetRemoteOperationLocks(paths);
         if (locks.Length == 0)
             throw new InvalidOperationException("At least one operation lock is required.");
-        if (waitSeconds is < 0 or > 3600)
-            throw new InvalidOperationException("Operation lock wait must be from 0 through 3600 seconds.");
+        if (waitSecondsPerLock is < 0 or > 3600)
+            throw new InvalidOperationException("Operation lock wait per lock must be from 0 through 3600 seconds.");
 
         var builder = new StringBuilder("set -e; ");
         foreach (var path in locks)
             builder.Append(BuildOperationLockPostcondition(path)).Append("; ");
         foreach (var path in locks)
         {
-            builder.Append(waitSeconds > 0 ? $"flock -w {waitSeconds} " : "flock -n ")
+            builder.Append(waitSecondsPerLock > 0 ? $"flock -w {waitSecondsPerLock} " : "flock -n ")
                 .Append(ShellQuote(path))
                 .Append(' ');
         }
@@ -30,7 +30,7 @@ internal static partial class WebCliCommandHandlers
         string sshCommand,
         string target,
         IEnumerable<string> paths,
-        int waitSeconds = 0)
+        int waitSecondsPerLock = 0)
     {
         var locks = GetRemoteOperationLocks(paths);
         if (locks.Length == 0)
@@ -38,7 +38,7 @@ internal static partial class WebCliCommandHandlers
 
         var process = CreateProcess(
             sshCommand,
-            BuildSshArguments(target, BuildRemoteOperationLockCommand(locks, waitSeconds)));
+            BuildSshArguments(target, BuildRemoteOperationLockCommand(locks, waitSecondsPerLock)));
         process.StartInfo.RedirectStandardInput = true;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
@@ -49,7 +49,7 @@ internal static partial class WebCliCommandHandlers
         bool markerReady;
         try
         {
-            markerReady = markerTask.Wait(TimeSpan.FromSeconds(Math.Max(30, waitSeconds + 30)));
+            markerReady = markerTask.Wait(GetRemoteOperationLockMarkerTimeout(locks.Length, waitSecondsPerLock));
         }
         catch (Exception exception)
         {
@@ -74,6 +74,17 @@ internal static partial class WebCliCommandHandlers
         }
 
         return new RemoteOperationLock(process);
+    }
+
+    internal static TimeSpan GetRemoteOperationLockMarkerTimeout(int lockCount, int waitSecondsPerLock)
+    {
+        if (lockCount < 1)
+            throw new InvalidOperationException("At least one operation lock is required.");
+        if (waitSecondsPerLock is < 0 or > 3600)
+            throw new InvalidOperationException("Operation lock wait per lock must be from 0 through 3600 seconds.");
+
+        var waitSeconds = checked((long)lockCount * waitSecondsPerLock + 30);
+        return TimeSpan.FromSeconds(Math.Max(30L, waitSeconds));
     }
 
     private static string StopFailedOperationLockProcess(Process process)

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -172,7 +172,7 @@ internal static partial class WebCliCommandHandlers
                 sshCommand,
                 target,
                 manifest.OperationLocks ?? Array.Empty<string>(),
-                waitSeconds: 900);
+                waitSecondsPerLock: 900);
             for (var commandIndex = 0; commandIndex < commandList.Length; commandIndex++)
             {
                 var command = commandList[commandIndex];

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.Server.cs
@@ -171,7 +171,8 @@ internal static partial class WebCliCommandHandlers
             using var captureLock = AcquireRemoteOperationLocks(
                 sshCommand,
                 target,
-                manifest.OperationLocks ?? Array.Empty<string>());
+                manifest.OperationLocks ?? Array.Empty<string>(),
+                waitSeconds: 900);
             for (var commandIndex = 0; commandIndex < commandList.Length; commandIndex++)
             {
                 var command = commandList[commandIndex];

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
@@ -35,6 +35,14 @@ public static partial class WebApiDocsGenerator
             ContainsUnprovidedTemplateToken(footer, "NAV_ACTIONS", tokens) ||
             ContainsUnprovidedTemplateTokenPrefix(footer, "FOOTER_", tokens);
         var needsNavTokens = headerNeedsNavTokens || footerNeedsNavTokens;
+        var headerContainsNavTokens =
+            ContainsTemplateToken(header, "NAV_LINKS") ||
+            ContainsTemplateToken(header, "NAV_ACTIONS") ||
+            ContainsTemplateTokenPrefix(header, "FOOTER_");
+        var footerContainsNavTokens =
+            ContainsTemplateToken(footer, "NAV_LINKS") ||
+            ContainsTemplateToken(footer, "NAV_ACTIONS") ||
+            ContainsTemplateTokenPrefix(footer, "FOOTER_");
         if (needsNavTokens && string.IsNullOrWhiteSpace(options.NavJsonPath))
         {
             warnings?.Add("API docs nav required: header/footer fragments contain {{NAV_*}} or {{FOOTER_*}} placeholders but NavJsonPath is not set. Set apidocs.nav (or apidocs.config) so navigation can be injected.");
@@ -68,8 +76,8 @@ public static partial class WebApiDocsGenerator
             var hasCustomHeader = !string.IsNullOrWhiteSpace(options.HeaderHtmlPath);
             var hasCustomFooter = !string.IsNullOrWhiteSpace(options.FooterHtmlPath);
             var customFragmentsContainNavTokens =
-                (hasCustomHeader && headerNeedsNavTokens) ||
-                (hasCustomFooter && footerNeedsNavTokens);
+                (hasCustomHeader && headerContainsNavTokens) ||
+                (hasCustomFooter && footerContainsNavTokens);
             var customFragmentMissingNavTokens =
                 (hasCustomHeader || hasCustomFooter) &&
                 !customFragmentsContainNavTokens;
@@ -173,6 +181,32 @@ public static partial class WebApiDocsGenerator
 
             var token = html.Substring(open + 2, close - open - 2).Trim();
             if (token.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && !providedTokens.ContainsKey(token))
+                return true;
+
+            searchStart = close + 2;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsTemplateTokenPrefix(string html, string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(prefix))
+            return false;
+
+        var searchStart = 0;
+        while (searchStart < html.Length)
+        {
+            var open = html.IndexOf("{{", searchStart, StringComparison.Ordinal);
+            if (open < 0)
+                return false;
+
+            var close = html.IndexOf("}}", open + 2, StringComparison.Ordinal);
+            if (close < 0)
+                return false;
+
+            var token = html.Substring(open + 2, close - open - 2).Trim();
+            if (token.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 return true;
 
             searchStart = close + 2;

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.NavTokens.cs
@@ -65,9 +65,14 @@ public static partial class WebApiDocsGenerator
         {
             // If the site provides custom header/footer fragments but forgets to include navigation placeholders,
             // nav injection will be a no-op and API pages may render without expected site navigation.
+            var hasCustomHeader = !string.IsNullOrWhiteSpace(options.HeaderHtmlPath);
+            var hasCustomFooter = !string.IsNullOrWhiteSpace(options.FooterHtmlPath);
+            var customFragmentsContainNavTokens =
+                (hasCustomHeader && headerNeedsNavTokens) ||
+                (hasCustomFooter && footerNeedsNavTokens);
             var customFragmentMissingNavTokens =
-                (!string.IsNullOrWhiteSpace(options.HeaderHtmlPath) && !headerNeedsNavTokens) ||
-                (!string.IsNullOrWhiteSpace(options.FooterHtmlPath) && !footerNeedsNavTokens);
+                (hasCustomHeader || hasCustomFooter) &&
+                !customFragmentsContainNavTokens;
             if (customFragmentMissingNavTokens)
             {
                 warnings?.Add("API docs nav: header/footer fragments do not contain {{NAV_LINKS}} or {{NAV_ACTIONS}} placeholders; nav injection may be empty.");


### PR DESCRIPTION
## Summary

- wait up to 15 minutes per declared recovery lock before scheduled server capture, while preserving fail-fast deploy behavior
- align the client acquisition deadline with multi-lock remote wait semantics
- allow custom API-doc headers or footers to own navigation placeholders without requiring both fragments to duplicate them
- detect physical navigation placeholders even when a caller supplies matching template-token values

This prevents legitimate Website rebuild/backup overlap from failing recovery capture and removes the false API-doc navigation warning currently blocking the production Website rebuild.