### PR TITLE
Generate complete SEO and multi-package llms metadata

### DIFF
--- a/PowerForge.Tests/WebApiDocsGeneratorSuiteTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorSuiteTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using PowerForge.Web;
 using Xunit;
 
@@ -168,6 +169,11 @@ public class WebApiDocsGeneratorSuiteTests
             Assert.Contains("Guides & Samples", html, StringComparison.Ordinal);
             Assert.Contains("Suite Assets", html, StringComparison.Ordinal);
             Assert.Contains("/projects/testimox/api/", html, StringComparison.Ordinal);
+            var description = ExtractMetaContent(html, "description", isProperty: false);
+            Assert.InRange(description.Length, 120, 160);
+            Assert.Contains("Project APIs", description, StringComparison.Ordinal);
+            Assert.Equal(description, ExtractMetaContent(html, "og:description", isProperty: true));
+            Assert.Equal(description, ExtractMetaContent(html, "twitter:description", isProperty: false));
 
             using var json = JsonDocument.Parse(File.ReadAllText(result.JsonPath));
             Assert.Equal("api-suite-portal", json.RootElement.GetProperty("kind").GetString());
@@ -195,5 +201,14 @@ public class WebApiDocsGeneratorSuiteTests
         {
             // ignore cleanup failures in tests
         }
+    }
+
+    private static string ExtractMetaContent(string html, string name, bool isProperty)
+    {
+        var attribute = isProperty ? "property" : "name";
+        var pattern = $"""<meta\b(?=[^>]*\b{attribute}="{Regex.Escape(name)}")(?=[^>]*\bcontent="(?<value>[^"]*)")[^>]*>""";
+        var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase);
+        Assert.True(match.Success, $"Missing meta tag '{name}'.");
+        return match.Groups["value"].Value;
     }
 }

--- a/PowerForge.Tests/WebApiDocsGeneratorSuiteTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorSuiteTests.cs
@@ -190,6 +190,52 @@ public class WebApiDocsGeneratorSuiteTests
         }
     }
 
