### PR TITLE
Make GitHub release publishing visible and collision-safe

### DIFF
--- a/Build/release.json
+++ b/Build/release.json
@@ -114,7 +114,8 @@
     "TokenFilePath": "C:\\Support\\Important\\GithubAPI.txt",
     "GenerateReleaseNotes": true,
     "IsPreRelease": false,
-    "ReplaceExistingAssets": true,
+    "ReuseExistingRelease": false,
+    "ReplaceExistingAssets": false,
     "TagTemplate": "v{Version}",
     "ReleaseNameTemplate": "PSPublishModule {Version}"
   }

--- a/Docs/PSPublishModule.ProjectBuild.md
+++ b/Docs/PSPublishModule.ProjectBuild.md
@@ -230,13 +230,18 @@ Example unified GitHub release publishing from staged assets:
 "GitHub": {
   "Publish": true,
   "TagTemplate": "v{Version}",
-  "ReleaseNameTemplate": "{Repository} {Version}"
+  "ReleaseNameTemplate": "{Repository} {Version}",
+  "ReuseExistingRelease": false,
+  "ReplaceExistingAssets": false
 }
 ```
 
 - use `--publish-project-github` (or set `GitHub.Publish: true`) to upload the unified staged release as one repo release
 - when top-level `GitHub` is active, package-host GitHub publishing is suppressed and the staged release assets are uploaded instead
 - uploaded assets include staged `NuGet`, `Portable`, `Installer`, `Tool`, metadata files, top-level `release-manifest.json` / `SHA256SUMS.txt`, and any generated Winget manifests
+- publish-mode auto-version patterns reserve a version that is free in the module/package repository and in the configured GitHub tag/release namespace; build and plan modes stay offline
+- normal unified releases do not silently reuse an occupied GitHub tag; set `ReuseExistingRelease: true` only for a deliberate recovery run, and combine it with `ReplaceExistingAssets: true` only when same-named assets should be replaced
+- interactive PowerForge hosts show the active asset, transferred bytes, total bytes, and final created/reused/uploaded/skipped/replaced counts
 
 - Plan or build preview executables only:
 

--- a/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
+++ b/Docs/PSPublishModule.UnifiedModuleProjectRelease.md
@@ -100,6 +100,11 @@ NuGet package publishing stays in `New-ConfigurationProjectBuild` / `New-Configu
 that is package-lane behavior. PowerShell Gallery and top-level GitHub publishing stay with module/release
 publish configuration.
 
+For direct `Build-Module` GitHub publishing, an X-pattern version also skips occupied GitHub tags/releases during
+publish planning. The publish row switches to determinate byte progress and shows the active asset. Existing releases
+are not reused by default. Use `-ReuseExistingRelease` only for a deliberate recovery run, and add
+`-ReplaceExistingAssets` only when that recovery should replace same-name assets.
+
 ### PowerShell-authored package configuration
 
 For modules where you want the whole release in PowerShell, declare the package config inline. It maps to
@@ -436,7 +441,7 @@ Keep three layers:
 The release runtime executes these phases:
 
 1. Load and validate every section.
-2. Resolve one release version from `VersionTracks`, `ExpectedVersionMap`, explicit module version, or a declared primary package.
+2. Resolve one release version from `VersionTracks`, `ExpectedVersionMap`, explicit module version, or a declared primary package. Publish-mode auto-versioning also skips occupied unified GitHub tags/releases.
 3. Plan packages and module before doing any destructive or publishing work.
 4. If the module needs packages from this same release, build packages to a local staging feed first.
 5. Build the module against either project references or the staged local package feed.
@@ -445,7 +450,7 @@ The release runtime executes these phases:
 8. Publish the module to PSGallery or configured private gallery.
 9. Stage all release assets into one upload-ready folder.
 10. Write `release-manifest.json` and `SHA256SUMS.txt`.
-11. Publish one GitHub release from the staged asset list.
+11. Publish one GitHub release from the staged asset list, with visible per-asset byte progress and an explicit created-versus-recovery result.
 
 This keeps publication fail-fast while avoiding a half-published release where NuGet is updated before the
 module can even be built.

--- a/Module/Docs/New-ConfigurationPublish.md
+++ b/Module/Docs/New-ConfigurationPublish.md
@@ -11,12 +11,12 @@ Provides a way to configure publishing to PowerShell Gallery, GitHub, JFrog Arti
 ## SYNTAX
 ### ApiFromFile (Default)
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> [-FilePath <string>] [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [-RequiredModuleSourceRepositoryUri <string>] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> [-FilePath <string>] [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-ReuseExistingRelease] [-ReplaceExistingAssets] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [-RequiredModuleSourceRepositoryUri <string>] [<CommonParameters>]
 ```
 
 ### ApiKey
 ```powershell
-New-ConfigurationPublish -Type <PublishDestination> [-ApiKey <string>] [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [-RequiredModuleSourceRepositoryUri <string>] [<CommonParameters>]
+New-ConfigurationPublish -Type <PublishDestination> [-ApiKey <string>] [-UserName <string>] [-RepositoryName <string>] [-Tool <PublishTool>] [-RepositoryUri <string>] [-RepositorySourceUri <string>] [-RepositoryPublishUri <string>] [-RepositoryTrusted <bool>] [-RepositoryPriority <int>] [-RepositoryApiVersion <RepositoryApiVersion>] [-EnsureRepositoryRegistered <bool>] [-UnregisterRepositoryAfterPublish] [-RepositoryCredentialUserName <string>] [-RepositoryCredentialSecret <string>] [-RepositoryCredentialSecretFilePath <string>] [-RepositoryCredentialSecretEnvironmentVariable <string>] [-Enabled] [-OverwriteTagName <string>] [-Force] [-ID <string>] [-DoNotMarkAsPreRelease] [-GenerateReleaseNotes] [-ReuseExistingRelease] [-ReplaceExistingAssets] [-UseAsDependencyVersionSource] [-PublishRequiredModules] [-RequiredModuleSourceRepository <string>] [-RequiredModuleSourceRepositoryUri <string>] [<CommonParameters>]
 ```
 
 ### JFrog
@@ -440,6 +440,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -ReplaceExistingAssets
+Replace same-name assets when deliberately reusing an existing GitHub release.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ApiFromFile, ApiKey
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -RepositoryApiVersion
 Repository API version for PSResourceGet registration (v2/v3).
 
@@ -638,6 +654,22 @@ Repository URL or local feed path used by managed publishing as the source for m
 ```yaml
 Type: String
 Parameter Sets: ApiFromFile, ApiKey, JFrog, AzureArtifacts, Profile
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -ReuseExistingRelease
+Explicitly reuse an existing GitHub release when its tag is already occupied.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ApiFromFile, ApiKey
 Aliases: None
 Possible values:
 

--- a/Module/Docs/Send-GitHubRelease.md
+++ b/Module/Docs/Send-GitHubRelease.md
@@ -199,8 +199,8 @@ Accept wildcard characters: True
 ```
 
 ### -ReuseExistingReleaseOnConflict
-When true (default), a 422 tag conflict reuses the existing release.
-When false, the cmdlet fails on existing tags.
+When true, a 422 tag conflict deliberately reuses the existing release.
+The default is false so normal publishing cannot mutate an older release.
 
 ```yaml
 Type: Boolean

--- a/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
+++ b/PSPublishModule/Cmdlets/NewConfigurationPublishCommand.cs
@@ -269,6 +269,16 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
     [Parameter(ParameterSetName = "ApiFromFile")]
     public SwitchParameter GenerateReleaseNotes { get; set; }
 
+    /// <summary>Explicitly reuse an existing GitHub release when its tag is already occupied.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    public SwitchParameter ReuseExistingRelease { get; set; }
+
+    /// <summary>Replace same-name assets when deliberately reusing an existing GitHub release.</summary>
+    [Parameter(ParameterSetName = "ApiKey")]
+    [Parameter(ParameterSetName = "ApiFromFile")]
+    public SwitchParameter ReplaceExistingAssets { get; set; }
+
     /// <summary>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</summary>
     [Parameter(ParameterSetName = "ApiKey")]
     [Parameter(ParameterSetName = "ApiFromFile")]
@@ -427,6 +437,8 @@ public sealed class NewConfigurationPublishCommand : PSCmdlet
             ID = ID,
             DoNotMarkAsPreRelease = DoNotMarkAsPreRelease.IsPresent,
             GenerateReleaseNotes = GenerateReleaseNotes.IsPresent,
+            ReuseExistingRelease = ReuseExistingRelease.IsPresent,
+            ReplaceExistingAssets = ReplaceExistingAssets.IsPresent,
             UseAsDependencyVersionSource = UseAsDependencyVersionSource.IsPresent,
             PublishRequiredModules = PublishRequiredModules.IsPresent,
             RequiredModuleSourceRepository = requiredModuleSourceRepository,

--- a/PSPublishModule/Cmdlets/SendGitHubReleaseCommand.cs
+++ b/PSPublishModule/Cmdlets/SendGitHubReleaseCommand.cs
@@ -83,11 +83,11 @@ public sealed class SendGitHubReleaseCommand : PSCmdlet
     public bool IsPreRelease { get; set; }
 
     /// <summary>
-    /// When true (default), a 422 tag conflict reuses the existing release.
-    /// When false, the cmdlet fails on existing tags.
+    /// When true, a 422 tag conflict deliberately reuses the existing release.
+    /// The default is false so normal publishing cannot mutate an older release.
     /// </summary>
     [Parameter]
-    public bool ReuseExistingReleaseOnConflict { get; set; } = true;
+    public bool ReuseExistingReleaseOnConflict { get; set; }
 
     /// <summary>Creates the release and uploads assets.</summary>
     protected override void ProcessRecord()

--- a/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
@@ -350,7 +350,7 @@ internal static class SpectreModulePipelineConsoleUi
         }
     }
 
-    private sealed class SpectrePipelineProgressReporter : IModulePipelineProgressReporterV2
+    private sealed class SpectrePipelineProgressReporter : IModulePipelineProgressReporterV3
     {
         private readonly IReadOnlyDictionary<string, ProgressTask> _tasks;
         private readonly IReadOnlyDictionary<string, string> _labels;
@@ -430,6 +430,27 @@ internal static class SpectreModulePipelineConsoleUi
                 task.Description = $"{label.TrimEnd()} SKIPPED";
 
             try { task.StopTask(); } catch { }
+        }
+
+        public void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null)
+        {
+            if (step is null || !_tasks.TryGetValue(step.Key, out var task)) return;
+
+            task.IsIndeterminate = maximum <= 0;
+            if (maximum > 0)
+            {
+                task.MaxValue = maximum;
+                task.Value = Math.Min(Math.Max(0, value), maximum);
+            }
+
+            if (_labels.TryGetValue(step.Key, out var label))
+            {
+                task.Description = string.IsNullOrWhiteSpace(detail)
+                    ? label
+                    : $"{label.TrimEnd()} [grey]— {Markup.Escape(detail!)}[/]";
+            }
+
+            try { task.StartTask(); } catch { }
         }
     }
 

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -19,7 +19,10 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         if (run is null) throw new ArgumentNullException(nameof(run));
 
         var phases = ResolvePhases(spec, request);
-        WriteHeader(spec, request, phases);
+        var phaseNames = phases.ToDictionary(
+            phase => phase,
+            phase => GetPhaseName(phase, spec, request));
+        WriteHeader(spec, request, phases, phaseNames);
         PowerForgeReleaseResult? result = null;
         Exception? failure = null;
 
