### PR TITLE
Automate resumable Apple release advancement

### DIFF
--- a/PowerForge.Cli/AppleReleaseCliSummary.cs
+++ b/PowerForge.Cli/AppleReleaseCliSummary.cs
@@ -39,5 +39,9 @@ internal sealed class AppleReleaseCliTargetSummary
 
     public string Scheme { get; set; } = string.Empty;
 
+    public string? MarketingVersion { get; set; }
+
+    public string? BuildNumber { get; set; }
+
     public bool GenerateProjectIfMissing { get; set; }
 }

--- a/PowerForge.Cli/Program.Command.AppleRelease.cs
+++ b/PowerForge.Cli/Program.Command.AppleRelease.cs
@@ -4,8 +4,9 @@ using PowerForge.Cli;
 internal static partial class Program
 {
     private const string AppleReleaseUsage =
-        "Usage: powerforge apple-release <Status|Archive|Upload|UploadExisting|Prepare|Screenshots|TestFlight|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup> " +
+        "Usage: powerforge apple-release <Status|Version|Archive|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup> " +
         "[--config <release.json>] [--plan] [--validate] [--confirm-apple-action] " +
+        "[--apple-version <marketing-version>] " +
         "[--apple-resume|--no-apple-resume] [--apple-wait|--no-apple-wait] " +
         "[--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>] " +
         "[--target <Name[,Name...]>] [--summary] [--output json]";
@@ -84,6 +85,7 @@ internal static partial class Program
             "--target",
             "--apple-timeout-seconds",
             "--apple-poll-seconds",
+            "--apple-version",
             "--output"
         };
 

--- a/PowerForge.Cli/Program.Command.Release.cs
+++ b/PowerForge.Cli/Program.Command.Release.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 internal static partial class Program
 {
     private const string ReleaseUsage =
-        "Usage: powerforge release [--config <release.json>] [--plan] [--validate] [--packages-only] [--module-only] [--tools-only] [--apple-action <Configured|Status|Archive|Upload|UploadExisting|Prepare|Screenshots|TestFlight|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>] [--confirm-apple-action] [--apple-resume|--no-apple-resume] [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>] [--summary] [--configuration <Release|Debug>] [--module-framework <auto|net10.0|net8.0>] [--module-run-mode <Manifest|Documentation|Build|Publish>] [--module-timeout-seconds <seconds>] [--module-no-dotnet-build] [--module-version <version>] [--module-prerelease-tag <tag>] [--module-no-sign] [--module-sign] [--module-certificate-thumbprint <sha1>] [--module-sign-include-binaries|--module-no-sign-include-binaries] [--module-sign-include-internals|--module-no-sign-include-internals] [--module-sign-include-exe|--module-no-sign-include-exe] [--module-diagnostics-baseline <path>] [--module-diagnostics-baseline-generate|--module-no-diagnostics-baseline-generate] [--module-diagnostics-baseline-update|--module-no-diagnostics-baseline-update] [--module-fail-on-new-diagnostics|--module-no-fail-on-new-diagnostics] [--module-fail-on-diagnostics-severity <Warning|Error>] [--skip-workspace-validation] [--workspace-config <workspace.validation.json>] [--workspace-profile <name>] [--workspace-testimox-root <path>] [--workspace-enable-feature <name[,name...]>] [--workspace-disable-feature <name[,name...]>] [--publish-nuget] [--publish-project-github] [--publish-tool-github] [--submit-winget] [--skip-winget-submit] [--winget-submit-mode <Manifest|Update>] [--winget-tool-path <path>] [--winget-token-env <name>] [--winget-token-file <path>] [--winget-pr-title <text>] [--winget-open-browser] [--winget-replace [version]] [--winget-allow-interactive-auth] [--winget-timeout-seconds <seconds>] [--skip-restore] [--skip-build] [--output-root <path>] [--stage-root <path>] [--manifest-json <path>] [--allow-output-outside-project-root] [--allow-manifest-outside-project-root] [--checksums-path <path>] [--skip-release-checksums] [--keep-symbols] [--sign] [--sign-profile <name>] [--sign-tool-path <path>] [--sign-thumbprint <sha1>] [--sign-subject-name <name>] [--sign-on-missing-tool <Warn|Fail|Skip>] [--sign-on-failure <Warn|Fail|Skip>] [--sign-timeout-seconds <seconds>] [--sign-timestamp-url <url>] [--sign-description <text>] [--sign-url <url>] [--sign-csp <name>] [--sign-key-container <name>] [--package-sign-thumbprint <sha1>] [--package-sign-store <CurrentUser|LocalMachine>] [--package-sign-timestamp-url <url>] [--installer-property <Name=Value>] [--tool-output <Tool|Portable|Installer|Store>[,<...>]] [--skip-tool-output <...>] [--target <Name[,Name...]>] [--rid <Rid[,Rid...]>] [--framework <tfm[,tfm...]>] [--style <Portable|PortableCompat|PortableSize|FrameworkDependent|AotSpeed|AotSize>[,<...>]] [--flavor <SingleContained|SingleFx|Portable|Fx>[,<...>]] [--output json]";
+        "Usage: powerforge release [--config <release.json>] [--plan] [--validate] [--packages-only] [--module-only] [--tools-only] [--apple-action <Configured|Status|Version|Archive|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>] [--apple-version <marketing-version>] [--confirm-apple-action] [--apple-resume|--no-apple-resume] [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>] [--summary] [--configuration <Release|Debug>] [--module-framework <auto|net10.0|net8.0>] [--module-run-mode <Manifest|Documentation|Build|Publish>] [--module-timeout-seconds <seconds>] [--module-no-dotnet-build] [--module-version <version>] [--module-prerelease-tag <tag>] [--module-no-sign] [--module-sign] [--module-certificate-thumbprint <sha1>] [--module-sign-include-binaries|--module-no-sign-include-binaries] [--module-sign-include-internals|--module-no-sign-include-internals] [--module-sign-include-exe|--module-no-sign-include-exe] [--module-diagnostics-baseline <path>] [--module-diagnostics-baseline-generate|--module-no-diagnostics-baseline-generate] [--module-diagnostics-baseline-update|--module-no-diagnostics-baseline-update] [--module-fail-on-new-diagnostics|--module-no-fail-on-new-diagnostics] [--module-fail-on-diagnostics-severity <Warning|Error>] [--skip-workspace-validation] [--workspace-config <workspace.validation.json>] [--workspace-profile <name>] [--workspace-testimox-root <path>] [--workspace-enable-feature <name[,name...]>] [--workspace-disable-feature <name[,name...]>] [--publish-nuget] [--publish-project-github] [--publish-tool-github] [--submit-winget] [--skip-winget-submit] [--winget-submit-mode <Manifest|Update>] [--winget-tool-path <path>] [--winget-token-env <name>] [--winget-token-file <path>] [--winget-pr-title <text>] [--winget-open-browser] [--winget-replace [version]] [--winget-allow-interactive-auth] [--winget-timeout-seconds <seconds>] [--skip-restore] [--skip-build] [--output-root <path>] [--stage-root <path>] [--manifest-json <path>] [--allow-output-outside-project-root] [--allow-manifest-outside-project-root] [--checksums-path <path>] [--skip-release-checksums] [--keep-symbols] [--sign] [--sign-profile <name>] [--sign-tool-path <path>] [--sign-thumbprint <sha1>] [--sign-subject-name <name>] [--sign-on-missing-tool <Warn|Fail|Skip>] [--sign-on-failure <Warn|Fail|Skip>] [--sign-timeout-seconds <seconds>] [--sign-timestamp-url <url>] [--sign-description <text>] [--sign-url <url>] [--sign-csp <name>] [--sign-key-container <name>] [--package-sign-thumbprint <sha1>] [--package-sign-store <CurrentUser|LocalMachine>] [--package-sign-timestamp-url <url>] [--installer-property <Name=Value>] [--tool-output <Tool|Portable|Installer|Store>[,<...>]] [--skip-tool-output <...>] [--target <Name[,Name...]>] [--rid <Rid[,Rid...]>] [--framework <tfm[,tfm...]>] [--style <Portable|PortableCompat|PortableSize|FrameworkDependent|AotSpeed|AotSize>[,<...>]] [--flavor <SingleContained|SingleFx|Portable|Fx>[,<...>]] [--output json]";
 
     private static int CommandRelease(
         string[] filteredArgs,
@@ -359,6 +359,7 @@ internal static partial class Program
         request.ModuleOnly = moduleOnly;
         request.ToolsOnly = request.ToolsOnly || toolsOnly;
         request.AppleAction = ParseAppleReleaseAction(TryGetOptionValue(argv, "--apple-action"));
+        request.AppleMarketingVersion = ChooseString(request.AppleMarketingVersion, TryGetOptionValue(argv, "--apple-version"));
         request.AppleActionConfirmed = argv.Any(a => a.Equals("--confirm-apple-action", StringComparison.OrdinalIgnoreCase));
         request.AppleResume = ResolveBooleanOverride(argv, "--apple-resume", "--no-apple-resume", request.AppleResume);
         request.AppleWaitForProcessing = ResolveBooleanOverride(argv, "--apple-wait", "--no-apple-wait", request.AppleWaitForProcessing);
@@ -521,7 +522,7 @@ internal static partial class Program
         PowerForgeReleaseResult result,
         PowerForgeReleaseRequest request)
     {
-        if (result.AppleReceipt is not null)
+        if (result.AppleReceipt is not null && !request.PlanOnly)
             return CliJson.SerializeToElement(result.AppleReceipt, CliJson.Context.PowerForgeAppleReleaseReceipt);
         if (result.AppleAppPlan is null)
             return CliJson.SerializeToElement(result, CliJson.Context.PowerForgeReleaseResult);
@@ -542,6 +543,10 @@ internal static partial class Program
         AddEnabledStep(enabledSteps, plan.ReleaseApprovedVersion, "release");
         if (plan.Action == PowerForgeAppleReleaseAction.Status)
             enabledSteps.Add("status");
+        if (plan.Action == PowerForgeAppleReleaseAction.Version)
+            enabledSteps.Add("version");
+        if (plan.Action == PowerForgeAppleReleaseAction.Advance)
+            enabledSteps.Add("stopBeforeReview");
         if (plan.Action == PowerForgeAppleReleaseAction.Cleanup)
             enabledSteps.Add("cleanup");
 
@@ -550,20 +555,24 @@ internal static partial class Program
             Action = plan.Action,
             PlanOnly = request.PlanOnly,
             ValidateOnly = request.ValidateOnly,
-            ReceiptPath = Path.GetRelativePath(plan.ProjectRoot, plan.ReceiptPath).Replace('\\', '/'),
+            ReceiptPath = Path.GetRelativePath(
+                plan.ProjectRoot,
+                request.PlanOnly ? plan.PlanReceiptPath : plan.ReceiptPath).Replace('\\', '/'),
             Resume = plan.Automation.Resume,
             WaitForProcessing = plan.Automation.WaitForProcessing,
             ProcessingTimeoutSeconds = plan.Automation.ProcessingTimeoutSeconds,
             PollIntervalSeconds = plan.Automation.PollIntervalSeconds,
             EnabledSteps = enabledSteps.ToArray(),
             RequiresConfirmation = RequiresAppleActionConfirmation(plan),
-            Targets = plan.Apps.Select(static app => new AppleReleaseCliTargetSummary
+            Targets = plan.Apps.Select(app => new AppleReleaseCliTargetSummary
             {
                 Name = app.Name,
                 Platform = app.Platform,
                 BundleId = app.BundleId,
                 AppId = app.AppStoreConnectAppId,
                 Scheme = app.Scheme,
+                MarketingVersion = result.AppleReceipt?.Versioning?.MarketingVersion ?? app.MarketingVersion,
+                BuildNumber = result.AppleReceipt?.Versioning?.BuildNumber ?? app.BuildNumber,
                 GenerateProjectIfMissing = app.GenerateProjectIfMissing
             }).ToArray()
         };
@@ -583,6 +592,8 @@ internal static partial class Program
              plan.ReleaseApprovedVersion ||
              (plan.SyncScreenshots && plan.ReplaceScreenshots))) ||
            plan.Action == PowerForgeAppleReleaseAction.SubmitTestFlightReview ||