+    [Fact]
+    public void GenerateSuitePortal_DescribesOnlyConfiguredCapabilities()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-webapidocs-suite-portal-minimal-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var outputPath = Path.Combine(root, "_site", "projects", "api-suite");
+            var result = WebApiDocsGenerator.GenerateSuitePortal(new WebApiDocsOptions
+            {
+                OutputPath = outputPath,
+                Title = "Project APIs",
+                BaseUrl = "/projects/api-suite",
+                ApiSuiteEntries =
+                {
+                    new WebApiDocsSuiteEntry
+                    {
+                        Id = "first",
+                        Label = "First",
+                        Href = "/projects/first/api/"
+                    },
+                    new WebApiDocsSuiteEntry
+                    {
+                        Id = "second",
+                        Label = "Second",
+                        Href = "/projects/second/api/"
+                    }
+                }
+            });
+
+            var html = File.ReadAllText(result.IndexPath);
+            var description = ExtractMetaContent(html, "description", isProperty: false);
+            Assert.InRange(description.Length, 120, 160);
+            Assert.Contains("2 API references", description, StringComparison.Ordinal);
+            Assert.DoesNotContain("searchable symbols", description, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("curated guidance", description, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("coverage signals", description, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("related guides", description, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try

--- a/PowerForge.Tests/WebApiDocsGeneratorSuiteTests.cs
+++ b/PowerForge.Tests/WebApiDocsGeneratorSuiteTests.cs
@@ -172,6 +172,7 @@ public class WebApiDocsGeneratorSuiteTests
             var description = ExtractMetaContent(html, "description", isProperty: false);
             Assert.InRange(description.Length, 120, 160);
             Assert.Contains("Project APIs", description, StringComparison.Ordinal);
+            Assert.DoesNotMatch(@"\b(?:and|or|with|including|from|to)\.$", description);
             Assert.Equal(description, ExtractMetaContent(html, "og:description", isProperty: true));
             Assert.Equal(description, ExtractMetaContent(html, "twitter:description", isProperty: false));
 

--- a/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
+++ b/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
@@ -42,7 +42,8 @@ public sealed class WebApiDocsSeoDescriptionTests
 
             var indexDescription = ReadMetaContent(Path.Combine(outputPath, "index.html"), "description");
             Assert.InRange(indexDescription.Length, 120, 160);
-            Assert.Contains("documented types", indexDescription, StringComparison.Ordinal);
+            Assert.Contains("1 documented type", indexDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("1 documented types", indexDescription, StringComparison.Ordinal);
 
             var typePath = Directory.GetDirectories(outputPath)
                 .Select(path => Path.Combine(path, "index.html"))
@@ -106,7 +107,8 @@ public sealed class WebApiDocsSeoDescriptionTests
 
             var indexDescription = ReadMetaContent(Path.Combine(outputPath, "index.html"), "description");
             Assert.InRange(indexDescription.Length, 120, 160);
-            Assert.Contains("documented reference entries", indexDescription, StringComparison.Ordinal);
+            Assert.Contains("1 documented reference entry", indexDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("1 documented reference entries", indexDescription, StringComparison.Ordinal);
 
             var cmdletDescription = ReadMetaContent(
                 Path.Combine(outputPath, "save-samplereport", "index.html"),

--- a/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
+++ b/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Text.RegularExpressions;
 using PowerForge.Web;
@@ -52,6 +53,9 @@ public sealed class WebApiDocsSeoDescriptionTests
             Assert.StartsWith("ReportBuilder:", typeDescription, StringComparison.Ordinal);
             Assert.Contains("Builds validated reports", typeDescription, StringComparison.Ordinal);
             Assert.Contains("parameters", typeDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("examples", typeDescription, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("source links", typeDescription, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("related APIs", typeDescription, StringComparison.OrdinalIgnoreCase);
             Assert.Equal(typeDescription, ReadMetaContent(typeHtml, "og:description", propertyAttribute: true));
             Assert.Equal(typeDescription, ReadMetaContent(typeHtml, "twitter:description"));
         }
@@ -102,7 +106,7 @@ public sealed class WebApiDocsSeoDescriptionTests
 
             var indexDescription = ReadMetaContent(Path.Combine(outputPath, "index.html"), "description");
             Assert.InRange(indexDescription.Length, 120, 160);
-            Assert.Contains("documented cmdlets", indexDescription, StringComparison.Ordinal);
+            Assert.Contains("documented reference entries", indexDescription, StringComparison.Ordinal);
 
             var cmdletDescription = ReadMetaContent(
                 Path.Combine(outputPath, "save-samplereport", "index.html"),
@@ -113,6 +117,95 @@ public sealed class WebApiDocsSeoDescriptionTests
         }
         finally
         {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_PreservesLiteralAngleBracketNotationInSummary()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-apidocs-seo-angle-brackets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "Sample.Api.xml");
+            File.WriteAllText(xmlPath,
+                """
+                <doc>
+                  <assembly><name>Sample.Api</name></assembly>
+                  <members>
+                    <member name="T:Sample.Api.ComparisonGuide">
+                      <summary>Compares x &lt; y &gt; z and preserves List&lt;T&gt; notation.</summary>
+                    </member>
+                  </members>
+                </doc>
+                """);
+
+            var outputPath = Path.Combine(root, "_site", "api");
+            _ = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                Type = ApiDocsType.CSharp,
+                XmlPath = xmlPath,
+                OutputPath = outputPath,
+                Title = "Sample API Reference",
+                BaseUrl = "/api",
+                Format = "html",
+                Template = "docs"
+            });
+
+            var typePath = Directory.GetDirectories(outputPath)
+                .Select(path => Path.Combine(path, "index.html"))
+                .Single(File.Exists);
+            var description = ReadMetaContent(typePath, "description");
+            Assert.Contains("x < y > z", description, StringComparison.Ordinal);
+            Assert.Contains("List<T>", description, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void GenerateSuitePortal_FormatsCountsIndependentlyOfBuildCulture()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-apidocs-seo-culture-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            var outputPath = Path.Combine(root, "_site", "api-suite");
+            var options = new WebApiDocsOptions
+            {
+                OutputPath = outputPath,
+                Title = "Project APIs",
+                BaseUrl = "/api-suite"
+            };
+            for (var index = 0; index < 1_000; index++)
+            {
+                options.ApiSuiteEntries.Add(new WebApiDocsSuiteEntry
+                {
+                    Id = $"project-{index}",
+                    Label = $"Project {index}",
+                    Href = $"/projects/{index}/api/",
+                    Order = index
+                });
+            }
+
+            _ = WebApiDocsGenerator.GenerateSuitePortal(options);
+
+            var description = ReadMetaContent(Path.Combine(outputPath, "index.html"), "description");
+            Assert.Contains("1,000 API references", description, StringComparison.Ordinal);
+            Assert.DoesNotContain("1.000 API references", description, StringComparison.Ordinal);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
         }

--- a/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
+++ b/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
@@ -256,6 +256,7 @@ public sealed class WebApiDocsSeoDescriptionTests
             var typeDescription = ReadMetaContent(typePath, "description");
             Assert.InRange(typeDescription.Length, 120, 160);
             Assert.Contains("member details", typeDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("searchable", typeDescription, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("type relationships", typeDescription, StringComparison.Ordinal);
         }
         finally

--- a/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
+++ b/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using PowerForge.Web;
+
+namespace PowerForge.Tests;
+
+public sealed class WebApiDocsSeoDescriptionTests
+{
+    [Fact]
+    public void Generate_DocsTemplate_EmitsSpecificSearchDescriptionsWithinRecommendedBounds()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-apidocs-seo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "Sample.Api.xml");
+            File.WriteAllText(xmlPath,
+                """
+                <doc>
+                  <assembly><name>Sample.Api</name></assembly>
+                  <members>
+                    <member name="T:Sample.Api.ReportBuilder">
+                      <summary>Builds validated reports from document data.</summary>
+                    </member>
+                  </members>
+                </doc>
+                """);
+
+            var outputPath = Path.Combine(root, "_site", "api");
+            _ = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                Type = ApiDocsType.CSharp,
+                XmlPath = xmlPath,
+                OutputPath = outputPath,
+                Title = "Sample API Reference",
+                BaseUrl = "/api",
+                Format = "html",
+                Template = "docs"
+            });
+
+            var indexDescription = ReadMetaContent(Path.Combine(outputPath, "index.html"), "description");
+            Assert.InRange(indexDescription.Length, 120, 160);
+            Assert.Contains("documented types", indexDescription, StringComparison.Ordinal);
+
+            var typePath = Directory.GetDirectories(outputPath)
+                .Select(path => Path.Combine(path, "index.html"))
+                .Single(File.Exists);
+            var typeHtml = File.ReadAllText(typePath);
+            var typeDescription = ReadMetaContent(typeHtml, "description");
+            Assert.InRange(typeDescription.Length, 120, 160);
+            Assert.StartsWith("ReportBuilder:", typeDescription, StringComparison.Ordinal);
+            Assert.Contains("Builds validated reports", typeDescription, StringComparison.Ordinal);
+            Assert.Contains("parameters", typeDescription, StringComparison.Ordinal);
+            Assert.Equal(typeDescription, ReadMetaContent(typeHtml, "og:description", propertyAttribute: true));
+            Assert.Equal(typeDescription, ReadMetaContent(typeHtml, "twitter:description"));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void Generate_PowerShellHelp_UsesCmdletSynopsisInSearchDescription()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-apidocs-powershell-seo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var helpPath = Path.Combine(root, "Sample.Module-help.xml");
+            File.WriteAllText(helpPath,
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <helpItems schema="maml" xmlns="http://msh" xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+                  <command:command>
+                    <command:details>
+                      <command:name>Save-SampleReport</command:name>
+                      <command:commandType>Function</command:commandType>
+                      <maml:description><maml:para>Saves a validated report to a file or stream.</maml:para></maml:description>
+                    </command:details>
+                    <command:syntax>
+                      <command:syntaxItem><command:name>Save-SampleReport</command:name></command:syntaxItem>
+                    </command:syntax>
+                  </command:command>
+                </helpItems>
+                """);
+
+            var outputPath = Path.Combine(root, "_site", "api", "powershell");
+            _ = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                Type = ApiDocsType.PowerShell,
+                HelpPath = helpPath,
+                OutputPath = outputPath,
+                Title = "Sample Cmdlet Reference",
+                BaseUrl = "/api/powershell",
+                Format = "html",
+                Template = "docs"
+            });
+
+            var indexDescription = ReadMetaContent(Path.Combine(outputPath, "index.html"), "description");
+            Assert.InRange(indexDescription.Length, 120, 160);
+            Assert.Contains("documented cmdlets", indexDescription, StringComparison.Ordinal);
+
+            var cmdletDescription = ReadMetaContent(
+                Path.Combine(outputPath, "save-samplereport", "index.html"),
+                "description");
+            Assert.InRange(cmdletDescription.Length, 120, 160);
+            Assert.Contains("Saves a validated report", cmdletDescription, StringComparison.Ordinal);
+            Assert.Contains("Save-SampleReport", cmdletDescription, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    private static string ReadMetaContent(string path, string name, bool propertyAttribute = false)
+    {
+        var html = File.Exists(path) ? File.ReadAllText(path) : path;
+        var attribute = propertyAttribute ? "property" : "name";
+        var match = Regex.Match(
+            html,
+            $"<meta\\s+{attribute}=\"{Regex.Escape(name)}\"\\s+content=\"(?<content>[^\"]*)\"",
+            RegexOptions.IgnoreCase);
+
+        Assert.True(match.Success, $"Expected {attribute}={name} in generated HTML.");
+        return WebUtility.HtmlDecode(match.Groups["content"].Value);
+    }
+}

--- a/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
+++ b/PowerForge.Tests/WebApiDocsSeoDescriptionTests.cs
@@ -211,6 +211,152 @@ public sealed class WebApiDocsSeoDescriptionTests
         }
     }
 
+    [Fact]
+    public void Generate_SimpleTemplate_UsesCapabilityNeutralDescriptions()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-apidocs-seo-simple-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var xmlPath = Path.Combine(root, "Sample.Api.xml");
+            File.WriteAllText(xmlPath,
+                """
+                <doc>
+                  <assembly><name>Sample.Api</name></assembly>
+                  <members>
+                    <member name="T:Sample.Api.ReportBuilder">
+                      <summary>Builds validated reports from document data.</summary>
+                    </member>
+                  </members>
+                </doc>
+                """);
+
+            var outputPath = Path.Combine(root, "_site", "api");
+            _ = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                Type = ApiDocsType.CSharp,
+                XmlPath = xmlPath,
+                OutputPath = outputPath,
+                Title = "Sample API Reference",
+                BaseUrl = "/api",
+                Format = "html",
+                Template = "simple"
+            });
+
+            var indexDescription = ReadMetaContent(Path.Combine(outputPath, "index.html"), "description");
+            Assert.InRange(indexDescription.Length, 120, 160);
+            Assert.Contains("generated reference pages", indexDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("searchable signatures", indexDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("type relationships", indexDescription, StringComparison.Ordinal);
+
+            var typePath = Directory.GetFiles(Path.Combine(outputPath, "types"), "*.html").Single();
+            var typeDescription = ReadMetaContent(typePath, "description");
+            Assert.InRange(typeDescription.Length, 120, 160);
+            Assert.Contains("member details", typeDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("type relationships", typeDescription, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void BuildApiTypeSeoDescription_UsesConceptualWordingForAboutTopics()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-apidocs-seo-about-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var helpPath = Path.Combine(root, "en-US", "Sample.Module-help.xml");
+            Directory.CreateDirectory(Path.GetDirectoryName(helpPath)!);
+            File.WriteAllText(helpPath,
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <helpItems schema="maml" xmlns="http://msh" xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+                  <command:command>
+                    <command:details>
+                      <command:name>Get-Sample</command:name>
+                      <maml:description><maml:para>Gets sample data.</maml:para></maml:description>
+                    </command:details>
+                    <command:syntax><command:syntaxItem><command:name>Get-Sample</command:name></command:syntaxItem></command:syntax>
+                  </command:command>
+                </helpItems>
+                """);
+            File.WriteAllText(Path.Combine(root, "about_Sample.help.txt"),
+                """
+                # about_Sample
+
+                Explains configuration and workflow behavior.
+                """);
+
+            var outputPath = Path.Combine(root, "_site", "api", "powershell");
+            _ = WebApiDocsGenerator.Generate(new WebApiDocsOptions
+            {
+                Type = ApiDocsType.PowerShell,
+                HelpPath = root,
+                OutputPath = outputPath,
+                Title = "Sample PowerShell Reference",
+                BaseUrl = "/api/powershell",
+                Template = "docs",
+                Format = "html"
+            });
+
+            var description = ReadMetaContent(
+                Path.Combine(outputPath, "about-sample", "index.html"),
+                "description");
+            Assert.InRange(description.Length, 120, 160);
+            Assert.Contains("complete conceptual topic", description, StringComparison.Ordinal);
+            Assert.DoesNotContain("syntax", description, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("parameters", description, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("pipeline", description, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void FitApiSeoDescription_PreservesUnicodeScalarsAndMinimumLength()
+    {
+        var method = typeof(WebApiDocsGenerator).GetMethod(
+            "FitApiSeoDescription",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var unicodeInput = new string('界', 158) + "😀tail";
+        var unicodeDescription = Assert.IsType<string>(method!.Invoke(null, [unicodeInput]));
+        Assert.InRange(unicodeDescription.Length, 120, 160);
+        Assert.DoesNotContain('\uFFFD', unicodeDescription);
+        AssertValidSurrogatePairs(unicodeDescription);
+
+        var conjunctionInput = new string('x', 116) + " and " + new string('y', 100);
+        var conjunctionDescription = Assert.IsType<string>(method.Invoke(null, [conjunctionInput]));
+        Assert.InRange(conjunctionDescription.Length, 120, 160);
+        Assert.DoesNotMatch(@"\b(?:and|or|with|including|from|to)\.$", conjunctionDescription);
+    }
+
+    private static void AssertValidSurrogatePairs(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (char.IsHighSurrogate(value[index]))
+            {
+                Assert.True(index + 1 < value.Length && char.IsLowSurrogate(value[index + 1]));
+                index++;
+            }
+            else
+            {
+                Assert.False(char.IsLowSurrogate(value[index]));
+            }
+        }
+    }
+
     private static string ReadMetaContent(string path, string name, bool propertyAttribute = false)
     {
         var html = File.Exists(path) ? File.ReadAllText(path) : path;

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -178,6 +178,222 @@ public class WebLlmsGeneratorTests
         }
     }
 
+    [Fact]
+    public void Generate_DescribesMultiPackageSuiteFromProjectAndModuleManifests()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-package-suite-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectPath = Path.Combine(root, "OfficeIMO.Word.csproj");
+            File.WriteAllText(projectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>OfficeIMO.Word</PackageId>
+                    <VersionPrefix>3.0.3</VersionPrefix>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var modulePath = Path.Combine(root, "PSWriteOffice.psd1");
+            File.WriteAllText(modulePath,
+                """
+                @{
+                    ModuleVersion = '3.0.1'
+                    Description = 'PowerShell document automation powered by OfficeIMO.'
+                }
+                """);
+            var quickstartPath = Path.Combine(root, "quickstart.cs");
+            File.WriteAllText(quickstartPath,
+                """
+                using OfficeIMO.Word;
+
+                using var document = WordDocument.Create("Example.docx");
+                document.AddParagraph("Hello from OfficeIMO");
+                document.Save();
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                Name = "OfficeIMO library suite",
+                PackageFiles = new[] { projectPath, modulePath },
+                QuickstartPath = quickstartPath
+            });
+
+            Assert.Equal(2, result.PackageCount);
+            Assert.Equal("varies by package", result.Version);
+
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            Assert.Contains("- Packages: 2", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("`dotnet add package OfficeIMO.Word` — source version `3.0.3`", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("`Install-Module PSWriteOffice` — source version `3.0.1`", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("using OfficeIMO.Word;", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("Version: unknown", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("dotnet add package OfficeIMO library suite", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("TODO", llmsTxt, StringComparison.Ordinal);
+
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("\"packages\"", llmsJson, StringComparison.Ordinal);
+            Assert.Contains("\"id\": \"OfficeIMO.Word\"", llmsJson, StringComparison.Ordinal);
+            Assert.Contains("\"install\": \"Install-Module PSWriteOffice\"", llmsJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"package\": \"OfficeIMO library suite\"", llmsJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Generate_RejectsMissingConfiguredPackageManifest()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-missing-package-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var missingPath = Path.Combine(root, "Missing.Package.csproj");
+            var error = Assert.Throws<FileNotFoundException>(() => WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                Name = "Example Suite",
+                PackageFiles = new[] { missingPath }
+            }));
+
+            Assert.Equal(missingPath, error.FileName);
+            Assert.Contains("Configured package manifest not found", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Generate_PreservesPowerShellSurfaceForLegacyProjectFile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-powershell-project-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var modulePath = Path.Combine(root, "ExampleModule.psd1");
+            File.WriteAllText(modulePath,
+                """
+                @{
+                    ModuleVersion = '2.4.1'
+                    Description = 'Example PowerShell automation module.'
+                }
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                ProjectFile = modulePath
+            });
+
+            Assert.Equal(1, result.PackageCount);
+            Assert.Equal("ExampleModule", result.PackageId);
+            Assert.Equal("2.4.1", result.Version);
+
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            Assert.Contains("`Install-Module ExampleModule`", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("```powershell", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("Import-Module ExampleModule", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("dotnet add package", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("```csharp", llmsTxt, StringComparison.Ordinal);
+
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("\"quickstartLanguage\": \"powershell\"", llmsJson, StringComparison.Ordinal);
+            Assert.Contains("\"Install-Module ExampleModule\"", llmsJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Generate_ReportsUnknownSuiteVersionWhenAnyManifestHasNoVersion()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-unknown-suite-version-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var versionedPath = Path.Combine(root, "Versioned.csproj");
+            File.WriteAllText(versionedPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>Example.Versioned</PackageId>
+                    <Version>1.2.3</Version>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var unversionedPath = Path.Combine(root, "Unversioned.csproj");
+            File.WriteAllText(unversionedPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>Example.Unversioned</PackageId>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                PackageFiles = new[] { versionedPath, unversionedPath }
+            });
+
+            Assert.Equal(2, result.PackageCount);
+            Assert.Equal("unknown", result.Version);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Generate_UsesDotNetToolInstallationForToolManifest()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-dotnet-tool-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var toolPath = Path.Combine(root, "Example.Tool.csproj");
+            File.WriteAllText(toolPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>Example.Tool</PackageId>
+                    <Version>1.2.3</Version>
+                    <PackAsTool>true</PackAsTool>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                PackageFiles = new[] { toolPath }
+            });
+
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            Assert.Contains("`dotnet tool install --global Example.Tool`", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("dotnet add package Example.Tool", llmsTxt, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -533,6 +533,46 @@ public class WebLlmsGeneratorTests
     }
 
     [Fact]
+    public void Generate_IncludesPowerShellPrereleaseLabelInEffectiveVersion()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-powershell-prerelease-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var modulePath = Path.Combine(root, "ExampleModule.psd1");
+            File.WriteAllText(modulePath,
+                """
+                @{
+                    ModuleVersion = '2.4.1'
+                    Description = 'Example PowerShell automation module.'
+                    PrivateData = @{
+                        PSData = @{
+                            Prerelease = 'beta1'
+                        }
+                    }
+                }
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                PackageFiles = new[] { modulePath }
+            });
+
+            Assert.Equal("2.4.1-beta1", result.Version);
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("source version `2.4.1-beta1`", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("\"version\": \"2.4.1-beta1\"", llmsJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Generate_FallsBackFromUnresolvedMsBuildMetadata()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-msbuild-properties-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -573,6 +573,37 @@ public class WebLlmsGeneratorTests
     }
 
     [Fact]
+    public void Generate_ReadsInlinePowerShellManifestMetadata()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-powershell-inline-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var modulePath = Path.Combine(root, "InlineModule.psd1");
+            File.WriteAllText(
+                modulePath,
+                "@{ ModuleVersion = '1.7.0'; Description = 'Inline PowerShell module metadata.'; PrivateData = @{ PSData = @{ Prerelease = 'preview2' } } }");
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                ProjectFile = modulePath,
+                PackageFiles = new[] { modulePath }
+            });
+
+            Assert.Equal("1.7.0-preview2", result.Version);
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            Assert.Contains("Inline PowerShell module metadata.", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("source version `1.7.0-preview2`", llmsTxt, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Generate_FallsBackFromUnresolvedMsBuildMetadata()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-msbuild-properties-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -36,6 +36,48 @@ public class WebLlmsGeneratorTests
     }
 
     [Fact]
+    public void Generate_AppendsCuratedDiscoveryToIndexAndFullContext()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-discovery-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var discoveryPath = Path.Combine(root, "discovery.md");
+            var extraPath = Path.Combine(root, "extra.md");
+            File.WriteAllText(discoveryPath,
+                """
+                ## Decision guides
+
+                - [Compare libraries](/comparisons/): Dated first-party evidence.
+                - [License policy](/licensing/): License and public crawler policy.
+                """);
+            File.WriteAllText(extraPath, "## Full-only implementation notes");
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                Name = "Example Product",
+                PackageId = "Example.Product",
+                DiscoveryContentPath = discoveryPath,
+                ExtraContentPath = extraPath
+            });
+
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            var llmsFull = File.ReadAllText(result.LlmsFullPath);
+            Assert.Contains("[Compare libraries](/comparisons/)", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("[License policy](/licensing/)", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("Full-only implementation notes", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("[Compare libraries](/comparisons/)", llmsFull, StringComparison.Ordinal);
+            Assert.Contains("Full-only implementation notes", llmsFull, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Generate_AggregatesMultipleApiCatalogsWithTheirPublishedRoutes()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-multi-api-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -374,6 +374,7 @@ public class WebLlmsGeneratorTests
                     <PackageId>Example.Tool</PackageId>
                     <Version>1.2.3</Version>
                     <PackAsTool>true</PackAsTool>
+                    <ToolCommandName>example-tool</ToolCommandName>
                   </PropertyGroup>
                 </Project>
                 """);
@@ -387,6 +388,63 @@ public class WebLlmsGeneratorTests
             var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
             Assert.Contains("`dotnet tool install --global Example.Tool`", llmsTxt, StringComparison.Ordinal);
             Assert.DoesNotContain("dotnet add package Example.Tool", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("```shell", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("example-tool --help", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("using Example.Tool", llmsTxt, StringComparison.Ordinal);
+
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("\"quickstartLanguage\": \"shell\"", llmsJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Generate_UsesEffectiveNuGetPackageVersions()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-package-version-precedence-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var packageVersionPath = Path.Combine(root, "PackageVersion.csproj");
+            File.WriteAllText(packageVersionPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>Example.PackageVersion</PackageId>
+                    <PackageVersion>4.2.0</PackageVersion>
+                    <Version>1.0.0</Version>
+                    <VersionPrefix>2.0.0</VersionPrefix>
+                    <VersionSuffix>preview.1</VersionSuffix>
+                  </PropertyGroup>
+                </Project>
+                """);
+            var prefixedPath = Path.Combine(root, "Prefixed.csproj");
+            File.WriteAllText(prefixedPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>Example.Prefixed</PackageId>
+                    <VersionPrefix>2.0.0</VersionPrefix>
+                    <VersionSuffix>rc.1</VersionSuffix>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                PackageFiles = new[] { packageVersionPath, prefixedPath }
+            });
+
+            Assert.Equal("varies by package", result.Version);
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("\"version\": \"4.2.0\"", llmsJson, StringComparison.Ordinal);
+            Assert.Contains("\"version\": \"2.0.0-rc.1\"", llmsJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"version\": \"1.0.0\"", llmsJson, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -394,6 +394,121 @@ public class WebLlmsGeneratorTests
         }
     }
 
+    [Fact]
+    public void Generate_UsesPowerShellQuickstartForPackageManifest()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-powershell-package-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var modulePath = Path.Combine(root, "ExampleModule.psd1");
+            File.WriteAllText(modulePath,
+                """
+                @{
+                    ModuleVersion = '2.4.1'
+                    Description = 'Example PowerShell automation module.'
+                }
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                PackageFiles = new[] { modulePath }
+            });
+
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            Assert.Contains("```powershell", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("Import-Module ExampleModule", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("```csharp", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("using ExampleModule", llmsTxt, StringComparison.Ordinal);
+
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("\"quickstartLanguage\": \"powershell\"", llmsJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Generate_FallsBackFromUnresolvedMsBuildMetadata()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-msbuild-properties-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectPath = Path.Combine(root, "Example.Indirect.csproj");
+            File.WriteAllText(projectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>$(PackageName)</PackageId>
+                    <Version>$(VersionPrefix)</Version>
+                    <Description>$(PackageDescription)</Description>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                PackageFiles = new[] { projectPath }
+            });
+
+            Assert.Equal("unknown", result.Version);
+            var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
+            var llmsJson = File.ReadAllText(result.LlmsJsonPath);
+            Assert.Contains("dotnet add package Example.Indirect", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("$(", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("$(", llmsJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Generate_RecordsExplicitVersionForPackageSuite()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-explicit-suite-version-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var projectPath = Path.Combine(root, "Example.Package.csproj");
+            File.WriteAllText(projectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <PackageId>Example.Package</PackageId>
+                    <Version>1.0.0</Version>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var result = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                Name = "Example Suite",
+                Version = "2026.7.0",
+                PackageFiles = new[] { projectPath }
+            });
+
+            Assert.Equal("2026.7.0", result.Version);
+            Assert.Contains("- Suite version: 2026.7.0", File.ReadAllText(result.LlmsTxtPath), StringComparison.Ordinal);
+            Assert.Contains("\"version\": \"2026.7.0\"", File.ReadAllText(result.LlmsJsonPath), StringComparison.Ordinal);
+            Assert.Contains("- Suite version: 2026.7.0", File.ReadAllText(result.LlmsFullPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
     private static void TryDeleteDirectory(string path)
     {
         try

--- a/PowerForge.Tests/WebLlmsGeneratorTests.cs
+++ b/PowerForge.Tests/WebLlmsGeneratorTests.cs
@@ -260,6 +260,7 @@ public class WebLlmsGeneratorTests
             {
                 SiteRoot = root,
                 Name = "OfficeIMO library suite",
+                ProjectFile = projectPath,
                 PackageFiles = new[] { projectPath, modulePath },
                 QuickstartPath = quickstartPath
             });
@@ -281,6 +282,16 @@ public class WebLlmsGeneratorTests
             Assert.Contains("\"id\": \"OfficeIMO.Word\"", llmsJson, StringComparison.Ordinal);
             Assert.Contains("\"install\": \"Install-Module PSWriteOffice\"", llmsJson, StringComparison.Ordinal);
             Assert.DoesNotContain("\"package\": \"OfficeIMO library suite\"", llmsJson, StringComparison.Ordinal);
+
+            var overridden = WebLlmsGenerator.Generate(new WebLlmsOptions
+            {
+                SiteRoot = root,
+                Name = "OfficeIMO library suite",
+                ProjectFile = projectPath,
+                PackageFiles = new[] { projectPath, modulePath },
+                Version = "2026.7.0"
+            });
+            Assert.Equal("2026.7.0", overridden.Version);
         }
         finally
         {
@@ -583,7 +594,13 @@ public class WebLlmsGeneratorTests
             var modulePath = Path.Combine(root, "InlineModule.psd1");
             File.WriteAllText(
                 modulePath,
-                "@{ ModuleVersion = '1.7.0'; Description = 'Inline PowerShell module metadata.'; PrivateData = @{ PSData = @{ Prerelease = 'preview2' } } }");
+                """
+                # Example only: @{ ModuleVersion = '0.1.0'; Description = 'Commented metadata.'; Prerelease = 'ignored' }
+                <# Another example:
+                @{ ModuleVersion = '0.2.0'; Description = 'Blocked metadata.' }
+                #>
+                @{ ModuleVersion = '1.7.0'; Description = 'Inline # PowerShell module metadata.'; PrivateData = @{ PSData = @{ Prerelease = 'preview2' } } }
+                """);
 
             var result = WebLlmsGenerator.Generate(new WebLlmsOptions
             {
@@ -594,8 +611,10 @@ public class WebLlmsGeneratorTests
 
             Assert.Equal("1.7.0-preview2", result.Version);
             var llmsTxt = File.ReadAllText(result.LlmsTxtPath);
-            Assert.Contains("Inline PowerShell module metadata.", llmsTxt, StringComparison.Ordinal);
+            Assert.Contains("Inline # PowerShell module metadata.", llmsTxt, StringComparison.Ordinal);
             Assert.Contains("source version `1.7.0-preview2`", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("Commented metadata", llmsTxt, StringComparison.Ordinal);
+            Assert.DoesNotContain("Blocked metadata", llmsTxt, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebPipelineLlmsContractTests.cs
+++ b/PowerForge.Tests/WebPipelineLlmsContractTests.cs
@@ -1,0 +1,87 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using PowerForge.Web.Cli;
+
+namespace PowerForge.Tests;
+
+public sealed class WebPipelineLlmsContractTests
+{
+    [Fact]
+    public void LlmsStep_schema_declares_package_manifest_arrays()
+    {
+        var schemaDocument = JsonNode.Parse(File.ReadAllText(GetRepoPath(
+            "Schemas",
+            "powerforge.web.pipelinespec.schema.json")))!;
+        var properties = schemaDocument["$defs"]!["LlmsStep"]!["properties"]!;
+
+        foreach (var propertyName in new[] { "packageFiles", "package-files" })
+        {
+            Assert.Equal("array", properties[propertyName]!["type"]!.GetValue<string>());
+            Assert.Equal("string", properties[propertyName]!["items"]!["type"]!.GetValue<string>());
+        }
+    }
+
+    [Theory]
+    [InlineData("packageFiles")]
+    [InlineData("package-files")]
+    public void Llms_fingerprint_changes_when_package_manifest_changes(string propertyName)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-llms-fingerprint-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var manifestPath = Path.Combine(root, "Module.psd1");
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '1.0.0' }");
+            using var document = JsonDocument.Parse(
+                $$"""
+                {
+                  "task": "llms",
+                  "siteRoot": "_site",
+                  "{{propertyName}}": ["Module.psd1"]
+                }
+                """);
+            var method = typeof(WebPipelineRunner).GetMethod(
+                "ComputeStepFingerprint",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            var first = (string)method!.Invoke(null, new object?[] { root, document.RootElement, null })!;
+            File.WriteAllText(manifestPath, "@{ ModuleVersion = '1.0.0'; Description = 'Changed' }");
+            var second = (string)method.Invoke(null, new object?[] { root, document.RootElement, null })!;
+
+            Assert.NotEqual(first, second);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static string GetRepoPath(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 12 && current is not null; i++)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PowerForge", "PowerForge.csproj")))
+                return Path.Combine([current.FullName, .. relativePath]);
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate repository root.");
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup.
+        }
+    }
+}

--- a/PowerForge.Tests/WebSiteAuditSeoMetaTests.cs
+++ b/PowerForge.Tests/WebSiteAuditSeoMetaTests.cs
@@ -98,6 +98,59 @@ public class WebSiteAuditSeoMetaTests
     }
 
     [Fact]
+    public void Audit_AllowsNoIndexAliasCanonicalToIndexableSitemapRoute()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-audit-seo-sitemap-noindex-alias-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "convert"));
+        Directory.CreateDirectory(Path.Combine(root, "playground"));
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "convert", "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Converter</title>
+                  <link rel="canonical" href="https://example.test/convert/" />
+                  <meta name="robots" content="index,follow" />
+                </head>
+                <body>Converter</body>
+                </html>
+                """);
+            File.WriteAllText(Path.Combine(root, "playground", "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Converter alias</title>
+                  <link rel="canonical" href="https://example.test/convert/" />
+                  <meta name="robots" content="noindex,follow" />
+                </head>
+                <body>Converter alias</body>
+                </html>
+                """);
+            File.WriteAllText(Path.Combine(root, "sitemap.xml"),
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://example.test/convert/</loc></url>
+                </urlset>
+                """);
+
+            var result = WebSiteAuditor.Audit(CreateSeoOnlyOptions(root));
+
+            Assert.DoesNotContain(result.Issues, issue =>
+                issue.Hint.StartsWith("seo-sitemap-noindex", StringComparison.Ordinal));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Audit_FlagsSitemapCanonicalMismatch_WhenSitemapLocDiffersFromPageCanonical()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-audit-seo-sitemap-canonical-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
+++ b/PowerForge.Tests/WebSiteSitemapFreshnessPolicyTests.cs
@@ -131,6 +131,45 @@ public class WebSiteSitemapFreshnessPolicyTests
     }
 
     [Fact]
+    public void Build_SourceDateSitemapLastmod_UsesGitDateWhenSiteRootIsNestedInRepository()
+    {
+        var repositoryRoot = CreateTempRoot("pf-web-sitemap-nested-source-freshness-");
+        var siteRoot = Path.Combine(repositoryRoot, "website");
+        Directory.CreateDirectory(siteRoot);
+        try
+        {
+            WriteMarkdown(repositoryRoot, "website/content/pages/about.md",
+                """
+                ---
+                title: About
+                slug: about
+                ---
+
+                Reference content in a nested website root.
+                """);
+            CommitAll(repositoryRoot, "2026-01-15T12:34:56Z");
+
+            Build(siteRoot, new[]
+            {
+                new CollectionSpec
+                {
+                    Name = "pages",
+                    Preset = "pages",
+                    Input = "content/pages",
+                    Output = "/",
+                    SitemapLastModified = SitemapLastModifiedPolicy.SourceDate
+                }
+            });
+
+            Assert.Equal("2026-01-15T12:34:56.000Z", ReadSitemapMetadataLastModified(siteRoot, "/about/"));
+        }
+        finally
+        {
+            Cleanup(repositoryRoot);
+        }
+    }
+
+    [Fact]
     public void Build_AutoSitemapLastmod_DoesNotTreatBlogPrefixedReferenceRoutesAsEditorial()
     {
         var root = CreateTempRoot("pf-web-sitemap-blog-tools-freshness-");

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -183,6 +183,14 @@ public class WebSiteTaxonomyFeedMetadataTests
 
                 Zmiana.
                 """);
+            File.WriteAllText(Path.Combine(blogPath, "x.md"),
+                """
+                ---
+                title: X
+                language: pl
+                tags: [x]
+                ---
+                """);
 
             var themeRoot = Path.Combine(root, "themes", "taxonomy-feed-meta");
             Directory.CreateDirectory(Path.Combine(themeRoot, "layouts"));
@@ -328,6 +336,13 @@ public class WebSiteTaxonomyFeedMetadataTests
             Assert.InRange(polishMinimumDescription.Length, 120, 160);
             Assert.Contains("sygnal", polishMinimumDescription, StringComparison.Ordinal);
             Assert.Contains("2026-01-04", polishMinimumDescription, StringComparison.Ordinal);
+
+            var polishExtremeMinimumDescription = ReadMetaDescription(
+                File.ReadAllText(Path.Combine(result.OutputPath, "pl", "tags", "x", "index.html")));
+            Assert.InRange(polishExtremeMinimumDescription.Length, 120, 160);
+            Assert.Contains("x — Feed Metadata Test", polishExtremeMinimumDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("Browse", polishExtremeMinimumDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("Explore", polishExtremeMinimumDescription, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -117,13 +117,13 @@ public class WebSiteTaxonomyFeedMetadataTests
                 """
                 ---
                 title: Pierwszy wpis
-                description: Opisuje polskie wydanie produktu, najważniejsze poprawki, zgodność pakietów oraz praktyczne informacje potrzebne podczas aktualizacji środowiska.
+                description: Krótki opis.
                 date: 2026-01-02
                 language: pl
                 tags: [wydanie]
                 ---
 
-                Cześć
+                Opisuje polskie wydanie produktu, najważniejsze poprawki, zgodność pakietów oraz praktyczne informacje potrzebne podczas aktualizacji środowiska.
                 """);
 
             var themeRoot = Path.Combine(root, "themes", "taxonomy-feed-meta");
@@ -246,6 +246,7 @@ public class WebSiteTaxonomyFeedMetadataTests
             var polishTaxonomyDescription = ReadMetaDescription(polishTaxonomyHtml);
             Assert.InRange(polishTaxonomyDescription.Length, 120, 160);
             Assert.Contains("Opisuje polskie wydanie produktu", polishTaxonomyDescription, StringComparison.Ordinal);
+            Assert.Contains("Krótki opis", polishTaxonomyDescription, StringComparison.Ordinal);
             Assert.DoesNotContain("Browse", polishTaxonomyDescription, StringComparison.Ordinal);
             Assert.DoesNotContain("Explore", polishTaxonomyDescription, StringComparison.Ordinal);
         }

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -17,9 +17,10 @@ public class WebSiteTaxonomyFeedMetadataTests
             Directory.CreateDirectory(contentPath);
             for (var index = 1; index <= 12; index++)
             {
-                var tags = string.Join(", ", Enumerable.Range(1, 27)
-                    .Where(tag => tag == index || index == 1)
-                    .Select(tag => $"tag-{tag}"));
+                var tags = string.Join(", ", new[] { "shared" }.Concat(
+                    Enumerable.Range(1, 27)
+                        .Where(tag => tag == index || index == 1)
+                        .Select(tag => $"tag-{tag}")));
                 File.WriteAllText(Path.Combine(contentPath, $"post-{index}.md"),
                     $"""
                     ---
@@ -61,6 +62,7 @@ public class WebSiteTaxonomyFeedMetadataTests
                     {
                         Name = "tags",
                         BasePath = "/tags",
+                        PageSize = 5,
                         ListLayout = "page",
                         TermLayout = "page"
                     }
@@ -73,12 +75,44 @@ public class WebSiteTaxonomyFeedMetadataTests
             var description = ReadMetaDescription(File.ReadAllText(Path.Combine(result.OutputPath, "tags", "index.html")));
 
             Assert.InRange(description.Length, 120, 160);
-            Assert.Contains("Browse 12 published OfficeIMO pages through 27 Tags terms", description, StringComparison.Ordinal);
+            Assert.Contains("Browse 12 published OfficeIMO pages through 28 Tags terms", description, StringComparison.Ordinal);
+
+            var paginatedDescription = ReadMetaDescription(
+                File.ReadAllText(Path.Combine(result.OutputPath, "tags", "shared", "page", "2", "index.html")));
+            Assert.DoesNotContain("in one place", paginatedDescription, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("available result set", paginatedDescription, StringComparison.Ordinal);
         }
         finally
         {
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void FitTaxonomyDescription_PreservesUnicodeScalars()
+    {
+        var method = typeof(WebSiteBuilder).GetMethod(
+            "FitTaxonomyDescription",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var input = new string('界', 158) + "😀tail";
+        var description = Assert.IsType<string>(method!.Invoke(null, [input, false]));
+
+        Assert.InRange(description.Length, 120, 160);
+        Assert.DoesNotContain('\uFFFD', description);
+        for (var index = 0; index < description.Length; index++)
+        {
+            if (char.IsHighSurrogate(description[index]))
+            {
+                Assert.True(index + 1 < description.Length && char.IsLowSurrogate(description[index + 1]));
+                index++;
+            }
+            else
+            {
+                Assert.False(char.IsLowSurrogate(description[index]));
+            }
         }
     }
 

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -31,6 +31,7 @@ public class WebSiteTaxonomyFeedMetadataTests
                 description: First release notes entry.
                 date: 2026-01-01
                 tags: [release]
+                authors: [Alice]
                 ---
 
                 Hello
@@ -91,6 +92,17 @@ public class WebSiteTaxonomyFeedMetadataTests
                         FeedDescription = "Browse release notes and tutorial topics.",
                         TermFeedTitleTemplate = "{site} tag: {term}",
                         TermFeedDescriptionTemplate = "Posts filed under {term} in {site}."
+                    },
+                    new TaxonomySpec
+                    {
+                        Name = "authors",
+                        BasePath = "/authors",
+                        ListLayout = "taxonomy",
+                        TermLayout = "term",
+                        FeedTitle = "Blog Authors",
+                        FeedDescription = "Browse articles by author.",
+                        TermFeedTitleTemplate = "{site} author: {term}",
+                        TermFeedDescriptionTemplate = "Posts written by {term} in {site}."
                     }
                 }
             };
@@ -118,6 +130,12 @@ public class WebSiteTaxonomyFeedMetadataTests
             var termDescription = ReadMetaDescription(termHtml);
             Assert.InRange(termDescription.Length, 120, 160);
             Assert.Contains("Explore 1 Feed Metadata Test page tagged release", termDescription, StringComparison.Ordinal);
+
+            var authorHtml = File.ReadAllText(Path.Combine(result.OutputPath, "authors", "alice", "index.html"));
+            var authorDescription = ReadMetaDescription(authorHtml);
+            Assert.InRange(authorDescription.Length, 120, 160);
+            Assert.Contains("filed under Alice in the Authors taxonomy", authorDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("tagged Alice", authorDescription, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -46,12 +46,12 @@ public class WebSiteTaxonomyFeedMetadataTests
             File.WriteAllText(Path.Combine(themeRoot, "layouts", "taxonomy.html"),
                 """
                 <!doctype html>
-                <html><head>{{ head_html }}</head><body>{{ content }}</body></html>
+                <html><head>{{ description_meta_html }}{{ head_html }}</head><body>{{ content }}</body></html>
                 """);
             File.WriteAllText(Path.Combine(themeRoot, "layouts", "term.html"),
                 """
                 <!doctype html>
-                <html><head>{{ head_html }}</head><body>{{ content }}</body></html>
+                <html><head>{{ description_meta_html }}{{ head_html }}</head><body>{{ content }}</body></html>
                 """);
             File.WriteAllText(Path.Combine(themeRoot, "theme.json"),
                 """
@@ -108,11 +108,31 @@ public class WebSiteTaxonomyFeedMetadataTests
             var termFeed = XDocument.Load(Path.Combine(result.OutputPath, "tags", "release", "index.xml"));
             Assert.Equal("Feed Metadata Test tag: release", termFeed.Root?.Element("channel")?.Element("title")?.Value);
             Assert.Equal("Posts filed under release in Feed Metadata Test.", termFeed.Root?.Element("channel")?.Element("description")?.Value);
+
+            var taxonomyHtml = File.ReadAllText(Path.Combine(result.OutputPath, "tags", "index.html"));
+            var taxonomyDescription = ReadMetaDescription(taxonomyHtml);
+            Assert.InRange(taxonomyDescription.Length, 120, 160);
+            Assert.Contains("Browse Feed Metadata Test content by Tags", taxonomyDescription, StringComparison.Ordinal);
+
+            var termHtml = File.ReadAllText(Path.Combine(result.OutputPath, "tags", "release", "index.html"));
+            var termDescription = ReadMetaDescription(termHtml);
+            Assert.InRange(termDescription.Length, 120, 160);
+            Assert.Contains("Explore 1 Feed Metadata Test page tagged release", termDescription, StringComparison.Ordinal);
         }
         finally
         {
             if (Directory.Exists(root))
                 Directory.Delete(root, true);
         }
+    }
+
+    private static string ReadMetaDescription(string html)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(
+            html,
+            "<meta\\s+name=\"description\"\\s+content=\"(?<content>[^\"]*)\"",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        Assert.True(match.Success, "Expected a generated meta description.");
+        return System.Net.WebUtility.HtmlDecode(match.Groups["content"].Value);
     }
 }

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -36,6 +36,18 @@ public class WebSiteTaxonomyFeedMetadataTests
 
                 Hello
                 """);
+            File.WriteAllText(Path.Combine(blogPath, "pierwszy-wpis.md"),
+                """
+                ---
+                title: Pierwszy wpis
+                description: Opisuje polskie wydanie produktu, najważniejsze poprawki, zgodność pakietów oraz praktyczne informacje potrzebne podczas aktualizacji środowiska.
+                date: 2026-01-02
+                language: pl
+                tags: [wydanie]
+                ---
+
+                Cześć
+                """);
 
             var themeRoot = Path.Combine(root, "themes", "taxonomy-feed-meta");
             Directory.CreateDirectory(Path.Combine(themeRoot, "layouts"));
@@ -70,6 +82,16 @@ public class WebSiteTaxonomyFeedMetadataTests
                 ContentRoot = "content",
                 DefaultTheme = "taxonomy-feed-meta",
                 ThemesRoot = "themes",
+                Localization = new LocalizationSpec
+                {
+                    Enabled = true,
+                    DefaultLanguage = "en",
+                    Languages =
+                    [
+                        new LanguageSpec { Code = "en", Default = true },
+                        new LanguageSpec { Code = "pl" }
+                    ]
+                },
                 Collections = new[]
                 {
                     new CollectionSpec
@@ -124,18 +146,31 @@ public class WebSiteTaxonomyFeedMetadataTests
             var taxonomyHtml = File.ReadAllText(Path.Combine(result.OutputPath, "tags", "index.html"));
             var taxonomyDescription = ReadMetaDescription(taxonomyHtml);
             Assert.InRange(taxonomyDescription.Length, 120, 160);
-            Assert.Contains("Browse Feed Metadata Test content by Tags", taxonomyDescription, StringComparison.Ordinal);
+            Assert.Contains("Browse 1 published Feed Metadata Test page through 1 Tags term", taxonomyDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("guides", taxonomyDescription, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("articles", taxonomyDescription, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("examples", taxonomyDescription, StringComparison.OrdinalIgnoreCase);
 
             var termHtml = File.ReadAllText(Path.Combine(result.OutputPath, "tags", "release", "index.html"));
             var termDescription = ReadMetaDescription(termHtml);
             Assert.InRange(termDescription.Length, 120, 160);
-            Assert.Contains("Explore 1 Feed Metadata Test page tagged release", termDescription, StringComparison.Ordinal);
+            Assert.Contains("Explore 1 published Feed Metadata Test page tagged release", termDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("guides", termDescription, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("articles", termDescription, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("examples", termDescription, StringComparison.OrdinalIgnoreCase);
 
             var authorHtml = File.ReadAllText(Path.Combine(result.OutputPath, "authors", "alice", "index.html"));
             var authorDescription = ReadMetaDescription(authorHtml);
             Assert.InRange(authorDescription.Length, 120, 160);
             Assert.Contains("filed under Alice in the Authors taxonomy", authorDescription, StringComparison.Ordinal);
             Assert.DoesNotContain("tagged Alice", authorDescription, StringComparison.Ordinal);
+
+            var polishTaxonomyHtml = File.ReadAllText(Path.Combine(result.OutputPath, "pl", "tags", "index.html"));
+            var polishTaxonomyDescription = ReadMetaDescription(polishTaxonomyHtml);
+            Assert.InRange(polishTaxonomyDescription.Length, 120, 160);
+            Assert.Contains("Opisuje polskie wydanie produktu", polishTaxonomyDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("Browse", polishTaxonomyDescription, StringComparison.Ordinal);
+            Assert.DoesNotContain("Explore", polishTaxonomyDescription, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -154,10 +154,34 @@ public class WebSiteTaxonomyFeedMetadataTests
                 description: Krótki opis.
                 date: 2026-01-02
                 language: pl
-                tags: [wydanie]
+                tags: [wydanie, aktualizacja]
                 ---
 
                 Opisuje polskie wydanie produktu, najważniejsze poprawki, zgodność pakietów oraz praktyczne informacje potrzebne podczas aktualizacji środowiska.
+                """);
+            File.WriteAllText(Path.Combine(blogPath, "komunikat.md"),
+                """
+                ---
+                title: Komunikat
+                description: Krótka informacja.
+                date: 2026-01-03
+                language: pl
+                tags: [komunikat]
+                ---
+
+                Aktualizacja opisuje zmianę pakietu i sposób bezpiecznego wdrożenia.
+                """);
+            File.WriteAllText(Path.Combine(blogPath, "sygnal.md"),
+                """
+                ---
+                title: Sygnał
+                description: Krótko.
+                date: 2026-01-04
+                language: pl
+                tags: [sygnal]
+                ---
+
+                Zmiana.
                 """);
 
             var themeRoot = Path.Combine(root, "themes", "taxonomy-feed-meta");
@@ -279,10 +303,31 @@ public class WebSiteTaxonomyFeedMetadataTests
             var polishTaxonomyHtml = File.ReadAllText(Path.Combine(result.OutputPath, "pl", "tags", "index.html"));
             var polishTaxonomyDescription = ReadMetaDescription(polishTaxonomyHtml);
             Assert.InRange(polishTaxonomyDescription.Length, 120, 160);
-            Assert.Contains("Opisuje polskie wydanie produktu", polishTaxonomyDescription, StringComparison.Ordinal);
-            Assert.Contains("Krótki opis", polishTaxonomyDescription, StringComparison.Ordinal);
+            Assert.Contains("Tags — Feed Metadata Test", polishTaxonomyDescription, StringComparison.Ordinal);
             Assert.DoesNotContain("Browse", polishTaxonomyDescription, StringComparison.Ordinal);
             Assert.DoesNotContain("Explore", polishTaxonomyDescription, StringComparison.Ordinal);
+
+            var polishReleaseDescription = ReadMetaDescription(
+                File.ReadAllText(Path.Combine(result.OutputPath, "pl", "tags", "wydanie", "index.html")));
+            var polishUpdateDescription = ReadMetaDescription(
+                File.ReadAllText(Path.Combine(result.OutputPath, "pl", "tags", "aktualizacja", "index.html")));
+            Assert.InRange(polishReleaseDescription.Length, 120, 160);
+            Assert.InRange(polishUpdateDescription.Length, 120, 160);
+            Assert.Contains("wydanie", polishReleaseDescription, StringComparison.Ordinal);
+            Assert.Contains("aktualizacja", polishUpdateDescription, StringComparison.Ordinal);
+            Assert.NotEqual(polishReleaseDescription, polishUpdateDescription);
+
+            var polishSparseDescription = ReadMetaDescription(
+                File.ReadAllText(Path.Combine(result.OutputPath, "pl", "tags", "komunikat", "index.html")));
+            Assert.InRange(polishSparseDescription.Length, 120, 160);
+            Assert.Contains("komunikat", polishSparseDescription, StringComparison.Ordinal);
+            Assert.Contains("Aktualizacja opisuje zmianę pakietu", polishSparseDescription, StringComparison.Ordinal);
+
+            var polishMinimumDescription = ReadMetaDescription(
+                File.ReadAllText(Path.Combine(result.OutputPath, "pl", "tags", "sygnal", "index.html")));
+            Assert.InRange(polishMinimumDescription.Length, 120, 160);
+            Assert.Contains("sygnal", polishMinimumDescription, StringComparison.Ordinal);
+            Assert.Contains("2026-01-04", polishMinimumDescription, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
+++ b/PowerForge.Tests/WebSiteTaxonomyFeedMetadataTests.cs
@@ -6,6 +6,83 @@ namespace PowerForge.Tests;
 public class WebSiteTaxonomyFeedMetadataTests
 {
     [Fact]
+    public void Build_TaxonomyIndexDescription_StaysWithinSearchSnippetRangeForMultiDigitCounts()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-taxonomy-seo-counts-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var contentPath = Path.Combine(root, "content", "blog");
+            Directory.CreateDirectory(contentPath);
+            for (var index = 1; index <= 12; index++)
+            {
+                var tags = string.Join(", ", Enumerable.Range(1, 27)
+                    .Where(tag => tag == index || index == 1)
+                    .Select(tag => $"tag-{tag}"));
+                File.WriteAllText(Path.Combine(contentPath, $"post-{index}.md"),
+                    $"""
+                    ---
+                    title: Post {index}
+                    description: Published content item {index}.
+                    tags: [{tags}]
+                    ---
+
+                    Content
+                    """);
+            }
+
+            var themeRoot = Path.Combine(root, "themes", "taxonomy-seo-counts");
+            Directory.CreateDirectory(Path.Combine(themeRoot, "layouts"));
+            File.WriteAllText(Path.Combine(themeRoot, "layouts", "page.html"),
+                "<!doctype html><html><head>{{ description_meta_html }}{{ head_html }}</head><body>{{ content }}</body></html>");
+            File.WriteAllText(Path.Combine(themeRoot, "theme.json"),
+                """{"name":"taxonomy-seo-counts","engine":"scriban","defaultLayout":"page"}""");
+
+            var spec = new SiteSpec
+            {
+                Name = "OfficeIMO",
+                BaseUrl = "https://example.test",
+                ContentRoot = "content",
+                DefaultTheme = "taxonomy-seo-counts",
+                ThemesRoot = "themes",
+                Collections =
+                [
+                    new CollectionSpec
+                    {
+                        Name = "blog",
+                        Input = "content/blog",
+                        Output = "/blog"
+                    }
+                ],
+                Taxonomies =
+                [
+                    new TaxonomySpec
+                    {
+                        Name = "tags",
+                        BasePath = "/tags",
+                        ListLayout = "page",
+                        TermLayout = "page"
+                    }
+                ]
+            };
+
+            var configPath = Path.Combine(root, "site.json");
+            File.WriteAllText(configPath, "{}");
+            var result = WebSiteBuilder.Build(spec, WebSitePlanner.Plan(spec, configPath), Path.Combine(root, "_site"));
+            var description = ReadMetaDescription(File.ReadAllText(Path.Combine(result.OutputPath, "tags", "index.html")));
+
+            Assert.InRange(description.Length, 120, 160);
+            Assert.Contains("Browse 12 published OfficeIMO pages through 27 Tags terms", description, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void Build_TaxonomyFeeds_UseConfiguredTaxonomyMetadata()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-taxonomy-feed-meta-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
@@ -518,6 +518,7 @@ internal static partial class WebCliCommandHandlers
                        TryGetOptionValue(subArgs, "--root") ??
                        TryGetOptionValue(subArgs, "--path");
         var projectFile = TryGetOptionValue(subArgs, "--project");
+        var packageFiles = ReadOptionList(subArgs, "--package-files");
         var apiIndex = TryGetOptionValue(subArgs, "--api-index");
         var apiIndexes = ReadOptionList(subArgs, "--api-indexes");
         var apiBase = TryGetOptionValue(subArgs, "--api-base");
@@ -547,6 +548,7 @@ internal static partial class WebCliCommandHandlers
         {
             SiteRoot = siteRoot,
             ProjectFile = projectFile,
+            PackageFiles = packageFiles.ToArray(),
             ApiIndexPath = apiIndex,
             ApiIndexPaths = apiIndexes.ToArray(),
             ApiBase = apiBase ?? "/api",

--- a/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
+++ b/PowerForge.Web.Cli/WebCliCommandHandlers.DocsCommands.cs
@@ -530,6 +530,7 @@ internal static partial class WebCliCommandHandlers
         var license = TryGetOptionValue(subArgs, "--license");
         var targets = TryGetOptionValue(subArgs, "--targets");
         var extra = TryGetOptionValue(subArgs, "--extra");
+        var discovery = TryGetOptionValue(subArgs, "--discovery");
         var apiLevelText = TryGetOptionValue(subArgs, "--api-level");
         var apiMaxTypesText = TryGetOptionValue(subArgs, "--api-max-types");
         var apiMaxMembersText = TryGetOptionValue(subArgs, "--api-max-members");
@@ -560,6 +561,7 @@ internal static partial class WebCliCommandHandlers
             License = license,
             Targets = targets,
             ExtraContentPath = extra,
+            DiscoveryContentPath = discovery,
             ApiDetailLevel = apiLevel,
             ApiMaxTypes = apiMaxTypes,
             ApiMaxMembers = apiMaxMembers

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -122,7 +122,7 @@ internal static partial class WebCliHelpers
         Console.WriteLine("  powerforge-web links promote-404 --source <404-suggestions.json> --config <site.json> [--out <redirects.json>] [--review-csv <file>] [--enable] [--output json]");
         Console.WriteLine("  powerforge-web links ignore-404 --source <404-suggestions.json> --config <site.json> (--path <url>|--without-suggestions|--all) [--reason <text>] [--review-csv <file>] [--output json]");
         Console.WriteLine("  powerforge-web contributions validate --root <dir> [--fail-on-warnings|--strict] [--output json]");
-        Console.WriteLine("  powerforge-web llms --site-root <dir> [--project <path>] [--api-index <path>] [--api-indexes <path[,path...]>]");
+        Console.WriteLine("  powerforge-web llms --site-root <dir> [--project <path>] [--package-files <path[,path...]>] [--api-index <path>] [--api-indexes <path[,path...]>]");
         Console.WriteLine("                     [--api-base /api]");
         Console.WriteLine("                     [--name <Name>] [--package <Id>] [--version <X.Y.Z>] [--quickstart <file>]");
         Console.WriteLine("                     [--overview <text>] [--license <text>] [--targets <text>] [--extra <file>]");

--- a/PowerForge.Web.Cli/WebCliHelpers.cs
+++ b/PowerForge.Web.Cli/WebCliHelpers.cs
@@ -125,7 +125,7 @@ internal static partial class WebCliHelpers
         Console.WriteLine("  powerforge-web llms --site-root <dir> [--project <path>] [--package-files <path[,path...]>] [--api-index <path>] [--api-indexes <path[,path...]>]");
         Console.WriteLine("                     [--api-base /api]");
         Console.WriteLine("                     [--name <Name>] [--package <Id>] [--version <X.Y.Z>] [--quickstart <file>]");
-        Console.WriteLine("                     [--overview <text>] [--license <text>] [--targets <text>] [--extra <file>]");
+        Console.WriteLine("                     [--overview <text>] [--license <text>] [--targets <text>] [--discovery <file>] [--extra <file>]");
         Console.WriteLine("                     [--api-level none|summary|full] [--api-max-types <n>] [--api-max-members <n>]");
         Console.WriteLine("  powerforge-web sitemap --site-root <dir> --base-url <url> [--api-sitemap <path>] [--out <file>] [--entries <file>] [--entries-json <file>]");
         Console.WriteLine("                     [--sitemap-json] [--sitemap-json-out <file>] [--html] [--html-out <file>] [--html-template <file>] [--html-css <href>] [--html-title <text>]");

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
@@ -1675,6 +1675,7 @@ internal static partial class WebPipelineRunner
             License = GetString(step, "license"),
             Targets = GetString(step, "targets"),
             ExtraContentPath = ResolvePath(baseDir, GetString(step, "extra")),
+            DiscoveryContentPath = ResolvePath(baseDir, GetString(step, "discovery")),
             ApiDetailLevel = ParseApiDetailLevel(apiLevelText),
             ApiMaxTypes = GetInt(step, "apiMaxTypes") ?? 200,
             ApiMaxMembers = GetInt(step, "apiMaxMembers") ?? 2000

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.Content.cs
@@ -1652,10 +1652,18 @@ internal static partial class WebPipelineRunner
             .Where(path => !string.IsNullOrWhiteSpace(path))
             .Select(path => path!)
             .ToArray();
+        var packageFiles = (GetArrayOfStrings(step, "packageFiles") ??
+                            GetArrayOfStrings(step, "package-files") ??
+                            Array.Empty<string>())
+            .Select(path => ResolvePath(baseDir, path))
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path!)
+            .ToArray();
         var res = WebLlmsGenerator.Generate(new WebLlmsOptions
         {
             SiteRoot = siteRoot,
             ProjectFile = ResolvePath(baseDir, GetString(step, "project")),
+            PackageFiles = packageFiles,
             ApiIndexPath = ResolvePath(baseDir, GetString(step, "apiIndex") ?? GetString(step, "api-index")),
             ApiIndexPaths = apiIndexPaths,
             ApiBase = GetString(step, "apiBase") ?? "/api",

--- a/PowerForge.Web.Cli/WebPipelineRunner.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.cs
@@ -67,7 +67,7 @@ internal static partial class WebPipelineRunner
         "csvSources", "csv-sources", "apacheOut", "apache-out",
         "csproj", "csprojFiles", "csproj-files", "psd1", "psd1Files", "psd1-files",
         "markdownOut", "markdown-out", "markdownOutput", "markdown-output",
-        "headerHtml", "footerHtml", "quickstart", "extra",
+        "headerHtml", "footerHtml", "quickstart", "extra", "discovery",
         "htmlOutput", "htmlTemplate",
         "entriesJson", "entriesFile", "entries-json", "entries-file",
         "jsonOutput", "jsonOut", "json-output", "json-out",

--- a/PowerForge.Web.Cli/WebPipelineRunner.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.cs
@@ -68,6 +68,7 @@ internal static partial class WebPipelineRunner
         "csproj", "csprojFiles", "csproj-files", "psd1", "psd1Files", "psd1-files",
         "markdownOut", "markdown-out", "markdownOutput", "markdown-output",
         "headerHtml", "footerHtml", "quickstart", "extra", "discovery",
+        "packageFiles", "package-files",
         "htmlOutput", "htmlTemplate",
         "entriesJson", "entriesFile", "entries-json", "entries-file",
         "jsonOutput", "jsonOut", "json-output", "json-out",

--- a/PowerForge.Web/Models/WebLlmsResult.cs
+++ b/PowerForge.Web/Models/WebLlmsResult.cs
@@ -15,6 +15,8 @@ public sealed class WebLlmsResult
     public string PackageId { get; set; } = string.Empty;
     /// <summary>Package version.</summary>
     public string Version { get; set; } = "unknown";
+    /// <summary>Number of installable packages represented by the generated files.</summary>
+    public int PackageCount { get; set; }
     /// <summary>Optional count of API types included.</summary>
     public int? ApiTypeCount { get; set; }
     /// <summary>Number of API catalogs represented in the generated files.</summary>

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.SuitePortal.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.SuitePortal.cs
@@ -34,13 +34,14 @@ public static partial class WebApiDocsGenerator
         var social = ResolveApiSocialProfile(options);
         var baseUrl = NormalizeApiRoute(options.BaseUrl);
         var title = string.IsNullOrWhiteSpace(options.Title) ? (suite.Title ?? "API Suite") : options.Title.Trim();
+        var description = BuildApiSuiteSeoDescription(title, suite.Entries.Count);
 
         var template = LoadTemplate(options, "suite-portal.html", null);
         var html = ApplyTemplate(template, new Dictionary<string, string?>
         {
             ["TITLE"] = System.Web.HttpUtility.HtmlEncode(title),
-            ["DESCRIPTION_META"] = BuildDescriptionMetaTag($"Search and browse the {title} API suite."),
-            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, title, $"Search and browse the {title} API suite.", baseUrl),
+            ["DESCRIPTION_META"] = BuildDescriptionMetaTag(description),
+            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, title, description, baseUrl),
             ["HEAD_HTML"] = head,
             ["CRITICAL_CSS"] = criticalCss,
             ["CSS"] = cssBlock,

--- a/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.SuitePortal.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.ApiDocs.SuitePortal.cs
@@ -34,7 +34,7 @@ public static partial class WebApiDocsGenerator
         var social = ResolveApiSocialProfile(options);
         var baseUrl = NormalizeApiRoute(options.BaseUrl);
         var title = string.IsNullOrWhiteSpace(options.Title) ? (suite.Title ?? "API Suite") : options.Title.Trim();
-        var description = BuildApiSuiteSeoDescription(title, suite.Entries.Count);
+        var description = BuildApiSuiteSeoDescription(title, suite);
 
         var template = LoadTemplate(options, "suite-portal.html", null);
         var html = ApplyTemplate(template, new Dictionary<string, string?>

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Html.cs
@@ -44,6 +44,7 @@ public static partial class WebApiDocsGenerator
         var cssBlock = BuildCssBlockWithFallback(fallbackCss, cssLinks, prismCss);
         var social = ResolveApiSocialProfile(options);
         var indexRoute = NormalizeApiIndexRoute(options.BaseUrl);
+        var indexDescription = BuildApiIndexSeoDescription(options, types.Count);
 
         var indexTemplate = LoadTemplate(options, "index.html", options.IndexTemplatePath);
         var searchScript = JoinHtmlFragments(
@@ -52,8 +53,8 @@ public static partial class WebApiDocsGenerator
         var indexHtml = ApplyTemplate(indexTemplate, new Dictionary<string, string?>
         {
             ["TITLE"] = System.Web.HttpUtility.HtmlEncode(options.Title),
-            ["DESCRIPTION_META"] = BuildDescriptionMetaTag($"API reference for {options.Title}."),
-            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, options.Title, $"API reference for {options.Title}.", indexRoute),
+            ["DESCRIPTION_META"] = BuildDescriptionMetaTag(indexDescription),
+            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, options.Title, indexDescription, indexRoute),
             ["HEAD_HTML"] = head,
             ["CRITICAL_CSS"] = criticalCss,
             ["CSS"] = cssBlock,
@@ -72,14 +73,15 @@ public static partial class WebApiDocsGenerator
         foreach (var type in types)
         {
             var typeTitle = $"{type.FullName} - {options.Title}";
+            var typeDescription = BuildApiTypeSeoDescription(options, type, type.FullName);
             var typeTemplate = LoadTemplate(options, "type.html", options.TypeTemplatePath);
             var typeRoute = $"{NormalizeApiRoute(options.BaseUrl).TrimEnd('/')}/types/{type.Slug}.html";
             var typeHtml = ApplyTemplate(typeTemplate, new Dictionary<string, string?>
             {
                 ["TYPE_TITLE"] = System.Web.HttpUtility.HtmlEncode(typeTitle),
                 ["TYPE_FULLNAME"] = System.Web.HttpUtility.HtmlEncode(type.FullName),
-                ["DESCRIPTION_META"] = BuildDescriptionMetaTag($"API reference for {type.FullName} in {options.Title}."),
-                ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, typeTitle, $"API reference for {type.FullName} in {options.Title}.", typeRoute),
+                ["DESCRIPTION_META"] = BuildDescriptionMetaTag(typeDescription),
+                ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, typeTitle, typeDescription, typeRoute),
                 ["HEAD_HTML"] = head,
                 ["CRITICAL_CSS"] = criticalCss,
                 ["CSS"] = cssBlock,
@@ -135,13 +137,14 @@ public static partial class WebApiDocsGenerator
         var slugMap = BuildTypeSlugMap(types);
         var typeIndex = BuildTypeIndex(types);
         var derivedMap = BuildDerivedTypeMap(types, typeIndex);
+        var indexDescription = BuildApiIndexSeoDescription(options, types.Count);
 
         var indexTemplate = LoadTemplate(options, "docs-index.html", options.DocsIndexTemplatePath);
         var indexHtml = ApplyTemplate(indexTemplate, new Dictionary<string, string?>
         {
             ["TITLE"] = System.Web.HttpUtility.HtmlEncode(options.Title),
-            ["DESCRIPTION_META"] = BuildDescriptionMetaTag($"API reference for {options.Title}."),
-            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, options.Title, $"API reference for {options.Title}.", NormalizeApiIndexRoute(baseUrl)),
+            ["DESCRIPTION_META"] = BuildDescriptionMetaTag(indexDescription),
+            ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, options.Title, indexDescription, NormalizeApiIndexRoute(baseUrl)),
             ["HEAD_HTML"] = head,
             ["CRITICAL_CSS"] = criticalCss,
             ["CSS"] = cssBlock,
@@ -165,12 +168,13 @@ public static partial class WebApiDocsGenerator
             var typeMain = BuildDocsTypeDetail(type, baseUrl, slugMap, typeIndex, derivedMap, usage, relatedContent, codeLanguage, displayName);
             var typeTemplate = LoadTemplate(options, "docs-type.html", options.DocsTypeTemplatePath);
             var pageTitle = $"{displayName} - {options.Title}";
+            var typeDescription = BuildApiTypeSeoDescription(options, type, displayName);
             var typeRoute = $"{NormalizeApiRoute(baseUrl).TrimEnd('/')}/{type.Slug}/";
             var typeHtml = ApplyTemplate(typeTemplate, new Dictionary<string, string?>
             {
                 ["TITLE"] = System.Web.HttpUtility.HtmlEncode(pageTitle),
-                ["DESCRIPTION_META"] = BuildDescriptionMetaTag($"API reference for {displayName} in {options.Title}."),
-                ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, pageTitle, $"API reference for {displayName} in {options.Title}.", typeRoute),
+                ["DESCRIPTION_META"] = BuildDescriptionMetaTag(typeDescription),
+                ["OPEN_GRAPH_META"] = BuildApiOpenGraphMetaTags(options, social, pageTitle, typeDescription, typeRoute),
                 ["HEAD_HTML"] = head,
                 ["CRITICAL_CSS"] = criticalCss,
                 ["CSS"] = cssBlock,

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -48,19 +48,19 @@ public static partial class WebApiDocsGenerator
         var count = FormatApiSeoCount(suite.Entries.Count);
         var capabilities = new List<string>();
         if (!string.IsNullOrWhiteSpace(suite.SearchUrl))
-            capabilities.Add("search symbols");
+            capabilities.Add("symbol search");
         if (!string.IsNullOrWhiteSpace(suite.NarrativeUrl))
-            capabilities.Add("follow curated guidance");
+            capabilities.Add("curated guidance");
         if (!string.IsNullOrWhiteSpace(suite.CoverageUrl))
-            capabilities.Add("review coverage signals");
+            capabilities.Add("coverage signals");
         if (!string.IsNullOrWhiteSpace(suite.RelatedContentUrl))
-            capabilities.Add("find related guides and samples");
+            capabilities.Add("related guides and samples");
         if (!string.IsNullOrWhiteSpace(suite.XrefMapUrl))
-            capabilities.Add("follow cross-project references");
+            capabilities.Add("cross-project references");
 
         var description = capabilities.Count == 0
             ? $"Browse {normalizedTitle} across {count} API references, compare project scopes, and open each documented API from one cross-project landing page."
-            : $"Browse {normalizedTitle} across {count} API references, compare project scopes, {FormatApiSeoActions(capabilities)}, and open each API from one landing page.";
+            : $"Browse {normalizedTitle} across {count} API references with {FormatApiSeoActions(capabilities)}. Compare project scopes and open each API from one landing page.";
 
         return FitApiSeoDescription(description);
     }
@@ -104,6 +104,12 @@ public static partial class WebApiDocsGenerator
         if (wordBoundary < ApiSeoDescriptionMinimumLength)
             wordBoundary = limit;
 
-        return description[..wordBoundary].TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?') + ".";
+        var truncated = description[..wordBoundary].TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?');
+        truncated = Regex.Replace(
+            truncated,
+            @"(?:,\s*)?\b(?:and|or|with|including|from|to)\z",
+            string.Empty,
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant).TrimEnd(' ', ',', ';', ':', '-');
+        return truncated + ".";
     }
 }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -42,14 +42,37 @@ public static partial class WebApiDocsGenerator
 
     private static string BuildApiSuiteSeoDescription(
         string title,
-        int entryCount)
+        ApiSuiteContext suite)
     {
         var normalizedTitle = NormalizeApiSeoText(title);
-        var count = FormatApiSeoCount(entryCount);
-        var description =
-            $"Browse {normalizedTitle} across {count} API references, with searchable symbols, curated guidance, coverage signals, and cross-project navigation from one landing page.";
+        var count = FormatApiSeoCount(suite.Entries.Count);
+        var capabilities = new List<string>();
+        if (!string.IsNullOrWhiteSpace(suite.SearchUrl))
+            capabilities.Add("search symbols");
+        if (!string.IsNullOrWhiteSpace(suite.NarrativeUrl))
+            capabilities.Add("follow curated guidance");
+        if (!string.IsNullOrWhiteSpace(suite.CoverageUrl))
+            capabilities.Add("review coverage signals");
+        if (!string.IsNullOrWhiteSpace(suite.RelatedContentUrl))
+            capabilities.Add("find related guides and samples");
+        if (!string.IsNullOrWhiteSpace(suite.XrefMapUrl))
+            capabilities.Add("follow cross-project references");
+
+        var description = capabilities.Count == 0
+            ? $"Browse {normalizedTitle} across {count} API references, compare project scopes, and open each documented API from one cross-project landing page."
+            : $"Browse {normalizedTitle} across {count} API references, compare project scopes, {FormatApiSeoActions(capabilities)}, and open each API from one landing page.";
 
         return FitApiSeoDescription(description);
+    }
+
+    private static string FormatApiSeoActions(IReadOnlyList<string> actions)
+    {
+        if (actions.Count == 1)
+            return actions[0];
+        if (actions.Count == 2)
+            return $"{actions[0]} and {actions[1]}";
+
+        return $"{string.Join(", ", actions.Take(actions.Count - 1))}, and {actions[^1]}";
     }
 
     private static string FormatApiSeoCount(int value)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -119,7 +119,7 @@ public static partial class WebApiDocsGenerator
         var description = NormalizeApiSeoText(value);
         if (description.Length < ApiSeoDescriptionMinimumLength)
         {
-            description = $"{description.TrimEnd('.', '!', '?')}. Includes current reference details, navigation context, and searchable documentation for practical implementation work.";
+            description = $"{description.TrimEnd('.', '!', '?')}. Includes current reference details, navigation context, and practical implementation guidance for the documented API.";
         }
 
         if (description.Length <= ApiSeoDescriptionMaximumLength)

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -1,0 +1,67 @@
+using System.Text.RegularExpressions;
+
+namespace PowerForge.Web;
+
+/// <summary>Generates API documentation artifacts from XML docs.</summary>
+public static partial class WebApiDocsGenerator
+{
+    private const int ApiSeoDescriptionMinimumLength = 120;
+    private const int ApiSeoDescriptionMaximumLength = 160;
+
+    private static string BuildApiIndexSeoDescription(
+        WebApiDocsOptions options,
+        int documentedTypeCount)
+    {
+        var title = NormalizeApiSeoText(options.Title);
+        var itemLabel = options.Type == ApiDocsType.PowerShell ? "cmdlets" : "types";
+        var description =
+            $"Browse {title} for {documentedTypeCount:N0} documented {itemLabel}, with signatures, parameters, examples, related APIs, inheritance details, and source links.";
+
+        return FitApiSeoDescription(description);
+    }
+
+    private static string BuildApiTypeSeoDescription(
+        WebApiDocsOptions options,
+        ApiTypeModel type,
+        string displayName)
+    {
+        var title = NormalizeApiSeoText(options.Title);
+        var name = NormalizeApiSeoText(displayName);
+        var summary = NormalizeApiSeoText(type.Summary);
+        var description = string.IsNullOrWhiteSpace(summary)
+            ? $"Explore {name} in {title}, including syntax, members, parameters, examples, related APIs, inheritance details, and source links."
+            : $"{name}: {summary.TrimEnd('.', '!', '?')}. Review syntax, members, parameters, examples, related APIs, and source links in {title}.";
+
+        return FitApiSeoDescription(description);
+    }
+
+    private static string NormalizeApiSeoText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var text = StripCrefTokens(value);
+        text = Regex.Replace(text, "<[^>]+>", " ");
+        text = System.Web.HttpUtility.HtmlDecode(text);
+        return Regex.Replace(text, "\\s+", " ").Trim();
+    }
+
+    private static string FitApiSeoDescription(string value)
+    {
+        var description = NormalizeApiSeoText(value);
+        if (description.Length < ApiSeoDescriptionMinimumLength)
+        {
+            description = $"{description.TrimEnd('.', '!', '?')}. Includes current signatures, parameters, examples, related APIs, and source links.";
+        }
+
+        if (description.Length <= ApiSeoDescriptionMaximumLength)
+            return description;
+
+        var limit = ApiSeoDescriptionMaximumLength - 1;
+        var wordBoundary = description.LastIndexOf(' ', limit);
+        if (wordBoundary < ApiSeoDescriptionMinimumLength)
+            wordBoundary = limit;
+
+        return description[..wordBoundary].TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?') + ".";
+    }
+}

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -15,9 +15,14 @@ public static partial class WebApiDocsGenerator
     {
         var title = NormalizeApiSeoText(options.Title);
         var count = FormatApiSeoCount(documentedTypeCount);
+        var richTemplate = UsesRichApiDocsTemplate(options);
         var description = options.Type == ApiDocsType.PowerShell
-            ? $"Browse {title} for {count} documented reference entries, with searchable syntax, parameters, pipeline details, and navigation across the API."
-            : $"Browse {title} for {count} documented types, with searchable signatures, members, parameters, type relationships, and navigation across the API.";
+            ? richTemplate
+                ? $"Browse {title} for {count} documented reference entries, with searchable syntax, parameters, pipeline details, and navigation across the API."
+                : $"Browse {title} for {count} documented reference entries, with command summaries, reference pages, and navigation across the available API."
+            : richTemplate
+                ? $"Browse {title} for {count} documented types, with searchable signatures, members, parameters, type relationships, and navigation across the API."
+                : $"Browse {title} for {count} documented types, with summaries, generated reference pages, member details, and navigation across the available API.";
 
         return FitApiSeoDescription(description);
     }
@@ -30,9 +35,18 @@ public static partial class WebApiDocsGenerator
         var title = NormalizeApiSeoText(options.Title);
         var name = NormalizeApiSeoText(displayName);
         var summary = NormalizeApiSeoText(type.Summary);
-        var referenceDetails = options.Type == ApiDocsType.PowerShell
-            ? "available syntax, parameters, pipeline guidance, and reference details"
-            : "signatures, members, parameters, type relationships, and available reference details";
+        var richTemplate = UsesRichApiDocsTemplate(options);
+        var isAboutTopic = options.Type == ApiDocsType.PowerShell &&
+                           string.Equals(type.Kind, "About", StringComparison.OrdinalIgnoreCase);
+        var referenceDetails = isAboutTopic
+            ? "the complete conceptual topic, related help context, and navigation"
+            : options.Type == ApiDocsType.PowerShell
+                ? richTemplate
+                    ? "available syntax, parameters, pipeline guidance, and reference details"
+                    : "command summaries, syntax details, and navigation"
+                : richTemplate
+                    ? "signatures, members, parameters, type relationships, and available reference details"
+                    : "type summaries, signatures, member details, and navigation";
         var description = string.IsNullOrWhiteSpace(summary)
             ? $"Explore {name} in {title}, including {referenceDetails}."
             : $"{name}: {summary.TrimEnd('.', '!', '?')}. Review {referenceDetails} in {title}.";
@@ -78,6 +92,12 @@ public static partial class WebApiDocsGenerator
     private static string FormatApiSeoCount(int value)
         => value.ToString("N0", CultureInfo.InvariantCulture);
 
+    private static bool UsesRichApiDocsTemplate(WebApiDocsOptions options)
+    {
+        var template = (options.Template ?? string.Empty).Trim().ToLowerInvariant();
+        return template is "docs" or "sidebar";
+    }
+
     private static string NormalizeApiSeoText(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -102,14 +122,35 @@ public static partial class WebApiDocsGenerator
         var limit = ApiSeoDescriptionMaximumLength - 1;
         var wordBoundary = description.LastIndexOf(' ', limit);
         if (wordBoundary < ApiSeoDescriptionMinimumLength)
-            wordBoundary = limit;
+            wordBoundary = ClampToUnicodeScalarBoundary(description, limit);
 
         var truncated = description[..wordBoundary].TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?');
-        truncated = Regex.Replace(
+        var withoutDanglingWord = Regex.Replace(
             truncated,
             @"(?:,\s*)?\b(?:and|or|with|including|from|to)\z",
             string.Empty,
             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant).TrimEnd(' ', ',', ';', ':', '-');
+        if (withoutDanglingWord.Length + 1 >= ApiSeoDescriptionMinimumLength)
+            return withoutDanglingWord + ".";
+
+        var completed = withoutDanglingWord + " reference details";
+        if (completed.Length <= limit)
+            return completed + ".";
+
         return truncated + ".";
+    }
+
+    private static int ClampToUnicodeScalarBoundary(string value, int boundary)
+    {
+        var safeBoundary = Math.Clamp(boundary, 0, value.Length);
+        if (safeBoundary > 0 &&
+            safeBoundary < value.Length &&
+            char.IsHighSurrogate(value[safeBoundary - 1]) &&
+            char.IsLowSurrogate(value[safeBoundary]))
+        {
+            safeBoundary--;
+        }
+
+        return safeBoundary;
     }
 }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -35,6 +35,17 @@ public static partial class WebApiDocsGenerator
         return FitApiSeoDescription(description);
     }
 
+    private static string BuildApiSuiteSeoDescription(
+        string title,
+        int entryCount)
+    {
+        var normalizedTitle = NormalizeApiSeoText(title);
+        var description =
+            $"Browse {normalizedTitle} across {entryCount:N0} API references, with searchable symbols, curated guidance, coverage signals, related samples, and source links.";
+
+        return FitApiSeoDescription(description);
+    }
+
     private static string NormalizeApiSeoText(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -15,14 +15,20 @@ public static partial class WebApiDocsGenerator
     {
         var title = NormalizeApiSeoText(options.Title);
         var count = FormatApiSeoCount(documentedTypeCount);
+        var referenceEntryLabel = documentedTypeCount == 1
+            ? "documented reference entry"
+            : "documented reference entries";
+        var typeLabel = documentedTypeCount == 1
+            ? "documented type"
+            : "documented types";
         var richTemplate = UsesRichApiDocsTemplate(options);
         var description = options.Type == ApiDocsType.PowerShell
             ? richTemplate
-                ? $"Browse {title} for {count} documented reference entries, with searchable syntax, parameters, pipeline details, and navigation across the API."
-                : $"Browse {title} for {count} documented reference entries, with command summaries, reference pages, and navigation across the available API."
+                ? $"Browse {title} for {count} {referenceEntryLabel}, with searchable syntax, parameters, pipeline details, and navigation across the API."
+                : $"Browse {title} for {count} {referenceEntryLabel}, with command summaries, reference pages, and navigation across the available API."
             : richTemplate
-                ? $"Browse {title} for {count} documented types, with searchable signatures, members, parameters, type relationships, and navigation across the API."
-                : $"Browse {title} for {count} documented types, with summaries, generated reference pages, member details, and navigation across the available API.";
+                ? $"Browse {title} for {count} {typeLabel}, with searchable signatures, members, parameters, type relationships, and navigation across the API."
+                : $"Browse {title} for {count} {typeLabel}, with summaries, generated reference pages, member details, and navigation across the available API.";
 
         return FitApiSeoDescription(description);
     }

--- a/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
+++ b/PowerForge.Web/Services/WebApiDocsGenerator.Seo.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace PowerForge.Web;
@@ -13,9 +14,10 @@ public static partial class WebApiDocsGenerator
         int documentedTypeCount)
     {
         var title = NormalizeApiSeoText(options.Title);
-        var itemLabel = options.Type == ApiDocsType.PowerShell ? "cmdlets" : "types";
-        var description =
-            $"Browse {title} for {documentedTypeCount:N0} documented {itemLabel}, with signatures, parameters, examples, related APIs, inheritance details, and source links.";
+        var count = FormatApiSeoCount(documentedTypeCount);
+        var description = options.Type == ApiDocsType.PowerShell
+            ? $"Browse {title} for {count} documented reference entries, with searchable syntax, parameters, pipeline details, and navigation across the API."
+            : $"Browse {title} for {count} documented types, with searchable signatures, members, parameters, type relationships, and navigation across the API.";
 
         return FitApiSeoDescription(description);
     }
@@ -28,9 +30,12 @@ public static partial class WebApiDocsGenerator
         var title = NormalizeApiSeoText(options.Title);
         var name = NormalizeApiSeoText(displayName);
         var summary = NormalizeApiSeoText(type.Summary);
+        var referenceDetails = options.Type == ApiDocsType.PowerShell
+            ? "available syntax, parameters, pipeline guidance, and reference details"
+            : "signatures, members, parameters, type relationships, and available reference details";
         var description = string.IsNullOrWhiteSpace(summary)
-            ? $"Explore {name} in {title}, including syntax, members, parameters, examples, related APIs, inheritance details, and source links."
-            : $"{name}: {summary.TrimEnd('.', '!', '?')}. Review syntax, members, parameters, examples, related APIs, and source links in {title}.";
+            ? $"Explore {name} in {title}, including {referenceDetails}."
+            : $"{name}: {summary.TrimEnd('.', '!', '?')}. Review {referenceDetails} in {title}.";
 
         return FitApiSeoDescription(description);
     }
@@ -40,11 +45,15 @@ public static partial class WebApiDocsGenerator
         int entryCount)
     {
         var normalizedTitle = NormalizeApiSeoText(title);
+        var count = FormatApiSeoCount(entryCount);
         var description =
-            $"Browse {normalizedTitle} across {entryCount:N0} API references, with searchable symbols, curated guidance, coverage signals, related samples, and source links.";
+            $"Browse {normalizedTitle} across {count} API references, with searchable symbols, curated guidance, coverage signals, and cross-project navigation from one landing page.";
 
         return FitApiSeoDescription(description);
     }
+
+    private static string FormatApiSeoCount(int value)
+        => value.ToString("N0", CultureInfo.InvariantCulture);
 
     private static string NormalizeApiSeoText(string? value)
     {
@@ -52,7 +61,6 @@ public static partial class WebApiDocsGenerator
             return string.Empty;
 
         var text = StripCrefTokens(value);
-        text = Regex.Replace(text, "<[^>]+>", " ");
         text = System.Web.HttpUtility.HtmlDecode(text);
         return Regex.Replace(text, "\\s+", " ").Trim();
     }
@@ -62,7 +70,7 @@ public static partial class WebApiDocsGenerator
         var description = NormalizeApiSeoText(value);
         if (description.Length < ApiSeoDescriptionMinimumLength)
         {
-            description = $"{description.TrimEnd('.', '!', '?')}. Includes current signatures, parameters, examples, related APIs, and source links.";
+            description = $"{description.TrimEnd('.', '!', '?')}. Includes current reference details, navigation context, and searchable documentation for practical implementation work.";
         }
 
         if (description.Length <= ApiSeoDescriptionMaximumLength)

--- a/PowerForge.Web/Services/WebLlmsGenerator.PackageMetadata.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.PackageMetadata.cs
@@ -1,0 +1,261 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PowerForge.Web;
+
+public static partial class WebLlmsGenerator
+{
+    private static List<PackageInfo> ResolvePackages(IEnumerable<string>? packageFiles)
+    {
+        var packages = new List<PackageInfo>();
+        foreach (var packageFile in packageFiles ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(packageFile))
+                continue;
+
+            var fullPath = Path.GetFullPath(packageFile);
+            if (!File.Exists(fullPath))
+                throw new FileNotFoundException($"Configured package manifest not found: {fullPath}", fullPath);
+
+            var project = ReadProjectInfo(fullPath);
+            var id = project.PackageId ?? project.Name ?? Path.GetFileNameWithoutExtension(fullPath);
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            packages.Add(new PackageInfo
+            {
+                Id = id,
+                Version = project.Version,
+                InstallCommand = CreateInstallCommand(id, project.IsPowerShellModule, project.IsDotNetTool),
+                IsPowerShellModule = project.IsPowerShellModule,
+                IsDotNetTool = project.IsDotNetTool,
+                ToolCommandName = project.ToolCommandName
+            });
+        }
+
+        return packages
+            .GroupBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToList();
+    }
+
+    private static string? ResolveSuiteVersion(IReadOnlyList<PackageInfo> packages)
+    {
+        if (packages.Count == 0)
+            return null;
+
+        var versions = packages
+            .Select(static package => package.Version)
+            .Where(static version => !string.IsNullOrWhiteSpace(version))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (packages.Any(static package => string.IsNullOrWhiteSpace(package.Version)))
+            return "unknown";
+
+        return versions.Length == 1 ? versions[0] : "varies by package";
+    }
+
+    private static ProjectInfo ReadProjectInfo(string? projectFile)
+    {
+        if (string.IsNullOrWhiteSpace(projectFile))
+            return new ProjectInfo();
+
+        var full = Path.GetFullPath(projectFile);
+        if (!File.Exists(full))
+            return new ProjectInfo();
+
+        var content = File.ReadAllText(full);
+        if (Path.GetExtension(full).Equals(".psd1", StringComparison.OrdinalIgnoreCase))
+        {
+            var manifestContent = RemovePowerShellComments(content);
+            var moduleVersion = NormalizeEmpty(MatchPowerShellDataValue(manifestContent, "ModuleVersion"));
+            var prerelease = NormalizeEmpty(MatchPowerShellDataValue(manifestContent, "Prerelease"));
+            return new ProjectInfo
+            {
+                Name = Path.GetFileNameWithoutExtension(full),
+                PackageId = Path.GetFileNameWithoutExtension(full),
+                Version = CombineMsBuildVersion(moduleVersion, prerelease),
+                Description = NormalizeEmpty(MatchPowerShellDataValue(manifestContent, "Description")),
+                IsPowerShellModule = true
+            };
+        }
+
+        var assemblyName = NormalizeMsBuildMetadataValue(MatchValue(content, "AssemblyName"));
+        var rootNamespace = NormalizeMsBuildMetadataValue(MatchValue(content, "RootNamespace"));
+        var packageId = NormalizeMsBuildMetadataValue(MatchValue(content, "PackageId"));
+        var packageVersion = NormalizeMsBuildMetadataValue(MatchValue(content, "PackageVersion"));
+        var versionValue = NormalizeMsBuildMetadataValue(MatchValue(content, "Version"));
+        var versionPrefix = NormalizeMsBuildMetadataValue(MatchValue(content, "VersionPrefix"));
+        var versionSuffix = NormalizeMsBuildMetadataValue(MatchValue(content, "VersionSuffix"));
+        var version = packageVersion ??
+                      versionValue ??
+                      CombineMsBuildVersion(versionPrefix, versionSuffix);
+        var description = NormalizeMsBuildMetadataValue(MatchValue(content, "Description"));
+        var packAsTool = NormalizeMsBuildMetadataValue(MatchValue(content, "PackAsTool"));
+        var toolCommandName = NormalizeMsBuildMetadataValue(MatchValue(content, "ToolCommandName"));
+
+        return new ProjectInfo
+        {
+            Name = assemblyName ?? rootNamespace,
+            PackageId = packageId,
+            Version = version,
+            Description = description,
+            ToolCommandName = toolCommandName ?? assemblyName ?? rootNamespace ?? packageId,
+            IsDotNetTool = string.Equals(
+                packAsTool,
+                "true",
+                StringComparison.OrdinalIgnoreCase)
+        };
+    }
+
+    private static string? CombineMsBuildVersion(string? versionPrefix, string? versionSuffix)
+    {
+        if (string.IsNullOrWhiteSpace(versionPrefix))
+            return null;
+        if (string.IsNullOrWhiteSpace(versionSuffix))
+            return versionPrefix;
+
+        return $"{versionPrefix}-{versionSuffix.TrimStart('-')}";
+    }
+
+    private static string? NormalizeMsBuildMetadataValue(string value)
+    {
+        var normalized = NormalizeEmpty(value);
+        if (normalized is null)
+            return null;
+
+        return normalized.Contains("$(", StringComparison.Ordinal) ||
+               normalized.Contains("%(", StringComparison.Ordinal)
+            ? null
+            : normalized;
+    }
+
+    private static string MatchPowerShellDataValue(string content, string name)
+    {
+        var pattern = $@"(?im)(?:^|[;{{])\s*{Regex.Escape(name)}\s*=\s*['""](?<value>[^'""]+)['""]";
+        var match = Regex.Match(content, pattern, RegexOptions.CultureInvariant);
+        return match.Success ? match.Groups["value"].Value.Trim() : string.Empty;
+    }
+
+    private static string RemovePowerShellComments(string content)
+    {
+        var output = new StringBuilder(content.Length);
+        var inSingleQuotedString = false;
+        var inDoubleQuotedString = false;
+        var inLineComment = false;
+        var inBlockComment = false;
+
+        for (var index = 0; index < content.Length; index++)
+        {
+            var current = content[index];
+            var next = index + 1 < content.Length ? content[index + 1] : '\0';
+
+            if (inLineComment)
+            {
+                if (current is '\r' or '\n')
+                {
+                    inLineComment = false;
+                    output.Append(current);
+                }
+                continue;
+            }
+
+            if (inBlockComment)
+            {
+                if (current == '#' && next == '>')
+                {
+                    inBlockComment = false;
+                    index++;
+                }
+                else if (current is '\r' or '\n')
+                {
+                    output.Append(current);
+                }
+                continue;
+            }
+
+            if (inSingleQuotedString)
+            {
+                output.Append(current);
+                if (current == '\'' && next == '\'')
+                {
+                    output.Append(next);
+                    index++;
+                }
+                else if (current == '\'')
+                {
+                    inSingleQuotedString = false;
+                }
+                continue;
+            }
+
+            if (inDoubleQuotedString)
+            {
+                output.Append(current);
+                if (current == '`' && next != '\0')
+                {
+                    output.Append(next);
+                    index++;
+                }
+                else if (current == '"')
+                {
+                    inDoubleQuotedString = false;
+                }
+                continue;
+            }
+
+            if (current == '<' && next == '#')
+            {
+                inBlockComment = true;
+                index++;
+            }
+            else if (current == '#')
+            {
+                inLineComment = true;
+            }
+            else
+            {
+                output.Append(current);
+                if (current == '\'')
+                    inSingleQuotedString = true;
+                else if (current == '"')
+                    inDoubleQuotedString = true;
+            }
+        }
+
+        return output.ToString();
+    }
+
+    private static string MatchValue(string content, string name)
+    {
+        var pattern = $@"<{name}>([^<]+)</{name}>";
+        var match = Regex.Match(content, pattern, RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value.Trim() : string.Empty;
+    }
+
+    private static string? NormalizeEmpty(string value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private sealed class PackageInfo
+    {
+        public string Id { get; set; } = string.Empty;
+        public string? Version { get; set; }
+        public string InstallCommand { get; set; } = string.Empty;
+        public bool IsPowerShellModule { get; set; }
+        public bool IsDotNetTool { get; set; }
+        public string? ToolCommandName { get; set; }
+    }
+
+    private sealed class ProjectInfo
+    {
+        public string? Name { get; set; }
+        public string? PackageId { get; set; }
+        public string? Version { get; set; }
+        public string? Description { get; set; }
+        public string? ToolCommandName { get; set; }
+        public bool IsPowerShellModule { get; set; }
+        public bool IsDotNetTool { get; set; }
+    }
+}

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -165,11 +165,13 @@ public static class WebLlmsGenerator
         var content = File.ReadAllText(full);
         if (Path.GetExtension(full).Equals(".psd1", StringComparison.OrdinalIgnoreCase))
         {
+            var moduleVersion = NormalizeEmpty(MatchPowerShellDataValue(content, "ModuleVersion"));
+            var prerelease = NormalizeEmpty(MatchPowerShellDataValue(content, "Prerelease"));
             return new ProjectInfo
             {
                 Name = Path.GetFileNameWithoutExtension(full),
                 PackageId = Path.GetFileNameWithoutExtension(full),
-                Version = NormalizeEmpty(MatchPowerShellDataValue(content, "ModuleVersion")),
+                Version = CombineMsBuildVersion(moduleVersion, prerelease),
                 Description = NormalizeEmpty(MatchPowerShellDataValue(content, "Description")),
                 IsPowerShellModule = true
             };

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -229,7 +229,7 @@ public static class WebLlmsGenerator
 
     private static string MatchPowerShellDataValue(string content, string name)
     {
-        var pattern = $@"(?im)^\s*{Regex.Escape(name)}\s*=\s*['""](?<value>[^'""]+)['""]";
+        var pattern = $@"(?im)(?:^|[;{{])\s*{Regex.Escape(name)}\s*=\s*['""](?<value>[^'""]+)['""]";
         var match = Regex.Match(content, pattern, RegexOptions.CultureInvariant);
         return match.Success ? match.Groups["value"].Value.Trim() : string.Empty;
     }

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -36,6 +36,8 @@ public sealed class WebLlmsOptions
     public string? Targets { get; set; }
     /// <summary>Optional path to extra content for llms-full.</summary>
     public string? ExtraContentPath { get; set; }
+    /// <summary>Optional curated Markdown appended to both llms.txt and llms-full.txt.</summary>
+    public string? DiscoveryContentPath { get; set; }
     /// <summary>Optional API detail level for llms-full (none, summary, full).</summary>
     public WebApiDetailLevel ApiDetailLevel { get; set; } = WebApiDetailLevel.None;
     /// <summary>Maximum number of API types to include.</summary>
@@ -83,7 +85,7 @@ public static class WebLlmsGenerator
             primaryPackage?.ToolCommandName ?? projectInfo.ToolCommandName);
         var legacyInstallCommand = CreateInstallCommand(packageId, projectInfo.IsPowerShellModule, projectInfo.IsDotNetTool);
         var overview = ResolveOverview(options, projectInfo, siteRoot, name);
-        WriteLlmsTxt(llmsTxtPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, overview, quickstart);
+        WriteLlmsTxt(llmsTxtPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, overview, quickstart, options.DiscoveryContentPath);
         WriteLlmsJson(llmsJsonPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, quickstart);
         WriteLlmsFull(llmsFullPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, overview, quickstart, options);
 
@@ -490,7 +492,8 @@ public static class WebLlmsGenerator
         int? typeCount,
         IReadOnlyList<ApiCatalogInfo> apiCatalogs,
         string overview,
-        QuickstartInfo quickstart)
+        QuickstartInfo quickstart,
+        string? discoveryContentPath)
     {
         var lines = new List<string>
         {
@@ -526,6 +529,7 @@ public static class WebLlmsGenerator
         lines.Add(string.Empty);
         lines.Add("## Machine-friendly API data");
         AppendApiResourceLinks(lines, apiCatalogs);
+        AppendOptionalMarkdown(lines, discoveryContentPath);
         lines.Add(string.Empty);
         lines.Add("Slug rule: lower-case, dots/symbols -> dashes.");
 
@@ -637,6 +641,7 @@ public static class WebLlmsGenerator
         AppendApiResourceLinks(lines, apiCatalogs);
 
         AppendApiDetails(lines, options, apiCatalogs);
+        AppendOptionalMarkdown(lines, options.DiscoveryContentPath);
 
         if (!string.IsNullOrWhiteSpace(options.ExtraContentPath))
         {
@@ -649,6 +654,19 @@ public static class WebLlmsGenerator
         }
 
         File.WriteAllText(path, string.Join(Environment.NewLine, lines), Encoding.UTF8);
+    }
+
+    private static void AppendOptionalMarkdown(List<string> lines, string? contentPath)
+    {
+        if (string.IsNullOrWhiteSpace(contentPath))
+            return;
+
+        var fullPath = Path.GetFullPath(contentPath);
+        if (!File.Exists(fullPath))
+            return;
+
+        lines.Add(string.Empty);
+        lines.AddRange(File.ReadAllLines(fullPath));
     }
 
     private static void AppendPackageInstallMarkdown(List<string> lines, IReadOnlyList<PackageInfo> packages)

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -78,7 +78,9 @@ public static class WebLlmsGenerator
         var quickstart = ResolveQuickstart(
             options.QuickstartPath,
             primaryPackage?.Id ?? name,
-            primaryPackage?.IsPowerShellModule ?? projectInfo.IsPowerShellModule);
+            primaryPackage?.IsPowerShellModule ?? projectInfo.IsPowerShellModule,
+            primaryPackage?.IsDotNetTool ?? projectInfo.IsDotNetTool,
+            primaryPackage?.ToolCommandName ?? projectInfo.ToolCommandName);
         var legacyInstallCommand = CreateInstallCommand(packageId, projectInfo.IsPowerShellModule, projectInfo.IsDotNetTool);
         var overview = ResolveOverview(options, projectInfo, siteRoot, name);
         WriteLlmsTxt(llmsTxtPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, overview, quickstart);
@@ -121,7 +123,9 @@ public static class WebLlmsGenerator
                 Id = id,
                 Version = project.Version,
                 InstallCommand = CreateInstallCommand(id, project.IsPowerShellModule, project.IsDotNetTool),
-                IsPowerShellModule = project.IsPowerShellModule
+                IsPowerShellModule = project.IsPowerShellModule,
+                IsDotNetTool = project.IsDotNetTool,
+                ToolCommandName = project.ToolCommandName
             });
         }
 
@@ -172,10 +176,16 @@ public static class WebLlmsGenerator
         var assemblyName = NormalizeMsBuildMetadataValue(MatchValue(content, "AssemblyName"));
         var rootNamespace = NormalizeMsBuildMetadataValue(MatchValue(content, "RootNamespace"));
         var packageId = NormalizeMsBuildMetadataValue(MatchValue(content, "PackageId"));
-        var version = NormalizeMsBuildMetadataValue(MatchValue(content, "Version")) ??
-                      NormalizeMsBuildMetadataValue(MatchValue(content, "VersionPrefix"));
+        var packageVersion = NormalizeMsBuildMetadataValue(MatchValue(content, "PackageVersion"));
+        var versionValue = NormalizeMsBuildMetadataValue(MatchValue(content, "Version"));
+        var versionPrefix = NormalizeMsBuildMetadataValue(MatchValue(content, "VersionPrefix"));
+        var versionSuffix = NormalizeMsBuildMetadataValue(MatchValue(content, "VersionSuffix"));
+        var version = packageVersion ??
+                      versionValue ??
+                      CombineMsBuildVersion(versionPrefix, versionSuffix);
         var description = NormalizeMsBuildMetadataValue(MatchValue(content, "Description"));
         var packAsTool = NormalizeMsBuildMetadataValue(MatchValue(content, "PackAsTool"));
+        var toolCommandName = NormalizeMsBuildMetadataValue(MatchValue(content, "ToolCommandName"));
 
         return new ProjectInfo
         {
@@ -183,11 +193,22 @@ public static class WebLlmsGenerator
             PackageId = packageId,
             Version = version,
             Description = description,
+            ToolCommandName = toolCommandName ?? assemblyName ?? rootNamespace ?? packageId,
             IsDotNetTool = string.Equals(
                 packAsTool,
                 "true",
                 StringComparison.OrdinalIgnoreCase)
         };
+    }
+
+    private static string? CombineMsBuildVersion(string? versionPrefix, string? versionSuffix)
+    {
+        if (string.IsNullOrWhiteSpace(versionPrefix))
+            return null;
+        if (string.IsNullOrWhiteSpace(versionSuffix))
+            return versionPrefix;
+
+        return $"{versionPrefix}-{versionSuffix.TrimStart('-')}";
     }
 
     private static string? NormalizeMsBuildMetadataValue(string value)
@@ -389,7 +410,12 @@ public static class WebLlmsGenerator
         return Regex.Replace(decoded, @"\s+", " ").Trim();
     }
 
-    private static QuickstartInfo ResolveQuickstart(string? quickstartPath, string name, bool isPowerShellModule)
+    private static QuickstartInfo ResolveQuickstart(
+        string? quickstartPath,
+        string name,
+        bool isPowerShellModule,
+        bool isDotNetTool,
+        string? toolCommandName)
     {
         if (!string.IsNullOrWhiteSpace(quickstartPath))
         {
@@ -416,6 +442,21 @@ public static class WebLlmsGenerator
                 [
                     $"Import-Module {name}",
                     $"Get-Command -Module {name}"
+                ]
+            };
+        }
+
+        if (isDotNetTool)
+        {
+            var commandName = string.IsNullOrWhiteSpace(toolCommandName)
+                ? name
+                : toolCommandName;
+            return new QuickstartInfo
+            {
+                Language = "shell",
+                Lines =
+                [
+                    $"{commandName} --help"
                 ]
             };
         }
@@ -833,6 +874,8 @@ public static class WebLlmsGenerator
         public string? Version { get; set; }
         public string InstallCommand { get; set; } = string.Empty;
         public bool IsPowerShellModule { get; set; }
+        public bool IsDotNetTool { get; set; }
+        public string? ToolCommandName { get; set; }
     }
 
     private sealed class ProjectInfo
@@ -841,6 +884,7 @@ public static class WebLlmsGenerator
         public string? PackageId { get; set; }
         public string? Version { get; set; }
         public string? Description { get; set; }
+        public string? ToolCommandName { get; set; }
         public bool IsPowerShellModule { get; set; }
         public bool IsDotNetTool { get; set; }
     }

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -47,7 +47,7 @@ public sealed class WebLlmsOptions
 }
 
 /// <summary>Generates llms.txt files for documentation consumers.</summary>
-public static class WebLlmsGenerator
+public static partial class WebLlmsGenerator
 {
     /// <summary>Generates llms.txt, llms.json, and llms-full.txt.</summary>
     /// <param name="options">Generation options.</param>
@@ -65,7 +65,7 @@ public static class WebLlmsGenerator
         var name = options.Name ?? projectInfo.Name ?? options.PackageId ?? projectInfo.PackageId ??
                    packages.FirstOrDefault()?.Id ?? Path.GetFileName(siteRoot);
         var packageId = options.PackageId ?? projectInfo.PackageId ?? name;
-        var version = options.Version ?? projectInfo.Version ?? ResolveSuiteVersion(packages) ?? "unknown";
+        var version = options.Version ?? ResolveSuiteVersion(packages) ?? projectInfo.Version ?? "unknown";
 
         var apiCatalogs = ResolveApiCatalogs(options, siteRoot);
         int? typeCount = apiCatalogs.Any(catalog => catalog.TypeCount.HasValue)
@@ -101,137 +101,6 @@ public static class WebLlmsGenerator
             ApiTypeCount = typeCount,
             ApiCatalogCount = apiCatalogs.Count
         };
-    }
-
-    private static List<PackageInfo> ResolvePackages(IEnumerable<string>? packageFiles)
-    {
-        var packages = new List<PackageInfo>();
-        foreach (var packageFile in packageFiles ?? Array.Empty<string>())
-        {
-            if (string.IsNullOrWhiteSpace(packageFile))
-                continue;
-
-            var fullPath = Path.GetFullPath(packageFile);
-            if (!File.Exists(fullPath))
-                throw new FileNotFoundException($"Configured package manifest not found: {fullPath}", fullPath);
-
-            var project = ReadProjectInfo(fullPath);
-            var id = project.PackageId ?? project.Name ?? Path.GetFileNameWithoutExtension(fullPath);
-            if (string.IsNullOrWhiteSpace(id))
-                continue;
-
-            packages.Add(new PackageInfo
-            {
-                Id = id,
-                Version = project.Version,
-                InstallCommand = CreateInstallCommand(id, project.IsPowerShellModule, project.IsDotNetTool),
-                IsPowerShellModule = project.IsPowerShellModule,
-                IsDotNetTool = project.IsDotNetTool,
-                ToolCommandName = project.ToolCommandName
-            });
-        }
-
-        return packages
-            .GroupBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
-            .Select(static group => group.First())
-            .ToList();
-    }
-
-    private static string? ResolveSuiteVersion(IReadOnlyList<PackageInfo> packages)
-    {
-        if (packages.Count == 0)
-            return null;
-
-        var versions = packages
-            .Select(static package => package.Version)
-            .Where(static version => !string.IsNullOrWhiteSpace(version))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (packages.Any(static package => string.IsNullOrWhiteSpace(package.Version)))
-            return "unknown";
-
-        return versions.Length == 1 ? versions[0] : "varies by package";
-    }
-
-    private static ProjectInfo ReadProjectInfo(string? projectFile)
-    {
-        if (string.IsNullOrWhiteSpace(projectFile))
-            return new ProjectInfo();
-
-        var full = Path.GetFullPath(projectFile);
-        if (!File.Exists(full))
-            return new ProjectInfo();
-
-        var content = File.ReadAllText(full);
-        if (Path.GetExtension(full).Equals(".psd1", StringComparison.OrdinalIgnoreCase))
-        {
-            var moduleVersion = NormalizeEmpty(MatchPowerShellDataValue(content, "ModuleVersion"));
-            var prerelease = NormalizeEmpty(MatchPowerShellDataValue(content, "Prerelease"));
-            return new ProjectInfo
-            {
-                Name = Path.GetFileNameWithoutExtension(full),
-                PackageId = Path.GetFileNameWithoutExtension(full),
-                Version = CombineMsBuildVersion(moduleVersion, prerelease),
-                Description = NormalizeEmpty(MatchPowerShellDataValue(content, "Description")),
-                IsPowerShellModule = true
-            };
-        }
-
-        var assemblyName = NormalizeMsBuildMetadataValue(MatchValue(content, "AssemblyName"));
-        var rootNamespace = NormalizeMsBuildMetadataValue(MatchValue(content, "RootNamespace"));
-        var packageId = NormalizeMsBuildMetadataValue(MatchValue(content, "PackageId"));
-        var packageVersion = NormalizeMsBuildMetadataValue(MatchValue(content, "PackageVersion"));
-        var versionValue = NormalizeMsBuildMetadataValue(MatchValue(content, "Version"));
-        var versionPrefix = NormalizeMsBuildMetadataValue(MatchValue(content, "VersionPrefix"));
-        var versionSuffix = NormalizeMsBuildMetadataValue(MatchValue(content, "VersionSuffix"));
-        var version = packageVersion ??
-                      versionValue ??
-                      CombineMsBuildVersion(versionPrefix, versionSuffix);
-        var description = NormalizeMsBuildMetadataValue(MatchValue(content, "Description"));
-        var packAsTool = NormalizeMsBuildMetadataValue(MatchValue(content, "PackAsTool"));
-        var toolCommandName = NormalizeMsBuildMetadataValue(MatchValue(content, "ToolCommandName"));
-
-        return new ProjectInfo
-        {
-            Name = assemblyName ?? rootNamespace,
-            PackageId = packageId,
-            Version = version,
-            Description = description,
-            ToolCommandName = toolCommandName ?? assemblyName ?? rootNamespace ?? packageId,
-            IsDotNetTool = string.Equals(
-                packAsTool,
-                "true",
-                StringComparison.OrdinalIgnoreCase)
-        };
-    }
-
-    private static string? CombineMsBuildVersion(string? versionPrefix, string? versionSuffix)
-    {
-        if (string.IsNullOrWhiteSpace(versionPrefix))
-            return null;
-        if (string.IsNullOrWhiteSpace(versionSuffix))
-            return versionPrefix;
-
-        return $"{versionPrefix}-{versionSuffix.TrimStart('-')}";
-    }
-
-    private static string? NormalizeMsBuildMetadataValue(string value)
-    {
-        var normalized = NormalizeEmpty(value);
-        if (normalized is null)
-            return null;
-
-        return normalized.Contains("$(", StringComparison.Ordinal) ||
-               normalized.Contains("%(", StringComparison.Ordinal)
-            ? null
-            : normalized;
-    }
-
-    private static string MatchPowerShellDataValue(string content, string name)
-    {
-        var pattern = $@"(?im)(?:^|[;{{])\s*{Regex.Escape(name)}\s*=\s*['""](?<value>[^'""]+)['""]";
-        var match = Regex.Match(content, pattern, RegexOptions.CultureInvariant);
-        return match.Success ? match.Groups["value"].Value.Trim() : string.Empty;
     }
 
     private static string ResolveOverview(WebLlmsOptions options, ProjectInfo projectInfo, string siteRoot, string name)
@@ -325,18 +194,6 @@ public static class WebLlmsGenerator
     {
         var normalized = string.IsNullOrWhiteSpace(apiBase) ? "/api" : apiBase.Trim();
         return normalized.Length > 1 ? normalized.TrimEnd('/') : normalized;
-    }
-
-    private static string MatchValue(string content, string name)
-    {
-        var pattern = $@"<{name}>([^<]+)</{name}>";
-        var match = Regex.Match(content, pattern, RegexOptions.IgnoreCase);
-        return match.Success ? match.Groups[1].Value.Trim() : string.Empty;
-    }
-
-    private static string? NormalizeEmpty(string value)
-    {
-        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     private static bool TryReadOverviewFromHomepage(string siteRoot, out string overview)
@@ -886,27 +743,6 @@ public static class WebLlmsGenerator
         public string Name { get; set; } = string.Empty;
         public string Summary { get; set; } = string.Empty;
         public string Signature { get; set; } = string.Empty;
-    }
-
-    private sealed class PackageInfo
-    {
-        public string Id { get; set; } = string.Empty;
-        public string? Version { get; set; }
-        public string InstallCommand { get; set; } = string.Empty;
-        public bool IsPowerShellModule { get; set; }
-        public bool IsDotNetTool { get; set; }
-        public string? ToolCommandName { get; set; }
-    }
-
-    private sealed class ProjectInfo
-    {
-        public string? Name { get; set; }
-        public string? PackageId { get; set; }
-        public string? Version { get; set; }
-        public string? Description { get; set; }
-        public string? ToolCommandName { get; set; }
-        public bool IsPowerShellModule { get; set; }
-        public bool IsDotNetTool { get; set; }
     }
 
     private sealed class QuickstartInfo

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -74,10 +74,11 @@ public static class WebLlmsGenerator
         var llmsJsonPath = Path.Combine(siteRoot, "llms.json");
         var llmsFullPath = Path.Combine(siteRoot, "llms-full.txt");
 
+        var primaryPackage = packages.FirstOrDefault();
         var quickstart = ResolveQuickstart(
             options.QuickstartPath,
-            packages.FirstOrDefault()?.Id ?? name,
-            packages.Count == 0 && projectInfo.IsPowerShellModule);
+            primaryPackage?.Id ?? name,
+            primaryPackage?.IsPowerShellModule ?? projectInfo.IsPowerShellModule);
         var legacyInstallCommand = CreateInstallCommand(packageId, projectInfo.IsPowerShellModule, projectInfo.IsDotNetTool);
         var overview = ResolveOverview(options, projectInfo, siteRoot, name);
         WriteLlmsTxt(llmsTxtPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, overview, quickstart);
@@ -119,7 +120,8 @@ public static class WebLlmsGenerator
             {
                 Id = id,
                 Version = project.Version,
-                InstallCommand = CreateInstallCommand(id, project.IsPowerShellModule, project.IsDotNetTool)
+                InstallCommand = CreateInstallCommand(id, project.IsPowerShellModule, project.IsDotNetTool),
+                IsPowerShellModule = project.IsPowerShellModule
             });
         }
 
@@ -167,17 +169,37 @@ public static class WebLlmsGenerator
             };
         }
 
+        var assemblyName = NormalizeMsBuildMetadataValue(MatchValue(content, "AssemblyName"));
+        var rootNamespace = NormalizeMsBuildMetadataValue(MatchValue(content, "RootNamespace"));
+        var packageId = NormalizeMsBuildMetadataValue(MatchValue(content, "PackageId"));
+        var version = NormalizeMsBuildMetadataValue(MatchValue(content, "Version")) ??
+                      NormalizeMsBuildMetadataValue(MatchValue(content, "VersionPrefix"));
+        var description = NormalizeMsBuildMetadataValue(MatchValue(content, "Description"));
+        var packAsTool = NormalizeMsBuildMetadataValue(MatchValue(content, "PackAsTool"));
+
         return new ProjectInfo
         {
-            Name = NormalizeEmpty(MatchValue(content, "AssemblyName")) ?? NormalizeEmpty(MatchValue(content, "RootNamespace")),
-            PackageId = NormalizeEmpty(MatchValue(content, "PackageId")),
-            Version = NormalizeEmpty(MatchValue(content, "Version")) ?? NormalizeEmpty(MatchValue(content, "VersionPrefix")),
-            Description = NormalizeEmpty(MatchValue(content, "Description")),
+            Name = assemblyName ?? rootNamespace,
+            PackageId = packageId,
+            Version = version,
+            Description = description,
             IsDotNetTool = string.Equals(
-                NormalizeEmpty(MatchValue(content, "PackAsTool")),
+                packAsTool,
                 "true",
                 StringComparison.OrdinalIgnoreCase)
         };
+    }
+
+    private static string? NormalizeMsBuildMetadataValue(string value)
+    {
+        var normalized = NormalizeEmpty(value);
+        if (normalized is null)
+            return null;
+
+        return normalized.Contains("$(", StringComparison.Ordinal) ||
+               normalized.Contains("%(", StringComparison.Ordinal)
+            ? null
+            : normalized;
     }
 
     private static string MatchPowerShellDataValue(string content, string name)
@@ -445,6 +467,7 @@ public static class WebLlmsGenerator
         else
         {
             lines.Add($"- Packages: {packages.Count}");
+            lines.Add($"- Suite version: {version}");
         }
         if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
         if (apiCatalogs.Count > 1) lines.Add($"- API catalogs: {apiCatalogs.Count}");
@@ -482,13 +505,13 @@ public static class WebLlmsGenerator
         var payload = new Dictionary<string, object?>
         {
             ["name"] = name,
+            ["version"] = version,
             ["quickstart"] = quickstart.Lines.Where(l => l != null).ToArray(),
             ["quickstartLanguage"] = quickstart.Language,
             ["apiTypeCount"] = typeCount
         };
         if (packages.Count == 0)
         {
-            payload["version"] = version;
             payload["package"] = packageId;
             payload["install"] = new[] { legacyInstallCommand };
         }
@@ -544,6 +567,7 @@ public static class WebLlmsGenerator
         else
         {
             lines.Add($"- Packages: {packages.Count}");
+            lines.Add($"- Suite version: {version}");
         }
         if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
         if (apiCatalogs.Count > 1) lines.Add($"- API catalogs: {apiCatalogs.Count}");
@@ -808,6 +832,7 @@ public static class WebLlmsGenerator
         public string Id { get; set; } = string.Empty;
         public string? Version { get; set; }
         public string InstallCommand { get; set; } = string.Empty;
+        public bool IsPowerShellModule { get; set; }
     }
 
     private sealed class ProjectInfo

--- a/PowerForge.Web/Services/WebLlmsGenerator.cs
+++ b/PowerForge.Web/Services/WebLlmsGenerator.cs
@@ -12,6 +12,8 @@ public sealed class WebLlmsOptions
     public string SiteRoot { get; set; } = ".";
     /// <summary>Optional project file for metadata lookup.</summary>
     public string? ProjectFile { get; set; }
+    /// <summary>Optional project or module manifests used to describe every installable package in a suite.</summary>
+    public string[] PackageFiles { get; set; } = Array.Empty<string>();
     /// <summary>Optional API index path.</summary>
     public string? ApiIndexPath { get; set; }
     /// <summary>Optional API index paths for sites that publish more than one API catalog.</summary>
@@ -57,9 +59,11 @@ public static class WebLlmsGenerator
             throw new DirectoryNotFoundException($"Site root not found: {siteRoot}");
 
         var projectInfo = ReadProjectInfo(options.ProjectFile);
-        var name = options.Name ?? projectInfo.Name ?? options.PackageId ?? projectInfo.PackageId ?? Path.GetFileName(siteRoot);
+        var packages = ResolvePackages(options.PackageFiles);
+        var name = options.Name ?? projectInfo.Name ?? options.PackageId ?? projectInfo.PackageId ??
+                   packages.FirstOrDefault()?.Id ?? Path.GetFileName(siteRoot);
         var packageId = options.PackageId ?? projectInfo.PackageId ?? name;
-        var version = options.Version ?? projectInfo.Version ?? "unknown";
+        var version = options.Version ?? projectInfo.Version ?? ResolveSuiteVersion(packages) ?? "unknown";
 
         var apiCatalogs = ResolveApiCatalogs(options, siteRoot);
         int? typeCount = apiCatalogs.Any(catalog => catalog.TypeCount.HasValue)
@@ -70,11 +74,15 @@ public static class WebLlmsGenerator
         var llmsJsonPath = Path.Combine(siteRoot, "llms.json");
         var llmsFullPath = Path.Combine(siteRoot, "llms-full.txt");
 
-        var quickstart = ResolveQuickstart(options.QuickstartPath, name);
+        var quickstart = ResolveQuickstart(
+            options.QuickstartPath,
+            packages.FirstOrDefault()?.Id ?? name,
+            packages.Count == 0 && projectInfo.IsPowerShellModule);
+        var legacyInstallCommand = CreateInstallCommand(packageId, projectInfo.IsPowerShellModule, projectInfo.IsDotNetTool);
         var overview = ResolveOverview(options, projectInfo, siteRoot, name);
-        WriteLlmsTxt(llmsTxtPath, name, packageId, version, typeCount, apiCatalogs, overview, quickstart);
-        WriteLlmsJson(llmsJsonPath, name, packageId, version, typeCount, apiCatalogs, quickstart);
-        WriteLlmsFull(llmsFullPath, name, packageId, version, typeCount, apiCatalogs, overview, quickstart, options);
+        WriteLlmsTxt(llmsTxtPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, overview, quickstart);
+        WriteLlmsJson(llmsJsonPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, quickstart);
+        WriteLlmsFull(llmsFullPath, name, packageId, version, legacyInstallCommand, packages, typeCount, apiCatalogs, overview, quickstart, options);
 
         return new WebLlmsResult
         {
@@ -84,9 +92,57 @@ public static class WebLlmsGenerator
             Name = name,
             PackageId = packageId,
             Version = version,
+            PackageCount = packages.Count == 0 ? 1 : packages.Count,
             ApiTypeCount = typeCount,
             ApiCatalogCount = apiCatalogs.Count
         };
+    }
+
+    private static List<PackageInfo> ResolvePackages(IEnumerable<string>? packageFiles)
+    {
+        var packages = new List<PackageInfo>();
+        foreach (var packageFile in packageFiles ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(packageFile))
+                continue;
+
+            var fullPath = Path.GetFullPath(packageFile);
+            if (!File.Exists(fullPath))
+                throw new FileNotFoundException($"Configured package manifest not found: {fullPath}", fullPath);
+
+            var project = ReadProjectInfo(fullPath);
+            var id = project.PackageId ?? project.Name ?? Path.GetFileNameWithoutExtension(fullPath);
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            packages.Add(new PackageInfo
+            {
+                Id = id,
+                Version = project.Version,
+                InstallCommand = CreateInstallCommand(id, project.IsPowerShellModule, project.IsDotNetTool)
+            });
+        }
+
+        return packages
+            .GroupBy(static package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToList();
+    }
+
+    private static string? ResolveSuiteVersion(IReadOnlyList<PackageInfo> packages)
+    {
+        if (packages.Count == 0)
+            return null;
+
+        var versions = packages
+            .Select(static package => package.Version)
+            .Where(static version => !string.IsNullOrWhiteSpace(version))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (packages.Any(static package => string.IsNullOrWhiteSpace(package.Version)))
+            return "unknown";
+
+        return versions.Length == 1 ? versions[0] : "varies by package";
     }
 
     private static ProjectInfo ReadProjectInfo(string? projectFile)
@@ -99,13 +155,36 @@ public static class WebLlmsGenerator
             return new ProjectInfo();
 
         var content = File.ReadAllText(full);
+        if (Path.GetExtension(full).Equals(".psd1", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ProjectInfo
+            {
+                Name = Path.GetFileNameWithoutExtension(full),
+                PackageId = Path.GetFileNameWithoutExtension(full),
+                Version = NormalizeEmpty(MatchPowerShellDataValue(content, "ModuleVersion")),
+                Description = NormalizeEmpty(MatchPowerShellDataValue(content, "Description")),
+                IsPowerShellModule = true
+            };
+        }
+
         return new ProjectInfo
         {
             Name = NormalizeEmpty(MatchValue(content, "AssemblyName")) ?? NormalizeEmpty(MatchValue(content, "RootNamespace")),
             PackageId = NormalizeEmpty(MatchValue(content, "PackageId")),
             Version = NormalizeEmpty(MatchValue(content, "Version")) ?? NormalizeEmpty(MatchValue(content, "VersionPrefix")),
-            Description = NormalizeEmpty(MatchValue(content, "Description"))
+            Description = NormalizeEmpty(MatchValue(content, "Description")),
+            IsDotNetTool = string.Equals(
+                NormalizeEmpty(MatchValue(content, "PackAsTool")),
+                "true",
+                StringComparison.OrdinalIgnoreCase)
         };
+    }
+
+    private static string MatchPowerShellDataValue(string content, string name)
+    {
+        var pattern = $@"(?im)^\s*{Regex.Escape(name)}\s*=\s*['""](?<value>[^'""]+)['""]";
+        var match = Regex.Match(content, pattern, RegexOptions.CultureInvariant);
+        return match.Success ? match.Groups["value"].Value.Trim() : string.Empty;
     }
 
     private static string ResolveOverview(WebLlmsOptions options, ProjectInfo projectInfo, string siteRoot, string name)
@@ -288,7 +367,7 @@ public static class WebLlmsGenerator
         return Regex.Replace(decoded, @"\s+", " ").Trim();
     }
 
-    private static string[] ResolveQuickstart(string? quickstartPath, string name)
+    private static QuickstartInfo ResolveQuickstart(string? quickstartPath, string name, bool isPowerShellModule)
     {
         if (!string.IsNullOrWhiteSpace(quickstartPath))
         {
@@ -296,27 +375,59 @@ public static class WebLlmsGenerator
             if (File.Exists(full))
             {
                 var text = File.ReadAllText(full).TrimEnd();
-                return text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+                return new QuickstartInfo
+                {
+                    Language = Path.GetExtension(full).Equals(".ps1", StringComparison.OrdinalIgnoreCase)
+                        ? "powershell"
+                        : "csharp",
+                    Lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)
+                };
             }
         }
 
-        return new[]
+        if (isPowerShellModule)
         {
-            $"using {name};",
-            string.Empty,
-            "// TODO: add quickstart snippet"
+            return new QuickstartInfo
+            {
+                Language = "powershell",
+                Lines =
+                [
+                    $"Import-Module {name}",
+                    $"Get-Command -Module {name}"
+                ]
+            };
+        }
+
+        return new QuickstartInfo
+        {
+            Language = "csharp",
+            Lines =
+            [
+                $"using {name};",
+                string.Empty,
+                "// TODO: add quickstart snippet"
+            ]
         };
     }
