### PR TITLE
Support optional .NET workloads in website workflows

### DIFF
--- a/.github/workflows/powerforge-website-ci.yml
+++ b/.github/workflows/powerforge-website-ci.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: "10.0.x"
+      dotnet_workloads:
+        description: Optional comma, semicolon, or whitespace-separated .NET workloads to install before running the website pipeline.
+        required: false
+        type: string
+        default: ""
       report_artifact_name:
         required: false
         type: string
@@ -98,6 +103,7 @@ jobs:
       runner_labels_json: ${{ inputs.runner_labels_json }}
       timeout_minutes: ${{ inputs.timeout_minutes }}
       dotnet_version: ${{ inputs.dotnet_version }}
+      dotnet_workloads: ${{ inputs.dotnet_workloads }}
       report_artifact_name: ${{ inputs.report_artifact_name }}
       powerforge_lock_path: ${{ inputs.powerforge_lock_path }}
       powerforge_repository: ${{ inputs.powerforge_repository }}

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -338,6 +338,7 @@ jobs:
       runner_labels_json: ${{ inputs.runner_labels_json }}
       timeout_minutes: ${{ inputs.timeout_minutes }}
       dotnet_version: ${{ inputs.dotnet_version }}
+      dotnet_workloads: ${{ inputs.dotnet_workloads }}
       report_artifact_name: ${{ inputs.post_deploy_report_artifact_name }}
       powerforge_lock_path: ${{ inputs.powerforge_lock_path }}
       powerforge_repository: ${{ inputs.powerforge_repository }}

--- a/.github/workflows/powerforge-website-deploy.yml
+++ b/.github/workflows/powerforge-website-deploy.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: string
         default: "10.0.x"
+      dotnet_workloads:
+        description: Optional comma, semicolon, or whitespace-separated .NET workloads to install before running the website build pipeline.
+        required: false
+        type: string
+        default: ""
       report_artifact_name:
         required: false
         type: string
@@ -225,6 +230,7 @@ jobs:
       runner_labels_json: ${{ inputs.runner_labels_json }}
       timeout_minutes: ${{ inputs.build_timeout_minutes }}
       dotnet_version: ${{ inputs.dotnet_version }}
+      dotnet_workloads: ${{ inputs.dotnet_workloads }}
       report_artifact_name: ${{ inputs.report_artifact_name }}
       powerforge_lock_path: ${{ inputs.powerforge_lock_path }}
       powerforge_repository: ${{ inputs.powerforge_repository }}

--- a/.github/workflows/powerforge-website-maintenance.yml
+++ b/.github/workflows/powerforge-website-maintenance.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: "10.0.x"
+      dotnet_workloads:
+        description: Optional comma, semicolon, or whitespace-separated .NET workloads to install before running the website pipeline.
+        required: false
+        type: string
+        default: ""
       report_artifact_name:
         required: false
         type: string
@@ -89,6 +94,7 @@ jobs:
       runner_labels_json: ${{ inputs.runner_labels_json }}
       timeout_minutes: ${{ inputs.timeout_minutes }}
       dotnet_version: ${{ inputs.dotnet_version }}
+      dotnet_workloads: ${{ inputs.dotnet_workloads }}
       report_artifact_name: ${{ inputs.report_artifact_name }}
       powerforge_lock_path: ${{ inputs.powerforge_lock_path }}
       powerforge_repository: ${{ inputs.powerforge_repository }}

--- a/.github/workflows/powerforge-website-run.yml
+++ b/.github/workflows/powerforge-website-run.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: string
         default: "10.0.x"
+      dotnet_workloads:
+        description: Optional comma, semicolon, or whitespace-separated .NET workloads to install before running the website pipeline.
+        required: false
+        type: string
+        default: ""
       report_artifact_name:
         required: false
         type: string