+           plan.Action == PowerForgeAppleReleaseAction.Advance ||
+           plan.Action == PowerForgeAppleReleaseAction.Version ||
            plan.Action == PowerForgeAppleReleaseAction.SubmitAppReview ||
            plan.Action == PowerForgeAppleReleaseAction.Release ||
            (plan.Action == PowerForgeAppleReleaseAction.Screenshots && plan.ReplaceScreenshots);

--- a/PowerForge.Cli/Program.Helpers.cs
+++ b/PowerForge.Cli/Program.Helpers.cs
@@ -33,7 +33,7 @@ internal static partial class Program
                         [--package-sign-thumbprint <sha1>] [--package-sign-store <CurrentUser|LocalMachine>] [--package-sign-timestamp-url <url>]
                         [--tool-output <Tool|Portable|Installer|Store>[,<...>]] [--skip-tool-output <Tool|Portable|Installer|Store>[,<...>]]
                         [--target <Name[,Name...]>] [--rid <Rid[,Rid...]>] [--framework <tfm[,tfm...]>] [--style <Portable|PortableCompat|PortableSize|FrameworkDependent|AotSpeed|AotSize>[,<...>]] [--flavor <SingleContained|SingleFx|Portable|Fx>[,<...>]] [--output json]
-      powerforge apple-release <Status|Archive|Upload|UploadExisting|Prepare|Screenshots|TestFlight|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>
+      powerforge apple-release <Status|Version|Archive|Upload|UploadExisting|Prepare|Screenshots|TestFlight|Advance|SubmitTestFlightReview|SubmitAppReview|Release|Cleanup>
                         [--config <release.json>] [--plan] [--validate] [--confirm-apple-action] [--apple-resume|--no-apple-resume]
                         [--apple-wait|--no-apple-wait] [--apple-timeout-seconds <seconds>] [--apple-poll-seconds <seconds>]
                         [--target <Name[,Name...]>] [--summary] [--output json]

--- a/PowerForge.Tests/AppStoreConnectClientTests.cs
+++ b/PowerForge.Tests/AppStoreConnectClientTests.cs
@@ -109,6 +109,29 @@ public sealed partial class AppStoreConnectClientTests
     }
 
     [Fact]
+    public async Task GetBuildsAsync_FollowsEveryPaginationLink()
+    {
+        var handler = new SequenceHandler(
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [{ "id": "build-199", "type": "builds", "attributes": { "version": "199", "processingState": "VALID" } }],
+                  "links": { "next": "https://api.appstoreconnect.apple.com/v1/builds?cursor=next" }
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """{ "data": [{ "id": "build-205", "type": "builds", "attributes": { "version": "205", "processingState": "VALID" } }], "links": { "next": null } }"""));
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+        using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+        var builds = await client.GetBuildsAsync("123", limit: 200);
+
+        Assert.Equal(new[] { "199", "205" }, builds.Select(static build => build.Version).ToArray());
+        Assert.Equal(2, handler.RequestUris.Count);
+        Assert.Equal("?cursor=next", handler.RequestUris[1].Query);
+    }
+
+    [Fact]
     public async Task GetBuildsAsync_FiltersIncludedPreReleaseVersionByMarketingVersionAndPlatform()
     {
         var handler = new RecordingHandler(
@@ -985,6 +1008,125 @@ public sealed partial class AppStoreConnectClientTests
         }
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ScreenshotSyncService_RetryRetainsMatchingChecksumWithoutReupload(bool replaceExisting)
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-home.png"), new byte[] { 9, 8, 7 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "shot-1", "type": "appScreenshots", "attributes": { "fileName": "01-home.png", "fileSize": 3, "sourceFileChecksum": "0c8e83d7bd4e4d5e9c170932482c3264", "assetDeliveryState": { "state": "UPLOAD_COMPLETE" } } }] }"""));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+            var result = await new AppStoreConnectScreenshotSyncService(client).SyncAsync(new AppStoreConnectScreenshotSyncRequest
+            {
+                BaseDirectory = root.FullName,
+                ReplaceExisting = replaceExisting,
+                Spec = new AppStoreConnectScreenshotSyncSpec
+                {
+                    AppId = "app-1",
+                    VersionString = "1.0.0",
+                    Platform = ApplePlatform.iOS,
+                    Locale = "en-US",
+                    ScreenshotSets = new[]
+                    {
+                        new AppStoreConnectScreenshotSetSyncSpec
+                        {
+                            ScreenshotDisplayType = "APP_IPHONE_65",
+                            Path = "iphone-6-5"
+                        }
+                    }
+                }
+            });
+
+            var set = Assert.Single(result.ScreenshotSets);
+            Assert.Equal(0, set.DeletedCount);
+            Assert.Empty(set.Uploaded);
+            Assert.Equal(4, handler.RequestUris.Count);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task ScreenshotSyncService_ReplaceExistingRebuildsChangedScreenshotOrder()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "PowerForge.Tests", Guid.NewGuid().ToString("N")));
+        try
+        {
+            var folder = Directory.CreateDirectory(Path.Combine(root.FullName, "iphone-6-5"));
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "01-first.png"), new byte[] { 1 });
+            await File.WriteAllBytesAsync(Path.Combine(folder.FullName, "02-second.png"), new byte[] { 2 });
+            var handler = new SequenceHandler(
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "version-1", "type": "appStoreVersions", "attributes": { "versionString": "1.0.0", "platform": "IOS" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "loc-1", "type": "appStoreVersionLocalizations", "attributes": { "locale": "en-US" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK, """{ "data": [{ "id": "set-1", "type": "appScreenshotSets", "attributes": { "screenshotDisplayType": "APP_IPHONE_65" } }] }"""),
+                new SequenceResponse(HttpStatusCode.OK,
+                    """{ "data": [{ "id": "shot-second", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "9e688c58a5487b8eaf69c9e1005ad0bf" } }, { "id": "shot-first", "type": "appScreenshots", "attributes": { "sourceFileChecksum": "55a54008ad1ba589aa210d2629c1df41" } }] }"""),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                new SequenceResponse(HttpStatusCode.NoContent, string.Empty),
+                ScreenshotReservation("new-first", "01-first.png", 1),
+                ScreenshotCommit("new-first", "01-first.png", "55a54008ad1ba589aa210d2629c1df41"),
+                ScreenshotReservation("new-second", "02-second.png", 1),
+                ScreenshotCommit("new-second", "02-second.png", "9e688c58a5487b8eaf69c9e1005ad0bf"));
+            using var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.appstoreconnect.apple.com/v1/") };
+            using var client = new AppStoreConnectClient(CreateCredential(), http);
+
+            var result = await new AppStoreConnectScreenshotSyncService(client).SyncAsync(new AppStoreConnectScreenshotSyncRequest
+            {
+                BaseDirectory = root.FullName,
+                ReplaceExisting = true,
+                Spec = new AppStoreConnectScreenshotSyncSpec
+                {
+                    AppId = "app-1",
+                    VersionString = "1.0.0",
+                    Platform = ApplePlatform.iOS,
+                    Locale = "en-US",
+                    ScreenshotSets = new[]
+                    {
+                        new AppStoreConnectScreenshotSetSyncSpec
+                        {
+                            ScreenshotDisplayType = "APP_IPHONE_65",
+                            Path = "iphone-6-5"
+                        }
+                    }
+                }
+            });
+
+            var set = Assert.Single(result.ScreenshotSets);
+            Assert.Equal(2, set.DeletedCount);
+            Assert.Equal(new[] { "01-first.png", "02-second.png" }, set.Uploaded.Select(upload => Path.GetFileName(upload.FilePath)).ToArray());
+            Assert.Equal(HttpMethod.Delete, handler.Methods[4]);
+            Assert.Equal(HttpMethod.Delete, handler.Methods[5]);
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static SequenceResponse ScreenshotReservation(string id, string fileName, long fileSize)
+        => new(HttpStatusCode.Created,
+            $$"""{ "data": { "id": "{{id}}", "type": "appScreenshots", "attributes": { "fileName": "{{fileName}}", "fileSize": {{fileSize}}, "uploadOperations": [] } } }""");
+
+    private static SequenceResponse ScreenshotCommit(string id, string fileName, string checksum)
+        => new(HttpStatusCode.OK,
+            $$"""{ "data": { "id": "{{id}}", "type": "appScreenshots", "attributes": { "fileName": "{{fileName}}", "sourceFileChecksum": "{{checksum}}", "assetDeliveryState": { "state": "UPLOAD_COMPLETE" } } } }""");
+
     [Fact]
     public async Task ScreenshotSyncService_PreflightsAllLocalMappingsBeforeRemoteRequests()
     {
@@ -1662,9 +1804,29 @@ public sealed partial class AppStoreConnectClientTests
                 {
                   "data": [
                     {
+                      "id": "review-old",
+                      "type": "reviewSubmissions",
+                      "attributes": { "platform": "IOS", "state": "COMPLETE", "submitted": true }
+                    },
+                    {
                       "id": "review-1",
                       "type": "reviewSubmissions",
                       "attributes": { "platform": "IOS", "state": "WAITING_FOR_REVIEW", "submitted": true }
+                    }
+                  ]
+                }
+                """),
+            new SequenceResponse(HttpStatusCode.OK,
+                """
+                {
+                  "data": [
+                    {
+                      "id": "review-item-1",
+                      "type": "reviewSubmissionItems",
+                      "attributes": { "state": "WAITING_FOR_REVIEW" },
+                      "relationships": {
+                        "appStoreVersion": { "data": { "type": "appStoreVersions", "id": "version-1" } }
+                      }
                     }
                   ]
                 }

--- a/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
+++ b/PowerForge.Tests/PowerForgeCliAppleReleaseTests.cs
@@ -45,6 +45,20 @@ public sealed class PowerForgeCliAppleReleaseTests
                 Assert.Equal("status", Assert.Single(result.GetProperty("enabledSteps").EnumerateArray()).GetString());
             }
 
+            var advance = await RunCliAsync(
+                repoRoot,
+                $"\"{GetCliPath(repoRoot)}\" apple-release Advance --config \"{configPath}\" --plan --summary --output json");
+            Assert.Equal(0, advance.ExitCode);
+            using (var advanceDocument = JsonDocument.Parse(advance.StdOut))
+            {
+                var result = advanceDocument.RootElement.GetProperty("result");
+                Assert.Equal("Advance", result.GetProperty("action").GetString());
+                Assert.True(result.GetProperty("requiresConfirmation").GetBoolean());
+                Assert.Contains(
+                    result.GetProperty("enabledSteps").EnumerateArray(),
+                    static step => step.GetString() == "stopBeforeReview");
+            }
+
             var configuredDedicated = await RunCliAsync(
                 repoRoot,
                 $"\"{GetCliPath(repoRoot)}\" apple-release Configured --config \"{configPath}\" --plan --summary --output json");

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleAutomation.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleAutomation.cs
@@ -605,7 +605,7 @@ public sealed partial class PowerForgeReleaseServiceTests
                 });
 
             Assert.False(result.Success);
