### PR TITLE
Keep project build progress detailed and terminal-safe

### DIFF
--- a/PSPublishModule/PSPublishModule.csproj
+++ b/PSPublishModule/PSPublishModule.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" />

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -40,6 +40,7 @@
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" />

--- a/PowerForge.ConsoleShared/SpectreBoundedProgressLedger.cs
+++ b/PowerForge.ConsoleShared/SpectreBoundedProgressLedger.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PowerForge;
+using Spectre.Console;
+
+namespace PowerForge.ConsoleShared;
+
+/// <summary>
+/// Keeps detailed work visible without allowing a Spectre live region to grow with
+/// every planned item. The complete history is retained for a durable post-run ledger.
+/// </summary>
+internal sealed class SpectreBoundedProgressLedger
+{
+    private const int RecentCompletedLimit = 3;
+    private const int ActiveLimit = 2;
+    private const int UpcomingLimit = 2;
+    private const int PinnedFailureLimit = 3;
+
+    private readonly ProgressContext _context;
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, ProgressTask> _visibleTasks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _sync = new();
+    private long _terminalSequence;
+
+    internal SpectreBoundedProgressLedger(ProgressContext context)
+        => _context = context ?? throw new ArgumentNullException(nameof(context));
+
+    internal void Plan(IEnumerable<SpectreProgressLedgerItem> items)
+    {
+        if (items is null)
+            return;
+
+        lock (_sync)
+        {
+            foreach (var item in items)
+            {
+                if (item is null || string.IsNullOrWhiteSpace(item.Key))
+                    continue;
+
+                if (_entries.TryGetValue(item.Key, out var existing))
+                {
+                    existing.Item = item;
+                    continue;
+                }
+
+                _entries[item.Key] = new Entry(item);
+            }
+
+            ReconcileVisibleTasks();
+        }
+    }
+
+    internal void Update(
+        SpectreProgressLedgerItem item,
+        SpectreProgressLedgerState state,
+        string? detail)
+    {
+        if (item is null || string.IsNullOrWhiteSpace(item.Key))
+            return;
+
+        lock (_sync)
+        {
+            if (!_entries.TryGetValue(item.Key, out var entry))
+            {
+                entry = new Entry(item);
+                _entries[item.Key] = entry;
+            }
+            else
+            {
+                entry.Item = item;
+            }
+
+            entry.State = state;
+            entry.Detail = detail;
+            entry.ProgressFraction = ResolveProgressFraction(item, state);
+
+            var task = EnsureVisibleTask(entry);
+            task.Description = BuildLiveLabel(entry);
+
+            if (state == SpectreProgressLedgerState.Started)
+            {
+                if (!task.IsStarted)
+                    task.StartTask();
+
+                task.IsIndeterminate = item.ProgressMaximum <= 0;
+                if (!task.IsIndeterminate)
+                    task.Value = task.MaxValue * entry.ProgressFraction;
+            }
+            else if (IsTerminal(state))
+            {
+                if (!task.IsStarted)
+                    task.StartTask();
+
+                task.IsIndeterminate = false;
+                task.Value = task.MaxValue;
+                task.StopTask();
+
+                entry.Duration = item.Duration ?? task.ElapsedTime ?? TimeSpan.Zero;
+                entry.TerminalSequence = ++_terminalSequence;
+            }
+
+            ReconcileVisibleTasks();
+            _context.Refresh();
+        }
+    }
+
+    internal double GetCompletionRatio(string groupKey)
+    {
+        lock (_sync)
+        {
+            var entries = _entries.Values
+                .Where(entry => string.Equals(entry.Item.GroupKey, groupKey, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (entries.Length == 0)
+                return 0;
+
+            return entries.Sum(entry => entry.ProgressFraction) / entries.Length;
+        }
+    }
+
+    internal int GetItemCount(string groupKey)
+    {
+        lock (_sync)
+        {
+            return _entries.Values.Count(entry =>
+                string.Equals(entry.Item.GroupKey, groupKey, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    internal int VisibleTaskCount
+    {
+        get
+        {
+            lock (_sync)
+                return _visibleTasks.Count;
+        }
+    }
+
+    internal TimeSpan? GetVisibleElapsedTime(string key)
+    {
+        lock (_sync)
+            return _visibleTasks.TryGetValue(key, out var task) ? task.ElapsedTime : null;
+    }
+
+    internal void FinishRemaining(bool success)
+    {
+        lock (_sync)
+        {
+            foreach (var entry in _entries.Values.Where(entry => !IsTerminal(entry.State)).ToArray())
+            {
+                var state = entry.State == SpectreProgressLedgerState.Started && !success
+                    ? SpectreProgressLedgerState.Failed
+                    : SpectreProgressLedgerState.Skipped;
+                Update(
+                    entry.Item,
+                    state,
+                    success ? "not required" : "skipped after failure");
+            }
+        }
+    }
+
+    internal void ClearLiveTasks()
+    {
+        lock (_sync)
+        {
+            foreach (var task in _visibleTasks.Values.ToArray())
+                _context.RemoveTask(task);
+
+            _visibleTasks.Clear();
+            _context.Refresh();
+        }
+    }
+
+    internal IReadOnlyList<SpectreProgressLedgerSnapshot> GetSnapshots()
+    {
+        lock (_sync)
+        {
+            return _entries.Values
+                .OrderBy(entry => entry.Item.GroupOrder)
+                .ThenBy(entry => entry.Item.Position <= 0 ? int.MaxValue : entry.Item.Position)
+                .ThenBy(entry => entry.Item.Title, StringComparer.OrdinalIgnoreCase)
+                .Select(entry => new SpectreProgressLedgerSnapshot(
+                    entry.Item.GroupTitle,
+                    entry.Item.Position,
+                    entry.Item.Total,
+                    entry.Item.Title,
+                    entry.State,
+                    entry.Detail,
+                    entry.Duration ?? entry.Item.Duration ?? TimeSpan.Zero))
+                .ToArray();
+        }
+    }
+
+    internal static void WriteLedger(
+        IAnsiConsole console,
+        IReadOnlyList<SpectreProgressLedgerSnapshot> snapshots,
+        string title)
+    {
+        if (console is null) throw new ArgumentNullException(nameof(console));
+        if (snapshots is null || snapshots.Count == 0) return;
+
+        static string Esc(string? value) => Markup.Escape(value ?? string.Empty);
+        var unicode = ConsoleEncoding.ShouldRenderUnicode(console.Profile.Capabilities.Unicode);
+        console.Write(new Rule($"[yellow]{Esc(title)}[/]").LeftJustified());
+
+        var table = new Table()
+            .Border(TableBorder.None)
+            .HideHeaders()
+            .AddColumn(new TableColumn("Status").NoWrap().Width(1))
+            .AddColumn(new TableColumn("Item").NoWrap())
+            .AddColumn(new TableColumn("Result"))
+            .AddColumn(new TableColumn("Duration").RightAligned().NoWrap());
+
+        string? currentGroup = null;
+        foreach (var snapshot in snapshots)
+        {
+            if (!string.Equals(currentGroup, snapshot.GroupTitle, StringComparison.Ordinal))
+            {
+                currentGroup = snapshot.GroupTitle;
+                table.AddRow(
+                    string.Empty,
+                    $"[grey bold]{Esc(currentGroup)}[/]",
+                    string.Empty,
+                    string.Empty);
+            }
+
+            var (icon, color) = GetStateVisual(snapshot.State, unicode);
+            var ordinal = snapshot.Position > 0 && snapshot.Total > 0
+                ? $"{snapshot.Position:00}/{snapshot.Total:00}"
+                : "–";
+            table.AddRow(
+                $"[{color}]{icon}[/]",
+                $"[{color}]{Esc($"{ordinal} {snapshot.Title}")}[/]",
+                $"[{color}]{Esc(snapshot.Detail)}[/]",
+                $"[deepskyblue1]{Esc(FormatDuration(snapshot.Duration))}[/]");
+        }
+
+        console.Write(table);
+    }
+
+    private ProgressTask EnsureVisibleTask(Entry entry)
+    {
+        if (_visibleTasks.TryGetValue(entry.Item.Key, out var task))
+            return task;
+
+        task = _context.AddTask(
+            BuildLiveLabel(entry),
+            maxValue: 1,
+            autoStart: false);
+        _visibleTasks[entry.Item.Key] = task;
+        return task;
+    }
+
+    private void ReconcileVisibleTasks()
+    {
+        var desired = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in _entries.Values
+                     .Where(entry => entry.State == SpectreProgressLedgerState.Started)
+                     .OrderBy(entry => entry.Item.GroupOrder)
+                     .ThenBy(entry => entry.Item.Position <= 0 ? int.MaxValue : entry.Item.Position)
+                     .Take(ActiveLimit))
+        {
+            desired.Add(entry.Item.Key);
+        }
+
+        foreach (var entry in _entries.Values
+                     .Where(entry => entry.State == SpectreProgressLedgerState.Completed ||
+                                     entry.State == SpectreProgressLedgerState.Skipped)
+                     .OrderByDescending(entry => entry.TerminalSequence)
+                     .Take(RecentCompletedLimit))
+        {
+            desired.Add(entry.Item.Key);
+        }
+
+        foreach (var entry in _entries.Values
+                     .Where(entry => entry.State == SpectreProgressLedgerState.Failed)
+                     .OrderByDescending(entry => entry.TerminalSequence)
+                     .Take(PinnedFailureLimit))
+        {
+            desired.Add(entry.Item.Key);
+        }
+
+        foreach (var entry in _entries.Values
+                     .Where(entry => entry.State == SpectreProgressLedgerState.Planned)
+                     .OrderBy(entry => entry.Item.GroupOrder)
+                     .ThenBy(entry => entry.Item.Position <= 0 ? int.MaxValue : entry.Item.Position)
+                     .Take(UpcomingLimit))
+        {
+            desired.Add(entry.Item.Key);
+        }
+
+        foreach (var key in _visibleTasks.Keys.Where(key => !desired.Contains(key)).ToArray())
+        {
+            _context.RemoveTask(_visibleTasks[key]);
+            _visibleTasks.Remove(key);
+        }
+
+        foreach (var entry in _entries.Values.Where(entry => desired.Contains(entry.Item.Key)))
+            EnsureVisibleTask(entry).Description = BuildLiveLabel(entry);
+    }
+
+    private static string BuildLiveLabel(Entry entry)
+    {
+        var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
+        var (icon, color) = GetStateVisual(entry.State, unicode);
+        var ordinal = entry.Item.Position > 0 && entry.Item.Total > 0
+            ? $"{entry.Item.Position:00}/{entry.Item.Total:00} "
+            : string.Empty;
+        var suffix = string.IsNullOrWhiteSpace(entry.Detail) ? string.Empty : $" — {entry.Detail}";
+        return $"[{color}]{Markup.Escape($"  {icon} {ordinal}{entry.Item.Title}{suffix}")}[/]";
+    }
+
+    private static (string Icon, string Color) GetStateVisual(
+        SpectreProgressLedgerState state,
+        bool unicode)
+        => state switch
+        {
+            SpectreProgressLedgerState.Started => (unicode ? "▶" : ">", "cyan"),
+            SpectreProgressLedgerState.Completed => (unicode ? "✓" : "+", "green"),
+            SpectreProgressLedgerState.Failed => ("x", "red"),
+            SpectreProgressLedgerState.Skipped => (unicode ? "–" : "-", "grey"),
+            _ => (unicode ? "·" : ".", "grey")
+        };
+
+    private static bool IsTerminal(SpectreProgressLedgerState state)
+        => state == SpectreProgressLedgerState.Completed ||
+           state == SpectreProgressLedgerState.Failed ||
+           state == SpectreProgressLedgerState.Skipped;
+
+    private static double ResolveProgressFraction(
+        SpectreProgressLedgerItem item,
+        SpectreProgressLedgerState state)
+    {
+        if (IsTerminal(state))
+            return 1;
+        if (item.ProgressMaximum <= 0)
+            return 0;
+
+        return Math.Min(1d, Math.Max(0d, item.ProgressValue / item.ProgressMaximum));
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration < TimeSpan.Zero)
+            duration = TimeSpan.Zero;
+        return duration.TotalHours >= 1
+            ? duration.ToString(@"hh\:mm\:ss")
+            : duration.ToString(@"mm\:ss\.fff");
+    }
+
+    private sealed class Entry
+    {
+        internal Entry(SpectreProgressLedgerItem item)
+            => Item = item;
+
+        internal SpectreProgressLedgerItem Item { get; set; }
+        internal SpectreProgressLedgerState State { get; set; }
+        internal string? Detail { get; set; }
+        internal double ProgressFraction { get; set; }
+        internal TimeSpan? Duration { get; set; }
+        internal long TerminalSequence { get; set; }
+    }
+}
+
+internal sealed class SpectreProgressLedgerItem
+{
+    internal string Key { get; set; } = string.Empty;
+    internal string GroupKey { get; set; } = string.Empty;
+    internal string GroupTitle { get; set; } = string.Empty;
+    internal int GroupOrder { get; set; }
+    internal string Title { get; set; } = string.Empty;
+    internal string? Kind { get; set; }
+    internal int Position { get; set; }
+    internal int Total { get; set; }
+    internal double ProgressValue { get; set; }
+    internal double ProgressMaximum { get; set; }
+    internal TimeSpan? Duration { get; set; }
+}
+
+internal enum SpectreProgressLedgerState
+{
+    Planned,
+    Started,
+    Completed,
+    Failed,
+    Skipped
+}
+
+internal sealed class SpectreProgressLedgerSnapshot
+{
+    internal SpectreProgressLedgerSnapshot(
+        string groupTitle,
+        int position,
+        int total,
+        string title,
+        SpectreProgressLedgerState state,
+        string? detail,
+        TimeSpan duration)
+    {
+        GroupTitle = groupTitle;
+        Position = position;
+        Total = total;
+        Title = title;
+        State = state;
+        Detail = detail;
+        Duration = duration;
+    }
+
+    internal string GroupTitle { get; }
+    internal int Position { get; }
+    internal int Total { get; }
+    internal string Title { get; }
+    internal SpectreProgressLedgerState State { get; }
+    internal string? Detail { get; }
+    internal TimeSpan Duration { get; }
+}

--- a/PowerForge.ConsoleShared/SpectreBuildProgressColumns.cs
+++ b/PowerForge.ConsoleShared/SpectreBuildProgressColumns.cs
@@ -16,7 +16,7 @@ internal static class SpectreBuildProgressColumns
     public static ProgressColumn[] CreateStandard()
         =>
         [
-            new TaskDescriptionColumn { Alignment = Justify.Left },
+            new LeftMarkupDescriptionColumn(),
             new ProgressBarColumn
             {
                 CompletedStyle = new Style(Color.Green),
@@ -97,6 +97,16 @@ internal static class SpectreBuildProgressColumns
             try { text.Overflow = Overflow.Ellipsis; } catch { }
             return text;
         }
+    }
+
+    private sealed class LeftMarkupDescriptionColumn : ProgressColumn
+    {
+        public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
+            => new Markup(task.Description ?? string.Empty)
+            {
+                Justification = Justify.Left,
+                Overflow = Overflow.Ellipsis
+            };
     }
 
     private sealed class FixedElapsedColumn : ProgressColumn

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -25,6 +25,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         WriteHeader(spec, request, phases, phaseNames);
         PowerForgeReleaseResult? result = null;
         Exception? failure = null;
+        Reporter? reporter = null;
 
         SpectreProgressDisplay.Run(
             SpectreBuildProgressColumns.CreateStandard(),
@@ -33,7 +34,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 var tasks = phases.ToDictionary(
                     phase => phase,
                     phase => context.AddTask($"[grey]{Markup.Escape(phaseNames[phase])} — pending[/]", maxValue: 100, autoStart: false));
-                var reporter = new Reporter(context, tasks, phaseNames);
+                reporter = new Reporter(context, tasks, phaseNames);
                 try
                 {
                     result = run(reporter);
@@ -46,6 +47,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 }
             });
 
+        reporter?.WriteLedger();
         if (failure is not null)
             ExceptionDispatchInfo.Capture(failure).Throw();
         return result!;
@@ -193,9 +195,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> _tasks;
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> _phaseNames;
         private readonly HashSet<PowerForgeReleaseProgressPhase> _failed = new();
-        private readonly Dictionary<string, ProgressTask> _itemTasks = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, PowerForgeReleaseProgressItem> _items = new(StringComparer.OrdinalIgnoreCase);
-        private readonly object _sync = new();
+        private readonly SpectreBoundedProgressLedger _ledger;
 
         public Reporter(
             ProgressContext context,
@@ -205,6 +205,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             _context = context;
             _tasks = tasks;
             _phaseNames = phaseNames;
+            _ledger = new SpectreBoundedProgressLedger(context);
         }
 
         public void PhaseStarted(PowerForgeReleaseProgressPhase phase, int totalItems, string? detail = null)
@@ -241,24 +242,9 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             if (items is null || items.Count == 0)
                 return;
 
-            lock (_sync)
-            {
-                foreach (var item in items)
-                {
-                    if (item is null)
-                        continue;
-
-                    var key = ItemKey(item);
-                    if (_itemTasks.ContainsKey(key))
-                        continue;
-
-                    _items[key] = item;
-                    _itemTasks[key] = _context.AddTask(
-                        BuildItemLabel(item, PowerForgeReleaseProgressItemState.Planned, null),
-                        maxValue: 1,
-                        autoStart: false);
-                }
-            }
+            _ledger.Plan(items
+                .Where(item => item is not null)
+                .Select(ToLedgerItem));
 
             if (_tasks.TryGetValue(phase, out var phaseTask))
                 phaseTask.Description = Label(phase, $"{CountItems(phase)} detailed step(s)", "cyan");
@@ -272,46 +258,17 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             if (item is null)
                 return;
 
-            ProgressTask task;
-            lock (_sync)
-            {
-                var key = ItemKey(item);
-                if (!_itemTasks.TryGetValue(key, out task!))
+            _ledger.Update(
+                ToLedgerItem(item),
+                state switch
                 {
-                    _items[key] = item;
-                    task = _context.AddTask(
-                        BuildItemLabel(item, PowerForgeReleaseProgressItemState.Planned, null),
-                        maxValue: 1,
-                        autoStart: false);
-                    _itemTasks[key] = task;
-                }
-            }
-
-            task.Description = BuildItemLabel(item, state, detail);
-            switch (state)
-            {
-                case PowerForgeReleaseProgressItemState.Started:
-                    if (!task.IsStarted) task.StartTask();
-                    if (item.ProgressMaximum > 0)
-                    {
-                        task.IsIndeterminate = false;
-                        task.Value = task.MaxValue *
-                                     Math.Min(1d, Math.Max(0d, item.ProgressValue / item.ProgressMaximum));
-                    }
-                    else
-                    {
-                        task.IsIndeterminate = true;
-                    }
-                    break;
-                case PowerForgeReleaseProgressItemState.Completed:
-                case PowerForgeReleaseProgressItemState.Failed:
-                case PowerForgeReleaseProgressItemState.Skipped:
-                    if (!task.IsStarted) task.StartTask();
-                    task.IsIndeterminate = false;
-                    task.Value = task.MaxValue;
-                    task.StopTask();
-                    break;
-            }
+                    PowerForgeReleaseProgressItemState.Started => SpectreProgressLedgerState.Started,
+                    PowerForgeReleaseProgressItemState.Completed => SpectreProgressLedgerState.Completed,
+                    PowerForgeReleaseProgressItemState.Failed => SpectreProgressLedgerState.Failed,
+                    PowerForgeReleaseProgressItemState.Skipped => SpectreProgressLedgerState.Skipped,
+                    _ => SpectreProgressLedgerState.Planned
+                },
+                detail);
 
             UpdatePhaseProgress(item.Phase);
         }
@@ -333,23 +290,16 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 entry.Value.StopTask();
             }
 