@@ -29,8 +32,8 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             {
                 var tasks = phases.ToDictionary(
                     phase => phase,
-                    phase => context.AddTask($"[grey]{Markup.Escape(GetPhaseName(phase))} — pending[/]", maxValue: 100, autoStart: false));
-                var reporter = new Reporter(context, tasks);
+                    phase => context.AddTask($"[grey]{Markup.Escape(phaseNames[phase])} — pending[/]", maxValue: 100, autoStart: false));
+                var reporter = new Reporter(context, tasks, phaseNames);
                 try
                 {
                     result = run(reporter);
@@ -68,13 +71,26 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             .AddColumn(new TableColumn("Item").NoWrap())
             .AddColumn(new TableColumn("Value"));
         table.AddRow("Status", result.Success ? "[green]Succeeded[/]" : "[red]Failed[/]");
-        if (!string.IsNullOrWhiteSpace(packageVersion)) table.AddRow("Package version", Esc(packageVersion));
+        if (!string.IsNullOrWhiteSpace(packageVersion)) table.AddRow("Package build version", Esc(packageVersion));
         if (!string.IsNullOrWhiteSpace(moduleVersion)) table.AddRow("Module version", Esc(moduleVersion));
         if (toolSteps > 0) table.AddRow("Tool output steps", toolSteps.ToString());
         table.AddRow("Release assets", result.ReleaseAssets.Length.ToString());
         var gitHubReleaseUrl = result.UnifiedGitHubRelease?.ReleaseUrl;
         if (!string.IsNullOrWhiteSpace(gitHubReleaseUrl))
+        {
             table.AddRow("GitHub release", Esc(gitHubReleaseUrl));
+            table.AddRow(
+                "GitHub action",
+                result.UnifiedGitHubRelease!.ReusedExistingRelease
+                    ? "[yellow]Reused existing release[/]"
+                    : "[green]Created new release[/]");
+            table.AddRow(
+                "GitHub assets",
+                Esc(
+                    $"{result.UnifiedGitHubRelease.UploadedAssets.Length} uploaded, " +
+                    $"{result.UnifiedGitHubRelease.SkippedExistingAssets.Length} skipped, " +
+                    $"{result.UnifiedGitHubRelease.ReplacedExistingAssets.Length} replaced"));
+        }
         table.AddRow("Duration", Esc(new BufferedLogSupportService().FormatDuration(duration)));
         if (!result.Success && !string.IsNullOrWhiteSpace(result.ErrorMessage))
             table.AddRow("Error", $"[red]{Esc(result.ErrorMessage)}[/]");
@@ -120,7 +136,8 @@ internal static class SpectrePowerForgeReleaseConsoleUi
     private static void WriteHeader(
         PowerForgeReleaseSpec spec,
         PowerForgeReleaseRequest request,
-        IReadOnlyList<PowerForgeReleaseProgressPhase> phases)
+        IReadOnlyList<PowerForgeReleaseProgressPhase> phases,
+        IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> phaseNames)
     {
         static string Esc(string? value) => Markup.Escape(value ?? string.Empty);
         var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
@@ -138,7 +155,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             .AddColumn(new TableColumn("Value"));
         table.AddRow("[grey]Mode[/]", request.PlanOnly ? "[yellow]Plan only[/]" : request.ValidateOnly ? "[yellow]Validate only[/]" : "[green]Release execution[/]");
         table.AddRow("[grey]Config[/]", Esc(request.ConfigPath));
-        table.AddRow("[grey]Order[/]", Esc(string.Join(" → ", phases.Select(GetPhaseName))));
+        table.AddRow("[grey]Order[/]", Esc(string.Join(" → ", phases.Select(phase => phaseNames[phase]))));
         table.AddRow("[grey]Version[/]", Esc(versionPolicy));
         if (toolOutputs > 0) table.AddRow("[grey]Tool matrix[/]", Esc($"{spec.Tools!.Targets.Length} target(s), {toolOutputs} output(s)"));
         AnsiConsole.Write(table);
@@ -153,12 +170,18 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 Math.Max(1, target.Runtimes?.Length ?? 0) *
                 Math.Max(1, target.Flavors?.Length ?? 0));
 
-    private static string GetPhaseName(PowerForgeReleaseProgressPhase phase)
+    private static string GetPhaseName(
+        PowerForgeReleaseProgressPhase phase,
+        PowerForgeReleaseSpec spec,
+        PowerForgeReleaseRequest request)
         => phase switch
         {
             PowerForgeReleaseProgressPhase.Versioning => "Plan packages and resolve shared version",
             PowerForgeReleaseProgressPhase.Module => "Build PowerShell module",
-            PowerForgeReleaseProgressPhase.Packages => "Build and publish NuGet packages",
+            PowerForgeReleaseProgressPhase.Packages =>
+                (request.PublishNuget ?? spec.Packages?.PublishNuget) == true
+                    ? "Build and publish NuGet packages"
+                    : "Build NuGet packages",
             PowerForgeReleaseProgressPhase.Tools => "Build executable matrix",
             PowerForgeReleaseProgressPhase.GitHub => "Publish unified GitHub release",
             _ => phase.ToString()
@@ -168,6 +191,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
     {
         private readonly ProgressContext _context;
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> _tasks;
+        private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> _phaseNames;
         private readonly HashSet<PowerForgeReleaseProgressPhase> _failed = new();
         private readonly Dictionary<string, ProgressTask> _itemTasks = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, PowerForgeReleaseProgressItem> _items = new(StringComparer.OrdinalIgnoreCase);
@@ -175,10 +199,12 @@ internal static class SpectrePowerForgeReleaseConsoleUi
 
         public Reporter(
             ProgressContext context,
-            IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> tasks)
+            IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> tasks,
+            IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> phaseNames)
         {
             _context = context;
             _tasks = tasks;
+            _phaseNames = phaseNames;
         }
 
         public void PhaseStarted(PowerForgeReleaseProgressPhase phase, int totalItems, string? detail = null)
@@ -266,7 +292,16 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             {
                 case PowerForgeReleaseProgressItemState.Started:
                     if (!task.IsStarted) task.StartTask();
-                    task.IsIndeterminate = true;
+                    if (item.ProgressMaximum > 0)
+                    {
+                        task.IsIndeterminate = false;
+                        task.Value = task.MaxValue *
+                                     Math.Min(1d, Math.Max(0d, item.ProgressValue / item.ProgressMaximum));
+                    }
+                    else
+                    {
+                        task.IsIndeterminate = true;
+                    }
                     break;
                 case PowerForgeReleaseProgressItemState.Completed:
                 case PowerForgeReleaseProgressItemState.Failed:
@@ -277,6 +312,8 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                     task.StopTask();
                     break;
             }
+
+            UpdatePhaseProgress(item.Phase);
         }
 
         public void FinishRemaining(bool success)
@@ -314,11 +351,35 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             }
         }
 
-        private static string Label(PowerForgeReleaseProgressPhase phase, string? detail, string color, string? status = null)
+        private string Label(PowerForgeReleaseProgressPhase phase, string? detail, string color, string? status = null)
         {
             var prefix = string.IsNullOrWhiteSpace(status) ? string.Empty : status + " ";
             var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : " — " + detail;
-            return $"[{color}]{Markup.Escape(prefix + GetPhaseName(phase) + suffix)}[/]";
+            return $"[{color}]{Markup.Escape(prefix + _phaseNames[phase] + suffix)}[/]";
+        }
+
+        private void UpdatePhaseProgress(PowerForgeReleaseProgressPhase phase)
+        {
+            if (!_tasks.TryGetValue(phase, out var phaseTask) ||
+                !phaseTask.IsStarted ||
+                phaseTask.IsFinished)
+            {
+                return;
+            }
+
+            lock (_sync)
+            {
+                var tasks = _items
+                    .Where(entry => entry.Value.Phase == phase)
+                    .Select(entry => _itemTasks[entry.Key])
+                    .ToArray();
+                if (tasks.Length == 0)
+                    return;
+
+                var completed = tasks.Sum(task =>
+                    task.MaxValue <= 0 ? 0 : Math.Min(1d, Math.Max(0d, task.Value / task.MaxValue)));
+                phaseTask.Value = Math.Max(5d, Math.Min(99d, completed / tasks.Length * 100d));
+            }
         }
 
         private int CountItems(PowerForgeReleaseProgressPhase phase)

--- a/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
+++ b/PowerForge.PowerShell/Models/PublishConfigurationRequest.cs
@@ -126,6 +126,12 @@ internal sealed class PublishConfigurationRequest
     /// <summary>Whether GitHub should generate release notes automatically.</summary>
     public bool GenerateReleaseNotes { get; set; }
 
+    /// <summary>Whether an existing GitHub release may be reused as an explicit recovery action.</summary>
+    public bool ReuseExistingRelease { get; set; }
+
+    /// <summary>Whether same-name GitHub assets may be replaced during explicit recovery.</summary>
+    public bool ReplaceExistingAssets { get; set; }
+
     /// <summary>Whether this repository should be used as a dependency-version source.</summary>
     public bool UseAsDependencyVersionSource { get; set; }
 

--- a/PowerForge.PowerShell/Services/ModulePipelineGitHubReleaseProgressAdapter.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineGitHubReleaseProgressAdapter.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PowerForge;
+
+internal sealed class ModulePipelineGitHubReleaseProgressAdapter : IGitHubReleaseProgressReporter
+{
+    private readonly ModulePipelineExecutionSession _session;
+    private readonly ModulePipelineStep? _step;
+    private readonly Dictionary<string, GitHubReleaseAssetProgress> _assets =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal ModulePipelineGitHubReleaseProgressAdapter(
+        ModulePipelineExecutionSession session,
+        ModulePipelineStep? step)
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _step = step;
+    }
+
+    public void Report(GitHubReleaseAssetProgress progress)
+    {
+        if (progress is null || string.IsNullOrWhiteSpace(progress.FilePath))
+            return;
+
+        _assets[progress.FilePath] = progress;
+        var maximum = _assets.Values.Sum(static asset => Math.Max(0, asset.TotalBytes));
+        var value = _assets.Values.Sum(GetCompletedBytes);
+        var fileName = string.IsNullOrWhiteSpace(progress.FileName)
+            ? Path.GetFileName(progress.FilePath)
+            : progress.FileName;
+        var detail = $"{Math.Max(1, progress.Position)}/{Math.Max(1, progress.TotalAssets)} {fileName}";
+        if (progress.TotalBytes > 0)
+        {
+            detail += $" — {DotNetRepositoryReleaseService.FormatBytes(Math.Max(0, progress.BytesTransferred))} / " +
+                      DotNetRepositoryReleaseService.FormatBytes(progress.TotalBytes);
+        }
+
+        _session.Progress(_step, value, maximum, detail);
+    }
+
+    private static long GetCompletedBytes(GitHubReleaseAssetProgress progress)
+        => progress.State is GitHubReleaseAssetProgressState.Uploaded or GitHubReleaseAssetProgressState.Skipped
+            ? Math.Max(0, progress.TotalBytes)
+            : Math.Max(0, progress.BytesTransferred);
+}

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.GitHubVersioning.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.GitHubVersioning.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PowerForge;
+
+public sealed partial class ModulePipelineRunner
+{
+    private string ResolveGitHubReleaseVersion(
+        string expectedVersion,
+        string candidateVersion,
+        IReadOnlyList<ConfigurationPublishSegment> publishes,
+        string projectRoot,
+        string moduleName,
+        string? preRelease)
+    {
+        var gitHubPublishes = (publishes ?? Array.Empty<ConfigurationPublishSegment>())
+            .Where(static segment => segment?.Configuration is
+            {
+                Enabled: true,
+                Destination: PublishDestination.GitHub
+            })
+            .Select(static segment => segment.Configuration)
+            .ToArray();
+        if (gitHubPublishes.Length == 0)
+            return candidateVersion;
+
+        var candidate = candidateVersion;
+        for (var pass = 0; pass < 24; pass++)
+        {
+            var before = candidate;
+            foreach (var publish in gitHubPublishes)
+            {
+                candidate = _gitHubVersionAvailabilityResolver(
+                    expectedVersion,
+                    candidate,
+                    publish,
+                    projectRoot,
+                    moduleName,
+                    preRelease);
+            }
+
+            if (string.Equals(before, candidate, StringComparison.OrdinalIgnoreCase))
+                return candidate;
+        }
+
+        throw new InvalidOperationException(
+            $"GitHub release version coordination did not stabilize after 24 passes for module '{moduleName}'.");
+    }
+}

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Plan.cs
@@ -560,6 +560,7 @@ public sealed partial class ModulePipelineRunner
         ApplyGateModeToPlanInputs(
             gateMode,
             ref refreshPsd1Only);
+        var enabledPublishes = ResolveGateFilteredPublishes(gateMode, publishes);
 
         var synchronizeModuleVersionForRun =
             !refreshPsd1Only &&
@@ -625,6 +626,17 @@ public sealed partial class ModulePipelineRunner
                 localPsd1,
                 prerelease: !string.IsNullOrWhiteSpace(preRelease),
                 verifyRepositoryAvailability: gateMode == ConfigurationGateMode.Publish).Version;
+            if (gateMode == ConfigurationGateMode.Publish &&
+                IsVersionPattern(expectedVersionResolved))
+            {
+                resolved = ResolveGitHubReleaseVersion(
+                    expectedVersionResolved,
+                    resolved,
+                    enabledPublishes,
+                    projectRoot,
+                    moduleName,
+                    preRelease);
+            }
         }
 
         // Resolve .csproj path: explicit build setting wins, otherwise derive from BuildLibraries NETProjectPath/ProjectName.
@@ -784,7 +796,6 @@ public sealed partial class ModulePipelineRunner
             _logger.Info("ResolveMissingModulesOnline not explicitly set; enabling because module dependencies use Auto/Latest/Guid Auto.");
         }
 
-        var enabledPublishes = ResolveGateFilteredPublishes(gateMode, publishes);
         var dependencyVersionSourceRepository = ResolvePublishDependencyVersionSource(
             ResolveDependencyVersionSourcePublishes(gateMode, publishes));
 

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.PublishOperations.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.PublishOperations.cs
@@ -231,11 +231,14 @@ public sealed partial class ModulePipelineRunner
         Action remotePublishAttempted)
     {
         var step = session.GetPublishStep(publish);
+        var gitHubProgress = publish.Configuration.Destination == PublishDestination.GitHub
+            ? new ModulePipelineGitHubReleaseProgressAdapter(session, step)
+            : null;
         session.Start(step);
         try
         {
             state.PublishResults.Add(ShouldPublishUnifiedGitHubRelease(plan, publish.Configuration)
-                ? PublishUnifiedGitHubRelease(publish.Configuration, plan, state, remotePublishAttempted)
+                ? PublishUnifiedGitHubRelease(publish.Configuration, plan, state, remotePublishAttempted, gitHubProgress)
                 : _hostedOperations.PublishModule(
                     publish.Configuration,
                     plan,
@@ -243,7 +246,8 @@ public sealed partial class ModulePipelineRunner
                     state.ArtefactResults,
                     includeScriptFolders: !state.PackageWithoutScriptFolders,
                     remotePublishAttempted: remotePublishAttempted,
-                    remoteSideEffectObserved: () => MarkSynchronizedReleaseRemoteSideEffectObserved(state)));
+                    remoteSideEffectObserved: () => MarkSynchronizedReleaseRemoteSideEffectObserved(state),
+                    gitHubProgress: gitHubProgress));
             session.Done(step);
         }
         catch (Exception ex)

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.Release.cs
@@ -391,7 +391,8 @@ public sealed partial class ModulePipelineRunner
         PublishConfiguration publish,
         ModulePipelinePlan plan,
         ModulePipelineRunState state,