-            Assert.Equal(2, stateCalls);
+            Assert.Equal(3, stateCalls);
             var receipt = Assert.IsType<PowerForgeAppleReleaseReceipt>(result.AppleReceipt);
             Assert.False(receipt.Success);
             Assert.Contains(
@@ -657,8 +657,10 @@ public sealed partial class PowerForgeReleaseServiceTests
         Func<AppleAppArchiveRequest, AppleAppArchiveResult>? archiveAppleApp = null,
         Func<AppleAppArchiveUploadRequest, AppleAppArchiveUploadResult>? uploadAppleApp = null,
         Func<AppStoreConnectReleasePreparationRequest, AppStoreConnectReleasePreparationResult>? prepareAppleDistribution = null,
+        Func<AppStoreConnectTestFlightDistributionRequest, AppStoreConnectTestFlightDistributionResult>? distributeTestFlight = null,
         Func<AppStoreConnectApiCredential, string, AppStoreConnectBuildUploadInfo?>? getAppleBuildUpload = null,
-        Func<PowerForgeAppleAppReleaseTargetPlan, bool>? generateAppleProject = null)
+        Func<PowerForgeAppleAppReleaseTargetPlan, bool>? generateAppleProject = null,
+        Func<AppStoreConnectApiCredential, string, ApplePlatform, long>? getHighestAppleBuildNumber = null)
         => new(
             new NullLogger(),
             executePackages: (_, _, _) => throw new InvalidOperationException("Packages should not run."),
@@ -671,11 +673,13 @@ public sealed partial class PowerForgeReleaseServiceTests
             archiveAppleApp: archiveAppleApp ?? (_ => throw new InvalidOperationException("Exact remote build should skip archive.")),
             uploadAppleApp: uploadAppleApp ?? (_ => throw new InvalidOperationException("Exact remote build should skip upload.")),
             prepareAppleDistribution: prepareAppleDistribution,
+            distributeTestFlight: distributeTestFlight,
             getAppleReleaseState: getState,
             getAppleBuildUpload: getAppleBuildUpload,
             generateAppleProject: generateAppleProject,
             delay: delay,
-            appleArtifactService: new AppleReleaseArtifactService(getAvailableBytes ?? (_ => long.MaxValue)));
+            appleArtifactService: new AppleReleaseArtifactService(getAvailableBytes ?? (_ => long.MaxValue)),
+            getHighestAppleBuildNumber: getHighestAppleBuildNumber);
 
     private static AppStoreConnectReleaseStateResult CreateReleaseState(
         AppStoreConnectReleaseStateRequest request,

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReleaseAdvancement.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReleaseAdvancement.cs
@@ -1,0 +1,377 @@
+namespace PowerForge.Tests;
+
+public sealed partial class PowerForgeReleaseServiceTests
+{
+    [Fact]
+    public void Execute_AppleVersion_UsesOneBuildAboveLocalAndEveryRemotePlatform()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.Apps = new[]
+            {
+                spec.AppleApps.Apps.Single(),
+                new AppleAppConfiguration
+                {
+                    Name = "CasaRay Mac",
+                    BundleId = "com.evotecit.casaray",
+                    Platform = ApplePlatform.macOS,
+                    ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                    ProjectPath = "CasaRay.xcodeproj",
+                    Scheme = "CasaRay",
+                    AppStoreConnectAppId = "6778025328"
+                }
+            };
+            var generationCalls = 0;
+            var service = CreateAppleAutomationService(
+                _ => throw new InvalidOperationException("Version must not query release status."),
+                generateAppleProject: _ =>
+                {
+                    generationCalls++;
+                    var version = new AppleReleaseVersionSourceService().Read(Path.Combine(root, "project.yml"));
+                    Assert.Equal("1.6.0", version.MarketingVersion);
+                    Assert.Equal("16", version.BuildNumber);
+                    return true;
+                },
+                getHighestAppleBuildNumber: (_, _, platform) => platform == ApplePlatform.iOS ? 15 : 14);
+
+            var result = service.Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                AppleAction = PowerForgeAppleReleaseAction.Version,
+                AppleMarketingVersion = "1.6.0",
+                AppleActionConfirmed = true
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(1, generationCalls);
+            var versioning = Assert.IsType<PowerForgeAppleVersionReceipt>(result.AppleReceipt!.Versioning);
+            Assert.Equal("1.6.0", versioning.MarketingVersion);
+            Assert.Equal("16", versioning.BuildNumber);
+            Assert.Equal(15, versioning.HighestRemoteBuildNumber);
+            Assert.All(result.AppleReceipt.Targets, target =>
+            {
+                Assert.Equal("1.6.0", target.Version);
+                Assert.Equal("16", target.Build);
+            });
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleVersion_RetryKeepsUnpublishedSelectedBuild()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "16");
+            WriteXcodeGenVersionSource(root, "1.6.0", "16");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Version must not query release status."),
+                    generateAppleProject: _ => true,
+                    getHighestAppleBuildNumber: (_, _, _) => 15)
+                .Execute(spec, new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Version,
+                    AppleMarketingVersion = "1.6.0",
+                    AppleActionConfirmed = true
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal("16", result.AppleReceipt!.Versioning!.BuildNumber);
+            Assert.False(result.AppleReceipt.Versioning.Changed);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleVersionPlan_WritesSeparatePlanReceiptWithoutChangingSource()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Version plan must not query release status."),
+                    getHighestAppleBuildNumber: (_, _, _) => 13)
+                .Execute(spec, new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Version,
+                    AppleMarketingVersion = "1.6.0",
+                    PlanOnly = true
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.True(result.AppleReceipt!.PlanOnly);
+            Assert.Equal("14", result.AppleReceipt.Versioning!.BuildNumber);
+            Assert.True(File.Exists(Path.Combine(root, "build/powerforge/apple/release-plan.json")));
+            Assert.False(File.Exists(Path.Combine(root, "build/powerforge/apple/release-receipt.json")));
+            var source = new AppleReleaseVersionSourceService().Read(Path.Combine(root, "project.yml"));
+            Assert.Equal("1.5.0", source.MarketingVersion);
+            Assert.Equal("13", source.BuildNumber);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleAdvancePlan_EnablesSafeStepsAndStopsBeforeReview()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+
+            var result = new PowerForgeReleaseService(new NullLogger()).Execute(spec, new PowerForgeReleaseRequest
+            {
+                ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                AppleAction = PowerForgeAppleReleaseAction.Advance,
+                PlanOnly = true
+            });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var plan = Assert.IsType<PowerForgeAppleReleasePlan>(result.AppleAppPlan);
+            Assert.True(plan.Archive);
+            Assert.True(plan.Upload);
+            Assert.True(plan.PrepareDistribution);
+            Assert.True(plan.SelectBuildForDistribution);
+            Assert.True(plan.CheckReleaseReadiness);
+            Assert.False(plan.SubmitTestFlightBetaReview);
+            Assert.False(plan.SubmitForReview);
+            Assert.False(plan.ReleaseApprovedVersion);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleScreenshots_BindsVersionAtRuntimeWhenMappingOmitsVersionAndId()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var folder = Directory.CreateDirectory(Path.Combine(root, "shots"));
+            File.WriteAllBytes(
+                Path.Combine(folder.FullName, "01.png"),
+                Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2n1sAAAAASUVORK5CYII="));
+            File.WriteAllText(
+                Path.Combine(root, "screenshots.json"),
+                """
+                {
+                  "appId": "6778025328",
+                  "useReleaseVersion": true,
+                  "platform": "iOS",
+                  "locale": "en-US",
+                  "quality": {
+                    "enabled": true,
+                    "minimumFileBytes": 0,
+                    "minimumKilobytesPerMegapixel": 0
+                  },
+                  "screenshotSets": [
+                    {
+                      "screenshotDisplayType": "APP_IPHONE_65",
+                      "path": "shots",
+                      "filter": "*.png"
+                    }
+                  ]
+                }
+                """);
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.ScreenshotConfigPath = "screenshots.json";
+            AppStoreConnectReleasePreparationRequest? observed = null;
+
+            var result = CreateAppleAutomationService(
+                    request => CreateReleaseState(request, "VALID"),
+                    prepareAppleDistribution: request =>
+                    {
+                        observed = request;
+                        return CreateSuccessfulPreparation(request);
+                    })
+                .Execute(spec, new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Screenshots,
+                    AppleActionConfirmed = true
+                });
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.NotNull(observed?.ScreenshotSpec);
+            Assert.Equal("1.6.0", observed!.ScreenshotSpec!.VersionString);
+            Assert.Null(observed.ScreenshotSpec.VersionId);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void AppleReleaseOperationLock_RejectsOverlappingOwnerAndRecoversAfterDispose()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            var path = Path.Combine(root, "release.lock");
+            using (AppleReleaseOperationLock.Acquire(path, PowerForgeAppleReleaseAction.Advance))
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                    AppleReleaseOperationLock.Acquire(path, PowerForgeAppleReleaseAction.Version));
+                Assert.Contains("Another Apple release operation", exception.Message, StringComparison.Ordinal);
+            }
+
+            using var recovered = AppleReleaseOperationLock.Acquire(path, PowerForgeAppleReleaseAction.Version);
+            Assert.True(File.Exists(path));
+            recovered.Dispose();
+            Assert.True(File.Exists(path));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleVersion_ProjectGenerationFailureRetainsSelectedIdentityInReceipt()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+            spec.AppleApps.Apps = new[]
+            {
+                spec.AppleApps.Apps.Single(),
+                new AppleAppConfiguration
+                {
+                    Name = "CasaRay Mac",
+                    BundleId = "com.evotecit.casaray",
+                    Platform = ApplePlatform.macOS,
+                    ArchiveVariant = AppleArchiveVariant.MacCatalyst,
+                    ProjectPath = "CasaRay.xcodeproj",
+                    Scheme = "CasaRay",
+                    AppStoreConnectAppId = "6778025328"
+                }
+            };
+
+            var result = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Version must not query release status."),
+                    generateAppleProject: _ => throw new InvalidOperationException("xcodegen failed"),
+                    getHighestAppleBuildNumber: (_, _, _) => 13)
+                .Execute(spec, new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Version,
+                    AppleMarketingVersion = "1.6.0",
+                    AppleActionConfirmed = true
+                });
+
+            Assert.False(result.Success);
+            Assert.Equal("1.6.0", result.AppleReceipt!.Versioning!.MarketingVersion);
+            Assert.Equal("14", result.AppleReceipt.Versioning.BuildNumber);
+            Assert.All(result.AppleReceipt.Targets, target =>
+            {
+                Assert.Equal("1.6.0", target.Version);
+                Assert.Equal("14", target.Build);
+            });
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void Execute_AppleAdvance_PartialFailureRefreshesRemoteStateAndKeepsOriginalError()
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.6.0", "14");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.TestFlightBetaGroupNames = new[] { "Internal" };
+            var stateCalls = 0;
+
+            var result = CreateAppleAutomationService(
+                    request =>
+                    {
+                        stateCalls++;
+                        var state = CreateReleaseState(request, "VALID");
+                        state.Platforms.Single().Version!.Id = stateCalls == 1 ? "version-before" : "version-after";
+                        return state;
+                    },
+                    prepareAppleDistribution: CreateSuccessfulPreparation,
+                    distributeTestFlight: _ => throw new InvalidOperationException("group assignment failed"))
+                .Execute(spec, new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Advance,
+                    AppleActionConfirmed = true
+                });
+
+            Assert.False(result.Success);
+            Assert.Equal("group assignment failed", result.ErrorMessage);
+            var target = Assert.Single(result.AppleReceipt!.Targets);
+            Assert.Equal("group assignment failed", target.ErrorMessage);
+            Assert.Equal("version-after", target.DistributionVersionId);
+            Assert.True(stateCalls >= 2);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static void WriteXcodeGenVersionSource(string root, string marketingVersion, string buildNumber)
+    {
+        File.WriteAllText(
+            Path.Combine(root, "project.yml"),
+            $"""
+            name: CasaRay
+            settings:
+              base:
+                CURRENT_PROJECT_VERSION: "{buildNumber}"
+                MARKETING_VERSION: "{marketingVersion}"
+            """);
+    }
+}

