### PR TITLE
Fix MSI generated-state provenance

### DIFF
--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using PowerForge;
 using Xunit;
@@ -375,6 +377,118 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
             using var document = JsonDocument.Parse(File.ReadAllText(manifestPath));
             var entry = Assert.Single(document.RootElement.EnumerateArray());
             Assert.True(entry.GetProperty("SourceDirty").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void VerifiedMsiVersionStateWrites_RequireTheExactCurrentRunWrite()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var reservationOwner = Guid.NewGuid().ToString("N");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            var versionStatePath = Path.Combine(root, "Build", "versioning", "app.msi.state.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionStatePath)!);
+            File.WriteAllText(versionStatePath, "{\"Version\":\"1.0.0\"}");
+            RunGit(root, "add Build/versioning/app.msi.state.json");
+            RunGit(root, "commit -m \"test source\"");
+
+            var initiallyCleanState =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenanceState(
+                    root,
+                    new[] { versionStatePath });
+            var initialState = Assert.Single(initiallyCleanState);
+
+            var hookBytes = Encoding.UTF8.GetBytes(
+                "{\"Version\":\"1.0.1\",\"Source\":\"hook\"}");
+            File.WriteAllBytes(versionStatePath, hookBytes);
+
+            var writerBytes = Encoding.UTF8.GetBytes(
+                "{\"Version\":\"1.0.1\",\"Source\":\"powerforge\"}");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                Convert.ToHexString(SHA256.HashData(hookBytes)),
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+
+            Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                initiallyCleanState,
+                reservationOwner));
+
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
+            File.WriteAllText(versionStatePath, "{\"Version\":\"1.0.0\"}");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                initialState.Value,
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+
+            Assert.Equal(
+                new[] { initialState.Key },
+                DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                    initiallyCleanState,
+                    reservationOwner));
+
+            File.AppendAllText(versionStatePath, Environment.NewLine);
+            Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                initiallyCleanState,
+                reservationOwner));
+        }
+        finally
+        {
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
+            if (Directory.Exists(root))
+            {
+                foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void Run_ReportsInvalidVersionStatePathAsAFailedResult()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            File.WriteAllText(Path.Combine(root, "source.txt"), "committed");
+            RunGit(root, "add source.txt");
+            RunGit(root, "commit -m \"test source\"");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                MsiVersions = new Dictionary<string, DotNetPublishMsiVersionPlan>
+                {
+                    ["app"] = new() { StatePath = "\0" }
+                }
+            };
+
+            var result = new DotNetPublishPipelineRunner(new NullLogger()).Run(plan, progress: null);
+
+            Assert.False(result.Succeeded);
+            Assert.False(string.IsNullOrWhiteSpace(result.ErrorMessage));
         }
         finally
         {

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -199,6 +199,122 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
         }
     }
 
+    [Fact]
+    public void WriteManifests_ExcludesTrackedGeneratedVersionState()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            File.WriteAllText(Path.Combine(root, "source.txt"), "committed");
+            var versionStatePath = Path.Combine(root, "Build", "versioning", "app.msi.state.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionStatePath)!);
+            File.WriteAllText(versionStatePath, "{\"Version\":\"1.0.0\"}");
+            RunGit(root, "add source.txt Build/versioning/app.msi.state.json");
+            RunGit(root, "commit -m \"test source\"");
+            string revision = RunGit(root, "rev-parse HEAD").Trim();
+
+            File.WriteAllText(versionStatePath, "{\"Version\":\"1.0.1\"}");
+            var manifestPath = Path.Combine(root, "Artifacts", "manifest.json");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Outputs = new DotNetPublishOutputs { ManifestJsonPath = manifestPath },
+                MsiVersions = new Dictionary<string, DotNetPublishMsiVersionPlan>
+                {
+                    ["app"] = new() { StatePath = versionStatePath }
+                }
+            };
+            var msiBuilds = new List<DotNetPublishMsiBuildResult>
+            {
+                new() { InstallerId = "app", VersionStatePath = versionStatePath }
+            };
+
+            InvokeWriteManifests(plan, new List<DotNetPublishArtefactResult>(), msiBuilds);
+
+            using (var document = JsonDocument.Parse(File.ReadAllText(manifestPath)))
+            {
+                var entry = Assert.Single(document.RootElement.EnumerateArray());
+                Assert.Equal(revision, entry.GetProperty("SourceRevision").GetString());
+                Assert.False(entry.GetProperty("SourceDirty").GetBoolean());
+            }
+
+            File.WriteAllText(Path.Combine(root, "source.txt"), "modified");
+            InvokeWriteManifests(plan, new List<DotNetPublishArtefactResult>(), msiBuilds);
+
+            using var dirtyDocument = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            var dirtyEntry = Assert.Single(dirtyDocument.RootElement.EnumerateArray());
+            Assert.True(dirtyEntry.GetProperty("SourceDirty").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void WriteManifests_DoesNotExcludeOtherTrackedGeneratedOutputs()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            var stagingPath = Directory.CreateDirectory(Path.Combine(root, "Artifacts", "Msi", "staging")).FullName;
+            var payloadPath = Path.Combine(stagingPath, "payload.dll");
+            File.WriteAllText(payloadPath, "committed");
+            RunGit(root, "add -f Artifacts/Msi/staging/payload.dll");
+            RunGit(root, "commit -m \"test source\"");
+
+            File.WriteAllText(payloadPath, "modified");
+            var manifestPath = Path.Combine(root, "Artifacts", "manifest.json");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Outputs = new DotNetPublishOutputs { ManifestJsonPath = manifestPath },
+                Steps =
+                [
+                    new DotNetPublishStep
+                    {
+                        Kind = DotNetPublishStepKind.MsiPrepare,
+                        StagingPath = stagingPath
+                    }
+                ]
+            };
+            var msiBuilds = new List<DotNetPublishMsiBuildResult>
+            {
+                new() { InstallerId = "app" }
+            };
+
+            InvokeWriteManifests(plan, new List<DotNetPublishArtefactResult>(), msiBuilds);
+
+            using var document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            var entry = Assert.Single(document.RootElement.EnumerateArray());
+            Assert.True(entry.GetProperty("SourceDirty").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
     private static void InvokeWriteManifests(
         DotNetPublishPlan plan,
         List<DotNetPublishArtefactResult> artefacts,

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -427,6 +427,7 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
                 Convert.ToHexString(SHA256.HashData(writerBytes)));
 
             Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                root,
                 initiallyCleanState,
                 reservationOwner));
 
@@ -442,11 +443,56 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
             Assert.Equal(
                 new[] { initialState.Key },
                 DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                    root,
                     initiallyCleanState,
                     reservationOwner));
 
             File.AppendAllText(versionStatePath, Environment.NewLine);
             Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                root,
+                initiallyCleanState,
+                reservationOwner));
+
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            var secondWriterBytes = Encoding.UTF8.GetBytes(
+                "{\"Version\":\"1.0.2\",\"Source\":\"powerforge\"}");
+            File.WriteAllBytes(versionStatePath, secondWriterBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                Convert.ToHexString(SHA256.HashData(writerBytes)),
+                Convert.ToHexString(SHA256.HashData(secondWriterBytes)));
+            Assert.Equal(
+                new[] { initialState.Key },
+                DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                    root,
+                    initiallyCleanState,
+                    reservationOwner));
+
+            var thirdWriterBytes = Encoding.UTF8.GetBytes(
+                "{\"Version\":\"1.0.3\",\"Source\":\"powerforge\"}");
+            File.WriteAllBytes(versionStatePath, thirdWriterBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                Convert.ToHexString(SHA256.HashData(hookBytes)),
+                Convert.ToHexString(SHA256.HashData(thirdWriterBytes)));
+            Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                root,
+                initiallyCleanState,
+                reservationOwner));
+
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
+            File.WriteAllText(versionStatePath, "{\"Version\":\"1.0.0\"}");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                initialState.Value,
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+            RunGit(root, "update-index --chmod=+x Build/versioning/app.msi.state.json");
+            Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                root,
                 initiallyCleanState,
                 reservationOwner));
         }
@@ -492,6 +538,60 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
         }
         finally
         {
+            if (Directory.Exists(root))
+            {
+                foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void VerifiedMsiVersionStateWrites_ResolveSubdirectoryProjectFromGitRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var projectRoot = Path.Combine(root, "src", "app");
+        var reservationOwner = Guid.NewGuid().ToString("N");
+        Directory.CreateDirectory(projectRoot);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            var versionStatePath = Path.Combine(projectRoot, "Build", "versioning", "app.msi.state.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionStatePath)!);
+            var initialBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.0\"}");
+            File.WriteAllBytes(versionStatePath, initialBytes);
+            RunGit(root, "add src/app/Build/versioning/app.msi.state.json");
+            RunGit(root, "commit -m \"test source\"");
+
+            var initiallyCleanState =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenanceState(
+                    projectRoot,
+                    new[] { versionStatePath });
+            var initialState = Assert.Single(initiallyCleanState);
+            Assert.Equal(versionStatePath, initialState.Key);
+
+            var writerBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.1\"}");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                Convert.ToHexString(SHA256.HashData(initialBytes)),
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+
+            Assert.Equal(
+                new[] { versionStatePath },
+                DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                    projectRoot,
+                    initiallyCleanState,
+                    reservationOwner));
+        }
+        finally
+        {
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
             if (Directory.Exists(root))
             {
                 foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -501,6 +501,54 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
         }
     }
 
