### PR TITLE
Unify build progress rendering and publish version selection

### DIFF
--- a/PSPublishModule/PSPublishModule.csproj
+++ b/PSPublishModule/PSPublishModule.csproj
@@ -60,6 +60,8 @@
     <Compile Include="..\PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\PipelinePublishSummary.cs" Link="PowerForge.ConsoleShared\PipelinePublishSummary.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" />

--- a/PowerForge.Cli/DotNetPublishConsoleUi.cs
+++ b/PowerForge.Cli/DotNetPublishConsoleUi.cs
@@ -3,8 +3,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using PowerForge;
+using PowerForge.ConsoleShared;
 using Spectre.Console;
-using Spectre.Console.Rendering;
 
 namespace PowerForge.Cli;
 
@@ -47,12 +47,15 @@ internal static class DotNetPublishConsoleUi
 
         DotNetPublishResult? result = null;
         var steps = plan.Steps ?? Array.Empty<DotNetPublishStep>();
-        AnsiConsole.Progress()
-            .AutoRefresh(true)
-            .AutoClear(false)
-            .HideCompleted(false)
-            .Columns(BuildColumns(includeBar, includeElapsed, barWidth, iconLookup, startLookup, doneLookup))
-            .Start(ctx =>
+        SpectreProgressDisplay.Run(
+            SpectreBuildProgressColumns.CreateDetailed(
+                includeBar,
+                includeElapsed,
+                barWidth,
+                iconLookup,
+                startLookup,
+                doneLookup),
+            ctx =>
             {
                 var tasksByKey = new Dictionary<string, ProgressTask>(StringComparer.OrdinalIgnoreCase);
                 var labelsByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -261,40 +264,6 @@ internal static class DotNetPublishConsoleUi
         AnsiConsole.WriteLine();
     }
 
-    private static ProgressColumn[] BuildColumns(
-        bool includeBar,
-        bool includeElapsed,
-        int barWidth,
-        ConcurrentDictionary<ProgressTask, string> iconLookup,
-        ConcurrentDictionary<ProgressTask, DateTimeOffset> startLookup,
-        ConcurrentDictionary<ProgressTask, TimeSpan> doneLookup)
-    {
-        var columns = new List<ProgressColumn>
-        {
-            new StepIconColumn(iconLookup),
-            new IconAndDescriptionColumn(string.Empty),
-        };
-
-        if (includeBar)
-        {
-            columns.Add(new ProgressBarColumn
-            {
-                Width = barWidth,
-                CompletedStyle = new Style(Color.Green),
-                FinishedStyle = new Style(Color.Green),
-                IndeterminateStyle = new Style(Color.Grey)
-            });
-        }
-
-        columns.Add(new PercentageColumn());
-
-        if (includeElapsed)
-            columns.Add(new FixedElapsedColumn(startLookup, doneLookup));
-
-        columns.Add(new SpinnerColumn());
-        return columns.ToArray();
-    }
-
     private static string BuildLabel(DotNetPublishStep step, int ord, int total, int digits, DotNetPublishPlan plan)
     {
         var prefix = ord.ToString().PadLeft(digits, '0') + "/" + total.ToString().PadLeft(digits, '0');
@@ -492,61 +461,4 @@ internal static class DotNetPublishConsoleUi
         }
     }
 
-    private sealed class StepIconColumn : ProgressColumn
-    {
-        private readonly ConcurrentDictionary<ProgressTask, string> _icons;
-
-        public StepIconColumn(ConcurrentDictionary<ProgressTask, string> icons) => _icons = icons;
-
-        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
-        {
-            var icon = _icons.TryGetValue(task, out var s) && !string.IsNullOrWhiteSpace(s) ? s : string.Empty;
-            var content = new Markup(icon);
-            return new Panel(content)
-            {
-                Border = BoxBorder.None,
-                Padding = new Padding(0, 0, 0, 0),
-                Width = 2
-            };
-        }
-    }
-
-    private sealed class IconAndDescriptionColumn : ProgressColumn
-    {
-        private readonly string _icon;
-
-        public IconAndDescriptionColumn(string icon = "•") => _icon = icon;
-
-        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
-        {
-            var desc = task.Description ?? string.Empty;
-            var prefix = string.IsNullOrWhiteSpace(_icon) ? string.Empty : _icon + " ";
-            var t = new Text(prefix + desc);
-            try { t.Overflow = Overflow.Ellipsis; } catch { }
-            return t;
-        }
-    }
-
-    private sealed class FixedElapsedColumn : ProgressColumn
-    {
-        private readonly ConcurrentDictionary<ProgressTask, DateTimeOffset> _start;
-        private readonly ConcurrentDictionary<ProgressTask, TimeSpan> _done;
-
-        public FixedElapsedColumn(ConcurrentDictionary<ProgressTask, DateTimeOffset> start, ConcurrentDictionary<ProgressTask, TimeSpan> done)
-        {
-            _start = start;
-            _done = done;
-        }
-
-        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
-        {
-            if (_done.TryGetValue(task, out var e)) return new Markup($"[blue]{e:mm\\:ss}[/]");
-            if (_start.TryGetValue(task, out var s))
-            {
-                var e2 = DateTimeOffset.Now - s;
-                return new Markup($"[blue]{e2:mm\\:ss}[/]");
-            }
-            return new Markup("[blue]00:00[/]");
-        }
-    }
 }

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -31,13 +31,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectrePipelineSummaryWriter.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\PipelinePublishSummary.cs" Link="PowerForge.ConsoleShared\PipelinePublishSummary.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" />