--- a/PowerForge/Models/AppStoreConnectScreenshotSyncModels.cs
+++ b/PowerForge/Models/AppStoreConnectScreenshotSyncModels.cs
@@ -14,6 +14,9 @@ public sealed class AppStoreConnectScreenshotSyncSpec
     /// <summary>Optional App Store version id. When provided, version lookup by string is skipped.</summary>
     public string? VersionId { get; set; }
 
+    /// <summary>Bind this mapping to the release version selected by the unified Apple workflow.</summary>
+    public bool UseReleaseVersion { get; set; }
+
     /// <summary>Apple platform for the App Store version.</summary>
     public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
 

--- a/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
+++ b/PowerForge/Models/AppStoreConnectVersionMetadataModels.cs
@@ -39,6 +39,9 @@ public sealed class AppStoreConnectVersionMetadataSpec
     /// <summary>Optional App Store version id. When provided, version lookup by string is skipped.</summary>
     public string? VersionId { get; set; }
 
+    /// <summary>Bind this mapping to the release version selected by the unified Apple workflow.</summary>
+    public bool UseReleaseVersion { get; set; }
+
     /// <summary>Apple platform for the App Store version.</summary>
     public ApplePlatform Platform { get; set; } = ApplePlatform.iOS;
 

--- a/PowerForge/Models/PowerForgeAppleReleaseAutomation.cs
+++ b/PowerForge/Models/PowerForgeAppleReleaseAutomation.cs
@@ -11,6 +11,9 @@ public enum PowerForgeAppleReleaseAction
     /// <summary>Read App Store Connect state without changing it.</summary>
     Status,
 
+    /// <summary>Set the requested marketing version and the next available build number in the configured version source.</summary>
+    Version,
+
     /// <summary>Create signed local archives without uploading them.</summary>
     Archive,
 
@@ -28,6 +31,9 @@ public enum PowerForgeAppleReleaseAction
 
     /// <summary>Assign a processed build to configured TestFlight groups and testers.</summary>
     TestFlight,
+
+    /// <summary>Run the resumable non-review release steps and stop at the first human approval gate.</summary>
+    Advance,
 
     /// <summary>Submit a processed build to TestFlight Beta App Review.</summary>
     SubmitTestFlightReview,
@@ -52,6 +58,15 @@ internal sealed class PowerForgeAppleReleaseAutomationOptions
 
     /// <summary>Receipt path relative to the Apple project root.</summary>
     public string ReceiptPath { get; set; } = "build/powerforge/apple/release-receipt.json";
+
+    /// <summary>Plan receipt path relative to the Apple project root.</summary>
+    public string PlanReceiptPath { get; set; } = "build/powerforge/apple/release-plan.json";
+
+    /// <summary>Exclusive operation lock path relative to the Apple project root.</summary>
+    public string LockPath { get; set; } = "build/powerforge/apple/release.lock";
+
+    /// <summary>Optional checked-in XcodeGen project.yml used as the authoritative version source.</summary>
+    public string? VersionSourcePath { get; set; }
 
     /// <summary>Reuse an exact remote build instead of uploading the same version/build again.</summary>
     public bool Resume { get; set; } = true;
@@ -87,6 +102,8 @@ internal sealed class PowerForgeAppleReleaseReceipt
 
     public PowerForgeAppleReleaseAction Action { get; set; }
 
+    public bool PlanOnly { get; set; }
+
     public DateTimeOffset CheckedAt { get; set; } = DateTimeOffset.UtcNow;
 
     public bool Success { get; set; }
@@ -95,11 +112,33 @@ internal sealed class PowerForgeAppleReleaseReceipt
 
     public string? ReceiptPath { get; set; }
 