-        Action remotePublishAttempted)
+        Action remotePublishAttempted,
+        IGitHubReleaseProgressReporter? gitHubProgress)
     {
         if (publish is null)
             throw new ArgumentNullException(nameof(publish));
@@ -429,8 +430,10 @@ public sealed partial class ModulePipelineRunner
             GenerateReleaseNotes = publish.GenerateReleaseNotes,
             IsDraft = false,
             IsPreRelease = isPreRelease,
-            ReuseExistingReleaseOnConflict = true,
-            AssetFilePaths = release.AssetPaths
+            ReuseExistingReleaseOnConflict = publish.ReuseExistingRelease,
+            ReplaceExistingAssets = publish.ReuseExistingRelease && publish.ReplaceExistingAssets,
+            AssetFilePaths = release.AssetPaths,
+            Progress = gitHubProgress
         });
 
         release.GitHub = gitHub;

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseFingerprint.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.SynchronizedReleaseFingerprint.cs
@@ -291,6 +291,8 @@ public sealed partial class ModulePipelineRunner
             publish.OverwriteTagName,
             publish.DoNotMarkAsPreRelease.ToString(),
             publish.GenerateReleaseNotes.ToString(),
+            publish.ReuseExistingRelease.ToString(),
+            publish.ReplaceExistingAssets.ToString(),
             publish.UseAsDependencyVersionSource.ToString(),
             publish.PublishRequiredModules.ToString(),
             NormalizeModuleRepositoryFingerprintSource(publish.RequiredModuleSourceRepository, plan.ProjectRoot),

--- a/PowerForge.PowerShell/Services/ModulePipelineRunner.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunner.cs
@@ -43,6 +43,7 @@ public sealed partial class ModulePipelineRunner
     private readonly ModulePipelineRunnerDefaults.ModulePackageBuildExecutor _packageBuildExecutor;
     private readonly ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher _gitHubReleasePublisher;
     private readonly ModulePipelineRunnerDefaults.ModuleVersionStepResolver _moduleVersionStepResolver;
+    private readonly ModulePipelineRunnerDefaults.ModuleGitHubVersionAvailabilityResolver _gitHubVersionAvailabilityResolver;
 
     private sealed class RequiredModuleDraft
     {
@@ -93,8 +94,9 @@ public sealed partial class ModulePipelineRunner
         IScriptFunctionExportDetector? scriptFunctionExportDetector = null,
         ModulePipelineRunnerDefaults.ModulePackageBuildExecutor? packageBuildExecutor = null,
         ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher? gitHubReleasePublisher = null,
-        ModulePipelineRunnerDefaults.ModuleVersionStepResolver? moduleVersionStepResolver = null)
-        : this(logger, ModulePipelineRunnerDefaults.Create(logger, powerShellRunner, moduleDependencyMetadataProvider, hostedOperations, manifestMutator, missingFunctionAnalysisService, scriptFunctionExportDetector, packageBuildExecutor, gitHubReleasePublisher, moduleVersionStepResolver))
+        ModulePipelineRunnerDefaults.ModuleVersionStepResolver? moduleVersionStepResolver = null,
+        ModulePipelineRunnerDefaults.ModuleGitHubVersionAvailabilityResolver? gitHubVersionAvailabilityResolver = null)
+        : this(logger, ModulePipelineRunnerDefaults.Create(logger, powerShellRunner, moduleDependencyMetadataProvider, hostedOperations, manifestMutator, missingFunctionAnalysisService, scriptFunctionExportDetector, packageBuildExecutor, gitHubReleasePublisher, moduleVersionStepResolver, gitHubVersionAvailabilityResolver))
     {
     }
 
@@ -113,6 +115,7 @@ public sealed partial class ModulePipelineRunner
         _packageBuildExecutor = services.PackageBuildExecutor;
         _gitHubReleasePublisher = services.GitHubReleasePublisher;
         _moduleVersionStepResolver = services.ModuleVersionStepResolver;
+        _gitHubVersionAvailabilityResolver = services.GitHubVersionAvailabilityResolver;
     }
 
 }

--- a/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
+++ b/PowerForge.PowerShell/Services/ModulePipelineRunnerDefaults.cs
@@ -18,6 +18,14 @@ internal static class ModulePipelineRunnerDefaults
         bool prerelease,
         bool verifyRepositoryAvailability);
 
+    internal delegate string ModuleGitHubVersionAvailabilityResolver(
+        string expectedVersion,
+        string candidateVersion,
+        PublishConfiguration publish,
+        string projectRoot,
+        string moduleName,
+        string? preRelease);
+
     internal static ModulePipelineRunnerServices Create(
         ILogger logger,
         IPowerShellRunner? powerShellRunner,
@@ -28,7 +36,8 @@ internal static class ModulePipelineRunnerDefaults
         IScriptFunctionExportDetector? scriptFunctionExportDetector,
         ModulePackageBuildExecutor? packageBuildExecutor = null,
         ModuleGitHubReleasePublisher? gitHubReleasePublisher = null,
-        ModuleVersionStepResolver? moduleVersionStepResolver = null)
+        ModuleVersionStepResolver? moduleVersionStepResolver = null,
+        ModuleGitHubVersionAvailabilityResolver? gitHubVersionAvailabilityResolver = null)
     {
         if (logger is null)
             throw new ArgumentNullException(nameof(logger));
@@ -59,7 +68,28 @@ internal static class ModulePipelineRunnerDefaults
                     moduleName,
                     localPsd1Path: localPsd1Path,
                     prerelease: prerelease,
-                    verifyRepositoryAvailability: verifyRepositoryAvailability)));
+                    verifyRepositoryAvailability: verifyRepositoryAvailability)),
+            gitHubVersionAvailabilityResolver ?? ((expectedVersion, candidateVersion, publish, projectRoot, moduleName, preRelease) =>
+            {
+                var owner = publish.UserName?.Trim();
+                if (string.IsNullOrWhiteSpace(owner))
+                    throw new InvalidOperationException("UserName is required for GitHub release version planning.");
+                var repository = string.IsNullOrWhiteSpace(publish.RepositoryName)
+                    ? moduleName
+                    : publish.RepositoryName!.Trim();
+                var token = ModulePublisher.ResolvePublishApiKey(publish, projectRoot);
+                if (string.IsNullOrWhiteSpace(token))
+                    throw new InvalidOperationException("API key (token) is required for GitHub release version planning.");
+
+                return new GitHubReleaseVersionAvailabilityService(logger).EnsureAvailable(
+                    expectedVersion,
+                    candidateVersion,
+                    owner!,
+                    repository,
+                    token,
+                    version => ModulePublisher.GetGitHubTag(publish, moduleName, version, preRelease),
+                    publish.ReuseExistingRelease);
+            }));
     }
 }
 
@@ -74,7 +104,8 @@ internal sealed class ModulePipelineRunnerServices
         IScriptFunctionExportDetector scriptFunctionExportDetector,
         ModulePipelineRunnerDefaults.ModulePackageBuildExecutor packageBuildExecutor,
         ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher gitHubReleasePublisher,
-        ModulePipelineRunnerDefaults.ModuleVersionStepResolver moduleVersionStepResolver)
+        ModulePipelineRunnerDefaults.ModuleVersionStepResolver moduleVersionStepResolver,
+        ModulePipelineRunnerDefaults.ModuleGitHubVersionAvailabilityResolver gitHubVersionAvailabilityResolver)
     {
         PowerShellRunner = powerShellRunner ?? throw new ArgumentNullException(nameof(powerShellRunner));
         ModuleDependencyMetadataProvider = moduleDependencyMetadataProvider ?? throw new ArgumentNullException(nameof(moduleDependencyMetadataProvider));
@@ -85,6 +116,7 @@ internal sealed class ModulePipelineRunnerServices
         PackageBuildExecutor = packageBuildExecutor ?? throw new ArgumentNullException(nameof(packageBuildExecutor));
         GitHubReleasePublisher = gitHubReleasePublisher ?? throw new ArgumentNullException(nameof(gitHubReleasePublisher));
         ModuleVersionStepResolver = moduleVersionStepResolver ?? throw new ArgumentNullException(nameof(moduleVersionStepResolver));
+        GitHubVersionAvailabilityResolver = gitHubVersionAvailabilityResolver ?? throw new ArgumentNullException(nameof(gitHubVersionAvailabilityResolver));
     }
 
     internal IPowerShellRunner PowerShellRunner { get; }
@@ -96,4 +128,5 @@ internal sealed class ModulePipelineRunnerServices
     internal ModulePipelineRunnerDefaults.ModulePackageBuildExecutor PackageBuildExecutor { get; }
     internal ModulePipelineRunnerDefaults.ModuleGitHubReleasePublisher GitHubReleasePublisher { get; }
     internal ModulePipelineRunnerDefaults.ModuleVersionStepResolver ModuleVersionStepResolver { get; }
+    internal ModulePipelineRunnerDefaults.ModuleGitHubVersionAvailabilityResolver GitHubVersionAvailabilityResolver { get; }
 }

--- a/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
+++ b/PowerForge.PowerShell/Services/PowerShellModulePipelineHostedOperations.cs
@@ -94,7 +94,8 @@ internal sealed class PowerShellModulePipelineHostedOperations :
         IReadOnlyList<ArtefactBuildResult> artefactResults,
         bool includeScriptFolders,
         Action? remotePublishAttempted,
-        Action? remoteSideEffectObserved)
+        Action? remoteSideEffectObserved,
+        IGitHubReleaseProgressReporter? gitHubProgress)
         => new ModulePublisher(_logger, _runner).Publish(
             publish,
             plan,
@@ -102,7 +103,8 @@ internal sealed class PowerShellModulePipelineHostedOperations :
             artefactResults,
             includeScriptFolders,
             remotePublishAttempted,
-            remoteSideEffectObserved);
+            remoteSideEffectObserved,
+            gitHubProgress: gitHubProgress);
 
     public ModulePublishVersionPreflightResult ValidateModulePublishVersion(
         PublishConfiguration publish,

--- a/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
+++ b/PowerForge.PowerShell/Services/PublishConfigurationFactory.cs
@@ -12,6 +12,12 @@ internal sealed class PublishConfigurationFactory
     {
         if (request is null)
             throw new ArgumentNullException(nameof(request));
+        if (request.ReplaceExistingAssets && !request.ReuseExistingRelease)
+        {
+            throw new ArgumentException(
+                "ReplaceExistingAssets requires ReuseExistingRelease because asset replacement is a recovery operation.",
+                nameof(request));
+        }
 
         var isAzureArtifacts = string.Equals(request.ParameterSetName, "AzureArtifacts", StringComparison.Ordinal);
         var destination = isAzureArtifacts ? PublishDestination.PowerShellGallery : request.Type;
@@ -254,6 +260,8 @@ internal sealed class PublishConfigurationFactory
                 OverwriteTagName = request.OverwriteTagName,
                 DoNotMarkAsPreRelease = request.DoNotMarkAsPreRelease,
                 GenerateReleaseNotes = request.GenerateReleaseNotes,
+                ReuseExistingRelease = request.ReuseExistingRelease,
+                ReplaceExistingAssets = request.ReuseExistingRelease && request.ReplaceExistingAssets,
                 UseAsDependencyVersionSource = request.UseAsDependencyVersionSource,
                 PublishRequiredModules = request.PublishRequiredModules,
                 RequiredModuleSourceRepository = string.IsNullOrWhiteSpace(request.RequiredModuleSourceRepository)

--- a/PowerForge.Tests/GitHubReleasePublisherTests.cs
+++ b/PowerForge.Tests/GitHubReleasePublisherTests.cs
@@ -61,6 +61,69 @@ public sealed class GitHubReleasePublisherTests
     }
 
     [Fact]
+    public async Task PublishRelease_ReportsPlannedAndByteLevelAssetProgress()
+    {
+        var listener = new HttpListener();
+        var port = GetAvailablePort();
+        var apiBaseUrl = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(apiBaseUrl);
+        listener.Start();
+        var assetPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".zip");
+        await File.WriteAllBytesAsync(assetPath, new byte[5 * 1024 * 1024]);
+        var progress = new RecordingGitHubProgress();
+        var server = Task.Run(async () =>
+        {
+            var create = await listener.GetContextAsync();
+            var createBody = Encoding.UTF8.GetBytes(
+                $$"""{"id":42,"html_url":"{{apiBaseUrl}}release","upload_url":"{{apiBaseUrl}}uploads{?name,label}","body":"generated"}""");
+            create.Response.StatusCode = 201;
+            create.Response.ContentType = "application/json";
+            create.Response.ContentLength64 = createBody.Length;
+            await create.Response.OutputStream.WriteAsync(createBody);
+            create.Response.Close();
+
+            var upload = await listener.GetContextAsync();
+            await upload.Request.InputStream.CopyToAsync(Stream.Null);
+            upload.Response.StatusCode = 201;
+            upload.Response.Close();
+        });
+
+        try
+        {
+            var result = new GitHubReleasePublisher(new NullLogger()).PublishRelease(
+                new GitHubReleasePublishRequest
+                {
+                    Owner = "EvotecIT",
+                    Repository = "example",
+                    Token = "token",
+                    ApiBaseUrl = apiBaseUrl,
+                    TagName = "v1.2.3",
+                    AssetFilePaths = [assetPath],
+                    Progress = progress
+                });
+
+            await server.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(result.Succeeded);
+            Assert.Equal(Path.GetFileName(assetPath), Assert.Single(result.UploadedAssets));
+            Assert.Equal(GitHubReleaseAssetProgressState.Planned, progress.Updates[0].State);
+            Assert.Contains(
+                progress.Updates,
+                update => update.State == GitHubReleaseAssetProgressState.Uploading &&
+                          update.BytesTransferred > 0 &&
+                          update.TotalBytes == new FileInfo(assetPath).Length);
+            var completed = progress.Updates[^1];
+            Assert.Equal(GitHubReleaseAssetProgressState.Uploaded, completed.State);
+            Assert.Equal(completed.TotalBytes, completed.BytesTransferred);
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            File.Delete(assetPath);
+        }
+    }
+
+    [Fact]
     public void PublishRelease_ThrowsWhenAssetDoesNotExist()
     {
         var publisher = new GitHubReleasePublisher(new NullLogger());
@@ -159,5 +222,13 @@ public sealed class GitHubReleasePublisherTests
         {
             listener.Stop();
         }
+    }
+
+    private sealed class RecordingGitHubProgress : IGitHubReleaseProgressReporter
+    {
+        public List<GitHubReleaseAssetProgress> Updates { get; } = new();
+
+        public void Report(GitHubReleaseAssetProgress progress)
+            => Updates.Add(progress);
     }
 }

