### PR TITLE
Harden website discovery and breadcrumb SEO

### DIFF
--- a/PowerForge.Tests/WebAgentReadinessTests.cs
+++ b/PowerForge.Tests/WebAgentReadinessTests.cs
@@ -64,6 +64,9 @@ public class WebAgentReadinessTests
             });
 
             Assert.True(result.Success, string.Join(Environment.NewLine, result.Checks.Select(check => $"{check.Status}: {check.Id} - {check.Message}")));
+            var breadcrumbCheck = result.Checks.Single(check => check.Id == "breadcrumb-list");
+            Assert.Equal("info", breadcrumbCheck.Status);
+            Assert.Contains("optional on a homepage", breadcrumbCheck.Message, StringComparison.OrdinalIgnoreCase);
             Assert.True(File.Exists(Path.Combine(root, "robots.txt")));
             Assert.True(File.Exists(Path.Combine(root, ".well-known", "custom-api-catalog")));
             Assert.True(File.Exists(Path.Combine(root, ".well-known", "agent-skills", "index.json")));

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -96,6 +96,37 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_RequiresEveryDeclaredHomeAssistantRedirectWithinFirstTenKilobytes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-all-targets-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var padding = new string('x', (10 * 1024) + 128);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                $"""
+                <!doctype html><html><head>
+                  <link rel="redirect_uri" href="com.example.first://home-assistant/auth-callback" />
+                  <!-- {padding} -->
+                  <link rel="redirect_uri" href="com.example.second://home-assistant/auth-callback" />
+                  <title>Home Assistant application discovery contract</title>
+                  <meta name="description" content="Every declared callback must remain discoverable within Home Assistant's byte budget." />
+                </head><body><h1>Home Assistant application</h1></body></html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "redirect-uri-first-10kb");
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_StillValidatesHomeAssistantRedirectOnNoIndexPage()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-noindex-" + Guid.NewGuid().ToString("N"));
@@ -245,6 +276,33 @@ public class WebSeoDoctorTests
                 </head>
                 <body><h1>Breadcrumb contract</h1></body>
                 </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_FlagsBreadcrumbAncestorWithoutTarget()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-breadcrumb-ancestor-target-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html><html><head>
+                  <title>Structured data breadcrumb ancestor contract</title>
+                  <meta name="description" content="Ancestor breadcrumbs identify the page represented by each hierarchy entry." />
+                  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home"},{"@type":"ListItem","position":2,"name":"Guide"}]}</script>
+                </head><body><h1>Breadcrumb contract</h1></body></html>
                 """);
 
             var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -5,6 +5,220 @@ namespace PowerForge.Tests;
 public class WebSeoDoctorTests
 {
     [Fact]
+    public void Analyze_AcceptsHomeAssistantRedirectLinkWithinFirstTenKilobytes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-ok-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <link href='com.example.app://home-assistant/auth-callback' data-owner='app' rel='alternate redirect_uri' />
+                  <title>Home Assistant application discovery contract</title>
+                  <meta name="description" content="This page validates the Home Assistant redirect discovery contract in generated HTML." />
+                </head>
+                <body><h1>Home Assistant application</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root));
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Category == "home-assistant-discovery");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_FailsWhenHomeAssistantRedirectLinkStartsAfterFirstTenKilobytes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-late-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var padding = new string('x', (10 * 1024) + 128);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                $"""
+                <!doctype html>
+                <html>
+                <head>
+                  <!-- {padding} -->
+                  <link rel="redirect_uri" href="com.example.app://home-assistant/auth-callback" />
+                  <title>Home Assistant application discovery contract</title>
+                  <meta name="description" content="This page validates the Home Assistant redirect discovery contract in generated HTML." />
+                </head>
+                <body><h1>Home Assistant application</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root));
+
+            Assert.Contains(result.Issues, issue =>
+                issue.Hint == "redirect-uri-first-10kb" &&
+                issue.Severity.Equals("error", StringComparison.OrdinalIgnoreCase));
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_StillValidatesHomeAssistantRedirectOnNoIndexPage()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-noindex-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var padding = new string('x', (10 * 1024) + 128);
+            File.WriteAllText(Path.Combine(root, "callback.html"),
+                $"""
+                <!doctype html>
+                <html>
+                <head>
+                  <meta name="robots" content="noindex,nofollow" />
+                  <!-- {padding} -->
+                  <link rel="redirect_uri" href="com.example.app://home-assistant/auth-callback" />
+                </head>
+                <body><h1>Application callback</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "redirect-uri-first-10kb");
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_DoesNotTreatCommentedRedirectExampleAsDiscoverable()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-comment-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var padding = new string('x', (10 * 1024) + 128);
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                $"""
+                <!doctype html>
+                <html>
+                <head>
+                  <!-- <link rel="redirect_uri" href="com.example.invalid://example" /> -->
+                  <script>const example = '<link rel="redirect_uri" href="com.example.invalid://script" />';</script>
+                  <!-- {padding} -->
+                  <link rel="redirect_uri" href="com.example.app://home-assistant/auth-callback" />
+                  <title>Home Assistant application discovery contract</title>
+                  <meta name="description" content="This page validates the Home Assistant redirect discovery contract in generated HTML." />
+                </head>
+                <body><h1>Home Assistant application</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "redirect-uri-first-10kb");
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_FlagsBreadcrumbListWithFewerThanTwoItems()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-breadcrumb-count-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Structured data breadcrumb contract page</title>
+                  <meta name="description" content="This page validates the minimum breadcrumb hierarchy required by search engines." />
+                  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home"}]}</script>
+                </head>
+                <body><h1>Breadcrumb contract</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_FlagsBreadcrumbListWithMalformedItems()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-breadcrumb-shape-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Structured data breadcrumb contract page</title>
+                  <meta name="description" content="This page validates the minimum breadcrumb hierarchy required by search engines." />
+                  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[null,{"@type":"ListItem","position":2}]}</script>
+                </head>
+                <body><h1>Breadcrumb contract</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    private static WebSeoDoctorOptions CreateFocusedOptions(string root, bool checkStructuredData = false) => new()
+    {
+        SiteRoot = root,
+        CheckTitleLength = false,
+        CheckDescriptionLength = false,
+        CheckH1 = false,
+        CheckImageAlt = false,
+        CheckDuplicateTitles = false,
+        CheckOrphanPages = false,
+        CheckCanonical = false,
+        CheckHreflang = false,
+        CheckStructuredData = checkStructuredData,
+        CheckContentLeaks = false
+    };
+
+    [Fact]
     public void Analyze_FlagsExpectedIssues_AndSkipsNoIndexByDefault()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-" + Guid.NewGuid().ToString("N"));

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -37,6 +37,29 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_AcceptsUtf16HomeAssistantRedirectLinkWithinFirstTenKilobytes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-utf16-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                "<!doctype html><html><head><link rel=\"redirect_uri\" href=\"com.example.app://home-assistant/auth-callback\" /><title>Home Assistant application discovery contract</title><meta name=\"description\" content=\"This page validates the Home Assistant redirect discovery contract in generated HTML.\" /></head><body><h1>Home Assistant application</h1></body></html>",
+                System.Text.Encoding.Unicode);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root));
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Category == "home-assistant-discovery");
+            Assert.True(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_FailsWhenHomeAssistantRedirectLinkStartsAfterFirstTenKilobytes()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-late-" + Guid.NewGuid().ToString("N"));
@@ -190,6 +213,68 @@ public class WebSeoDoctorTests
                   <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[null,{"@type":"ListItem","position":2}]}</script>
                 </head>
                 <body><h1>Breadcrumb contract</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_FlagsBreadcrumbListWithNonSequentialPositions()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-breadcrumb-order-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Structured data breadcrumb contract page</title>
+                  <meta name="description" content="This page validates ordered breadcrumb positions required by search engines." />
+                  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home"},{"@type":"ListItem","position":1,"name":"Guide"}]}</script>
+                </head>
+                <body><h1>Breadcrumb contract</h1></body>
+                </html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_ValidatesBreadcrumbListNestedInJsonLdGraph()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-breadcrumb-graph-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <title>Structured data breadcrumb graph contract page</title>
+                  <meta name="description" content="This page validates breadcrumb profiles nested inside a JSON-LD graph." />
+                  <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home"}]}]}</script>
+                </head>
+                <body><h1>Breadcrumb graph contract</h1></body>
                 </html>
                 """);
 