+
+    private static string CreateInstallCommand(string packageId, bool isPowerShellModule, bool isDotNetTool)
+        => isPowerShellModule
+            ? $"Install-Module {packageId}"
+            : isDotNetTool
+                ? $"dotnet tool install --global {packageId}"
+                : $"dotnet add package {packageId}";
 
     private static void WriteLlmsTxt(
         string path,
         string name,
         string packageId,
         string version,
+        string legacyInstallCommand,
+        IReadOnlyList<PackageInfo> packages,
         int? typeCount,
         IReadOnlyList<ApiCatalogInfo> apiCatalogs,
         string overview,
-        string[] quickstart)
+        QuickstartInfo quickstart)
     {
         var lines = new List<string>
         {
@@ -324,19 +435,29 @@ public static class WebLlmsGenerator
             string.Empty,
             $"> {overview}",
             string.Empty,
-            "## Metadata",
-            $"- Version: {version}",
-            $"- Package: {packageId}"
+            "## Metadata"
         };
+        if (packages.Count == 0)
+        {
+            lines.Add($"- Version: {version}");
+            lines.Add($"- Package: {packageId}");
+        }
+        else
+        {
+            lines.Add($"- Packages: {packages.Count}");
+        }
         if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
         if (apiCatalogs.Count > 1) lines.Add($"- API catalogs: {apiCatalogs.Count}");
         lines.Add(string.Empty);
         lines.Add("## Install");
-        lines.Add($"- dotnet add package {packageId}");
+        if (packages.Count == 0)
+            lines.Add($"- {FormatInlineCode(legacyInstallCommand)}");
+        else
+            AppendPackageInstallMarkdown(lines, packages);
         lines.Add(string.Empty);
         lines.Add("## Quickstart");
-        lines.Add("```csharp");
-        lines.AddRange(quickstart);
+        lines.Add($"```{quickstart.Language}");
+        lines.AddRange(quickstart.Lines);
         lines.Add("```");
         lines.Add(string.Empty);
         lines.Add("## Machine-friendly API data");
@@ -352,19 +473,35 @@ public static class WebLlmsGenerator
         string name,
         string packageId,
         string version,
+        string legacyInstallCommand,
+        IReadOnlyList<PackageInfo> packages,
         int? typeCount,
         IReadOnlyList<ApiCatalogInfo> apiCatalogs,
-        string[] quickstart)
+        QuickstartInfo quickstart)
     {
         var payload = new Dictionary<string, object?>
         {
             ["name"] = name,
-            ["version"] = version,
-            ["package"] = packageId,
-            ["install"] = new[] { $"dotnet add package {packageId}" },
-            ["quickstart"] = quickstart.Where(l => l != null).ToArray(),
+            ["quickstart"] = quickstart.Lines.Where(l => l != null).ToArray(),
+            ["quickstartLanguage"] = quickstart.Language,
             ["apiTypeCount"] = typeCount
         };
+        if (packages.Count == 0)
+        {
+            payload["version"] = version;
+            payload["package"] = packageId;
+            payload["install"] = new[] { legacyInstallCommand };
+        }
+        else
+        {
+            payload["packages"] = packages.Select(static package => new Dictionary<string, object?>
+            {
+                ["id"] = package.Id,
+                ["version"] = package.Version,
+                ["install"] = package.InstallCommand
+            }).ToArray();
+            payload["install"] = packages.Select(static package => package.InstallCommand).ToArray();
+        }
         if (apiCatalogs.Count == 1)
             payload["api"] = CreateApiResourcePayload(apiCatalogs[0]);
         else
@@ -384,10 +521,12 @@ public static class WebLlmsGenerator
         string name,
         string packageId,
         string version,
+        string legacyInstallCommand,
+        IReadOnlyList<PackageInfo> packages,
         int? typeCount,
         IReadOnlyList<ApiCatalogInfo> apiCatalogs,
         string overview,
-        string[] quickstart,
+        QuickstartInfo quickstart,
         WebLlmsOptions options)
     {
         var lines = new List<string>
@@ -395,10 +534,17 @@ public static class WebLlmsGenerator
             $"# {name} - Complete AI Context",
             string.Empty,
             "## Overview",
-            overview,
-            $"- Package: {packageId}",
-            $"- Version: {version}"
+            overview
         };