--- a/PowerForge.Tests/GitHubReleaseVersionAvailabilityServiceTests.cs
+++ b/PowerForge.Tests/GitHubReleaseVersionAvailabilityServiceTests.cs
@@ -1,0 +1,74 @@
+namespace PowerForge.Tests;
+
+public sealed class GitHubReleaseVersionAvailabilityServiceTests
+{
+    [Fact]
+    public void EnsureAvailable_StepsAcrossOccupiedReleaseAndTag()
+    {
+        var probedTags = new List<string>();
+        var service = new GitHubReleaseVersionAvailabilityService(
+            new NullLogger(),
+            (_, _, _, tag) =>
+            {
+                probedTags.Add(tag);
+                return tag switch
+                {
+                    "v3.0.77" => new GitHubReleaseVersionOccupancy { ReleaseExists = true },
+                    "v3.0.78" => new GitHubReleaseVersionOccupancy { TagExists = true },
+                    _ => new GitHubReleaseVersionOccupancy()
+                };
+            });
+
+        var version = service.EnsureAvailable(
+            "3.0.X",
+            "3.0.77",
+            "EvotecIT",
+            "PSPublishModule",
+            "token",
+            candidate => "v" + candidate,
+            reuseExistingRelease: false);
+
+        Assert.Equal("3.0.79", version);
+        Assert.Equal(["v3.0.77", "v3.0.78", "v3.0.79"], probedTags);
+    }
+
+    [Fact]
+    public void EnsureAvailable_RejectsOccupiedExactVersionWithoutRecoveryMode()
+    {
+        var service = new GitHubReleaseVersionAvailabilityService(
+            new NullLogger(),
+            (_, _, _, _) => new GitHubReleaseVersionOccupancy { ReleaseExists = true });
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            service.EnsureAvailable(
+                "3.0.77",
+                "3.0.77",
+                "EvotecIT",
+                "PSPublishModule",
+                "token",
+                candidate => "v" + candidate,
+                reuseExistingRelease: false));
+
+        Assert.Contains("exact release version", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ReuseExistingRelease", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnsureAvailable_AllowsExplicitRecoveryOfOccupiedVersion()
+    {
+        var service = new GitHubReleaseVersionAvailabilityService(
+            new NullLogger(),
+            (_, _, _, _) => new GitHubReleaseVersionOccupancy { ReleaseExists = true });
+
+        var version = service.EnsureAvailable(
+            "3.0.X",
+            "3.0.77",
+            "EvotecIT",
+            "PSPublishModule",
+            "token",
+            candidate => "v" + candidate,
+            reuseExistingRelease: true);
+
+        Assert.Equal("3.0.77", version);
+    }
+}

--- a/PowerForge.Tests/ModulePipelineExecutionSessionTests.cs
+++ b/PowerForge.Tests/ModulePipelineExecutionSessionTests.cs
@@ -95,6 +95,65 @@ public sealed class ModulePipelineExecutionSessionTests
         }
     }
 
+    [Fact]
+    public void GitHubProgressAdapter_ReportsDeterminateAggregateBytesOnPublishStep()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            const string moduleName = "TestModule";
+            WriteMinimalModule(root.FullName, moduleName, "1.0.0");
+
+            var reporter = new RecordingProgressReporter();
+            var plan = new ModulePipelineRunner(new NullLogger()).Plan(CreateSpec(root.FullName, moduleName));
+            var session = ModulePipelineExecutionSession.Create(plan, reporter);
+            var publish = Assert.Single(
+                plan.Publishes,
+                static segment => segment.Configuration.Destination == PublishDestination.GitHub);
+            var step = session.GetPublishStep(publish);
+            var adapter = new ModulePipelineGitHubReleaseProgressAdapter(session, step);
+
+            adapter.Report(new GitHubReleaseAssetProgress
+            {
+                FilePath = Path.Combine(root.FullName, "one.zip"),
+                FileName = "one.zip",
+                Position = 1,
+                TotalAssets = 2,
+                State = GitHubReleaseAssetProgressState.Planned,
+                TotalBytes = 100
+            });
+            adapter.Report(new GitHubReleaseAssetProgress
+            {
+                FilePath = Path.Combine(root.FullName, "two.zip"),
+                FileName = "two.zip",
+                Position = 2,
+                TotalAssets = 2,
+                State = GitHubReleaseAssetProgressState.Planned,
+                TotalBytes = 300
+            });
+            adapter.Report(new GitHubReleaseAssetProgress
+            {
+                FilePath = Path.Combine(root.FullName, "one.zip"),
+                FileName = "one.zip",
+                Position = 1,
+                TotalAssets = 2,
+                State = GitHubReleaseAssetProgressState.Uploading,
+                BytesTransferred = 50,
+                TotalBytes = 100
+            });
+
+            var update = reporter.Progress[reporter.Progress.Count - 1];
+            Assert.Equal(step!.Key, update.Key);
+            Assert.Equal(50, update.Value);
+            Assert.Equal(400, update.Maximum);
+            Assert.Contains("1/2 one.zip", update.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
     private static ModulePipelineSpec CreateSpec(string rootPath, string moduleName)
     {
         return new ModulePipelineSpec
@@ -233,12 +292,13 @@ public sealed class ModulePipelineExecutionSessionTests
         File.WriteAllText(Path.Combine(moduleRoot, $"{moduleName}.psd1"), psd1);
     }
 
-    private sealed class RecordingProgressReporter : IModulePipelineProgressReporterV2
+    private sealed class RecordingProgressReporter : IModulePipelineProgressReporterV3
     {
         public List<string> Started { get; } = new();
         public List<string> Completed { get; } = new();
         public List<string> Failed { get; } = new();
         public List<string> Skipped { get; } = new();
+        public List<(string Key, double Value, double Maximum, string? Detail)> Progress { get; } = new();
 
         public void StepStarting(ModulePipelineStep step)
         {
@@ -258,6 +318,11 @@ public sealed class ModulePipelineExecutionSessionTests
         public void StepSkipped(ModulePipelineStep step)
         {
             Skipped.Add(step.Key);
+        }
+
+        public void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null)
+        {
+            Progress.Add((step.Key, value, maximum, detail));
         }
     }
 }

--- a/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
+++ b/PowerForge.Tests/ModulePipelineHostedOperationsTests.cs
@@ -2714,7 +2714,8 @@ public sealed class ModulePipelineHostedOperationsTests
             IReadOnlyList<ArtefactBuildResult> artefactResults,
             bool includeScriptFolders,
             Action? remotePublishAttempted,
-            Action? remoteSideEffectObserved)
+            Action? remoteSideEffectObserved,
+            IGitHubReleaseProgressReporter? gitHubProgress)
             => throw new InvalidOperationException("Not used in this test.");
 
         public void ValidateModuleImports(

--- a/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
+++ b/PowerForge.Tests/ModulePipelineManifestRefreshTests.cs
@@ -614,7 +614,8 @@ public sealed class ModulePipelineManifestRefreshTests
             IReadOnlyList<ArtefactBuildResult> artefactResults,
             bool includeScriptFolders,
             Action? remotePublishAttempted,
-            Action? remoteSideEffectObserved)
+            Action? remoteSideEffectObserved,
+            IGitHubReleaseProgressReporter? gitHubProgress)
             => throw new InvalidOperationException("Not used in this test.");
 
         public void ValidateModuleImports(

--- a/PowerForge.Tests/ModulePipelineMissingAnalysisServiceTests.cs
+++ b/PowerForge.Tests/ModulePipelineMissingAnalysisServiceTests.cs
@@ -233,7 +233,8 @@ public sealed class ModulePipelineMissingAnalysisServiceTests
             IReadOnlyList<ArtefactBuildResult> artefactResults,
             bool includeScriptFolders,
             Action? remotePublishAttempted,
-            Action? remoteSideEffectObserved)
+            Action? remoteSideEffectObserved,
+            IGitHubReleaseProgressReporter? gitHubProgress)
             => throw new InvalidOperationException("Not used in this test.");
 
         public void ValidateModuleImports(

--- a/PowerForge.Tests/ModulePipelinePublishVersionAvailabilityTests.cs
+++ b/PowerForge.Tests/ModulePipelinePublishVersionAvailabilityTests.cs
@@ -169,4 +169,135 @@ public sealed class ModulePipelinePublishVersionAvailabilityTests
             }
         }
     }
+
+    [Fact]
+    public void Plan_GitHubPublishStepsAcrossOccupiedReleaseTag()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            const string moduleName = "GitHubAvailabilityModule";
+            File.WriteAllText(
+                Path.Combine(root.FullName, moduleName + ".psd1"),
+                "@{ ModuleVersion = '1.0.0'; RootModule = 'GitHubAvailabilityModule.psm1' }");
+            File.WriteAllText(Path.Combine(root.FullName, moduleName + ".psm1"), string.Empty);
+
+            var calls = new List<string>();
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: null,
+                gitHubReleasePublisher: null,
+                moduleVersionStepResolver: (expectedVersion, _, _, _, _) =>
+                    new ModuleVersionStepResult(
+                        expectedVersion,
+                        "1.0.2",
+                        "1.0.1",
+                        ModuleVersionSource.Repository,
+                        usedAutoVersioning: true),
+                gitHubVersionAvailabilityResolver: (expected, candidate, publish, projectRoot, name, preRelease) =>
+                {
+                    calls.Add(candidate);
+                    Assert.Equal("1.0.X", expected);
+                    Assert.Equal(moduleName, name);
+                    Assert.Null(preRelease);
+                    Assert.Equal(root.FullName, projectRoot);
+                    Assert.False(publish.ReuseExistingRelease);
+                    return candidate == "1.0.2" ? "1.0.3" : candidate;
+                });
+
+            var plan = runner.Plan(CreateGitHubPublishSpec(root.FullName, moduleName, "1.0.X"));
+
+            Assert.Equal("1.0.3", plan.ResolvedVersion);
+            Assert.Equal(new[] { "1.0.2", "1.0.3" }, calls);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Plan_GitHubPublishExactVersionDoesNotProbeDuringBuildPlanning()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+
+        try
+        {
+            const string moduleName = "GitHubExactModule";
+            File.WriteAllText(
+                Path.Combine(root.FullName, moduleName + ".psd1"),
+                "@{ ModuleVersion = '1.0.2'; RootModule = 'GitHubExactModule.psm1' }");
+            File.WriteAllText(Path.Combine(root.FullName, moduleName + ".psm1"), string.Empty);
+
+            var runner = new ModulePipelineRunner(
+                new NullLogger(),
+                powerShellRunner: null,
+                moduleDependencyMetadataProvider: null,
+                hostedOperations: null,
+                manifestMutator: null,
+                missingFunctionAnalysisService: null,
+                scriptFunctionExportDetector: null,
+                packageBuildExecutor: null,
+                gitHubReleasePublisher: null,
+                moduleVersionStepResolver: (expectedVersion, _, _, _, _) =>
+                    new ModuleVersionStepResult(
+                        expectedVersion,
+                        expectedVersion,
+                        "1.0.1",
+                        ModuleVersionSource.None,
+                        usedAutoVersioning: false),
+                gitHubVersionAvailabilityResolver: (_, _, _, _, _, _) =>
+                    throw new InvalidOperationException("Exact build planning must remain offline."));
+
+            var plan = runner.Plan(CreateGitHubPublishSpec(root.FullName, moduleName, "1.0.2"));
+
+            Assert.Equal("1.0.2", plan.ResolvedVersion);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { }
+        }
+    }
+
+    private static ModulePipelineSpec CreateGitHubPublishSpec(string rootPath, string moduleName, string version)
+        => new()
+        {
+            Build = new ModuleBuildSpec
+            {
+                Name = moduleName,
+                SourcePath = rootPath,
+                Version = version
+            },
+            Install = new ModulePipelineInstallOptions { Enabled = false },
+            Segments = new IConfigurationSegment[]
+            {
+                new ConfigurationGateSegment
+                {
+                    Configuration = new GateConfiguration { Mode = ConfigurationGateMode.Publish }
+                },
+                new ConfigurationPublishSegment
+                {
+                    Configuration = new PublishConfiguration
+                    {
+                        Destination = PublishDestination.GitHub,
+                        UserName = "EvotecIT",
+                        RepositoryName = moduleName,
+                        ApiKey = "test-token"
+                    }
+                }
+            }
+        };
 }