+    [Fact]
+    public void PlannedMsiVersionStatePaths_IncludeDeferredPackagingVersion()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var versionStatePath = Path.Combine(root, "Build", "versioning", "app.msi.state.json");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Installers =
+                [
+                    new DotNetPublishInstallerPlan
+                    {
+                        Id = "app",
+                        Versioning = new DotNetPublishMsiVersionOptions
+                        {
+                            Enabled = true,
+                            Monotonic = true,
+                            ApplyToPublish = false,
+                            StatePath = "Build/versioning/{installer}.msi.state.json"
+                        }
+                    }
+                ],
+                Steps =
+                [
+                    new DotNetPublishStep
+                    {
+                        Kind = DotNetPublishStepKind.MsiBuild,
+                        InstallerId = "app"
+                    }
+                ]
+            };
+
+            Assert.Equal(
+                new[] { versionStatePath },
+                DotNetPublishPipelineRunner.EnumeratePlannedMsiVersionStatePaths(plan));
+            Assert.Empty(plan.MsiVersions);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static void InvokeWriteManifests(
         DotNetPublishPlan plan,
         List<DotNetPublishArtefactResult> artefacts,

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -218,7 +218,85 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
             RunGit(root, "commit -m \"test source\"");
             string revision = RunGit(root, "rev-parse HEAD").Trim();
 
+            var manifestPath = Path.Combine(root, "Artifacts", "manifest.json");
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Outputs = new DotNetPublishOutputs { ManifestJsonPath = manifestPath },
+                MsiVersions = new Dictionary<string, DotNetPublishMsiVersionPlan>
+                {
+                    ["app"] = new() { StatePath = versionStatePath }
+                }
+            };
+            var cleanTrackedGeneratedPaths =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenancePaths(
+                    root,
+                    new[] { versionStatePath });
             File.WriteAllText(versionStatePath, "{\"Version\":\"1.0.1\"}");
+            var msiBuilds = new List<DotNetPublishMsiBuildResult>
+            {
+                new() { InstallerId = "app", VersionStatePath = versionStatePath }
+            };
+
+            InvokeWriteManifests(
+                plan,
+                new List<DotNetPublishArtefactResult>(),
+                msiBuilds,
+                cleanTrackedGeneratedPaths);
+
+            using (var document = JsonDocument.Parse(File.ReadAllText(manifestPath)))
+            {
+                var entry = Assert.Single(document.RootElement.EnumerateArray());
+                Assert.Equal(revision, entry.GetProperty("SourceRevision").GetString());
+                Assert.False(entry.GetProperty("SourceDirty").GetBoolean());
+            }
+
+            File.WriteAllText(Path.Combine(root, "source.txt"), "modified");
+            InvokeWriteManifests(
+                plan,
+                new List<DotNetPublishArtefactResult>(),
+                msiBuilds,
+                cleanTrackedGeneratedPaths);
+
+            using var dirtyDocument = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            var dirtyEntry = Assert.Single(dirtyDocument.RootElement.EnumerateArray());
+            Assert.True(dirtyEntry.GetProperty("SourceDirty").GetBoolean());
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+                    file.Attributes = FileAttributes.Normal;
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void WriteManifests_DoesNotExcludePreexistingTrackedVersionStateChange()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            var versionStatePath = Path.Combine(root, "Build", "versioning", "app.msi.state.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionStatePath)!);
+            File.WriteAllText(versionStatePath, "{\"Version\":\"1.0.0\"}");
+            RunGit(root, "add Build/versioning/app.msi.state.json");
+            RunGit(root, "commit -m \"test source\"");
+
+            File.WriteAllText(versionStatePath, "{\"Version\":\"9.9.9\"}");
+            var cleanTrackedGeneratedPaths =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenancePaths(
+                    root,
+                    new[] { versionStatePath });
+            Assert.Empty(cleanTrackedGeneratedPaths);
+
             var manifestPath = Path.Combine(root, "Artifacts", "manifest.json");
             var plan = new DotNetPublishPlan
             {
@@ -234,21 +312,15 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
                 new() { InstallerId = "app", VersionStatePath = versionStatePath }
             };
 
-            InvokeWriteManifests(plan, new List<DotNetPublishArtefactResult>(), msiBuilds);
+            InvokeWriteManifests(
+                plan,
+                new List<DotNetPublishArtefactResult>(),
+                msiBuilds,
+                cleanTrackedGeneratedPaths);
 
-            using (var document = JsonDocument.Parse(File.ReadAllText(manifestPath)))
-            {
-                var entry = Assert.Single(document.RootElement.EnumerateArray());
-                Assert.Equal(revision, entry.GetProperty("SourceRevision").GetString());
-                Assert.False(entry.GetProperty("SourceDirty").GetBoolean());
-            }
-
-            File.WriteAllText(Path.Combine(root, "source.txt"), "modified");
-            InvokeWriteManifests(plan, new List<DotNetPublishArtefactResult>(), msiBuilds);
-
-            using var dirtyDocument = JsonDocument.Parse(File.ReadAllText(manifestPath));
-            var dirtyEntry = Assert.Single(dirtyDocument.RootElement.EnumerateArray());
-            Assert.True(dirtyEntry.GetProperty("SourceDirty").GetBoolean());
+            using var document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+            var entry = Assert.Single(document.RootElement.EnumerateArray());
+            Assert.True(entry.GetProperty("SourceDirty").GetBoolean());
         }
         finally
         {
@@ -318,13 +390,15 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
     private static void InvokeWriteManifests(
         DotNetPublishPlan plan,
         List<DotNetPublishArtefactResult> artefacts,
-        List<DotNetPublishMsiBuildResult>? msiBuilds = null)
+        List<DotNetPublishMsiBuildResult>? msiBuilds = null,
+        IEnumerable<string>? cleanTrackedGeneratedPaths = null)
     {
         DotNetPublishPipelineRunner.WriteManifestsWithProvenance(
             plan,
             artefacts,
             new List<DotNetPublishStorePackageResult>(),
-            msiBuilds ?? new List<DotNetPublishMsiBuildResult>());
+            msiBuilds ?? new List<DotNetPublishMsiBuildResult>(),
+            cleanTrackedGeneratedPaths);
     }
 
     private static string RunGit(string root, string arguments)

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerManifestProvenanceTests.cs
@@ -490,6 +490,15 @@ public sealed class DotNetPublishPipelineRunnerManifestProvenanceTests
                 versionStatePath,
                 initialState.Value,
                 Convert.ToHexString(SHA256.HashData(writerBytes)));
+            File.WriteAllBytes(versionStatePath, hookBytes);
+            RunGit(root, "add Build/versioning/app.msi.state.json");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                root,
+                initiallyCleanState,
+                reservationOwner));
+
+            RunGit(root, "reset HEAD -- Build/versioning/app.msi.state.json");
             RunGit(root, "update-index --chmod=+x Build/versioning/app.msi.state.json");
             Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
                 root,

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerProvenanceEdgeCaseTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerProvenanceEdgeCaseTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
@@ -30,7 +31,7 @@ public sealed class DotNetPublishPipelineRunnerProvenanceEdgeCaseTests
         finally
         {
             if (Directory.Exists(root))
-                Directory.Delete(root, recursive: true);
+                DeleteTestDirectory(root);
         }
     }
 
@@ -94,7 +95,174 @@ public sealed class DotNetPublishPipelineRunnerProvenanceEdgeCaseTests
             if (Directory.Exists(linkedProjectRoot))
                 Directory.Delete(linkedProjectRoot);
             if (Directory.Exists(testRoot))