-            lock (_sync)
-            {
-                foreach (var entry in _itemTasks)
-                {
-                    var task = entry.Value;
-                    if (task.IsFinished) continue;
-                    var item = _items[entry.Key];
-                    var state = task.IsStarted && !success
-                        ? PowerForgeReleaseProgressItemState.Failed
-                        : PowerForgeReleaseProgressItemState.Skipped;
-                    ItemUpdated(
-                        item,
-                        state,
-                        success ? "not required" : "skipped after failure");
-                }
-            }
+            _ledger.FinishRemaining(success);
+            _ledger.ClearLiveTasks();
+            _context.Refresh();
         }
+
+        public void WriteLedger()
+            => SpectreBoundedProgressLedger.WriteLedger(
+                AnsiConsole.Console,
+                _ledger.GetSnapshots(),
+                "Unified release details");
 
         private string Label(PowerForgeReleaseProgressPhase phase, string? detail, string color, string? status = null)
         {
@@ -367,76 +317,30 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 return;
             }
 
-            lock (_sync)
-            {
-                var tasks = _items
-                    .Where(entry => entry.Value.Phase == phase)
-                    .Select(entry => _itemTasks[entry.Key])
-                    .ToArray();
-                if (tasks.Length == 0)
-                    return;
+            if (_ledger.GetItemCount(phase.ToString()) == 0)
+                return;
 
-                var completed = tasks.Sum(task =>
-                    task.MaxValue <= 0 ? 0 : Math.Min(1d, Math.Max(0d, task.Value / task.MaxValue)));
-                phaseTask.Value = Math.Max(5d, Math.Min(99d, completed / tasks.Length * 100d));
-            }
+            var completed = _ledger.GetCompletionRatio(phase.ToString());
+            phaseTask.Value = Math.Max(5d, Math.Min(99d, completed * 100d));
         }
 
         private int CountItems(PowerForgeReleaseProgressPhase phase)