--- a/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
+++ b/PowerForge.Tests/ModulePipelineScriptExecutionSeamTests.cs
@@ -687,7 +687,8 @@ public sealed class ModulePipelineScriptExecutionSeamTests
             IReadOnlyList<ArtefactBuildResult> artefactResults,
             bool includeScriptFolders,
             Action? remotePublishAttempted,
-            Action? remoteSideEffectObserved)
+            Action? remoteSideEffectObserved,
+            IGitHubReleaseProgressReporter? gitHubProgress)
             => throw new InvalidOperationException("Not used in this test.");
 
         public void ValidateModuleImports(

--- a/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
+++ b/PowerForge.Tests/ModulePipelineUnifiedReleaseTests.cs
@@ -139,6 +139,9 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             Assert.Equal("v1.2.3", gitHubRequest.TagName);
             Assert.False(gitHubRequest.IsPreRelease);
             Assert.True(gitHubRequest.GenerateReleaseNotes);
+            Assert.False(gitHubRequest.ReuseExistingReleaseOnConflict);
+            Assert.False(gitHubRequest.ReplaceExistingAssets);
+            Assert.NotNull(gitHubRequest.Progress);
             Assert.Equal("1.2.3", result.Plan.ResolvedVersion);
             Assert.Null(result.Plan.PreRelease);
             Assert.Equal("1.2.3", result.Plan.BuildSpec.Version);
@@ -1443,7 +1446,8 @@ public sealed partial class ModulePipelineUnifiedReleaseTests
             IReadOnlyList<ArtefactBuildResult> artefactResults,
             bool includeScriptFolders,
             Action? remotePublishAttempted,
-            Action? remoteSideEffectObserved)
+            Action? remoteSideEffectObserved,
+            IGitHubReleaseProgressReporter? gitHubProgress)
         {
             ModulePublishPreflightAction?.Invoke(publish, plan);
             ModulePublishRemoteSideEffectAction?.Invoke(remoteSideEffectObserved);

--- a/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
@@ -65,6 +65,58 @@ public sealed class PowerForgeReleaseProgressAdaptersTests
             release.Updates.Select(update => update.State));
     }
 
+    [Fact]
+    public void GitHubReleaseAdapter_ForwardsAssetBytesAndTerminalState()
+    {
+        var release = new RecordingReleaseProgress();
+        var adapter = new GitHubReleaseProgressAdapter(release);
+        var assetPath = Path.Combine(Path.GetTempPath(), "PowerForge.Build.zip");
+
+        adapter.Report(new GitHubReleaseAssetProgress
+        {
+            FilePath = assetPath,
+            FileName = "PowerForge.Build.zip",
+            Position = 4,
+            TotalAssets = 24,
+            State = GitHubReleaseAssetProgressState.Planned
+        });
+        adapter.Report(new GitHubReleaseAssetProgress
+        {
+            FilePath = assetPath,
+            FileName = "PowerForge.Build.zip",
+            Position = 4,
+            TotalAssets = 24,
+            State = GitHubReleaseAssetProgressState.Uploading,
+            BytesTransferred = 25,
+            TotalBytes = 100
+        });
+        adapter.Report(new GitHubReleaseAssetProgress
+        {
+            FilePath = assetPath,
+            FileName = "PowerForge.Build.zip",
+            Position = 4,
+            TotalAssets = 24,
+            State = GitHubReleaseAssetProgressState.Uploaded,
+            BytesTransferred = 100,
+            TotalBytes = 100
+        });
+
+        var item = Assert.Single(release.Planned);
+        Assert.Equal(PowerForgeReleaseProgressPhase.GitHub, item.Phase);
+        Assert.Equal(4, item.Position);
+        Assert.Equal(24, item.Total);
+        Assert.Equal(100, item.ProgressMaximum);
+        Assert.Equal(100, item.ProgressValue);
+        Assert.Collection(
+            release.Updates,
+            update =>
+            {
+                Assert.Equal(PowerForgeReleaseProgressItemState.Started, update.State);
+                Assert.Contains("/", update.Detail, StringComparison.Ordinal);
+            },
+            update => Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State));
+    }
+
     private sealed class RecordingReleaseProgress : IPowerForgeReleaseProgressReporterV2
     {
         public List<PowerForgeReleaseProgressItem> Planned { get; } = new();

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.UnifiedGitHubRelease.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.UnifiedGitHubRelease.cs
@@ -539,6 +539,8 @@ public sealed partial class PowerForgeReleaseServiceTests
             Assert.Equal(
                 new[] { zipPath, manifestPath, checksumsPath }.OrderBy(static path => path),
                 Assert.Single(publishCalls).AssetFilePaths.OrderBy(static path => path));
+            Assert.False(Assert.Single(publishCalls).ReuseExistingReleaseOnConflict);
+            Assert.False(Assert.Single(publishCalls).ReplaceExistingAssets);
             Assert.Equal("approved manifest", File.ReadAllText(manifestPath));
             Assert.Equal("approved checksums", File.ReadAllText(checksumsPath));
         }

--- a/PowerForge.Tests/PublishConfigurationFactoryTests.cs
+++ b/PowerForge.Tests/PublishConfigurationFactoryTests.cs
@@ -5,6 +5,21 @@ namespace PowerForge.Tests;
 public sealed class PublishConfigurationFactoryTests
 {
     [Fact]
+    public void Create_requires_explicit_release_reuse_before_asset_replacement()
+    {
+        var factory = new PublishConfigurationFactory();
+
+        var ex = Assert.Throws<ArgumentException>(() => factory.Create(new PublishConfigurationRequest
+        {
+            ParameterSetName = "ApiKey",
+            Type = PublishDestination.GitHub,
+            ReplaceExistingAssets = true
+        }));
+
+        Assert.Contains("ReuseExistingRelease", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Create_defers_enabled_publish_api_key_file_until_publish_runtime()
     {
         var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");

--- a/PowerForge/Abstractions/IModulePipelineHostedOperations.cs
+++ b/PowerForge/Abstractions/IModulePipelineHostedOperations.cs
@@ -36,7 +36,8 @@ internal interface IModulePipelineHostedOperations
         IReadOnlyList<ArtefactBuildResult> artefactResults,
         bool includeScriptFolders,
         Action? remotePublishAttempted,
-        Action? remoteSideEffectObserved);
+        Action? remoteSideEffectObserved,
+        IGitHubReleaseProgressReporter? gitHubProgress);
 
     ModulePipelineActionResult RunAction(
         ModulePipelineActionConfiguration action,

--- a/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
+++ b/PowerForge/Models/Configuration/ConfigurationPublishSegment.cs
@@ -63,6 +63,12 @@ public sealed class PublishConfiguration
     /// <summary>When true, asks GitHub to generate release notes automatically.</summary>
     public bool GenerateReleaseNotes { get; set; }
 
+    /// <summary>Explicitly reuse an existing GitHub release when its tag is already occupied.</summary>
+    public bool ReuseExistingRelease { get; set; }
+
+    /// <summary>Replace same-name assets when deliberately reusing an existing GitHub release.</summary>
+    public bool ReplaceExistingAssets { get; set; }
+
     /// <summary>Use this PowerShell repository as the source for resolving Auto/Latest dependency versions.</summary>
     public bool UseAsDependencyVersionSource { get; set; }
 

--- a/PowerForge/Models/GitHubReleaseProgress.cs
+++ b/PowerForge/Models/GitHubReleaseProgress.cs
@@ -1,0 +1,53 @@
+namespace PowerForge;
+
+/// <summary>State of one GitHub release asset operation.</summary>
+public enum GitHubReleaseAssetProgressState
+{
+    /// <summary>The asset is planned but has not started.</summary>
+    Planned,
+    /// <summary>An existing asset is being removed before replacement.</summary>
+    Replacing,
+    /// <summary>The asset bytes are being uploaded.</summary>
+    Uploading,
+    /// <summary>The asset upload completed successfully.</summary>
+    Uploaded,
+    /// <summary>The asset already existed and was skipped.</summary>
+    Skipped,
+    /// <summary>The asset operation failed.</summary>
+    Failed
+}
+
+/// <summary>Progress snapshot for one GitHub release asset.</summary>
+public sealed class GitHubReleaseAssetProgress
+{
+    /// <summary>Full source path of the asset.</summary>
+    public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>File name used on the GitHub release.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>One-based position within the release asset plan.</summary>
+    public int Position { get; set; }
+
+    /// <summary>Total number of assets in the release plan.</summary>
+    public int TotalAssets { get; set; }
+
+    /// <summary>Current operation state.</summary>
+    public GitHubReleaseAssetProgressState State { get; set; }
+
+    /// <summary>Number of bytes transferred for the current upload.</summary>
+    public long BytesTransferred { get; set; }
+
+    /// <summary>Total asset size in bytes.</summary>
+    public long TotalBytes { get; set; }
+
+    /// <summary>Optional failure or status detail.</summary>
+    public string? Detail { get; set; }
+}
+
+/// <summary>Receives structured progress from GitHub release asset operations.</summary>
+public interface IGitHubReleaseProgressReporter
+{
+    /// <summary>Reports the latest state of one release asset.</summary>
+    void Report(GitHubReleaseAssetProgress progress);
+}

--- a/PowerForge/Models/GitHubReleasePublishRequest.cs
+++ b/PowerForge/Models/GitHubReleasePublishRequest.cs
@@ -47,7 +47,7 @@ public sealed class GitHubReleasePublishRequest
     public bool IsPreRelease { get; set; }
 
     /// <summary>True to reuse an existing release when GitHub reports a tag conflict.</summary>
-    public bool ReuseExistingReleaseOnConflict { get; set; } = true;
+    public bool ReuseExistingReleaseOnConflict { get; set; }
 
     /// <summary>
     /// When true, a tag-conflict release may be reused only when its identifier matches
@@ -71,4 +71,7 @@ public sealed class GitHubReleasePublishRequest
 
     /// <summary>Asset file paths to upload.</summary>
     public IReadOnlyList<string> AssetFilePaths { get; set; } = System.Array.Empty<string>();
+
+    /// <summary>Optional structured reporter for release asset upload progress.</summary>
+    public IGitHubReleaseProgressReporter? Progress { get; set; }
 }

--- a/PowerForge/Models/GitHubReleasePublishResult.cs
+++ b/PowerForge/Models/GitHubReleasePublishResult.cs
@@ -30,4 +30,7 @@ public sealed class GitHubReleasePublishResult
 
     /// <summary>Assets deleted from an existing release before uploading replacements.</summary>
     public List<string> ReplacedExistingAssets { get; } = new();
+
+    /// <summary>Assets uploaded successfully during this operation.</summary>
+    public List<string> UploadedAssets { get; } = new();
 }

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -630,6 +630,8 @@ internal sealed class PowerForgeReleaseGitHubOptions
 
     public bool IsPreRelease { get; set; }
 
+    public bool ReuseExistingRelease { get; set; }
+
     public bool ReplaceExistingAssets { get; set; }
 
     public string? TagTemplate { get; set; }
@@ -1030,4 +1032,6 @@ internal sealed class PowerForgeUnifiedGitHubReleaseResult
     public string[] SkippedExistingAssets { get; set; } = Array.Empty<string>();
 
     public string[] ReplacedExistingAssets { get; set; } = Array.Empty<string>();
+
+    public string[] UploadedAssets { get; set; } = Array.Empty<string>();
 }

--- a/PowerForge/Models/PowerForgeReleaseProgress.cs
+++ b/PowerForge/Models/PowerForgeReleaseProgress.cs
@@ -63,6 +63,12 @@ public sealed class PowerForgeReleaseProgressItem
 
     /// <summary>Total number of items in the owning plan.</summary>
     public int Total { get; set; }