-                Directory.Delete(testRoot, recursive: true);
+                DeleteTestDirectory(testRoot);
+        }
+    }
+
+    [Fact]
+    public void VerifiedMsiVersionStateWrites_TreatColonPrefixedStatePathLiterally()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var reservationOwner = Guid.NewGuid().ToString("N");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            var versionStatePath = Path.Combine(root, ":state.json");
+            var initialBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.0\"}");
+            File.WriteAllBytes(versionStatePath, initialBytes);
+            RunGit(root, "add -- ./:state.json");
+            RunGit(root, "commit -m \"test source\"");
+
+            var initiallyCleanState =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenanceState(
+                    root,
+                    new[] { versionStatePath });
+            var writerBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.1\"}");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                Convert.ToHexString(SHA256.HashData(initialBytes)),
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+
+            Assert.Equal(
+                new[] { versionStatePath },
+                DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                    root,
+                    initiallyCleanState,
+                    reservationOwner));
+
+            var stagedBytes = Encoding.UTF8.GetBytes("{\"Version\":\"9.9.9\"}");
+            File.WriteAllBytes(versionStatePath, stagedBytes);
+            RunGit(root, "add -- ./:state.json");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                root,
+                initiallyCleanState,
+                reservationOwner));
+        }
+        finally
+        {
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
+            if (Directory.Exists(root))
+                DeleteTestDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void VerifiedMsiVersionStateWrites_RejectTrackedSymlinkStatePath()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var testRoot = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var repositoryRoot = Path.Combine(testRoot, "repository");
+        var reservationOwner = Guid.NewGuid().ToString("N");
+        Directory.CreateDirectory(repositoryRoot);
+
+        try
+        {
+            RunGit(repositoryRoot, "init");
+            RunGit(repositoryRoot, "config user.name \"PowerForge Tests\"");
+            RunGit(repositoryRoot, "config user.email \"powerforge-tests@example.invalid\"");
+            var firstTarget = Path.Combine(testRoot, "first-state.json");
+            var secondTarget = Path.Combine(testRoot, "second-state.json");
+            var initialBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.0\"}");
+            var writerBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.1\"}");
+            File.WriteAllBytes(firstTarget, initialBytes);
+            File.WriteAllBytes(secondTarget, writerBytes);
+            var versionStatePath = Path.Combine(
+                repositoryRoot,
+                "Build",
+                "versioning",
+                "app.msi.state.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(versionStatePath)!);
+            File.CreateSymbolicLink(versionStatePath, firstTarget);
+            RunGit(repositoryRoot, "add Build/versioning/app.msi.state.json");
+            RunGit(repositoryRoot, "commit -m \"test source\"");
+
+            var initiallyCleanState =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenanceState(
+                    repositoryRoot,
+                    new[] { versionStatePath });
+            File.Delete(versionStatePath);
+            File.CreateSymbolicLink(versionStatePath, secondTarget);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                Convert.ToHexString(SHA256.HashData(initialBytes)),
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+
+            Assert.Empty(DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                repositoryRoot,
+                initiallyCleanState,
+                reservationOwner));
+        }
+        finally
+        {
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
+            if (Directory.Exists(testRoot))
+                DeleteTestDirectory(testRoot);
+        }
+    }
+
+    [Fact]
+    public void ReadSourceProvenance_FailsClosedWhenStatusChangesDuringWriterVerification()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var reservationOwner = Guid.NewGuid().ToString("N");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            RunGit(root, "init");
+            RunGit(root, "config user.name \"PowerForge Tests\"");
+            RunGit(root, "config user.email \"powerforge-tests@example.invalid\"");
+            var versionStatePath = Path.Combine(root, "version.json");
+            var initialBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.0\"}");
+            var writerBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.1\"}");
+            var stagedBytes = Encoding.UTF8.GetBytes("{\"Version\":\"9.9.9\"}");
+            File.WriteAllBytes(versionStatePath, initialBytes);
+            RunGit(root, "add version.json");
+            RunGit(root, "commit -m \"test source\"");
+            File.WriteAllBytes(versionStatePath, writerBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                versionStatePath,
+                Convert.ToHexString(SHA256.HashData(initialBytes)),
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+            var initialState = new MutatingReadOnlyDictionary(
+                new KeyValuePair<string, string>(
+                    versionStatePath,
+                    Convert.ToHexString(SHA256.HashData(initialBytes))),
+                () =>
+                {
+                    File.WriteAllBytes(versionStatePath, stagedBytes);
+                    RunGit(root, "add version.json");
+                    File.WriteAllBytes(versionStatePath, writerBytes);
+                });
+
+            var provenance = DotNetPublishPipelineRunner.ReadSourceProvenance(
+                root,
+                generatedPaths: null,
+                trackedGeneratedPaths: null,
+                cleanTrackedGeneratedProvenanceState: initialState,
+                msiReservationOwner: reservationOwner);
+
+            Assert.True(provenance.Dirty);
+        }
+        finally
+        {
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
+            if (Directory.Exists(root))
+                DeleteTestDirectory(root);
         }
     }
 
@@ -116,5 +284,59 @@ public sealed class DotNetPublishPipelineRunnerProvenanceEdgeCaseTests
         Assert.True(process.WaitForExit(10000), $"git {arguments} timed out");
         Assert.True(process.ExitCode == 0, $"git {arguments} failed: {error}");
         return output;
+    }
+
+    private static void DeleteTestDirectory(string root)
+    {
+        foreach (var file in new DirectoryInfo(root).EnumerateFiles("*", SearchOption.AllDirectories))
+            file.Attributes = FileAttributes.Normal;
+        Directory.Delete(root, recursive: true);
+    }
+
+    private sealed class MutatingReadOnlyDictionary : IReadOnlyDictionary<string, string>
+    {
+        private readonly KeyValuePair<string, string> _item;
+        private readonly Action _afterYield;
+
+        internal MutatingReadOnlyDictionary(
+            KeyValuePair<string, string> item,
+            Action afterYield)
+        {
+            _item = item;
+            _afterYield = afterYield;
+        }
+
+        public int Count => 1;
+
+        public IEnumerable<string> Keys => new[] { _item.Key };
+
+        public IEnumerable<string> Values => new[] { _item.Value };
+
+        public string this[string key] => string.Equals(key, _item.Key, StringComparison.Ordinal)
+            ? _item.Value
+            : throw new KeyNotFoundException();
+
+        public bool ContainsKey(string key)
+            => string.Equals(key, _item.Key, StringComparison.Ordinal);
+
+        public bool TryGetValue(string key, out string value)
+        {
+            if (ContainsKey(key))
+            {
+                value = _item.Value;
+                return true;
+            }
+
+            value = string.Empty;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            yield return _item;
+            _afterYield();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/PowerForge.Tests/DotNetPublishPipelineRunnerProvenanceEdgeCaseTests.cs
+++ b/PowerForge.Tests/DotNetPublishPipelineRunnerProvenanceEdgeCaseTests.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using PowerForge;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed class DotNetPublishPipelineRunnerProvenanceEdgeCaseTests
+{
+    [Fact]
+    public void Run_TreatsNullStepsAsAnEmptyPlan()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var plan = new DotNetPublishPlan
+            {
+                ProjectRoot = root,
+                Steps = null!
+            };
+
+            var result = new DotNetPublishPipelineRunner(new NullLogger()).Run(plan, progress: null);
+
+            Assert.True(result.Succeeded, result.ErrorMessage);
+            Assert.Empty(DotNetPublishPipelineRunner.EnumeratePlannedMsiVersionStatePaths(plan));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void VerifiedMsiVersionStateWrites_ResolveSymlinkedProjectRoot()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var testRoot = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var repositoryRoot = Path.Combine(testRoot, "repository");
+        var physicalProjectRoot = Path.Combine(repositoryRoot, "src", "app");
+        var linkedProjectRoot = Path.Combine(testRoot, "project-link");
+        var reservationOwner = Guid.NewGuid().ToString("N");
+        Directory.CreateDirectory(physicalProjectRoot);
+
+        try
+        {
+            RunGit(repositoryRoot, "init");
+            RunGit(repositoryRoot, "config user.name \"PowerForge Tests\"");
+            RunGit(repositoryRoot, "config user.email \"powerforge-tests@example.invalid\"");
+            var physicalStatePath = Path.Combine(
+                physicalProjectRoot,
+                "Build",
+                "versioning",
+                "app.msi.state.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(physicalStatePath)!);
+            var initialBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.0\"}");
+            File.WriteAllBytes(physicalStatePath, initialBytes);
+            RunGit(repositoryRoot, "add src/app/Build/versioning/app.msi.state.json");
+            RunGit(repositoryRoot, "commit -m \"test source\"");
+            Directory.CreateSymbolicLink(linkedProjectRoot, physicalProjectRoot);
+
+            var linkedStatePath = Path.Combine(
+                linkedProjectRoot,
+                "Build",
+                "versioning",
+                "app.msi.state.json");
+            var initiallyCleanState =
+                DotNetPublishPipelineRunner.CaptureCleanTrackedGeneratedProvenanceState(
+                    linkedProjectRoot,
+                    new[] { linkedStatePath });
+            var writerBytes = Encoding.UTF8.GetBytes("{\"Version\":\"1.0.1\"}");
+            File.WriteAllBytes(linkedStatePath, writerBytes);
+            DotNetPublishPipelineRunner.RecordMsiVersionStateWrite(
+                reservationOwner,
+                linkedStatePath,
+                Convert.ToHexString(SHA256.HashData(initialBytes)),
+                Convert.ToHexString(SHA256.HashData(writerBytes)));
+
+            Assert.Equal(
+                new[] { linkedStatePath },
+                DotNetPublishPipelineRunner.GetVerifiedMsiVersionStateWrites(
+                    linkedProjectRoot,
+                    initiallyCleanState,
+                    reservationOwner));
+        }
+        finally
+        {
+            DotNetPublishPipelineRunner.ClearMsiVersionStateWrites(reservationOwner);
+            if (Directory.Exists(linkedProjectRoot))
+                Directory.Delete(linkedProjectRoot);
+            if (Directory.Exists(testRoot))
+                Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    private static string RunGit(string root, string arguments)
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = arguments,
+            WorkingDirectory = root,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        });
+        Assert.NotNull(process);
+        string output = process!.StandardOutput.ReadToEnd();
+        string error = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(10000), $"git {arguments} timed out");
+        Assert.True(process.ExitCode == 0, $"git {arguments} failed: {error}");
+        return output;
+    }
+}

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -351,6 +351,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 plan,
                 orderedArtefacts,
                 orderedStorePackages,
+                orderedMsiBuilds),
+            EnumerateTrackedGeneratedProvenancePaths(
+                plan,
                 orderedMsiBuilds));
         var manifestEntries = BuildManifestEntries(
             plan.ProjectRoot,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -322,7 +322,8 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishPlan plan,
         List<DotNetPublishArtefactResult> artefacts,
         List<DotNetPublishStorePackageResult>? storePackages,
-        List<DotNetPublishMsiBuildResult>? msiBuilds)
+        List<DotNetPublishMsiBuildResult>? msiBuilds,
+        IEnumerable<string>? cleanTrackedGeneratedPaths = null)
     {
         var orderedArtefacts = (artefacts ?? new List<DotNetPublishArtefactResult>())
             .OrderBy(a => a.Target, StringComparer.OrdinalIgnoreCase)
@@ -352,9 +353,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 orderedArtefacts,
                 orderedStorePackages,
                 orderedMsiBuilds),
