### PR TITLE
Include compiled cmdlet help in module packages

### DIFF
--- a/PowerForge.Tests/ModuleBuilderDependencyCopyTests.cs
+++ b/PowerForge.Tests/ModuleBuilderDependencyCopyTests.cs
@@ -174,6 +174,67 @@ public sealed class ModuleBuilderDependencyCopyTests
     }
 
     [Fact]
+    public void CopyPublishOutputBinaries_CopiesExternalHelpForExportAssembly()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));
+        var publishDir = Path.Combine(root, "publish");
+        var targetDir = Path.Combine(root, "target");
+
+        Directory.CreateDirectory(publishDir);
+        Directory.CreateDirectory(targetDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(publishDir, "TestModule.dll"), "module");
+            File.WriteAllText(Path.Combine(publishDir, "TestModule.dll-Help.xml"), "external help");
+            File.WriteAllText(Path.Combine(publishDir, "TestModule.deps.json"), """
+                {
+                  "targets": {
+                    ".NETFramework,Version=v4.7.2": {
+                      "TestModule/1.0.0": {
+                        "runtime": {
+                          "TestModule.dll": {}
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var builder = ModuleBuilderTestDependencies.Create();
+            var copyMethod = typeof(ModuleBuilder).GetMethod(
+                "CopyPublishOutputBinaries",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(copyMethod);
+
+            copyMethod!.Invoke(builder, new object[]
+            {
+                publishDir,
+                targetDir,
+                "net472",
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "TestModule.dll" },
+                null!
+            });
+
+            Assert.Equal(
+                "external help",
+                File.ReadAllText(Path.Combine(targetDir, "TestModule.dll-Help.xml")));
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+    }
+
+    [Fact]
     public void CopyPublishOutputBinaries_DoesNotReAddExcludedTopLevelDepsFiles()
     {
         var root = Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N"));

--- a/PowerForge/Services/ModuleBuilder.cs
+++ b/PowerForge/Services/ModuleBuilder.cs
@@ -480,12 +480,23 @@ public sealed class ModuleBuilder
 
             var xmlFileName = Path.ChangeExtension(fileName, ".xml");
             var xmlSource = TryResolveXmlDocPath(publishDir, xmlFileName);
-            if (string.IsNullOrWhiteSpace(xmlSource) || !File.Exists(xmlSource)) continue;
+            if (!string.IsNullOrWhiteSpace(xmlSource) && File.Exists(xmlSource))
+            {
+                var xmlDest = Path.Combine(targetDir, xmlFileName);
+                Directory.CreateDirectory(Path.GetDirectoryName(xmlDest)!);
+                File.Copy(xmlSource, xmlDest, overwrite: true);
+                copied++;
+            }
 
-            var xmlDest = Path.Combine(targetDir, xmlFileName);
-            Directory.CreateDirectory(Path.GetDirectoryName(xmlDest)!);
-            File.Copy(xmlSource, xmlDest, overwrite: true);
-            copied++;
+            var helpFileName = fileName + "-Help.xml";
+            var helpSource = TryResolveXmlDocPath(publishDir, helpFileName);
+            if (!string.IsNullOrWhiteSpace(helpSource) && File.Exists(helpSource))
+            {
+                var helpDest = Path.Combine(targetDir, helpFileName);
+                Directory.CreateDirectory(Path.GetDirectoryName(helpDest)!);
+                File.Copy(helpSource, helpDest, overwrite: true);
+                copied++;
+            }
         }
 
         copied += CopyReferencedTopLevelAssemblies(publishDir, targetDir, options);


### PR DESCRIPTION
## Summary

- copy generated `*.dll-Help.xml` files for every exported binary assembly
- keep external MAML help independent from C# API XML documentation
- cover the behavior with a focused ModuleBuilder regression test

## Why

Compiled cmdlets can publish complete MAML help while their package still loses it during module assembly. That makes `Get-Help -Examples` incomplete even though the source documentation and publish output are correct. Keeping the copy in ModuleBuilder fixes the shared packaging owner for Transferetto, DbaClientX, FabricClientX, and future binary modules.

## Validation

- focused `ModuleBuilderDependencyCopyTests`: 9 passed
- unsigned PSPublishModule self-build completed with documentation parity and module validation passing
- exact locally built owner produced packaged Transferetto, DbaClientX, and FabricClientX modules containing external help; all compiled cmdlets returned examples on PowerShell 7 and Windows PowerShell 5.1

No package or module was published as part of this change.