+    public PowerForgeAppleVersionReceipt? Versioning { get; set; }
+
     public PowerForgeAppleReleaseTargetReceipt[] Targets { get; set; } = Array.Empty<PowerForgeAppleReleaseTargetReceipt>();
 
     public PowerForgeAppleReleaseCleanupReceipt Cleanup { get; set; } = new();
 
     public string[] NextActions { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>
+/// Version identity selected for an Apple release.
+/// </summary>
+internal sealed class PowerForgeAppleVersionReceipt
+{
+    public string? SourcePath { get; set; }
+
+    public string MarketingVersion { get; set; } = string.Empty;
+
+    public string BuildNumber { get; set; } = string.Empty;
+
+    public string? PreviousMarketingVersion { get; set; }
+
+    public string? PreviousBuildNumber { get; set; }
+
+    public long HighestRemoteBuildNumber { get; set; }
+
+    public bool Changed { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/PowerForgeRelease.cs
+++ b/PowerForge/Models/PowerForgeRelease.cs
@@ -215,6 +215,8 @@ internal sealed class PowerForgeReleaseRequest
 
     public PowerForgeAppleReleaseAction AppleAction { get; set; } = PowerForgeAppleReleaseAction.Configured;
 
+    public string? AppleMarketingVersion { get; set; }
+
     public bool AppleActionConfirmed { get; set; }
 
     public bool? AppleResume { get; set; }
@@ -448,6 +450,14 @@ internal sealed class PowerForgeAppleReleasePlan
     public PowerForgeAppleReleaseAutomationOptions Automation { get; set; } = new();
 
     public string ReceiptPath { get; set; } = string.Empty;
+
+    public string PlanReceiptPath { get; set; } = string.Empty;
+
+    public string LockPath { get; set; } = string.Empty;
+
+    public string? VersionSourcePath { get; set; }
+
+    public string? RequestedMarketingVersion { get; set; }
 
     public bool Archive { get; set; }
 

--- a/PowerForge/Services/AppStoreConnectClient.cs
+++ b/PowerForge/Services/AppStoreConnectClient.cs
@@ -631,18 +631,29 @@ public sealed partial class AppStoreConnectClient : IDisposable
         ApplePlatform? platform,
         CancellationToken cancellationToken)
     {
-        using var doc = await GetJsonAsync(relativeUrl, cancellationToken).ConfigureAwait(false)
-            ?? throw new InvalidOperationException("App Store Connect API request returned no response body.");
-        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
-            return Array.Empty<AppStoreConnectBuildInfo>();
-
-        var preReleaseVersions = ReadIncludedPreReleaseVersions(doc.RootElement);
         var list = new List<AppStoreConnectBuildInfo>();
-        foreach (var item in data.EnumerateArray())
+        var visitedPages = new HashSet<string>(StringComparer.Ordinal);
+        string? nextPage = relativeUrl;
+        while (nextPage is not null)
         {
-            var build = ParseBuild(item, preReleaseVersions);
-            if (BuildMatches(build, marketingVersion, platform))
-                list.Add(build);
+            var currentPage = nextPage;
+            if (!visitedPages.Add(currentPage))
+                throw new InvalidOperationException($"App Store Connect API returned a repeated pagination link: {currentPage}");
+
+            using var doc = await GetJsonAsync(currentPage, cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException("App Store Connect API request returned no response body.");
+            if (doc.RootElement.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Array)
+            {
+                var preReleaseVersions = ReadIncludedPreReleaseVersions(doc.RootElement);
+                foreach (var item in data.EnumerateArray())
+                {
+                    var build = ParseBuild(item, preReleaseVersions);
+                    if (BuildMatches(build, marketingVersion, platform))
+                        list.Add(build);
+                }
+            }
+
+            nextPage = GetNextPageLink(doc.RootElement);
         }
 
         return list.ToArray();

--- a/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
+++ b/PowerForge/Services/AppStoreConnectReleasePreparationService.cs
@@ -234,6 +234,7 @@ public sealed class AppStoreConnectReleasePreparationService
             AppId = appId,
             VersionString = versionString,
             VersionId = versionId,
+            UseReleaseVersion = false,
             Platform = platform,
             Locale = source.Locale,
             ScreenshotSets = source.ScreenshotSets,
@@ -263,6 +264,7 @@ public sealed class AppStoreConnectReleasePreparationService
             AppId = appId,
             VersionString = versionString,
             VersionId = versionId,
+            UseReleaseVersion = false,
             Platform = platform,
             Locale = source.Locale,
             Metadata = source.Metadata

--- a/PowerForge/Services/AppStoreConnectReleaseStateService.cs
+++ b/PowerForge/Services/AppStoreConnectReleaseStateService.cs
@@ -124,6 +124,10 @@ public sealed class AppStoreConnectReleaseStateService
             platform,
             limit: 50,
             cancellationToken).ConfigureAwait(false);
+        reviewSubmissions = await FilterReviewSubmissionsForVersionAsync(
+            reviewSubmissions,
+            version?.Id,
+            cancellationToken).ConfigureAwait(false);
 
         var testFlightBuild = matchedBuild ?? selectedBuild;
         AppStoreConnectBuildBetaDetailInfo? betaDetail = null;
@@ -152,6 +156,36 @@ public sealed class AppStoreConnectReleaseStateService
             Messages = messages.ToArray()
         };
     }
+
+    private async Task<AppStoreConnectReviewSubmissionInfo[]> FilterReviewSubmissionsForVersionAsync(
+        AppStoreConnectReviewSubmissionInfo[] submissions,
+        string? versionId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(versionId) || submissions.Length == 0)
+            return Array.Empty<AppStoreConnectReviewSubmissionInfo>();
+
+        var matching = new List<AppStoreConnectReviewSubmissionInfo>();
+        foreach (var submission in submissions.Where(ShouldInspectReviewSubmission))
+        {
+            var items = await _client.GetReviewSubmissionItemsAsync(
+                submission.Id,
+                limit: 50,
+                cancellationToken).ConfigureAwait(false);
+            if (items.Any(item =>
+                    string.Equals(item.AppStoreVersionId, versionId, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(item.EncodedAppStoreVersionId, versionId, StringComparison.OrdinalIgnoreCase)))
+            {
+                matching.Add(submission);
+            }
+        }
+
+        return matching.ToArray();
+    }
+
+    private static bool ShouldInspectReviewSubmission(AppStoreConnectReviewSubmissionInfo submission)
+        => !string.Equals(submission.State, "COMPLETE", StringComparison.OrdinalIgnoreCase) &&
+           !string.Equals(submission.State, "CANCELLED", StringComparison.OrdinalIgnoreCase);
 
     private async Task<AppStoreConnectBetaGroupReleaseState[]> GetBetaGroupStatesAsync(
         string appId,

--- a/PowerForge/Services/AppStoreConnectScreenshotSyncConfigValidator.cs
+++ b/PowerForge/Services/AppStoreConnectScreenshotSyncConfigValidator.cs
@@ -25,7 +25,9 @@ public sealed class AppStoreConnectScreenshotSyncConfigValidator
         var messages = new List<string>();
         if (string.IsNullOrWhiteSpace(spec.AppId))
             messages.Add("AppId is required.");
-        if (string.IsNullOrWhiteSpace(spec.VersionString) && string.IsNullOrWhiteSpace(spec.VersionId))
+        if (!spec.UseReleaseVersion &&
+            string.IsNullOrWhiteSpace(spec.VersionString) &&
+            string.IsNullOrWhiteSpace(spec.VersionId))
             messages.Add("VersionString or VersionId is required.");
         if (string.IsNullOrWhiteSpace(spec.Locale))
             messages.Add("Locale is required.");

--- a/PowerForge/Services/AppStoreConnectScreenshotSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectScreenshotSyncService.cs
@@ -35,7 +35,11 @@ public sealed class AppStoreConnectScreenshotSyncService
         if (string.IsNullOrWhiteSpace(spec.AppId))
             throw new ArgumentException("Spec.AppId is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(spec.VersionString) && string.IsNullOrWhiteSpace(spec.VersionId))
-            throw new ArgumentException("Spec.VersionString or Spec.VersionId is required.", nameof(request));
+            throw new ArgumentException(
+                spec.UseReleaseVersion
+                    ? "Spec.UseReleaseVersion must be resolved by the unified Apple release workflow before screenshot sync."
+                    : "Spec.VersionString or Spec.VersionId is required.",
+                nameof(request));
         if (string.IsNullOrWhiteSpace(spec.Locale))
             throw new ArgumentException("Spec.Locale is required.", nameof(request));
         if (spec.ScreenshotSets.Length == 0)
@@ -100,11 +104,12 @@ public sealed class AppStoreConnectScreenshotSyncService
             if (set is not null)
                 existingScreenshots = await _client.GetScreenshotsAsync(set.Id, limit: 200, cancellationToken).ConfigureAwait(false);
 
-            if (!request.ReplaceExisting && existingScreenshots.Length + preflightedSet.Files.Length > AppleScreenshotSetLimit)
+            var missingFiles = FindMissingFiles(preflightedSet.Files, existingScreenshots);
+            if (!request.ReplaceExisting && existingScreenshots.Length + missingFiles.Length > AppleScreenshotSetLimit)
             {
                 throw new InvalidOperationException(
                     $"Screenshot display type '{preflightedSet.ScreenshotDisplayType}' already has {existingScreenshots.Length} screenshots; " +
-                    $"uploading {preflightedSet.Files.Length} more would exceed Apple's {AppleScreenshotSetLimit} screenshots per set limit.");
+                    $"uploading {missingFiles.Length} missing screenshots would exceed Apple's {AppleScreenshotSetLimit} screenshots per set limit.");
             }
 
             plannedSets.Add(new PlannedScreenshotSet(preflightedSet, set, existingScreenshots));
@@ -122,17 +127,33 @@ public sealed class AppStoreConnectScreenshotSyncService
             }
 
             var deletedCount = 0;
+            var filesToUpload = FindMissingFiles(plannedSet.Preflighted.Files, plannedSet.ExistingScreenshots);
             if (request.ReplaceExisting)
             {
-                foreach (var screenshot in plannedSet.ExistingScreenshots)
+                var retainedIds = new HashSet<string>(StringComparer.Ordinal);
+                var prefixLength = 0;
+                while (prefixLength < plannedSet.Preflighted.Files.Length &&
+                       prefixLength < plannedSet.ExistingScreenshots.Length)
+                {
+                    var expected = ComputeSourceChecksum(plannedSet.Preflighted.Files[prefixLength]);
+                    var existing = plannedSet.ExistingScreenshots[prefixLength];
+                    if (!string.Equals(expected, existing.SourceFileChecksum, StringComparison.OrdinalIgnoreCase))
+                        break;
+                    retainedIds.Add(existing.Id);
+                    prefixLength++;
+                }
+
+                foreach (var screenshot in plannedSet.ExistingScreenshots.Where(screenshot => !retainedIds.Contains(screenshot.Id)))
                 {
                     await _client.DeleteScreenshotAsync(screenshot.Id, cancellationToken).ConfigureAwait(false);
                     deletedCount++;
                 }
+
+                filesToUpload = plannedSet.Preflighted.Files.Skip(prefixLength).ToArray();
             }
 
             var uploaded = new List<AppStoreConnectScreenshotUploadResult>();
-            foreach (var file in plannedSet.Preflighted.Files)
+            foreach (var file in filesToUpload)
                 uploaded.Add(await _client.UploadScreenshotAsync(set.Id, file, cancellationToken).ConfigureAwait(false));
 
             results.Add(new AppStoreConnectScreenshotSetSyncResult
@@ -151,6 +172,37 @@ public sealed class AppStoreConnectScreenshotSyncService
             Localization = localization,
             ScreenshotSets = results.ToArray()
         };
+    }
+
+    private static string ComputeSourceChecksum(string filePath)
+    {
+        using var stream = File.OpenRead(filePath);
+        using var md5 = System.Security.Cryptography.MD5.Create();
+        return BitConverter.ToString(md5.ComputeHash(stream)).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    private static string[] FindMissingFiles(
+        IEnumerable<string> files,
+        IEnumerable<AppStoreConnectScreenshotInfo> existingScreenshots)
+    {
+        var available = existingScreenshots
+            .Where(static screenshot => !string.IsNullOrWhiteSpace(screenshot.SourceFileChecksum))
+            .GroupBy(static screenshot => screenshot.SourceFileChecksum!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Count(),
+                StringComparer.OrdinalIgnoreCase);
+        var missing = new List<string>();
+        foreach (var file in files)
+        {
+            var checksum = ComputeSourceChecksum(file);
+            if (available.TryGetValue(checksum, out var count) && count > 0)
+                available[checksum] = count - 1;
+            else
+                missing.Add(file);
+        }
+
+        return missing.ToArray();
     }
 
     private static string ResolvePath(string baseDirectory, string path)

--- a/PowerForge/Services/AppStoreConnectVersionMetadataSyncService.cs
+++ b/PowerForge/Services/AppStoreConnectVersionMetadataSyncService.cs
@@ -28,7 +28,11 @@ public sealed class AppStoreConnectVersionMetadataSyncService
         if (string.IsNullOrWhiteSpace(spec.AppId))
             throw new ArgumentException("Spec.AppId is required.", nameof(request));
         if (string.IsNullOrWhiteSpace(spec.VersionString) && string.IsNullOrWhiteSpace(spec.VersionId))
-            throw new ArgumentException("Spec.VersionString or Spec.VersionId is required.", nameof(request));
+            throw new ArgumentException(
+                spec.UseReleaseVersion
+                    ? "Spec.UseReleaseVersion must be resolved by the unified Apple release workflow before metadata sync."
+                    : "Spec.VersionString or Spec.VersionId is required.",
+                nameof(request));
         if (string.IsNullOrWhiteSpace(spec.Locale))
             throw new ArgumentException("Spec.Locale is required.", nameof(request));
 

--- a/PowerForge/Services/AppleReleaseOperationLock.cs
+++ b/PowerForge/Services/AppleReleaseOperationLock.cs
@@ -1,0 +1,45 @@
+using System.Text;
+
+namespace PowerForge;
+
+/// <summary>
+/// Owns an exclusive file lease for one mutating Apple release operation.
+/// </summary>
+internal sealed class AppleReleaseOperationLock : IDisposable
+{
+    private readonly FileStream _stream;
+
+    private AppleReleaseOperationLock(FileStream stream)
+    {
+        _stream = stream;
+    }
+
+    internal static AppleReleaseOperationLock Acquire(string lockPath, PowerForgeAppleReleaseAction action)
+    {
+        var directory = Path.GetDirectoryName(lockPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        try
+        {
+            var stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            stream.SetLength(0);
+            var processId = System.Diagnostics.Process.GetCurrentProcess().Id;
+            var payload = Encoding.UTF8.GetBytes($"pid={processId}\naction={action}\nstartedAt={DateTimeOffset.UtcNow:O}\n");
+            stream.Write(payload, 0, payload.Length);
+            stream.Flush(flushToDisk: true);
+            return new AppleReleaseOperationLock(stream);
+        }
+        catch (IOException exception)
+        {
+            throw new InvalidOperationException(
+                $"Another Apple release operation owns '{lockPath}'. Wait for it to finish or verify that no release process is active before removing a stale lock file.",
+                exception);
+        }
+    }
+
+    public void Dispose()
+    {
+        _stream.Dispose();
+    }
+}

--- a/PowerForge/Services/AppleReleaseVersionSourceService.cs
+++ b/PowerForge/Services/AppleReleaseVersionSourceService.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PowerForge;
+
+/// <summary>
+/// Reads and atomically updates the shared version values in an XcodeGen project specification.
+/// </summary>
+internal sealed class AppleReleaseVersionSourceService
+{
+    private static readonly Regex MarketingVersionPattern = CreateSettingPattern("MARKETING_VERSION");
+    private static readonly Regex BuildNumberPattern = CreateSettingPattern("CURRENT_PROJECT_VERSION");
+
+    internal PowerForgeAppleVersionReceipt Read(string sourcePath)
+    {
+        var fullPath = ResolveSourcePath(sourcePath);
+        var content = File.ReadAllText(fullPath);
+        return new PowerForgeAppleVersionReceipt
+        {
+            SourcePath = fullPath,
+            MarketingVersion = ReadSingleValue(content, MarketingVersionPattern, "MARKETING_VERSION", fullPath),
+            BuildNumber = ReadSingleValue(content, BuildNumberPattern, "CURRENT_PROJECT_VERSION", fullPath)
+        };
+    }
+
+    internal PowerForgeAppleVersionReceipt Update(
+        string sourcePath,
+        string marketingVersion,
+        string buildNumber,
+        long highestRemoteBuildNumber,
+        bool whatIf)
+    {
+        if (string.IsNullOrWhiteSpace(marketingVersion))
+            throw new ArgumentException("Marketing version is required.", nameof(marketingVersion));
+        if (!long.TryParse(buildNumber, out var parsedBuildNumber) || parsedBuildNumber <= 0)
+            throw new ArgumentException("Apple build number must be a positive integer.", nameof(buildNumber));
+
+        var fullPath = ResolveSourcePath(sourcePath);
+        var content = File.ReadAllText(fullPath);
+        var previousMarketingVersion = ReadSingleValue(content, MarketingVersionPattern, "MARKETING_VERSION", fullPath);
+        var previousBuildNumber = ReadSingleValue(content, BuildNumberPattern, "CURRENT_PROJECT_VERSION", fullPath);
+        var updated = ReplaceSingleValue(content, MarketingVersionPattern, marketingVersion.Trim());
+        updated = ReplaceSingleValue(updated, BuildNumberPattern, buildNumber.Trim());
+        var changed = !string.Equals(content, updated, StringComparison.Ordinal);
+
+        if (changed && !whatIf)
+            WriteAtomic(fullPath, updated);
+
+        return new PowerForgeAppleVersionReceipt
+        {
+            SourcePath = fullPath,
+            MarketingVersion = marketingVersion.Trim(),
+            BuildNumber = buildNumber.Trim(),
+            PreviousMarketingVersion = previousMarketingVersion,
+            PreviousBuildNumber = previousBuildNumber,
+            HighestRemoteBuildNumber = highestRemoteBuildNumber,
+            Changed = changed
+        };
+    }
+
+    private static Regex CreateSettingPattern(string settingName)
+        => new(
+            "(?m)^(?<prefix>\\s*" + Regex.Escape(settingName) + "\\s*:\\s*)(?<quote>[\\\"']?)(?<value>[^\\\"'\\r\\n#]+?)(?:\\k<quote>)(?<suffix>\\s*(?:#.*)?)$",
+            RegexOptions.Compiled);
+
+    private static string ReadSingleValue(string content, Regex pattern, string settingName, string sourcePath)
+    {
+        var matches = pattern.Matches(content);
+        if (matches.Count != 1)
+            throw new InvalidOperationException($"Expected exactly one {settingName} setting in '{sourcePath}', found {matches.Count}.");
+        return matches[0].Groups["value"].Value.Trim();
+    }
+
+    private static string ReplaceSingleValue(string content, Regex pattern, string value)
+    {
+        var matches = pattern.Matches(content);
+        if (matches.Count != 1)
+            throw new InvalidOperationException($"Expected exactly one match while updating Apple version source, found {matches.Count}.");
+
+        return pattern.Replace(
+            content,
+            match => match.Groups["prefix"].Value + "\"" + value + "\"" + match.Groups["suffix"].Value,
+            count: 1);
+    }
+
+    private static string ResolveSourcePath(string sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+            throw new ArgumentException("Apple version source path is required.", nameof(sourcePath));
+        var fullPath = Path.GetFullPath(sourcePath.Trim().Trim('"'));
+        if (!File.Exists(fullPath))
+            throw new FileNotFoundException($"Apple version source was not found: {fullPath}", fullPath);
+        return fullPath;
+    }
+
+    private static void WriteAtomic(string path, string content)
+    {
+        var directory = Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory();
+        var temporaryPath = Path.Combine(directory, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.WriteAllText(temporaryPath, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            if (File.Exists(path))
+                File.Replace(temporaryPath, path, destinationBackupFileName: null, ignoreMetadataErrors: true);
+            else
+                File.Move(temporaryPath, path);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+                File.Delete(temporaryPath);
+        }
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleAutomation.cs
@@ -41,6 +41,7 @@ internal sealed partial class PowerForgeReleaseService
         switch (request.AppleAction)
         {
             case PowerForgeAppleReleaseAction.Status:
+            case PowerForgeAppleReleaseAction.Version:
             case PowerForgeAppleReleaseAction.Cleanup:
                 break;
             case PowerForgeAppleReleaseAction.Archive:
@@ -67,6 +68,19 @@ internal sealed partial class PowerForgeReleaseService
             case PowerForgeAppleReleaseAction.TestFlight:
                 options.DistributeTestFlight = true;
                 break;
+            case PowerForgeAppleReleaseAction.Advance:
+                options.Archive = true;
+                options.Upload = true;
+                options.PrepareDistribution = true;
+                options.SelectBuildForDistribution = true;
+                options.SyncMetadata = HasConfiguredPath(options.MetadataConfigPath, options.MetadataConfigPaths);
+                options.SyncAppInfo = HasConfiguredPath(options.AppInfoConfigPath, options.AppInfoConfigPaths);
+                options.SyncScreenshots = HasConfiguredPath(options.ScreenshotConfigPath, options.ScreenshotConfigPaths);
+                options.CheckReleaseReadiness = true;
+                options.DistributeTestFlight =
+                    (options.TestFlightBetaGroupIds?.Length ?? 0) > 0 ||
+                    (options.TestFlightBetaGroupNames?.Length ?? 0) > 0;
+                break;
             case PowerForgeAppleReleaseAction.SubmitTestFlightReview:
                 options.SubmitTestFlightBetaReview = true;
                 break;
@@ -90,6 +104,8 @@ internal sealed partial class PowerForgeReleaseService
              options.ReleaseApprovedVersion ||
              (options.SyncScreenshots && options.ReplaceScreenshots))) ||
            action == PowerForgeAppleReleaseAction.SubmitTestFlightReview ||
+           action == PowerForgeAppleReleaseAction.Advance ||
+           action == PowerForgeAppleReleaseAction.Version ||
            action == PowerForgeAppleReleaseAction.SubmitAppReview ||
            action == PowerForgeAppleReleaseAction.Release ||
            (action == PowerForgeAppleReleaseAction.Screenshots && options.ReplaceScreenshots);
@@ -100,12 +116,17 @@ internal sealed partial class PowerForgeReleaseService
 
     private static bool IsUploadAction(PowerForgeAppleReleaseAction action)
         => action == PowerForgeAppleReleaseAction.Upload ||
-           action == PowerForgeAppleReleaseAction.UploadExisting;
+           action == PowerForgeAppleReleaseAction.UploadExisting ||
+           action == PowerForgeAppleReleaseAction.Advance;
 
     private static void ValidateAppleAutomation(PowerForgeAppleReleaseAutomationOptions automation)
     {
         if (string.IsNullOrWhiteSpace(automation.ReceiptPath))
             throw new InvalidOperationException("AppleApps.Automation.ReceiptPath is required.");
+        if (string.IsNullOrWhiteSpace(automation.PlanReceiptPath))
+            throw new InvalidOperationException("AppleApps.Automation.PlanReceiptPath is required.");
+        if (string.IsNullOrWhiteSpace(automation.LockPath))
+            throw new InvalidOperationException("AppleApps.Automation.LockPath is required.");
         if (automation.ProcessingTimeoutSeconds <= 0)
             throw new InvalidOperationException("AppleApps.Automation.ProcessingTimeoutSeconds must be greater than zero.");
         if (automation.PollIntervalSeconds <= 0)
@@ -300,16 +321,18 @@ internal sealed partial class PowerForgeReleaseService
     private PowerForgeAppleReleaseReceipt CompleteAppleReleaseReceipt(
         PowerForgeAppleReleasePlan plan,
         PowerForgeAppleAppReleaseResult[] results,
-        PowerForgeAppleReleaseCleanupReceipt cleanup)
+        PowerForgeAppleReleaseCleanupReceipt cleanup,
+        PowerForgeAppleVersionReceipt? versioning = null)
     {
         var resultByName = results.ToDictionary(static result => result.Plan.Name, StringComparer.OrdinalIgnoreCase);
         var remoteAction = plan.Action != PowerForgeAppleReleaseAction.Archive &&
+                           plan.Action != PowerForgeAppleReleaseAction.Version &&
                            plan.Action != PowerForgeAppleReleaseAction.Cleanup;
         foreach (var app in plan.Apps)
         {
             if (!resultByName.TryGetValue(app.Name, out var result))
                 continue;
-            if (remoteAction && result.Success && result.RemoteState is null)
+            if (remoteAction && (!result.Success || result.RemoteState is null))
             {
                 try
                 {
@@ -317,9 +340,12 @@ internal sealed partial class PowerForgeReleaseService
                 }
                 catch (Exception exception)
                 {
-                    result.Success = false;
-                    result.ErrorMessage =
-                        $"Unable to read the final App Store Connect state for '{app.Name}': {exception.Message}";
+                    if (result.Success)
+                    {
+                        result.Success = false;
+                        result.ErrorMessage =
+                            $"Unable to read the final App Store Connect state for '{app.Name}': {exception.Message}";
+                    }
                 }
             }
         }
@@ -433,11 +459,13 @@ internal sealed partial class PowerForgeReleaseService
         var receipt = new PowerForgeAppleReleaseReceipt
         {
             Action = plan.Action,
+            PlanOnly = false,
             CheckedAt = DateTimeOffset.UtcNow,
             Success = results.Length == plan.Apps.Length &&
                       results.All(static result => result.Success),
             ErrorMessage = errors.Length == 0 ? null : string.Join(" ", errors),
             ReceiptPath = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, plan.ReceiptPath).Replace('\\', '/'),
+            Versioning = versioning,
             Targets = targets,
             Cleanup = cleanup,
             NextActions = targets

--- a/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.AppleVersioning.cs
@@ -1,0 +1,125 @@
+namespace PowerForge;
+
+internal sealed partial class PowerForgeReleaseService
+{
+    private PowerForgeAppleReleaseReceipt CreateApplePlanReceipt(PowerForgeAppleReleasePlan plan)
+    {
+        PowerForgeAppleVersionReceipt? versioning = null;
+        if (plan.Action == PowerForgeAppleReleaseAction.Version)
+            versioning = PlanAppleVersion(plan, whatIf: true);
+
+        var receipt = new PowerForgeAppleReleaseReceipt
+        {
+            Action = plan.Action,
+            PlanOnly = true,
+            CheckedAt = DateTimeOffset.UtcNow,
+            Success = true,
+            ReceiptPath = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, plan.PlanReceiptPath).Replace('\\', '/'),
+            Versioning = versioning,
+            Targets = plan.Apps.Select(app => new PowerForgeAppleReleaseTargetReceipt
+            {
+                Name = app.Name,
+                BundleId = app.BundleId,
+                Platform = app.Platform,
+                AppId = app.AppStoreConnectAppId,
+                Version = versioning?.MarketingVersion ?? app.MarketingVersion,
+                Build = versioning?.BuildNumber ?? app.BuildNumber,
+                SkippedSteps = new[] { "plan-only" }
+            }).ToArray(),
+            NextActions = new[] { $"Run Apple action '{plan.Action}' without --plan after reviewing this plan receipt." }
+        };
+
+        if (plan.Automation.WriteReceipt)
+            WriteAppleReceipt(plan.ProjectRoot, plan.PlanReceiptPath, receipt);
+        return receipt;
+    }
+
+    private PowerForgeAppleVersionReceipt SelectAppleVersion(PowerForgeAppleReleasePlan plan)
+    {
+        var versioning = PlanAppleVersion(plan, whatIf: false);
+        foreach (var app in plan.Apps)
+        {
+            app.MarketingVersion = versioning.MarketingVersion;
+            app.BuildNumber = versioning.BuildNumber;
+        }
+
+        return versioning;
+    }
+
+    private PowerForgeAppleAppReleaseResult[] RunAppleVersion(PowerForgeAppleReleasePlan plan)
+    {
+        var generatedProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var results = new List<PowerForgeAppleAppReleaseResult>();
+        foreach (var app in plan.Apps)
+        {
+            var result = new PowerForgeAppleAppReleaseResult
+            {
+                Plan = app,
+                Success = true,
+                SkippedSteps = new[] { "archive", "upload", "distribution", "review", "release" }
+            };
+            if (generatedProjects.Add(app.ProjectPath))
+            {
+                var generationPlan = new PowerForgeAppleAppReleaseTargetPlan
+                {
+                    Name = app.Name,
+                    ProjectPath = app.ProjectPath,
+                    GenerateProjectIfMissing = true,
+                    RegenerateProject = true,
+                    XcodeGenExecutable = app.XcodeGenExecutable,
+                    ProjectGenerationTimeoutSeconds = app.ProjectGenerationTimeoutSeconds
+                };
+                result.ProjectGenerated = _generateAppleProject(generationPlan);
+            }
+            results.Add(result);
+        }
+
+        return results.ToArray();
+    }
+
+    private PowerForgeAppleVersionReceipt PlanAppleVersion(PowerForgeAppleReleasePlan plan, bool whatIf)
+    {
+        if (string.IsNullOrWhiteSpace(plan.VersionSourcePath))
+            throw new InvalidOperationException("Apple version source path is required for Version.");
+        if (string.IsNullOrWhiteSpace(plan.RequestedMarketingVersion))
+            throw new InvalidOperationException("Requested Apple marketing version is required for Version.");
+
+        var source = new AppleReleaseVersionSourceService();
+        var current = source.Read(plan.VersionSourcePath!);
+        if (!long.TryParse(current.BuildNumber, out var currentBuild) || currentBuild < 0)
+            throw new InvalidOperationException($"Apple version source build number '{current.BuildNumber}' is not a non-negative integer.");
+
+        var credential = CreateAppStoreConnectCredential(plan);
+        var highestRemote = plan.Apps
+            .Select(app => _getHighestAppleBuildNumber(credential, app.AppStoreConnectAppId!, app.Platform))
+            .DefaultIfEmpty(0)
+            .Max();
+        var requestedVersion = plan.RequestedMarketingVersion!.Trim();
+        var nextBuild = string.Equals(current.MarketingVersion, requestedVersion, StringComparison.OrdinalIgnoreCase) &&
+                        currentBuild > highestRemote
+            ? currentBuild
+            : checked(Math.Max(currentBuild, highestRemote) + 1);
+        var receipt = source.Update(
+            plan.VersionSourcePath!,
+            requestedVersion,
+            nextBuild.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            highestRemote,
+            whatIf);
+        receipt.SourcePath = FrameworkCompatibility.GetRelativePath(plan.ProjectRoot, plan.VersionSourcePath!).Replace('\\', '/');
+        return receipt;
+    }
+
+    private static long GetHighestAppleBuildNumber(
+        AppStoreConnectApiCredential credential,
+        string appId,
+        ApplePlatform platform)
+    {
+        using var client = new AppStoreConnectClient(credential);
+        return client.GetBuildsAsync(appId, limit: 200, platform: platform)
+            .GetAwaiter()
+            .GetResult()
+            .Select(static build => long.TryParse(build.Version, out var number) ? number : 0)
+            .DefaultIfEmpty(0)
+            .Max();
+    }
+}

--- a/PowerForge/Services/PowerForgeReleaseService.cs
+++ b/PowerForge/Services/PowerForgeReleaseService.cs
@@ -69,6 +69,7 @@ internal sealed partial class PowerForgeReleaseService
     private readonly Func<AppStoreConnectVersionReleaseRequest, AppStoreConnectVersionReleaseResult> _releaseAppleVersion;
     private readonly Func<AppStoreConnectReleaseStateRequest, AppStoreConnectReleaseStateResult> _getAppleReleaseState;
     private readonly Func<AppStoreConnectApiCredential, string, AppStoreConnectBuildUploadInfo?> _getAppleBuildUpload;
+    private readonly Func<AppStoreConnectApiCredential, string, ApplePlatform, long> _getHighestAppleBuildNumber;
     private readonly Func<PowerForgeAppleAppReleaseTargetPlan, bool> _generateAppleProject;
     private readonly Action<TimeSpan> _delay;
     private readonly AppleReleaseArtifactService _appleArtifactService;
@@ -162,7 +163,8 @@ internal sealed partial class PowerForgeReleaseService
         Func<PowerForgeToolReleasePlan, IPowerForgeReleaseProgressReporterV2?, CancellationToken, PowerForgeToolReleaseResult>? runToolsWithProgressAndCancellation = null,
         Func<ModuleBuildHostBuildRequest, CancellationToken, ModuleBuildHostExecutionResult>? executeModuleBuild = null,
         Func<GitHubReleasePublishRequest, CancellationToken, GitHubReleasePublishResult>? publishGitHubReleaseWithCancellation = null,
-        Func<string, string, string, string, GitHubReleaseVersionOccupancy>? probeGitHubReleaseVersion = null)
+        Func<string, string, string, string, GitHubReleaseVersionOccupancy>? probeGitHubReleaseVersion = null,
+        Func<AppStoreConnectApiCredential, string, ApplePlatform, long>? getHighestAppleBuildNumber = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _executePackages = executePackages ?? throw new ArgumentNullException(nameof(executePackages));
@@ -197,6 +199,7 @@ internal sealed partial class PowerForgeReleaseService
         _releaseAppleVersion = releaseAppleVersion ?? ReleaseAppleVersion;
         _getAppleReleaseState = getAppleReleaseState ?? GetAppleReleaseState;
         _getAppleBuildUpload = getAppleBuildUpload ?? GetAppleBuildUpload;
+        _getHighestAppleBuildNumber = getHighestAppleBuildNumber ?? GetHighestAppleBuildNumber;
         _generateAppleProject = generateAppleProject ?? (app => new AppleProjectGenerationService().Generate(app));
         _delay = delay ?? Thread.Sleep;
         _appleArtifactService = appleArtifactService ?? new AppleReleaseArtifactService();
@@ -538,6 +541,8 @@ internal sealed partial class PowerForgeReleaseService
                     (!request.PlanOnly && !request.ValidateOnly) ||
                     request.CheckpointAppleApps);
             result.AppleAppPlan = applePlan;
+            if (request.PlanOnly)
+                result.AppleReceipt = CreateApplePlanReceipt(applePlan);
             if (request.PlanOnly || request.ValidateOnly || request.CheckpointAppleApps)
                 ScrubApplePlanCredentials(result.AppleAppPlan);
         }
@@ -700,11 +705,18 @@ internal sealed partial class PowerForgeReleaseService
                 !request.ValidateOnly &&
                 (!request.CheckpointAppleApps || applePlan.Archive))
             {
+                using var operationLock = AppleReleaseOperationLock.Acquire(applePlan.LockPath, applePlan.Action);
                 var cleanup = new PowerForgeAppleReleaseCleanupReceipt();
                 PowerForgeAppleAppReleaseResult[] appleResults;
+                PowerForgeAppleVersionReceipt? appleVersioning = null;
                 try
                 {
-                    if (request.CheckpointAppleApps)
+                    if (applePlan.Action == PowerForgeAppleReleaseAction.Version)
+                    {
+                        appleVersioning = SelectAppleVersion(applePlan);
+                        appleResults = RunAppleVersion(applePlan);
+                    }
+                    else if (request.CheckpointAppleApps)
                     {
                         appleResults = RunAppleArchiveCheckpoint(applePlan, out cleanup);
                     }
@@ -742,7 +754,7 @@ internal sealed partial class PowerForgeReleaseService
                 if (!request.CheckpointAppleApps &&
                     (applePlan.Action != PowerForgeAppleReleaseAction.Configured ||
                      appleResults.Any(static app => !app.Success)))
-                    result.AppleReceipt = CompleteAppleReleaseReceipt(applePlan, appleResults, cleanup);
+                    result.AppleReceipt ??= CompleteAppleReleaseReceipt(applePlan, appleResults, cleanup, appleVersioning);
 
                 var failure = appleResults.FirstOrDefault(entry => !entry.Success);
                 if (failure is not null)
@@ -1377,6 +1389,15 @@ internal sealed partial class PowerForgeReleaseService
         ValidateAppleAutomation(automation);
         var receiptPath = ResolveOutputPath(projectRoot, automation.ReceiptPath);
         EnsurePathWithinProjectRoot(projectRoot, receiptPath, "AppleApps.Automation.ReceiptPath");
+        var planReceiptPath = ResolveOutputPath(projectRoot, automation.PlanReceiptPath);
+        EnsurePathWithinProjectRoot(projectRoot, planReceiptPath, "AppleApps.Automation.PlanReceiptPath");
+        var lockPath = ResolveOutputPath(projectRoot, automation.LockPath);
+        EnsurePathWithinProjectRoot(projectRoot, lockPath, "AppleApps.Automation.LockPath");
+        var versionSourcePath = string.IsNullOrWhiteSpace(automation.VersionSourcePath)
+            ? null
+            : ResolveOutputPath(projectRoot, automation.VersionSourcePath!);
+        if (versionSourcePath is not null)
+            EnsurePathWithinProjectRoot(projectRoot, versionSourcePath, "AppleApps.Automation.VersionSourcePath");
 
         var selectedTargets = NormalizeStrings(selectedTargetNames);
         var configuredApps = (options.Apps ?? Array.Empty<AppleAppConfiguration>())
@@ -1425,6 +1446,7 @@ internal sealed partial class PowerForgeReleaseService
             static app => app.ExportPath,
             "export");
         var requiresAppStoreConnect = request.AppleAction == PowerForgeAppleReleaseAction.Status ||
+                                      request.AppleAction == PowerForgeAppleReleaseAction.Version ||
                                       IsUploadAction(request.AppleAction) ||
                                       options.PrepareDistribution ||
                                       options.SyncScreenshots ||
@@ -1440,6 +1462,15 @@ internal sealed partial class PowerForgeReleaseService
             throw new InvalidOperationException(
                 $"Apple action '{request.AppleAction}' requires AppStoreConnectAppId for every selected target. " +
                 "Configure the missing app ids or select only targets that already have an App Store Connect record.");
+        if (request.AppleAction == PowerForgeAppleReleaseAction.Version)
+        {
+            if (string.IsNullOrWhiteSpace(request.AppleMarketingVersion))
+                throw new InvalidOperationException("Apple action 'Version' requires --apple-version.");
+            if (versionSourcePath is null)
+                throw new InvalidOperationException("Apple action 'Version' requires AppleApps.Automation.VersionSourcePath.");
+            if (!File.Exists(versionSourcePath))
+                throw new FileNotFoundException($"Apple version source was not found: {versionSourcePath}", versionSourcePath);
+        }
         if (options.DistributeTestFlight &&
             NormalizeStrings(options.TestFlightBetaGroupIds).Length == 0 &&
             NormalizeStrings(options.TestFlightBetaGroupNames).Length == 0)
@@ -1508,6 +1539,10 @@ internal sealed partial class PowerForgeReleaseService
             Action = request.AppleAction,
             Automation = automation,
             ReceiptPath = receiptPath,
+            PlanReceiptPath = planReceiptPath,
+            LockPath = lockPath,
+            VersionSourcePath = versionSourcePath,
+            RequestedMarketingVersion = request.AppleMarketingVersion?.Trim(),
             Archive = options.Archive,
             Upload = options.Upload,
             SyncScreenshots = options.SyncScreenshots,
@@ -1749,6 +1784,15 @@ internal sealed partial class PowerForgeReleaseService
                         valuesByApp[app].MarketingVersion,
                         required: plan.SyncScreenshots || screenshotSpecs.Length > 0)
                     : null;