-            EnumerateTrackedGeneratedProvenancePaths(
-                plan,
-                orderedMsiBuilds));
+            cleanTrackedGeneratedPaths);
         var manifestEntries = BuildManifestEntries(
             plan.ProjectRoot,
             orderedArtefacts,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.FailureAndManifests.cs
@@ -323,7 +323,9 @@ public sealed partial class DotNetPublishPipelineRunner
         List<DotNetPublishArtefactResult> artefacts,
         List<DotNetPublishStorePackageResult>? storePackages,
         List<DotNetPublishMsiBuildResult>? msiBuilds,
-        IEnumerable<string>? cleanTrackedGeneratedPaths = null)
+        IEnumerable<string>? cleanTrackedGeneratedPaths = null,
+        IReadOnlyDictionary<string, string>? cleanTrackedGeneratedProvenanceState = null,
+        string? msiReservationOwner = null)
     {
         var orderedArtefacts = (artefacts ?? new List<DotNetPublishArtefactResult>())
             .OrderBy(a => a.Target, StringComparer.OrdinalIgnoreCase)
@@ -353,7 +355,9 @@ public sealed partial class DotNetPublishPipelineRunner
                 orderedArtefacts,
                 orderedStorePackages,
                 orderedMsiBuilds),
-            cleanTrackedGeneratedPaths);
+            cleanTrackedGeneratedPaths,
+            cleanTrackedGeneratedProvenanceState,
+            msiReservationOwner);
         var manifestEntries = BuildManifestEntries(
             plan.ProjectRoot,
             orderedArtefacts,

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -610,23 +610,8 @@ public sealed partial class DotNetPublishPipelineRunner
 
         if (v.Monotonic)
         {
-            var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["installer"] = installer.Id,
-                ["target"] = step.TargetName ?? string.Empty,
-                ["rid"] = step.Runtime ?? string.Empty,
-                ["framework"] = step.Framework ?? string.Empty,
-                ["style"] = step.Style?.ToString() ?? string.Empty,
-                ["configuration"] = plan.Configuration ?? "Release"
-            };
-
-            var stateTemplate = string.IsNullOrWhiteSpace(v.StatePath)
-                ? "Artifacts/DotNetPublish/Msi/{installer}/version.state.json"
-                : v.StatePath!;
-            statePath = ResolvePath(plan.ProjectRoot, ApplyTemplate(stateTemplate, tokens));
-
-            if (!plan.AllowOutputOutsideProjectRoot)
-                EnsurePathWithinRoot(plan.ProjectRoot, statePath, $"Installer '{installer.Id}' version state path");
+            var tokens = BuildMsiVersionTemplateTokens(plan, installer, step);
+            statePath = ResolveMsiVersionStatePath(plan, installer, tokens);
 
             MsiVersionState? authorityState = null;
             if (v.Authority == DotNetPublishMsiVersionAuthorityKind.GitTags)
@@ -711,6 +696,36 @@ public sealed partial class DotNetPublishPipelineRunner
             authorityKey,
             gitRemote,
             gitTagPrefix);
+    }
+
+    private static Dictionary<string, string> BuildMsiVersionTemplateTokens(
+        DotNetPublishPlan plan,
+        DotNetPublishInstallerPlan installer,
+        DotNetPublishStep step)
+        => new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["installer"] = installer.Id,
+            ["target"] = step.TargetName ?? string.Empty,
+            ["rid"] = step.Runtime ?? string.Empty,
+            ["framework"] = step.Framework ?? string.Empty,
+            ["style"] = step.Style?.ToString() ?? string.Empty,
+            ["configuration"] = plan.Configuration ?? "Release"
+        };
+
+    private static string ResolveMsiVersionStatePath(
+        DotNetPublishPlan plan,
+        DotNetPublishInstallerPlan installer,
+        IReadOnlyDictionary<string, string> tokens)
+    {
+        var stateTemplate = string.IsNullOrWhiteSpace(installer.Versioning?.StatePath)
+            ? "Artifacts/DotNetPublish/Msi/{installer}/version.state.json"
+            : installer.Versioning!.StatePath!;
+        var statePath = ResolvePath(plan.ProjectRoot, ApplyTemplate(stateTemplate, tokens));
+
+        if (!plan.AllowOutputOutsideProjectRoot)
+            EnsurePathWithinRoot(plan.ProjectRoot, statePath, $"Installer '{installer.Id}' version state path");
+
+        return statePath;
     }
 
     private MsiVersionResolution ResolveMsiVersionForStep(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiBuild.cs
@@ -876,7 +876,16 @@ public sealed partial class DotNetPublishPipelineRunner
 
                 if (allowOutputOverwrite && string.IsNullOrWhiteSpace(previous.ReservationOwner))
                 {
-                    WriteMsiVersionState(stateStream, patch, version.Version, reservationOwner);
+                    var overwriteTransition = WriteMsiVersionState(
+                        stateStream,
+                        patch,
+                        version.Version,
+                        reservationOwner);
+                    RecordMsiVersionStateWrite(
+                        reservationOwner,
+                        version.StatePath!,
+                        overwriteTransition.PreviousContentHash,
+                        overwriteTransition.ContentHash);
                     return;
                 }
 
@@ -896,7 +905,12 @@ public sealed partial class DotNetPublishPipelineRunner
 
             ReserveMsiGitTagVersion(version, context, reservationOwner);
 
-            WriteMsiVersionState(stateStream, patch, version.Version, reservationOwner);
+            var transition = WriteMsiVersionState(stateStream, patch, version.Version, reservationOwner);
+            RecordMsiVersionStateWrite(
+                reservationOwner,
+                version.StatePath!,
+                transition.PreviousContentHash,
+                transition.ContentHash);
         }
     }
 
@@ -923,7 +937,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 return true;
             }
 
-            WriteMsiVersionState(stateStream, version.Patch.Value, version.Version, reservationOwner: null);
+            _ = WriteMsiVersionState(stateStream, version.Patch.Value, version.Version, reservationOwner: null);
             return true;
         }
         catch (IOException)
@@ -1095,12 +1109,14 @@ public sealed partial class DotNetPublishPipelineRunner
             && int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out patch);
     }
 
-    private static void WriteMsiVersionState(
+    private static (string PreviousContentHash, string ContentHash) WriteMsiVersionState(
         Stream stream,
         int patch,
         string version,
         string? reservationOwner)
     {
+        stream.Position = 0;
+        var previousContentHash = ComputeSha256Hex(stream);
         var state = new MsiVersionState
         {
             LastPatch = patch,
@@ -1110,17 +1126,16 @@ public sealed partial class DotNetPublishPipelineRunner
         };
 
         var json = JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true });
+        var bytes = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(json);
         stream.SetLength(0);
         stream.Position = 0;
-        using var writer = new StreamWriter(
-            stream,
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-            bufferSize: 1024,
-            leaveOpen: true);
-        writer.Write(json);
-        writer.Flush();
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Flush();
         if (stream is FileStream fileStream)
             fileStream.Flush(flushToDisk: true);
+        return (
+            previousContentHash,
+            ComputeSha256Hex(bytes));
     }
 
     private static DateTime ParseUtcDate(string value)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -104,7 +104,8 @@ public sealed partial class DotNetPublishPipelineRunner
 
     internal static SourceProvenance ReadSourceProvenance(
         string projectRoot,
-        IEnumerable<string>? generatedPaths = null)
+        IEnumerable<string>? generatedPaths = null,
+        IEnumerable<string>? trackedGeneratedPaths = null)
     {
         var gitRevision = ReadGitText(projectRoot, "rev-parse HEAD");
         var environmentRevision = Environment.GetEnvironmentVariable("GITHUB_SHA")?.Trim();
@@ -117,11 +118,16 @@ public sealed partial class DotNetPublishPipelineRunner
                 null);
         }
 
-        var trackedStatus = ReadGitText(gitRoot!, "status --porcelain --untracked-files=no");
+        var trackedStatus = ReadGitRawText(gitRoot!, "status --porcelain=v1 -z --untracked-files=no");
         var untrackedOutput = ReadGitText(gitRoot!, "ls-files --others --exclude-standard -z");
         bool? dirty = trackedStatus is null || untrackedOutput is null
             ? null