-        {
-            lock (_sync)
-                return _items.Values.Count(item => item.Phase == phase);
-        }
+            => _ledger.GetItemCount(phase.ToString());
 
-        private static string ItemKey(PowerForgeReleaseProgressItem item)
-            => $"{item.Phase}:{item.Key}";
-
-        private static string BuildItemLabel(
-            PowerForgeReleaseProgressItem item,
-            PowerForgeReleaseProgressItemState state,
-            string? detail)
-        {
-            var ordinal = item.Position > 0 && item.Total > 0
-                ? $"{item.Position:00}/{item.Total:00} "
-                : string.Empty;
-            var status = GetItemIcon(item, state) + " ";
-            var color = state switch
+        private SpectreProgressLedgerItem ToLedgerItem(PowerForgeReleaseProgressItem item)
+            => new()
             {
-                PowerForgeReleaseProgressItemState.Started => "cyan",
-                PowerForgeReleaseProgressItemState.Completed => "green",
-                PowerForgeReleaseProgressItemState.Failed => "red",
-                _ => "grey"
+                Key = $"{item.Phase}:{item.Key}",
+                GroupKey = item.Phase.ToString(),
+                GroupTitle = _phaseNames[item.Phase],
+                GroupOrder = (int)item.Phase,
+                Title = item.Title,
+                Kind = item.Kind,
+                Position = item.Position,
+                Total = item.Total,
+                ProgressValue = item.ProgressValue,
+                ProgressMaximum = item.ProgressMaximum,
+                Duration = item.Duration
             };
-            var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $" — {detail}";
-            return $"[{color}]{Markup.Escape($"  {status}{ordinal}{item.Title}{suffix}")}[/]";
-        }
-
-        private static string GetItemIcon(
-            PowerForgeReleaseProgressItem item,
-            PowerForgeReleaseProgressItemState state)
-        {
-            var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
-            if (state == PowerForgeReleaseProgressItemState.Completed) return unicode ? "✓" : "+";
-            if (state == PowerForgeReleaseProgressItemState.Failed) return "x";
-            if (state == PowerForgeReleaseProgressItemState.Skipped) return "–";
-            if (!unicode) return "·";
-
-            return item.Kind switch
-            {
-                nameof(ModulePipelineStepKind.Build) => "🔨",
-                nameof(ModulePipelineStepKind.Documentation) => "📝",
-                nameof(ModulePipelineStepKind.Formatting) => "🎨",
-                nameof(ModulePipelineStepKind.Signing) => "🔏",
-                nameof(ModulePipelineStepKind.Validation) => "🔎",
-                nameof(ModulePipelineStepKind.Tests) => "🧪",
-                nameof(ModulePipelineStepKind.Artefact) => "📦",
-                nameof(ModulePipelineStepKind.Install) => "📥",
-                nameof(ModulePipelineStepKind.Cleanup) => "🧹",
-                nameof(ProjectBuildProgressPhase.NuGetPublish) => "🚀",
-                nameof(ProjectBuildProgressPhase.PackageSigning) => "🔏",
-                "ToolPublish" => "🚀",
-                _ => "•"
-            };
-        }
     }
 }

--- a/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
@@ -27,23 +27,32 @@ internal static class SpectreProjectBuildConsoleUi
     public static ProjectBuildWorkflowResult RunInteractive(
         ProjectBuildConsolePlan plan,
         Func<IProjectBuildProgressReporter, ProjectBuildWorkflowResult> run)
+        => RunInteractive(AnsiConsole.Console, plan, run);
+
+    internal static ProjectBuildWorkflowResult RunInteractive(
+        IAnsiConsole console,
+        ProjectBuildConsolePlan plan,
+        Func<IProjectBuildProgressReporter, ProjectBuildWorkflowResult> run)
     {
+        if (console is null) throw new ArgumentNullException(nameof(console));
         if (plan is null) throw new ArgumentNullException(nameof(plan));
         if (run is null) throw new ArgumentNullException(nameof(run));
 
-        WriteHeader(plan);
+        WriteHeader(console, plan);
         var phases = ResolvePhases(plan);
         ProjectBuildWorkflowResult? result = null;
         Exception? failure = null;
+        SpectreProjectBuildProgressReporter? reporter = null;
 
         SpectreProgressDisplay.Run(
+            console,
             SpectreBuildProgressColumns.CreateStandard(),
             context =>
             {
                 var tasks = phases.ToDictionary(
                     phase => phase,
                     phase => context.AddTask(BuildPendingLabel(phase), maxValue: 100, autoStart: false));
-                var reporter = new SpectreProjectBuildProgressReporter(tasks);
+                reporter = new SpectreProjectBuildProgressReporter(context, tasks);
 
                 try
                 {
@@ -58,7 +67,10 @@ internal static class SpectreProjectBuildConsoleUi
             });
 
         if (failure is not null)
+        {
+            reporter?.WriteLedger(console);
             ExceptionDispatchInfo.Capture(failure).Throw();
+        }
 
         return result!;
     }
@@ -76,12 +88,12 @@ internal static class SpectreProjectBuildConsoleUi
         return phases.ToArray();
     }
 
-    private static void WriteHeader(ProjectBuildConsolePlan plan)
+    private static void WriteHeader(IAnsiConsole console, ProjectBuildConsolePlan plan)
     {
         static string Esc(string? value) => Markup.Escape(value ?? string.Empty);
-        var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
+        var unicode = ConsoleEncoding.ShouldRenderUnicode(console.Profile.Capabilities.Unicode);
         var title = unicode ? "🛠️ PowerForge • Project build" : "PowerForge • Project build";
-        AnsiConsole.Write(new Rule($"[yellow bold underline]{Esc(title)}[/]") { Justification = Justify.Left });
+        console.Write(new Rule($"[yellow bold underline]{Esc(title)}[/]") { Justification = Justify.Left });
 
         var actions = new List<string>();
         if (plan.UpdateVersions) actions.Add("versions");
@@ -102,8 +114,8 @@ internal static class SpectreProjectBuildConsoleUi
         if (!string.IsNullOrWhiteSpace(plan.StagingPath)) table.AddRow("[grey]Staging[/]", Esc(plan.StagingPath));
         if (!string.IsNullOrWhiteSpace(plan.OutputPath)) table.AddRow("[grey]Packages[/]", Esc(plan.OutputPath));
         if (!string.IsNullOrWhiteSpace(plan.PlanOutputPath)) table.AddRow("[grey]Plan file[/]", Esc(plan.PlanOutputPath));
-        AnsiConsole.Write(table);
-        AnsiConsole.WriteLine();
+        console.Write(table);
+        console.WriteLine();
     }
 
     private static string BuildPendingLabel(ProjectBuildProgressPhase phase)
@@ -121,13 +133,21 @@ internal static class SpectreProjectBuildConsoleUi
             _ => phase.ToString()
         };
 
-    private sealed class SpectreProjectBuildProgressReporter : IProjectBuildProgressReporter
+    private sealed class SpectreProjectBuildProgressReporter : IProjectBuildProgressReporterV2
     {
+        private readonly ProgressContext _context;
         private readonly IReadOnlyDictionary<ProjectBuildProgressPhase, ProgressTask> _tasks;
         private readonly HashSet<ProjectBuildProgressPhase> _failed = new();
+        private readonly SpectreBoundedProgressLedger _ledger;
 
-        public SpectreProjectBuildProgressReporter(IReadOnlyDictionary<ProjectBuildProgressPhase, ProgressTask> tasks)
-            => _tasks = tasks;
+        public SpectreProjectBuildProgressReporter(
+            ProgressContext context,
+            IReadOnlyDictionary<ProjectBuildProgressPhase, ProgressTask> tasks)
+        {
+            _context = context;
+            _tasks = tasks;
+            _ledger = new SpectreBoundedProgressLedger(context);
+        }
 
         public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null)
         {
@@ -165,6 +185,27 @@ internal static class SpectreProjectBuildConsoleUi
             task.StopTask();
         }
 
+        public void ItemsPlanned(
+            ProjectBuildProgressPhase phase,
+            IReadOnlyList<ProjectBuildProgressItem> items)
+            => _ledger.Plan(items.Select(item => ToLedgerItem(item)));
+
+        public void ItemUpdated(
+            ProjectBuildProgressItem item,
+            ProjectBuildProgressItemState state,
+            string? detail = null)
+            => _ledger.Update(
+                ToLedgerItem(item),
+                state switch
+                {
+                    ProjectBuildProgressItemState.Started => SpectreProgressLedgerState.Started,
+                    ProjectBuildProgressItemState.Completed => SpectreProgressLedgerState.Completed,
+                    ProjectBuildProgressItemState.Failed => SpectreProgressLedgerState.Failed,
+                    ProjectBuildProgressItemState.Skipped => SpectreProgressLedgerState.Skipped,
+                    _ => SpectreProgressLedgerState.Planned
+                },
+                detail);
+
         public void FinishRemaining(bool success)
         {
             foreach (var entry in _tasks)
@@ -183,7 +224,31 @@ internal static class SpectreProjectBuildConsoleUi
                 task.Value = 100;
                 task.StopTask();
             }
+
+            _ledger.FinishRemaining(success);
+            _ledger.ClearLiveTasks();
+            _context.Refresh();
         }