+                if (matchingScreenshotSpec is not null)
+                {
+                    matchingScreenshotSpec = (
+                        BindScreenshotSpec(
+                            matchingScreenshotSpec.Value.Spec,
+                            app,
+                            valuesByApp[app].MarketingVersion),
+                        matchingScreenshotSpec.Value.ConfigPath);
+                }
                 screenshotsByApp[app] = matchingScreenshotSpec;
                 if (plan.SyncScreenshots && matchingScreenshotSpec is not null)
                     ValidateAppleScreenshotPreflight(matchingScreenshotSpec.Value);
@@ -2266,10 +2310,26 @@ internal sealed partial class PowerForgeReleaseService
         var appIdMatches = string.IsNullOrWhiteSpace(spec.AppId) ||
                            string.Equals(spec.AppId.Trim(), app.AppStoreConnectAppId, StringComparison.OrdinalIgnoreCase);
         var specVersionString = string.IsNullOrWhiteSpace(spec.VersionString) ? null : spec.VersionString!.Trim();
-        var versionMatches = specVersionString is null ||
+        var versionMatches = (spec.UseReleaseVersion && specVersionString is null) ||
                              string.Equals(specVersionString, marketingVersion, StringComparison.OrdinalIgnoreCase);
         return appIdMatches && versionMatches && spec.Platform == app.Platform;
     }