+
+    /// <summary>Current numeric progress for presentation hosts; zero when unavailable.</summary>
+    public double ProgressValue { get; set; }
+
+    /// <summary>Maximum numeric progress for presentation hosts; zero when indeterminate.</summary>
+    public double ProgressMaximum { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Services/GitHubReleaseProgressAdapter.cs
+++ b/PowerForge/Services/GitHubReleaseProgressAdapter.cs
@@ -1,0 +1,91 @@
+namespace PowerForge;
+
+internal sealed class GitHubReleaseProgressAdapter : IGitHubReleaseProgressReporter
+{
+    private readonly IPowerForgeReleaseProgressReporterV2 _release;
+    private readonly Dictionary<string, PowerForgeReleaseProgressItem> _items =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal GitHubReleaseProgressAdapter(IPowerForgeReleaseProgressReporterV2 release)
+        => _release = release ?? throw new ArgumentNullException(nameof(release));
+
+    public void Report(GitHubReleaseAssetProgress progress)
+    {
+        if (progress is null || string.IsNullOrWhiteSpace(progress.FilePath))
+            return;
+
+        var item = GetOrCreate(progress);
+        item.ProgressValue = Math.Max(0, progress.BytesTransferred);
+        item.ProgressMaximum = Math.Max(0, progress.TotalBytes);
+
+        switch (progress.State)
+        {
+            case GitHubReleaseAssetProgressState.Planned:
+                return;
+            case GitHubReleaseAssetProgressState.Replacing:
+                _release.ItemUpdated(
+                    item,
+                    PowerForgeReleaseProgressItemState.Started,
+                    BuildDetail(progress, "Replacing existing asset"));
+                return;
+            case GitHubReleaseAssetProgressState.Uploading:
+                _release.ItemUpdated(
+                    item,
+                    PowerForgeReleaseProgressItemState.Started,
+                    BuildTransferDetail(progress));
+                return;
+            case GitHubReleaseAssetProgressState.Uploaded:
+                _release.ItemUpdated(
+                    item,
+                    PowerForgeReleaseProgressItemState.Completed,
+                    BuildDetail(progress, "Uploaded"));
+                return;
+            case GitHubReleaseAssetProgressState.Skipped:
+                _release.ItemUpdated(
+                    item,
+                    PowerForgeReleaseProgressItemState.Skipped,
+                    progress.Detail ?? "Already exists");
+                return;
+            case GitHubReleaseAssetProgressState.Failed:
+                _release.ItemUpdated(
+                    item,
+                    PowerForgeReleaseProgressItemState.Failed,
+                    progress.Detail);
+                return;
+        }
+    }
+
+    private PowerForgeReleaseProgressItem GetOrCreate(GitHubReleaseAssetProgress progress)
+    {
+        if (_items.TryGetValue(progress.FilePath, out var item))
+            return item;
+
+        item = new PowerForgeReleaseProgressItem
+        {
+            Phase = PowerForgeReleaseProgressPhase.GitHub,
+            Key = progress.FilePath,
+            Title = progress.FileName,
+            Kind = "GitHubAsset",
+            Position = progress.Position,
+            Total = progress.TotalAssets,
+            ProgressMaximum = Math.Max(0, progress.TotalBytes)
+        };
+        _items[progress.FilePath] = item;
+        _release.ItemsPlanned(PowerForgeReleaseProgressPhase.GitHub, new[] { item });
+        return item;
+    }
+
+    private static string BuildTransferDetail(GitHubReleaseAssetProgress progress)
+    {
+        if (progress.TotalBytes <= 0)
+            return "Uploading";
+
+        return $"{DotNetRepositoryReleaseService.FormatBytes(progress.BytesTransferred)} / " +
+               $"{DotNetRepositoryReleaseService.FormatBytes(progress.TotalBytes)}";
+    }
+
+    private static string BuildDetail(GitHubReleaseAssetProgress progress, string label)
+        => progress.TotalBytes > 0
+            ? $"{label} {DotNetRepositoryReleaseService.FormatBytes(progress.TotalBytes)}"
+            : label;
+}

--- a/PowerForge/Services/GitHubReleaseProgressFileContent.cs
+++ b/PowerForge/Services/GitHubReleaseProgressFileContent.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Net.Http;
+
+namespace PowerForge;
+
+internal sealed class GitHubReleaseProgressFileContent : HttpContent
+{
+    private const int BufferSize = 1024 * 1024;
+    private const long MinimumReportedBytes = 4L * 1024 * 1024;
+    private static readonly TimeSpan MaximumReportInterval = TimeSpan.FromMilliseconds(250);
+
+    private readonly string _filePath;
+    private readonly long _length;
+    private readonly Action<long, long>? _reportProgress;
+
+    internal GitHubReleaseProgressFileContent(
+        string filePath,
+        Action<long, long>? reportProgress)
+    {
+        _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+        _length = new FileInfo(filePath).Length;
+        _reportProgress = reportProgress;
+    }
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        var buffer = new byte[BufferSize];
+        long transferred = 0;
+        long lastReportedBytes = 0;
+        var lastReportedAt = DateTime.UtcNow;
+
+        using var source = File.OpenRead(_filePath);
+        while (true)
+        {
+            var read = await source.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+            if (read <= 0)
+                break;
+
+            await stream.WriteAsync(buffer, 0, read).ConfigureAwait(false);
+            transferred += read;
+
+            var now = DateTime.UtcNow;
+            if (transferred == _length ||
+                transferred - lastReportedBytes >= MinimumReportedBytes ||
+                now - lastReportedAt >= MaximumReportInterval)
+            {
+                _reportProgress?.Invoke(transferred, _length);
+                lastReportedBytes = transferred;
+                lastReportedAt = now;
+            }
+        }
+
+        if (lastReportedBytes != transferred)
+            _reportProgress?.Invoke(transferred, _length);
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = _length;
+        return true;
+    }
+}

--- a/PowerForge/Services/GitHubReleasePublisher.cs
+++ b/PowerForge/Services/GitHubReleasePublisher.cs
@@ -59,6 +59,7 @@ public sealed partial class GitHubReleasePublisher
         var expectedReleaseBodyMarker = request.ExpectedReleaseBodyMarker;
         var expectedTagCommitSha = request.ExpectedTagCommitSha;
         var replaceExistingAssets = request.ReplaceExistingAssets;
+        var progress = request.Progress;
 
         if (string.IsNullOrWhiteSpace(owner)) throw new ArgumentException("Owner is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(repo)) throw new ArgumentException("Repository is required.", nameof(request));
@@ -74,6 +75,16 @@ public sealed partial class GitHubReleasePublisher
         {
             if (!File.Exists(assetPath))
                 throw new FileNotFoundException($"GitHub asset not found: {assetPath}");
+        }
+
+        for (var index = 0; index < assets.Length; index++)
+        {
+            ReportAssetProgress(
+                progress,
+                assets[index],
+                index,
+                assets.Length,
+                GitHubReleaseAssetProgressState.Planned);
         }
 
         var releaseWatch = Stopwatch.StartNew();
@@ -123,6 +134,8 @@ public sealed partial class GitHubReleasePublisher
                 expectedTagCommitSha,
                 replaceExistingAssets,
                 result.ReplacedExistingAssets,
+                result.UploadedAssets,
+                progress,
                 cancellationToken));
             assetUploadWatch.Stop();
             var uploaded = assets.Length - result.SkippedExistingAssets.Count;
@@ -282,6 +295,8 @@ public sealed partial class GitHubReleasePublisher
         string? expectedTagCommitSha,
         bool replaceExistingAssets,
         List<string> replacedExistingAssets,
+        List<string> uploadedAssets,
+        IGitHubReleaseProgressReporter? progress,
         CancellationToken cancellationToken)
     {
         ValidateReleaseBeforeAssetMutation(
@@ -300,23 +315,51 @@ public sealed partial class GitHubReleasePublisher
             ? CreateReplaceableAssetNameSet(ListReleaseAssets(owner, repo, token, apiBaseUrl, releaseId, cancellationToken))
             : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var assetPath in assets)
+        for (var index = 0; index < assets.Length; index++)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            var assetPath = assets[index];
             var fileName = Path.GetFileName(assetPath) ?? assetPath;
+            var assetSize = new FileInfo(assetPath).Length;
 
             if (replaceExistingAssets &&
-                TryReserveExistingAssetNameForReplacement(replaceableAssetNames, fileName) &&
-                DeleteExistingAssetByName(owner, repo, token, apiBaseUrl, releaseId, fileName, cancellationToken))
+                TryReserveExistingAssetNameForReplacement(replaceableAssetNames, fileName))
             {
-                replacedExistingAssets.Add(fileName);
+                ReportAssetProgress(
+                    progress,
+                    assetPath,
+                    index,
+                    assets.Length,
+                    GitHubReleaseAssetProgressState.Replacing,
+                    totalBytes: assetSize);
+                if (DeleteExistingAssetByName(owner, repo, token, apiBaseUrl, releaseId, fileName, cancellationToken))
+                    replacedExistingAssets.Add(fileName);
             }
 
-            var assetSize = new FileInfo(assetPath).Length;
             _logger.Info($"Uploading GitHub release asset: {fileName} ({DotNetRepositoryReleaseService.FormatBytes(assetSize)})");
+            ReportAssetProgress(
+                progress,
+                assetPath,
+                index,
+                assets.Length,
+                GitHubReleaseAssetProgressState.Uploading,
+                totalBytes: assetSize);
 
             var assetWatch = Stopwatch.StartNew();
-            var resp = UploadAsset(uploadUrl, assetPath, fileName, token, cancellationToken);
+            var resp = UploadAsset(
+                uploadUrl,
+                assetPath,
+                fileName,
+                token,
+                (transferred, total) => ReportAssetProgress(
+                    progress,
+                    assetPath,
+                    index,
+                    assets.Length,
+                    GitHubReleaseAssetProgressState.Uploading,
+                    transferred,
+                    total),
+                cancellationToken);
             var respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             if (!resp.IsSuccessStatusCode && replaceExistingAssets &&
                 (int)resp.StatusCode == 422 &&
@@ -326,7 +369,20 @@ public sealed partial class GitHubReleasePublisher
             {
                 replacedExistingAssets.Add(fileName);
                 resp.Dispose();
-                resp = UploadAsset(uploadUrl, assetPath, fileName, token, cancellationToken);
+                resp = UploadAsset(
+                    uploadUrl,
+                    assetPath,
+                    fileName,
+                    token,
+                    (transferred, total) => ReportAssetProgress(
+                        progress,
+                        assetPath,
+                        index,
+                        assets.Length,
+                        GitHubReleaseAssetProgressState.Uploading,
+                        transferred,
+                        total),
+                    cancellationToken);
                 respText = resp.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             }
 
@@ -340,14 +396,39 @@ public sealed partial class GitHubReleasePublisher
                         assetWatch.Stop();
                         _logger.Info($"GitHub release asset '{fileName}' already exists; skipping upload after {DotNetRepositoryReleaseService.FormatDuration(assetWatch.Elapsed)}.");
                         skippedAssets.Add(fileName);
+                        ReportAssetProgress(
+                            progress,
+                            assetPath,
+                            index,
+                            assets.Length,
+                            GitHubReleaseAssetProgressState.Skipped,
+                            totalBytes: assetSize,
+                            detail: "Already exists");
                         continue;
                     }
 
+                    ReportAssetProgress(
+                        progress,
+                        assetPath,
+                        index,
+                        assets.Length,
+                        GitHubReleaseAssetProgressState.Failed,
+                        totalBytes: assetSize,
+                        detail: TrimForMessage(respText));
                     throw new InvalidOperationException($"GitHub asset upload failed for '{fileName}' ({(int)resp.StatusCode} {resp.ReasonPhrase}). {TrimForMessage(respText)}");
                 }
             }
 
             assetWatch.Stop();
+            uploadedAssets.Add(fileName);
+            ReportAssetProgress(
+                progress,
+                assetPath,
+                index,
+                assets.Length,
+                GitHubReleaseAssetProgressState.Uploaded,
+                assetSize,
+                assetSize);
             _logger.Success($"Uploaded GitHub release asset: {fileName} in {DotNetRepositoryReleaseService.FormatDuration(assetWatch.Elapsed)} ({DotNetRepositoryReleaseService.FormatBytes(assetSize)}).");
         }
 
@@ -392,18 +473,51 @@ public sealed partial class GitHubReleasePublisher
         string assetPath,
         string fileName,
         string token,
