### PR TITLE
Report App Store build upload validation failures

### DIFF
--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -206,6 +206,40 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task GetBuildUploadAsync_ParsesFlatDocumentedDeliveryState()
+    {
+        var handler = new RecordingHandler(
+            """
+            {
+              "data": {
+                "id": "upload-12",
+                "type": "buildUploads",
+                "attributes": {
+                  "cfBundleShortVersionString": "1.4.0",
+                  "cfBundleVersion": "12",
+                  "platform": "IOS",
+                  "state": "FAILED",
+                  "errors": [
+                    { "code": "90683", "message": "Missing purpose string in Info.plist." }
+                  ],
+                  "warnings": []
+                }
+              }
+            }
+            """);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var upload = await client.GetBuildUploadAsync("upload-12");
+
+        Assert.NotNull(upload);
+        Assert.Equal("FAILED", upload.State);
+        var error = Assert.Single(upload.Errors);
+        Assert.Equal("90683", error.Code);
+        Assert.Equal("Missing purpose string in Info.plist.", error.Description);
+    }
+
+    [Fact]
     public async Task CreateVersionAsync_PostsVersionPlatformAndAppRelationship()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -164,6 +164,48 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task GetBuildUploadAsync_ParsesTerminalDeliveryErrors()
+    {
+        var handler = new RecordingHandler(
+            """
+            {
+              "data": {
+                "id": "upload-11",
+                "type": "buildUploads",
+                "attributes": {
+                  "cfBundleShortVersionString": "1.4.0",
+                  "cfBundleVersion": "11",
+                  "platform": "IOS",
+                  "uploadedDate": "2026-07-23T14:10:00-07:00",
+                  "state": {
+                    "state": "FAILED",
+                    "errors": [
+                      { "code": "90683", "description": "Missing purpose string in Info.plist." }
+                    ],
+                    "warnings": []
+                  }
+                }
+              }
+            }
+            """);
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var upload = await client.GetBuildUploadAsync("upload-11");
+
+        Assert.NotNull(upload);
+        Assert.Equal("FAILED", upload.State);
+        Assert.Equal("1.4.0", upload.MarketingVersion);
+        Assert.Equal("11", upload.BuildNumber);
+        Assert.Equal("IOS", upload.Platform);
+        var error = Assert.Single(upload.Errors);
+        Assert.Equal("90683", error.Code);
+        Assert.Equal("Missing purpose string in Info.plist.", error.Description);
+        Assert.Empty(upload.Warnings);
+        Assert.Contains("buildUploads/upload-11", handler.RequestUris[0].ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CreateVersionAsync_PostsVersionPlatformAndAppRelationship()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/AppleAppArchiveServiceTests.cs
+++ b/PowerForge.Tests/AppleAppArchiveServiceTests.cs
@@ -251,6 +251,43 @@ public sealed class AppleAppArchiveServiceTests
     }
 
     [Fact]
+    public async Task UploadArchiveAsync_captures_build_upload_id_from_distribution_log()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var archive = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcarchive"));
+            var distributionLogs = Directory.CreateDirectory(Path.Combine(root.FullName, "Tactra.xcdistributionlogs"));
+            var buildUploadId = Guid.NewGuid().ToString();
+            File.WriteAllText(
+                Path.Combine(distributionLogs.FullName, "ContentDelivery.log"),
+                $"UPLOAD SUCCEEDED with no errors{Environment.NewLine}Delivery UUID: {buildUploadId}");
+            var runner = new CapturingProcessRunner(new ProcessRunResult(
+                0,
+                $"Created bundle at path \"{distributionLogs.FullName}\"",
+                string.Empty,
+                "xcodebuild",
+                TimeSpan.FromSeconds(1),
+                false));
+            var service = new AppleAppArchiveService(runner);
+
+            var result = await service.UploadArchiveAsync(new AppleAppArchiveUploadRequest
+            {
+                ArchivePath = archive.FullName,
+                ExportPath = Path.Combine(root.FullName, "export")
+            });
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(distributionLogs.FullName, result.DistributionLogPath);
+            Assert.Equal(buildUploadId, result.BuildUploadId);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public async Task UploadArchiveAsync_omits_allow_provisioning_updates_when_disabled()
     {
         var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
@@ -396,12 +433,19 @@ public sealed class AppleAppArchiveServiceTests
 
     private sealed class CapturingProcessRunner : IProcessRunner
     {
+        private readonly ProcessRunResult _result;
+
+        public CapturingProcessRunner(ProcessRunResult? result = null)
+        {
+            _result = result ?? new ProcessRunResult(0, "ok", string.Empty, "xcodebuild", TimeSpan.FromMilliseconds(1), false);
+        }
+
         public List<ProcessRunRequest> Requests { get; } = new();
 
         public Task<ProcessRunResult> RunAsync(ProcessRunRequest request, CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
-            return Task.FromResult(new ProcessRunResult(0, "ok", string.Empty, request.FileName, TimeSpan.FromMilliseconds(1), false));
+            return Task.FromResult(_result);
         }
     }
 }

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleAutomation.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleAutomation.cs
@@ -481,6 +481,62 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_AppleUpload_BuildUploadFailureReportsAppleValidationIssueImmediately()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.2.0", "9");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var upload = CreateSuccessfulUpload(new AppleAppArchiveUploadRequest
+            {
+                ArchivePath = Path.Combine(root, "build", "CasaRay.xcarchive"),
+                ExportPath = Path.Combine(root, "build", "export")
+            });
+            upload.BuildUploadId = "upload-9";
+            var delays = 0;
+            var service = CreateAppleAutomationService(
+                request => CreateReleaseState(request, processingState: null),
+                delay: _ => delays++,
+                archiveAppleApp: CreateSuccessfulArchive,
+                uploadAppleApp: _ => upload,
+                getAppleBuildUpload: (_, id) => new AppStoreConnectBuildUploadInfo
+                {
+                    Id = id,
+                    State = "FAILED",
+                    Errors = new[]
+                    {
+                        new AppStoreConnectBuildUploadIssue
+                        {
+                            Code = "90683",
+                            Description = "Missing purpose string in Info.plist."
+                        }
+                    }
+                });
+
+            var result = service.Execute(
+                CreateAppleAutomationSpec(root, keyPath),
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Upload
+                });
+
+            Assert.False(result.Success);
+            Assert.Equal(0, delays);
+            var target = Assert.Single(Assert.IsType<PowerForgeAppleReleaseReceipt>(result.AppleReceipt).Targets);
+            Assert.Equal("upload-9", target.BuildUploadId);
+            Assert.Contains("90683", Assert.IsType<string>(target.ErrorMessage), StringComparison.Ordinal);
+            Assert.Contains("Missing purpose string", target.ErrorMessage, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void Execute_AppleUpload_ProcessingTimeoutWritesLastKnownStateReceipt()
     {
         var root = CreateSandbox();
@@ -601,6 +657,7 @@ public sealed partial class PowerForgeReleaseServiceTests
         Func<AppleAppArchiveRequest, AppleAppArchiveResult>? archiveAppleApp = null,
         Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null,
         Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null,
+        Func<AppStoreConnectApiCredential, string, AppStoreConnectBuildUploadInfo?>? getAppleBuildUpload = null,
         Func<PowerForgeAppleAppReleaseTargetPlan, bool>? generateAppleProject = null)
         => new(
             new NullLogger(),
@@ -615,6 +672,7 @@ public sealed partial class PowerForgeReleaseServiceTests
             uploadAppleApp: uploadAppleApp ?? (_ => throw new InvalidOperationException("Exact remote build should skip upload.")),
             prepareAppleDistribution: prepareAppleDistribution,
             getAppleReleaseState: getState,
+            getAppleBuildUpload: getAppleBuildUpload,
             generateAppleProject: generateAppleProject,
             delay: delay,
             appleArtifactService: new AppleReleaseArtifactService(getAvailableBytes ?? (_ => long.MaxValue)));

--- a/PowerForge/Models/AppStoreConnectModels.cs
+++ b/PowerForge/Models/AppStoreConnectModels.cs
@@ -73,6 +73,48 @@ public sealed class AppStoreConnectBuildInfo
 }
 
 /// <summary>