+
+    private static AppStoreConnectScreenshotSyncSpec BindScreenshotSpec(
+        AppStoreConnectScreenshotSyncSpec source,
+        PowerForgeAppleAppReleaseTargetPlan app,
+        string marketingVersion)
+        => new()
+        {
+            AppId = app.AppStoreConnectAppId!,
+            VersionString = marketingVersion,
+            VersionId = null,
+            UseReleaseVersion = false,
+            Platform = app.Platform,
+            Locale = source.Locale,
+            ScreenshotSets = source.ScreenshotSets,
+            Quality = source.Quality
+        };
 
     private static (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)? ResolveMatchingMetadataSpec(
         (AppStoreConnectVersionMetadataSpec Spec, string ConfigPath)[] specs,
@@ -2300,7 +2360,7 @@ internal sealed partial class PowerForgeReleaseService
         var appIdMatches = string.IsNullOrWhiteSpace(spec.AppId) ||
                            string.Equals(spec.AppId.Trim(), app.AppStoreConnectAppId, StringComparison.OrdinalIgnoreCase);
         var specVersionString = string.IsNullOrWhiteSpace(spec.VersionString) ? null : spec.VersionString!.Trim();
-        var versionMatches = specVersionString is null ||
+        var versionMatches = (spec.UseReleaseVersion && specVersionString is null) ||
                              string.Equals(specVersionString, marketingVersion, StringComparison.OrdinalIgnoreCase);
         return appIdMatches && versionMatches && spec.Platform == app.Platform;
     }