+        Action<long, long>? reportProgress,
         CancellationToken cancellationToken)
     {
         var target = new Uri(uploadUrl + "?name=" + Uri.EscapeDataString(fileName));
 
-        using var fs = File.OpenRead(assetPath);
-        using var content = new StreamContent(fs);
+        using var content = new GitHubReleaseProgressFileContent(assetPath, reportProgress);
         content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 
         using var req = new HttpRequestMessage(HttpMethod.Post, target) { Content = content };
         req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         return SharedClient.SendAsync(req, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    private static void ReportAssetProgress(
+        IGitHubReleaseProgressReporter? progress,
+        string assetPath,
+        int zeroBasedPosition,
+        int totalAssets,
+        GitHubReleaseAssetProgressState state,
+        long bytesTransferred = 0,
+        long totalBytes = 0,
+        string? detail = null)
+    {
+        if (progress is null)
+            return;
+
+        try
+        {
+            progress.Report(new GitHubReleaseAssetProgress
+            {
+                FilePath = assetPath,
+                FileName = Path.GetFileName(assetPath) ?? assetPath,
+                Position = zeroBasedPosition + 1,
+                TotalAssets = totalAssets,
+                State = state,
+                BytesTransferred = bytesTransferred,
+                TotalBytes = totalBytes,
+                Detail = detail
+            });
+        }
+        catch
+        {
+            // Progress is best effort and must never change release correctness.
+        }
     }
 
     private bool DeleteExistingAssetByName(

--- a/PowerForge/Services/GitHubReleaseVersionAvailabilityService.cs
+++ b/PowerForge/Services/GitHubReleaseVersionAvailabilityService.cs
@@ -1,0 +1,176 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace PowerForge;
+
+/// <summary>Resolves a collision-free version for a GitHub release tag.</summary>
+public sealed class GitHubReleaseVersionAvailabilityService
+{
+    private const int MaximumCandidateCount = 24;
+    private readonly ILogger _logger;
+    private readonly Func<string, string, string, string, GitHubReleaseVersionOccupancy> _probe;
+
+    /// <summary>Creates a GitHub release version availability service.</summary>
+    public GitHubReleaseVersionAvailabilityService(ILogger logger)
+        : this(logger, probe: null)
+    {
+    }
+
+    internal GitHubReleaseVersionAvailabilityService(
+        ILogger logger,
+        Func<string, string, string, string, GitHubReleaseVersionOccupancy>? probe = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _probe = probe ?? Probe;
+    }
+
+    /// <summary>
+    /// Returns the first candidate whose generated GitHub tag is not occupied, or throws for an exact collision.
+    /// </summary>
+    public string EnsureAvailable(
+        string expectedVersion,
+        string candidateVersion,
+        string owner,
+        string repository,
+        string token,
+        Func<string, string> buildTag,
+        bool reuseExistingRelease)
+    {
+        if (string.IsNullOrWhiteSpace(expectedVersion))
+            throw new ArgumentException("Expected version is required.", nameof(expectedVersion));
+        if (string.IsNullOrWhiteSpace(candidateVersion))
+            throw new ArgumentException("Candidate version is required.", nameof(candidateVersion));
+        if (buildTag is null)
+            throw new ArgumentNullException(nameof(buildTag));
+
+        var candidate = candidateVersion.Trim();
+        var firstCandidate = candidate;
+        for (var index = 0; index < MaximumCandidateCount; index++)
+        {
+            var tag = buildTag(candidate);
+            var occupancy = _probe(owner, repository, token, tag);
+            if (!occupancy.Occupied)
+                return candidate;
+
+            if (reuseExistingRelease)
+            {
+                _logger.Warn(
+                    $"GitHub release recovery mode will reuse occupied tag '{tag}' " +
+                    $"({occupancy.Describe()}).");
+                return candidate;
+            }
+
+            if (Version.TryParse(expectedVersion, out _))
+            {
+                throw new InvalidOperationException(
+                    $"GitHub tag '{tag}' already exists ({occupancy.Describe()}) for exact release version '{candidate}'. " +
+                    "Choose a new version, or explicitly enable ReuseExistingRelease for a deliberate recovery run.");
+            }
+
+            if (!TrySplitVersion(candidate, out var numericVersion, out var suffix))
+            {
+                throw new InvalidOperationException(
+                    $"GitHub tag '{tag}' is occupied, but candidate version '{candidate}' could not be stepped using expected pattern '{expectedVersion}'.");
+            }
+
+            var next = VersionPatternStepper.Step(expectedVersion, numericVersion);
+            candidate = next + suffix;
+            _logger.Info(
+                $"GitHub tag '{tag}' is occupied ({occupancy.Describe()}); trying release version '{candidate}'.");
+        }
+
+        throw new InvalidOperationException(
+            $"GitHub reports that all {MaximumCandidateCount} candidate versions starting at '{firstCandidate}' are occupied for '{owner}/{repository}'. " +
+            "No free unified release version was selected.");
+    }
+
+    internal static GitHubReleaseVersionOccupancy Probe(
+        string owner,
+        string repository,
+        string token,
+        string tag)
+    {
+        using var client = CreateClient();
+        var escapedTag = Uri.EscapeDataString(tag);
+        var releaseUri = new Uri(
+            $"https://api.github.com/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repository)}/releases/tags/{escapedTag}");
+        var releaseStatus = SendProbe(client, releaseUri, token, tag, "release");
+        if (releaseStatus == HttpStatusCode.OK)
+            return new GitHubReleaseVersionOccupancy { ReleaseExists = true };
+
+        var tagUri = new Uri(
+            $"https://api.github.com/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repository)}/git/ref/tags/{escapedTag}");
+        var tagStatus = SendProbe(client, tagUri, token, tag, "tag");
+        return new GitHubReleaseVersionOccupancy
+        {
+            TagExists = tagStatus == HttpStatusCode.OK
+        };
+    }
+
+    private static HttpStatusCode SendProbe(
+        HttpClient client,
+        Uri uri,
+        string token,
+        string tag,
+        string resource)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        using var response = client.SendAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
+        if (response.StatusCode is HttpStatusCode.OK or HttpStatusCode.NotFound)
+            return response.StatusCode;
+
+        var responseText = response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        throw new InvalidOperationException(
+            $"GitHub {resource} availability check failed for '{tag}' ({(int)response.StatusCode} {response.ReasonPhrase}). " +
+            TrimForMessage(responseText));
+    }
+
+    private static bool TrySplitVersion(
+        string candidate,
+        out Version numericVersion,
+        out string suffix)
+    {
+        var separator = candidate.IndexOf('-');
+        var numeric = separator >= 0 ? candidate.Substring(0, separator) : candidate;
+        suffix = separator >= 0 ? candidate.Substring(separator) : string.Empty;
+        return Version.TryParse(numeric, out numericVersion!);
+    }
+
+    private static HttpClient CreateClient()
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        client.DefaultRequestHeaders.UserAgent.Clear();
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PowerForge", "1.0"));
+        client.DefaultRequestHeaders.Accept.Clear();
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        client.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+        return client;
+    }
+
+    private static string TrimForMessage(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+
+        var trimmed = text!.Trim();
+        return trimmed.Length > 1000 ? trimmed.Substring(0, 1000) + "..." : trimmed;
+    }
+}
+
+internal sealed class GitHubReleaseVersionOccupancy
+{
+    internal bool ReleaseExists { get; set; }
+
+    internal bool TagExists { get; set; }
+
+    internal bool Occupied => ReleaseExists || TagExists;
+
+    internal string Describe()
+        => ReleaseExists && TagExists
+            ? "release and tag already exist"
+            : ReleaseExists
+                ? "release already exists"
+                : "tag already exists";
+}

--- a/PowerForge/Services/IModulePipelineProgressReporter.cs
+++ b/PowerForge/Services/IModulePipelineProgressReporter.cs
@@ -25,3 +25,12 @@ public interface IModulePipelineProgressReporterV2 : IModulePipelineProgressRepo
     /// <summary>Called when a step is skipped (not executed).</summary>
     void StepSkipped(ModulePipelineStep step);
 }
+
+/// <summary>
+/// Optional extension for hosts that can render determinate progress within a running step.
+/// </summary>
+public interface IModulePipelineProgressReporterV3 : IModulePipelineProgressReporterV2
+{
+    /// <summary>Updates the current and maximum values for a running step.</summary>
+    void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null);
+}

--- a/PowerForge/Services/ModulePipelineExecutionSession.cs
+++ b/PowerForge/Services/ModulePipelineExecutionSession.cs
@@ -6,6 +6,7 @@ namespace PowerForge;
 internal sealed class ModulePipelineExecutionSession
 {
     private readonly IModulePipelineProgressReporterV2? _reporterV2;
+    private readonly IModulePipelineProgressReporterV3? _reporterV3;
     private readonly HashSet<string> _startedKeys;
     private readonly Dictionary<string, ModulePipelineStep> _stepsByKey;
     private readonly Dictionary<ConfigurationArtefactSegment, ModulePipelineStep> _artefactSteps;
@@ -22,6 +23,7 @@ internal sealed class ModulePipelineExecutionSession
         Steps = steps ?? Array.Empty<ModulePipelineStep>();
         Reporter = reporter ?? NullModulePipelineProgressReporter.Instance;
         _reporterV2 = Reporter as IModulePipelineProgressReporterV2;
+        _reporterV3 = Reporter as IModulePipelineProgressReporterV3;
         _startedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _stepsByKey = Steps
             .Where(static step => !string.IsNullOrWhiteSpace(step.Key))
@@ -151,6 +153,12 @@ internal sealed class ModulePipelineExecutionSession
     {
         if (step is null) return;
         try { Reporter.StepCompleted(step); } catch { }
+    }
+
+    internal void Progress(ModulePipelineStep? step, double value, double maximum, string? detail = null)
+    {
+        if (step is null || _reporterV3 is null) return;
+        try { _reporterV3.StepProgress(step, value, maximum, detail); } catch { }
     }
 
     internal void Fail(ModulePipelineStep? step, Exception error)

--- a/PowerForge/Services/ModulePipelineProgressProtocol.cs
+++ b/PowerForge/Services/ModulePipelineProgressProtocol.cs
@@ -56,7 +56,7 @@ internal static class ModulePipelineProgressProtocol
         Console.WriteLine(Prefix + payload);
     }
 
-    private sealed class ProtocolReporter : IModulePipelineProgressReporterV2
+    private sealed class ProtocolReporter : IModulePipelineProgressReporterV3
     {
         private readonly IReadOnlyDictionary<string, PowerForgeReleaseProgressItem> _items;
 
@@ -89,6 +89,16 @@ internal static class ModulePipelineProgressProtocol
 
         public void StepSkipped(ModulePipelineStep step)
             => Update(step, PowerForgeReleaseProgressItemState.Skipped);
+
+        public void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null)
+        {
+            if (step is null || !_items.TryGetValue(step.Key, out var item))
+                return;
+
+            item.ProgressValue = Math.Max(0, value);
+            item.ProgressMaximum = Math.Max(0, maximum);
+            Update(step, PowerForgeReleaseProgressItemState.Started, detail);
+        }
 
         private void Update(
             ModulePipelineStep step,

--- a/PowerForge/Services/ModulePublishConfigurationReader.cs
+++ b/PowerForge/Services/ModulePublishConfigurationReader.cs
@@ -77,6 +77,8 @@ public sealed class ModulePublishConfigurationReader
             OverwriteTagName = configuration.OverwriteTagName,
             DoNotMarkAsPreRelease = configuration.DoNotMarkAsPreRelease,
             GenerateReleaseNotes = configuration.GenerateReleaseNotes,
+            ReuseExistingRelease = configuration.ReuseExistingRelease,
+            ReplaceExistingAssets = configuration.ReplaceExistingAssets,
             Verbose = configuration.Verbose
         };
     }

--- a/PowerForge/Services/ModulePublisher.cs
+++ b/PowerForge/Services/ModulePublisher.cs
@@ -71,7 +71,8 @@ public sealed partial class ModulePublisher
             includeScriptFolders,
             remotePublishAttempted: null,
             remoteSideEffectObserved: null,
-            CancellationToken.None);
+            CancellationToken.None,
+            gitHubProgress: null);
 
     internal ModulePublishResult Publish(
         PublishConfiguration publish,
@@ -81,7 +82,8 @@ public sealed partial class ModulePublisher
         bool includeScriptFolders,
         Action? remotePublishAttempted,
         Action? remoteSideEffectObserved,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IGitHubReleaseProgressReporter? gitHubProgress = null)
     {
         if (publish is null) throw new ArgumentNullException(nameof(publish));
         if (plan is null) throw new ArgumentNullException(nameof(plan));
@@ -119,7 +121,8 @@ public sealed partial class ModulePublisher
                 publish,
                 plan,
                 artefactResults,
-                remotePublishAttempted),
+                remotePublishAttempted,
+                gitHubProgress),
             _ => throw new NotSupportedException($"Unsupported publish destination: {publish.Destination}")
         };
     }
@@ -278,6 +281,8 @@ public sealed partial class ModulePublisher
             OverwriteTagName = publish.OverwriteTagName,
             DoNotMarkAsPreRelease = publish.DoNotMarkAsPreRelease,
             GenerateReleaseNotes = publish.GenerateReleaseNotes,
+            ReuseExistingRelease = publish.ReuseExistingRelease,
+            ReplaceExistingAssets = publish.ReplaceExistingAssets,
             UseAsDependencyVersionSource = publish.UseAsDependencyVersionSource,
             PublishRequiredModules = publish.PublishRequiredModules,
             RequiredModuleSourceRepository = publish.RequiredModuleSourceRepository,
@@ -937,7 +942,8 @@ public sealed partial class ModulePublisher
         PublishConfiguration publish,
         ModulePipelinePlan plan,
         IReadOnlyList<ArtefactBuildResult> artefactResults,
