### PR TITLE
Prevent Windows PowerShell resolver recursion after module import

### DIFF
--- a/Module/PSPublishModule.psm1
+++ b/Module/PSPublishModule.psm1
@@ -62,6 +62,7 @@ if ($PSEdition -ne 'Core' -and $LibFolder) {
     }
     $PowerForgeDesktopAssemblyResolverState = [pscustomobject]@{
         BootstrapActive = $true
+        Registered      = $false
     }
 
     $PowerForgeDesktopAssemblyResolver = [System.ResolveEventHandler] {
@@ -119,15 +120,21 @@ if ($PSEdition -ne 'Core' -and $LibFolder) {
     }.GetNewClosure()
 
     [AppDomain]::CurrentDomain.add_AssemblyResolve($PowerForgeDesktopAssemblyResolver)
+    $PowerForgeDesktopAssemblyResolverState.Registered = $true
     $PowerForgeResolverForRemoval = $PowerForgeDesktopAssemblyResolver
     $UnregisterPowerForgeDesktopAssemblyResolver = {
-        [AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)
+        if ($PowerForgeDesktopAssemblyResolverState.Registered) {
+            [AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)
+            $PowerForgeDesktopAssemblyResolverState.Registered = $false
+        }
     }.GetNewClosure()
 
     $PowerForgePreviousOnRemove = $ExecutionContext.SessionState.Module.OnRemove
     $ExecutionContext.SessionState.Module.OnRemove = {
         try {
-            & $UnregisterPowerForgeDesktopAssemblyResolver
+            if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+                & $UnregisterPowerForgeDesktopAssemblyResolver
+            }
         } finally {
             if ($null -ne $PowerForgePreviousOnRemove) {
                 & $PowerForgePreviousOnRemove @args
@@ -756,6 +763,9 @@ if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded) {
 }
 if ($PSEdition -ne 'Core' -and $null -ne $PowerForgeDesktopAssemblyResolverState) {
     $PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false
+    if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+        & $UnregisterPowerForgeDesktopAssemblyResolver
+    }
 }
 
 $FunctionsToExport = @()

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests.cs
@@ -37,10 +37,10 @@ public sealed class ModuleBootstrapperGeneratorDesktopTypeAcceleratorTests
             Assert.Contains("if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded)", bootstrapper);
             Assert.Contains("& $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::Combine($PSScriptRoot, 'Lib', $LibFolder))", bootstrapper);
             Assert.True(
-                bootstrapper.IndexOf("$PowerForgeDesktopBinaryLoaded = $true", StringComparison.Ordinal) <
-                bootstrapper.IndexOf(". $LibrariesScript", StringComparison.Ordinal));
-            Assert.True(
                 bootstrapper.IndexOf(". $LibrariesScript", StringComparison.Ordinal) <
+                bootstrapper.IndexOf("$PowerForgeDesktopBinaryLoaded = $true", StringComparison.Ordinal));
+            Assert.True(
+                bootstrapper.IndexOf("$PowerForgeDesktopBinaryLoaded = $true", StringComparison.Ordinal) <
                 bootstrapper.IndexOf("& $RegisterPowerForgeDesktopAssemblyTypeAccelerators", StringComparison.Ordinal));
             Assert.Contains("    if ($PSEdition -ne 'Core') {\r\n        # Desktop loads module dependencies", bootstrapper);
         }

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorTests.cs
@@ -35,6 +35,9 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("$PowerForgeDesktopAssemblyResolverState = [pscustomobject]@{", bootstrapper);
             Assert.Contains("if (-not $PowerForgeDesktopAssemblyResolverState.BootstrapActive)", bootstrapper);
             Assert.Contains("$PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false", bootstrapper);
+            Assert.Contains("$PowerForgeDesktopAssemblyResolverState.Registered = $true", bootstrapper);
+            Assert.Contains("if ($PowerForgeDesktopAssemblyResolverState.Registered)", bootstrapper);
+            Assert.Contains("$PowerForgeDesktopAssemblyResolverState.Registered = $false", bootstrapper);
             Assert.Contains("StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)", bootstrapper);
             Assert.Contains("$PowerForgeRequestedAssemblyName -ne [IO.Path]::GetFileName($PowerForgeRequestedAssemblyName)", bootstrapper);
             Assert.Contains("$PowerForgeRequestedAssemblyName.IndexOfAny([IO.Path]::GetInvalidFileNameChars()) -ge 0", bootstrapper);
@@ -42,6 +45,10 @@ public class ModuleBootstrapperGeneratorTests
             Assert.Contains("$PowerForgeAssemblyCandidate.StartsWith($PowerForgeDesktopAssemblyRootPrefix, [StringComparison]::OrdinalIgnoreCase)", bootstrapper);
             Assert.Contains("[AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)", bootstrapper);
             Assert.Contains("$ExecutionContext.SessionState.Module.OnRemove", bootstrapper);