+
+        public void WriteLedger(IAnsiConsole console)
+            => SpectreBoundedProgressLedger.WriteLedger(
+                console,
+                _ledger.GetSnapshots(),
+                "Project build details");
+
+        private static SpectreProgressLedgerItem ToLedgerItem(ProjectBuildProgressItem item)
+            => new()
+            {
+                Key = $"{item.Phase}:{item.Key}",
+                GroupKey = item.Phase.ToString(),
+                GroupTitle = GetPhaseName(item.Phase),
+                GroupOrder = (int)item.Phase,
+                Title = item.Title,
+                Kind = item.Kind,
+                Position = item.Position,
+                Total = item.Total,
+                Duration = item.Duration
+            };
 
         private static string BuildLabel(
             ProjectBuildProgressPhase phase,

--- a/PowerForge.ConsoleShared/SpectreProjectBuildSummaryWriter.cs
+++ b/PowerForge.ConsoleShared/SpectreProjectBuildSummaryWriter.cs
@@ -33,6 +33,7 @@ internal static class SpectreProjectBuildSummaryWriter
             .AddColumn(new TableColumn("Packable").NoWrap())
             .AddColumn(new TableColumn("Version").NoWrap())
             .AddColumn(new TableColumn("Packages").NoWrap())
+            .AddColumn(new TableColumn("Duration").RightAligned().NoWrap())
             .AddColumn(new TableColumn("Status").NoWrap())
             .AddColumn(new TableColumn("Error"));
 
@@ -43,6 +44,7 @@ internal static class SpectreProjectBuildSummaryWriter
                 project.Packable,
                 Esc(project.VersionDisplay),
                 project.PackageCount,
+                $"[deepskyblue1]{Esc(project.Duration)}[/]",
                 $"[{ColorTag(project.StatusColor)}]{Esc(project.StatusText)}[/]",
                 Esc(project.ErrorPreview));
         }

--- a/PowerForge.Tests/DotNetRepositoryReleaseDisplayServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseDisplayServiceTests.cs
@@ -18,6 +18,7 @@ public sealed class DotNetRepositoryReleaseDisplayServiceTests
                     IsPackable = true,
                     VersionDisplay = "1.0.0 -> 1.0.1",
                     PackageCount = 2,
+                    PackageBuildDuration = TimeSpan.FromSeconds(12.5),
                     Status = DotNetRepositoryReleaseProjectStatus.Ok,
                     ErrorPreview = string.Empty
                 },
@@ -57,9 +58,11 @@ public sealed class DotNetRepositoryReleaseDisplayServiceTests
 
         Assert.Equal("Summary", display.Title);
         Assert.Equal("Yes", display.Projects[0].Packable);
+        Assert.Equal("12.5s", display.Projects[0].Duration);
         Assert.Equal("Ok", display.Projects[0].StatusText);
         Assert.Equal(ConsoleColor.Green, display.Projects[0].StatusColor);
         Assert.Equal("Skipped", display.Projects[1].StatusText);
+        Assert.Equal("-", display.Projects[1].Duration);
         Assert.Equal(ConsoleColor.Gray, display.Projects[1].StatusColor);
         Assert.Equal("Fail", display.Projects[2].StatusText);
         Assert.Equal(ConsoleColor.Red, display.Projects[2].StatusColor);

--- a/PowerForge.Tests/DotNetRepositoryReleaseSummaryServiceTests.cs
+++ b/PowerForge.Tests/DotNetRepositoryReleaseSummaryServiceTests.cs
@@ -16,7 +16,8 @@ public sealed class DotNetRepositoryReleaseSummaryServiceTests
             ProjectName = "LibraryA",
             IsPackable = true,
             OldVersion = "2.0.4",
-            NewVersion = "2.0.5"
+            NewVersion = "2.0.5",
+            PackageBuildDuration = TimeSpan.FromSeconds(12.5)
         });
         result.Projects[0].Packages.Add("LibraryA.2.0.5.nupkg");
         result.Projects[0].SymbolPackages.Add("LibraryA.2.0.5.snupkg");
@@ -42,6 +43,7 @@ public sealed class DotNetRepositoryReleaseSummaryServiceTests
         Assert.Equal(DotNetRepositoryReleaseProjectStatus.Ok, summary.Projects[0].Status);
         Assert.Equal("2.0.4 -> 2.0.5", summary.Projects[0].VersionDisplay);
         Assert.Equal(2, summary.Projects[0].PackageCount);
+        Assert.Equal(TimeSpan.FromSeconds(12.5), summary.Projects[0].PackageBuildDuration);
         Assert.Equal("LibraryB", summary.Projects[1].ProjectName);
         Assert.Equal(DotNetRepositoryReleaseProjectStatus.Skipped, summary.Projects[1].Status);
         Assert.Equal("LibraryC", summary.Projects[2].ProjectName);

--- a/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
+++ b/PowerForge.Tests/PowerForgeReleaseProgressAdaptersTests.cs
@@ -33,6 +33,44 @@ public sealed class PowerForgeReleaseProgressAdaptersTests
     }
 
     [Fact]
+    public void ProjectBuildAdapter_ForwardsPerProjectTimingAndState()
+    {
+        var release = new RecordingReleaseProgress();
+        var adapter = new ProjectBuildReleaseProgressAdapter(
+            release,
+            PowerForgeReleaseProgressPhase.Packages);
+        var item = new ProjectBuildProgressItem
+        {
+            Phase = ProjectBuildProgressPhase.PackageBuild,
+            Key = "package:Sample.Project",
+            Title = "Sample.Project",
+            Kind = nameof(ProjectBuildProgressPhase.PackageBuild),
+            Position = 7,
+            Total = 85
+        };
+
+        adapter.ItemsPlanned(ProjectBuildProgressPhase.PackageBuild, new[] { item });
+        adapter.ItemUpdated(item, ProjectBuildProgressItemState.Started, "building");
+        item.Duration = TimeSpan.FromSeconds(42);
+        adapter.ItemUpdated(item, ProjectBuildProgressItemState.Completed, "1 package, 1 archive");
+
+        var mapped = Assert.Single(release.Planned);
+        Assert.Equal(PowerForgeReleaseProgressPhase.Packages, mapped.Phase);
+        Assert.Equal("Sample.Project", mapped.Title);
+        Assert.Equal(7, mapped.Position);
+        Assert.Equal(85, mapped.Total);
+        Assert.Equal(TimeSpan.FromSeconds(42), mapped.Duration);
+        Assert.Collection(
+            release.Updates,
+            update => Assert.Equal(PowerForgeReleaseProgressItemState.Started, update.State),
+            update =>
+            {
+                Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State);
+                Assert.Equal(TimeSpan.FromSeconds(42), update.Item.Duration);
+            });
+    }
+
+    [Fact]
     public void DotNetPublishAdapter_ForwardsPlannedMatrixAndStepState()
     {
         var release = new RecordingReleaseProgress();

--- a/PowerForge.Tests/ProjectBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ProjectBuildHostServiceTests.cs
@@ -170,6 +170,82 @@ public sealed class ProjectBuildHostServiceTests
         Assert.Equal(Path.Combine(scope.RootPath, "Repo"), result.RootPath);
     }
 