+/// App Store Connect state for a package accepted by the upload transport before it becomes a build.
+/// </summary>
+public sealed class AppStoreConnectBuildUploadInfo
+{
+    /// <summary>Build upload id returned by Xcode delivery.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Marketing version declared by the uploaded bundle.</summary>
+    public string? MarketingVersion { get; set; }
+
+    /// <summary>Build number declared by the uploaded bundle.</summary>
+    public string? BuildNumber { get; set; }
+
+    /// <summary>Platform value returned by App Store Connect.</summary>
+    public string? Platform { get; set; }
+
+    /// <summary>Upload processing state such as AWAITING_PROCESSING or FAILED.</summary>
+    public string? State { get; set; }
+
+    /// <summary>Terminal validation errors reported for the uploaded package.</summary>
+    public AppStoreConnectBuildUploadIssue[] Errors { get; set; } = Array.Empty<AppStoreConnectBuildUploadIssue>();
+
+    /// <summary>Non-terminal validation warnings reported for the uploaded package.</summary>
+    public AppStoreConnectBuildUploadIssue[] Warnings { get; set; } = Array.Empty<AppStoreConnectBuildUploadIssue>();
+
+    /// <summary>Upload date when available.</summary>
+    public DateTimeOffset? UploadedDate { get; set; }
+}
+
+/// <summary>
+/// Validation issue attached to an App Store Connect build upload.
+/// </summary>
+public sealed class AppStoreConnectBuildUploadIssue
+{
+    /// <summary>Apple validation code.</summary>
+    public string? Code { get; set; }
+
+    /// <summary>Human-readable validation description.</summary>
+    public string? Description { get; set; }
+}
+
+/// <summary>
 /// App Store Connect subscription group summary.
 /// </summary>
 public sealed class AppStoreConnectSubscriptionGroupInfo