--- a/PowerForge.Cli/packages.lock.json
+++ b/PowerForge.Cli/packages.lock.json
@@ -4,9 +4,12 @@
     "net10.0": {
       "Spectre.Console": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA=="
+        "requested": "[0.55.2, )",
+        "resolved": "0.55.2",
+        "contentHash": "yc0g12YJpmZHofGJLTQX02/uqfzJ6XHRx6pe9rANNjleQptXMHPxD9KI2/DWkXiJWddc+4oizEdGox15c89hhw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.2"
+        }
       },
       "JetBrains.Annotations": {
         "type": "Transitive",
@@ -358,6 +361,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.2",
+        "contentHash": "tN3KEJQQZwLW9HJnG5YTSAxfBwxsmg1wVuGvhGG2rM+pbl+NGaHU8pDcNofPlOXlgpkbpBMxI5t9o9qPfy3sHQ=="
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -641,9 +649,12 @@
     "net8.0": {
       "Spectre.Console": {
         "type": "Direct",
-        "requested": "[0.54.0, )",
-        "resolved": "0.54.0",
-        "contentHash": "StDXCFayfy0yB1xzUHT2tgEpV1/HFTiS4JgsAQS49EYTfMixSwwucaQs/bIOCwXjWwIQTMuxjUIxcB5XsJkFJA=="
+        "requested": "[0.55.2, )",
+        "resolved": "0.55.2",
+        "contentHash": "yc0g12YJpmZHofGJLTQX02/uqfzJ6XHRx6pe9rANNjleQptXMHPxD9KI2/DWkXiJWddc+4oizEdGox15c89hhw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.2"
+        }
       },
       "JetBrains.Annotations": {
         "type": "Transitive",
@@ -1004,6 +1015,11 @@
         "type": "Transitive",
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.2",
+        "contentHash": "tN3KEJQQZwLW9HJnG5YTSAxfBwxsmg1wVuGvhGG2rM+pbl+NGaHU8pDcNofPlOXlgpkbpBMxI5t9o9qPfy3sHQ=="
       },
       "System.CodeDom": {
         "type": "Transitive",

--- a/PowerForge.ConsoleShared/SpectreBuildProgressColumns.cs
+++ b/PowerForge.ConsoleShared/SpectreBuildProgressColumns.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Concurrent;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace PowerForge.ConsoleShared;
+
+/// <summary>
+/// Creates the common Spectre column layout for build and release progress views.
+/// </summary>
+internal static class SpectreBuildProgressColumns
+{
+    /// <summary>
+    /// Creates a left-anchored progress layout matching the module pipeline presentation.
+    /// </summary>
+    public static ProgressColumn[] CreateStandard()
+        =>
+        [
+            new TaskDescriptionColumn { Alignment = Justify.Left },
+            new ProgressBarColumn
+            {
+                CompletedStyle = new Style(Color.Green),
+                FinishedStyle = new Style(Color.Green)
+            },
+            new PercentageColumn(),
+            new ElapsedTimeColumn(),
+            new SpinnerColumn()
+        ];
+
+    /// <summary>
+    /// Creates the common detailed-step layout used by module and executable pipelines.
+    /// </summary>
+    public static ProgressColumn[] CreateDetailed(
+        bool includeBar,
+        bool includeElapsed,
+        int barWidth,
+        ConcurrentDictionary<ProgressTask, string> iconLookup,
+        ConcurrentDictionary<ProgressTask, DateTimeOffset> startLookup,
+        ConcurrentDictionary<ProgressTask, TimeSpan> doneLookup)
+    {
+        if (iconLookup is null) throw new ArgumentNullException(nameof(iconLookup));
+        if (startLookup is null) throw new ArgumentNullException(nameof(startLookup));
+        if (doneLookup is null) throw new ArgumentNullException(nameof(doneLookup));
+
+        var columns = new System.Collections.Generic.List<ProgressColumn>
+        {
+            new StepIconColumn(iconLookup),
+            new LeftDescriptionColumn()
+        };
+
+        if (includeBar)
+        {
+            columns.Add(new ProgressBarColumn
+            {
+                Width = barWidth,
+                CompletedStyle = new Style(Color.Green),
+                FinishedStyle = new Style(Color.Green),
+                IndeterminateStyle = new Style(Color.Grey)
+            });
+        }
+
+        columns.Add(new PercentageColumn());
+
+        if (includeElapsed)
+            columns.Add(new FixedElapsedColumn(startLookup, doneLookup));
+
+        columns.Add(new SpinnerColumn());
+        return columns.ToArray();
+    }
+
+    private sealed class StepIconColumn : ProgressColumn
+    {
+        private readonly ConcurrentDictionary<ProgressTask, string> _icons;
+
+        public StepIconColumn(ConcurrentDictionary<ProgressTask, string> icons)
+            => _icons = icons;
+
+        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
+        {
+            var icon = _icons.TryGetValue(task, out var value) && !string.IsNullOrWhiteSpace(value)
+                ? value
+                : string.Empty;
+            return new Panel(new Markup(icon))
+            {
+                Border = BoxBorder.None,
+                Padding = new Padding(0, 0, 0, 0),
+                Width = 2
+            };
+        }
+    }
+
+    private sealed class LeftDescriptionColumn : ProgressColumn
+    {
+        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
+        {
+            var text = new Text(task.Description ?? string.Empty);
+            try { text.Overflow = Overflow.Ellipsis; } catch { }
+            return text;
+        }
+    }
+
+    private sealed class FixedElapsedColumn : ProgressColumn
+    {
+        private readonly ConcurrentDictionary<ProgressTask, DateTimeOffset> _start;
+        private readonly ConcurrentDictionary<ProgressTask, TimeSpan> _done;
+
+        public FixedElapsedColumn(
+            ConcurrentDictionary<ProgressTask, DateTimeOffset> start,
+            ConcurrentDictionary<ProgressTask, TimeSpan> done)
+        {
+            _start = start;
+            _done = done;
+        }
+
+        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
+        {
+            if (_done.TryGetValue(task, out var elapsed))
+                return new Markup($"[blue]{elapsed:mm\\:ss}[/]");
+
+            if (_start.TryGetValue(task, out var startedAt))
+                return new Markup($"[blue]{(DateTimeOffset.Now - startedAt):mm\\:ss}[/]");
+
+            return new Markup("[blue]00:00[/]");
+        }
+    }
+}

--- a/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using PowerForge;
 using Spectre.Console;
-using Spectre.Console.Rendering;
 
 namespace PowerForge.ConsoleShared;
 
@@ -61,12 +60,15 @@ internal static class SpectreModulePipelineConsoleUi
 
         Exception? failure = null;
         ModulePipelineResult? result = null;
-        AnsiConsole.Progress()
-            .AutoRefresh(true)
-            .AutoClear(false)
-            .HideCompleted(false)
-            .Columns(BuildColumns(includeBar, includeElapsed, barWidth, iconLookup, startLookup, doneLookup))
-            .Start(ctx =>
+        SpectreProgressDisplay.Run(
+            SpectreBuildProgressColumns.CreateDetailed(
+                includeBar,
+                includeElapsed,
+                barWidth,
+                iconLookup,
+                startLookup,
+                doneLookup),
+            ctx =>
             {
                 var tasksByKey = new Dictionary<string, ProgressTask>(StringComparer.OrdinalIgnoreCase);
                 var labelsByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -118,40 +120,6 @@ internal static class SpectreModulePipelineConsoleUi
         if (viewportWidth >= 100) return 14;
         if (viewportWidth >= 80) return 12;
         return 10;
-    }
-
-    private static ProgressColumn[] BuildColumns(
-        bool includeBar,
-        bool includeElapsed,
-        int barWidth,
-        ConcurrentDictionary<ProgressTask, string> iconLookup,
-        ConcurrentDictionary<ProgressTask, DateTimeOffset> startLookup,
-        ConcurrentDictionary<ProgressTask, TimeSpan> doneLookup)
-    {
-        var columns = new List<ProgressColumn>
-        {
-            new StepIconColumn(iconLookup),
-            new IconAndDescriptionColumn(string.Empty),
-        };
-
-        if (includeBar)
-        {
-            columns.Add(new ProgressBarColumn
-            {
-                Width = barWidth,
-                CompletedStyle = new Style(Color.Green),
-                FinishedStyle = new Style(Color.Green),
-                IndeterminateStyle = new Style(Color.Grey)
-            });
-        }
-
-        columns.Add(new PercentageColumn());
-
-        if (includeElapsed)
-            columns.Add(new FixedElapsedColumn(startLookup, doneLookup));
-
-        columns.Add(new SpinnerColumn());
-        return columns.ToArray();
     }
 
     private static void WriteHeader(ModulePipelinePlan plan, string? configLabel, ModulePipelineStep[] steps)
@@ -481,65 +449,4 @@ internal static class SpectreModulePipelineConsoleUi
             _ => unicode ? "[grey]•[/]" : "[grey]?[/]"
         };
 
-    private sealed class StepIconColumn : ProgressColumn
-    {
-        private readonly ConcurrentDictionary<ProgressTask, string> _icons;
-
-        public StepIconColumn(ConcurrentDictionary<ProgressTask, string> icons) => _icons = icons;
-
-        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
-        {
-            var icon = _icons.TryGetValue(task, out var s) && !string.IsNullOrWhiteSpace(s) ? s : string.Empty;
-            return new Panel(new Markup(icon))
-            {
-                Border = BoxBorder.None,
-                Padding = new Padding(0, 0, 0, 0),
-                Width = 2
-            };
-        }
-    }
-
-    private sealed class IconAndDescriptionColumn : ProgressColumn
-    {
-        private readonly string _icon;
-
-        public IconAndDescriptionColumn(string icon = "•") => _icon = icon;
-
-        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
-        {
-            var desc = task.Description ?? string.Empty;
-            var prefix = string.IsNullOrWhiteSpace(_icon) ? string.Empty : _icon + " ";
-            var text = new Text(prefix + desc);
-            try { text.Overflow = Overflow.Ellipsis; } catch { }
-            return text;
-        }
-    }
-
-    private sealed class FixedElapsedColumn : ProgressColumn
-    {
-        private readonly ConcurrentDictionary<ProgressTask, DateTimeOffset> _start;
-        private readonly ConcurrentDictionary<ProgressTask, TimeSpan> _done;
-
-        public FixedElapsedColumn(
-            ConcurrentDictionary<ProgressTask, DateTimeOffset> start,
-            ConcurrentDictionary<ProgressTask, TimeSpan> done)
-        {
-            _start = start;
-            _done = done;
-        }
-
-        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
-        {
-            if (_done.TryGetValue(task, out var elapsed))
-                return new Markup($"[blue]{elapsed:mm\\:ss}[/]");
-
-            if (_start.TryGetValue(task, out var start))
-            {
-                var current = DateTimeOffset.Now - start;
-                return new Markup($"[blue]{current:mm\\:ss}[/]");
-            }
-
-            return new Markup("[blue]00:00[/]");
-        }
-    }
 }

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -23,17 +23,9 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         PowerForgeReleaseResult? result = null;
         Exception? failure = null;
 
-        AnsiConsole.Progress()
-            .AutoRefresh(true)
-            .AutoClear(false)
-            .HideCompleted(false)
-            .Columns(
-                new TaskDescriptionColumn(),
-                new ProgressBarColumn { CompletedStyle = new Style(Color.Green), FinishedStyle = new Style(Color.Green) },
-                new PercentageColumn(),
-                new ElapsedTimeColumn(),
-                new SpinnerColumn())
-            .Start(context =>
+        SpectreProgressDisplay.Run(
+            SpectreBuildProgressColumns.CreateStandard(),
+            context =>
             {
                 var tasks = phases.ToDictionary(
                     phase => phase,

--- a/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
@@ -1,0 +1,42 @@
+using System;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace PowerForge.ConsoleShared;
+
+/// <summary>
+/// Runs a Spectre progress display and preserves its final frame as normal terminal output.
+/// </summary>
+internal static class SpectreProgressDisplay
+{
+    public static void Run(
+        ProgressColumn[] columns,
+        Action<ProgressContext> action)
+        => Run(AnsiConsole.Console, columns, action);
+
+    internal static void Run(
+        IAnsiConsole console,
+        ProgressColumn[] columns,
+        Action<ProgressContext> action)
+    {
+        if (console is null) throw new ArgumentNullException(nameof(console));
+        if (columns is null) throw new ArgumentNullException(nameof(columns));
+        if (action is null) throw new ArgumentNullException(nameof(action));
+
+        IRenderable? finalFrame = null;
+        console.Progress()
+            .AutoRefresh(true)
+            .AutoClear(true)
+            .HideCompleted(false)
+            .Columns(columns)
+            .UseRenderHook((renderable, _) =>
+            {
+                finalFrame = renderable;
+                return renderable;
+            })
+            .Start(action);
+
+        if (finalFrame is not null)
+            console.Write(finalFrame);
+    }
+}

--- a/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
@@ -36,17 +36,9 @@ internal static class SpectreProjectBuildConsoleUi
         ProjectBuildWorkflowResult? result = null;
         Exception? failure = null;
 
-        AnsiConsole.Progress()
-            .AutoRefresh(true)
-            .AutoClear(false)
-            .HideCompleted(false)
-            .Columns(
-                new TaskDescriptionColumn(),
-                new ProgressBarColumn { CompletedStyle = new Style(Color.Green), FinishedStyle = new Style(Color.Green) },
-                new PercentageColumn(),
-                new ElapsedTimeColumn(),
-                new SpinnerColumn())
-            .Start(context =>
+        SpectreProgressDisplay.Run(
+            SpectreBuildProgressColumns.CreateStandard(),
+            context =>
             {
                 var tasks = phases.ToDictionary(
                     phase => phase,

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.CoordinatedVersionFloor.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.CoordinatedVersionFloor.cs
@@ -36,11 +36,12 @@ public sealed partial class ModulePipelineRunner
         var localManifestPath = plan.UseLocalVersioning
             ? Path.Combine(plan.ProjectRoot, $"{plan.ModuleName}.psd1")
             : null;
-        var step = new ModuleVersionStepper(_logger).Step(
+        var step = _moduleVersionStepResolver(
             plan.ExpectedVersion,
             plan.ModuleName,
-            localPsd1Path: localManifestPath,
-            prerelease: !string.IsNullOrWhiteSpace(plan.PreRelease));
+            localManifestPath,
+            prerelease: !string.IsNullOrWhiteSpace(plan.PreRelease),
+            verifyRepositoryAvailability: plan.GateMode == ConfigurationGateMode.Publish);
         var candidate = ModulePathTokenFormatter.FormatVersionWithPreRelease(
             step.Version,
             plan.PreRelease);

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -619,8 +619,12 @@ public sealed partial class ModulePipelineRunner
         else
         {
             var localPsd1 = localVersioning ? Path.Combine(projectRoot, $"{moduleName}.psd1") : null;
-            var stepper = new ModuleVersionStepper(_logger);
-            resolved = stepper.Step(expectedVersionResolved, moduleName, localPsd1Path: localPsd1).Version;
+            resolved = _moduleVersionStepResolver(
+                expectedVersionResolved,
+                moduleName,
+                localPsd1,
+                prerelease: !string.IsNullOrWhiteSpace(preRelease),
+                verifyRepositoryAvailability: gateMode == ConfigurationGateMode.Publish).Version;
         }
 
         // Resolve .csproj path: explicit build setting wins, otherwise derive from BuildLibraries NETProjectPath/ProjectName.

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.cs
@@ -42,6 +42,7 @@ public sealed partial class ModulePipelineRunner
     private readonly IScriptFunctionExportDetector _scriptFunctionExportDetector;
     private readonly ModulePipelineRunnerDefaults.ModulePackageBuildExecutor _packageBuildExecutor;
     private readonly ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher _gitHubReleasePublisher;
+    private readonly ModulePipelineRunnerDefaults.ModuleVersionStepResolver _moduleVersionStepResolver;
 
     private sealed class RequiredModuleDraft
     {
@@ -91,8 +92,9 @@ public sealed partial class ModulePipelineRunner
         IMissingFunctionAnalysisService? missingFunctionAnalysisService = null,
         IScriptFunctionExportDetector? scriptFunctionExportDetector = null,
         ModulePipelineRunnerDefaults.ModulePackageBuildExecutor? packageBuildExecutor = null,
-        ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher? gitHubReleasePublisher = null)
-        : this(logger, ModulePipelineRunnerDefaults.Create(logger, powerShellRunner, moduleDependencyMetadataProvider, hostedOperations, manifestMutator, missingFunctionAnalysisService, scriptFunctionExportDetector, packageBuildExecutor, gitHubReleasePublisher))
+        ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher? gitHubReleasePublisher = null,
+        ModulePipelineRunnerDefaults.ModuleVersionStepResolver? moduleVersionStepResolver = null)
+        : this(logger, ModulePipelineRunnerDefaults.Create(logger, powerShellRunner, moduleDependencyMetadataProvider, hostedOperations, manifestMutator, missingFunctionAnalysisService, scriptFunctionExportDetector, packageBuildExecutor, gitHubReleasePublisher, moduleVersionStepResolver))
     {
     }
 
@@ -110,6 +112,7 @@ public sealed partial class ModulePipelineRunner
         _scriptFunctionExportDetector = services.ScriptFunctionExportDetector;
         _packageBuildExecutor = services.PackageBuildExecutor;
         _gitHubReleasePublisher = services.GitHubReleasePublisher;
+        _moduleVersionStepResolver = services.ModuleVersionStepResolver;
     }
 
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
@@ -11,6 +11,13 @@ internal static class ModulePipelineRunnerDefaults
 
     internal delegate GitHubReleasePublishResult ModuleGitHubReleasePublisher(GitHubReleasePublishRequest request);
 
+    internal delegate ModuleVersionStepResult ModuleVersionStepResolver(
+        string expectedVersion,
+        string moduleName,
+        string? localPsd1Path,
+        bool prerelease,
+        bool verifyRepositoryAvailability);
+
     internal static ModulePipelineRunnerServices Create(
         ILogger logger,
         IPowerShellRunner? powerShellRunner,
@@ -20,12 +27,14 @@ internal static class ModulePipelineRunnerDefaults
         IMissingFunctionAnalysisService? missingFunctionAnalysisService,
         IScriptFunctionExportDetector? scriptFunctionExportDetector,
         ModulePackageBuildExecutor? packageBuildExecutor = null,
-        ModuleGitHubReleasePublisher? gitHubReleasePublisher = null)
+        ModuleGitHubReleasePublisher? gitHubReleasePublisher = null,
+        ModuleVersionStepResolver? moduleVersionStepResolver = null)
     {
         if (logger is null)
             throw new ArgumentNullException(nameof(logger));
 
         var resolvedRunner = powerShellRunner ?? new PowerShellRunner();
+        var versionStepper = new ModuleVersionStepper(logger, resolvedRunner);
         return new ModulePipelineRunnerServices(
             resolvedRunner,
             moduleDependencyMetadataProvider ?? new PowerShellModuleDependencyMetadataProvider(resolvedRunner, logger),
@@ -43,7 +52,14 @@ internal static class ModulePipelineRunnerDefaults
                     ? service.Execute(request)
                     : service.Execute(request, configuration, configPath ?? request.ConfigPath);
             }),
-            gitHubReleasePublisher ?? (request => new GitHubReleasePublisher(logger).PublishRelease(request)));
+            gitHubReleasePublisher ?? (request => new GitHubReleasePublisher(logger).PublishRelease(request)),
+            moduleVersionStepResolver ?? ((expectedVersion, moduleName, localPsd1Path, prerelease, verifyRepositoryAvailability) =>
+                versionStepper.Step(
+                    expectedVersion,
+                    moduleName,
+                    localPsd1Path: localPsd1Path,
+                    prerelease: prerelease,
+                    verifyRepositoryAvailability: verifyRepositoryAvailability)));
     }
 }
 
@@ -57,7 +73,8 @@ internal sealed class ModulePipelineRunnerServices
         IMissingFunctionAnalysisService missingFunctionAnalysisService,
         IScriptFunctionExportDetector scriptFunctionExportDetector,
         ModulePipelineRunnerDefaults.ModulePackageBuildExecutor packageBuildExecutor,
-        ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher gitHubReleasePublisher)
+        ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher gitHubReleasePublisher,
+        ModulePipelineRunnerDefaults.ModuleVersionStepResolver moduleVersionStepResolver)
     {
         PowerShellRunner = powerShellRunner ?? throw new ArgumentNullException(nameof(powerShellRunner));
         ModuleDependencyMetadataProvider = moduleDependencyMetadataProvider ?? throw new ArgumentNullException(nameof(moduleDependencyMetadataProvider));
@@ -67,6 +84,7 @@ internal sealed class ModulePipelineRunnerServices
         ScriptFunctionExportDetector = scriptFunctionExportDetector ?? throw new ArgumentNullException(nameof(scriptFunctionExportDetector));
         PackageBuildExecutor = packageBuildExecutor ?? throw new ArgumentNullException(nameof(packageBuildExecutor));
         GitHubReleasePublisher = gitHubReleasePublisher ?? throw new ArgumentNullException(nameof(gitHubReleasePublisher));
+        ModuleVersionStepResolver = moduleVersionStepResolver ?? throw new ArgumentNullException(nameof(moduleVersionStepResolver));
     }
 
     internal IPowerShellRunner PowerShellRunner { get; }
@@ -77,4 +95,5 @@ internal sealed class ModulePipelineRunnerServices
     internal IScriptFunctionExportDetector ScriptFunctionExportDetector { get; }
     internal ModulePipelineRunnerDefaults.ModulePackageBuildExecutor PackageBuildExecutor { get; }
     internal ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher GitHubReleasePublisher { get; }
+    internal ModulePipelineRunnerDefaults.ModuleVersionStepResolver ModuleVersionStepResolver { get; }
 }

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -566,6 +566,52 @@ public sealed class ModuleBuildHostServiceTests
         Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State);
     }
 