-        Action? remotePublishAttempted)
+        Action? remotePublishAttempted,
+        IGitHubReleaseProgressReporter? gitHubProgress)
     {
         if (string.IsNullOrWhiteSpace(publish.UserName))
             throw new InvalidOperationException("UserName is required for GitHub publishing.");
@@ -959,18 +965,21 @@ public sealed partial class ModulePublisher
 
         _logger.Info($"Publishing GitHub release {owner}/{repo} tag '{tag}' with {assets.Length} asset(s)");
         remotePublishAttempted?.Invoke();
-        var created = _gitHub.PublishRelease(
-            owner: owner,
-            repo: repo,
-            token: publish.ApiKey,
-            tagName: tag,
-            releaseName: tag,
-            releaseNotes: null,
-            commitish: null,
-            generateReleaseNotes: publish.GenerateReleaseNotes,
-            isDraft: false,
-            isPreRelease: isPreRelease,
-            assetFilePaths: assets);
+        var created = _gitHub.PublishRelease(new GitHubReleasePublishRequest
+        {
+            Owner = owner,
+            Repository = repo,
+            Token = publish.ApiKey,
+            TagName = tag,
+            ReleaseName = tag,
+            GenerateReleaseNotes = publish.GenerateReleaseNotes,
+            IsDraft = false,
+            IsPreRelease = isPreRelease,
+            ReuseExistingReleaseOnConflict = publish.ReuseExistingRelease,
+            ReplaceExistingAssets = publish.ReuseExistingRelease && publish.ReplaceExistingAssets,
+            AssetFilePaths = assets,
+            Progress = gitHubProgress
+        });
 
         var releaseUrl = string.IsNullOrWhiteSpace(created.HtmlUrl)
             ? $"https://github.com/{owner}/{repo}/releases/tag/{tag}"

--- a/PowerForge/Services/PowerForgeReleaseService.VersionCoordination.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.VersionCoordination.cs
@@ -163,4 +163,81 @@ internal sealed partial class PowerForgeReleaseService
 
     private static string? NullIfEmpty(string value)
         => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private (ProjectBuildHostExecutionResult Packages, string Version) ResolveCoordinatedReleaseVersion(
+        PowerForgeReleaseSpec spec,
+        string configPath,
+        PowerForgeReleaseRequest request,
+        string? configurationOverride,
+        bool publishUnifiedGitHub,
+        string initialVersionFloor)
+    {
+        var versionFloor = initialVersionFloor;
+        const int maximumCoordinationAttempts = 24;
+        for (var attempt = 0; attempt < maximumCoordinationAttempts; attempt++)
+        {
+            var packages = ExecutePackageRelease(
+                spec.Packages!,
+                configPath,
+                request,
+                configurationOverride,
+                publishUnifiedGitHub,
+                versionFloor,
+                spec.Module!.VersionPrimaryProject,
+                forcePlanOnly: true,
+                suppressPublishing: true);
+            if (!packages.Success)
+                return (packages, versionFloor);
+
+            var resolvedVersion = ResolveCoordinatedPackageVersion(spec.Module!, packages, versionFloor);
+            if (!publishUnifiedGitHub)
+                return (packages, resolvedVersion);
+
+            var availableVersion = EnsureUnifiedGitHubVersionAvailable(
+                spec,
+                configPath,
+                request,
+                resolvedVersion);
+            if (string.Equals(availableVersion, resolvedVersion, StringComparison.OrdinalIgnoreCase))
+                return (packages, resolvedVersion);
+
+            versionFloor = availableVersion;
+        }
+
+        throw new InvalidOperationException(
+            $"Unable to coordinate a release version that is available to both package and GitHub destinations after {maximumCoordinationAttempts} attempts.");
+    }
+
+    private string EnsureUnifiedGitHubVersionAvailable(
+        PowerForgeReleaseSpec spec,
+        string releaseConfigPath,
+        PowerForgeReleaseRequest request,
+        string candidateVersion)
+    {
+        var gitHub = spec.GitHub
+            ?? throw new InvalidOperationException("Unified GitHub release options were not configured.");
+        var configDirectory = Path.GetDirectoryName(releaseConfigPath) ?? Directory.GetCurrentDirectory();
+        var resolved = ResolveUnifiedGitHubConfiguration(spec, gitHub, configDirectory);
+        if (resolved.Error is not null)
+            throw new InvalidOperationException(resolved.Error.ErrorMessage);
+
+        var expectedVersion = request.ModuleVersion ?? spec.Module?.ModuleVersion;
+        if (string.IsNullOrWhiteSpace(expectedVersion))
+            return candidateVersion;
+
+        var tagTemplate = string.IsNullOrWhiteSpace(gitHub.TagTemplate)
+            ? "v{Version}"
+            : gitHub.TagTemplate!;
+        var availability = new GitHubReleaseVersionAvailabilityService(
+            _logger,
+            _probeGitHubReleaseVersion);
+        return availability.EnsureAvailable(
+            expectedVersion!,
+            candidateVersion,
+            resolved.Owner!,
+            resolved.Repository!,
+            resolved.Token!,
+            version => ApplyUnifiedGitHubTemplate(tagTemplate, resolved.Repository!, version),
+            gitHub.ReuseExistingRelease);
+    }
 }

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -58,6 +58,7 @@ internal sealed partial class PowerForgeReleaseService
     private readonly Func<DotNetPublishSpec, string, PowerForgeReleaseRequest, ISet<PowerForgeReleaseToolOutputKind>, DotNetPublishPlan> _planDotNetTools;
     private readonly Func<DotNetPublishPlan, IDotNetPublishProgressReporter?, CancellationToken, DotNetPublishResult> _runDotNetTools;
     private readonly Func<GitHubReleasePublishRequest, CancellationToken, GitHubReleasePublishResult> _publishGitHubRelease;
+    private readonly Func<string, string, string, string, GitHubReleaseVersionOccupancy> _probeGitHubReleaseVersion;
     private readonly Func<PowerForgeWingetSubmissionPlan, PowerForgeWingetSubmissionResult> _submitWinget;
     private readonly Func<AppleAppArchiveRequest, AppleAppArchiveResult> _archiveAppleApp;
     private readonly Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult> _uploadAppleApp;
@@ -160,7 +161,8 @@ internal sealed partial class PowerForgeReleaseService
         Func<DotNetPublishPlan, IDotNetPublishProgressReporter?, CancellationToken, DotNetPublishResult>? runDotNetToolsWithProgressAndCancellation = null,
         Func<PowerForgeToolReleasePlan, IPowerForgeReleaseProgressReporterV2?, CancellationToken, PowerForgeToolReleaseResult>? runToolsWithProgressAndCancellation = null,
         Func<ModuleBuildHostBuildRequest, CancellationToken, ModuleBuildHostExecutionResult>? executeModuleBuild = null,
-        Func<GitHubReleasePublishRequest, CancellationToken, GitHubReleasePublishResult>? publishGitHubReleaseWithCancellation = null)
+        Func<GitHubReleasePublishRequest, CancellationToken, GitHubReleasePublishResult>? publishGitHubReleaseWithCancellation = null,
+        Func<string, string, string, string, GitHubReleaseVersionOccupancy>? probeGitHubReleaseVersion = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -183,6 +185,8 @@ internal sealed partial class PowerForgeReleaseService
             throw new ArgumentNullException(nameof(publishGitHubRelease));
         _publishGitHubRelease = publishGitHubReleaseWithCancellation
             ?? ((publishRequest, _) => publishGitHubRelease(publishRequest));
+        _probeGitHubReleaseVersion = probeGitHubReleaseVersion
+            ?? GitHubReleaseVersionAvailabilityService.Probe;
         _submitWinget = submitWinget ?? (plan => new WingetSubmissionService(logger).Run(plan));
         _archiveAppleApp = archiveAppleApp ?? (request => new AppleAppArchiveService().CreateArchiveAsync(request).GetAwaiter().GetResult());
         _uploadAppleApp = uploadAppleApp ?? (request => new AppleAppArchiveService().UploadArchiveAsync(request).GetAwaiter().GetResult());
@@ -363,26 +367,25 @@ internal sealed partial class PowerForgeReleaseService
                 PowerForgeReleaseProgressPhase.Versioning,
                 CountConfiguredPackageProjects(spec.Packages!),
                 $"Resolving shared version from {spec.Module!.VersionPrimaryProject}");
-            var packages = ExecutePackageRelease(
-                spec.Packages!,
+            var coordination = ResolveCoordinatedReleaseVersion(
+                spec,
                 configPath,
                 request,
                 configurationOverride,
                 publishUnifiedGitHub,
-                versionFloor,
-                spec.Module!.VersionPrimaryProject,
-                forcePlanOnly: true,
-                suppressPublishing: true);
-            result.Packages = packages;
-            if (!packages.Success)
+                versionFloor);
+            result.Packages = coordination.Packages;
+            if (!coordination.Packages.Success)
             {
-                request.Progress?.PhaseFailed(PowerForgeReleaseProgressPhase.Versioning, packages.ErrorMessage);
+                request.Progress?.PhaseFailed(
+                    PowerForgeReleaseProgressPhase.Versioning,
+                    coordination.Packages.ErrorMessage);
                 result.Success = false;
-                result.ErrorMessage = packages.ErrorMessage ?? "Package release workflow failed.";
+                result.ErrorMessage = coordination.Packages.ErrorMessage ?? "Package release workflow failed.";
                 return result;
             }
 
-            request.ResolvedReleaseVersion = ResolveCoordinatedPackageVersion(spec.Module!, packages, versionFloor);
+            request.ResolvedReleaseVersion = coordination.Version;
             request.Progress?.PhaseCompleted(
                 PowerForgeReleaseProgressPhase.Versioning,
                 $"Shared version {request.ResolvedReleaseVersion}");
@@ -807,6 +810,7 @@ internal sealed partial class PowerForgeReleaseService
                     configDirectory,
                     result,
                     sharedReleaseVersion,
+                    request.Progress,
                     request.CancellationToken);
                 result.UnifiedGitHubRelease = unifiedGitHubRelease;
                 if (!unifiedGitHubRelease.Success)
@@ -934,6 +938,7 @@ internal sealed partial class PowerForgeReleaseService
                 configDirectory,
                 builtResult,
                 sharedReleaseVersion,
+                request.Progress,
                 request.CancellationToken);
             builtResult.UnifiedGitHubRelease = unified;
             if (!unified.Success)
@@ -2839,6 +2844,7 @@ internal sealed partial class PowerForgeReleaseService
         string configDirectory,
         PowerForgeReleaseResult result,
         string? sharedReleaseVersion,
+        IPowerForgeReleaseProgressReporter? progress,
         CancellationToken cancellationToken)
     {
         var gitHub = spec.GitHub ?? throw new InvalidOperationException("Unified GitHub release options were not configured.");
@@ -2935,9 +2941,12 @@ internal sealed partial class PowerForgeReleaseService
                     ReleaseName = releaseName,
                     GenerateReleaseNotes = gitHub.GenerateReleaseNotes,
                     IsPreRelease = gitHub.IsPreRelease,
-                    ReuseExistingReleaseOnConflict = true,
-                    ReplaceExistingAssets = gitHub.ReplaceExistingAssets,
-                    AssetFilePaths = assets
+                    ReuseExistingReleaseOnConflict = gitHub.ReuseExistingRelease,
+                    ReplaceExistingAssets = gitHub.ReuseExistingRelease && gitHub.ReplaceExistingAssets,
+                    AssetFilePaths = assets,
+                    Progress = progress is IPowerForgeReleaseProgressReporterV2 detailedProgress
+                        ? new GitHubReleaseProgressAdapter(detailedProgress)
+                        : null
                 },
                 cancellationToken);
 
@@ -2954,7 +2963,8 @@ internal sealed partial class PowerForgeReleaseService
                 ReusedExistingRelease = publishResult.ReusedExistingRelease,
                 ErrorMessage = publishResult.Succeeded ? null : "Unified GitHub release publish failed.",
                 SkippedExistingAssets = publishResult.SkippedExistingAssets?.ToArray() ?? Array.Empty<string>(),
-                ReplacedExistingAssets = publishResult.ReplacedExistingAssets?.ToArray() ?? Array.Empty<string>()
+                ReplacedExistingAssets = publishResult.ReplacedExistingAssets?.ToArray() ?? Array.Empty<string>(),
+                UploadedAssets = publishResult.UploadedAssets?.ToArray() ?? Array.Empty<string>()
             };
         }
         catch (OperationCanceledException)

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -113,9 +113,13 @@
         "TokenEnvName": { "type": [ "string", "null" ] },
         "GenerateReleaseNotes": { "type": "boolean" },
         "IsPreRelease": { "type": "boolean" },
+        "ReuseExistingRelease": {
+          "type": "boolean",
+          "description": "Explicit recovery mode. When true, a release with the same tag may be reused. Auto-versioned normal releases should leave this false so an occupied GitHub tag selects a new version."
+        },
         "ReplaceExistingAssets": {
           "type": "boolean",
-          "description": "When true and an existing release is reused, delete same-named assets before uploading replacements."
+          "description": "When ReuseExistingRelease is true, delete same-named assets before uploading replacements."
         },
         "TagTemplate": { "type": [ "string", "null" ] },
         "ReleaseNameTemplate": { "type": [ "string", "null" ] }

--- a/Schemas/powerforge.segments.schema.json
+++ b/Schemas/powerforge.segments.schema.json
@@ -373,6 +373,8 @@
         "OverwriteTagName": { "type": ["string", "null"] },
         "DoNotMarkAsPreRelease": { "type": "boolean" },
         "GenerateReleaseNotes": { "type": "boolean" },
+        "ReuseExistingRelease": { "type": "boolean" },
+        "ReplaceExistingAssets": { "type": "boolean" },
         "Verbose": { "type": "boolean" }
       }
     },


### PR DESCRIPTION
## What changed

- keeps standard `Build-Module`, hosted module builds, `Invoke-ProjectBuild`, and unified releases on the shared PowerForge progress contract
- shows determinate GitHub asset upload progress, including the active asset and transferred bytes, and keeps the final progress frame visible
- makes summaries explicit about whether GitHub created or reused a release and how many assets were uploaded, skipped, or replaced
- makes normal publishing collision-safe: X-pattern publish planning skips occupied GitHub tags/releases, while exact collisions fail clearly
- changes release reuse and same-name asset replacement into explicit recovery settings instead of silent defaults
- labels package-only work honestly when NuGet publishing is disabled

## Recovery behavior

Normal releases now create a new GitHub release. A deliberate recovery can opt into `ReuseExistingRelease`; `ReplaceExistingAssets` is accepted only with that recovery option. The low-level `Send-GitHubRelease` cmdlet also defaults to failing on an occupied tag.

## Validation

- end-to-end local unified build succeeded with module, six package projects, executable matrix, and 24 release assets; no remote publish destinations were enabled
- 125 focused release/version/progress/schema tests passed
- full suite: 5,160 passed; the two initial failures (an over-broad online planning check and an unrelated load-sensitive static-server timeout) both passed in isolated reruns after correction
- PowerForge and PSPublishModule built clean for net472; module/CLI supported net8/net10 targets built during the full validation
- live GitHub occupancy probe resolved occupied v3.0.77 to free v3.0.78 without mutating GitHub

## Release-state note

The earlier v3.0.77 run reused a GitHub release created two days earlier and replaced its 24 assets. PSGallery received PSPublishModule 3.0.77; the PowerForge NuGet packages were built and attached to GitHub but were not published to NuGet.org. This PR prevents that reuse from happening silently again.