--- a/PowerForge/Models/AppleAppArchiveModels.cs
+++ b/PowerForge/Models/AppleAppArchiveModels.cs
@@ -143,6 +143,12 @@ public sealed class AppleAppArchiveUploadResult
     /// <summary>Generated export options plist path.</summary>
     public string ExportOptionsPlistPath { get; set; } = string.Empty;
 
+    /// <summary>Xcode distribution log bundle associated with this upload, when reported.</summary>
+    public string? DistributionLogPath { get; set; }
+
+    /// <summary>Build-upload id accepted by App Store Connect, when reported by Xcode delivery.</summary>
+    public string? BuildUploadId { get; set; }
+
     /// <summary>xcodebuild process result.</summary>
     public ProcessRunResult ProcessResult { get; set; } = new(0, string.Empty, string.Empty, "xcodebuild", TimeSpan.Zero, false);
 

--- a/PowerForge/Models/PowerForgeAppleReleaseAutomation.cs
+++ b/PowerForge/Models/PowerForgeAppleReleaseAutomation.cs
@@ -125,6 +125,8 @@ internal sealed class PowerForgeAppleReleaseTargetReceipt
 
     public string? BuildProcessingState { get; set; }
 
+    public string? BuildUploadId { get; set; }
+
     public string? DistributionVersionId { get; set; }
 
     public string? DistributionState { get; set; }