-            : trackedStatus.Length > 0 || HasUntrackedSourceFiles(
+            : HasTrackedSourceChanges(
+                projectRoot,
+                gitRoot!,
+                trackedStatus,
+                trackedGeneratedPaths)
+              || HasUntrackedSourceFiles(
                 projectRoot,
                 gitRoot!,
                 untrackedOutput,
@@ -182,6 +188,17 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
+    private static IEnumerable<string> EnumerateTrackedGeneratedProvenancePaths(
+        DotNetPublishPlan plan,
+        IEnumerable<DotNetPublishMsiBuildResult> msiBuilds)
+    {
+        foreach (var version in plan.MsiVersions.Values)
+            yield return version.StatePath ?? string.Empty;
+
+        foreach (var msiBuild in msiBuilds)
+            yield return msiBuild.VersionStatePath ?? string.Empty;
+    }
+
     private static bool HasUntrackedSourceFiles(
         string projectRoot,
         string gitRoot,
@@ -189,24 +206,70 @@ public sealed partial class DotNetPublishPipelineRunner
         IEnumerable<string>? generatedPaths)
     {
         var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        var exclusions = (generatedPaths ?? Array.Empty<string>())
-            .Select(path => ToGitRelativeExclusion(projectRoot, gitRoot, path))
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
-            .ToArray();
+        var exclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
 
         foreach (var untrackedPath in untrackedOutput.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries))
         {
             var normalizedPath = untrackedPath.Replace('\\', '/').TrimStart('/');
-            bool generated = exclusions.Any(exclusion =>
-                string.Equals(normalizedPath, exclusion, comparison)
-                || normalizedPath.StartsWith(exclusion + "/", comparison));
-            if (!generated)
+            if (!IsGeneratedPath(normalizedPath, exclusions, comparison))
                 return true;
         }
 
         return false;
     }
+
+    private static bool HasTrackedSourceChanges(
+        string projectRoot,
+        string gitRoot,
+        string trackedOutput,
+        IEnumerable<string>? generatedPaths)
+    {
+        var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var exclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
+        var records = trackedOutput.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        for (var index = 0; index < records.Length; index++)
+        {
+            var record = records[index];
+            if (record.Length < 4)
+                return true;
+
+            var status = record.Substring(0, 2);
+            var path = record.Substring(3).Replace('\\', '/').TrimStart('/');
+            bool renameOrCopy = status.IndexOf('R') >= 0 || status.IndexOf('C') >= 0;
+            if (!IsGeneratedPath(path, exclusions, comparison))
+                return true;
+
+            if (renameOrCopy)
+            {
+                if (++index >= records.Length)
+                    return true;
+
+                var sourcePath = records[index].Replace('\\', '/').TrimStart('/');
+                if (!IsGeneratedPath(sourcePath, exclusions, comparison))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string[] BuildGeneratedPathExclusions(
+        string projectRoot,
+        string gitRoot,
+        IEnumerable<string>? generatedPaths)
+        => (generatedPaths ?? Array.Empty<string>())
+            .Select(path => ToGitRelativeExclusion(projectRoot, gitRoot, path))
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
+            .ToArray()!;
+
+    private static bool IsGeneratedPath(
+        string path,
+        IEnumerable<string> exclusions,
+        StringComparison comparison)
+        => exclusions.Any(exclusion =>
+            string.Equals(path, exclusion, comparison)
+            || path.StartsWith(exclusion + "/", comparison));
 
     private static string? ToGitRelativeExclusion(string projectRoot, string gitRoot, string? path)
     {
@@ -234,6 +297,12 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static string? ReadGitText(string projectRoot, string arguments)
     {
+        var output = ReadGitRawText(projectRoot, arguments);
+        return output?.Trim();
+    }
+
+    private static string? ReadGitRawText(string projectRoot, string arguments)
+    {
         try
         {
             using var process = new Process
@@ -250,7 +319,7 @@ public sealed partial class DotNetPublishPipelineRunner
                 }
             };
             if (!process.Start()) return null;
-            var output = process.StandardOutput.ReadToEnd().Trim();
+            var output = process.StandardOutput.ReadToEnd();
             if (!process.WaitForExit(5000) || process.ExitCode != 0) return null;
             return output;
         }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -192,11 +192,47 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishPlan plan,
         IEnumerable<DotNetPublishMsiBuildResult> msiBuilds)
     {
+        foreach (var statePath in EnumeratePlannedMsiVersionStatePaths(plan))
+            yield return statePath;
+
         foreach (var version in plan.MsiVersions.Values)
             yield return version.StatePath ?? string.Empty;
 
         foreach (var msiBuild in msiBuilds)
             yield return msiBuild.VersionStatePath ?? string.Empty;
+    }
+
+    private static IEnumerable<string> EnumeratePlannedMsiVersionStatePaths(DotNetPublishPlan plan)
+    {
+        foreach (var step in plan.Steps.Where(step => step.Kind == DotNetPublishStepKind.MsiBuild))
+        {
+            var installer = plan.Installers.FirstOrDefault(candidate =>
+                string.Equals(candidate.Id, step.InstallerId, StringComparison.OrdinalIgnoreCase));
+            if (installer?.Versioning is not { Enabled: true, Monotonic: true })
+                continue;
+
+            var tokens = BuildMsiVersionTemplateTokens(plan, installer, step);
+            yield return ResolveMsiVersionStatePath(plan, installer, tokens);
+        }
+    }
+
+    internal static string[] CaptureCleanTrackedGeneratedProvenancePaths(
+        string projectRoot,
+        IEnumerable<string>? generatedPaths)
+    {
+        var gitRoot = ReadGitText(projectRoot, "rev-parse --show-toplevel");
+        if (string.IsNullOrWhiteSpace(gitRoot))
+            return Array.Empty<string>();
+
+        var trackedOutput = ReadGitRawText(gitRoot!, "status --porcelain=v1 -z --untracked-files=no");
+        if (trackedOutput is null || !TryParseTrackedStatusPaths(trackedOutput, out var changedPaths))
+            return Array.Empty<string>();
+
+        var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return BuildGeneratedPathExclusions(projectRoot, gitRoot!, generatedPaths)
+            .Where(candidate => !changedPaths.Any(path =>
+                IsGeneratedPath(path, new[] { candidate }, comparison)))
+            .ToArray();
     }
 
     private static bool HasUntrackedSourceFiles(
@@ -226,31 +262,48 @@ public sealed partial class DotNetPublishPipelineRunner
     {
         var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         var exclusions = BuildGeneratedPathExclusions(projectRoot, gitRoot, generatedPaths);
+        if (!TryParseTrackedStatusPaths(trackedOutput, out var changedPaths))
+            return true;
+
+        foreach (var path in changedPaths)
+        {
+            if (!IsGeneratedPath(path, exclusions, comparison))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseTrackedStatusPaths(string trackedOutput, out string[] paths)
+    {
+        var parsed = new List<string>();
         var records = trackedOutput.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
         for (var index = 0; index < records.Length; index++)
         {
             var record = records[index];
-            if (record.Length < 4)
-                return true;
+            if (record.Length < 4 || record[2] != ' ')
+            {
+                paths = Array.Empty<string>();
+                return false;
+            }
 
             var status = record.Substring(0, 2);
-            var path = record.Substring(3).Replace('\\', '/').TrimStart('/');
+            parsed.Add(record.Substring(3).Replace('\\', '/').TrimStart('/'));
             bool renameOrCopy = status.IndexOf('R') >= 0 || status.IndexOf('C') >= 0;
-            if (!IsGeneratedPath(path, exclusions, comparison))
-                return true;
+            if (!renameOrCopy)
+                continue;
 
-            if (renameOrCopy)
+            if (++index >= records.Length)
             {
-                if (++index >= records.Length)
-                    return true;
-
-                var sourcePath = records[index].Replace('\\', '/').TrimStart('/');
-                if (!IsGeneratedPath(sourcePath, exclusions, comparison))
-                    return true;
+                paths = Array.Empty<string>();
+                return false;
             }
+
+            parsed.Add(records[index].Replace('\\', '/').TrimStart('/'));
         }
 
-        return false;
+        paths = parsed.ToArray();
+        return true;
     }
 
     private static string[] BuildGeneratedPathExclusions(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -239,15 +239,27 @@ public sealed partial class DotNetPublishPipelineRunner
                 IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal));
         writes.AddOrUpdate(
             Path.GetFullPath(statePath),
-            _ => new MsiVersionStateWrite(previousContentHash, contentHash),
-            (_, priorWrite) => new MsiVersionStateWrite(priorWrite.PreviousContentHash, contentHash));
+            _ => new MsiVersionStateWrite(previousContentHash, contentHash, isContinuous: true),
+            (_, priorWrite) => new MsiVersionStateWrite(
+                priorWrite.PreviousContentHash,
+                contentHash,
+                priorWrite.IsContinuous
+                && string.Equals(
+                    priorWrite.ContentHash,
+                    previousContentHash,
+                    StringComparison.Ordinal)));
     }
 
     internal static string[] GetVerifiedMsiVersionStateWrites(
+        string projectRoot,
         IReadOnlyDictionary<string, string> cleanTrackedGeneratedPaths,
         string reservationOwner)
     {
         if (!MsiVersionStateWrites.TryGetValue(reservationOwner, out var writes))
+            return Array.Empty<string>();
+
+        var gitRoot = ReadGitText(projectRoot, "rev-parse --show-toplevel");
+        if (string.IsNullOrWhiteSpace(gitRoot))
             return Array.Empty<string>();
 
         var verified = new List<string>();
@@ -257,7 +269,18 @@ public sealed partial class DotNetPublishPipelineRunner
             {
                 var fullPath = Path.GetFullPath(candidate.Key);
                 if (!writes.TryGetValue(fullPath, out var write)
+                    || !write.IsContinuous
                     || !File.Exists(fullPath))
+                    continue;
+
+                var gitRelativePath = ToGitRelativeExclusion(projectRoot, gitRoot!, fullPath);
+                if (string.IsNullOrWhiteSpace(gitRelativePath))
+                    continue;
+
+                var metadataDiff = ReadGitRawText(
+                    gitRoot!,
+                    $"diff --summary HEAD -- {QuoteGitPath(gitRelativePath!)}");
+                if (metadataDiff is null || !string.IsNullOrWhiteSpace(metadataDiff))
                     continue;
 
                 var actualHash = ComputeSha256Hex(File.ReadAllBytes(fullPath));
@@ -282,10 +305,7 @@ public sealed partial class DotNetPublishPipelineRunner
         var state = new Dictionary<string, string>(comparison);
         foreach (var candidate in CaptureCleanTrackedGeneratedProvenancePaths(projectRoot, generatedPaths))
         {
-            var fullPath = Path.GetFullPath(
-                Path.IsPathRooted(candidate)
-                    ? candidate
-                    : Path.Combine(projectRoot, candidate));
+            var fullPath = Path.GetFullPath(candidate);
             var content = File.Exists(fullPath) ? File.ReadAllBytes(fullPath) : Array.Empty<byte>();
             state[fullPath] = ComputeSha256Hex(content);
         }
@@ -327,9 +347,25 @@ public sealed partial class DotNetPublishPipelineRunner
             return Array.Empty<string>();
 
         var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        return BuildGeneratedPathExclusions(projectRoot, gitRoot!, generatedPaths)
+        return (generatedPaths ?? Array.Empty<string>())
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => Path.GetFullPath(
+                Path.IsPathRooted(path)
+                    ? path
+                    : Path.Combine(projectRoot, path)))
+            .Select(path => new
+            {
+                FullPath = path,
+                GitRelativePath = ToGitRelativeExclusion(projectRoot, gitRoot!, path)
+            })
+            .Where(candidate => !string.IsNullOrWhiteSpace(candidate.GitRelativePath))
             .Where(candidate => !changedPaths.Any(path =>
-                IsGeneratedPath(path, new[] { candidate }, comparison)))
+                IsGeneratedPath(
+                    path,
+                    new[] { candidate.GitRelativePath! },
+                    comparison)))
+            .Select(candidate => candidate.FullPath)
+            .Distinct(IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
             .ToArray();
     }
 
@@ -480,6 +516,9 @@ public sealed partial class DotNetPublishPipelineRunner
         }
     }
 