+        if (packages.Count == 0)
+        {
+            lines.Add($"- Package: {packageId}");
+            lines.Add($"- Version: {version}");
+        }
+        else
+        {
+            lines.Add($"- Packages: {packages.Count}");
+        }
         if (typeCount.HasValue) lines.Add($"- API types: {typeCount.Value}");
         if (apiCatalogs.Count > 1) lines.Add($"- API catalogs: {apiCatalogs.Count}");
         if (!string.IsNullOrWhiteSpace(options.License)) lines.Add($"- License: {options.License}");
@@ -406,13 +552,20 @@ public static class WebLlmsGenerator
 
         lines.Add(string.Empty);
         lines.Add("## Installation");
-        lines.Add("```");
-        lines.Add($"dotnet add package {packageId}");
-        lines.Add("```");
+        if (packages.Count == 0)
+        {
+            lines.Add("```");
+            lines.Add(legacyInstallCommand);
+            lines.Add("```");
+        }
+        else
+        {
+            AppendPackageInstallMarkdown(lines, packages);
+        }
         lines.Add(string.Empty);
         lines.Add("## Quickstart");
-        lines.Add("```csharp");
-        lines.AddRange(quickstart);
+        lines.Add($"```{quickstart.Language}");
+        lines.AddRange(quickstart.Lines);
         lines.Add("```");
         lines.Add(string.Empty);
         lines.Add("## API Resources");