--- a/PowerForge/Services/AppStoreConnectClient.BuildUploads.cs
+++ b/PowerForge/Services/AppStoreConnectClient.BuildUploads.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectClient
+{
+    /// <summary>
+    /// Reads the delivery state for a package accepted by App Store Connect upload transport.
+    /// </summary>
+    public Task<AppStoreConnectBuildUploadInfo?> GetBuildUploadAsync(
+        string buildUploadId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(buildUploadId))
+            throw new ArgumentException("Build upload id is required.", nameof(buildUploadId));
+
+        return GetSingleAsync(
+            $"buildUploads/{Uri.EscapeDataString(buildUploadId.Trim())}",
+            ParseBuildUpload,
+            cancellationToken);
+    }
+
+    private static AppStoreConnectBuildUploadInfo ParseBuildUpload(JsonElement item)
+    {
+        var attributes = GetAttributes(item);
+        var state = attributes.ValueKind == JsonValueKind.Object &&
+                    attributes.TryGetProperty("state", out var stateElement) &&
+                    stateElement.ValueKind == JsonValueKind.Object
+            ? stateElement
+            : default;
+
+        return new AppStoreConnectBuildUploadInfo
+        {
+            Id = GetString(item, "id") ?? string.Empty,
+            MarketingVersion = GetString(attributes, "cfBundleShortVersionString"),
+            BuildNumber = GetString(attributes, "cfBundleVersion"),
+            Platform = GetString(attributes, "platform"),
+            State = state.ValueKind == JsonValueKind.Object ? GetString(state, "state") : null,
+            Errors = ParseBuildUploadIssues(state, "errors"),
+            Warnings = ParseBuildUploadIssues(state, "warnings"),
+            UploadedDate = GetDateTimeOffset(attributes, "uploadedDate")
+        };
+    }
+
+    private static AppStoreConnectBuildUploadIssue[] ParseBuildUploadIssues(
+        JsonElement state,
+        string propertyName)
+    {
+        if (state.ValueKind != JsonValueKind.Object ||
+            !state.TryGetProperty(propertyName, out var issues) ||
+            issues.ValueKind != JsonValueKind.Array)
+        {
+            return Array.Empty<AppStoreConnectBuildUploadIssue>();
+        }
+
+        return issues.EnumerateArray()
+            .Where(static issue => issue.ValueKind == JsonValueKind.Object)
+            .Select(issue => new AppStoreConnectBuildUploadIssue
+            {
+                Code = GetString(issue, "code"),
+                Description = GetString(issue, "description")
+            })
+            .ToArray();
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.BuildUploads.cs
+++ b/PowerForge/Services/AppStoreConnectClient.BuildUploads.cs
@@ -23,11 +23,19 @@ public sealed partial class AppStoreConnectClient
     private static AppStoreConnectBuildUploadInfo ParseBuildUpload(JsonElement item)
     {
         var attributes = GetAttributes(item);
-        var state = attributes.ValueKind == JsonValueKind.Object &&
-                    attributes.TryGetProperty("state", out var stateElement) &&
-                    stateElement.ValueKind == JsonValueKind.Object
+        var stateElement = default(JsonElement);
+        var hasState = attributes.ValueKind == JsonValueKind.Object &&
+                       attributes.TryGetProperty("state", out stateElement);
+        var issueContainer = hasState && stateElement.ValueKind == JsonValueKind.Object
             ? stateElement
-            : default;
+            : attributes;
+        var state = !hasState
+            ? null
+            : stateElement.ValueKind == JsonValueKind.Object
+                ? GetString(stateElement, "state")
+                : stateElement.ValueKind == JsonValueKind.String
+                    ? stateElement.GetString()
+                    : null;
 
         return new AppStoreConnectBuildUploadInfo
         {
@@ -35,9 +43,9 @@ public sealed partial class AppStoreConnectClient
             MarketingVersion = GetString(attributes, "cfBundleShortVersionString"),
             BuildNumber = GetString(attributes, "cfBundleVersion"),
             Platform = GetString(attributes, "platform"),
-            State = state.ValueKind == JsonValueKind.Object ? GetString(state, "state") : null,
-            Errors = ParseBuildUploadIssues(state, "errors"),
-            Warnings = ParseBuildUploadIssues(state, "warnings"),
+            State = state,
+            Errors = ParseBuildUploadIssues(issueContainer, "errors"),
+            Warnings = ParseBuildUploadIssues(issueContainer, "warnings"),
             UploadedDate = GetDateTimeOffset(attributes, "uploadedDate")
         };
     }
@@ -58,7 +66,7 @@ public sealed partial class AppStoreConnectClient
             .Select(issue => new AppStoreConnectBuildUploadIssue
             {
                 Code = GetString(issue, "code"),
-                Description = GetString(issue, "description")
+                Description = GetString(issue, "description") ?? GetString(issue, "message")
             })
             .ToArray();
     }

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -1,5 +1,6 @@
 using System.Security;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace PowerForge;
 
