### PR TITLE
Add guarded Apple release workflows

### DIFF
--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -1,0 +1,168 @@
+$ErrorActionPreference = 'Stop'
+
+function Resolve-ReleasePath {
+    param(
+        [Parameter(Mandatory)] [string] $ProjectRoot,
+        [Parameter(Mandatory)] [string] $Path
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $ProjectRoot $Path))
+}
+
+function Write-ReleaseOutput {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [AllowEmptyString()] [string] $Value
+    )
+
+    if ($env:GITHUB_OUTPUT) {
+        "$Name=$Value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    }
+}
+
+$allowedActions = @(
+    'Status', 'Version', 'Archive', 'Upload', 'UploadExisting', 'Prepare',
+    'Screenshots', 'TestFlight', 'Advance', 'SubmitTestFlightReview',
+    'SubmitAppReview', 'Release', 'Cleanup'
+)
+$action = $allowedActions | Where-Object { $_ -ieq $env:INPUT_ACTION } | Select-Object -First 1
+if (-not $action) {
+    throw "Unsupported Apple release action '$($env:INPUT_ACTION)'."
+}
+
+$planOnly = [bool]::Parse($env:INPUT_PLAN_ONLY)
+$confirm = [bool]::Parse($env:INPUT_CONFIRM)
+if ($planOnly -and $confirm) {
+    throw 'A plan-only run must not carry mutation confirmation.'
+}
+if ($action -eq 'Version' -and [string]::IsNullOrWhiteSpace($env:INPUT_MARKETING_VERSION)) {
+    throw 'Version requires marketing-version.'
+}
+if ($action -eq 'Version' -and $env:INPUT_MARKETING_VERSION -notmatch '^\d+\.\d+\.\d+$') {
+    throw 'Version marketing-version must use x.y.z.'
+}
+
+$configPath = (Resolve-Path -LiteralPath $env:INPUT_CONFIG_PATH -ErrorAction Stop).Path
+$config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json -Depth 100
+$projectRootSetting = [string] $config.AppleApps.ProjectRoot
+if ([string]::IsNullOrWhiteSpace($projectRootSetting)) { $projectRootSetting = '.' }
+$projectRoot = if ([System.IO.Path]::IsPathRooted($projectRootSetting)) {
+    [System.IO.Path]::GetFullPath($projectRootSetting)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path (Split-Path -Parent $configPath) $projectRootSetting))
+}
+$configuredReceiptPath = if ($planOnly) {
+    [string] $config.AppleApps.Automation.PlanReceiptPath
+} else {
+    [string] $config.AppleApps.Automation.ReceiptPath
+}
+if ([string]::IsNullOrWhiteSpace($configuredReceiptPath)) {
+    $configuredReceiptPath = if ($planOnly) {
+        'build/powerforge/apple/release-plan.json'
+    } else {
+        'build/powerforge/apple/release-receipt.json'
+    }
+}
+$receiptPath = Resolve-ReleasePath -ProjectRoot $projectRoot -Path $configuredReceiptPath
+
+# Expose the expected artifact before invoking PowerForge. GitHub Actions then retains
+# the path even when the transition fails after PowerForge writes a failure receipt.
+Write-ReleaseOutput -Name 'receipt-path' -Value $receiptPath
+
+$arguments = @('apple-release', $action, '--config', $env:INPUT_CONFIG_PATH, '--summary', '--output', 'json')
+if ($planOnly) { $arguments += '--plan' }
+if ($confirm) { $arguments += '--confirm-apple-action' }
+if (-not [string]::IsNullOrWhiteSpace($env:INPUT_MARKETING_VERSION)) {
+    $arguments += @('--apple-version', $env:INPUT_MARKETING_VERSION)
+}
+if (-not [string]::IsNullOrWhiteSpace($env:INPUT_TARGET)) {
+    $arguments += @('--target', $env:INPUT_TARGET)
+}
+
+$output = & $env:POWERFORGE_TOOL_PATH @arguments
+$exitCode = $LASTEXITCODE
+$json = $output -join [Environment]::NewLine
+$envelope = $null
+if (-not [string]::IsNullOrWhiteSpace($json)) {
+    try {
+        $envelope = $json | ConvertFrom-Json -Depth 100
+    } catch {
+        if ($exitCode -eq 0) { throw }
+    }
+}
+
+$result = $envelope.result
+$reportedReceiptPath = [string] $result.receiptPath
+if (-not [string]::IsNullOrWhiteSpace($reportedReceiptPath)) {
+    $receiptPath = Resolve-ReleasePath -ProjectRoot $projectRoot -Path $reportedReceiptPath
+    Write-ReleaseOutput -Name 'receipt-path' -Value $receiptPath
+}
+
+if ($exitCode -ne 0) {
+    $json | Write-Host
+    $detail = if ($envelope -and -not [string]::IsNullOrWhiteSpace([string] $envelope.error)) {
+        ": $($envelope.error)"
+    } else {
+        '.'
+    }
+    throw "PowerForge Apple action '$action' failed with exit code $exitCode$detail"
+}
+
+if (-not $envelope.success) {
+    throw "PowerForge Apple action '$action' failed: $($envelope.error)"
+}
+if ([string] $result.action -ine $action) {
+    throw "PowerForge returned action '$($result.action)' instead of '$action'."
+}
+
+if (-not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) {
+    throw "PowerForge action '$action' did not write its required receipt '$receiptPath'."
+}
+$marketingVersion = [string] $result.versioning.marketingVersion
+$buildNumber = [string] $result.versioning.buildNumber
+$versionSourcePath = [string] $result.versioning.sourcePath
+if ([string]::IsNullOrWhiteSpace($marketingVersion) -and $result.targets.Count -gt 0) {
+    $marketingVersion = [string] ($result.targets[0].version ?? $result.targets[0].marketingVersion)
+}
+if ([string]::IsNullOrWhiteSpace($buildNumber) -and $result.targets.Count -gt 0) {
+    $buildNumber = [string] ($result.targets[0].build ?? $result.targets[0].buildNumber)
+}
+
+$readiness = @($result.targets | Where-Object { $null -ne $_.readyForSubmission })
+$readyForSubmission = if ($readiness.Count -eq 0) { '' } else { [string] (-not ($readiness.readyForSubmission -contains $false)) }
+$reportedNextActions = @($result.nextActions | Where-Object { -not [string]::IsNullOrWhiteSpace([string] $_) })
+$nextActions = $reportedNextActions | ConvertTo-Json -Compress -AsArray
+
+if ($env:GITHUB_OUTPUT) {
+    "action=$action" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "version-source-path=$versionSourcePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "marketing-version=$marketingVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "build-number=$buildNumber" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "ready-for-submission=$readyForSubmission" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "next-actions=$nextActions" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    $targetLines = @($result.targets | ForEach-Object {
+        $state = if ($_.buildProcessingState) { $_.buildProcessingState } elseif ($_.distributionState) { $_.distributionState } else { 'not reported' }
+        "- $($_.name): $($_.platform) $($_.version ?? $_.marketingVersion) ($($_.build ?? $_.buildNumber)) — $state"
+    })
+    @(
+        "## Apple release: $action$($planOnly ? ' plan' : '')",
+        '',
+        "- PowerForge: $($env:POWERFORGE_VERSION)",
+        "- Version/build: $marketingVersion ($buildNumber)",
+        "- Receipt: $receiptPath",
+        "- Ready for submission: $readyForSubmission",
+        '',
+        '### Targets',
+        $targetLines,
+        '',
+        '### Next actions',
+        ($reportedNextActions | ForEach-Object { "- $_" })
+    ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+}

--- a/.github/actions/apple-release/action.yml
+++ b/.github/actions/apple-release/action.yml
@@ -1,0 +1,110 @@
+name: PowerForge Apple release action
+description: Run one planned or confirmed Apple release transition with compact receipts.
+
+inputs:
+  action:
+    description: Explicit PowerForge Apple action.
+    required: true
+  config-path:
+    description: Release configuration path.
+    required: false
+    default: powerforge.release.json
+  tool-manifest-path:
+    description: Checked-in PowerForge tool manifest path.
+    required: false
+    default: .powerforge/powerforge.tool.json
+  marketing-version:
+    description: Marketing version required by Version.
+    required: false
+    default: ""
+  target:
+    description: Optional comma-separated recovery target selection.
+    required: false
+    default: ""
+  plan-only:
+    description: Run without mutation and write the plan receipt.
+    required: false
+    default: "true"
+  confirm:
+    description: Pass the explicit Apple mutation confirmation flag.
+    required: false
+    default: "false"
+  issuer-id:
+    description: App Store Connect issuer id supplied from a protected secret.
+    required: true
+  key-id:
+    description: App Store Connect API key id supplied from a protected secret.
+    required: true
+  private-key:
+    description: App Store Connect private key content supplied from a protected secret.
+    required: true
+
+outputs:
+  action:
+    description: Action reported by PowerForge.
+    value: ${{ steps.release.outputs.action }}
+  receipt-path:
+    description: Actual or plan receipt path.
+    value: ${{ steps.release.outputs.receipt-path }}
+  version-source-path:
+    description: Version source changed by Version, when applicable.
+    value: ${{ steps.release.outputs.version-source-path }}
+  marketing-version:
+    description: Resolved marketing version.
+    value: ${{ steps.release.outputs.marketing-version }}
+  build-number:
+    description: Resolved build number.
+    value: ${{ steps.release.outputs.build-number }}
+  ready-for-submission:
+    description: Aggregate readiness when checked.
+    value: ${{ steps.release.outputs.ready-for-submission }}
+  next-actions:
+    description: Compact JSON array of recommended next actions.
+    value: ${{ steps.release.outputs.next-actions }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pinned PowerForge
+      id: setup
+      shell: pwsh
+      env:
+        MANIFEST_PATH: ${{ inputs.tool-manifest-path }}
+      run: |
+        & '${{ github.action_path }}/../setup-powerforge/Install-PinnedPowerForge.ps1' -ManifestPath $env:MANIFEST_PATH
+
+    - name: Write the temporary App Store Connect key
+      id: credential
+      shell: pwsh
+      env:
+        PRIVATE_KEY: ${{ inputs.private-key }}
+      run: |
+        $path = Join-Path $env:RUNNER_TEMP "AuthKey_PowerForge_$PID.p8"
+        [System.IO.File]::WriteAllText($path, $env:PRIVATE_KEY, [System.Text.UTF8Encoding]::new($false))
+        if (-not $IsWindows) { & chmod 600 $path }
+        "path=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Run Apple release transition
+      id: release
+      shell: pwsh
+      env:
+        INPUT_ACTION: ${{ inputs.action }}
+        INPUT_CONFIG_PATH: ${{ inputs.config-path }}
+        INPUT_MARKETING_VERSION: ${{ inputs.marketing-version }}
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_PLAN_ONLY: ${{ inputs.plan-only }}
+        INPUT_CONFIRM: ${{ inputs.confirm }}
+        POWERFORGE_TOOL_PATH: ${{ steps.setup.outputs.tool-path }}
+        POWERFORGE_VERSION: ${{ steps.setup.outputs.version }}
+        APP_STORE_CONNECT_ISSUER_ID: ${{ inputs.issuer-id }}
+        APP_STORE_CONNECT_KEY_ID: ${{ inputs.key-id }}
+        APP_STORE_CONNECT_PRIVATE_KEY_PATH: ${{ steps.credential.outputs.path }}
+      run: >-
+        & '${{ github.action_path }}/Invoke-PowerForgeAppleRelease.ps1'
+
+    - name: Remove the temporary App Store Connect key
+      if: always() && steps.credential.outputs.path != ''
+      shell: pwsh
+      env:
+        PRIVATE_KEY_PATH: ${{ steps.credential.outputs.path }}
+      run: Remove-Item -LiteralPath $env:PRIVATE_KEY_PATH -Force -ErrorAction SilentlyContinue

--- a/.github/actions/setup-powerforge/Install-PinnedPowerForge.ps1
+++ b/.github/actions/setup-powerforge/Install-PinnedPowerForge.ps1
@@ -1,0 +1,113 @@
+param(
+    [Parameter(Mandatory)]
+    [string] $ManifestPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$resolvedManifest = (Resolve-Path -LiteralPath $ManifestPath -ErrorAction Stop).Path
+$manifest = Get-Content -LiteralPath $resolvedManifest -Raw | ConvertFrom-Json -Depth 20
+if ($manifest.schemaVersion -ne 1) {
+    throw "Unsupported PowerForge tool manifest schema '$($manifest.schemaVersion)'."
+}
+
+$version = [string] $manifest.version
+if ($version -notmatch '^\d+\.\d+\.\d+$') {
+    throw "PowerForge tool manifest version must use x.y.z."
+}
+
+$repository = [string] $manifest.repository
+if ([string]::IsNullOrWhiteSpace($repository)) {
+    $repository = 'EvotecIT/PSPublishModule'
+}
+if ($repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+    throw "PowerForge repository must use owner/name."
+}
+
+$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+$rid = if ($IsMacOS) {
+    "osx-$architecture"
+} elseif ($IsLinux) {
+    "linux-$architecture"
+} elseif ($IsWindows) {
+    "win-$architecture"
+} else {
+    throw 'PowerForge setup supports macOS, Linux, and Windows runners.'
+}
+
+$asset = $manifest.assets.$rid
+if ($null -eq $asset) {
+    throw "PowerForge tool manifest does not define asset '$rid'."
+}
+
+$expectedSha256 = ([string] $asset.sha256).ToLowerInvariant()
+if ($expectedSha256 -notmatch '^[a-f0-9]{64}$') {
+    throw "PowerForge asset '$rid' requires a 64-character SHA-256 digest."
+}
+
+$assetName = "PowerForge-$version-net10.0-$rid-SingleContained.zip"
+$downloadUrl = "https://github.com/$repository/releases/download/v$version/$assetName"
+$tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$executionScope = if ($env:GITHUB_RUN_ID) {
+    "$($env:GITHUB_RUN_ID)-$($env:GITHUB_JOB)-$($env:GITHUB_RUN_ATTEMPT)"
+} else {
+    "local-$PID"
+}
+$executionScope = $executionScope -replace '[^A-Za-z0-9_.-]', '-'
+$downloadRoot = Join-Path $tempRoot "powerforge-$version-$rid-$($expectedSha256.Substring(0, 12))-$executionScope"
+$installRoot = Join-Path $downloadRoot 'bin'
+$archivePath = Join-Path $downloadRoot $assetName
+$executableName = if ($IsWindows) { 'PowerForge.exe' } else { 'PowerForge' }
+$toolPath = Join-Path $installRoot $executableName
+
+New-Item -ItemType Directory -Path $downloadRoot -Force | Out-Null
+if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) {
+    $downloaded = $false
+    for ($attempt = 1; $attempt -le 3 -and -not $downloaded; $attempt++) {
+        try {
+            Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -UseBasicParsing
+            $downloaded = $true
+        } catch {
+            if ($attempt -eq 3) { throw }
+            Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+        }
+    }
+
+}
+
+$actualSha256 = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $expectedSha256) {
+    throw "PowerForge asset checksum mismatch for '$assetName'. Expected '$expectedSha256', received '$actualSha256'."
+}
+
+New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+Expand-Archive -LiteralPath $archivePath -DestinationPath $installRoot -Force
+
+if (-not (Test-Path -LiteralPath $toolPath -PathType Leaf)) {
+    throw "Verified PowerForge archive did not contain '$executableName'."
+}
+if (-not $IsWindows) {
+    & chmod +x $toolPath
+    if ($LASTEXITCODE -ne 0) { throw "Failed to mark '$toolPath' executable." }
+}
+
+$probe = & $toolPath apple-release --help --output json
+if ($LASTEXITCODE -ne 0 -or ($probe -join "`n") -notmatch 'apple-release') {
+    throw "The verified PowerForge executable does not expose the Apple release command."
+}
+
+if ($env:GITHUB_PATH) {
+    $installRoot | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+}
+if ($env:GITHUB_OUTPUT) {
+    "tool-path=$toolPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    "rid=$rid" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+}
+
+[pscustomobject]@{
+    ToolPath = $toolPath
+    Version = $version
+    Rid = $rid
+    Sha256 = $expectedSha256
+}

--- a/.github/actions/setup-powerforge/action.yml
+++ b/.github/actions/setup-powerforge/action.yml
@@ -1,0 +1,30 @@
+name: Setup pinned PowerForge
+description: Install an exact standalone PowerForge CLI asset after SHA-256 verification.
+
+inputs:
+  manifest-path:
+    description: Path to the checked-in PowerForge tool manifest.
+    required: false
+    default: .powerforge/powerforge.tool.json
+
+outputs:
+  tool-path:
+    description: Absolute path to the verified PowerForge executable.
+    value: ${{ steps.setup.outputs.tool-path }}
+  version:
+    description: Exact installed PowerForge version.
+    value: ${{ steps.setup.outputs.version }}
+  rid:
+    description: Resolved runtime identifier.
+    value: ${{ steps.setup.outputs.rid }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify PowerForge
+      id: setup
+      shell: pwsh
+      env:
+        MANIFEST_PATH: ${{ inputs.manifest-path }}
+      run: |
+        & '${{ github.action_path }}/Install-PinnedPowerForge.ps1' -ManifestPath $env:MANIFEST_PATH

--- a/.github/workflows/powerforge-apple-advance.yml
+++ b/.github/workflows/powerforge-apple-advance.yml
@@ -1,0 +1,138 @@
+name: PowerForge Apple Advance
+
+on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Exact merged source ref to release.
+        required: true
+        type: string
+      config_path:
+        description: PowerForge release configuration path.
+        required: false
+        default: powerforge.release.json
+        type: string
+      tool_manifest_path:
+        description: Checked-in PowerForge tool manifest path.
+        required: false
+        default: .powerforge/powerforge.tool.json
+        type: string
+      powerforge_ref:
+        description: Exact PSPublishModule commit containing the shared action.
+        required: true
+        type: string
+      runner_labels_json:
+        description: JSON array of trusted Apple runner labels.
+        required: false
+        default: '["self-hosted","macOS","ARM64"]'
+        type: string
+      environment_name:
+        description: Protected GitHub environment for Apple draft/TestFlight mutation.
+        required: false
+        default: apple-release
+        type: string
+    secrets:
+      app_store_connect_issuer_id:
+        required: true
+      app_store_connect_key_id:
+        required: true
+      app_store_connect_private_key:
+        required: true
+
+concurrency:
+  group: powerforge-apple-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  advance:
+    runs-on: ${{ fromJson(inputs.runner_labels_json) }}
+    timeout-minutes: 120
+    environment: ${{ inputs.environment_name }}
+    permissions:
+      contents: read
+    outputs:
+      marketing-version: ${{ steps.advance.outputs.marketing-version }}
+      build-number: ${{ steps.advance.outputs.build-number }}
+      ready-for-submission: ${{ steps.advance.outputs.ready-for-submission }}
+      next-actions: ${{ steps.advance.outputs.next-actions }}
+    steps:
+      - name: Require immutable source and shared refs
+        shell: pwsh
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+          POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+        run: |
+          foreach ($entry in @{ source_ref = $env:SOURCE_REF; powerforge_ref = $env:POWERFORGE_REF }.GetEnumerator()) {
+            if ($entry.Value -notmatch '^[0-9A-Fa-f]{40}$') { throw "$($entry.Key) must be an exact 40-character commit SHA." }
+          }
+
+      - name: Checkout the exact merged release source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+          path: source
+          persist-credentials: false
+
+      - name: Checkout the pinned shared release action
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: EvotecIT/PSPublishModule
+          ref: ${{ inputs.powerforge_ref }}
+          fetch-depth: 1
+          path: powerforge-shared
+          persist-credentials: false
+
+      - name: Verify exact checked-out commits
+        shell: pwsh
+        env:
+          EXPECTED_SOURCE_REF: ${{ inputs.source_ref }}
+          EXPECTED_POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+        run: |
+          $source = (git -C source rev-parse HEAD).Trim()
+          $shared = (git -C powerforge-shared rev-parse HEAD).Trim()
+          if ($source -ine $env:EXPECTED_SOURCE_REF) { throw "Expected source '$($env:EXPECTED_SOURCE_REF)', received '$source'." }
+          if ($shared -ine $env:EXPECTED_POWERFORGE_REF) { throw "Expected shared '$($env:EXPECTED_POWERFORGE_REF)', received '$shared'." }
+
+      - name: Plan safe release advancement
+        id: plan
+        uses: ./powerforge-shared/.github/actions/apple-release
+        with:
+          action: Advance
+          config-path: ${{ github.workspace }}/source/${{ inputs.config_path }}
+          tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
+          plan-only: "true"
+          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
+          key-id: ${{ secrets.app_store_connect_key_id }}
+          private-key: ${{ secrets.app_store_connect_private_key }}
+
+      - name: Advance through upload, preparation, screenshots, and configured TestFlight
+        id: advance
+        uses: ./powerforge-shared/.github/actions/apple-release
+        with:
+          action: Advance
+          config-path: ${{ github.workspace }}/source/${{ inputs.config_path }}
+          tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
+          plan-only: "false"
+          confirm: "true"
+          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
+          key-id: ${{ secrets.app_store_connect_key_id }}
+          private-key: ${{ secrets.app_store_connect_private_key }}
+
+      - name: Upload compact release plan receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: powerforge-apple-advance-${{ inputs.source_ref }}-plan
+          path: ${{ steps.plan.outputs.receipt-path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload compact release action receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: powerforge-apple-advance-${{ inputs.source_ref }}-actual
+          path: ${{ steps.advance.outputs.receipt-path }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/powerforge-apple-approval.yml
+++ b/.github/workflows/powerforge-apple-approval.yml
@@ -1,0 +1,141 @@
+name: PowerForge Apple Approval Gate
+
+on:
+  workflow_call:
+    inputs:
+      action:
+        description: SubmitTestFlightReview, SubmitAppReview, or Release.
+        required: true
+        type: string
+      source_ref:
+        description: Exact source ref whose receipt is being approved.
+        required: true
+        type: string
+      config_path:
+        description: PowerForge release configuration path.
+        required: false
+        default: powerforge.release.json
+        type: string
+      tool_manifest_path:
+        description: Checked-in PowerForge tool manifest path.
+        required: false
+        default: .powerforge/powerforge.tool.json
+        type: string
+      powerforge_ref:
+        description: Exact PSPublishModule commit containing the shared action.
+        required: true
+        type: string
+      runner_labels_json:
+        description: JSON array of trusted Apple runner labels.
+        required: false
+        default: '["self-hosted","macOS","ARM64"]'
+        type: string
+      environment_name:
+        description: GitHub environment with required reviewers.
+        required: false
+        default: apple-release-approval
+        type: string
+    secrets:
+      app_store_connect_issuer_id:
+        required: true
+      app_store_connect_key_id:
+        required: true
+      app_store_connect_private_key:
+        required: true
+
+concurrency:
+  group: powerforge-apple-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ${{ fromJson(inputs.runner_labels_json) }}
+    timeout-minutes: 30
+    environment: ${{ inputs.environment_name }}
+    permissions:
+      contents: read
+    steps:
+      - name: Validate the protected action
+        shell: pwsh
+        env:
+          ACTION: ${{ inputs.action }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+        run: |
+          if ($env:ACTION -notin @('SubmitTestFlightReview', 'SubmitAppReview', 'Release')) {
+            throw "Approval workflow accepts only SubmitTestFlightReview, SubmitAppReview, or Release."
+          }
+          foreach ($entry in @{ source_ref = $env:SOURCE_REF; powerforge_ref = $env:POWERFORGE_REF }.GetEnumerator()) {
+            if ($entry.Value -notmatch '^[0-9A-Fa-f]{40}$') { throw "$($entry.Key) must be an exact 40-character commit SHA." }
+          }
+
+      - name: Checkout the exact approved source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+          path: source
+          persist-credentials: false
+
+      - name: Checkout the pinned shared release action
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: EvotecIT/PSPublishModule
+          ref: ${{ inputs.powerforge_ref }}
+          fetch-depth: 1
+          path: powerforge-shared
+          persist-credentials: false
+
+      - name: Verify exact checked-out commits
+        shell: pwsh
+        env:
+          EXPECTED_SOURCE_REF: ${{ inputs.source_ref }}
+          EXPECTED_POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+        run: |
+          $source = (git -C source rev-parse HEAD).Trim()
+          $shared = (git -C powerforge-shared rev-parse HEAD).Trim()
+          if ($source -ine $env:EXPECTED_SOURCE_REF) { throw "Expected source '$($env:EXPECTED_SOURCE_REF)', received '$source'." }
+          if ($shared -ine $env:EXPECTED_POWERFORGE_REF) { throw "Expected shared '$($env:EXPECTED_POWERFORGE_REF)', received '$shared'." }
+
+      - name: Plan the protected transition
+        id: plan
+        uses: ./powerforge-shared/.github/actions/apple-release
+        with:
+          action: ${{ inputs.action }}
+          config-path: ${{ github.workspace }}/source/${{ inputs.config_path }}
+          tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
+          plan-only: "true"
+          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
+          key-id: ${{ secrets.app_store_connect_key_id }}
+          private-key: ${{ secrets.app_store_connect_private_key }}
+
+      - name: Execute the approved transition
+        id: approval
+        uses: ./powerforge-shared/.github/actions/apple-release
+        with:
+          action: ${{ inputs.action }}
+          config-path: ${{ github.workspace }}/source/${{ inputs.config_path }}
+          tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
+          plan-only: "false"
+          confirm: "true"
+          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
+          key-id: ${{ secrets.app_store_connect_key_id }}
+          private-key: ${{ secrets.app_store_connect_private_key }}
+
+      - name: Upload compact approval plan receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: powerforge-apple-${{ inputs.action }}-${{ inputs.source_ref }}-plan
+          path: ${{ steps.plan.outputs.receipt-path }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload compact approval action receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: powerforge-apple-${{ inputs.action }}-${{ inputs.source_ref }}-actual
+          path: ${{ steps.approval.outputs.receipt-path }}
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/powerforge-apple-version-pr.yml
+++ b/.github/workflows/powerforge-apple-version-pr.yml
@@ -1,0 +1,196 @@
+name: PowerForge Apple Version PR
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: New three-part Apple marketing version.
+        required: true
+        type: string
+      default_branch:
+        description: Branch used as the version PR base.
+        required: false
+        default: main
+        type: string
+      config_path:
+        description: PowerForge release configuration path.
+        required: false
+        default: powerforge.release.json
+        type: string
+      tool_manifest_path:
+        description: Checked-in PowerForge tool manifest path.
+        required: false
+        default: .powerforge/powerforge.tool.json
+        type: string
+      powerforge_ref:
+        description: Exact PSPublishModule commit containing the shared action.
+        required: true
+        type: string
+      runner_labels_json:
+        description: JSON array of trusted runner labels.
+        required: false
+        default: '["self-hosted","macOS","ARM64"]'
+        type: string
+    secrets:
+      app_store_connect_issuer_id:
+        required: true
+      app_store_connect_key_id:
+        required: true
+      app_store_connect_private_key:
+        required: true
+      github-token:
+        required: false
+
+concurrency:
+  group: powerforge-apple-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ${{ fromJson(inputs.runner_labels_json) }}
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      pull-request-url: ${{ steps.pull-request.outputs.url }}
+      marketing-version: ${{ steps.version.outputs.marketing-version }}
+      build-number: ${{ steps.version.outputs.build-number }}
+    steps:
+      - name: Require an immutable shared workflow ref
+        shell: pwsh
+        env:
+          POWERFORGE_REF: ${{ inputs.powerforge_ref }}
+        run: |
+          if ($env:POWERFORGE_REF -notmatch '^[0-9A-Fa-f]{40}$') {
+            throw 'powerforge_ref must be an exact 40-character commit SHA.'
+          }
+
+      - name: Checkout the trusted default branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.default_branch }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+
+      - name: Checkout the pinned shared release action
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: EvotecIT/PSPublishModule
+          ref: ${{ inputs.powerforge_ref }}
+          fetch-depth: 1
+          path: powerforge-shared
+          persist-credentials: false
+
+      - name: Verify the shared action commit
+        shell: pwsh
+        env:
+          EXPECTED_REF: ${{ inputs.powerforge_ref }}
+        run: |
+          $actual = (git -C powerforge-shared rev-parse HEAD).Trim()
+          if ($actual -ine $env:EXPECTED_REF) { throw "Expected shared commit '$($env:EXPECTED_REF)', received '$actual'." }
+
+      - name: Plan the version update
+        id: plan
+        uses: ./powerforge-shared/.github/actions/apple-release
+        with:
+          action: Version
+          config-path: ${{ github.workspace }}/source/${{ inputs.config_path }}
+          tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
+          marketing-version: ${{ inputs.version }}
+          plan-only: "true"
+          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
+          key-id: ${{ secrets.app_store_connect_key_id }}
+          private-key: ${{ secrets.app_store_connect_private_key }}
+
+      - name: Apply the version update
+        id: version
+        uses: ./powerforge-shared/.github/actions/apple-release
+        with:
+          action: Version
+          config-path: ${{ github.workspace }}/source/${{ inputs.config_path }}
+          tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
+          marketing-version: ${{ inputs.version }}
+          plan-only: "false"
+          confirm: "true"
+          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
+          key-id: ${{ secrets.app_store_connect_key_id }}
+          private-key: ${{ secrets.app_store_connect_private_key }}
+
+      - name: Create the release version pull request
+        id: pull-request
+        shell: pwsh
+        working-directory: source
+        env:
+          GH_TOKEN: ${{ secrets['github-token'] != '' && secrets['github-token'] || github.token }}
+          DEFAULT_BRANCH: ${{ inputs.default_branch }}
+          MARKETING_VERSION: ${{ steps.version.outputs.marketing-version }}
+          BUILD_NUMBER: ${{ steps.version.outputs.build-number }}
+          VERSION_SOURCE_PATH: ${{ steps.version.outputs.version-source-path }}
+        run: |
+          $sourceRoot = (Resolve-Path -LiteralPath '.').Path
+          $versionSource = (Resolve-Path -LiteralPath $env:VERSION_SOURCE_PATH).Path
+          if (-not $versionSource.StartsWith($sourceRoot + [System.IO.Path]::DirectorySeparatorChar, [StringComparison]::Ordinal)) {
+            throw "Version source '$versionSource' is outside the checked-out repository."
+          }
+
+          $relativeSource = [System.IO.Path]::GetRelativePath($sourceRoot, $versionSource)
+          $trackedChanges = @(git status --short --untracked-files=no)
+          if ($trackedChanges.Count -ne 1 -or $trackedChanges[0].Substring(3) -ne $relativeSource) {
+            throw "Version must change only '$relativeSource'. Tracked changes: $($trackedChanges -join ', ')"
+          }
+          git add -- $relativeSource
+          if (git diff --cached --quiet) {
+            throw 'PowerForge Version did not produce a version-source change.'
+          }
+
+          $branch = "release/apple-$($env:MARKETING_VERSION)"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c $branch
+          git commit -m "Prepare Apple release $($env:MARKETING_VERSION)"
+          gh auth setup-git
+
+          $body = @"
+          ## Summary
+
+          - set the Apple marketing version to `$($env:MARKETING_VERSION)`
+          - select remote-safe build `$($env:BUILD_NUMBER)` across configured Apple platforms
+          - keep upload, review, and release as separate guarded workflows
+          "@
+
+          $remoteExists = [bool] (git ls-remote --exit-code --heads origin $branch 2>$null)
+          if ($remoteExists) {
+            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
+            git diff --quiet HEAD "origin/$branch"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Remote branch '$branch' exists with different release content."
+            }
+          } else {
+            git push origin "HEAD:refs/heads/$branch"
+          }
+
+          $url = gh pr list --repo $env:GITHUB_REPOSITORY --base $env:DEFAULT_BRANCH --head $branch --state open --json url --jq '.[0].url'
+          if ([string]::IsNullOrWhiteSpace($url)) {
+            $url = gh pr create --repo $env:GITHUB_REPOSITORY --base $env:DEFAULT_BRANCH --head $branch --title "Prepare Apple release $($env:MARKETING_VERSION)" --body $body
+          }
+          "url=$url" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Upload compact version plan receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: powerforge-apple-version-${{ inputs.version }}-plan
+          path: ${{ steps.plan.outputs.receipt-path }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload compact version action receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: powerforge-apple-version-${{ inputs.version }}-actual
+          path: ${{ steps.version.outputs.receipt-path }}
+          if-no-files-found: error
+          retention-days: 30

--- a/Docs/PSPublishModule.AppleRelease.md
+++ b/Docs/PSPublishModule.AppleRelease.md
@@ -225,6 +225,52 @@ powerforge apple-release Advance --config powerforge.release.json --confirm-appl
 uses a separate plan receipt, checks the exact version/build remotely, and stops before
 `SubmitTestFlightReview`, `SubmitAppReview`, or `Release`.
 
+## Reusable GitHub workflows
+
+Commit one tool lock in each Apple app repository so CI downloads an exact standalone
+PowerForge release asset and verifies it before execution:
+
+```json
+{
+  "$schema": "https://schemas.evotec.xyz/powerforge.tool.schema.json",
+  "schemaVersion": 1,
+  "repository": "EvotecIT/PSPublishModule",
+  "version": "3.0.80",
+  "assets": {
+    "osx-arm64": {
+      "sha256": "<64-character release asset digest>"
+    }
+  }
+}
+```
+
+The reusable workflow boundary mirrors the human approval boundary:
+
+- `powerforge-apple-version-pr.yml` runs `Version`, stages only the configured
+  version source, and opens a release-ready pull request. It never merges it.
+- `powerforge-apple-advance.yml` runs a plan and confirmed resumable `Advance` from
+  an exact merged commit. It stops before every review and public-release action.
+- `powerforge-apple-approval.yml` accepts only `SubmitTestFlightReview`,
+  `SubmitAppReview`, or `Release` and runs inside a protected GitHub environment.
+
+Callers must pass 40-character commit SHAs for `powerforge_ref` and release
+`source_ref`; the workflows reject branches and tags and verify both checked-out
+commits. Pass App Store Connect credentials through GitHub secrets. The composite
+action writes the private key to a permission-restricted temporary file and removes
+it after every plan or action. All three workflows share one repository-scoped
+concurrency group, so version selection, draft mutation, review submission, and
+release cannot overlap.
+
+The workflows upload the exact configured plan and actual receipt paths and fail if
+a required receipt is absent. Successful logs contain only the short step summary,
+while failure logs retain the PowerForge error envelope. A partially completed
+version workflow reuses an identical remote release branch and creates or returns its
+open pull request; it refuses to overwrite different remote content.
+
+An iOS/iPadOS app, a companion Watch app, and CarPlay remain one iOS archive lane.
+Add another workflow target only for a separately archived store platform, such as
+Mac Catalyst or an independently distributed Watch app.
+
 `SubmitTestFlightReview`, `SubmitAppReview`, and `Release` require
 `--confirm-apple-action`. `Screenshots` also requires confirmation when
 `ReplaceScreenshots=true`. The PowerShell surface uses the same actions:

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -1,0 +1,107 @@
+namespace PowerForge.Tests;
+
+public sealed class AppleReleaseWorkflowTests
+{
+    [Fact]
+    public void SetupActionRequiresExactVersionAndChecksum()
+    {
+        var root = FindRepoRoot();
+        var action = Read(root, ".github", "actions", "setup-powerforge", "action.yml");
+        var script = Read(root, ".github", "actions", "setup-powerforge", "Install-PinnedPowerForge.ps1");
+        var schema = Read(root, "Schemas", "powerforge.tool.schema.json");
+
+        Assert.Contains("manifest-path", action, StringComparison.Ordinal);
+        Assert.Contains("Get-FileHash", script, StringComparison.Ordinal);
+        Assert.Contains("checksum mismatch", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("^\\d+\\.\\d+\\.\\d+$", script, StringComparison.Ordinal);
+        Assert.Contains("sha256", schema, StringComparison.Ordinal);
+        Assert.DoesNotContain("latest", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("MANIFEST_PATH: ${{ inputs.manifest-path }}", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("-ManifestPath '${{", action, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AppleActionKeepsPlansAndConfirmedMutationExplicit()
+    {
+        var root = FindRepoRoot();
+        var action = Read(root, ".github", "actions", "apple-release", "action.yml");
+        var script = Read(root, ".github", "actions", "apple-release", "Invoke-PowerForgeAppleRelease.ps1");
+
+        Assert.Contains("plan-only", action, StringComparison.Ordinal);
+        Assert.Contains("confirm", action, StringComparison.Ordinal);
+        Assert.Contains("if ($planOnly -and $confirm)", script, StringComparison.Ordinal);
+        Assert.Contains("--confirm-apple-action", script, StringComparison.Ordinal);
+        Assert.Contains("--summary", script, StringComparison.Ordinal);
+        Assert.Contains("--output', 'json", script, StringComparison.Ordinal);
+        Assert.Contains("instead of '$action'", script, StringComparison.Ordinal);
+        Assert.Contains("marketing-version must use x.y.z", script, StringComparison.Ordinal);
+        Assert.Contains("did not write its required receipt", script, StringComparison.Ordinal);
+        Assert.Contains("IsPathRooted($projectRootSetting)", script, StringComparison.Ordinal);
+        Assert.True(
+            script.IndexOf("Write-ReleaseOutput -Name 'receipt-path'", StringComparison.Ordinal) <
+            script.IndexOf("& $env:POWERFORGE_TOOL_PATH", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void VersionWorkflowCreatesOnlyAReviewedVersionPullRequest()
+    {
+        var root = FindRepoRoot();
+        var workflow = Read(root, ".github", "workflows", "powerforge-apple-version-pr.yml");
+
+        Assert.Contains("action: Version", workflow, StringComparison.Ordinal);
+        Assert.Equal(2, Count(workflow, "uses: ./powerforge-shared/.github/actions/apple-release"));
+        Assert.Contains("Tracked changes", workflow, StringComparison.Ordinal);
+        Assert.Contains("gh pr create", workflow, StringComparison.Ordinal);
+        Assert.Contains("gh pr list", workflow, StringComparison.Ordinal);
+        Assert.Contains("Remote branch '$branch' exists with different release content", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr merge", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("SubmitAppReview", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReleaseApprovedVersion", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AdvanceAndApprovalWorkflowsKeepReviewAndReleaseSeparated()
+    {
+        var root = FindRepoRoot();
+        var advance = Read(root, ".github", "workflows", "powerforge-apple-advance.yml");
+        var approval = Read(root, ".github", "workflows", "powerforge-apple-approval.yml");
+
+        Assert.Equal(2, Count(advance, "action: Advance"));
+        Assert.DoesNotContain("SubmitTestFlightReview", advance, StringComparison.Ordinal);
+        Assert.DoesNotContain("SubmitAppReview", advance, StringComparison.Ordinal);
+        Assert.DoesNotContain("action: Release", advance, StringComparison.Ordinal);
+        Assert.Contains("environment: ${{ inputs.environment_name }}", approval, StringComparison.Ordinal);
+        Assert.Contains("@('SubmitTestFlightReview', 'SubmitAppReview', 'Release')", approval, StringComparison.Ordinal);
+        Assert.Contains("plan-only: \"true\"", approval, StringComparison.Ordinal);
+        Assert.Contains("confirm: \"true\"", approval, StringComparison.Ordinal);
+        Assert.Contains("^[0-9A-Fa-f]{40}$", advance, StringComparison.Ordinal);
+        Assert.Contains("^[0-9A-Fa-f]{40}$", approval, StringComparison.Ordinal);
+        Assert.Equal(1, Count(advance, "group: powerforge-apple-${{ github.repository }}"));
+        Assert.Equal(1, Count(approval, "group: powerforge-apple-${{ github.repository }}"));
+        Assert.Contains("${{ steps.plan.outputs.receipt-path }}", advance, StringComparison.Ordinal);
+        Assert.Contains("${{ steps.advance.outputs.receipt-path }}", advance, StringComparison.Ordinal);
+        Assert.Equal(2, Count(advance, "if-no-files-found: error"));
+        Assert.Equal(2, Count(approval, "if-no-files-found: error"));
+        Assert.Contains("-plan", advance, StringComparison.Ordinal);
+        Assert.Contains("-actual", advance, StringComparison.Ordinal);
+    }
+
+    private static string Read(string root, params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { root }.Concat(parts).ToArray()));
+
+    private static int Count(string value, string search)
+        => value.Split(search, StringSplitOptions.None).Length - 1;
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return current.FullName;
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate the PSPublishModule repository root.");
+    }
+}

--- a/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReleaseAdvancement.cs
+++ b/PowerForge.Tests/PowerForgeReleaseServiceTests.AppleReleaseAdvancement.cs
@@ -2,6 +2,45 @@ namespace PowerForge.Tests;
 
 public sealed partial class PowerForgeReleaseServiceTests
 {
+    [Theory]
+    [InlineData("1.6")]
+    [InlineData("1.6.0-beta")]
+    [InlineData("1.6.0\nCURRENT_PROJECT_VERSION: 999")]
+    public void Execute_AppleVersion_RejectsNonThreePartMarketingVersion(string marketingVersion)
+    {
+        var root = CreateSandbox();
+        try
+        {
+            CreateXcodeProject(root, "CasaRay.xcodeproj", "1.5.0", "13");
+            WriteXcodeGenVersionSource(root, "1.5.0", "13");
+            var keyPath = Path.Combine(root, "AuthKey_TEST.p8");
+            File.WriteAllText(keyPath, "private-key");
+            var spec = CreateAppleAutomationSpec(root, keyPath);
+            spec.AppleApps!.Automation.VersionSourcePath = "project.yml";
+
+            var service = CreateAppleAutomationService(
+                    _ => throw new InvalidOperationException("Version must not query release status."),
+                    getHighestAppleBuildNumber: (_, _, _) => 13);
+
+            var exception = Assert.Throws<ArgumentException>(() => service.Execute(spec, new PowerForgeReleaseRequest
+                {
+                    ConfigPath = Path.Combine(root, "powerforge.release.json"),
+                    AppleAction = PowerForgeAppleReleaseAction.Version,
+                    AppleMarketingVersion = marketingVersion,
+                    PlanOnly = true
+                }));
+
+            Assert.Contains("must use x.y.z", exception.Message, StringComparison.Ordinal);
+            var source = new AppleReleaseVersionSourceService().Read(Path.Combine(root, "project.yml"));
+            Assert.Equal("1.5.0", source.MarketingVersion);
+            Assert.Equal("13", source.BuildNumber);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
     [Fact]
     public void Execute_AppleVersion_UsesOneBuildAboveLocalAndEveryRemotePlatform()
     {

--- a/PowerForge/Services/AppleReleaseVersionSourceService.cs
+++ b/PowerForge/Services/AppleReleaseVersionSourceService.cs
@@ -10,6 +10,9 @@ internal sealed class AppleReleaseVersionSourceService
 {
     private static readonly Regex MarketingVersionPattern = CreateSettingPattern("MARKETING_VERSION");
     private static readonly Regex BuildNumberPattern = CreateSettingPattern("CURRENT_PROJECT_VERSION");
+    private static readonly Regex MarketingVersionValuePattern = new(
+        "^\\d+\\.\\d+\\.\\d+$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     internal PowerForgeAppleVersionReceipt Read(string sourcePath)
     {
@@ -30,8 +33,11 @@ internal sealed class AppleReleaseVersionSourceService
         long highestRemoteBuildNumber,
         bool whatIf)
     {
-        if (string.IsNullOrWhiteSpace(marketingVersion))
-            throw new ArgumentException("Marketing version is required.", nameof(marketingVersion));
+        if (string.IsNullOrWhiteSpace(marketingVersion) ||
+            !MarketingVersionValuePattern.IsMatch(marketingVersion.Trim()))
+        {
+            throw new ArgumentException("Apple marketing version must use x.y.z.", nameof(marketingVersion));
+        }
         if (!long.TryParse(buildNumber, out var parsedBuildNumber) || parsedBuildNumber <= 0)
             throw new ArgumentException("Apple build number must be a positive integer.", nameof(buildNumber));
 

--- a/Schemas/powerforge.tool.schema.json
+++ b/Schemas/powerforge.tool.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.evotec.xyz/powerforge.tool.schema.json",
+  "title": "PowerForge Tool Lock",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "version", "assets"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "repository": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$",
+      "default": "EvotecIT/PSPublishModule"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "assets": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(osx|linux|win)-(arm64|x64)$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sha256"],
+          "properties": {
+            "sha256": { "type": "string", "pattern": "^[A-Fa-f0-9]{64}$" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds reusable GitHub Actions building blocks for Apple releases so app repositories can keep their release wiring small and repeatable.

- installs an exact three-part PowerForge version from a SHA-256-verified standalone asset
- opens a reviewed version-bump PR from the authoritative version source
- advances upload, App Store preparation, screenshots, and configured TestFlight distribution without crossing review or release boundaries
- isolates TestFlight review, App Review, and release behind a separate protected workflow
- preserves compact plan and action receipts as separate required artifacts, including failure paths

The workflows verify immutable source and shared-tool commit SHAs, share one repository-wide Apple release lock, clean up temporary App Store Connect keys, and can resume a version branch after an interrupted PR-creation step.

Review and public release remain explicit actions. Nothing in this change merges a version PR, submits a build for review, or releases an approved version automatically.

## Consumer shape

An app repository pins one published PowerForge version and checksum in `.powerforge/powerforge.tool.json`, then calls the reusable version, advance, or approval workflow at an exact commit SHA.

## Validation

- 11 focused Apple release and workflow contracts
- PowerForge `net472` build
- `actionlint` across all reusable workflows
- live read-only CasaRay status checks with relative and absolute project roots
- forced-failure receipt-path smoke check
