### PR TITLE
Use generated notes for Home Assistant releases

### DIFF
--- a/.agents/skills/powerforge-homeassistant-release/SKILL.md
+++ b/.agents/skills/powerforge-homeassistant-release/SKILL.md
@@ -23,6 +23,8 @@ Use PowerForge as the release owner. A receiver repository should contain only t
 - With no release label, product/config/dependency changes increment patch; docs, tests, workflows, and maintainer metadata do not release.
 - Exactly one release label overrides that default. Conflicting release labels fail closed.
 - PowerForge queues every merge trigger and runs three isolated jobs: privileged metadata prepare/push without receiver commands, read-only exact-commit build without write credentials, then privileged publish without receiver checkout or execution. It verifies the marker, tag target, conflict provenance, and required asset.
+- Published releases use GitHub-generated change and contributor notes. PowerForge
+  prepends only hidden provenance metadata needed for safe retry and recovery.
 - Treat three-part versions as the public contract. Do not introduce four-part consumer versions.
 
 ## Recover a failed run

--- a/.github/actions/homeassistant-release/action.yml
+++ b/.github/actions/homeassistant-release/action.yml
@@ -52,7 +52,7 @@ inputs:
   powerforge-version:
     description: Exact PowerForge.Build tool version used by the action.
     required: false
-    default: "1.0.4"
+    default: "1.0.8"
 
 outputs:
   action:

--- a/.github/workflows/powerforge-homeassistant-release.yml
+++ b/.github/workflows/powerforge-homeassistant-release.yml
@@ -67,7 +67,7 @@ jobs:
           default-branch: ${{ inputs.default_branch }}
           increment: ${{ inputs.increment }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
-          powerforge-version: 1.0.4
+          powerforge-version: 1.0.8
 
   build:
     needs: prepare
@@ -101,7 +101,7 @@ jobs:
           repository-root: ${{ github.workspace }}/source
           release-version: ${{ needs.prepare.outputs.version }}
           release-commit: ${{ needs.prepare.outputs.release-commit }}
-          powerforge-version: 1.0.4
+          powerforge-version: 1.0.8
 
       - name: Transfer the single release asset to the publish job
         if: steps.build.outputs.required-asset != ''
@@ -144,4 +144,4 @@ jobs:
           required-asset: ${{ needs.build.outputs.required-asset }}
           asset-path: ${{ needs.build.outputs.required-asset != '' && format('{0}/powerforge-homeassistant-release-asset/{1}', runner.temp, needs.build.outputs.required-asset) || '' }}
           github-token: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
-          powerforge-version: 1.0.4
+          powerforge-version: 1.0.8

--- a/Docs/PowerForge.HomeAssistantRelease.md
+++ b/Docs/PowerForge.HomeAssistantRelease.md
@@ -109,7 +109,10 @@ When a release is required, PowerForge:
 4. rejects any tracked source mutation made by build scripts and transfers only the declared asset;
 5. starts a separate privileged publish job that never executes receiver code;
 6. preflights any existing `v<version>` release and tag for the expected PowerForge marker and commit before same-named assets may be replaced;
-7. creates or safely resumes the release and reads it back from GitHub to verify the source marker, tag target, and required asset.
+7. creates or safely resumes the release with GitHub-generated change and contributor
+   notes, while retaining hidden PowerForge provenance metadata;
+8. reads the release back from GitHub to verify the source marker, tag target, and
+   required asset.
 
 The version commit is pushed with `GITHUB_TOKEN`, so GitHub does not recursively start ordinary push workflows. Safety comes from the merged PR checks, constrained version edit, job-level credential boundary, conflict preflight, and post-publication verification.
 

--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -1,26 +1,63 @@
 using PowerForge;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json.Nodes;
 
 namespace PowerForge.Tests;
 
 public sealed class GitHubReleasePublisherTests
 {
     [Fact]
-    public void PublishRelease_ThrowsWhenReleaseNotesConflictWithGenerateReleaseNotes()
+    public async Task PublishRelease_SendsMetadataWithGeneratedReleaseNotes()
     {
-        var publisher = new GitHubReleasePublisher(new NullLogger());
-
-        var request = new GitHubReleasePublishRequest
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        string? requestBody = null;
+        var server = Task.Run(async () =>
         {
-            Owner = "EvotecIT",
-            Repository = "PSPublishModule",
-            Token = "token",
-            TagName = "v1.2.3",
-            ReleaseNotes = "notes",
-            GenerateReleaseNotes = true
-        };
+            var context = await listener.GetContextAsync();
+            using var reader = new StreamReader(
+                context.Request.InputStream,
+                context.Request.ContentEncoding);
+            requestBody = await reader.ReadToEndAsync();
+            var responseBody = Encoding.UTF8.GetBytes(
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}","body":"generated"}""");
+            context.Response.StatusCode = 201;
+            context.Response.ContentType = "application/json";
+            context.Response.ContentLength64 = responseBody.Length;
+            await context.Response.OutputStream.WriteAsync(responseBody);
+            context.Response.Close();
+        });
+        const string metadata = "<!-- release provenance -->";
+        try
+        {
+            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    ReleaseNotes = metadata,
+                    GenerateReleaseNotes = true
+                });
 