@@ -213,6 +218,34 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Install requested .NET workloads
+        if: ${{ inputs.dotnet_workloads != '' }}
+        shell: pwsh
+        env:
+          DOTNET_WORKLOADS: ${{ inputs.dotnet_workloads }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $workloads = @(
+            $env:DOTNET_WORKLOADS -split '[,;\s]+' |
+              Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+              Select-Object -Unique
+          )
+
+          if ($workloads.Count -eq 0) {
+            throw 'dotnet_workloads did not contain a workload identifier.'
+          }
+
+          foreach ($workload in $workloads) {
+            if ($workload -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*$') {
+              throw "Invalid .NET workload identifier '$workload'."
+            }
+          }
+
+          dotnet workload install @workloads --skip-manifest-update
+          if ($LASTEXITCODE -ne 0) {
+            throw "dotnet workload install failed with exit code $LASTEXITCODE."
+          }
 
       - name: Cache NuGet packages
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -77,10 +77,10 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Theory]
-    [InlineData("powerforge-website-ci.yml")]
-    [InlineData("powerforge-website-deploy.yml")]
-    [InlineData("powerforge-website-maintenance.yml")]
-    public void WebsiteWorkflows_ShouldForwardRequestedDotNetWorkloads(string workflowFileName)
+    [InlineData("powerforge-website-ci.yml", 1)]
+    [InlineData("powerforge-website-deploy.yml", 2)]
+    [InlineData("powerforge-website-maintenance.yml", 1)]
+    public void WebsiteWorkflows_ShouldForwardRequestedDotNetWorkloads(string workflowFileName, int expectedForwardCount)
     {
         var repoRoot = FindRepoRoot();
         var workflowPath = Path.Combine(repoRoot, ".github", "workflows", workflowFileName);
@@ -90,7 +90,10 @@ public sealed class GitHubWebsiteRunWorkflowTests
         var workflowYaml = File.ReadAllText(workflowPath);
 
         Assert.Contains("dotnet_workloads:", workflowYaml, StringComparison.Ordinal);
-        Assert.Contains("dotnet_workloads: ${{ inputs.dotnet_workloads }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Equal(
+            expectedForwardCount,
+            workflowYaml.Split('\n').Count(static line =>
+                line.Trim().Equals("dotnet_workloads: ${{ inputs.dotnet_workloads }}", StringComparison.Ordinal)));
     }
 
     [Fact]

--- a/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
+++ b/PowerForge.Tests/GitHubWebsiteRunWorkflowTests.cs
@@ -60,6 +60,40 @@ public sealed class GitHubWebsiteRunWorkflowTests
     }
 
     [Fact]
+    public void WebsiteRunWorkflow_ShouldInstallRequestedDotNetWorkloads()
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", "powerforge-website-run.yml");
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("dotnet_workloads:", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("if: ${{ inputs.dotnet_workloads != '' }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("DOTNET_WORKLOADS: ${{ inputs.dotnet_workloads }}", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("dotnet workload install @workloads --skip-manifest-update", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("Invalid .NET workload identifier", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("powerforge-website-ci.yml")]
+    [InlineData("powerforge-website-deploy.yml")]
+    [InlineData("powerforge-website-maintenance.yml")]
+    public void WebsiteWorkflows_ShouldForwardRequestedDotNetWorkloads(string workflowFileName)
+    {
+        var repoRoot = FindRepoRoot();
+        var workflowPath = Path.Combine(repoRoot, ".github", "workflows", workflowFileName);
+
+        Assert.True(File.Exists(workflowPath), $"Website workflow not found: {workflowPath}");
+
+        var workflowYaml = File.ReadAllText(workflowPath);
+
+        Assert.Contains("dotnet_workloads:", workflowYaml, StringComparison.Ordinal);
+        Assert.Contains("dotnet_workloads: ${{ inputs.dotnet_workloads }}", workflowYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WebsiteRunWorkflow_ShouldResolveOptionalCallerSourceRefToExactProvenance()
     {
         var repoRoot = FindRepoRoot();


### PR DESCRIPTION
Website consumers can now request the .NET workloads their build actually needs through the reusable PowerForge workflows.

- Adds an optional `dotnet_workloads` input to website CI, deploy, maintenance, and the shared runner.
- Validates workload identifiers before invoking the .NET CLI.
- Installs requested workloads before each applicable website pipeline.
- For deployments, forwards the request to both the build and optional post-deploy pipeline.
- Leaves existing consumers unchanged when the input is empty.

This closes a deployment gap for applications with native build requirements, such as Blazor WebAssembly projects that must link native archives. Without the workload, those projects can otherwise produce an incomplete artifact while the surrounding pipeline appears successful.

Validation: focused reusable-workflow contract suite, 14/14 passing.