+    [Fact]
+    public async Task ExecuteBuildAsync_PreservesConciseStructuredFailureFromChildHost()
+    {
+        var progress = new RecordingReleaseProgress();
+        var runner = new StubPowerShellRunner(request =>
+        {
+            var item = new PowerForgeReleaseProgressItem
+            {
+                Phase = PowerForgeReleaseProgressPhase.Module,
+                Key = "publish:module",
+                Title = "Publish module",
+                Kind = ModulePipelineStepKind.Publish.ToString(),
+                Position = 1,
+                Total = 1
+            };
+            var failed = JsonSerializer.Serialize(new ModulePipelineProgressProtocolMessage
+            {
+                Item = item,
+                State = PowerForgeReleaseProgressItemState.Failed,
+                Detail = "Module version '3.0.76' is not greater than repository version '3.0.76'."
+            });
+            request.OutputLineReceived!(
+                "##powerforge-module-progress-v1##" +
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(failed)));
+            return new PowerShellRunResult(
+                1,
+                "many lines of successful build output",
+                string.Empty,
+                "pwsh");
+        });
+
+        var result = await new ModuleBuildHostService(runner).ExecuteBuildAsync(
+            new ModuleBuildHostBuildRequest
+            {
+                RepositoryRoot = @"C:\repo",
+                ScriptPath = @"C:\repo\Build\Build-Module.ps1",
+                ModulePath = @"C:\repo\Module\PSPublishModule.psd1",
+                Progress = progress
+            });
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(
+            "Module version '3.0.76' is not greater than repository version '3.0.76'.",
+            result.FailureMessage);
+    }
+
     private sealed class RecordingReleaseProgress : IPowerForgeReleaseProgressReporterV2
     {
         public List<PowerForgeReleaseProgressItem> Planned { get; } = new();

--- a/PowerForge.Tests/ModulePipelinePublishVersionAvailabilityTests.cs
+++ b/PowerForge.Tests/ModulePipelinePublishVersionAvailabilityTests.cs
@@ -1,0 +1,172 @@
+namespace PowerForge.Tests;
+
+public sealed class ModulePipelinePublishVersionAvailabilityTests
+{
+    [Fact]
+    public void Plan_PublishGateVerifiesRepositoryAvailabilityForLocalVersion()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            const string moduleName = "AvailabilityModule";
+            File.WriteAllText(
+                Path.Combine(root.FullName, moduleName + ".psd1"),
+                "@{ ModuleVersion = '1.0.0'; RootModule = 'AvailabilityModule.psm1' }");
+            File.WriteAllText(
+                Path.Combine(root.FullName, moduleName + ".psm1"),
+                string.Empty);
+
+            bool? capturedVerification = null;
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: null,
+                gitHubReleasePublisher: null,
+                moduleVersionStepResolver: (expectedVersion, _, _, _, verifyRepositoryAvailability) =>
+                {
+                    capturedVerification = verifyRepositoryAvailability;
+                    return new ModuleVersionStepResult(
+                        expectedVersion,
+                        "1.0.2",
+                        "1.0.1",
+                        ModuleVersionSource.Repository,
+                        usedAutoVersioning: true);
+                });
+
+            var plan = runner.Plan(new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.X"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationGateSegment
+                    {
+                        Configuration = new GateConfiguration
+                        {
+                            Mode = ConfigurationGateMode.Publish
+                        }
+                    },
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            LocalVersion = true
+                        }
+                    }
+                }
+            });
+
+            Assert.True(capturedVerification);
+            Assert.Equal("1.0.2", plan.ResolvedVersion);
+        }
+        finally
+        {
+            try
+            {
+                root.Delete(recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup for transient file handles.
+            }
+        }
+    }
+
+    [Fact]
+    public void Plan_BuildGateKeepsLocalVersionResolutionOffline()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            const string moduleName = "OfflineModule";
+            File.WriteAllText(
+                Path.Combine(root.FullName, moduleName + ".psd1"),
+                "@{ ModuleVersion = '1.0.0'; RootModule = 'OfflineModule.psm1' }");
+            File.WriteAllText(
+                Path.Combine(root.FullName, moduleName + ".psm1"),
+                string.Empty);
+
+            bool? capturedVerification = null;
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: null,
+                gitHubReleasePublisher: null,
+                moduleVersionStepResolver: (expectedVersion, _, _, _, verifyRepositoryAvailability) =>
+                {
+                    capturedVerification = verifyRepositoryAvailability;
+                    return new ModuleVersionStepResult(
+                        expectedVersion,
+                        "1.0.1",
+                        "1.0.0",
+                        ModuleVersionSource.LocalPsd1,
+                        usedAutoVersioning: true);
+                });
+
+            var plan = runner.Plan(new ModulePipelineSpec
+            {
+                Build = new ModuleBuildSpec
+                {
+                    Name = moduleName,
+                    SourcePath = root.FullName,
+                    Version = "1.0.X"
+                },
+                Install = new ModulePipelineInstallOptions { Enabled = false },
+                Segments = new IConfigurationSegment[]
+                {
+                    new ConfigurationGateSegment
+                    {
+                        Configuration = new GateConfiguration
+                        {
+                            Mode = ConfigurationGateMode.Build
+                        }
+                    },
+                    new ConfigurationBuildSegment
+                    {
+                        BuildModule = new BuildModuleConfiguration
+                        {
+                            LocalVersion = true
+                        }
+                    }
+                }
+            });
+
+            Assert.False(capturedVerification);
+            Assert.Equal("1.0.1", plan.ResolvedVersion);
+        }
+        finally
+        {
+            try
+            {
+                root.Delete(recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup for transient file handles.
+            }
+        }
+    }
+}

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -552,6 +552,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
 
             string? capturedFloor = null;
             string? capturedProject = null;