-        var ex = Assert.Throws<ArgumentException>(() => publisher.PublishRelease(request));
-        Assert.Contains("ReleaseNotes", ex.Message, StringComparison.OrdinalIgnoreCase);
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            var request = JsonNode.Parse(requestBody!)!.AsObject();
+            Assert.Equal(metadata, request["body"]!.GetValue<string>());
+            Assert.True(request["generate_release_notes"]!.GetValue<bool>());
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+        }
     }
 
     [Fact]
@@ -90,5 +127,19 @@ public sealed class GitHubReleasePublisherTests
             "/repos/EvotecIT/example/releases");
 
         Assert.Equal("https://github.enterprise.example/api/v3/repos/EvotecIT/example/releases", uri.AbsoluteUri);
+    }
+
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 }

--- a/PowerForge.Tests/HomeAssistantReleaseTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseTests.cs
@@ -48,16 +48,16 @@ public sealed class HomeAssistantReleaseTests {
     }
 
     [Fact]
-    public void ReleaseNotes_RecordTheExactTagCommit() {
+    public void ReleaseMetadata_RecordsProvenanceWithoutVisiblePlaceholder() {
         const string releaseCommit = "cccccccccccccccccccccccccccccccccccccccc";
-        var notes = HomeAssistantReleasePolicy.BuildReleaseNotes(
-            new HomeAssistantPullRequest { Number = 42, Title = "Fix telemetry", HtmlUrl = "https://github.example/pull/42" },
+        var notes = HomeAssistantReleasePolicy.BuildReleaseMetadata(
             HomeAssistantReleasePolicy.BuildMarker(42, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
             releaseCommit,
             requiredAsset: null);
 
         Assert.Equal(releaseCommit, HomeAssistantReleasePolicy.ReadReleaseCommit(notes));
         Assert.Null(HomeAssistantReleasePolicy.ReadRequiredAsset(notes));
+        Assert.DoesNotContain("Release triggered by", notes, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -616,8 +616,7 @@ public sealed class HomeAssistantReleaseTests {
         var release = new HomeAssistantGitHubRelease {
             Id = 123,
             TagName = "v0.2.7",
-            Body = HomeAssistantReleasePolicy.BuildReleaseNotes(
-                new HomeAssistantPullRequest { Number = 42, Title = "Fix", HtmlUrl = "https://github.example/pull/42" },
+            Body = HomeAssistantReleasePolicy.BuildReleaseMetadata(
                 marker,
                 releaseCommit,
                 "example.zip"),
@@ -659,6 +658,9 @@ public sealed class HomeAssistantReleaseTests {
         Assert.Equal(123, publisher.CapturedRequest.ExpectedExistingReleaseId);
         Assert.Equal(marker, publisher.CapturedRequest.ExpectedReleaseBodyMarker);
         Assert.Equal(releaseCommit, publisher.CapturedRequest.ExpectedTagCommitSha);
+        Assert.True(publisher.CapturedRequest.GenerateReleaseNotes);
+        Assert.Contains(marker, publisher.CapturedRequest.ReleaseNotes, StringComparison.Ordinal);
+        Assert.DoesNotContain("Release triggered by", publisher.CapturedRequest.ReleaseNotes, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/HomeAssistantReleaseWorkflowTests.cs
@@ -22,10 +22,10 @@ public sealed class HomeAssistantReleaseWorkflowTests {
         var action = File.ReadAllText(Path.Combine(root, ".github", "actions", "homeassistant-release", "action.yml"));
         var skill = File.ReadAllText(Path.Combine(root, ".agents", "skills", "powerforge-homeassistant-release", "SKILL.md"));
 
-        Assert.Equal(3, CountOccurrences(workflow, "powerforge-version: 1.0.4"));
+        Assert.Equal(3, CountOccurrences(workflow, "powerforge-version: 1.0.8"));
         Assert.Contains("actions: read", workflow, StringComparison.Ordinal);
         Assert.Contains("`actions: read`", skill, StringComparison.Ordinal);
-        Assert.Contains("default: \"1.0.4\"", action, StringComparison.Ordinal);
+        Assert.Contains("default: \"1.0.8\"", action, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge/Models/GitHubReleasePublishRequest.cs
+++ b/PowerForge/Models/GitHubReleasePublishRequest.cs
@@ -25,13 +25,19 @@ public sealed class GitHubReleasePublishRequest
     /// <summary>Optional release title. When omitted, <see cref="TagName"/> is used.</summary>
     public string? ReleaseName { get; set; }
 
-    /// <summary>Optional release notes body.</summary>
+    /// <summary>
+    /// Optional release notes body. GitHub prepends it when
+    /// <see cref="GenerateReleaseNotes"/> is enabled.
+    /// </summary>
     public string? ReleaseNotes { get; set; }
 
     /// <summary>Optional commitish to create the tag from.</summary>
     public string? Commitish { get; set; }
 
-    /// <summary>True to ask GitHub to generate release notes automatically.</summary>
+    /// <summary>
+    /// True to ask GitHub to generate release notes automatically after any supplied
+    /// <see cref="ReleaseNotes"/> body.
+    /// </summary>
     public bool GenerateReleaseNotes { get; set; }
 
     /// <summary>True to create a draft release.</summary>

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -55,9 +55,6 @@ public sealed partial class GitHubReleasePublisher
         if (string.IsNullOrWhiteSpace(token)) throw new ArgumentException("Token is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(tagName)) throw new ArgumentException("TagName is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(releaseName)) releaseName = tagName;
-        if (generateReleaseNotes && !string.IsNullOrWhiteSpace(releaseNotes))
-            throw new ArgumentException("ReleaseNotes cannot be provided when GenerateReleaseNotes is enabled.", nameof(request));
-
         var assets = (request.AssetFilePaths ?? Array.Empty<string>())
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Select(p => Path.GetFullPath(p.Trim().Trim('"')))
@@ -178,8 +175,8 @@ public sealed partial class GitHubReleasePublisher
         var uri = BuildApiUri(apiBaseUrl, $"/repos/{owner}/{repo}/releases");
 
         var normalizedCommitish = string.IsNullOrWhiteSpace(commitish) ? null : commitish!.Trim();
-        var normalizedReleaseNotes = string.IsNullOrWhiteSpace(releaseNotes) ? null : releaseNotes;
-        if (generateReleaseNotes) normalizedReleaseNotes = null;
+        var normalizedReleaseNotes =
+            string.IsNullOrWhiteSpace(releaseNotes) ? null : releaseNotes;
         var body = new CreateReleaseRequest
         {
             TagName = tagName,

--- a/PowerForge/Services/HomeAssistantReleasePolicy.cs
+++ b/PowerForge/Services/HomeAssistantReleasePolicy.cs
@@ -42,11 +42,10 @@ internal static class HomeAssistantReleasePolicy {
     internal static string BuildMarker(int pullRequestNumber, string mergeCommitSha)
         => $"<!-- powerforge-homeassistant source-pr:{pullRequestNumber} merge:{mergeCommitSha} -->";
 
-    internal static string BuildReleaseNotes(HomeAssistantPullRequest pullRequest, string marker, string releaseCommitSha, string? requiredAsset)
+    internal static string BuildReleaseMetadata(string marker, string releaseCommitSha, string? requiredAsset)
         => $"{marker}{Environment.NewLine}" +
            $"<!-- powerforge-homeassistant release-commit:{releaseCommitSha} -->{Environment.NewLine}" +
-           $"<!-- powerforge-homeassistant required-asset:{Convert.ToBase64String(Encoding.UTF8.GetBytes(requiredAsset ?? string.Empty))} -->{Environment.NewLine}{Environment.NewLine}" +
-           $"Release triggered by #{pullRequest.Number}: [{pullRequest.Title}]({pullRequest.HtmlUrl}).";
+           $"<!-- powerforge-homeassistant required-asset:{Convert.ToBase64String(Encoding.UTF8.GetBytes(requiredAsset ?? string.Empty))} -->";
 
     internal static string? ReadReleaseCommit(string releaseBody) {
         if (string.IsNullOrWhiteSpace(releaseBody)) return null;

--- a/PowerForge/Services/HomeAssistantReleaseService.cs
+++ b/PowerForge/Services/HomeAssistantReleaseService.cs
@@ -255,8 +255,7 @@ public sealed class HomeAssistantReleaseService {
         var assets = string.IsNullOrWhiteSpace(spec.RequiredAssetName)
             ? Array.Empty<string>()
             : new[] { Path.GetFullPath(spec.AssetFilePath) };
-        var notes = HomeAssistantReleasePolicy.BuildReleaseNotes(
-            pullRequest,
+        var notes = HomeAssistantReleasePolicy.BuildReleaseMetadata(
             marker,
             spec.ReleaseCommitSha,
             string.IsNullOrWhiteSpace(spec.RequiredAssetName) ? null : spec.RequiredAssetName);
@@ -269,7 +268,7 @@ public sealed class HomeAssistantReleaseService {
             ReleaseName = tagName,
             ReleaseNotes = notes,
             Commitish = spec.ReleaseCommitSha,
-            GenerateReleaseNotes = false,
+            GenerateReleaseNotes = true,
             ReuseExistingReleaseOnConflict = true,
             ReplaceExistingAssets = true,
             RequireExpectedExistingRelease = true,


### PR DESCRIPTION
## Summary

- use GitHub-generated change and contributor notes for PowerForge-managed Home Assistant releases
- retain only hidden PowerForge provenance metadata in the supplied release body so retries and recovery remain safe
- allow release callers to combine a supplied body with `generate_release_notes`
- move the reusable Home Assistant workflow and action to PowerForge.Build 1.0.8

## Release order

Receiver repositories should keep their current immutable workflow SHA until PowerForge.Build 1.0.8 is published. After publication, `homeassistant-dreamelawnmower` and `lovelace-lawn-mower-card` can both repin to the merged reusable-workflow commit without adding local release logic.

Existing releases are left unchanged; newly created releases use generated notes.

## Validation

- 34 focused Home Assistant release, publisher, and workflow tests passed
- full PowerForge test project: 4,957 passed; the two failures reproduce unchanged on clean `origin/main`
- independent read-only review found no actionable correctness issues