### PR TITLE
Harden App Store release asset recovery

### DIFF
--- a/PowerForge.Tests/AppStoreConnectClientScreenshotReleaseTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientScreenshotReleaseTests.cs
@@ -1,0 +1,196 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppStoreConnectClientTests
+{
+    [Fact]
+    public void Constructor_OwnedClientUsesReleaseAssetTimeout()
+    {
+        using var client = new AppStoreConnectClient(CreateCredential());
+
+        Assert.Equal(TimeSpan.FromMinutes(10), client.RequestTimeout);
+    }
+
+    [Fact]
+    public async Task GetVersionsAsync_RetriesTransientServerFailureWithoutRetryingMutations()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.InternalServerError, """{ "errors": [{ "code": "UNEXPECTED_ERROR" }] }"""),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "version-1",
+                      "type": "appStoreVersions",
+                      "attributes": {
+                        "versionString": "1.4.0",
+                        "appStoreState": "PREPARE_FOR_SUBMISSION",
+                        "platform": "IOS"
+                      }
+                    }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var delays = new List<TimeSpan>();
+        client.TransientReadDelayAsync = (delay, _) =>
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        };
+
+        var versions = await client.GetVersionsAsync("app-1", "1.4.0", ApplePlatform.iOS);
+
+        Assert.Equal("version-1", Assert.Single(versions).Id);
+        Assert.Equal(2, handler.RequestUris.Count);
+        Assert.All(handler.Methods, method => Assert.Equal(HttpMethod.Get, method));
+        Assert.Equal(new[] { TimeSpan.FromSeconds(1) }, delays);
+    }
+
+    [Fact]
+    public async Task GetVersionsAsync_StopsAfterBoundedTransientRetries()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.InternalServerError, """{ "errors": [{ "code": "UNEXPECTED_ERROR" }] }"""),
+            new SequenceResponse(HttpStatusCode.BadGateway, """{ "errors": [{ "code": "UPSTREAM_ERROR" }] }"""),
+            new SequenceResponse(HttpStatusCode.ServiceUnavailable, """{ "errors": [{ "code": "UNAVAILABLE" }] }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var delays = new List<TimeSpan>();
+        client.TransientReadDelayAsync = (delay, _) =>
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetVersionsAsync("app-1", "1.4.0", ApplePlatform.iOS));
+
+        Assert.Contains("503 Service Unavailable", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(3, handler.RequestUris.Count);
+        Assert.Equal(new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2) }, delays);
+    }
+
+    [Fact]
+    public async Task ReleasePreparationService_UsesConfiguredScreenshotVersionIdWithoutVersionLookup()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "desktop"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 1, 2, 3 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK,
+                    """
+                    {
+                      "data": [
+                        {
+                          "id": "loc-1",
+                          "type": "appStoreVersionLocalizations",
+                          "attributes": { "locale": "en-US" }
+                        }
+                      ]
+                    }
+                    """),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """
+                    {
+                      "data": [
+                        {
+                          "id": "set-1",
+                          "type": "appScreenshotSets",
+                          "attributes": { "screenshotDisplayType": "APP_DESKTOP" }
+                        }
+                      ]
+                    }
+                    """),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [] }"""),
+                new SequenceResponse(HttpStatusCode.Created,
+                    """
+                    {
+                      "data": {
+                        "id": "shot-1",
+                        "type": "appScreenshots",
+                        "attributes": {
+                          "fileName": "01-home.png",
+                          "fileSize": 3,
+                          "uploadOperations": [
+                            {
+                              "method": "PUT",
+                              "url": "https://asset-upload.example/upload/shot-1",
+                              "offset": 0,
+                              "length": 3,
+                              "requestHeaders": []
+                            }
+                          ]
+                        }
+                      }
+                    }
+                    """),
+                new SequenceResponse(HttpStatusCode.OK, string.Empty),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """
+                    {
+                      "data": {
+                        "id": "shot-1",
+                        "type": "appScreenshots",
+                        "attributes": {
+                          "fileName": "01-home.png",
+                          "fileSize": 3,
+                          "sourceFileChecksum": "5289df737df57326fcdd22597afb1fac",
+                          "assetDeliveryState": { "state": "UPLOAD_COMPLETE" }
+                        }
+                      }
+                    }
+                    """));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+            var service = new AppStoreConnectReleasePreparationService(client);
+
+            var result = await service.PrepareAsync(new AppStoreConnectReleasePreparationRequest
+            {
+                AppId = "app-1",
+                VersionString = "1.4.0",
+                BuildNumber = "12",
+                Platform = ApplePlatform.macOS,
+                CreateVersion = false,
+                SelectBuild = false,
+                ScreenshotSpec = new AppStoreConnectScreenshotSyncSpec
+                {
+                    AppId = "app-1",
+                    VersionString = "1.4.0",
+                    VersionId = "version-exact",
+                    Platform = ApplePlatform.macOS,
+                    Locale = "en-US",
+                    ScreenshotSets = new[]
+                    {
+                        new AppStoreConnectScreenshotSetSyncSpec
+                        {
+                            ScreenshotDisplayType = "APP_DESKTOP",
+                            Path = folder.FullName
+                        }
+                    }
+                },
+                BaseDirectory = root.FullName
+            });
+
+            Assert.Equal("version-exact", result.Version?.Id);
+            Assert.Single(result.Screenshots!.ScreenshotSets);
+            Assert.DoesNotContain(handler.RequestUris, uri => uri.AbsolutePath.Contains("/apps/app-1/appStoreVersions", StringComparison.Ordinal));
+            Assert.Contains("appStoreVersions/version-exact/appStoreVersionLocalizations", handler.RequestUris[0].ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/PowerForge.Tests/AppStoreConnectClientScreenshotReleaseTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientScreenshotReleaseTests.cs
@@ -57,6 +57,45 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task GetVersionsAsync_HonorsRetryAfterForRateLimit()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(
+                (HttpStatusCode)429,
+                """{ "errors": [{ "code": "RATE_LIMIT_EXCEEDED" }] }""",
+                TimeSpan.FromSeconds(30)),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "version-1",
+                      "type": "appStoreVersions",
+                      "attributes": {
+                        "versionString": "1.4.0",
+                        "appStoreState": "PREPARE_FOR_SUBMISSION",
+                        "platform": "IOS"
+                      }
+                    }
+                  ]
+                }
+                """));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var delays = new List<TimeSpan>();
+        client.TransientReadDelayAsync = (delay, _) =>
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        };
+
+        var versions = await client.GetVersionsAsync("app-1", "1.4.0", ApplePlatform.iOS);
+
+        Assert.Equal("version-1", Assert.Single(versions).Id);
+        Assert.Equal(new[] { TimeSpan.FromSeconds(30) }, delays);
+    }
+
+    [Fact]
     public async Task GetVersionsAsync_StopsAfterBoundedTransientRetries()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/AppStoreConnectClientScreenshotReleaseTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientScreenshotReleaseTests.cs
@@ -96,6 +96,31 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task GetVersionsAsync_DoesNotRetryBeforeLongRetryAfterExpires()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(
+                (HttpStatusCode)429,
+                """{ "errors": [{ "code": "RATE_LIMIT_EXCEEDED" }] }""",
+                TimeSpan.FromMinutes(5)));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+        var delays = new List<TimeSpan>();
+        client.TransientReadDelayAsync = (delay, _) =>
+        {
+            delays.Add(delay);
+            return Task.CompletedTask;
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetVersionsAsync("app-1", "1.4.0", ApplePlatform.iOS));
+
+        Assert.Contains("429", exception.Message, StringComparison.Ordinal);
+        Assert.Single(handler.RequestUris);
+        Assert.Empty(delays);
+    }
+
+    [Fact]
     public async Task GetVersionsAsync_StopsAfterBoundedTransientRetries()
     {
         var handler = new SequenceHandler(

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -2115,15 +2115,18 @@ public sealed partial class AppStoreConnectClientTests
 
     private sealed class SequenceResponse
     {
-        public SequenceResponse(HttpStatusCode statusCode, string content)
+        public SequenceResponse(HttpStatusCode statusCode, string content, TimeSpan? retryAfter = null)
         {
             StatusCode = statusCode;
             Content = content;
+            RetryAfter = retryAfter;
         }
 
         public HttpStatusCode StatusCode { get; }
 
         public string Content { get; }
+
+        public TimeSpan? RetryAfter { get; }
     }
 
     private sealed class SequenceHandler : HttpMessageHandler
@@ -2163,10 +2166,13 @@ public sealed partial class AppStoreConnectClientTests
             }
 
             var response = _responses.Dequeue();
-            return new HttpResponseMessage(response.StatusCode)
+            var message = new HttpResponseMessage(response.StatusCode)
             {
                 Content = new StringContent(response.Content)
             };
+            if (response.RetryAfter.HasValue)
+                message.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(response.RetryAfter.Value);
+            return message;
         }
     }
 }

--- a/PowerForge.Tests/packages.lock.json
+++ b/PowerForge.Tests/packages.lock.json
@@ -151,16 +151,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "Markdig.Signed": {
         "type": "Transitive",
@@ -898,7 +898,7 @@
         "type": "Project",
         "dependencies": {
           "HtmlTinkerX": "[2.2.0, )",
-          "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
+          "Magick.NET-Q8-AnyCPU": "[14.15.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
           "PowerForge": "[1.0.4, )",
           "Scriban": "[7.2.5, )",

--- a/PowerForge.Web.Cli/packages.lock.json
+++ b/PowerForge.Web.Cli/packages.lock.json
@@ -76,16 +76,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -193,7 +193,7 @@
         "type": "Project",
         "dependencies": {
           "HtmlTinkerX": "[2.2.0, )",
-          "Magick.NET-Q8-AnyCPU": "[14.14.0, )",
+          "Magick.NET-Q8-AnyCPU": "[14.15.0, )",
           "OfficeIMO.Markdown": "[0.6.13, )",
           "PowerForge": "[1.0.6, )",
           "Scriban": "[7.2.5, )",

--- a/PowerForge.Web/PowerForge.Web.csproj
+++ b/PowerForge.Web/PowerForge.Web.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlTinkerX" Version="2.2.0" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.15.0" />
     <PackageReference Include="OfficeIMO.Markdown" Version="0.6.13" />
     <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />

--- a/PowerForge.Web/packages.lock.json
+++ b/PowerForge.Web/packages.lock.json
@@ -23,11 +23,11 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Direct",
-        "requested": "[14.14.0, )",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "requested": "[14.15.0, )",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "OfficeIMO.Markdown": {
@@ -104,8 +104,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -217,11 +217,11 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Direct",
-        "requested": "[14.14.0, )",
-        "resolved": "14.14.0",
-        "contentHash": "Af7QdAb1AfLN09gpr4lzrTjioDez1hW1IQN3Tb0qJWi8NY3ywTJyteoH/8P/mripXq4D5Khz0uWBEX5O59i5Zw==",
+        "requested": "[14.15.0, )",
+        "resolved": "14.15.0",
+        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
         "dependencies": {
-          "Magick.NET.Core": "14.14.0"
+          "Magick.NET.Core": "14.15.0"
         }
       },
       "OfficeIMO.Markdown": {
@@ -298,8 +298,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.14.0",
-        "contentHash": "pACR3w4QmjBkebtYvZwNk0oow8YwEAF4CLfzSrGmPcWsObL8wvt/lOXsrzK9M0cVwYES7jp+bdnHQBTeQgfoIg=="
+        "resolved": "14.15.0",
+        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",

--- a/PowerForge/Services/AppStoreConnectClient.Http.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Http.cs
@@ -45,11 +45,19 @@ public sealed partial class AppStoreConnectClient
             }
 
             var delay = ResolveTransientReadDelay(response.Headers.RetryAfter, attempt);
-            await TransientReadDelayAsync(delay, cancellationToken).ConfigureAwait(false);
+            if (!delay.HasValue)
+            {
+                return new AppStoreConnectHttpResponse(
+                    response.StatusCode,
+                    response.ReasonPhrase,
+                    content);
+            }
+
+            await TransientReadDelayAsync(delay.Value, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private static TimeSpan ResolveTransientReadDelay(RetryConditionHeaderValue? retryAfter, int attempt)
+    private static TimeSpan? ResolveTransientReadDelay(RetryConditionHeaderValue? retryAfter, int attempt)
     {
         var fallback = TimeSpan.FromSeconds(attempt);
         if (retryAfter is null)
@@ -62,7 +70,7 @@ public sealed partial class AppStoreConnectClient
             return fallback;
 
         var maximum = TimeSpan.FromMinutes(2);
-        return requested.Value <= maximum ? requested.Value : maximum;
+        return requested.Value <= maximum ? requested.Value : null;
     }
 
     private static bool IsTransientReadFailure(HttpStatusCode statusCode)

--- a/PowerForge/Services/AppStoreConnectClient.Http.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Http.cs
@@ -44,8 +44,25 @@ public sealed partial class AppStoreConnectClient
                     content);
             }
 
-            await TransientReadDelayAsync(TimeSpan.FromSeconds(attempt), cancellationToken).ConfigureAwait(false);
+            var delay = ResolveTransientReadDelay(response.Headers.RetryAfter, attempt);
+            await TransientReadDelayAsync(delay, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static TimeSpan ResolveTransientReadDelay(RetryConditionHeaderValue? retryAfter, int attempt)
+    {
+        var fallback = TimeSpan.FromSeconds(attempt);
+        if (retryAfter is null)
+            return fallback;
+
+        var requested = retryAfter.Delta;
+        if (!requested.HasValue && retryAfter.Date.HasValue)
+            requested = retryAfter.Date.Value - DateTimeOffset.UtcNow;
+        if (!requested.HasValue || requested.Value <= TimeSpan.Zero)
+            return fallback;
+
+        var maximum = TimeSpan.FromMinutes(2);
+        return requested.Value <= maximum ? requested.Value : maximum;
     }
 
     private static bool IsTransientReadFailure(HttpStatusCode statusCode)

--- a/PowerForge/Services/AppStoreConnectClient.Http.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Http.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace PowerForge;
+
+public sealed partial class AppStoreConnectClient
+{
+    internal static readonly TimeSpan DefaultOwnedClientTimeout = TimeSpan.FromMinutes(10);
+
+    private const int MaximumReadAttempts = 3;
+
+    internal TimeSpan RequestTimeout => _httpClient.Timeout;
+
+    internal Func<TimeSpan, CancellationToken, Task> TransientReadDelayAsync { get; set; }
+        = static (delay, cancellationToken) => Task.Delay(delay, cancellationToken);
+
+    private static HttpClient CreateDefaultHttpClient()
+        => new()
+        {
+            BaseAddress = DefaultBaseUri,
+            Timeout = DefaultOwnedClientTimeout
+        };
+
+    private async Task<AppStoreConnectHttpResponse> SendGetWithTransientRetryAsync(
+        string relativeUrl,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, relativeUrl);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _tokenGenerator.CreateToken(_credential));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode ||
+                attempt >= MaximumReadAttempts ||
+                !IsTransientReadFailure(response.StatusCode))
+            {
+                return new AppStoreConnectHttpResponse(
+                    response.StatusCode,
+                    response.ReasonPhrase,
+                    content);
+            }
+
+            await TransientReadDelayAsync(TimeSpan.FromSeconds(attempt), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsTransientReadFailure(HttpStatusCode statusCode)
+        => statusCode is HttpStatusCode.TooManyRequests
+            or HttpStatusCode.InternalServerError
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.GatewayTimeout;
+
+    private readonly record struct AppStoreConnectHttpResponse(
+        HttpStatusCode StatusCode,
+        string? ReasonPhrase,
+        string Content)
+    {
+        public bool IsSuccessStatusCode => (int)StatusCode is >= 200 and <= 299;
+    }
+}

--- a/PowerForge/Services/AppStoreConnectClient.Http.cs
+++ b/PowerForge/Services/AppStoreConnectClient.Http.cs
@@ -33,7 +33,7 @@ public sealed partial class AppStoreConnectClient
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            var content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             if (response.IsSuccessStatusCode ||
                 attempt >= MaximumReadAttempts ||
                 !IsTransientReadFailure(response.StatusCode))
@@ -49,17 +49,30 @@ public sealed partial class AppStoreConnectClient
     }
 
     private static bool IsTransientReadFailure(HttpStatusCode statusCode)
-        => statusCode is HttpStatusCode.TooManyRequests
-            or HttpStatusCode.InternalServerError
+        => (int)statusCode == 429
+            || statusCode is HttpStatusCode.InternalServerError
             or HttpStatusCode.BadGateway
             or HttpStatusCode.ServiceUnavailable
             or HttpStatusCode.GatewayTimeout;
 
-    private readonly record struct AppStoreConnectHttpResponse(
-        HttpStatusCode StatusCode,
-        string? ReasonPhrase,
-        string Content)
+    private readonly struct AppStoreConnectHttpResponse
     {
+        public AppStoreConnectHttpResponse(
+            HttpStatusCode statusCode,
+            string? reasonPhrase,
+            string content)
+        {
+            StatusCode = statusCode;
+            ReasonPhrase = reasonPhrase;
+            Content = content;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+
+        public string? ReasonPhrase { get; }
+
+        public string Content { get; }
+
         public bool IsSuccessStatusCode => (int)StatusCode is >= 200 and <= 299;
     }
 }

--- a/PowerForge/Services/AppStoreConnectClient.cs
+++ b/PowerForge/Services/AppStoreConnectClient.cs
@@ -30,7 +30,7 @@ public sealed partial class AppStoreConnectClient : IDisposable
     {
         _credential = credential ?? throw new ArgumentNullException(nameof(credential));
         _tokenGenerator = tokenGenerator ?? new AppStoreConnectJwtTokenGenerator();
-        _httpClient = httpClient ?? new HttpClient { BaseAddress = DefaultBaseUri };
+        _httpClient = httpClient ?? CreateDefaultHttpClient();
         _disposeClient = httpClient is null;
         if (_httpClient.BaseAddress is null)
             _httpClient.BaseAddress = DefaultBaseUri;
@@ -650,19 +650,14 @@ public sealed partial class AppStoreConnectClient : IDisposable
 
     private async Task<JsonDocument?> GetJsonAsync(string relativeUrl, CancellationToken cancellationToken, bool returnNullOnNotFound = false)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, relativeUrl);
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _tokenGenerator.CreateToken(_credential));
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var response = await SendGetWithTransientRetryAsync(relativeUrl, cancellationToken).ConfigureAwait(false);
         if (returnNullOnNotFound && response.StatusCode == HttpStatusCode.NotFound)
             return null;
 
         if (!response.IsSuccessStatusCode)
-            throw new InvalidOperationException($"App Store Connect API request failed ({(int)response.StatusCode} {response.ReasonPhrase}): {content}");
+            throw new InvalidOperationException($"App Store Connect API request failed ({(int)response.StatusCode} {response.ReasonPhrase}): {response.Content}");
 
-        return JsonDocument.Parse(content);
+        return JsonDocument.Parse(response.Content);
     }
 
     private async Task<JsonDocument?> SendJsonAsync(HttpMethod method, string relativeUrl, object body, CancellationToken cancellationToken)

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -45,13 +45,28 @@ public sealed class AppStoreConnectReleasePreparationService
         AppStoreConnectVersionInfo? version = null;
         if (requiresVersion)
         {
-            var versions = await _client.GetVersionsAsync(
-                appId,
-                versionString,
-                request.Platform,
-                limit: 10,
-                cancellationToken).ConfigureAwait(false);
-            version = versions.FirstOrDefault();
+            var configuredVersionId = ResolveConfiguredVersionId(request);
+            if (!request.CreateVersion && configuredVersionId is not null)
+            {
+                version = new AppStoreConnectVersionInfo
+                {
+                    Id = configuredVersionId,
+                    VersionString = versionString,
+                    Platform = request.Platform.ToString()
+                };
+                messages.Add($"Using configured App Store version '{versionString}' for platform '{request.Platform}'.");
+            }
+            else
+            {
+                var versions = await _client.GetVersionsAsync(
+                    appId,
+                    versionString,
+                    request.Platform,
+                    limit: 10,
+                    cancellationToken).ConfigureAwait(false);
+                version = versions.FirstOrDefault();
+            }
+
             if (version is null)
             {
                 if (!request.CreateVersion)
@@ -169,6 +184,24 @@ public sealed class AppStoreConnectReleasePreparationService
             Readiness = readiness,
             Messages = messages.ToArray()
         };
+    }
+
+    private static string? ResolveConfiguredVersionId(AppStoreConnectReleasePreparationRequest request)
+    {
+        var configuredIds = new[]
+            {
+                request.ScreenshotSpec?.VersionId,
+                request.MetadataSpec?.VersionId
+            }
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Select(static value => value!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (configuredIds.Length > 1)
+            throw new InvalidOperationException("Configured screenshot and metadata mappings target different App Store version ids.");
+
+        return configuredIds.SingleOrDefault();
     }
 
     private static void ValidateBuildIsSelectable(AppStoreConnectBuildInfo build, string buildNumber)


### PR DESCRIPTION
## What changed

- use exact configured App Store version IDs during screenshot-only preparation instead of querying the version list again
- give owned App Store Connect clients enough time for large screenshot uploads
- retry transient failures only for idempotent App Store Connect reads, with a strict three-attempt bound
- honor server-provided Retry-After delays within the retry budget and fail without an early retry when Apple requests a longer wait
- reject conflicting screenshot and metadata version IDs before any remote change
- update Magick.NET to 14.15.0 after NuGet began rejecting 14.14.0 for a newly published advisory

## Why

CasaRay 1.4 exposed three real release failure modes: Apple intermittently returned 500 responses for version/status reads, Mac screenshot replacement exceeded the default 100-second HTTP timeout, and screenshot-only preparation queried an unnecessary endpoint even though the exact draft ID was configured. These changes let release automation recover safely without retrying uploads or submissions.

## Validation

- 54 focused App Store Connect, screenshot, CLI release, and submission tests pass
- locked restores pass for PowerForge.Web, PowerForge.Web.Cli, and PowerForge.Tests
- PowerForge.Web.Cli Release/net10.0 and PowerForge Release/net472 builds pass with zero warnings
- NuGet reports no vulnerable direct or transitive packages for PowerForge.Web
- live CasaRay Mac screenshot replacement completed all 10 files with exact checksum matches
- live final status reconciled iOS/iPadOS and macOS 1.4 as WAITING_FOR_REVIEW after transient Apple 500 responses