@@ -432,6 +585,20 @@ public static class WebLlmsGenerator
 
         File.WriteAllText(path, string.Join(Environment.NewLine, lines), Encoding.UTF8);
     }
+
+    private static void AppendPackageInstallMarkdown(List<string> lines, IReadOnlyList<PackageInfo> packages)
+    {
+        foreach (var package in packages)
+        {
+            var version = string.IsNullOrWhiteSpace(package.Version)
+                ? string.Empty
+                : $" — source version `{package.Version}`";
+            lines.Add($"- {FormatInlineCode(package.InstallCommand)}{version}");
+        }
+    }
+
+    private static string FormatInlineCode(string value)
+        => $"`{value.Replace("`", "\\`", StringComparison.Ordinal)}`";
 
     private static void AppendApiResourceLinks(List<string> lines, IReadOnlyList<ApiCatalogInfo> apiCatalogs)
     {
@@ -636,11 +803,26 @@ public static class WebLlmsGenerator
         public string Signature { get; set; } = string.Empty;
     }
 
+    private sealed class PackageInfo
+    {
+        public string Id { get; set; } = string.Empty;
+        public string? Version { get; set; }
+        public string InstallCommand { get; set; } = string.Empty;
+    }
+
     private sealed class ProjectInfo
     {
         public string? Name { get; set; }
         public string? PackageId { get; set; }
         public string? Version { get; set; }
         public string? Description { get; set; }
+        public bool IsPowerShellModule { get; set; }
+        public bool IsDotNetTool { get; set; }
+    }
+
+    private sealed class QuickstartInfo
+    {
+        public string Language { get; set; } = "csharp";
+        public string[] Lines { get; set; } = Array.Empty<string>();
     }
 }