@@ -142,14 +143,47 @@ public sealed class AppleAppArchiveService
                 request.Timeout <= TimeSpan.Zero ? TimeSpan.FromHours(1) : request.Timeout),
             cancellationToken).ConfigureAwait(false);
 
+        var diagnostics = ResolveUploadDiagnostics(result);
+
         return new AppleAppArchiveUploadResult
         {
             ArchivePath = archivePath,
             ExportPath = exportPath,
             ExportOptionsPlistPath = plistPath,
+            DistributionLogPath = diagnostics.DistributionLogPath,
+            BuildUploadId = diagnostics.BuildUploadId,
             ProcessResult = result
         };
     }
+
+    private static AppleUploadDiagnostics ResolveUploadDiagnostics(ProcessRunResult result)
+    {
+        var output = string.Join(Environment.NewLine, result.StdOut, result.StdErr);
+        var match = Regex.Match(
+            output,
+            "Created bundle at path \\\"(?<path>[^\\\"]+\\.xcdistributionlogs)\\\"",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        if (!match.Success)
+            return new AppleUploadDiagnostics(null, null);
+
+        var logPath = Path.GetFullPath(match.Groups["path"].Value);
+        var contentDeliveryLog = Path.Combine(logPath, "ContentDelivery.log");
+        if (!File.Exists(contentDeliveryLog))
+            return new AppleUploadDiagnostics(logPath, null);
+
+        var deliveryMatches = Regex.Matches(
+            File.ReadAllText(contentDeliveryLog),
+            "Delivery UUID:\\s*(?<id>[0-9a-fA-F-]{36})",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        var buildUploadId = deliveryMatches.Count == 0
+            ? null
+            : deliveryMatches[^1].Groups["id"].Value;
+        return new AppleUploadDiagnostics(logPath, buildUploadId);
+    }
+
+    private readonly record struct AppleUploadDiagnostics(
+        string? DistributionLogPath,
+        string? BuildUploadId);
 
     private static void AddAppStoreConnectAuthenticationArguments(
         string? appStoreConnectApiKeyPath,

--- a/PowerForge/Services/AppleAppArchiveService.cs
+++ b/PowerForge/Services/AppleAppArchiveService.cs
@@ -177,13 +177,22 @@ public sealed class AppleAppArchiveService
             RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         var buildUploadId = deliveryMatches.Count == 0
             ? null
-            : deliveryMatches[^1].Groups["id"].Value;
+            : deliveryMatches[deliveryMatches.Count - 1].Groups["id"].Value;
         return new AppleUploadDiagnostics(logPath, buildUploadId);
     }
 
-    private readonly record struct AppleUploadDiagnostics(
-        string? DistributionLogPath,
-        string? BuildUploadId);
+    private readonly struct AppleUploadDiagnostics
+    {
+        internal AppleUploadDiagnostics(string? distributionLogPath, string? buildUploadId)
+        {
+            DistributionLogPath = distributionLogPath;
+            BuildUploadId = buildUploadId;
+        }
+
+        internal string? DistributionLogPath { get; }
+
+        internal string? BuildUploadId { get; }
+    }
 
     private static void AddAppStoreConnectAuthenticationArguments(
         string? appStoreConnectApiKeyPath,

--- a/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
@@ -219,7 +219,8 @@ internal sealed partial class PowerForgeReleaseService
     private AppStoreConnectReleaseStateResult WaitForAppleBuild(
         PowerForgeAppleReleasePlan plan,
         PowerForgeAppleAppReleaseTargetPlan app,
-        AppStoreConnectReleaseStateResult? initial = null)
+        AppStoreConnectReleaseStateResult? initial = null,
+        string? buildUploadId = null)
     {
         var state = initial ?? ReadAppleReleaseState(plan, app);
         var maximumChecks = Math.Max(
@@ -237,6 +238,24 @@ internal sealed partial class PowerForgeReleaseService
                     $"App Store Connect marked build {state.VersionString} ({state.BuildNumber}) " +
                     $"as '{processingState}' for '{app.Name}'.",
                     state);
+            }
+            if (!string.IsNullOrWhiteSpace(buildUploadId))
+            {
+                var upload = _getAppleBuildUpload(CreateAppStoreConnectCredential(plan), buildUploadId!);
+                if (upload is not null && IsTerminalAppleBuildFailure(upload.State))
+                {
+                    var issues = upload.Errors
+                        .Select(static issue => FormatAppleBuildUploadIssue(issue))
+                        .Where(static issue => !string.IsNullOrWhiteSpace(issue))
+                        .ToArray();
+                    var issueDetail = issues.Length == 0
+                        ? string.Empty
+                        : $" {string.Join(" ", issues)}";
+                    throw new AppleBuildProcessingException(
+                        $"App Store Connect rejected uploaded build {state.VersionString} ({state.BuildNumber}) " +
+                        $"for '{app.Name}' in build-upload state '{upload.State}'.{issueDetail}",
+                        state);
+                }
             }
             if (check == maximumChecks - 1)
                 break;
@@ -256,6 +275,19 @@ internal sealed partial class PowerForgeReleaseService
            string.Equals(state, "FAILED", StringComparison.OrdinalIgnoreCase) ||
            string.Equals(state, "ERROR", StringComparison.OrdinalIgnoreCase) ||
            string.Equals(state, "REJECTED", StringComparison.OrdinalIgnoreCase);
+
+    private static string FormatAppleBuildUploadIssue(AppStoreConnectBuildUploadIssue issue)
+    {
+        var code = string.IsNullOrWhiteSpace(issue.Code) ? null : issue.Code!.Trim();
+        var description = string.IsNullOrWhiteSpace(issue.Description) ? null : issue.Description!.Trim();
+        return (code, description) switch
+        {
+            (not null, not null) => $"[{code}] {description}",
+            (not null, null) => $"[{code}]",
+            (null, not null) => description,
+            _ => string.Empty
+        };
+    }
 
     private static AppStoreConnectPlatformReleaseState AssertSinglePlatformState(
         AppStoreConnectReleaseStateResult state,
@@ -368,6 +400,7 @@ internal sealed partial class PowerForgeReleaseService
                 Build = state?.BuildNumber ?? values.BuildNumber,
                 BuildId = build?.Id,
                 BuildProcessingState = build?.ProcessingState,
+                BuildUploadId = result?.Upload?.BuildUploadId,
                 DistributionVersionId = platform?.Version?.Id,
                 DistributionState = platform?.Version?.AppStoreState ?? platform?.Version?.AppVersionState,
                 BuildSelected = platform?.MatchedBuildSelected,
@@ -498,6 +531,14 @@ internal sealed partial class PowerForgeReleaseService
 
         using var client = new AppStoreConnectClient(request.Credential);
         return new AppStoreConnectReleaseStateService(client).GetAsync(request).GetAwaiter().GetResult();
+    }
+
+    private static AppStoreConnectBuildUploadInfo? GetAppleBuildUpload(
+        AppStoreConnectApiCredential credential,
+        string buildUploadId)
+    {
+        using var client = new AppStoreConnectClient(credential);
+        return client.GetBuildUploadAsync(buildUploadId).GetAwaiter().GetResult();
     }
 
     private sealed class AppleBuildProcessingException : InvalidOperationException

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -63,6 +63,7 @@ internal sealed partial class PowerForgeReleaseService
     private readonly Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult> _submitAppleReview;
     private readonly Func<AppStoreConnectVersionReleaseRequest, AppStoreConnectVersionReleaseResult> _releaseAppleVersion;
     private readonly Func<AppStoreConnectReleaseStateRequest, AppStoreConnectReleaseStateResult> _getAppleReleaseState;
+    private readonly Func<AppStoreConnectApiCredential, string, AppStoreConnectBuildUploadInfo?> _getAppleBuildUpload;
     private readonly Func<PowerForgeAppleAppReleaseTargetPlan, bool> _generateAppleProject;
     private readonly Action<TimeSpan> _delay;
     private readonly AppleReleaseArtifactService _appleArtifactService;
@@ -138,6 +139,7 @@ internal sealed partial class PowerForgeReleaseService
         Func<AppStoreConnectReviewSubmissionRequest, AppStoreConnectReviewSubmissionResult>? submitAppleReview = null,
         Func<AppStoreConnectVersionReleaseRequest, AppStoreConnectVersionReleaseResult>? releaseAppleVersion = null,
         Func<AppStoreConnectReleaseStateRequest, AppStoreConnectReleaseStateResult>? getAppleReleaseState = null,
+        Func<AppStoreConnectApiCredential, string, AppStoreConnectBuildUploadInfo?>? getAppleBuildUpload = null,
         Func<PowerForgeAppleAppReleaseTargetPlan, bool>? generateAppleProject = null,
         Action<TimeSpan>? delay = null,
         AppleReleaseArtifactService? appleArtifactService = null)
@@ -159,6 +161,7 @@ internal sealed partial class PowerForgeReleaseService
         _submitAppleReview = submitAppleReview ?? SubmitAppleReview;
         _releaseAppleVersion = releaseAppleVersion ?? ReleaseAppleVersion;
         _getAppleReleaseState = getAppleReleaseState ?? GetAppleReleaseState;
+        _getAppleBuildUpload = getAppleBuildUpload ?? GetAppleBuildUpload;
         _generateAppleProject = generateAppleProject ?? (app => new AppleProjectGenerationService().Generate(app));
         _delay = delay ?? Thread.Sleep;
         _appleArtifactService = appleArtifactService ?? new AppleReleaseArtifactService();
@@ -1376,7 +1379,7 @@ internal sealed partial class PowerForgeReleaseService
 
                 if (IsUploadAction(plan.Action) &&
                     plan.Automation.WaitForProcessing)
-                    result.RemoteState = WaitForAppleBuild(plan, app);
+                    result.RemoteState = WaitForAppleBuild(plan, app, buildUploadId: upload.BuildUploadId);
             }
 
             var appInfoMetadataSpecs = plan.SyncAppInfo && pendingAppInfoAppIds.Remove(app.AppStoreConnectAppId!)


### PR DESCRIPTION
## Summary

PowerForge now follows Xcode's delivery UUID into App Store Connect's build-upload state. When Apple accepts the transport but rejects the package during validation, the release action reports the actual Apple code and description immediately instead of waiting for a build record that will never appear.

The parser accepts both the nested response returned by the real failed CasaRay upload and Apple's flat documented/alternate response shape. The upload receipt also retains the build-upload identifier for diagnostics.

## Why

CasaRay 1.4 build 11 was fully transferred and Xcode reported success, but Apple rejected it with validation code 90683 before creating a normal build. The previous polling path could only query normal builds, so it timed out and concealed the actionable error.

## Validation

- 207 focused App Store Connect, Apple archive, and Apple release automation tests pass
- PowerForge builds for net472, net8.0, and net10.0 with zero warnings/errors
- Windows, Linux, and macOS CI passed on the compatible parser implementation before the response-shape hardening; refreshed current-head CI is pending