--- a/PowerForge.Tests/WebSeoDoctorTests.cs
+++ b/PowerForge.Tests/WebSeoDoctorTests.cs
@@ -127,6 +127,35 @@ public class WebSeoDoctorTests
     }
 
     [Fact]
+    public void Analyze_FailsWhenAnyDeclaredHomeAssistantRedirectHasNoHref()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-each-href-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html><html><head>
+                  <link rel="redirect_uri" href="com.example.valid://home-assistant/auth-callback" />
+                  <link rel="redirect_uri" href="" />
+                  <title>Home Assistant application discovery contract</title>
+                  <meta name="description" content="Every declared Home Assistant callback must provide a discoverable target." />
+                </head><body><h1>Home Assistant application</h1></body></html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "redirect-uri-href-missing");
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Analyze_StillValidatesHomeAssistantRedirectOnNoIndexPage()
     {
         var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-ha-redirect-noindex-" + Guid.NewGuid().ToString("N"));
@@ -339,6 +368,60 @@ public class WebSeoDoctorTests
             var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
 
             Assert.Contains(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_ValidatesExpandedSchemaOrgBreadcrumbType()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-breadcrumb-expanded-type-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html><html><head>
+                  <title>Expanded structured data breadcrumb contract</title>
+                  <meta name="description" content="Expanded Schema.org identifiers receive the same breadcrumb validation as compact names." />
+                  <script type="application/ld+json">{"@context":"https://schema.org","@type":"https://schema.org/BreadcrumbList","itemListElement":[{"@type":"https://schema.org/ListItem","position":1,"name":"Home"}]}</script>
+                </head><body><h1>Breadcrumb contract</h1></body></html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
+
+            Assert.Contains(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void Analyze_AcceptsExpandedSchemaOrgListItemTypes()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-web-seo-doctor-breadcrumb-expanded-list-item-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "index.html"),
+                """
+                <!doctype html><html><head>
+                  <title>Expanded structured data list item contract</title>
+                  <meta name="description" content="Expanded Schema.org list items remain valid breadcrumb hierarchy entries." />
+                  <script type="application/ld+json">{"@context":"https://schema.org","@type":"https://schema.org/BreadcrumbList","itemListElement":[{"@type":"https://schema.org/ListItem","position":1,"name":"Home","item":"https://example.test/"},{"@type":"https://schema.org/ListItem","position":2,"name":"Guide"}]}</script>
+                </head><body><h1>Breadcrumb contract</h1></body></html>
+                """);
+
+            var result = WebSeoDoctor.Analyze(CreateFocusedOptions(root, checkStructuredData: true));
+
+            Assert.DoesNotContain(result.Issues, issue => issue.Hint == "structured-data-breadcrumb-items");
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteSocialCardsTests.cs
+++ b/PowerForge.Tests/WebSiteSocialCardsTests.cs
@@ -796,6 +796,40 @@ public class WebSiteSocialCardsTests
     }
 
     [Fact]
