### PR TITLE
Harden product URL validation and image tag rewriting

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogProductTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogProductTests.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using PowerForge.Web.Cli;
 using Xunit;
 
-public class WebPipelineRunnerProjectCatalogProductTests
+public partial class WebPipelineRunnerProjectCatalogProductTests
 {
     [Fact]
     public void RunPipeline_ProjectCatalog_GeneratesDedicatedProductProfileWithTypedMedia()

--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogProductValidationTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogProductValidationTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using PowerForge.Web.Cli;
+using Xunit;
+
+public partial class WebPipelineRunnerProjectCatalogProductTests
+{
+    [Theory]
+    [InlineData("//untrusted.example/install")]
+    [InlineData("/\\untrusted.example/install")]
+    [InlineData("/\t/untrusted.example/install")]
+    [InlineData("/\n/untrusted.example/install")]
+    [InlineData("/\r/untrusted.example/install")]
+    public void RunPipeline_ProjectCatalog_RejectsBrowserNormalizedExternalProductAction(string actionUrl)
+    {
+        var root = CreateTestRoot("protocol-relative-action");
+
+        try
+        {
+            var serializedActionUrl = JsonSerializer.Serialize(actionUrl);
+            WriteCatalog(root,
+                $$"""
+                {
+                  "projects": [
+                    {
+                      "slug": "unsafe-action",
+                      "name": "Unsafe Action",
+                      "kind": "product",
+                      "mode": "hub-full",
+                      "description": "A product with an invalid protocol-relative action.",
+                      "links": {
+                        "support": "/projects/unsafe-action/#support",
+                        "privacy": "/projects/unsafe-action/#privacy"
+                      },
+                      "brand": {
+                        "accent": "#123456",
+                        "icon": "/assets/products/unsafe/icon.png",
+                        "iconWidth": 256,
+                        "iconHeight": 256
+                      },
+                      "product": {
+                        "category": "Utilities",
+                        "tagline": "Reject unsafe action targets.",
+                        "platforms": ["Web"],
+                        "primaryAction": {
+                          "label": "Install",
+                          "url": {{serializedActionUrl}}
+                        },
+                        "media": [
+                          {
+                            "src": "/assets/products/unsafe/home.png",
+                            "alt": "Unsafe Action home screen",
+                            "width": 1200,
+                            "height": 800,
+                            "role": "hero",
+                            "frame": "wide",
+                            "fit": "contain"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+                """);
+            var pipelinePath = WritePipeline(root);
+
+            var result = WebPipelineRunner.RunPipeline(pipelinePath, logger: null);
+
+            Assert.False(result.Success);
+            Assert.False(result.Steps[0].Success);
+            Assert.Contains("validation failed", result.Steps[0].Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+}

--- a/PowerForge.Tests/WebSiteAuditOptimizeBuildImageMarkupTests.cs
+++ b/PowerForge.Tests/WebSiteAuditOptimizeBuildImageMarkupTests.cs
@@ -1,0 +1,53 @@
+using ImageMagick;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public partial class WebSiteAuditOptimizeBuildTests
+{
+    [Fact]
+    public void OptimizeDetailed_ImageHints_PreserveUnquotedAttributeValuesEndingInSlash()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-opt-image-unquoted-slash-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var nonBreakingSpace = '\u00A0';
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                $$"""
+                <!doctype html>
+                <html>
+                  <body>
+                    <img src="/hero.png" data-marker=/>
+                    <img src="/hero.png" data-marker=x{{nonBreakingSpace}}/>
+                    <img src="/hero.png"/>
+                  </body>
+                </html>
+                """);
+
+            using (var image = new MagickImage(MagickColors.DeepSkyBlue, 640, 320))
+                image.Write(Path.Combine(root, "hero.png"), MagickFormat.Png);
+
+            var result = WebAssetOptimizer.OptimizeDetailed(new WebAssetOptimizerOptions
+            {
+                SiteRoot = root,
+                OptimizeImages = true,
+                ImageExtensions = new[] { ".png" },
+                EnhanceImageTags = true
+            });
+
+            var html = File.ReadAllText(Path.Combine(root, "index.html"));
+            Assert.Equal(1, result.ImageHtmlRewriteCount);
+            Assert.Contains("data-marker=/ width=\"640\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("data-marker= width=", html, StringComparison.Ordinal);
+            Assert.Contains($"data-marker=x{nonBreakingSpace}/ width=\"640\"", html, StringComparison.Ordinal);
+            Assert.Contains("decoding=\"async\" />", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+}

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.cs
@@ -1536,7 +1536,11 @@ internal static partial class WebPipelineRunner
 
         var trimmed = value.Trim();
         if (trimmed.StartsWith("/", StringComparison.Ordinal))
-            return true;
+        {
+            return !trimmed.StartsWith("//", StringComparison.Ordinal) &&
+                   !trimmed.Contains('\\') &&
+                   !trimmed.Any(char.IsControl);
+        }
 
         if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
             return false;

--- a/PowerForge.Web/Services/WebAssetOptimizer.Images.cs
+++ b/PowerForge.Web/Services/WebAssetOptimizer.Images.cs
@@ -222,7 +222,7 @@ public static partial class WebAssetOptimizer
             {
                 var attrs = match.Groups["attrs"].Value;
                 var trimmedAttrs = attrs.TrimEnd();
-                var selfClosing = trimmedAttrs.EndsWith("/", StringComparison.Ordinal);
+                var selfClosing = HasHtmlSelfClosingMarker(trimmedAttrs);
                 if (selfClosing)
                     attrs = trimmedAttrs[..^1].TrimEnd();
                 var srcMatch = ImgSrcAttrRegex.Match(attrs);
@@ -316,6 +316,60 @@ public static partial class WebAssetOptimizer
             result.ImageHintedCount += hintedInFile;
             onUpdated?.Invoke(htmlFile);
         }
+    }
+
+    private static bool HasHtmlSelfClosingMarker(string attributes)
+    {
+        if (!attributes.EndsWith("/", StringComparison.Ordinal))
+            return false;
+        if (attributes.Length == 1)
+            return true;
+
+        var state = HtmlAttributeParseState.BeforeName;
+        for (var index = 0; index < attributes.Length - 1; index++)
+        {
+            var character = attributes[index];
+            state = state switch
+            {
+                HtmlAttributeParseState.BeforeName when IsHtmlSpace(character) => state,
+                HtmlAttributeParseState.BeforeName => HtmlAttributeParseState.Name,
+                HtmlAttributeParseState.Name when IsHtmlSpace(character) => HtmlAttributeParseState.AfterName,
+                HtmlAttributeParseState.Name when character == '=' => HtmlAttributeParseState.BeforeValue,
+                HtmlAttributeParseState.Name => state,
+                HtmlAttributeParseState.AfterName when IsHtmlSpace(character) => state,
+                HtmlAttributeParseState.AfterName when character == '=' => HtmlAttributeParseState.BeforeValue,
+                HtmlAttributeParseState.AfterName => HtmlAttributeParseState.Name,
+                HtmlAttributeParseState.BeforeValue when IsHtmlSpace(character) => state,
+                HtmlAttributeParseState.BeforeValue when character == '\'' => HtmlAttributeParseState.SingleQuotedValue,
+                HtmlAttributeParseState.BeforeValue when character == '"' => HtmlAttributeParseState.DoubleQuotedValue,
+                HtmlAttributeParseState.BeforeValue => HtmlAttributeParseState.UnquotedValue,
+                HtmlAttributeParseState.UnquotedValue when IsHtmlSpace(character) => HtmlAttributeParseState.BeforeName,
+                HtmlAttributeParseState.UnquotedValue => state,
+                HtmlAttributeParseState.SingleQuotedValue when character == '\'' => HtmlAttributeParseState.AfterName,
+                HtmlAttributeParseState.SingleQuotedValue => state,
+                HtmlAttributeParseState.DoubleQuotedValue when character == '"' => HtmlAttributeParseState.AfterName,
+                HtmlAttributeParseState.DoubleQuotedValue => state,
+                _ => state
+            };
+        }
+
+        return state is HtmlAttributeParseState.BeforeName
+            or HtmlAttributeParseState.Name
+            or HtmlAttributeParseState.AfterName;
+    }
+
+    private static bool IsHtmlSpace(char value)
+        => value is '\t' or '\n' or '\f' or '\r' or ' ';
+
+    private enum HtmlAttributeParseState
+    {
+        BeforeName,
+        Name,
+        AfterName,
+        BeforeValue,
+        UnquotedValue,
+        SingleQuotedValue,
+        DoubleQuotedValue
     }
 
     private static bool TryResolveImageReference(string siteRoot, string htmlFile, string sourceUrl, out string relativePath)


### PR DESCRIPTION
## Summary

- reject protocol-relative and browser-normalized external targets where product and project catalog URLs require absolute HTTP(S) URLs or root-relative routes
- preserve slashes that belong to unquoted `<img>` attribute values while still recognizing genuine self-closing image tags using HTML whitespace rules
- cover literal and normalized network-path variants, Unicode separator handling, and the existing responsive-image rewrite contract

This follows up on the two review findings posted after #546 merged.