--- a/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
+++ b/PowerForge.Web/Services/WebSiteAuditor.Helpers.cs
@@ -693,24 +693,6 @@ public static partial class WebSiteAuditor
         return $"{uri.Scheme.ToLowerInvariant()}://{uri.Host.ToLowerInvariant()}{path}";
     }
 
-    private static string[] BuildRouteCandidatesForSeoChecks(string relativePath, string routePath, AngleSharp.Dom.IDocument doc)
-    {
-        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        AddGeneratedPageRouteCandidates(candidates, relativePath, routePath);
-
-        if (doc.Head is not null)
-        {
-            var canonicalHref = doc.Head.QuerySelectorAll("link[rel][href]")
-                .Where(link => ContainsRelToken(link.GetAttribute("rel"), "canonical"))
-                .Select(link => (link.GetAttribute("href") ?? string.Empty).Trim())
-                .FirstOrDefault(href => !string.IsNullOrWhiteSpace(href));
-            if (!string.IsNullOrWhiteSpace(canonicalHref))
-                AddRouteCandidates(candidates, canonicalHref);
-        }
-
-        return candidates.ToArray();
-    }
-
     private static string[] BuildGeneratedPageRouteCandidates(string relativePath, string routePath)
     {
         var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -854,7 +836,7 @@ public static partial class WebSiteAuditor
             if (!HasNoIndexRobots(doc, html))
                 continue;
 
-            foreach (var candidate in BuildRouteCandidatesForSeoChecks(relativePath, routePath, doc))
+            foreach (var candidate in BuildGeneratedPageRouteCandidates(relativePath, routePath))
             {
                 if (!string.IsNullOrWhiteSpace(candidate))
                     noIndexRoutes.Add(candidate);

--- a/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
@@ -541,6 +541,10 @@ public static partial class WebSiteBuilder
 
                 var taxRoute = BuildRoute(taxonomy.BasePath, string.Empty, spec.TrailingSlash);
                 taxRoute = ApplyLanguagePrefixToRoute(spec, taxRoute, language);
+                var taxonomyPageCount = languageTerms.Values
+                    .SelectMany(static termItems => termItems)
+                    .Distinct()
+                    .Count();
                 results.Add(new ContentItem
                 {
                     Collection = taxonomy.Name,
@@ -548,7 +552,11 @@ public static partial class WebSiteBuilder
                     Language = language,
                     TranslationKey = $"taxonomy:{taxonomy.Name}",
                     Title = HumanizeSegment(taxonomy.Name),
-                    Description = string.Empty,
+                    Description = BuildTaxonomyIndexDescription(
+                        spec,
+                        taxonomy.Name,
+                        languageTerms.Count,
+                        taxonomyPageCount),
                     LastModifiedUtc = MaxLastModifiedUtc(languageTerms
                         .SelectMany(static term => term.Value)
                         .Select(static item => item.LastModifiedUtc)),
@@ -566,6 +574,7 @@ public static partial class WebSiteBuilder
                     var slug = Slugify(term);
                     var termRoute = BuildRoute(taxonomy.BasePath, slug, spec.TrailingSlash);
                     termRoute = ApplyLanguagePrefixToRoute(spec, termRoute, language);
+                    var taxonomyTermPageCount = languageTerms[term].Distinct().Count();
                     results.Add(new ContentItem
                     {
                         Collection = taxonomy.Name,
@@ -573,7 +582,11 @@ public static partial class WebSiteBuilder
                         Language = language,
                         TranslationKey = $"taxonomy:{taxonomy.Name}:term:{slug}",
                         Title = term,
-                        Description = string.Empty,
+                        Description = BuildTaxonomyTermDescription(
+                            spec,
+                            taxonomy.Name,
+                            term,
+                            taxonomyTermPageCount),
                         LastModifiedUtc = MaxLastModifiedUtc(languageTerms[term]
                             .Select(static item => item.LastModifiedUtc)),
                         Kind = PageKind.Term,

--- a/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
@@ -541,10 +541,10 @@ public static partial class WebSiteBuilder
 
                 var taxRoute = BuildRoute(taxonomy.BasePath, string.Empty, spec.TrailingSlash);
                 taxRoute = ApplyLanguagePrefixToRoute(spec, taxRoute, language);
-                var taxonomyPageCount = languageTerms.Values
+                var taxonomyItems = languageTerms.Values
                     .SelectMany(static termItems => termItems)
                     .Distinct()
-                    .Count();
+                    .ToArray();
                 results.Add(new ContentItem
                 {
                     Collection = taxonomy.Name,
@@ -555,8 +555,10 @@ public static partial class WebSiteBuilder
                     Description = BuildTaxonomyIndexDescription(
                         spec,
                         taxonomy.Name,
+                        language,
                         languageTerms.Count,
-                        taxonomyPageCount),
+                        taxonomyItems.Length,
+                        taxonomyItems),
                     LastModifiedUtc = MaxLastModifiedUtc(languageTerms
                         .SelectMany(static term => term.Value)
                         .Select(static item => item.LastModifiedUtc)),
@@ -574,7 +576,7 @@ public static partial class WebSiteBuilder
                     var slug = Slugify(term);
                     var termRoute = BuildRoute(taxonomy.BasePath, slug, spec.TrailingSlash);
                     termRoute = ApplyLanguagePrefixToRoute(spec, termRoute, language);
-                    var taxonomyTermPageCount = languageTerms[term].Distinct().Count();
+                    var taxonomyTermItems = languageTerms[term].Distinct().ToArray();
                     results.Add(new ContentItem
                     {
                         Collection = taxonomy.Name,
@@ -586,7 +588,9 @@ public static partial class WebSiteBuilder
                             spec,
                             taxonomy.Name,
                             term,
-                            taxonomyTermPageCount),
+                            language,
+                            taxonomyTermItems.Length,
+                            taxonomyTermItems),
                         LastModifiedUtc = MaxLastModifiedUtc(languageTerms[term]
                             .Select(static item => item.LastModifiedUtc)),
                         Kind = PageKind.Term,

--- a/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.ContentDiscovery.cs
@@ -1240,6 +1240,7 @@ public static partial class WebSiteBuilder
             process.StartInfo.ArgumentList.Add("core.quotePath=false");
             process.StartInfo.ArgumentList.Add("log");
             process.StartInfo.ArgumentList.Add("--format=@@POWERFORGE_DATE@@%aI");
+            process.StartInfo.ArgumentList.Add("--relative");
             process.StartInfo.ArgumentList.Add("--name-only");
             process.StartInfo.ArgumentList.Add("--diff-filter=AMR");
             process.StartInfo.ArgumentList.Add("--");

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -1,0 +1,47 @@
+namespace PowerForge.Web;
+
+public static partial class WebSiteBuilder
+{
+    private static string BuildTaxonomyIndexDescription(
+        SiteSpec spec,
+        string taxonomyName,
+        int termCount,
+        int pageCount)
+    {
+        var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
+        var taxonomyTitle = HumanizeSegment(taxonomyName);
+        var topics = termCount == 1 ? "topic" : "topics";
+        var pages = pageCount == 1 ? "page" : "pages";
+        return FitTaxonomyDescription(
+            $"Browse {siteName} content by {taxonomyTitle}, with {termCount} {topics} across {pageCount} published {pages}, including guides, articles, examples, and reference material.");
+    }
+
+    private static string BuildTaxonomyTermDescription(
+        SiteSpec spec,
+        string taxonomyName,
+        string term,
+        int pageCount)
+    {
+        var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
+        var pages = pageCount == 1 ? "page" : "pages";
+        var relationship = taxonomyName.Equals("categories", StringComparison.OrdinalIgnoreCase)
+            ? $"in the {term} category"
+            : $"tagged {term}";
+
+        return FitTaxonomyDescription(
+            $"Explore {pageCount} {siteName} {pages} {relationship}, with related guides, articles, examples, workflow notes, and reference material collected in one place.");
+    }
+
+    private static string FitTaxonomyDescription(string description)
+    {
+        const int maximumLength = 160;
+        if (description.Length <= maximumLength)
+            return description;
+
+        var wordBoundary = description.LastIndexOf(' ', maximumLength - 1);
+        if (wordBoundary < 120)
+            wordBoundary = maximumLength - 1;
+
+        return description[..wordBoundary].TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?') + ".";
+    }
+}

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -5,23 +5,33 @@ public static partial class WebSiteBuilder
     private static string BuildTaxonomyIndexDescription(
         SiteSpec spec,
         string taxonomyName,
+        string language,
         int termCount,
-        int pageCount)
+        int pageCount,
+        IReadOnlyList<ContentItem> items)
     {
+        if (!IsEnglishTaxonomyLanguage(language))
+            return BuildLocalizedTaxonomyDescription(items);
+
         var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
         var taxonomyTitle = HumanizeSegment(taxonomyName);
-        var topics = termCount == 1 ? "topic" : "topics";
+        var terms = termCount == 1 ? "term" : "terms";
         var pages = pageCount == 1 ? "page" : "pages";
         return FitTaxonomyDescription(
-            $"Browse {siteName} content by {taxonomyTitle}, with {termCount} {topics} across {pageCount} published {pages}, including guides, articles, examples, and reference material.");
+            $"Browse {pageCount} published {siteName} {pages} through {termCount} {taxonomyTitle} {terms}, with each term linking to its matching content on the site.");
     }
 
     private static string BuildTaxonomyTermDescription(
         SiteSpec spec,
         string taxonomyName,
         string term,
-        int pageCount)
+        string language,
+        int pageCount,
+        IReadOnlyList<ContentItem> items)
     {
+        if (!IsEnglishTaxonomyLanguage(language))
+            return BuildLocalizedTaxonomyDescription(items);
+
         var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
         var pages = pageCount == 1 ? "page" : "pages";
         var taxonomyTitle = HumanizeSegment(taxonomyName);
@@ -32,7 +42,37 @@ public static partial class WebSiteBuilder
                 : $"filed under {term} in the {taxonomyTitle} taxonomy";
 
         return FitTaxonomyDescription(
-            $"Explore {pageCount} {siteName} {pages} {relationship}, with related guides, articles, examples, workflow notes, and reference material collected in one place.");
+            $"Explore {pageCount} published {siteName} {pages} {relationship}. This taxonomy page collects the matching content and links to each available page in one place.");
+    }
+
+    private static bool IsEnglishTaxonomyLanguage(string? language)
+    {
+        if (string.IsNullOrWhiteSpace(language))
+            return true;
+
+        var normalized = language.Trim();
+        var separator = normalized.IndexOfAny(['-', '_']);
+        if (separator >= 0)
+            normalized = normalized[..separator];
+        return normalized.Equals("en", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BuildLocalizedTaxonomyDescription(IReadOnlyList<ContentItem> items)
+    {
+        var fragments = items
+            .Select(static item =>
+            {
+                var title = item.Title?.Trim() ?? string.Empty;
+                var description = item.Description?.Trim() ?? string.Empty;
+                if (description.Length == 0)
+                    return title;
+                return title.Length == 0 ? description : $"{title}: {description}";
+            })
+            .Where(static value => value.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return FitTaxonomyDescription(string.Join(". ", fragments));
     }
 
     private static string FitTaxonomyDescription(string description)

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -66,9 +66,10 @@ public static partial class WebSiteBuilder
             {
                 var title = item.Title?.Trim() ?? string.Empty;
                 var description = item.Description?.Trim() ?? string.Empty;
-                if (description.Length == 0)
-                    return title;
-                return title.Length == 0 ? description : $"{title}: {description}";
+                var body = BuildSnippet(item.HtmlContent, 220);
+                return string.Join(". ", new[] { title, description, body }
+                    .Where(static value => value.Length > 0)
+                    .Distinct(StringComparer.Ordinal));
             })
             .Where(static value => value.Length > 0)
             .Distinct(StringComparer.Ordinal)

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -18,7 +18,8 @@ public static partial class WebSiteBuilder
         var terms = termCount == 1 ? "term" : "terms";
         var pages = pageCount == 1 ? "page" : "pages";
         return FitTaxonomyDescription(
-            $"Browse {pageCount} published {siteName} {pages} through {termCount} {taxonomyTitle} {terms}, with each term linking to its matching content on the site.");
+            $"Browse {pageCount} published {siteName} {pages} through {termCount} {taxonomyTitle} {terms}, with each term linking to its matching content on the site.",
+            ensureEnglishMinimum: true);
     }
 
     private static string BuildTaxonomyTermDescription(
@@ -42,7 +43,8 @@ public static partial class WebSiteBuilder
                 : $"filed under {term} in the {taxonomyTitle} taxonomy";
 
         return FitTaxonomyDescription(
-            $"Explore {pageCount} published {siteName} {pages} {relationship}. This taxonomy page collects the matching content and links to each available page in one place.");
+            $"Explore {pageCount} published {siteName} {pages} {relationship}. This taxonomy page collects the matching content and links to each available page in one place.",
+            ensureEnglishMinimum: true);
     }
 
     private static bool IsEnglishTaxonomyLanguage(string? language)
@@ -72,17 +74,21 @@ public static partial class WebSiteBuilder
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        return FitTaxonomyDescription(string.Join(". ", fragments));
+        return FitTaxonomyDescription(string.Join(". ", fragments), ensureEnglishMinimum: false);
     }
 
-    private static string FitTaxonomyDescription(string description)
+    private static string FitTaxonomyDescription(string description, bool ensureEnglishMinimum)
     {
+        const int minimumLength = 120;
         const int maximumLength = 160;
+        if (ensureEnglishMinimum && description.Length < minimumLength)
+            description = $"{description.TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?')}. Browse the grouped results and open any matching page from this index.";
+
         if (description.Length <= maximumLength)
             return description;
 
         var wordBoundary = description.LastIndexOf(' ', maximumLength - 1);
-        if (wordBoundary < 120)
+        if (wordBoundary < minimumLength)
             wordBoundary = maximumLength - 1;
 
         return description[..wordBoundary].TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?') + ".";

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -24,9 +24,12 @@ public static partial class WebSiteBuilder
     {
         var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
         var pages = pageCount == 1 ? "page" : "pages";
+        var taxonomyTitle = HumanizeSegment(taxonomyName);
         var relationship = taxonomyName.Equals("categories", StringComparison.OrdinalIgnoreCase)
             ? $"in the {term} category"
-            : $"tagged {term}";
+            : taxonomyName.Equals("tags", StringComparison.OrdinalIgnoreCase)
+                ? $"tagged {term}"
+                : $"filed under {term} in the {taxonomyTitle} taxonomy";
 
         return FitTaxonomyDescription(
             $"Explore {pageCount} {siteName} {pages} {relationship}, with related guides, articles, examples, workflow notes, and reference material collected in one place.");

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -43,7 +43,7 @@ public static partial class WebSiteBuilder
                 : $"filed under {term} in the {taxonomyTitle} taxonomy";
 
         return FitTaxonomyDescription(
-            $"Explore {pageCount} published {siteName} {pages} {relationship}. This taxonomy page collects the matching content and links to each available page in one place.",
+            $"Explore {pageCount} published {siteName} {pages} {relationship}. This taxonomy page groups the matching content across the available result set.",
             ensureEnglishMinimum: true);
     }
 
@@ -90,8 +90,22 @@ public static partial class WebSiteBuilder
 
         var wordBoundary = description.LastIndexOf(' ', maximumLength - 1);
         if (wordBoundary < minimumLength)
-            wordBoundary = maximumLength - 1;
+            wordBoundary = ClampTaxonomyDescriptionToUnicodeScalarBoundary(description, maximumLength - 1);
 
         return description[..wordBoundary].TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?') + ".";
+    }
+
+    private static int ClampTaxonomyDescriptionToUnicodeScalarBoundary(string value, int boundary)
+    {
+        var safeBoundary = Math.Clamp(boundary, 0, value.Length);
+        if (safeBoundary > 0 &&
+            safeBoundary < value.Length &&
+            char.IsHighSurrogate(value[safeBoundary - 1]) &&
+            char.IsLowSurrogate(value[safeBoundary]))
+        {
+            safeBoundary--;
+        }
+
+        return safeBoundary;
     }
 }

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -150,9 +150,26 @@ public static partial class WebSiteBuilder
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        return details.Length == 0
+        var completed = details.Length == 0
             ? description
             : $"{description.TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?')}. {string.Join(" · ", details)}";