+    public void Build_PreservesOrdinaryLeadingLanguageLikeSegment_WhenLocalizationIsDisabled()
+    {
+        var root = CreateTempRoot("pf-web-structured-breadcrumb-nonlocalized-en-route-");
+        try
+        {
+            WritePage(root, "guide.md",
+                """
+                ---
+                title: English Guide
+                slug: en/docs/guide
+                ---
+
+                Guide body.
+                """);
+
+            var spec = BuildPagesSpec();
+            spec.StructuredData = new StructuredDataSpec
+            {
+                Enabled = true,
+                Breadcrumbs = true
+            };
+
+            var html = BuildAndRead(root, spec, Path.Combine("en", "docs", "guide", "index.html"));
+            Assert.Contains("\"item\":\"https://example.test/en/\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"item\":\"https://example.test/en/docs/\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"item\":\"https://example.test/en/docs/guide/\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
     public void Build_EmitsExtendedOrganizationStructuredData_WhenConfigured()
     {
         var root = CreateTempRoot("pf-web-structured-org-extended-");

--- a/PowerForge.Tests/WebSiteSocialCardsTests.cs
+++ b/PowerForge.Tests/WebSiteSocialCardsTests.cs
@@ -839,6 +839,49 @@ public class WebSiteSocialCardsTests
     }
 
     [Fact]
+    public void Build_StripsEmittedLanguagePrefix_WhenPrefixUsesUnderscore()
+    {
+        var root = CreateTempRoot("pf-web-structured-breadcrumb-underscore-prefix-");
+        try
+        {
+            WritePage(root, "guide-pt-br.md",
+                """
+                ---
+                title: Guia
+                slug: docs/guide
+                language: pt-BR
+                ---
+
+                Conteúdo do guia.
+                """);
+
+            var spec = BuildPagesSpec();
+            spec.Localization = new LocalizationSpec
+            {
+                Enabled = true,
+                DefaultLanguage = "en",
+                PrefixDefaultLanguage = false,
+                Languages = new[]
+                {
+                    new LanguageSpec { Code = "en", Label = "EN", Default = true, Prefix = "en" },
+                    new LanguageSpec { Code = "pt-BR", Label = "PT-BR", Prefix = "pt_BR" }
+                }
+            };
+            spec.StructuredData = new StructuredDataSpec { Enabled = true, Breadcrumbs = true };
+
+            var html = BuildAndRead(root, spec, Path.Combine("pt_BR", "docs", "guide", "index.html"));
+
+            Assert.Contains("\"item\":\"https://example.test/pt_BR/docs/\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"item\":\"https://example.test/pt_BR/docs/guide/\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("https://example.test/pt_BR/pt_BR/", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
     public void Build_PreservesOrdinaryLeadingLanguageLikeSegment_WhenLocalizationIsDisabled()
     {
         var root = CreateTempRoot("pf-web-structured-breadcrumb-nonlocalized-en-route-");

--- a/PowerForge.Tests/WebSiteSocialCardsTests.cs
+++ b/PowerForge.Tests/WebSiteSocialCardsTests.cs
@@ -796,6 +796,49 @@ public class WebSiteSocialCardsTests
     }
 
     [Fact]
+    public void Build_StripsCompleteMultiSegmentLanguagePrefix_FromBreadcrumbHierarchy()
+    {
+        var root = CreateTempRoot("pf-web-structured-breadcrumb-multisegment-prefix-");
+        try
+        {
+            WritePage(root, "guide-pl.md",
+                """
+                ---
+                title: Przewodnik
+                slug: docs/guide
+                language: pl
+                ---
+
+                Treść przewodnika.
+                """);
+
+            var spec = BuildPagesSpec();
+            spec.Localization = new LocalizationSpec
+            {
+                Enabled = true,
+                DefaultLanguage = "en",
+                PrefixDefaultLanguage = false,
+                Languages = new[]
+                {
+                    new LanguageSpec { Code = "en", Label = "EN", Default = true, Prefix = "en" },
+                    new LanguageSpec { Code = "pl", Label = "PL", Prefix = "regional/pl" }
+                }
+            };
+            spec.StructuredData = new StructuredDataSpec { Enabled = true, Breadcrumbs = true };
+
+            var html = BuildAndRead(root, spec, Path.Combine("regional", "pl", "docs", "guide", "index.html"));
+
+            Assert.Contains("\"item\":\"https://example.test/regional/pl/docs/\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"item\":\"https://example.test/regional/pl/docs/guide/\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("https://example.test/regional/pl/regional/", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
     public void Build_PreservesOrdinaryLeadingLanguageLikeSegment_WhenLocalizationIsDisabled()
     {
         var root = CreateTempRoot("pf-web-structured-breadcrumb-nonlocalized-en-route-");

--- a/PowerForge.Tests/WebSiteSocialCardsTests.cs
+++ b/PowerForge.Tests/WebSiteSocialCardsTests.cs
@@ -749,6 +749,53 @@ public class WebSiteSocialCardsTests
     }
 
     [Fact]
+    public void Build_PreservesLanguagePrefix_InLocalizedBreadcrumbHierarchy()
+    {
+        var root = CreateTempRoot("pf-web-structured-breadcrumb-localized-hierarchy-");
+        try
+        {
+            WritePage(root, "guide-pl.md",
+                """
+                ---
+                title: Przewodnik
+                slug: docs/guide
+                language: pl
+                ---
+
+                Treść przewodnika.
+                """);
+
+            var spec = BuildPagesSpec();
+            spec.Localization = new LocalizationSpec
+            {
+                Enabled = true,
+                DefaultLanguage = "en",
+                PrefixDefaultLanguage = false,
+                Languages = new[]
+                {
+                    new LanguageSpec { Code = "en", Label = "EN", Default = true, Prefix = "en" },
+                    new LanguageSpec { Code = "pl", Label = "PL", Prefix = "pl" }
+                }
+            };
+            spec.StructuredData = new StructuredDataSpec
+            {
+                Enabled = true,
+                Breadcrumbs = true
+            };
+
+            var html = BuildAndRead(root, spec, Path.Combine("pl", "docs", "guide", "index.html"));
+            Assert.Contains("\"item\":\"https://example.test/pl\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"item\":\"https://example.test/pl/docs/\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"item\":\"https://example.test/pl/docs/guide/\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"item\":\"https://example.test/docs/\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
     public void Build_EmitsExtendedOrganizationStructuredData_WhenConfigured()
     {
         var root = CreateTempRoot("pf-web-structured-org-extended-");

--- a/PowerForge.Tests/WebSiteSocialCardsTests.cs
+++ b/PowerForge.Tests/WebSiteSocialCardsTests.cs
@@ -649,9 +649,98 @@ public class WebSiteSocialCardsTests
             };
 
             var html = BuildAndRead(root, spec, "index.html");
-            Assert.Contains("\"@type\":\"BreadcrumbList\"", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"@type\":\"BreadcrumbList\"", html, StringComparison.Ordinal);
             Assert.Contains("\"@type\":\"WebSite\"", html, StringComparison.Ordinal);
             Assert.Contains("\"@type\":\"Organization\"", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_EmitsBreadcrumbStructuredData_ForHierarchicalPage()
+    {
+        var root = CreateTempRoot("pf-web-structured-breadcrumb-hierarchy-");
+        try
+        {
+            WritePage(root, "index.md",
+                """
+                ---
+                title: Home
+                slug: index
+                ---
+
+                Home body.
+                """);
+            WritePage(root, "guide.md",
+                """
+                ---
+                title: Guide
+                slug: guide
+                ---
+
+                Guide body.
+                """);
+
+            var spec = BuildPagesSpec();
+            spec.StructuredData = new StructuredDataSpec
+            {
+                Enabled = true,
+                Breadcrumbs = true
+            };
+
+            var html = BuildAndRead(root, spec, Path.Combine("guide", "index.html"));
+            Assert.Contains("\"@type\":\"BreadcrumbList\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"position\":1", html, StringComparison.Ordinal);
+            Assert.Contains("\"position\":2", html, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Cleanup(root);
+        }
+    }
+
+    [Fact]
+    public void Build_DoesNotEmitBreadcrumbStructuredData_ForLocalizedHomepage()
+    {
+        var root = CreateTempRoot("pf-web-structured-breadcrumb-localized-home-");
+        try
+        {
+            WritePage(root, "index.md",
+                """
+                ---
+                title: Home
+                slug: index
+                language: en
+                ---
+
+                Home body.
+                """);
+
+            var spec = BuildPagesSpec();
+            spec.Localization = new LocalizationSpec
+            {
+                Enabled = true,
+                DefaultLanguage = "en",
+                PrefixDefaultLanguage = false,
+                FallbackToDefaultLanguage = true,
+                MaterializeFallbackPages = true,
+                Languages = new[]
+                {
+                    new LanguageSpec { Code = "en", Label = "EN", Default = true, Prefix = "en" },
+                    new LanguageSpec { Code = "pl", Label = "PL", Prefix = "pl" }
+                }
+            };
+            spec.StructuredData = new StructuredDataSpec
+            {
+                Enabled = true,
+                Breadcrumbs = true
+            };
+
+            var html = BuildAndRead(root, spec, Path.Combine("pl", "index.html"));
+            Assert.DoesNotContain("\"@type\":\"BreadcrumbList\"", html, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Web/Services/WebAgentReadiness.cs
+++ b/PowerForge.Web/Services/WebAgentReadiness.cs
@@ -2017,8 +2017,8 @@ public static class WebAgentReadiness
             target);
         AddCheck(checks, "breadcrumb-list", "ai-search-signals", "BreadcrumbList",
             jsonLd.Any(static item => item.Contains("BreadcrumbList", StringComparison.OrdinalIgnoreCase)) ||
-            html.Contains("BreadcrumbList", StringComparison.OrdinalIgnoreCase) ? "pass" : "warn",
-            "BreadcrumbList structured data helps agents resolve page context.",
+            html.Contains("BreadcrumbList", StringComparison.OrdinalIgnoreCase) ? "pass" : "info",
+            "BreadcrumbList is optional on a homepage and useful on hierarchical pages with at least two items.",
             target);
         AddCheck(checks, "organization-schema", "ai-search-signals", "Organization Schema",
             jsonLd.Any(static item => item.Contains("Organization", StringComparison.OrdinalIgnoreCase)) ? "pass" : "warn",

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -1448,7 +1448,8 @@ public static partial class WebSeoDoctor
         if (!obj.TryGetProperty("itemListElement", out var items) ||
             items.ValueKind != JsonValueKind.Array ||
             items.GetArrayLength() < 2 ||
-            items.EnumerateArray().Any(static item => !IsValidBreadcrumbListItem(item)))
+            items.EnumerateArray().Select((item, index) => (item, expectedPosition: index + 1))
+                .Any(static entry => !IsValidBreadcrumbListItem(entry.item, entry.expectedPosition)))
         {
             addIssue("warning", "structured-data", relativePath,
                 $"JSON-LD payload ({objectLabel}) type BreadcrumbList should contain at least two ListItem entries.",
@@ -1457,14 +1458,14 @@ public static partial class WebSeoDoctor
         }
     }
 
-    private static bool IsValidBreadcrumbListItem(JsonElement item)
+    private static bool IsValidBreadcrumbListItem(JsonElement item, int expectedPosition)
     {
         if (item.ValueKind != JsonValueKind.Object ||
             !GetJsonLdTypes(item).Contains("ListItem", StringComparer.OrdinalIgnoreCase) ||
             !item.TryGetProperty("position", out var position) ||
             position.ValueKind != JsonValueKind.Number ||
             !position.TryGetInt32(out var positionValue) ||
-            positionValue < 1 ||
+            positionValue != expectedPosition ||
             !item.TryGetProperty("name", out var name) ||
             name.ValueKind != JsonValueKind.String)
         {
@@ -1510,7 +1511,7 @@ public static partial class WebSeoDoctor
         }
 
         var prefixLength = Math.Min(bytes.Length, HomeAssistantRedirectDiscoveryByteLimit);
-        var prefix = System.Text.Encoding.UTF8.GetString(bytes, 0, prefixLength);
+        var prefix = DecodeHtmlPrefix(bytes, prefixLength);
         var lastCompleteTagBoundary = prefix.LastIndexOf('>');
         if (lastCompleteTagBoundary >= 0)
         {
@@ -1539,6 +1540,19 @@ public static partial class WebSeoDoctor
             $"redirect_uri link must be complete within the first {HomeAssistantRedirectDiscoveryByteLimit} bytes for Home Assistant discovery.",
             "redirect-uri-first-10kb",
             null);
+    }
+
+    private static string DecodeHtmlPrefix(byte[] bytes, int prefixLength)
+    {
+        if (prefixLength <= 0)
+            return string.Empty;
+
+        using var stream = new MemoryStream(bytes, 0, prefixLength, writable: false);
+        using var reader = new StreamReader(
+            stream,
+            System.Text.Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
     }
 
     private static void ValidateFaqProfile(
@@ -1698,17 +1712,26 @@ public static partial class WebSeoDoctor
 
     private static JsonElement[] EnumerateJsonLdObjects(JsonElement root)
     {
-        if (root.ValueKind == JsonValueKind.Object)
-            return new[] { root };
+        var objects = new List<JsonElement>();
+        AddJsonLdObjects(root, objects);
+        return objects.ToArray();
+    }
 
-        if (root.ValueKind == JsonValueKind.Array)
+    private static void AddJsonLdObjects(JsonElement value, List<JsonElement> objects)
+    {
+        if (value.ValueKind == JsonValueKind.Array)
         {
-            return root.EnumerateArray()
-                .Where(static value => value.ValueKind == JsonValueKind.Object)
-                .ToArray();
+            foreach (var item in value.EnumerateArray())
+                AddJsonLdObjects(item, objects);
+            return;
         }
 
-        return Array.Empty<JsonElement>();
+        if (value.ValueKind != JsonValueKind.Object)
+            return;
+
+        objects.Add(value);
+        if (value.TryGetProperty("@graph", out var graph))
+            AddJsonLdObjects(graph, objects);
     }
 
     private static string[] GetJsonLdTypes(JsonElement obj)

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -1447,18 +1447,27 @@ public static partial class WebSeoDoctor
     {
         if (!obj.TryGetProperty("itemListElement", out var items) ||
             items.ValueKind != JsonValueKind.Array ||
-            items.GetArrayLength() < 2 ||
-            items.EnumerateArray().Select((item, index) => (item, expectedPosition: index + 1))
-                .Any(static entry => !IsValidBreadcrumbListItem(entry.item, entry.expectedPosition)))
+            items.GetArrayLength() < 2)
         {
             addIssue("warning", "structured-data", relativePath,
                 $"JSON-LD payload ({objectLabel}) type BreadcrumbList should contain at least two ListItem entries.",
                 "structured-data-breadcrumb-items",
                 objectLabel);
+            return;
+        }
+
+        var entries = items.EnumerateArray().ToArray();
+        if (entries.Select((item, index) => (item, expectedPosition: index + 1, isFinal: index == entries.Length - 1))
+            .Any(static entry => !IsValidBreadcrumbListItem(entry.item, entry.expectedPosition, entry.isFinal)))
+        {
+            addIssue("warning", "structured-data", relativePath,
+                $"JSON-LD payload ({objectLabel}) type BreadcrumbList should contain sequential, named ListItem entries with targets on every ancestor.",
+                "structured-data-breadcrumb-items",
+                objectLabel);
         }
     }
 
-    private static bool IsValidBreadcrumbListItem(JsonElement item, int expectedPosition)
+    private static bool IsValidBreadcrumbListItem(JsonElement item, int expectedPosition, bool isFinal)
     {
         if (item.ValueKind != JsonValueKind.Object ||
             !GetJsonLdTypes(item).Contains("ListItem", StringComparer.OrdinalIgnoreCase) ||
@@ -1472,7 +1481,21 @@ public static partial class WebSeoDoctor
             return false;
         }
 
-        return !string.IsNullOrWhiteSpace(name.GetString());
+        if (string.IsNullOrWhiteSpace(name.GetString()))
+            return false;
+
+        if (isFinal)
+            return true;
+
+        if (!item.TryGetProperty("item", out var target))
+            return false;
+
+        return target.ValueKind switch
+        {
+            JsonValueKind.String => !string.IsNullOrWhiteSpace(target.GetString()),
+            JsonValueKind.Object => JsonLdObjectHasNonEmptyValue(target, "@id"),
+            _ => false
+        };
     }
 
     private static void ValidateHomeAssistantRedirectDiscovery(
@@ -1528,11 +1551,23 @@ public static partial class WebSeoDoctor
                 // Fall through to the contract error below.
             }
 
-            if (prefixDocument is not null && prefixDocument.QuerySelectorAll("link[rel]")
-                    .Any(link => ContainsRelToken(link.GetAttribute("rel"), "redirect_uri") &&
-                                 !string.IsNullOrWhiteSpace(link.GetAttribute("href"))))
+            if (prefixDocument is not null)
             {
-                return;
+                var declaredTargets = redirectLinks
+                    .Select(static link => link.GetAttribute("href")?.Trim())
+                    .Where(static href => !string.IsNullOrWhiteSpace(href))
+                    .Cast<string>()
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                var prefixTargets = prefixDocument.QuerySelectorAll("link[rel]")
+                    .Where(link => ContainsRelToken(link.GetAttribute("rel"), "redirect_uri"))
+                    .Select(static link => link.GetAttribute("href")?.Trim())
+                    .Where(static href => !string.IsNullOrWhiteSpace(href))
+                    .Cast<string>()
+                    .ToHashSet(StringComparer.Ordinal);
+
+                if (declaredTargets.All(prefixTargets.Contains))
+                    return;
             }
         }
 

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -1510,7 +1510,7 @@ public static partial class WebSeoDoctor
         if (redirectLinks.Length == 0)
             return;
 
-        if (redirectLinks.All(link => string.IsNullOrWhiteSpace(link.GetAttribute("href"))))
+        if (redirectLinks.Any(link => string.IsNullOrWhiteSpace(link.GetAttribute("href"))))
         {
             addIssue("error", "home-assistant-discovery", relativePath,
                 "redirect_uri link is missing a non-empty href.",
@@ -1776,7 +1776,7 @@ public static partial class WebSeoDoctor
 
         if (typeValue.ValueKind == JsonValueKind.String)
         {
-            var type = NormalizeWhitespace(typeValue.GetString());
+            var type = NormalizeJsonLdType(typeValue.GetString());
             return string.IsNullOrWhiteSpace(type) ? Array.Empty<string>() : new[] { type };
         }
 
@@ -1784,13 +1784,34 @@ public static partial class WebSeoDoctor
         {
             return typeValue.EnumerateArray()
                 .Where(static value => value.ValueKind == JsonValueKind.String)
-                .Select(value => NormalizeWhitespace(value.GetString()))
+                .Select(value => NormalizeJsonLdType(value.GetString()))
                 .Where(static value => !string.IsNullOrWhiteSpace(value))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
         }
 
         return Array.Empty<string>();
+    }
+
+    private static string NormalizeJsonLdType(string? value)
+    {
+        var type = NormalizeWhitespace(value);
+        if (string.IsNullOrWhiteSpace(type))
+            return string.Empty;
+
+        if (!Uri.TryCreate(type, UriKind.Absolute, out var uri) ||
+            !(uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+              uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)) ||
+            !(uri.Host.Equals("schema.org", StringComparison.OrdinalIgnoreCase) ||
+              uri.Host.Equals("www.schema.org", StringComparison.OrdinalIgnoreCase)))
+        {
+            return type;
+        }
+
+        var schemaType = uri.AbsolutePath.Trim('/');
+        return string.IsNullOrWhiteSpace(schemaType) || schemaType.Contains('/', StringComparison.Ordinal)
+            ? type
+            : schemaType;
     }
 
     private static bool TryValidateJsonLdElement(JsonElement root, out bool hasContext, out bool hasType)

--- a/PowerForge.Web/Services/WebSeoDoctor.cs
+++ b/PowerForge.Web/Services/WebSeoDoctor.cs
@@ -39,6 +39,7 @@ public static partial class WebSeoDoctor
         TimeSpan.FromMilliseconds(250));
     private static readonly TimeSpan GlobMatchRegexTimeout = TimeSpan.FromMilliseconds(100);
     private const int MaxJsonLdPayloadLength = 1_000_000;
+    private const int HomeAssistantRedirectDiscoveryByteLimit = 10 * 1024;
     private static readonly StringComparison FileSystemPathComparison = OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
@@ -161,6 +162,14 @@ public static partial class WebSeoDoctor
                     "canonical-alias-noindex",
                     canonicalAliasRoute);
             }
+
+            // Home Assistant discovery is a machine-facing contract and still matters
+            // on callback or association pages that intentionally opt out of indexing.
+            ValidateHomeAssistantRedirectDiscovery(
+                doc,
+                file,
+                relativePath,
+                AddIssue);
 
             if (!options.IncludeNoIndexPages && hasNoIndexRobots)
                 continue;
@@ -1385,6 +1394,12 @@ public static partial class WebSeoDoctor
                     continue;
                 }
 
+                if (type.Equals("BreadcrumbList", StringComparison.OrdinalIgnoreCase))
+                {
+                    ValidateBreadcrumbProfile(obj, relativePath, objectLabel, addIssue);
+                    continue;
+                }
+
                 if (type.Equals("HowTo", StringComparison.OrdinalIgnoreCase))
                 {
                     ValidateHowToProfile(obj, relativePath, objectLabel, addIssue);
@@ -1422,6 +1437,108 @@ public static partial class WebSeoDoctor
                 }
             }
         }
+    }
+
+    private static void ValidateBreadcrumbProfile(
+        JsonElement obj,
+        string relativePath,
+        string objectLabel,
+        Action<string, string, string?, string, string?, string?> addIssue)
+    {
+        if (!obj.TryGetProperty("itemListElement", out var items) ||
+            items.ValueKind != JsonValueKind.Array ||
+            items.GetArrayLength() < 2 ||
+            items.EnumerateArray().Any(static item => !IsValidBreadcrumbListItem(item)))
+        {
+            addIssue("warning", "structured-data", relativePath,
+                $"JSON-LD payload ({objectLabel}) type BreadcrumbList should contain at least two ListItem entries.",
+                "structured-data-breadcrumb-items",
+                objectLabel);
+        }
+    }
+
+    private static bool IsValidBreadcrumbListItem(JsonElement item)
+    {
+        if (item.ValueKind != JsonValueKind.Object ||
+            !GetJsonLdTypes(item).Contains("ListItem", StringComparer.OrdinalIgnoreCase) ||
+            !item.TryGetProperty("position", out var position) ||
+            position.ValueKind != JsonValueKind.Number ||
+            !position.TryGetInt32(out var positionValue) ||
+            positionValue < 1 ||
+            !item.TryGetProperty("name", out var name) ||
+            name.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        return !string.IsNullOrWhiteSpace(name.GetString());
+    }
+
+    private static void ValidateHomeAssistantRedirectDiscovery(
+        AngleSharp.Dom.IDocument doc,
+        string filePath,
+        string relativePath,
+        Action<string, string, string?, string, string?, string?> addIssue)
+    {
+        var redirectLinks = doc.QuerySelectorAll("link[rel]")
+            .Where(link => ContainsRelToken(link.GetAttribute("rel"), "redirect_uri"))
+            .ToArray();
+        if (redirectLinks.Length == 0)
+            return;
+
+        if (redirectLinks.All(link => string.IsNullOrWhiteSpace(link.GetAttribute("href"))))
+        {
+            addIssue("error", "home-assistant-discovery", relativePath,
+                "redirect_uri link is missing a non-empty href.",
+                "redirect-uri-href-missing",
+                null);
+            return;
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = File.ReadAllBytes(filePath);
+        }
+        catch (Exception ex)
+        {
+            addIssue("error", "home-assistant-discovery", relativePath,
+                $"failed to inspect the first {HomeAssistantRedirectDiscoveryByteLimit} bytes ({ex.Message}).",
+                "redirect-uri-read",
+                ex.GetType().Name);
+            return;
+        }
+
+        var prefixLength = Math.Min(bytes.Length, HomeAssistantRedirectDiscoveryByteLimit);
+        var prefix = System.Text.Encoding.UTF8.GetString(bytes, 0, prefixLength);
+        var lastCompleteTagBoundary = prefix.LastIndexOf('>');
+        if (lastCompleteTagBoundary >= 0)
+        {
+            AngleSharp.Dom.IDocument? prefixDocument = null;
+            try
+            {
+                // Parse the prefix as one document so comments, scripts, and other HTML
+                // contexts remain non-executable discovery examples. Trimming after the
+                // last complete tag also prevents parser recovery of a boundary-crossing tag.
+                prefixDocument = HtmlParser.ParseWithAngleSharp(prefix[..(lastCompleteTagBoundary + 1)]);
+            }
+            catch
+            {
+                // Fall through to the contract error below.
+            }
+
+            if (prefixDocument is not null && prefixDocument.QuerySelectorAll("link[rel]")
+                    .Any(link => ContainsRelToken(link.GetAttribute("rel"), "redirect_uri") &&
+                                 !string.IsNullOrWhiteSpace(link.GetAttribute("href"))))
+            {
+                return;
+            }
+        }
+
+        addIssue("error", "home-assistant-discovery", relativePath,
+            $"redirect_uri link must be complete within the first {HomeAssistantRedirectDiscoveryByteLimit} bytes for Home Assistant discovery.",
+            "redirect-uri-first-10kb",
+            null);
     }
 
     private static void ValidateFaqProfile(

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.Breadcrumbs.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.Breadcrumbs.cs
@@ -13,7 +13,8 @@ public static partial class WebSiteBuilder
 {
     private static BreadcrumbItem[] BuildBreadcrumbs(SiteSpec spec, ContentItem item, MenuSpec[] menuSpecs)
     {
-        var current = NormalizeRouteForMatch(item.OutputPath);
+        var localization = ResolveLocalizationConfig(spec);
+        var current = NormalizeRouteForMatch(StripLanguagePrefix(localization, item.OutputPath));
         var crumbs = new List<BreadcrumbItem>();
         var nav = BuildNavigation(spec, item, menuSpecs);
 
@@ -130,4 +131,3 @@ public static partial class WebSiteBuilder
 
 
 }
-

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.Breadcrumbs.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.Breadcrumbs.cs
@@ -17,9 +17,10 @@ public static partial class WebSiteBuilder
         var current = NormalizeRouteForMatch(StripLanguagePrefix(localization, item.OutputPath));
         var crumbs = new List<BreadcrumbItem>();
         var nav = BuildNavigation(spec, item, menuSpecs);
+        var localizedHomeRoute = ApplyLanguagePrefixToRoute(spec, "/", item.Language);
 
-        var homeTitle = FindNavTitle(nav, "/") ?? "Home";
-        crumbs.Add(new BreadcrumbItem { Title = homeTitle, Url = "/", IsCurrent = current == "/" });
+        var homeTitle = FindNavTitle(nav, localizedHomeRoute) ?? FindNavTitle(nav, "/") ?? "Home";
+        crumbs.Add(new BreadcrumbItem { Title = homeTitle, Url = localizedHomeRoute, IsCurrent = current == "/" });
         if (current == "/")
             return crumbs.ToArray();
 
@@ -29,8 +30,9 @@ public static partial class WebSiteBuilder
         {
             path += "/" + segments[i];
             var route = path + "/";
+            var localizedRoute = ApplyLanguagePrefixToRoute(spec, route, item.Language);
             var isCurrent = i == segments.Length - 1;
-            var navTitle = FindNavTitle(nav, route);
+            var navTitle = FindNavTitle(nav, localizedRoute) ?? FindNavTitle(nav, route);
             var breadcrumbTitle = GetMetaString(item.Meta, "breadcrumb_title");
             var title = isCurrent
                 ? (!string.IsNullOrWhiteSpace(breadcrumbTitle) ? breadcrumbTitle : navTitle ?? item.Title)
@@ -38,7 +40,7 @@ public static partial class WebSiteBuilder
             crumbs.Add(new BreadcrumbItem
             {
                 Title = title,
-                Url = route,
+                Url = localizedRoute,
                 IsCurrent = isCurrent
             });
         }

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
@@ -341,6 +341,9 @@ public static partial class WebSiteBuilder
             return "/";
 
         var normalized = route.StartsWith("/", StringComparison.Ordinal) ? route : "/" + route;
+        if (!localization.Enabled)
+            return normalized;
+
         if (!TryExtractLeadingSegment(normalized.TrimStart('/'), out var segment, out var remainder))
             return normalized;
 

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
@@ -344,17 +344,22 @@ public static partial class WebSiteBuilder
         if (!localization.Enabled)
             return normalized;
 
-        if (!TryExtractLeadingSegment(normalized.TrimStart('/'), out var segment, out var remainder))
-            return normalized;
+        var routeWithoutLeadingSlash = normalized.Replace('\\', '/').TrimStart('/');
+        foreach (var prefix in localization.ByPrefix.Keys.OrderByDescending(static value => value.Length))
+        {
+            var normalizedPrefix = NormalizePath(prefix).Trim('/');
+            if (string.IsNullOrWhiteSpace(normalizedPrefix))
+                continue;
 
-        var token = NormalizeLanguageToken(segment);
-        if (string.IsNullOrWhiteSpace(token))
-            return normalized;
+            if (routeWithoutLeadingSlash.Equals(normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+                return "/";
 
-        if (!localization.ByPrefix.ContainsKey(token))
-            return normalized;
+            var prefixWithBoundary = normalizedPrefix + "/";
+            if (routeWithoutLeadingSlash.StartsWith(prefixWithBoundary, StringComparison.OrdinalIgnoreCase))
+                return "/" + routeWithoutLeadingSlash[prefixWithBoundary.Length..];
+        }
 
-        return string.IsNullOrWhiteSpace(remainder) ? "/" : "/" + remainder;
+        return normalized;
     }
 
     private static bool TryExtractLeadingSegment(string value, out string segment, out string remainder)

--- a/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.Navigation.LocalizationAndVersioning.cs
@@ -345,7 +345,10 @@ public static partial class WebSiteBuilder
             return normalized;
 
         var routeWithoutLeadingSlash = normalized.Replace('\\', '/').TrimStart('/');
-        foreach (var prefix in localization.ByPrefix.Keys.OrderByDescending(static value => value.Length))
+        foreach (var prefix in localization.Languages
+                     .Select(static language => language.Prefix)
+                     .Distinct(StringComparer.OrdinalIgnoreCase)
+                     .OrderByDescending(static value => value.Length))
         {
             var normalizedPrefix = NormalizePath(prefix).Trim('/');
             if (string.IsNullOrWhiteSpace(normalizedPrefix))

--- a/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.RenderAssetsAndRouting.cs
@@ -781,7 +781,10 @@ public static partial class WebSiteBuilder
         var baseUrl = languageBaseUrl?.TrimEnd('/') ?? string.Empty;
         var scripts = new List<string>();
 
-        if (spec.StructuredData.Breadcrumbs && breadcrumbs.Length > 0)
+        // A BreadcrumbList represents a path through a hierarchy. A single home-page
+        // item is not a useful trail and is not eligible for Google's breadcrumb
+        // presentation, which requires at least two ListItem entries.
+        if (spec.StructuredData.Breadcrumbs && breadcrumbs.Length > 1)
         {
             var items = breadcrumbs
                 .Select((crumb, index) => new Dictionary<string, object?>


### PR DESCRIPTION
## Summary

- add a declarative SEO Doctor contract for every Home Assistant OAuth discovery link that must appear in the first 10 KiB
- validate the byte prefix as one HTML document using its BOM-declared encoding so comments, scripts, truncated tags, non-UTF-8 documents, and multiple callback targets are handled correctly
- emit breadcrumb structured data only for real hierarchies and validate usable, sequential `ListItem` entries, including ancestor targets and payloads nested in `@graph`
- preserve complete configured language prefixes, including multi-segment overrides, without stripping ordinary language-like routes when localization is disabled
- keep localized homepages breadcrumb-free and classify missing homepage breadcrumbs as informational in agent-readiness reporting

## Why it matters

Home Assistant requires the public `redirect_uri` discovery link near the start of the page. This makes that integration constraint enforceable by every PowerForge.Web consumer while improving search and AI-discovery correctness without adding consumer-side scripts.

## Validation

- 73 focused PowerForge.Web SEO, structured-data, localization, and agent-readiness tests pass on .NET 10
- focused coverage includes multiple callback targets, noindex callback pages, UTF-16 documents, HTML comments/scripts, a tag crossing the 10 KiB boundary, malformed or unordered breadcrumbs, missing ancestor targets, JSON-LD graphs, localized homepages, multi-segment prefixes, and ordinary non-localized language-like routes
- CasaRay and Tactra full website CI pipelines pass locally against the exact shared candidate
- `git diff --check` passes

No consumer configuration migration is required.