+            bool? capturedRepositoryVerification = null;
             var runner = new ModulePipelineRunner(
                 new NullLogger(),
                 powerShellRunner: null,
@@ -588,6 +589,17 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                             Release = release
                         }
                     };
+                },
+                gitHubReleasePublisher: null,
+                moduleVersionStepResolver: (expectedVersion, _, _, _, verifyRepositoryAvailability) =>
+                {
+                    capturedRepositoryVerification = verifyRepositoryAvailability;
+                    return new ModuleVersionStepResult(
+                        expectedVersion,
+                        coordinatedVersion,
+                        "2.1.6",
+                        ModuleVersionSource.Repository,
+                        usedAutoVersioning: true);
                 });
 
             var result = runner.Run(new ModulePipelineSpec
@@ -602,6 +614,13 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
                 Install = new ModulePipelineInstallOptions { Enabled = false },
                 Segments = new IConfigurationSegment[]
                 {
+                    new ConfigurationGateSegment
+                    {
+                        Configuration = new GateConfiguration
+                        {
+                            Mode = ConfigurationGateMode.Publish
+                        }
+                    },
                     new ConfigurationBuildSegment
                     {
                         BuildModule = new BuildModuleConfiguration { LocalVersion = true }
@@ -631,6 +650,7 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.Equal(coordinatedVersion, capturedFloor);
             Assert.Equal(moduleName, capturedProject);
             Assert.Equal(coordinatedVersion, result.Plan.ResolvedVersion);
+            Assert.True(capturedRepositoryVerification);
         }
         finally
         {

--- a/PowerForge.Tests/ModuleVersionStepperTests.cs
+++ b/PowerForge.Tests/ModuleVersionStepperTests.cs
@@ -109,6 +109,35 @@ public sealed class ModuleVersionStepperTests
     }
 
     [Fact]
+    public void Step_PublishAvailabilityCheckBumpsPastRepositoryVersionWhenLocalManifestIsStale()
+    {
+        using var directory = new TemporaryDirectory();
+        var manifestPath = Path.Combine(directory.Path, "PSPublishModule.psd1");
+        File.WriteAllText(manifestPath, "@{ ModuleVersion = '3.0.75' }");
+
+        using var client = new HttpClient(new FakeCandidateReservationHandler("3.0.76"));
+        var stepper = new ModuleVersionStepper(
+            new NullLogger(),
+            new StubPowerShellRunner(new PowerShellRunResult(
+                1,
+                string.Empty,
+                "Find-PSResource should not run.",
+                "pwsh.exe")),
+            client);
+
+        var result = stepper.Step(
+            "3.0.X",
+            moduleName: "PSPublishModule",
+            localPsd1Path: manifestPath,
+            repository: "PSGallery",
+            verifyRepositoryAvailability: true);
+
+        Assert.Equal("3.0.77", result.Version);
+        Assert.Equal(ModuleVersionSource.LocalPsd1, result.CurrentVersionSource);
+        Assert.Equal("3.0.75", result.CurrentVersion);
+    }
+
+    [Fact]
     public void Step_MissingLocalPsd1DoesNotUseAnUnverifiedBaselineCandidate()
     {
         using var directory = new TemporaryDirectory();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
@@ -144,6 +144,23 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void BuildModuleFailureMessage_UsesBoundedStdoutTailWhenStructuredFailureIsUnavailable()
+    {
+        var message = PowerForgeReleaseService.BuildModuleFailureMessage(
+            @"C:\repo\powerforge.json",
+            new ModuleBuildHostExecutionResult
+            {
+                ExitCode = 1,
+                StandardOutput = "\u001b[31m" + new string('x', 5_000) + "\u001b[0m\r\nActual module failure"
+            });
+
+        Assert.Contains("Actual module failure", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\u001b[31m", message, StringComparison.Ordinal);
+        Assert.DoesNotContain(new string('x', 5_000), message, StringComparison.Ordinal);
+        Assert.InRange(message.Length, 1, 4_200);
+    }
+
+    [Fact]
     public void Execute_deferred_json_module_publish_reuses_and_cleans_staging_directory()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.ModulePublicationOrdering.cs
@@ -91,6 +91,59 @@ public sealed partial class PowerForgeReleaseServiceTests
     }
 
     [Fact]
+    public void Execute_build_mode_never_defers_or_publishes_module()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var scriptPath = Path.Combine(root, "Build-Module.ps1");
+            var releasePath = Path.Combine(root, "release.json");
+            File.WriteAllText(scriptPath, "# module build");
+            File.WriteAllText(releasePath, "{}");
+            var moduleCalls = new List<ModuleExecutionSnapshot>();
+            var service = CreateReleaseService(
+                root,
+                moduleCalls,
+                new PowerForgeToolReleaseResult { Success = true });
+
+            var result = service.Execute(
+                CreateReleaseSpec(root, scriptPath),
+                new PowerForgeReleaseRequest
+                {
+                    ConfigPath = releasePath,
+                    ModuleRunMode = ConfigurationGateMode.Build
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var build = Assert.Single(moduleCalls);
+            Assert.Equal(ConfigurationGateMode.Build, build.RunMode);
+            Assert.True(build.IncludeModulePublishing);
+            Assert.Null(result.ModulePublication);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void BuildModuleFailureMessage_UsesStructuredFailureWithoutRepeatingStandardOutput()
+    {
+        var message = PowerForgeReleaseService.BuildModuleFailureMessage(
+            @"C:\repo\powerforge.json",
+            new ModuleBuildHostExecutionResult
+            {
+                ExitCode = 1,
+                FailureMessage = "The module version is already published.",
+                StandardOutput = "hundreds of lines of ordinary build output"
+            });
+
+        Assert.Contains("exit code 1", message, StringComparison.Ordinal);
+        Assert.Contains("The module version is already published.", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("ordinary build output", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_deferred_json_module_publish_reuses_and_cleans_staging_directory()
     {
         var root = CreateSandbox();

--- a/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
+++ b/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Concurrent;
+using PowerForge.ConsoleShared;
+using Spectre.Console;
+
+namespace PowerForge.Tests;
+
+public sealed class SpectreBuildProgressColumnsTests
+{
+    [Fact]
+    public void CreateStandard_UsesLeftAnchoredModuleStyleLayout()
+    {
+        var columns = SpectreBuildProgressColumns.CreateStandard();
+
+        Assert.Collection(
+            columns,
+            column =>
+            {
+                var description = Assert.IsType<TaskDescriptionColumn>(column);
+                Assert.Equal(Justify.Left, description.Alignment);
+            },
+            column => Assert.IsType<ProgressBarColumn>(column),
+            column => Assert.IsType<PercentageColumn>(column),
+            column => Assert.IsType<ElapsedTimeColumn>(column),
+            column => Assert.IsType<SpinnerColumn>(column));
+    }
+
+    [Fact]
+    public void CreateDetailed_UsesTheSharedModuleAndExecutableLayout()
+    {
+        var columns = SpectreBuildProgressColumns.CreateDetailed(
+            includeBar: true,
+            includeElapsed: true,
+            barWidth: 18,
+            new ConcurrentDictionary<ProgressTask, string>(),
+            new ConcurrentDictionary<ProgressTask, DateTimeOffset>(),
+            new ConcurrentDictionary<ProgressTask, TimeSpan>());
+
+        Assert.Collection(
+            columns,
+            column => Assert.Equal("StepIconColumn", column.GetType().Name),
+            column => Assert.Equal("LeftDescriptionColumn", column.GetType().Name),
+            column =>
+            {
+                var bar = Assert.IsType<ProgressBarColumn>(column);
+                Assert.Equal(18, bar.Width);
+            },
+            column => Assert.IsType<PercentageColumn>(column),
+            column => Assert.Equal("FixedElapsedColumn", column.GetType().Name),
+            column => Assert.IsType<SpinnerColumn>(column));
+    }
+
+    [Fact]
+    public void Run_WritesCompletedProgressFrameAfterLiveDisplayCloses()
+    {
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new TerminalConsoleOutput(writer),
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Interactive = InteractionSupport.Yes
+        });
+
+        SpectreProgressDisplay.Run(
+            console,
+            [
+                new TaskDescriptionColumn { Alignment = Justify.Left },
+                new PercentageColumn()
+            ],
+            context =>
+            {
+                var task = context.AddTask("Retained build step", maxValue: 1, autoStart: false);
+                task.StartTask();
+                context.Refresh();
+                task.Value = 1;
+                task.StopTask();
+                context.Refresh();
+            });
+
+        var output = writer.ToString().TrimEnd();
+        Assert.EndsWith("Retained build step 100%", output, StringComparison.Ordinal);
+    }
+
+    private sealed class TerminalConsoleOutput : IAnsiConsoleOutput
+    {
+        public TerminalConsoleOutput(TextWriter writer)
+            => Writer = writer;
+
+        public TextWriter Writer { get; }
+
+        public bool IsTerminal => true;
+
+        public int Width => 120;
+
+        public int Height => 40;
+
+        public void SetEncoding(System.Text.Encoding encoding)
+        {
+        }
+    }
+}

--- a/PowerForge/Models/ModuleBuildHostExecutionResult.cs
+++ b/PowerForge/Models/ModuleBuildHostExecutionResult.cs
@@ -26,6 +26,11 @@ public sealed class ModuleBuildHostExecutionResult
     public string StandardError { get; set; } = string.Empty;
 
     /// <summary>
+    /// Concise failure detail reported by the structured module progress protocol.
+    /// </summary>
+    public string? FailureMessage { get; set; }
+
+    /// <summary>
     /// PowerShell executable used for the run.
     /// </summary>
     public string Executable { get; set; } = string.Empty;

--- a/PowerForge/Services/ModuleBuildHostService.cs
+++ b/PowerForge/Services/ModuleBuildHostService.cs
@@ -91,9 +91,15 @@ public sealed class ModuleBuildHostService
             {
                 [ModulePipelineProgressProtocol.EnvironmentVariable] = "1"
             };
+        string? progressFailure = null;
         Action<string>? outputLineReceived = progress is null
             ? null
-            : line => ForwardProgress(line, progress);
+            : line =>
+            {
+                var failure = ForwardProgress(line, progress);
+                if (!string.IsNullOrWhiteSpace(failure))
+                    progressFailure = failure;
+            };
         var runRequest = requiredRuntimeMajor > 0
             ? PowerShellRunRequest.ForCompatibleCommand(
                 commandText: script,
@@ -127,6 +133,7 @@ public sealed class ModuleBuildHostService
             Duration = startedAt.Elapsed,
             StandardOutput = progress is null ? result.StdOut : StripProgressLines(result.StdOut),
             StandardError = result.StdErr,
+            FailureMessage = progressFailure,
             Executable = result.Executable
         };
     }
@@ -142,18 +149,22 @@ public sealed class ModuleBuildHostService
         return string.Join(Environment.NewLine, lines).TrimEnd('\r', '\n');
     }
 
-    private static void ForwardProgress(
+    private static string? ForwardProgress(
         string line,
         IPowerForgeReleaseProgressReporterV2 progress)
     {
         if (!ModulePipelineProgressProtocol.TryParse(line, out var message) || message is null)
-            return;
+            return null;
 
         if (message.Items is { Length: > 0 })
             progress.ItemsPlanned(PowerForgeReleaseProgressPhase.Module, message.Items);
 
         if (message.Item is not null && message.State.HasValue)
             progress.ItemUpdated(message.Item, message.State.Value, message.Detail);
+
+        return message.State == PowerForgeReleaseProgressItemState.Failed
+            ? message.Detail
+            : null;
     }
 
     private static PowerShellHostRequirements ResolveHostRequirements(string? framework)

--- a/PowerForge/Services/ModuleVersionStepper.cs
+++ b/PowerForge/Services/ModuleVersionStepper.cs
@@ -48,12 +48,17 @@ public sealed class ModuleVersionStepper
     /// <param name="localPsd1Path">Optional local PSD1 path to resolve current version from.</param>
     /// <param name="repository">Repository name used with PSResourceGet (default: PSGallery).</param>
     /// <param name="prerelease">Whether to include prerelease versions when resolving current version.</param>
+    /// <param name="verifyRepositoryAvailability">
+    /// Whether a candidate derived from a local manifest must also be checked against the repository.
+    /// Enable this for publish planning so a stale local manifest cannot select an already-published version.
+    /// </param>
     public ModuleVersionStepResult Step(
         string expectedVersion,
         string? moduleName = null,
         string? localPsd1Path = null,
         string repository = "PSGallery",
-        bool prerelease = false)
+        bool prerelease = false,
+        bool verifyRepositoryAvailability = false)
     {
         if (string.IsNullOrWhiteSpace(expectedVersion))
             throw new ArgumentException("ExpectedVersion is required.", nameof(expectedVersion));
@@ -71,8 +76,12 @@ public sealed class ModuleVersionStepper
 
         var (current, source) = ResolveCurrentVersion(expectedVersion, moduleName, localPsd1Path, repository, prerelease);
         var proposed = ComputeNextVersion(expectedVersion, current);
-        if (source != ModuleVersionSource.LocalPsd1 || current is null)
+        if (verifyRepositoryAvailability ||
+            source != ModuleVersionSource.LocalPsd1 ||
+            current is null)
+        {
             proposed = EnsureResolvedVersionIsAvailable(expectedVersion, moduleName, repository, prerelease, proposed);
+        }
 
         return new ModuleVersionStepResult(
             expectedVersion: expectedVersion,

--- a/PowerForge/Services/PowerForgeReleaseService.VersionCoordination.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.VersionCoordination.cs
@@ -84,7 +84,9 @@ internal sealed partial class PowerForgeReleaseService
             expectedVersion!,
             moduleName,
             manifestPath,
-            prerelease: !string.IsNullOrWhiteSpace(preRelease));
+            prerelease: !string.IsNullOrWhiteSpace(preRelease),
+            verifyRepositoryAvailability:
+                request.ModuleRunMode == ConfigurationGateMode.Publish);
         var candidate = ModulePathTokenFormatter.FormatVersionWithPreRelease(step.Version, preRelease);
         if (!PackageVersionUtility.TryNormalizeExact(candidate, out var normalizedFloor))
             throw new InvalidOperationException($"Coordinated module version floor '{candidate}' is not a valid exact package version.");

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace PowerForge;
 
@@ -12,6 +13,9 @@ internal sealed partial class PowerForgeReleaseService
 {
     private static readonly JsonSerializerOptions DotNetToolsJsonOptions = CreateJsonOptions();
     private static readonly JsonSerializerOptions WorkspaceValidationJsonOptions = CreateJsonOptions();
+    private static readonly Regex AnsiEscapeSequence = new(
+        @"\x1B\[[0-?]*[ -/]*[@-~]",
+        RegexOptions.Compiled);
 
     private const string DefaultDotNetTargetOutputTemplate =
         "Artifacts/DotNetPublish/{target}/{rid}/{framework}/{style}";
@@ -4871,11 +4875,38 @@ internal sealed partial class PowerForgeReleaseService
         var detail = result.FailureMessage is string structuredFailure &&
                      !string.IsNullOrWhiteSpace(structuredFailure)
             ? structuredFailure
-            : result.StandardError;
+            : !string.IsNullOrWhiteSpace(result.StandardError)
+                ? result.StandardError
+                : NormalizeModuleFailureOutput(result.StandardOutput);
 
         if (string.IsNullOrWhiteSpace(detail))
             return heading + " See the captured module log for details.";
 
-        return heading + Environment.NewLine + detail.Trim();
+        return heading + Environment.NewLine + detail!.Trim();
+    }
+
+    private static string? NormalizeModuleFailureOutput(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return null;
+
+        var plain = AnsiEscapeSequence
+            .Replace(output, string.Empty)
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n');
+        var normalized = string.Join(
+            Environment.NewLine,
+            plain.Split('\n')
+                .Select(static line => line.Trim())
+                .Where(static line => line.Length > 0));
+
+        if (normalized.Length == 0)
+            return null;
+
+        const int maxCharacters = 4_000;
+        if (normalized.Length <= maxCharacters)
+            return normalized;
+
+        return "…" + normalized.Substring(normalized.Length - (maxCharacters - 1));
     }
 }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -4865,19 +4865,17 @@ internal sealed partial class PowerForgeReleaseService
         return fullPath + Path.DirectorySeparatorChar;
     }
 
-    private static string BuildModuleFailureMessage(string scriptPath, ModuleBuildHostExecutionResult result)
+    internal static string BuildModuleFailureMessage(string scriptPath, ModuleBuildHostExecutionResult result)
     {
-        var message = string.Join(
-            Environment.NewLine,
-            new[]
-            {
-                result.StandardError,
-                result.StandardOutput
-            }.Where(text => !string.IsNullOrWhiteSpace(text)));
+        var heading = $"Module release workflow failed while executing '{scriptPath}' (exit code {result.ExitCode}).";
+        var detail = result.FailureMessage is string structuredFailure &&
+                     !string.IsNullOrWhiteSpace(structuredFailure)
+            ? structuredFailure
+            : result.StandardError;
 
-        if (string.IsNullOrWhiteSpace(message))
-            return $"Module release workflow failed while executing '{scriptPath}'.";
+        if (string.IsNullOrWhiteSpace(detail))
+            return heading + " See the captured module log for details.";
 
-        return $"Module release workflow failed while executing '{scriptPath}'.{Environment.NewLine}{message}";
+        return heading + Environment.NewLine + detail.Trim();
     }
 }


### PR DESCRIPTION
## Summary

- use one shared Spectre progress lifecycle across module, project, unified release, and executable builds
- left-anchor standard phase descriptions and retain the completed progress frame after live rendering ends
- consolidate the detailed module/tool icon, description, bar, percentage, elapsed, and spinner columns in `PowerForge.ConsoleShared`
- preserve concise structured module failures, with a normalized bounded stdout tail when redirected execution cannot emit structured progress
- make standalone and unified Publish planning skip module versions already present in the target repository while keeping Build planning local and offline

## Behavior

OfficeIMO's existing `Build/Build-Project.ps1` remains a thin `Invoke-ProjectBuild` consumer and receives the standard project progress visual through PSPublishModule. Detailed module and tool rows keep their step icons, while their alignment and progress lifecycle come from the same shared renderer.

No public API or consumer-wrapper change is required. Consumers receive the behavior after the updated PSPublishModule/PowerForge package is published and installed.

## Validation

- complete PSPublishModule unified Build workflow: succeeded in 8m16s with module/package version 3.0.76, 10 tool-output steps, and 24 release assets
- OfficeIMO 85-project plan through the locally built module: succeeded with 85 packable projects and 85 packages
- 297 affected tests passed; PSPublishModule and PowerForge CLI built cleanly for all supported target frameworks
- live Publish planning selected 3.0.77 because public version 3.0.76 was already occupied