+    private static string QuoteGitPath(string path)
+        => "\"" + path.Replace("\\", "/").Replace("\"", "\\\"") + "\"";
+
     internal sealed class SourceProvenance
     {
         public SourceProvenance(string? revision, bool? dirty)
@@ -495,15 +534,21 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private sealed class MsiVersionStateWrite
     {
-        internal MsiVersionStateWrite(string previousContentHash, string contentHash)
+        internal MsiVersionStateWrite(
+            string previousContentHash,
+            string contentHash,
+            bool isContinuous)
         {
             PreviousContentHash = previousContentHash;
             ContentHash = contentHash;
+            IsContinuous = isContinuous;
         }
 
         internal string PreviousContentHash { get; }
 
         internal string ContentHash { get; }
+
+        internal bool IsContinuous { get; }
     }
 
     private static void TryDeleteReservation(string path)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -110,7 +110,9 @@ public sealed partial class DotNetPublishPipelineRunner
     internal static SourceProvenance ReadSourceProvenance(
         string projectRoot,
         IEnumerable<string>? generatedPaths = null,
-        IEnumerable<string>? trackedGeneratedPaths = null)
+        IEnumerable<string>? trackedGeneratedPaths = null,
+        IReadOnlyDictionary<string, string>? cleanTrackedGeneratedProvenanceState = null,
+        string? msiReservationOwner = null)
     {
         var gitRevision = ReadGitText(projectRoot, "rev-parse HEAD");
         var environmentRevision = Environment.GetEnvironmentVariable("GITHUB_SHA")?.Trim();
@@ -124,13 +126,30 @@ public sealed partial class DotNetPublishPipelineRunner
         }
 
         var trackedStatus = ReadGitRawText(gitRoot!, "status --porcelain=v1 -z --untracked-files=no");
+        var hasWriterContext = cleanTrackedGeneratedProvenanceState is not null
+            && !string.IsNullOrWhiteSpace(msiReservationOwner);
+        if (hasWriterContext && trackedStatus is not null)
+        {
+            trackedGeneratedPaths = GetVerifiedMsiVersionStateWrites(
+                projectRoot,
+                cleanTrackedGeneratedProvenanceState!,
+                msiReservationOwner!,
+                trackedStatus);
+        }
+
+        var finalTrackedStatus = hasWriterContext
+            ? ReadGitRawText(gitRoot!, "status --porcelain=v1 -z --untracked-files=no")
+            : trackedStatus;
         var untrackedOutput = ReadGitText(gitRoot!, "ls-files --others --exclude-standard -z");
+        var statusChangedDuringVerification = hasWriterContext
+            && !string.Equals(trackedStatus, finalTrackedStatus, StringComparison.Ordinal);
         bool? dirty = trackedStatus is null || untrackedOutput is null
             ? null
-            : HasTrackedSourceChanges(
+            : statusChangedDuringVerification
+              || HasTrackedSourceChanges(
                 projectRoot,
                 gitRoot!,
-                trackedStatus,
+                finalTrackedStatus!,
                 trackedGeneratedPaths)
               || HasUntrackedSourceFiles(
                 projectRoot,
@@ -254,13 +273,19 @@ public sealed partial class DotNetPublishPipelineRunner
     internal static string[] GetVerifiedMsiVersionStateWrites(
         string projectRoot,
         IReadOnlyDictionary<string, string> cleanTrackedGeneratedPaths,
-        string reservationOwner)
+        string reservationOwner,
+        string? trackedStatus = null)
     {
         if (!MsiVersionStateWrites.TryGetValue(reservationOwner, out var writes))
             return Array.Empty<string>();
 
         var gitRoot = ReadGitText(projectRoot, "rev-parse --show-toplevel");
         if (string.IsNullOrWhiteSpace(gitRoot))
+            return Array.Empty<string>();
+        trackedStatus ??= ReadGitRawText(
+            gitRoot!,
+            "status --porcelain=v1 -z --untracked-files=no");
+        if (trackedStatus is null)
             return Array.Empty<string>();
 
         var verified = new List<string>();
@@ -275,19 +300,17 @@ public sealed partial class DotNetPublishPipelineRunner
                     continue;
 
                 var gitRelativePath = ToGitRelativeExclusion(projectRoot, gitRoot!, fullPath);
-                if (string.IsNullOrWhiteSpace(gitRelativePath))
+                if (string.IsNullOrWhiteSpace(gitRelativePath)
+                    || !HasExactTrackedStatus(trackedStatus, gitRelativePath!, " M")
+                    || !IsRegularTrackedFile(gitRoot!, gitRelativePath!)
+                    || (File.GetAttributes(fullPath) & FileAttributes.ReparsePoint) != 0)
                     continue;
 
                 var workingTreeMetadataDiff = ReadGitRawText(
                     gitRoot!,
-                    $"diff --summary HEAD -- {QuoteGitPath(gitRelativePath!)}");
-                var indexDiff = ReadGitRawText(
-                    gitRoot!,
-                    $"diff --cached --name-only HEAD -- {QuoteGitPath(gitRelativePath!)}");
+                    $"diff --summary HEAD -- {QuoteLiteralGitPath(gitRelativePath!)}");
                 if (workingTreeMetadataDiff is null
-                    || indexDiff is null
-                    || !string.IsNullOrWhiteSpace(workingTreeMetadataDiff)
-                    || !string.IsNullOrWhiteSpace(indexDiff))
+                    || !string.IsNullOrWhiteSpace(workingTreeMetadataDiff))
                     continue;
 
                 var actualHash = ComputeSha256Hex(File.ReadAllBytes(fullPath));
@@ -302,6 +325,49 @@ public sealed partial class DotNetPublishPipelineRunner
         }
 
         return verified.ToArray();
