### PR TITLE
Rewrite fingerprinted srcset image references

### DIFF
--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildTests.Part2.cs
@@ -895,6 +895,60 @@ public partial class WebSiteAuditOptimizeBuildTests
     }
 
     [Fact]
+    public void OptimizeDetailed_HashedImages_RewritesSrcSetReferencesWithoutChangingDataUrls()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-opt-hash-srcset-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "assets"));
+
+        try
+        {
+            var htmlPath = Path.Combine(root, "index.html");
+            File.WriteAllText(htmlPath,
+                """
+                <!doctype html>
+                <html>
+                  <head>
+                    <link rel="preload" as="image" imagesrcset="/assets/camera.png 1x, /assets/camera.png?large=1 2x" />
+                  </head>
+                  <body>
+                    <picture>
+                      <source srcset="/assets/camera.png, /assets/camera.png#wide 2x" />
+                      <img src="/assets/camera.png" srcset="data:image/png;base64,AAAA 1x, /assets/camera.png 2x" alt="Camera" />
+                      <img src="data:text/plain,/assets/camera.png" srcset="data:text/plain,/assets/camera.png 1x" alt="Inline data" />
+                    </picture>
+                  </body>
+                </html>
+                """);
+            File.WriteAllBytes(Path.Combine(root, "assets", "camera.png"), new byte[] { 1, 2, 3, 4 });
+
+            var result = WebAssetOptimizer.OptimizeDetailed(new WebAssetOptimizerOptions
+            {
+                SiteRoot = root,
+                HashAssets = true,
+                HashExtensions = new[] { ".png" }
+            });
+
+            var html = File.ReadAllText(htmlPath);
+            var hashedAsset = Assert.Single(result.HashedAssets);
+            Assert.Equal("/assets/camera.png", hashedAsset.OriginalPath);
+            Assert.DoesNotContain("src=\"/assets/camera.png\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("srcset=\"/assets/camera.png", html, StringComparison.Ordinal);
+            Assert.Contains($"imagesrcset=\"{hashedAsset.HashedPath} 1x, {hashedAsset.HashedPath}?large=1 2x\"", html, StringComparison.Ordinal);
+            Assert.Contains($"srcset=\"{hashedAsset.HashedPath}, {hashedAsset.HashedPath}#wide 2x\"", html, StringComparison.Ordinal);
+            Assert.Contains($"srcset=\"data:image/png;base64,AAAA 1x, {hashedAsset.HashedPath} 2x\"", html, StringComparison.Ordinal);
+            Assert.Contains("src=\"data:text/plain,/assets/camera.png\"", html, StringComparison.Ordinal);
+            Assert.Contains("srcset=\"data:text/plain,/assets/camera.png 1x\"", html, StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(root, hashedAsset.HashedPath.TrimStart('/').Replace('/', Path.DirectorySeparatorChar))));
+            Assert.False(File.Exists(Path.Combine(root, "assets", "camera.png")));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void OptimizeDetailed_AssetRewrites_PreservesEncodedUrlWhenNoRuleMatches()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-opt-rewrite-encoded-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web/Services/WebAssetOptimizer.cs
+++ b/PowerForge.Web/Services/WebAssetOptimizer.cs
@@ -16,6 +16,7 @@ public static partial class WebAssetOptimizer
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
     private static readonly HttpClient RewriteDownloadClient = CreateRewriteDownloadClient();
     private static readonly Regex HtmlAttrRegex = new("(?<attr>href|src)=\"(?<url>[^\"]+)\"", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
+    private static readonly Regex HtmlSrcSetAttrRegex = new("(?<attr>\\b(?:srcset|imagesrcset))\\s*=\\s*(?<quote>['\"])(?<value>[^'\"]+)\\k<quote>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
     private static readonly Regex CssUrlRegex = new("url\\((?<quote>['\"]?)(?<url>[^'\")]+)\\k<quote>\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
     private static readonly Regex StylesheetLinkRegex = new("<link\\s+rel=\"stylesheet\"\\s+href=\"([^\"]+)\"\\s*/?>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
     private static readonly Regex ImgTagRegex = new("<img\\b(?<attrs>[^>]*?)>", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexTimeout);
@@ -796,12 +797,80 @@ public static partial class WebAssetOptimizer
 
     private static string RewriteReferences(string html, Dictionary<string, string> map)
     {
-        return HtmlAttrRegex.Replace(html, match =>
+        var rewrittenHtml = HtmlAttrRegex.Replace(html, match =>
         {
             var url = match.Groups["url"].Value;
             var rewritten = RewriteUrlWithMap(url, map);
             return rewritten == url ? match.Value : $"{match.Groups["attr"].Value}=\"{rewritten}\"";
         });
+
+        return HtmlSrcSetAttrRegex.Replace(rewrittenHtml, match =>
+        {
+            var value = match.Groups["value"].Value;
+            var rewritten = RewriteSrcSetWithMap(value, map);
+            if (string.Equals(rewritten, value, StringComparison.Ordinal))
+                return match.Value;
+
+            var quote = match.Groups["quote"].Value;
+            return $"{match.Groups["attr"].Value}={quote}{rewritten}{quote}";
+        });
+    }
+
+    private static string RewriteSrcSetWithMap(string srcSet, Dictionary<string, string> map)
+    {
+        StringBuilder? rewritten = null;
+        var copyFrom = 0;
+        var index = 0;
+        while (index < srcSet.Length)
+        {
+            while (index < srcSet.Length && (char.IsWhiteSpace(srcSet[index]) || srcSet[index] == ','))
+                index++;
+            if (index >= srcSet.Length)
+                break;
+
+            var urlStart = index;
+            while (index < srcSet.Length && !char.IsWhiteSpace(srcSet[index]))
+                index++;
+
+            var urlEnd = index;
+            while (urlEnd > urlStart && srcSet[urlEnd - 1] == ',')
+                urlEnd--;
+            var candidateEndedWithComma = urlEnd < index;
+
+            if (urlEnd > urlStart)
+            {
+                var url = srcSet[urlStart..urlEnd];
+                var mapped = RewriteUrlWithMap(url, map);
+                if (!string.Equals(mapped, url, StringComparison.Ordinal))
+                {
+                    rewritten ??= new StringBuilder(srcSet.Length + 32);
+                    rewritten.Append(srcSet, copyFrom, urlStart - copyFrom);
+                    rewritten.Append(mapped);
+                    copyFrom = urlEnd;
+                }
+            }
+
+            if (candidateEndedWithComma)
+                continue;
+
+            var parentheses = 0;
+            while (index < srcSet.Length)
+            {
+                var current = srcSet[index++];
+                if (current == '(')
+                    parentheses++;
+                else if (current == ')' && parentheses > 0)
+                    parentheses--;
+                else if (current == ',' && parentheses == 0)
+                    break;
+            }
+        }
+
+        if (rewritten is null)
+            return srcSet;
+
+        rewritten.Append(srcSet, copyFrom, srcSet.Length - copyFrom);
+        return rewritten.ToString();
     }
 
     private static string RewriteCssUrls(string css, Dictionary<string, string> map)


### PR DESCRIPTION
## Summary

PowerForge now rewrites local image candidates in `srcset` and `imagesrcset` when asset hashing moves those files to fingerprinted names. It preserves descriptors, query strings, fragments, and inline `data:` URLs, including descriptorless candidates separated by commas.

This lets PowerForge websites content-hash mutable screenshots and responsive images without leaving references to files that no longer exist.

## Validation

- 13 focused `OptimizeDetailed` tests pass
- a new regression contract covers `source[srcset]`, `img[srcset]`, preload `imagesrcset`, query/fragment suffixes, descriptorless candidates, and `data:` URLs
- CasaRay’s strict PowerForge website pipeline passes with 21 fingerprinted assets and a clean rendered-site audit

## Review

An independent local review found a `data:` URL boundary issue. The fix was confirmed, and a directly caused descriptorless-candidate regression was then fixed and covered by the final focused test.