+            Assert.True(
+                bootstrapper.LastIndexOf("& $UnregisterPowerForgeDesktopAssemblyResolver", StringComparison.Ordinal) >
+                bootstrapper.LastIndexOf("$PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false", StringComparison.Ordinal),
+                "The Desktop resolver must be removed after the bounded bootstrap window.");
             Assert.DoesNotContain("ProcessArchitecture", bootstrapper);
         }
         finally

--- a/PowerForge.Tests/ModuleBootstrapperGeneratorWindowsPowerShellTests.cs
+++ b/PowerForge.Tests/ModuleBootstrapperGeneratorWindowsPowerShellTests.cs
@@ -1,0 +1,172 @@
+using System.Diagnostics;
+using PowerForge;
+
+public sealed class ModuleBootstrapperGeneratorWindowsPowerShellTests
+{
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void GeneratedDesktopResolverStopsAfterBootstrapAndDoesNotReenterForMissingPowerShellResources()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var windowsPowerShell = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "WindowsPowerShell",
+            "v1.0",
+            "powershell.exe");
+        if (!File.Exists(windowsPowerShell))
+        {
+            return;
+        }
+
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "pf-bootstrapper-desktop-resolver-" + Guid.NewGuid().ToString("N"));
+        var libDefault = Path.Combine(root, "Lib", "Default");
+        Directory.CreateDirectory(libDefault);
+
+        try
+        {
+            var moduleAssembly = BuildDesktopFixture(root);
+            File.Copy(
+                moduleAssembly,
+                Path.Combine(libDefault, "DemoModule.dll"),
+                overwrite: true);
+
+            ModuleBootstrapperGenerator.Generate(
+                root,
+                "DemoModule",
+                new ExportSet(
+                    Array.Empty<string>(),
+                    Array.Empty<string>(),
+                    Array.Empty<string>()),
+                new[] { "DemoModule.dll" },
+                handleRuntimes: false);
+
+            var proofScript = Path.Combine(root, "Validate-ResolverLifetime.ps1");
+            File.WriteAllText(
+                proofScript,
+                """
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'DemoModule.psm1') -Force
+$module = Get-Module DemoModule
+$resolverState = & $module { $PowerForgeDesktopAssemblyResolverState }
+if ($null -eq $resolverState -or
+    $resolverState.PSObject.Properties.Name -notcontains 'Registered' -or
+    $resolverState.Registered) {
+    throw 'The Desktop assembly resolver remained registered after bootstrap.'
+}
+try {
+    Get-Item -LiteralPath (Join-Path $PSScriptRoot 'missing-file') -ErrorAction Stop
+} catch [System.Management.Automation.ItemNotFoundException] {
+}
+'RESOLVER_BOUNDED_OK'
+""");
+
+            var result = RunProcess(
+                windowsPowerShell,
+                $"-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"{proofScript}\"",
+                root,
+                timeoutMilliseconds: 20000);
+
+            Assert.True(
+                result.ExitCode == 0,
+                $"Windows PowerShell resolver proof failed.{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}{result.StandardError}");
+            Assert.Contains("RESOLVER_BOUNDED_OK", result.StandardOutput);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    private static string BuildDesktopFixture(string root)
+    {
+        var projectRoot = Directory.CreateDirectory(Path.Combine(root, "Fixture"));
+        var projectPath = Path.Combine(projectRoot.FullName, "DemoModule.csproj");
+        File.WriteAllText(
+            projectPath,
+            """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>DemoModule</AssemblyName>
+  </PropertyGroup>
+</Project>
+""");
+        File.WriteAllText(
+            Path.Combine(projectRoot.FullName, "Initialize.cs"),
+            """
+namespace DemoModule
+{
+    public static class Initialize
+    {
+    }
+}
+""");
+
+        var result = RunProcess(
+            "dotnet",
+            $"build \"{projectPath}\" -c Release -nologo --verbosity quiet",
+            projectRoot.FullName,
+            timeoutMilliseconds: 60000);
+        Assert.True(
+            result.ExitCode == 0,
+            $"dotnet build failed for the Desktop resolver fixture.{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}{result.StandardError}");
+
+        var assemblyPath = Path.Combine(
+            projectRoot.FullName,
+            "bin",
+            "Release",
+            "netstandard2.0",
+            "DemoModule.dll");
+        Assert.True(File.Exists(assemblyPath), $"Built assembly not found: {assemblyPath}");
+        return assemblyPath;
+    }
+
+    private static ProcessResult RunProcess(
+        string executable,
+        string arguments,
+        string workingDirectory,
+        int timeoutMilliseconds)
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = executable,
+            Arguments = arguments,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        })!;
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(timeoutMilliseconds))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            throw new TimeoutException(
+                $"Process '{executable}' did not exit within {timeoutMilliseconds} ms.");
+        }
+
+        Task.WaitAll(standardOutput, standardError);
+        return new ProcessResult(
+            process.ExitCode,
+            standardOutput.Result,
+            standardError.Result);
+    }
+
+    private sealed record ProcessResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError);
+}