+        if (completed.Length >= minimumLength)
+            return completed;
+
+        // Extremely sparse source pages may not expose 120 unique characters. Reuse
+        // only their own locale-neutral context rather than inventing capabilities or
+        // English prose, and let the normal fitter trim the result at a word boundary.
+        var completionFragments = details
+            .Append(description)
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .ToArray();
+        for (var index = 0; completed.Length < minimumLength; index++)
+        {
+            var fragment = completionFragments[index % completionFragments.Length];
+            completed = $"{completed.TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?')}. {fragment}";
+        }
+
+        return completed;
     }
 
     private static string FitTaxonomyDescription(string description, bool ensureEnglishMinimum)

--- a/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.TaxonomySeo.cs
@@ -11,7 +11,14 @@ public static partial class WebSiteBuilder
         IReadOnlyList<ContentItem> items)
     {
         if (!IsEnglishTaxonomyLanguage(language))
-            return BuildLocalizedTaxonomyDescription(items);
+            return BuildLocalizedTaxonomyDescription(
+                spec,
+                taxonomyName,
+                null,
+                language,
+                termCount,
+                pageCount,
+                items);
 
         var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
         var taxonomyTitle = HumanizeSegment(taxonomyName);
@@ -31,7 +38,14 @@ public static partial class WebSiteBuilder
         IReadOnlyList<ContentItem> items)
     {
         if (!IsEnglishTaxonomyLanguage(language))
-            return BuildLocalizedTaxonomyDescription(items);
+            return BuildLocalizedTaxonomyDescription(
+                spec,
+                taxonomyName,
+                term,
+                language,
+                null,
+                pageCount,
+                items);
 
         var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
         var pages = pageCount == 1 ? "page" : "pages";
@@ -59,8 +73,20 @@ public static partial class WebSiteBuilder
         return normalized.Equals("en", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string BuildLocalizedTaxonomyDescription(IReadOnlyList<ContentItem> items)
+    private static string BuildLocalizedTaxonomyDescription(
+        SiteSpec spec,
+        string taxonomyName,
+        string? term,
+        string language,
+        int? termCount,
+        int pageCount,
+        IReadOnlyList<ContentItem> items)
     {
+        var siteName = string.IsNullOrWhiteSpace(spec.Name) ? "Site" : spec.Name.Trim();
+        var taxonomyTitle = HumanizeSegment(taxonomyName);
+        var scope = string.IsNullOrWhiteSpace(term)
+            ? $"{taxonomyTitle} — {siteName}"
+            : $"{term.Trim()} — {siteName}";
         var fragments = items
             .Select(static item =>
             {
@@ -75,7 +101,58 @@ public static partial class WebSiteBuilder
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        return FitTaxonomyDescription(string.Join(". ", fragments), ensureEnglishMinimum: false);
+        var description = string.Join(". ", new[] { scope, string.Join(". ", fragments) }
+            .Where(static value => value.Length > 0));
+        description = EnsureLocalizedTaxonomyMinimum(
+            description,
+            spec,
+            language,
+            termCount,
+            pageCount,
+            items);
+
+        return FitTaxonomyDescription(
+            description,
+            ensureEnglishMinimum: false);
+    }
+
+    private static string EnsureLocalizedTaxonomyMinimum(
+        string description,
+        SiteSpec spec,
+        string language,
+        int? termCount,
+        int pageCount,
+        IReadOnlyList<ContentItem> items)
+    {
+        const int minimumLength = 120;
+        if (description.Length >= minimumLength)
+            return description;
+
+        // Keep the fallback language-neutral and source-derived rather than inventing
+        // translated prose. Route and taxonomy facts are only added for sparse pages.
+        var details = new[]
+            {
+                language.Trim(),
+                termCount?.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                pageCount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                spec.BaseUrl?.Trim()
+            }
+            .Concat(items.SelectMany(static item => new[]
+            {
+                item.Collection?.Trim(),
+                item.Slug?.Trim(),
+                item.OutputPath?.Trim(),
+                item.Date?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
+                string.Join(", ", item.Tags ?? Array.Empty<string>()),
+                string.Join(", ", item.Categories ?? Array.Empty<string>())
+            }))
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return details.Length == 0
+            ? description
+            : $"{description.TrimEnd(' ', ',', ';', ':', '-', '.', '!', '?')}. {string.Join(" · ", details)}";
     }
 
     private static string FitTaxonomyDescription(string description, bool ensureEnglishMinimum)

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -3453,6 +3453,8 @@
         "name": { "type": "string" },
         "package": { "type": "string" },
         "packageId": { "type": "string" },
+        "packageFiles": { "type": "array", "items": { "type": "string" } },
+        "package-files": { "type": "array", "items": { "type": "string" } },
         "version": { "type": "string" },
         "quickstart": { "type": "string" },
         "discovery": { "type": "string" },

--- a/Schemas/powerforge.web.pipelinespec.schema.json
+++ b/Schemas/powerforge.web.pipelinespec.schema.json
@@ -3455,6 +3455,7 @@
         "packageId": { "type": "string" },
         "version": { "type": "string" },
         "quickstart": { "type": "string" },
+        "discovery": { "type": "string" },
         "overview": { "type": "string" },
         "license": { "type": "string" },
         "targets": { "type": "string" },


### PR DESCRIPTION
## What changed

- generate page-specific search descriptions for API indexes, types, cmdlets, suite portals, and taxonomy pages
- keep localized taxonomy descriptions source-language, page-specific, and within the intended search-snippet range even for pathologically sparse content
- generate multi-package llms.txt, llms.json, and llms-full.txt for .NET suites and PowerShell modules
- derive suite versions from package manifests, preserve explicit overrides, and keep unknown/mixed-version semantics accurate
- add a curated discovery Markdown input shared by llms.txt and llms-full.txt
- emit correct NuGet, .NET tool, and PowerShell installation guidance
- derive sitemap source dates correctly when a website lives below the repository root
- track configured package manifests in pipeline fingerprints and accept both packageFiles aliases in the schema
- parse active PowerShell manifest metadata without treating commented assignments as package facts
- fail clearly for missing configured package manifests and report accurate package counts
- keep the LLMS generator maintainable through a semantic package-metadata partial

## Why

Generated API metadata, AI discovery files, and sitemap freshness belong in PowerForge. Keeping those rules in the shared generator prevents per-site copies and lets OfficeIMO and future sites publish verifiable discovery metadata from one owner.

## Validation

- 40 focused taxonomy-SEO, sitemap-freshness, LLMS-generation, schema, fingerprint, manifest-comment, sparse-localization, API-fallback, and prerelease tests pass
- PowerForge.Web.Cli builds successfully on .NET 10
- the generator split is 753 and 261 lines
- the full local suite passed 5,214 of 5,216 tests; the transient async lifecycle test passed on targeted rerun, while the remaining Windows CRLF failure is an unchanged macOS-script expectation
- OfficeIMO's complete 3,774-page pipeline passed against exact PowerForge head `99aed49fecbe9a6b9b3eeee4951d5cd57a9bb64e`, producing 3,773 sitemap URLs, 199 lastmod values, zero SEO errors/new issues, and a clean link/asset audit