### PR TITLE
Preserve benchmark README tables after failed samples

### DIFF
--- a/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkArtifactWriter.cs
+++ b/PowerForge.PowerShell/Services/Benchmarks/PowerShellBenchmarkArtifactWriter.cs
@@ -67,6 +67,11 @@ internal static class PowerShellBenchmarkArtifactWriter
     /// <param name="result">Run result.</param>
     public static void UpdateReadmeBlocks(PowerShellBenchmarkSuite suite, BenchmarkRunResult result)
     {
+        if (result.Samples.Any(sample => sample.Status == BenchmarkSampleStatus.Failed))
+        {
+            return;
+        }
+
         var updater = new BenchmarkDocumentUpdater();
         var renderer = new BenchmarkMarkdownRenderer();
         foreach (var block in suite.ReadmeBlocks)

--- a/PowerForge.Tests/BenchmarkServicesTests.Part07.cs
+++ b/PowerForge.Tests/BenchmarkServicesTests.Part07.cs
@@ -127,6 +127,29 @@ public sealed partial class BenchmarkServicesTests
     }
 
     [Fact]
+    public void Runner_DoesNotUpdateReadmeBlocksWhenValidationFails()
+    {
+        var suite = CreateRunnableSuite();
+        suite.Artifacts = BenchmarkArtifactKind.Json;
+        suite.Validate = ScriptBlock.Create("throw 'expected validation failure'");
+        var readme = Path.Combine(CreateTempRoot(), "README.md");
+        const string original = "<!-- BENCHMARK:results:START -->\nvalidated content\n<!-- BENCHMARK:results:END -->\n";
+        File.WriteAllText(readme, original);
+        suite.ReadmeBlocks.Add(new PowerShellBenchmarkReadmeBlock
+        {
+            Path = readme,
+            BlockId = "results",
+            Renderer = "SummaryTable"
+        });
+
+        var result = new PowerShellBenchmarkRunner().Run(suite);
+
+        Assert.Equal(BenchmarkSampleStatus.Failed, Assert.Single(result.Samples).Status);
+        Assert.Equal(original, File.ReadAllText(readme));
+        Assert.True(result.Artifacts.ContainsKey("summary.json"));
+    }
+
+    [Fact]
     public void TemporaryUserExecutor_CapturesFileBackedCallerModules()
     {
         var modulePath = typeof(PSPublishModule.TestBenchmarkGateCommand).Assembly.Location;


### PR DESCRIPTION
## Summary

- prevent a failed benchmark sample from replacing generated README benchmark blocks
- keep failed-run JSON and summary artifacts available for diagnosis
- cover validation failures with a regression test that proves the existing README content is preserved

## Why

A benchmark can finish execution and then fail its validation contract. README tables should only describe fully validated runs; failed samples must remain diagnostic evidence rather than becoming published results.

## Validation

- 285/285 `BenchmarkServicesTests` passed
- `PowerForge.PowerShell` built warning-free for `net472`, `net8.0`, and `net10.0`