+    [Fact]
+    public async Task Execute_RejectsConcurrentMutationOfTheSameStagingWorkspace()
+    {
+        using var scope = new TemporaryDirectoryScope();
+        var configDirectory = scope.CreateDirectory("Repo");
+        var stagingDirectory = Path.Combine(configDirectory, "artifacts", "ProjectBuild");
+        var configPath = Path.Combine(configDirectory, "project.build.json");
+        File.WriteAllText(
+            configPath,
+            """
+            {
+              "RootPath": ".",
+              "StagingPath": "artifacts/ProjectBuild",
+              "Build": true,
+              "PublishNuget": false,
+              "PublishGitHub": false
+            }
+            """);
+
+        using var releaseStarted = new ManualResetEventSlim();
+        using var releaseMayFinish = new ManualResetEventSlim();
+        var firstCall = 0;
+        var firstService = new ProjectBuildHostService(
+            new NullLogger(),
+            executeRelease: spec =>
+            {
+                if (Interlocked.Increment(ref firstCall) == 1)
+                    return new DotNetRepositoryReleaseResult { Success = true };
+
+                releaseStarted.Set();
+                Assert.True(releaseMayFinish.Wait(TimeSpan.FromSeconds(10)));
+                return new DotNetRepositoryReleaseResult { Success = true };
+            },
+            publishGitHub: null,
+            validateGitHubPreflight: null);
+        var request = new ProjectBuildHostRequest
+        {
+            ConfigPath = configPath,
+            ExecuteBuild = true,
+            Build = true,
+            UpdateVersions = false,
+            PublishNuget = false,
+            PublishGitHub = false
+        };
+
+        var firstExecution = Task.Run(() => firstService.Execute(request));
+        Assert.True(releaseStarted.Wait(TimeSpan.FromSeconds(10)));
+
+        try
+        {
+            var secondService = new ProjectBuildHostService(
+                new NullLogger(),
+                executeRelease: _ => new DotNetRepositoryReleaseResult { Success = true },
+                publishGitHub: null,
+                validateGitHubPreflight: null);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => secondService.Execute(request));
+            Assert.Contains("Another project build is already using workspace", exception.Message, StringComparison.Ordinal);
+            Assert.Contains(stagingDirectory, exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            releaseMayFinish.Set();
+        }
+
+        var result = await firstExecution;
+        Assert.True(result.Success);
+
+        var retryService = new ProjectBuildHostService(
+            new NullLogger(),
+            executeRelease: _ => new DotNetRepositoryReleaseResult { Success = true },
+            publishGitHub: null,
+            validateGitHubPreflight: null);
+        Assert.True(retryService.Execute(request).Success);
+    }
+
     private sealed class TemporaryDirectoryScope : IDisposable
     {
         public TemporaryDirectoryScope()

--- a/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
+++ b/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
@@ -1,0 +1,330 @@
+using PowerForge.ConsoleShared;
+using Spectre.Console;
+
+namespace PowerForge.Tests;
+
+public sealed class ProjectBuildProgressLedgerTests
+{
+    [Fact]
+    public void BoundedLedger_KeepsLiveTasksSmallAndRetainsCompleteTimedHistory()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 12);
+        SpectreBoundedProgressLedger? ledger = null;
+
+        SpectreProgressDisplay.Run(
+            console,
+            [
+                new TaskDescriptionColumn { Alignment = Justify.Left },
+                new ProgressBarColumn(),
+                new PercentageColumn(),
+                new ElapsedTimeColumn()
+            ],
+            context =>
+            {
+                ledger = new SpectreBoundedProgressLedger(context);
+                var items = Enumerable.Range(1, 85)
+                    .Select(index => new SpectreProgressLedgerItem
+                    {
+                        Key = $"package:{index}",
+                        GroupKey = "PackageBuild",
+                        GroupTitle = "Build packages and archives",
+                        GroupOrder = 1,
+                        Title = $"Project.{index:00}",
+                        Position = index,
+                        Total = 85
+                    })
+                    .ToArray();
+
+                ledger.Plan(items);
+                Assert.Equal(2, ledger.VisibleTaskCount);
+
+                foreach (var item in items)
+                {
+                    ledger.Update(item, SpectreProgressLedgerState.Started, "building");
+                    Assert.InRange(ledger.VisibleTaskCount, 1, 6);
+
+                    item.Duration = TimeSpan.FromSeconds(item.Position);
+                    ledger.Update(item, SpectreProgressLedgerState.Completed, "1 package, 1 archive");
+                    Assert.InRange(ledger.VisibleTaskCount, 1, 5);
+                    if (item.Position == items.Length)
+                    {
+                        var stoppedAt = ledger.GetVisibleElapsedTime(item.Key);
+                        Thread.Sleep(25);
+                        Assert.Equal(stoppedAt, ledger.GetVisibleElapsedTime(item.Key));
+                    }
+                }
+
+                Assert.Equal(85, ledger.GetItemCount("PackageBuild"));
+                Assert.Equal(1d, ledger.GetCompletionRatio("PackageBuild"), 5);
+                Assert.Equal(3, ledger.VisibleTaskCount);
+                ledger.ClearLiveTasks();
+                Assert.Equal(0, ledger.VisibleTaskCount);
+            });
+
+        var snapshots = Assert.IsAssignableFrom<IReadOnlyList<SpectreProgressLedgerSnapshot>>(
+            ledger!.GetSnapshots());
+        Assert.Equal(85, snapshots.Count);
+        Assert.All(snapshots, snapshot => Assert.Equal(SpectreProgressLedgerState.Completed, snapshot.State));
+        Assert.Equal(TimeSpan.FromSeconds(1), snapshots[0].Duration);
+        Assert.Equal(TimeSpan.FromSeconds(85), snapshots[^1].Duration);
+
+        SpectreBoundedProgressLedger.WriteLedger(console, snapshots, "Project build details");
+        var output = writer.ToString();
+        Assert.Contains("Project.01", output, StringComparison.Ordinal);
+        Assert.Contains("Project.85", output, StringComparison.Ordinal);
+        Assert.Contains("01:25.000", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BoundedLedger_KeepsConcurrentBatchItemsBounded()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 12);
+
+        SpectreProgressDisplay.Run(
+            console,
+            SpectreBuildProgressColumns.CreateStandard(),
+            context =>
+            {
+                var ledger = new SpectreBoundedProgressLedger(context);
+                var items = Enumerable.Range(1, 85)
+                    .Select(index => new SpectreProgressLedgerItem
+                    {
+                        Key = $"package:{index}",
+                        GroupKey = "PackageBuild",
+                        GroupTitle = "Build packages and archives",
+                        GroupOrder = 1,
+                        Title = $"Project.{index:00}",
+                        Position = index,
+                        Total = 85
+                    })
+                    .ToArray();
+
+                ledger.Plan(items);
+                foreach (var item in items)
+                    ledger.Update(item, SpectreProgressLedgerState.Started, "building in MSBuild batch");
+
+                Assert.Equal(2, ledger.VisibleTaskCount);
+            });
+    }
+
+    [Fact]
+    public void StandaloneConsole_WritesDetailedLedgerBeforeRethrowingFailure()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 12);
+        var expected = new InvalidOperationException("synthetic failure");
+
+        var actual = Assert.Throws<InvalidOperationException>(() =>
+            SpectreProjectBuildConsoleUi.RunInteractive(
+                console,
+                new ProjectBuildConsolePlan
+                {
+                    ConfigPath = "project.build.json",
+                    RootPath = "repository",
+                    Build = true
+                },
+                progress =>
+                {
+                    var detailed = Assert.IsAssignableFrom<IProjectBuildProgressReporterV2>(progress);
+                    var item = new ProjectBuildProgressItem
+                    {
+                        Phase = ProjectBuildProgressPhase.PackageBuild,
+                        Key = "package:Sample.Project",
+                        Title = "Sample.Project",
+                        Position = 1,
+                        Total = 2
+                    };
+                    detailed.ItemsPlanned(ProjectBuildProgressPhase.PackageBuild, [item]);
+                    detailed.ItemUpdated(item, ProjectBuildProgressItemState.Started, "building");
+                    item.Duration = TimeSpan.FromSeconds(2);
+                    detailed.ItemUpdated(item, ProjectBuildProgressItemState.Completed, "1 package, 1 archive");
+                    throw expected;
+                }));
+
+        Assert.Same(expected, actual);
+        var output = writer.ToString();
+        Assert.Contains("Project build details", output, StringComparison.Ordinal);
+        Assert.Contains("Sample.Project", output, StringComparison.Ordinal);
+        Assert.Contains("00:02.000", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ReportsPerProjectPackageEventsAndDurations()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            WriteProject(root.FullName, "Sample.First");
+            WriteProject(root.FullName, "Sample.Second");
+            var progress = new RecordingProjectBuildProgress();
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    Configuration = "Release",
+                    OutputPath = Path.Combine(root.FullName, "packages"),
+                    Pack = true,
+                    Publish = false,
+                    UpdateVersions = false,
+                    WhatIf = true,
+                    CreateReleaseZip = false
+                },
+                signAssemblies: null,
+                validateAssemblySigning: null,
+                progress);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Equal(
+                new[] { "Sample.First", "Sample.Second" },
+                progress.Planned.Select(item => item.Title).OrderBy(title => title, StringComparer.Ordinal));
+            Assert.Equal(new[] { 1, 2 }, progress.Planned.Select(item => item.Position).OrderBy(position => position));
+            Assert.All(progress.Planned, item => Assert.Equal(2, item.Total));
+            Assert.Equal(2, progress.Updates.Count(update => update.State == ProjectBuildProgressItemState.Started));
+            Assert.Equal(2, progress.Updates.Count(update => update.State == ProjectBuildProgressItemState.Completed));
+            Assert.All(
+                progress.Updates.Where(update => update.State == ProjectBuildProgressItemState.Completed),
+                update =>
+                {
+                    Assert.NotNull(update.Item.Duration);
+                    Assert.True(update.Item.Duration >= TimeSpan.Zero);
+                    Assert.Contains("package(s)", update.Detail, StringComparison.Ordinal);
+                    Assert.Contains("planned", update.Detail, StringComparison.Ordinal);
+                });
+            Assert.All(result.Projects.Where(project => project.IsPackable), project =>
+                Assert.True(project.PackageBuildDuration >= TimeSpan.Zero));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Execute_MsBuildBatchStartsEveryProjectBeforeCompletingAnyAndIncludesBatchTime()
+    {
+        var root = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(),
+            "PowerForge.Tests",
+            Guid.NewGuid().ToString("N")));
+        try
+        {
+            WriteProject(root.FullName, "Sample.First");
+            WriteProject(root.FullName, "Sample.Second");
+            var progress = new RecordingProjectBuildProgress();
+
+            var result = new DotNetRepositoryReleaseService(new NullLogger()).Execute(
+                new DotNetRepositoryReleaseSpec
+                {
+                    RootPath = root.FullName,
+                    Configuration = "Release",
+                    OutputPath = Path.Combine(root.FullName, "packages"),
+                    Pack = true,
+                    PackStrategy = DotNetRepositoryPackStrategy.MSBuild,
+                    Publish = false,
+                    UpdateVersions = false,
+                    CreateReleaseZip = false
+                },
+                signAssemblies: null,
+                validateAssemblySigning: null,
+                progress);
+
+            Assert.True(result.Success, result.ErrorMessage);
+            var firstTerminal = progress.Updates.FindIndex(update =>
+                update.State is ProjectBuildProgressItemState.Completed or ProjectBuildProgressItemState.Failed);
+            Assert.Equal(2, progress.Updates.Take(firstTerminal).Count(update =>
+                update.State == ProjectBuildProgressItemState.Started &&
+                update.Detail == "building in MSBuild batch"));
+            Assert.Equal(2, progress.Updates.Take(firstTerminal).Count(update =>
+                update.State == ProjectBuildProgressItemState.Started &&
+                update.Detail == "MSBuild batch complete; awaiting package collection" &&
+                update.Item.Duration > TimeSpan.Zero));
+            Assert.All(
+                result.Projects.Where(project => project.IsPackable),
+                project => Assert.True(project.PackageBuildDuration > TimeSpan.Zero));
+        }
+        finally
+        {
+            try { root.Delete(recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static IAnsiConsole CreateConsole(TextWriter writer, int height)
+        => AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new TerminalConsoleOutput(writer, height),
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Interactive = InteractionSupport.Yes
+        });
+
+    private static void WriteProject(string rootPath, string name)
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(rootPath, name));
+        File.WriteAllText(
+            Path.Combine(directory.FullName, $"{name}.csproj"),
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <VersionPrefix>1.0.0</VersionPrefix>
+                <IsPackable>true</IsPackable>
+              </PropertyGroup>
+            </Project>
+            """);
+    }
+
+    private sealed class RecordingProjectBuildProgress : IProjectBuildProgressReporterV2
+    {
+        public List<ProjectBuildProgressItem> Planned { get; } = new();
+        public List<(ProjectBuildProgressItem Item, ProjectBuildProgressItemState State, string? Detail)> Updates { get; } = new();
+
+        public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null) { }
+        public void PhaseUpdated(ProjectBuildProgressPhase phase, int completedItems, int totalItems, string? detail = null) { }
+        public void PhaseCompleted(ProjectBuildProgressPhase phase, string? detail = null) { }
+        public void PhaseFailed(ProjectBuildProgressPhase phase, string? detail = null) { }
+
+        public void ItemsPlanned(
+            ProjectBuildProgressPhase phase,
+            IReadOnlyList<ProjectBuildProgressItem> items)
+            => Planned.AddRange(items);
+
+        public void ItemUpdated(
+            ProjectBuildProgressItem item,
+            ProjectBuildProgressItemState state,
+            string? detail = null)
+            => Updates.Add((
+                new ProjectBuildProgressItem
+                {
+                    Phase = item.Phase,
+                    Key = item.Key,
+                    Title = item.Title,
+                    Kind = item.Kind,
+                    Position = item.Position,
+                    Total = item.Total,
+                    Duration = item.Duration
+                },
+                state,
+                detail));
+    }
+
+    private sealed class TerminalConsoleOutput : IAnsiConsoleOutput
+    {
+        public TerminalConsoleOutput(TextWriter writer, int height)
+        {
+            Writer = writer;
+            Height = height;
+        }
+
+        public TextWriter Writer { get; }
+        public bool IsTerminal => true;
+        public int Width => 140;
+        public int Height { get; }
+        public void SetEncoding(System.Text.Encoding encoding) { }
+    }
+}

--- a/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
+++ b/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
@@ -13,11 +13,7 @@ public sealed class SpectreBuildProgressColumnsTests
 
         Assert.Collection(
             columns,
-            column =>
-            {
-                var description = Assert.IsType<TaskDescriptionColumn>(column);
-                Assert.Equal(Justify.Left, description.Alignment);
-            },
+            column => Assert.Equal("LeftMarkupDescriptionColumn", column.GetType().Name),
             column => Assert.IsType<ProgressBarColumn>(column),
             column => Assert.IsType<PercentageColumn>(column),
             column => Assert.IsType<ElapsedTimeColumn>(column),

--- a/PowerForge/Models/DotNetRepositoryReleaseDisplayModels.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseDisplayModels.cs
@@ -18,6 +18,7 @@ internal sealed class DotNetRepositoryReleaseProjectDisplayRow
     internal string Packable { get; set; } = string.Empty;
     internal string VersionDisplay { get; set; } = string.Empty;
     internal string PackageCount { get; set; } = string.Empty;
+    internal string Duration { get; set; } = string.Empty;
     internal string StatusText { get; set; } = string.Empty;
     internal ConsoleColor? StatusColor { get; set; }
     internal string ErrorPreview { get; set; } = string.Empty;

--- a/PowerForge/Models/DotNetRepositoryReleaseResult.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseResult.cs
@@ -67,6 +67,9 @@ public sealed class DotNetRepositoryProjectResult
     /// <summary>Release zip path (if created).</summary>
     public string? ReleaseZipPath { get; set; }
 
+    /// <summary>Total time spent building packages and release archives for this project.</summary>
+    public TimeSpan PackageBuildDuration { get; set; }
+
     /// <summary>Optional error message for the project.</summary>
     public string? ErrorMessage { get; set; }
 }

--- a/PowerForge/Models/DotNetRepositoryReleaseSummary.cs
+++ b/PowerForge/Models/DotNetRepositoryReleaseSummary.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace PowerForge;
@@ -43,6 +44,11 @@ public sealed class DotNetRepositoryReleaseProjectSummaryRow
     /// Gets or sets the number of produced packages.
     /// </summary>
     public int PackageCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the measured package/archive build duration.
+    /// </summary>
+    public TimeSpan PackageBuildDuration { get; set; }
 
     /// <summary>
     /// Gets or sets the status classification used for summary rendering.

--- a/PowerForge/Models/PowerForgeReleaseProgress.cs
+++ b/PowerForge/Models/PowerForgeReleaseProgress.cs
@@ -69,6 +69,9 @@ public sealed class PowerForgeReleaseProgressItem
 
     /// <summary>Maximum numeric progress for presentation hosts; zero when indeterminate.</summary>
     public double ProgressMaximum { get; set; }
+
+    /// <summary>Measured duration after the item reaches a terminal state.</summary>
+    public TimeSpan? Duration { get; set; }
 }
 
 /// <summary>

--- a/PowerForge/Models/ProjectBuildProgress.cs
+++ b/PowerForge/Models/ProjectBuildProgress.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace PowerForge;
 
 /// <summary>
@@ -35,4 +38,64 @@ public interface IProjectBuildProgressReporter
 
     /// <summary>Marks a phase as failed.</summary>
     void PhaseFailed(ProjectBuildProgressPhase phase, string? detail = null);
+}
+
+/// <summary>State of a concrete project-build work item.</summary>
+public enum ProjectBuildProgressItemState
+{
+    /// <summary>The item has not started.</summary>
+    Planned,
+    /// <summary>The item is currently running.</summary>
+    Started,
+    /// <summary>The item completed successfully.</summary>
+    Completed,
+    /// <summary>The item failed.</summary>
+    Failed,
+    /// <summary>The item was not required or was cancelled.</summary>
+    Skipped
+}
+
+/// <summary>
+/// Describes one durable work item within a project-build phase.
+/// </summary>
+public sealed class ProjectBuildProgressItem
+{
+    /// <summary>Owning project-build phase.</summary>
+    public ProjectBuildProgressPhase Phase { get; set; }
+
+    /// <summary>Stable key within the owning phase.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Human-friendly item title.</summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Optional item kind used by presentation hosts.</summary>
+    public string? Kind { get; set; }
+
+    /// <summary>One-based position in the owning phase.</summary>
+    public int Position { get; set; }
+
+    /// <summary>Total number of items in the owning phase.</summary>
+    public int Total { get; set; }
+
+    /// <summary>Measured duration after the item reaches a terminal state.</summary>
+    public TimeSpan? Duration { get; set; }
+}
+
+/// <summary>
+/// Optional detailed project-build progress contract. Hosts implementing this interface
+/// receive individual project work items in addition to aggregate phase progress.
+/// </summary>
+public interface IProjectBuildProgressReporterV2 : IProjectBuildProgressReporter
+{
+    /// <summary>Registers planned work items for a project-build phase.</summary>
+    void ItemsPlanned(
+        ProjectBuildProgressPhase phase,
+        IReadOnlyList<ProjectBuildProgressItem> items);
+
+    /// <summary>Updates one concrete project-build work item.</summary>
+    void ItemUpdated(
+        ProjectBuildProgressItem item,
+        ProjectBuildProgressItemState state,
+        string? detail = null);
 }

--- a/PowerForge/Services/DotNetRepositoryReleaseDisplayService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseDisplayService.cs
@@ -20,6 +20,9 @@ internal sealed class DotNetRepositoryReleaseDisplayService
                 Packable = project.IsPackable ? "Yes" : "No",
                 VersionDisplay = project.VersionDisplay,
                 PackageCount = project.PackageCount.ToString(),
+                Duration = project.PackageBuildDuration > TimeSpan.Zero
+                    ? DotNetRepositoryReleaseService.FormatDuration(project.PackageBuildDuration)
+                    : "-",
                 StatusText = ResolveStatusText(project.Status),
                 StatusColor = ResolveStatusColor(project.Status),
                 ErrorPreview = project.ErrorPreview

--- a/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.BatchPacking.cs
@@ -9,6 +9,49 @@ namespace PowerForge;
 
 public sealed partial class DotNetRepositoryReleaseService
 {
+    private static DotNetRepositoryProjectResult[] PrepareMsBuildBatchCandidates(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        ILogger logger)
+    {
+        var candidates = projects
+            .Where(project =>
+                string.IsNullOrWhiteSpace(project.ErrorMessage) &&
+                !string.IsNullOrWhiteSpace(project.NewVersion))
+            .ToArray();
+        var missingVersions = projects
+            .Where(project =>
+                string.IsNullOrWhiteSpace(project.ErrorMessage) &&
+                string.IsNullOrWhiteSpace(project.NewVersion))
+            .ToArray();
+        if (missingVersions.Length == 0)
+            return candidates;
+
+        var names = string.Join(", ", missingVersions.Select(project => project.ProjectName));
+        logger.Warn($"MSBuild batch pack excluded {missingVersions.Length} project(s) without a resolved version; they will be skipped during pack: {names}");
+        foreach (var project in missingVersions)
+            project.ErrorMessage = "No resolved version; skipping pack.";
+        return candidates;
+    }
+
+    private static DotNetPackResult PackProjectsWithMsBuildAndTrackProgress(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        DotNetRepositoryReleaseSpec spec,
+        ILogger logger,
+        Action<DotNetReleaseBuildAssemblySigningRequest>? signAssemblies,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, ProjectBuildProgressItem> items,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, Stopwatch> watches,
+        IProjectBuildProgressReporterV2? detailedProgress)
+    {
+        try
+        {
+            return PackProjectsWithMsBuild(projects, spec, logger, signAssemblies);
+        }
+        finally
+        {
+            PauseMsBuildBatchProgress(projects, items, watches, detailedProgress);
+        }
+    }
+
     private static DotNetPackResult PackProjectsWithMsBuild(
         IReadOnlyList<DotNetRepositoryProjectResult> projects,
         DotNetRepositoryReleaseSpec spec,

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Execute.cs
@@ -372,35 +372,19 @@ public sealed partial class DotNetRepositoryReleaseService
                 progress?.PhaseFailed(ProjectBuildProgressPhase.Versioning, "One or more project versions could not be resolved");
             else
                 progress?.PhaseCompleted(ProjectBuildProgressPhase.Versioning, $"{packable.Length} project version(s) resolved");
-
             if (spec.Pack)
             {
                 progress?.PhaseStarted(ProjectBuildProgressPhase.PackageBuild, packable.Length, "Building and packing projects");
+                var detailedProgress = progress as IProjectBuildProgressReporterV2;
+                var packageProgressItems = CreatePackageProgressItems(packable, detailedProgress);
+                var packageWatches = new Dictionary<DotNetRepositoryProjectResult, Stopwatch>();
                 DotNetPackResult? batchPackResult = null;
                 HashSet<DotNetRepositoryProjectResult>? batchCandidateSet = null;
                 var batchPackRequested = spec.PackStrategy == DotNetRepositoryPackStrategy.MSBuild && !spec.WhatIf;
                 if (batchPackRequested)
                 {
-                    var batchCandidates = packable
-                        .Where(project =>
-                            string.IsNullOrWhiteSpace(project.ErrorMessage) &&
-                            !string.IsNullOrWhiteSpace(project.NewVersion))
-                        .ToArray();
-                    var missingVersionCandidates = packable
-                        .Where(project =>
-                            string.IsNullOrWhiteSpace(project.ErrorMessage) &&
-                            string.IsNullOrWhiteSpace(project.NewVersion))
-                        .ToArray();
+                    var batchCandidates = PrepareMsBuildBatchCandidates(packable, _logger);
                     batchCandidateSet = new HashSet<DotNetRepositoryProjectResult>(batchCandidates);
-
-                    if (missingVersionCandidates.Length > 0)
-                    {
-                        var names = string.Join(", ", missingVersionCandidates.Select(project => project.ProjectName));
-                        _logger.Warn($"MSBuild batch pack excluded {missingVersionCandidates.Length} project(s) without a resolved version; they will be skipped during pack: {names}");
-                        foreach (var project in missingVersionCandidates)
-                            project.ErrorMessage = "No resolved version; skipping pack.";
-                    }
-
                     if (string.IsNullOrWhiteSpace(spec.OutputPath))
                     {
                         _logger.Warn("MSBuild pack strategy requires OutputPath/StagingPath; falling back to per-project dotnet pack.");
@@ -408,7 +392,16 @@ public sealed partial class DotNetRepositoryReleaseService
                     else if (batchCandidates.Length > 0)
                     {
                         _logger.Info($"Packing {batchCandidates.Length} project(s) with MSBuild batch strategy...");
-                        batchPackResult = PackProjectsWithMsBuild(batchCandidates, spec, _logger, signAssemblyOutputs ? signAssemblies : null);
+                        StartMsBuildBatchProgress(
+                            batchCandidates,
+                            packageProgressItems,
+                            packageWatches,
+                            detailedProgress,
+                            progress,
+                            packable.Length);
+                        batchPackResult = PackProjectsWithMsBuildAndTrackProgress(
+                            batchCandidates, spec, _logger, signAssemblyOutputs ? signAssemblies : null,
+                            packageProgressItems, packageWatches, detailedProgress);
                         if (!batchPackResult.Success)
                         {
                             var batchError = $"{batchPackResult.ErrorMessage ?? "MSBuild batch pack failed."} (MSBuild batch failed; enable verbose logging to see per-project MSBuild output.)";
@@ -418,7 +411,13 @@ public sealed partial class DotNetRepositoryReleaseService
                             result.Success = false;
                             _logger.Warn(batchError);
                             if (spec.PublishFailFast)
+                            {
+                                CompleteFailedMsBuildBatchProgress(
+                                    batchCandidates, packageProgressItems, packageWatches, spec.WhatIf,
+                                    detailedProgress, progress, packable.Length);
+                                progress?.PhaseFailed(ProjectBuildProgressPhase.PackageBuild, batchError);
                                 return result;
+                            }
                         }
                         else
                         {
@@ -426,12 +425,22 @@ public sealed partial class DotNetRepositoryReleaseService
                         }
                     }
                 }
-
                 var packageProgress = 0;
                 foreach (var project in packable)
                 {
-                    progress?.PhaseUpdated(ProjectBuildProgressPhase.PackageBuild, packageProgress, packable.Length, project.ProjectName);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var progressItem = packageProgressItems[project];
+                    var packageWatch = GetProjectPackageProgressWatch(
+                        project,
+                        progressItem,
+                        packageWatches,
+                        detailedProgress,
+                        progress,
+                        packageProgress,
+                        packable.Length);
                     packageProgress++;
+                    try
+                    {
                     if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
                     {
                         result.Success = false;
@@ -545,6 +554,31 @@ public sealed partial class DotNetRepositoryReleaseService
                                 _logger.Success($"{project.ProjectName}: release zip created in {FormatDuration(zipWatch.Elapsed)} ({zippedFiles} file(s), {FormatBytes(zippedBytes)} input, {FormatBytes(zipSize)} zip).");
                             }
                         }
+                    }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (string.IsNullOrWhiteSpace(project.ErrorMessage))
+                            project.ErrorMessage = ex.Message;
+                        throw;
+                    }
+                    finally
+                    {
+                        packageWatch.Stop();
+                        CompleteProjectPackageProgress(
+                            project,
+                            progressItem,
+                            packageWatch.Elapsed,
+                            spec.WhatIf,
+                            cancellationToken.IsCancellationRequested,
+                            detailedProgress,
+                            progress,
+                            packageProgress,
+                            packable.Length);
                     }
                 }
 
@@ -739,12 +773,7 @@ public sealed partial class DotNetRepositoryReleaseService
                     result.ResolvedVersion = distinct[0];
             }
 
-            var projectErrors = projects
-                .Where(p => !string.IsNullOrWhiteSpace(p.ErrorMessage))
-                .Select(p => $"{p.ProjectName}: {p.ErrorMessage}")
-                .ToArray();
-            if (projectErrors.Length > 0 && string.IsNullOrWhiteSpace(result.ErrorMessage))
-                result.ErrorMessage = "One or more projects failed: " + string.Join("; ", projectErrors);
+            SetAggregateProjectError(result, projects);
 
             return result;
         }
@@ -761,32 +790,6 @@ public sealed partial class DotNetRepositoryReleaseService
         finally
         {
             ActiveCancellationToken.Value = previousCancellationToken;
-        }
-    }
-
-    private static void MarkPackageSigningFailure(
-        IEnumerable<DotNetRepositoryProjectResult> projects,
-        IReadOnlyList<string> packagesToSign,
-        string signError)
-    {
-        var failedPackages = new HashSet<string>(
-            packagesToSign.Where(package => !string.IsNullOrWhiteSpace(package)),
-            StringComparer.OrdinalIgnoreCase);
-
-        if (failedPackages.Count == 0)
-            return;
-
-        var message = string.IsNullOrWhiteSpace(signError)
-            ? "Package signing failed."
-            : $"Package signing failed: {signError}";
-
-        foreach (var project in projects)
-        {
-            if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
-                continue;
-
-            if (project.Packages.Concat(project.SymbolPackages).Any(package => failedPackages.Contains(package)))
-                project.ErrorMessage = message;
         }
     }
 

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Progress.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Progress.cs
@@ -1,0 +1,199 @@
+using System.Diagnostics;
+
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private static Dictionary<DotNetRepositoryProjectResult, ProjectBuildProgressItem> CreatePackageProgressItems(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        IProjectBuildProgressReporterV2? progress)
+    {
+        var items = projects
+            .Select((project, index) => new
+            {
+                Project = project,
+                Item = new ProjectBuildProgressItem
+                {
+                    Phase = ProjectBuildProgressPhase.PackageBuild,
+                    Key = $"package:{project.ProjectName}",
+                    Title = project.ProjectName,
+                    Kind = nameof(ProjectBuildProgressPhase.PackageBuild),
+                    Position = index + 1,
+                    Total = projects.Count
+                }
+            })
+            .ToDictionary(entry => entry.Project, entry => entry.Item);
+        progress?.ItemsPlanned(
+            ProjectBuildProgressPhase.PackageBuild,
+            items.Values.OrderBy(item => item.Position).ToArray());
+        return items;
+    }
+
+    private static void CompleteProjectPackageProgress(
+        DotNetRepositoryProjectResult project,
+        ProjectBuildProgressItem item,
+        TimeSpan duration,
+        bool whatIf,
+        bool cancelled,
+        IProjectBuildProgressReporterV2? detailedProgress,
+        IProjectBuildProgressReporter? progress,
+        int completed,
+        int total)
+    {
+        project.PackageBuildDuration = duration;
+        item.Duration = duration;
+        var state = cancelled
+            ? ProjectBuildProgressItemState.Skipped
+            : string.IsNullOrWhiteSpace(project.ErrorMessage)
+                ? ProjectBuildProgressItemState.Completed
+                : ProjectBuildProgressItemState.Failed;
+        detailedProgress?.ItemUpdated(
+            item,
+            state,
+            BuildProjectPackageProgressDetail(project, whatIf, cancelled));
+        progress?.PhaseUpdated(
+            ProjectBuildProgressPhase.PackageBuild,
+            completed,
+            total,
+            project.ProjectName);
+    }
+
+    private static Stopwatch StartProjectPackageProgress(
+        DotNetRepositoryProjectResult project,
+        ProjectBuildProgressItem item,
+        IProjectBuildProgressReporterV2? detailedProgress,
+        IProjectBuildProgressReporter? progress,
+        int completed,
+        int total,
+        string detail = "building packages and archives")
+    {
+        progress?.PhaseUpdated(
+            ProjectBuildProgressPhase.PackageBuild,
+            completed,
+            total,
+            $"Current: {project.ProjectName}");
+        detailedProgress?.ItemUpdated(
+            item,
+            ProjectBuildProgressItemState.Started,
+            detail);
+        return Stopwatch.StartNew();
+    }
+
+    private static void StartMsBuildBatchProgress(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, ProjectBuildProgressItem> items,
+        IDictionary<DotNetRepositoryProjectResult, Stopwatch> watches,
+        IProjectBuildProgressReporterV2? detailedProgress,
+        IProjectBuildProgressReporter? progress,
+        int total)
+    {
+        progress?.PhaseUpdated(
+            ProjectBuildProgressPhase.PackageBuild,
+            0,
+            total,
+            $"MSBuild batch building {projects.Count} project(s)");
+        foreach (var project in projects)
+        {
+            watches[project] = StartProjectPackageProgress(
+                project,
+                items[project],
+                detailedProgress,
+                progress: null,
+                completed: 0,
+                total,
+                detail: "building in MSBuild batch");
+        }
+    }
+
+    private static void CompleteFailedMsBuildBatchProgress(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, ProjectBuildProgressItem> items,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, Stopwatch> watches,
+        bool whatIf,
+        IProjectBuildProgressReporterV2? detailedProgress,
+        IProjectBuildProgressReporter? progress,
+        int total)
+    {
+        var completed = 0;
+        foreach (var project in projects)
+        {
+            completed++;
+            var watch = watches[project];
+            watch.Stop();
+            CompleteProjectPackageProgress(
+                project,
+                items[project],
+                watch.Elapsed,
+                whatIf,
+                cancelled: false,
+                detailedProgress,
+                progress,
+                completed,
+                total);
+        }
+    }
+
+    private static void PauseMsBuildBatchProgress(
+        IReadOnlyList<DotNetRepositoryProjectResult> projects,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, ProjectBuildProgressItem> items,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, Stopwatch> watches,
+        IProjectBuildProgressReporterV2? detailedProgress)
+    {
+        foreach (var project in projects)
+        {
+            var watch = watches[project];
+            watch.Stop();
+            project.PackageBuildDuration = watch.Elapsed;
+            var item = items[project];
+            item.Duration = watch.Elapsed;
+            detailedProgress?.ItemUpdated(
+                item,
+                ProjectBuildProgressItemState.Started,
+                "MSBuild batch complete; awaiting package collection");
+        }
+    }
+
+    private static Stopwatch GetProjectPackageProgressWatch(
+        DotNetRepositoryProjectResult project,
+        ProjectBuildProgressItem item,
+        IReadOnlyDictionary<DotNetRepositoryProjectResult, Stopwatch> watches,
+        IProjectBuildProgressReporterV2? detailedProgress,
+        IProjectBuildProgressReporter? progress,
+        int completed,
+        int total)
+    {
+        if (!watches.TryGetValue(project, out var watch))
+            return StartProjectPackageProgress(project, item, detailedProgress, progress, completed, total);
+
+        watch.Start();
+        progress?.PhaseUpdated(
+            ProjectBuildProgressPhase.PackageBuild,
+            completed,
+            total,
+            $"Collecting: {project.ProjectName}");
+        return watch;
+    }
+
+    private static string BuildProjectPackageProgressDetail(
+        DotNetRepositoryProjectResult project,
+        bool whatIf,
+        bool cancelled)
+    {
+        if (cancelled)
+            return "cancelled";
+        if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
+            return project.ErrorMessage!;
+
+        var outputs = new List<string>
+        {
+            $"{project.Packages.Count} package(s)"
+        };
+        if (project.SymbolPackages.Count > 0)
+            outputs.Add($"{project.SymbolPackages.Count} symbol package(s)");
+        if (!string.IsNullOrWhiteSpace(project.ReleaseZipPath))
+            outputs.Add("1 archive");
+        if (whatIf)
+            outputs.Add("planned");
+        return string.Join(", ", outputs);
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Results.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Results.cs
@@ -1,0 +1,16 @@
+namespace PowerForge;
+
+public sealed partial class DotNetRepositoryReleaseService
+{
+    private static void SetAggregateProjectError(
+        DotNetRepositoryReleaseResult result,
+        IReadOnlyList<DotNetRepositoryProjectResult> projects)
+    {
+        var projectErrors = projects
+            .Where(project => !string.IsNullOrWhiteSpace(project.ErrorMessage))
+            .Select(project => $"{project.ProjectName}: {project.ErrorMessage}")
+            .ToArray();
+        if (projectErrors.Length > 0 && string.IsNullOrWhiteSpace(result.ErrorMessage))
+            result.ErrorMessage = "One or more projects failed: " + string.Join("; ", projectErrors);
+    }
+}

--- a/PowerForge/Services/DotNetRepositoryReleaseService.Signing.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseService.Signing.cs
@@ -58,6 +58,32 @@ public sealed partial class DotNetRepositoryReleaseService
         return result.ExitCode;
     }
 
+    private static void MarkPackageSigningFailure(
+        IEnumerable<DotNetRepositoryProjectResult> projects,
+        IReadOnlyList<string> packagesToSign,
+        string signError)
+    {
+        var failedPackages = new HashSet<string>(
+            packagesToSign.Where(package => !string.IsNullOrWhiteSpace(package)),
+            StringComparer.OrdinalIgnoreCase);
+
+        if (failedPackages.Count == 0)
+            return;
+
+        var message = string.IsNullOrWhiteSpace(signError)
+            ? "Package signing failed."
+            : $"Package signing failed: {signError}";
+
+        foreach (var project in projects)
+        {
+            if (!string.IsNullOrWhiteSpace(project.ErrorMessage))
+                continue;
+
+            if (project.Packages.Concat(project.SymbolPackages).Any(package => failedPackages.Contains(package)))
+                project.ErrorMessage = message;
+        }
+    }
+
     private static string? GetCertificateSha256(string thumbprint, CertificateStoreLocation storeLocation)
     {
         try

--- a/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
+++ b/PowerForge/Services/DotNetRepositoryReleaseSummaryService.cs
@@ -25,6 +25,7 @@ public sealed class DotNetRepositoryReleaseSummaryService
                 IsPackable = project.IsPackable,
                 VersionDisplay = BuildVersionDisplay(project),
                 PackageCount = project.Packages.Count + project.SymbolPackages.Count,
+                PackageBuildDuration = project.PackageBuildDuration,
                 Status = ResolveStatus(project),
                 ErrorMessage = project.ErrorMessage?.Trim() ?? string.Empty,
                 ErrorPreview = TrimForSummary(project.ErrorMessage, maxErrorLength)

--- a/PowerForge/Services/PowerForgeReleaseProgressAdapters.cs
+++ b/PowerForge/Services/PowerForgeReleaseProgressAdapters.cs
@@ -1,10 +1,11 @@
 namespace PowerForge;
 
-internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgressReporter
+internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgressReporterV2
 {
     private readonly IPowerForgeReleaseProgressReporterV2 _release;
     private readonly PowerForgeReleaseProgressPhase _releasePhase;
     private readonly Dictionary<ProjectBuildProgressPhase, PowerForgeReleaseProgressItem> _items = new();
+    private readonly Dictionary<string, PowerForgeReleaseProgressItem> _projectItems = new(StringComparer.OrdinalIgnoreCase);
 
     internal ProjectBuildReleaseProgressAdapter(
         IPowerForgeReleaseProgressReporterV2 release,
@@ -39,6 +40,43 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
     public void PhaseFailed(ProjectBuildProgressPhase phase, string? detail = null)
         => _release.ItemUpdated(GetOrCreate(phase), PowerForgeReleaseProgressItemState.Failed, detail);
 
+    public void ItemsPlanned(
+        ProjectBuildProgressPhase phase,
+        IReadOnlyList<ProjectBuildProgressItem> items)
+    {
+        if (items is null || items.Count == 0)
+            return;
+
+        var mapped = items
+            .Where(item => item is not null)
+            .Select(item => MapItem(item))
+            .ToArray();
+        _release.ItemsPlanned(_releasePhase, mapped);
+    }
+
+    public void ItemUpdated(
+        ProjectBuildProgressItem item,
+        ProjectBuildProgressItemState state,
+        string? detail = null)
+    {
+        if (item is null)
+            return;
+
+        var mapped = MapItem(item);
+        mapped.Duration = item.Duration;
+        _release.ItemUpdated(
+            mapped,
+            state switch
+            {
+                ProjectBuildProgressItemState.Started => PowerForgeReleaseProgressItemState.Started,
+                ProjectBuildProgressItemState.Completed => PowerForgeReleaseProgressItemState.Completed,
+                ProjectBuildProgressItemState.Failed => PowerForgeReleaseProgressItemState.Failed,
+                ProjectBuildProgressItemState.Skipped => PowerForgeReleaseProgressItemState.Skipped,
+                _ => PowerForgeReleaseProgressItemState.Planned
+            },
+            detail);
+    }
+
     private PowerForgeReleaseProgressItem GetOrCreate(ProjectBuildProgressPhase phase)
     {
         if (_items.TryGetValue(phase, out var item))
@@ -54,6 +92,29 @@ internal sealed class ProjectBuildReleaseProgressAdapter : IProjectBuildProgress
         _items[phase] = item;
         _release.ItemsPlanned(_releasePhase, new[] { item });
         return item;
+    }
+
+    private PowerForgeReleaseProgressItem MapItem(ProjectBuildProgressItem item)
+    {
+        var key = $"project:{item.Phase}:{item.Key}";
+        if (_projectItems.TryGetValue(key, out var mapped))
+        {
+            mapped.Duration = item.Duration;
+            return mapped;
+        }
+
+        mapped = new PowerForgeReleaseProgressItem
+        {
+            Phase = _releasePhase,
+            Key = key,
+            Title = item.Title,
+            Kind = item.Kind,
+            Position = item.Position,
+            Total = item.Total,
+            Duration = item.Duration
+        };
+        _projectItems[key] = mapped;
+        return mapped;
     }
 
     private static string GetTitle(ProjectBuildProgressPhase phase)

--- a/PowerForge/Services/ProjectBuildOperationLock.cs
+++ b/PowerForge/Services/ProjectBuildOperationLock.cs
@@ -1,0 +1,84 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PowerForge;
+
+/// <summary>
+/// Owns an exclusive lease for one mutating project-build workspace.
+/// </summary>
+internal sealed class ProjectBuildOperationLock : IDisposable
+{
+    private readonly FileStream _stream;
+
+    private ProjectBuildOperationLock(FileStream stream)
+    {
+        _stream = stream;
+    }
+
+    internal static ProjectBuildOperationLock Acquire(ProjectBuildPreparedContext preparation)
+    {
+        if (preparation is null)
+            throw new ArgumentNullException(nameof(preparation));
+
+        var workspacePath = ResolveWorkspacePath(preparation);
+        var lockPath = ResolveLockPath(workspacePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+
+        FileStream? stream = null;
+        try
+        {
+            stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            stream.SetLength(0);
+            var payload = Encoding.UTF8.GetBytes(
+                $"pid={System.Diagnostics.Process.GetCurrentProcess().Id}{Environment.NewLine}" +
+                $"workspace={workspacePath}{Environment.NewLine}" +
+                $"startedAt={DateTimeOffset.UtcNow:O}{Environment.NewLine}");
+            stream.Write(payload, 0, payload.Length);
+            stream.Flush(flushToDisk: true);
+            return new ProjectBuildOperationLock(stream);
+        }
+        catch (IOException exception)
+        {
+            stream?.Dispose();
+            throw new InvalidOperationException(
+                $"Another project build is already using workspace '{workspacePath}'. " +
+                "Wait for it to finish before starting another build or publish operation that uses the same staging/output paths.",
+                exception);
+        }
+    }
+
+    internal static string ResolveLockPath(string workspacePath)
+    {
+        var normalizedPath = Path.GetFullPath(workspacePath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (Path.DirectorySeparatorChar == '\\')
+            normalizedPath = normalizedPath.ToUpperInvariant();
+
+        byte[] hash;
+        using (var algorithm = SHA256.Create())
+            hash = algorithm.ComputeHash(Encoding.UTF8.GetBytes(normalizedPath));
+
+        var key = BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
+        return Path.Combine(Path.GetTempPath(), "PowerForge", "project-build-locks", $"{key}.lock");
+    }
+
+    private static string ResolveWorkspacePath(ProjectBuildPreparedContext preparation)
+    {
+        var workspacePath = preparation.StagingPath;
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            workspacePath = preparation.OutputPath;
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            workspacePath = preparation.ReleaseZipOutputPath;
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            workspacePath = preparation.RootPath;
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            throw new InvalidOperationException("Project build workspace could not be resolved.");
+
+        return Path.GetFullPath(workspacePath);
+    }
+
+    public void Dispose()
+    {
+        _stream.Dispose();
+    }
+}

--- a/PowerForge/Services/ProjectBuildWorkflowService.cs
+++ b/PowerForge/Services/ProjectBuildWorkflowService.cs
@@ -49,6 +49,10 @@ internal sealed class ProjectBuildWorkflowService
         if (preparation is null)
             throw new ArgumentNullException(nameof(preparation));
 
+        using var operationLock = executeBuild && !preparation.PlanOnly
+            ? ProjectBuildOperationLock.Acquire(preparation)
+            : null;
+
         var spec = preparation.Spec ?? throw new ArgumentException("Prepared spec is required.", nameof(preparation));
         spec.WhatIf = true;
         progress?.PhaseStarted(ProjectBuildProgressPhase.Plan, 1, "Discovering projects and resolving versions");


### PR DESCRIPTION
## Summary

- show bounded recent, active, and upcoming project work while retaining the complete per-project timing history
- keep standalone project builds and unified releases on the same shared Spectre progress lifecycle, including durable final and failure frames
- report MSBuild batch work while it runs and separate the shared batch duration from each project's own collection/archive time
- prevent concurrent builds from mutating the same staging workspace

## User-facing behavior

Large repositories no longer collapse into one opaque `35/85` phase line or lose their earliest rows. The live display stays terminal-safe, while the completed result lists every project, its outcome, and its duration for troubleshooting.

No project configuration changes are required.

## Validation

- full local OfficeIMO build: 85 projects, 85 packages, and 85 release archives
- 19 focused progress, summary, adapter, and concurrency tests
- full test suite exercised locally; one known async pipeline-stop load flake passed in isolation
- PowerForge, PSPublishModule, and PowerForge CLI built cleanly across supported target frameworks