+    }
+
+    private static bool HasExactTrackedStatus(
+        string trackedStatus,
+        string gitRelativePath,
+        string expectedStatus)
+    {
+        var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var records = trackedStatus.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+        for (var index = 0; index < records.Length; index++)
+        {
+            var record = records[index];
+            if (record.Length < 4 || record[2] != ' ')
+                return false;
+
+            var status = record.Substring(0, 2);
+            var path = record.Substring(3).Replace('\\', '/').TrimStart('/');
+            if (string.Equals(path, gitRelativePath, comparison))
+                return string.Equals(status, expectedStatus, StringComparison.Ordinal);
+
+            bool renameOrCopy = status.IndexOf('R') >= 0 || status.IndexOf('C') >= 0;
+            if (renameOrCopy && ++index >= records.Length)
+                return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsRegularTrackedFile(string gitRoot, string gitRelativePath)
+    {
+        var stage = ReadGitText(
+            gitRoot,
+            $"ls-files --stage -- {QuoteLiteralGitPath(gitRelativePath)}");
+        if (string.IsNullOrWhiteSpace(stage))
+            return false;
+
+        var separator = stage!.IndexOf(' ');
+        if (separator <= 0)
+            return false;
+
+        var mode = stage.Substring(0, separator);
+        return string.Equals(mode, "100644", StringComparison.Ordinal)
+            || string.Equals(mode, "100755", StringComparison.Ordinal);
     }
 
     internal static IReadOnlyDictionary<string, string> CaptureCleanTrackedGeneratedProvenanceState(
@@ -542,6 +608,9 @@ public sealed partial class DotNetPublishPipelineRunner
 
     private static string QuoteGitPath(string path)
         => "\"" + path.Replace("\\", "/").Replace("\"", "\\\"") + "\"";
+
+    private static string QuoteLiteralGitPath(string path)
+        => QuoteGitPath(":(literal)" + path.Replace('\\', '/'));
 
     internal sealed class SourceProvenance
     {

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -277,10 +277,16 @@ public sealed partial class DotNetPublishPipelineRunner
                 if (string.IsNullOrWhiteSpace(gitRelativePath))
                     continue;
 
-                var metadataDiff = ReadGitRawText(
+                var workingTreeMetadataDiff = ReadGitRawText(
                     gitRoot!,
                     $"diff --summary HEAD -- {QuoteGitPath(gitRelativePath!)}");
-                if (metadataDiff is null || !string.IsNullOrWhiteSpace(metadataDiff))
+                var indexMetadataDiff = ReadGitRawText(
+                    gitRoot!,
+                    $"diff --cached --summary HEAD -- {QuoteGitPath(gitRelativePath!)}");
+                if (workingTreeMetadataDiff is null
+                    || indexMetadataDiff is null
+                    || !string.IsNullOrWhiteSpace(workingTreeMetadataDiff)
+                    || !string.IsNullOrWhiteSpace(indexMetadataDiff))
                     continue;
 
                 var actualHash = ComputeSha256Hex(File.ReadAllBytes(fullPath));

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -157,7 +157,7 @@ public sealed partial class DotNetPublishPipelineRunner
         foreach (var version in plan.MsiVersions.Values)
             yield return version.StatePath ?? string.Empty;
 
-        foreach (var step in plan.Steps)
+        foreach (var step in plan.Steps ?? Array.Empty<DotNetPublishStep>())
         {
             yield return step.StagingPath ?? string.Empty;
             yield return step.ManifestPath ?? string.Empty;
@@ -209,7 +209,8 @@ public sealed partial class DotNetPublishPipelineRunner
 
     internal static IEnumerable<string> EnumeratePlannedMsiVersionStatePaths(DotNetPublishPlan plan)
     {
-        foreach (var step in plan.Steps.Where(step => step.Kind == DotNetPublishStepKind.MsiBuild))
+        foreach (var step in (plan.Steps ?? Array.Empty<DotNetPublishStep>())
+                     .Where(step => step.Kind == DotNetPublishStepKind.MsiBuild))
         {
             var installer = plan.Installers.FirstOrDefault(candidate =>
                 string.Equals(candidate.Id, step.InstallerId, StringComparison.OrdinalIgnoreCase));
@@ -280,13 +281,13 @@ public sealed partial class DotNetPublishPipelineRunner
                 var workingTreeMetadataDiff = ReadGitRawText(
                     gitRoot!,
                     $"diff --summary HEAD -- {QuoteGitPath(gitRelativePath!)}");
-                var indexMetadataDiff = ReadGitRawText(
+                var indexDiff = ReadGitRawText(
                     gitRoot!,
-                    $"diff --cached --summary HEAD -- {QuoteGitPath(gitRelativePath!)}");
+                    $"diff --cached --name-only HEAD -- {QuoteGitPath(gitRelativePath!)}");
                 if (workingTreeMetadataDiff is null
-                    || indexMetadataDiff is null
+                    || indexDiff is null
                     || !string.IsNullOrWhiteSpace(workingTreeMetadataDiff)
-                    || !string.IsNullOrWhiteSpace(indexMetadataDiff))
+                    || !string.IsNullOrWhiteSpace(indexDiff))
                     continue;
 
                 var actualHash = ComputeSha256Hex(File.ReadAllBytes(fullPath));
@@ -469,13 +470,30 @@ public sealed partial class DotNetPublishPipelineRunner
         if (string.IsNullOrWhiteSpace(path))
             return null;
 
-        var root = Path.GetFullPath(gitRoot)
+        var project = Path.GetFullPath(projectRoot)
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var fullPath = Path.GetFullPath(
             Path.IsPathRooted(path)
                 ? path
                 : Path.Combine(projectRoot, path));
         var comparison = IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        var projectPrefix = project + Path.DirectorySeparatorChar;
+        if (fullPath.StartsWith(projectPrefix, comparison))
+        {
+            var gitProjectPrefix = ReadGitText(projectRoot, "rev-parse --show-prefix");
+            if (gitProjectPrefix is not null)
+            {
+                var relativeToProject = fullPath.Substring(projectPrefix.Length)
+                    .Replace('\\', '/')
+                    .Trim('/');
+                return (gitProjectPrefix.Trim('/', '\\') + "/" + relativeToProject)
+                    .Trim('/');
+            }
+        }
+
+        var root = Path.GetFullPath(gitRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         if (string.Equals(root, fullPath, comparison))
             return null;
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -197,11 +197,28 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishPlan plan,
         IEnumerable<DotNetPublishMsiBuildResult> msiBuilds)
     {
+        foreach (var statePath in EnumeratePlannedMsiVersionStatePaths(plan))
+            yield return statePath;
+
         foreach (var version in plan.MsiVersions.Values)
             yield return version.StatePath ?? string.Empty;
 
         foreach (var msiBuild in msiBuilds)
             yield return msiBuild.VersionStatePath ?? string.Empty;
+    }
+
+    internal static IEnumerable<string> EnumeratePlannedMsiVersionStatePaths(DotNetPublishPlan plan)
+    {
+        foreach (var step in plan.Steps.Where(step => step.Kind == DotNetPublishStepKind.MsiBuild))
+        {
+            var installer = plan.Installers.FirstOrDefault(candidate =>
+                string.Equals(candidate.Id, step.InstallerId, StringComparison.OrdinalIgnoreCase));
+            if (installer?.Versioning is not { Enabled: true, Monotonic: true })
+                continue;
+
+            var tokens = BuildMsiVersionTemplateTokens(plan, installer, step);
+            yield return ResolveMsiVersionStatePath(plan, installer, tokens);
+        }
     }
 
     internal static void RecordMsiVersionStateWrite(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.MsiVersionIntegrity.cs
@@ -1,10 +1,15 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace PowerForge;
 
 public sealed partial class DotNetPublishPipelineRunner
 {
+    private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, MsiVersionStateWrite>>
+        MsiVersionStateWrites = new(StringComparer.Ordinal);
+
     internal static string CreateMsiReservationOwner()
         => Guid.NewGuid().ToString("N");
 
@@ -192,9 +197,6 @@ public sealed partial class DotNetPublishPipelineRunner
         DotNetPublishPlan plan,
         IEnumerable<DotNetPublishMsiBuildResult> msiBuilds)
     {
-        foreach (var statePath in EnumeratePlannedMsiVersionStatePaths(plan))
-            yield return statePath;
-
         foreach (var version in plan.MsiVersions.Values)
             yield return version.StatePath ?? string.Empty;
 
@@ -202,19 +204,98 @@ public sealed partial class DotNetPublishPipelineRunner
             yield return msiBuild.VersionStatePath ?? string.Empty;
     }
 
-    private static IEnumerable<string> EnumeratePlannedMsiVersionStatePaths(DotNetPublishPlan plan)
+    internal static void RecordMsiVersionStateWrite(
+        string reservationOwner,
+        string statePath,
+        string previousContentHash,
+        string contentHash)
     {
-        foreach (var step in plan.Steps.Where(step => step.Kind == DotNetPublishStepKind.MsiBuild))
-        {
-            var installer = plan.Installers.FirstOrDefault(candidate =>
-                string.Equals(candidate.Id, step.InstallerId, StringComparison.OrdinalIgnoreCase));
-            if (installer?.Versioning is not { Enabled: true, Monotonic: true })
-                continue;
+        if (string.IsNullOrWhiteSpace(reservationOwner)
+            || string.IsNullOrWhiteSpace(statePath)
+            || string.IsNullOrWhiteSpace(previousContentHash)
+            || string.IsNullOrWhiteSpace(contentHash))
+            return;
 
-            var tokens = BuildMsiVersionTemplateTokens(plan, installer, step);
-            yield return ResolveMsiVersionStatePath(plan, installer, tokens);
-        }
+        var writes = MsiVersionStateWrites.GetOrAdd(
+            reservationOwner,
+            _ => new ConcurrentDictionary<string, MsiVersionStateWrite>(
+                IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal));
+        writes.AddOrUpdate(
+            Path.GetFullPath(statePath),
+            _ => new MsiVersionStateWrite(previousContentHash, contentHash),
+            (_, priorWrite) => new MsiVersionStateWrite(priorWrite.PreviousContentHash, contentHash));
     }
+
+    internal static string[] GetVerifiedMsiVersionStateWrites(
+        IReadOnlyDictionary<string, string> cleanTrackedGeneratedPaths,
+        string reservationOwner)
+    {
+        if (!MsiVersionStateWrites.TryGetValue(reservationOwner, out var writes))
+            return Array.Empty<string>();
+
+        var verified = new List<string>();
+        foreach (var candidate in cleanTrackedGeneratedPaths)
+        {
+            try
+            {
+                var fullPath = Path.GetFullPath(candidate.Key);
+                if (!writes.TryGetValue(fullPath, out var write)
+                    || !File.Exists(fullPath))
+                    continue;
+
+                var actualHash = ComputeSha256Hex(File.ReadAllBytes(fullPath));
+                if (string.Equals(write.PreviousContentHash, candidate.Value, StringComparison.Ordinal)
+                    && string.Equals(actualHash, write.ContentHash, StringComparison.Ordinal))
+                    verified.Add(fullPath);
+            }
+            catch
+            {
+                // Fail closed: an unreadable or invalid state path remains dirty.
+            }
+        }
+
+        return verified.ToArray();
+    }
+
+    internal static IReadOnlyDictionary<string, string> CaptureCleanTrackedGeneratedProvenanceState(
+        string projectRoot,
+        IEnumerable<string>? generatedPaths)
+    {
+        var comparison = IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        var state = new Dictionary<string, string>(comparison);
+        foreach (var candidate in CaptureCleanTrackedGeneratedProvenancePaths(projectRoot, generatedPaths))
+        {
+            var fullPath = Path.GetFullPath(
+                Path.IsPathRooted(candidate)
+                    ? candidate
+                    : Path.Combine(projectRoot, candidate));
+            var content = File.Exists(fullPath) ? File.ReadAllBytes(fullPath) : Array.Empty<byte>();
+            state[fullPath] = ComputeSha256Hex(content);
+        }
+
+        return state;
+    }
+
+    internal static void ClearMsiVersionStateWrites(string reservationOwner)
+    {
+        if (!string.IsNullOrWhiteSpace(reservationOwner))
+            MsiVersionStateWrites.TryRemove(reservationOwner, out _);
+    }
+
+    private static string ComputeSha256Hex(byte[] content)
+    {
+        using var sha256 = SHA256.Create();
+        return ToUpperHex(sha256.ComputeHash(content));
+    }
+
+    private static string ComputeSha256Hex(Stream stream)
+    {
+        using var sha256 = SHA256.Create();
+        return ToUpperHex(sha256.ComputeHash(stream));
+    }
+
+    private static string ToUpperHex(byte[] value)
+        => BitConverter.ToString(value).Replace("-", string.Empty);
 
     internal static string[] CaptureCleanTrackedGeneratedProvenancePaths(
         string projectRoot,
@@ -393,6 +474,19 @@ public sealed partial class DotNetPublishPipelineRunner
         public string? Revision { get; }
 
         public bool? Dirty { get; }
+    }
+
+    private sealed class MsiVersionStateWrite
+    {
+        internal MsiVersionStateWrite(string previousContentHash, string contentHash)
+        {
+            PreviousContentHash = previousContentHash;
+            ContentHash = contentHash;
+        }
+
+        internal string PreviousContentHash { get; }
+
+        internal string ContentHash { get; }
     }
 
     private static void TryDeleteReservation(string path)

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -107,6 +107,7 @@ public sealed partial class DotNetPublishPipelineRunner
                         case DotNetPublishStepKind.Manifest:
                         {
                             var verifiedMsiVersionStateWrites = GetVerifiedMsiVersionStateWrites(
+                                plan.ProjectRoot,
                                 cleanTrackedGeneratedProvenanceState,
                                 msiReservationOwner);
                             (manifestJson, manifestText, checksumsPath) = WriteManifestsWithProvenance(

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -106,16 +106,16 @@ public sealed partial class DotNetPublishPipelineRunner
                             break;
                         case DotNetPublishStepKind.Manifest:
                         {
-                            var verifiedMsiVersionStateWrites = GetVerifiedMsiVersionStateWrites(
-                                plan.ProjectRoot,
-                                cleanTrackedGeneratedProvenanceState,
-                                msiReservationOwner);
                             (manifestJson, manifestText, checksumsPath) = WriteManifestsWithProvenance(
                                 plan,
                                 artefacts,
                                 storePackages,
                                 msiBuilds,
-                                verifiedMsiVersionStateWrites);
+                                cleanTrackedGeneratedPaths: null,
+                                cleanTrackedGeneratedProvenanceState:
+                                    cleanTrackedGeneratedProvenanceState,
+                                msiReservationOwner:
+                                    msiReservationOwner);
                             break;
                         }
                     }

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -32,6 +32,11 @@ public sealed partial class DotNetPublishPipelineRunner
         var benchmarkGates = new List<DotNetPublishBenchmarkGateResult>();
         var benchmarkExtracts = new Dictionary<string, DotNetPublishBenchmarkExtractionResult>(StringComparer.OrdinalIgnoreCase);
         var stepReports = new List<DotNetPublishRunReportStep>();
+        var cleanTrackedGeneratedProvenancePaths = CaptureCleanTrackedGeneratedProvenancePaths(
+            plan.ProjectRoot,
+            EnumerateTrackedGeneratedProvenancePaths(
+                plan,
+                Array.Empty<DotNetPublishMsiBuildResult>()));
         string? manifestJson = null;
         string? manifestText = null;
         string? checksumsPath = null;
@@ -101,7 +106,8 @@ public sealed partial class DotNetPublishPipelineRunner
                                 plan,
                                 artefacts,
                                 storePackages,
-                                msiBuilds);
+                                msiBuilds,
+                                cleanTrackedGeneratedProvenancePaths);
                             break;
                     }
 

--- a/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
+++ b/PowerForge/Services/DotNetPublishPipelineRunner.Run.cs
@@ -32,11 +32,8 @@ public sealed partial class DotNetPublishPipelineRunner
         var benchmarkGates = new List<DotNetPublishBenchmarkGateResult>();
         var benchmarkExtracts = new Dictionary<string, DotNetPublishBenchmarkExtractionResult>(StringComparer.OrdinalIgnoreCase);
         var stepReports = new List<DotNetPublishRunReportStep>();
-        var cleanTrackedGeneratedProvenancePaths = CaptureCleanTrackedGeneratedProvenancePaths(
-            plan.ProjectRoot,
-            EnumerateTrackedGeneratedProvenancePaths(
-                plan,
-                Array.Empty<DotNetPublishMsiBuildResult>()));
+        IReadOnlyDictionary<string, string> cleanTrackedGeneratedProvenanceState =
+            new Dictionary<string, string>();
         string? manifestJson = null;
         string? manifestText = null;
         string? checksumsPath = null;
@@ -45,6 +42,12 @@ public sealed partial class DotNetPublishPipelineRunner
 
         try
         {
+            cleanTrackedGeneratedProvenanceState = CaptureCleanTrackedGeneratedProvenanceState(
+                plan.ProjectRoot,
+                EnumerateTrackedGeneratedProvenancePaths(
+                    plan,
+                    Array.Empty<DotNetPublishMsiBuildResult>()));
+
             foreach (var step in plan.Steps ?? Array.Empty<DotNetPublishStep>())
             {
                 progress.StepStarting(step);
@@ -102,13 +105,18 @@ public sealed partial class DotNetPublishPipelineRunner
                             benchmarkGates.Add(RunBenchmarkGateStep(plan, benchmarkExtracts, step));
                             break;
                         case DotNetPublishStepKind.Manifest:
+                        {
+                            var verifiedMsiVersionStateWrites = GetVerifiedMsiVersionStateWrites(
+                                cleanTrackedGeneratedProvenanceState,
+                                msiReservationOwner);
                             (manifestJson, manifestText, checksumsPath) = WriteManifestsWithProvenance(
                                 plan,
                                 artefacts,
                                 storePackages,
                                 msiBuilds,
-                                cleanTrackedGeneratedProvenancePaths);
+                                verifiedMsiVersionStateWrites);
                             break;
+                        }
                     }
 
                     progress.StepCompleted(step);
@@ -207,14 +215,21 @@ public sealed partial class DotNetPublishPipelineRunner
         }
         finally
         {
-            foreach (var version in plan.MsiVersions.Values)
+            try
             {
-                if (!ReleaseMsiVersionStateReservation(version, msiReservationOwner))
+                foreach (var version in plan.MsiVersions.Values)
                 {
-                    _logger.Warn(
-                        $"MSI version reservation for '{version.Version}' in '{version.StatePath}' " +
-                        "could not be released. A later overwrite rebuild may require retrying after the state file is available.");
+                    if (!ReleaseMsiVersionStateReservation(version, msiReservationOwner))
+                    {
+                        _logger.Warn(
+                            $"MSI version reservation for '{version.Version}' in '{version.StatePath}' " +
+                            "could not be released. A later overwrite rebuild may require retrying after the state file is available.");
+                    }
                 }
+            }
+            finally
+            {
+                ClearMsiVersionStateWrites(msiReservationOwner);
             }
         }
     }


### PR DESCRIPTION
## Summary
- keep governed MSI provenance clean only for the exact monotonic version-state transition written by the current PowerForge reservation owner
- bind exclusion verification to unchanged final Git status, literal pathspecs, regular tracked files, continuous writer chains, and repository-relative paths including symlinked project roots
- preserve dirty provenance for pre-existing, staged, deleted, hook-mutated, concurrently changed, mode-changed, symlinked, malformed, or otherwise ambiguous state
- keep null-step publish plans and deferred `ApplyToPublish=false` MSI version resolution supported

## Validation
- focused DotNetPublish provenance suite passes on Windows (220 tests)
- colon-prefixed path, symlink, staged-index, symlinked-project-root, and concurrent-status regressions pass on Ubuntu
- public CI passes on Windows, Linux, and macOS
- PowerForge builds for net472, net8.0, and net10.0

## Release impact
This removes false dirty-provenance failures from governed MSI publishing without weakening source-integrity checks. Ambiguous state always fails closed as dirty.