--- a/Schemas/powerforge.release.schema.json
+++ b/Schemas/powerforge.release.schema.json
@@ -331,6 +331,9 @@
           "properties": {
             "WriteReceipt": { "type": "boolean" },
             "ReceiptPath": { "type": "string" },
+            "PlanReceiptPath": { "type": "string" },
+            "LockPath": { "type": "string" },
+            "VersionSourcePath": { "type": [ "string", "null" ] },
             "Resume": { "type": "boolean" },
             "WaitForProcessing": { "type": "boolean" },
             "ProcessingTimeoutSeconds": { "type": "integer", "minimum": 1 },


### PR DESCRIPTION
## What changed

- adds a single-source Apple Version action that selects one build number above local and every configured App Store platform, then updates XcodeGen once
- adds a resumable Advance action for archive, upload, App Store draft preparation, metadata, screenshots, readiness, and configured TestFlight groups
- stops before TestFlight Beta Review, App Review, and public release
- resolves App Store version identifiers from the active release instead of requiring committed version UUIDs
- writes separate compact plan and execution receipts and prevents overlapping mutating runs with a persistent file lease
- correlates review state to the exact App Store version and follows all build pagination
- makes screenshot synchronization retry-safe and order-aware by checksum

## Safety and compatibility

- Version and Advance require explicit confirmation outside plan mode
- TestFlight distribution runs only for configured real group ids or names
- retry paths preserve selected version/build identity and refresh remote state after partial failures
- no review submission or public release action is enabled by Advance

## Validation

- 258 focused PowerForge release, App Store Connect, and Apple CLI tests pass on net10.0
- PowerForge and PowerForge.Cli Release builds pass on net10.0
- independent read-only review found lock, pagination, retry, receipt, and compatibility issues; all validated findings were addressed
- a full local suite was sampled but stopped after reproducing unrelated existing macOS/Windows-assumption and long benchmark failures outside this change