--- a/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/AssemblyLoadContextBinaryLoader.Template.ps1
@@ -145,4 +145,7 @@ if ($PSEdition -ne 'Core' -and $PowerForgeDesktopBinaryLoaded) {
 }
 if ($PSEdition -ne 'Core' -and $null -ne $PowerForgeDesktopAssemblyResolverState) {
     $PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false
+    if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+        & $UnregisterPowerForgeDesktopAssemblyResolver
+    }
 }

--- a/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/BinaryLoader.Template.ps1
@@ -99,4 +99,7 @@ if (-not $PowerForgeDesktopLibrariesLoaded -and (Test-Path -LiteralPath $Librari
 }
 if ($PSEdition -ne 'Core' -and $null -ne $PowerForgeDesktopAssemblyResolverState) {
     $PowerForgeDesktopAssemblyResolverState.BootstrapActive = $false
+    if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+        & $UnregisterPowerForgeDesktopAssemblyResolver
+    }
 }

--- a/PowerForge/Scripts/ModuleBootstrapper/DesktopAssemblyResolver.Template.ps1
+++ b/PowerForge/Scripts/ModuleBootstrapper/DesktopAssemblyResolver.Template.ps1
@@ -7,6 +7,7 @@ if ($PSEdition -ne 'Core' -and $LibFolder) {
     }
     $PowerForgeDesktopAssemblyResolverState = [pscustomobject]@{
         BootstrapActive = $true
+        Registered      = $false
     }
 
     $PowerForgeDesktopAssemblyResolver = [System.ResolveEventHandler] {
@@ -64,15 +65,21 @@ if ($PSEdition -ne 'Core' -and $LibFolder) {
     }.GetNewClosure()
 
     [AppDomain]::CurrentDomain.add_AssemblyResolve($PowerForgeDesktopAssemblyResolver)
+    $PowerForgeDesktopAssemblyResolverState.Registered = $true
     $PowerForgeResolverForRemoval = $PowerForgeDesktopAssemblyResolver
     $UnregisterPowerForgeDesktopAssemblyResolver = {
-        [AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)
+        if ($PowerForgeDesktopAssemblyResolverState.Registered) {
+            [AppDomain]::CurrentDomain.remove_AssemblyResolve($PowerForgeResolverForRemoval)
+            $PowerForgeDesktopAssemblyResolverState.Registered = $false
+        }
     }.GetNewClosure()
 
     $PowerForgePreviousOnRemove = $ExecutionContext.SessionState.Module.OnRemove
     $ExecutionContext.SessionState.Module.OnRemove = {
         try {
-            & $UnregisterPowerForgeDesktopAssemblyResolver
+            if ($null -ne $UnregisterPowerForgeDesktopAssemblyResolver) {
+                & $UnregisterPowerForgeDesktopAssemblyResolver
+            }
         } finally {
             if ($null -ne $PowerForgePreviousOnRemove) {
                 & $PowerForgePreviousOnRemove @args


### PR DESCRIPTION
## Summary

- bound the generated Windows PowerShell `AssemblyResolve` hook to the module bootstrap window instead of leaving a PowerShell scriptblock handler registered for the module lifetime
- make resolver removal idempotent and retain the existing module-removal cleanup as a safety net
- keep private dependency loading and type-accelerator registration in their intended order
- add a real Windows PowerShell integration test that imports a generated binary module, verifies the resolver is detached, and exercises the missing-resource path that previously recursed to stack overflow

## Why this matters

A generated module could import successfully on Windows PowerShell 5.1 and then stack-overflow on an unrelated command. A missing `System.Management.Automation.resources` assembly caused the still-registered PowerShell resolver to re-enter itself. The generated library script has already loaded the module's private managed dependencies by this point, so keeping that handler attached provides no useful fallback and expands the failure surface.

## Consumer proof

A locally built PSPublishModule package generated a fresh PSEventViewer 4.0.0 artifact. In separate PowerShell 5.1 and PowerShell 7 processes the packed module imported, queried an EVTX through EventViewerX, and completed direct XML export without a stack overflow. No PSEventViewer compatibility shim is included.

## Validation

- 52/52 focused bootstrapper, resolver, import, and type-accelerator tests
- real Windows PowerShell resolver-lifetime regression test
- warning-free `net472`, `net8.0`, and `net10.0` builds for PowerForge, PowerForge.PowerShell, and PSPublishModule
- PSPublishModule self-build completed successfully
- broad suite: 4,971 passed; one Apple CLI test failed identically on untouched `origin/main` because its fixture enables distribution without App Store Connect credentials