### PR TITLE
Link SoftwareApplication schema to publisher and product websites

### DIFF
--- a/PowerForge.Tests/WebPipelineRunnerProjectCatalogProductTests.cs
+++ b/PowerForge.Tests/WebPipelineRunnerProjectCatalogProductTests.cs
@@ -94,6 +94,7 @@ public partial class WebPipelineRunnerProjectCatalogProductTests
             Assert.Contains("height: 1600", page, StringComparison.Ordinal);
             Assert.Contains("meta.software.application_category: \"UtilitiesApplication\"", page, StringComparison.Ordinal);
             Assert.Contains("meta.software.download_url: \"https://apps.apple.com/us/app/casaray/id6778025328\"", page, StringComparison.Ordinal);
+            Assert.Contains("meta.software.website_url: \"https://casaray.dev/\"", page, StringComparison.Ordinal);
             Assert.Contains("meta.social_card_image: \"/assets/products/casaray/social.png\"", page, StringComparison.Ordinal);
             Assert.Contains("meta.social_image_width: 1536", page, StringComparison.Ordinal);
             Assert.Contains("meta.social_image_height: 1024", page, StringComparison.Ordinal);

--- a/PowerForge.Tests/WebSiteStructuredDataProfilesTests.cs
+++ b/PowerForge.Tests/WebSiteStructuredDataProfilesTests.cs
@@ -80,6 +80,7 @@ public class WebSiteStructuredDataProfilesTests
                 meta.software.operating_system: Windows, Linux, macOS
                 meta.software.version: 1.4.0
                 meta.software.download_url: /downloads/ix-cli
+                meta.software.website_url: https://intelligencex.example/
                 meta.software.price: 0
                 meta.software.price_currency: USD
                 ---
@@ -103,6 +104,8 @@ public class WebSiteStructuredDataProfilesTests
             Assert.Contains("\"@type\":\"SoftwareApplication\"", html, StringComparison.Ordinal);
             Assert.Contains("\"applicationCategory\":\"DeveloperApplication\"", html, StringComparison.Ordinal);
             Assert.Contains("\"downloadUrl\":\"https://example.test/downloads/ix-cli\"", html, StringComparison.Ordinal);
+            Assert.Contains("\"publisher\":{\"@type\":\"Organization\",\"name\":\"Example Site\",\"url\":\"https://example.test\"}", html, StringComparison.Ordinal);
+            Assert.Contains("\"sameAs\":[\"https://intelligencex.example/\"]", html, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Tests/WebSiteStructuredDataProfilesTests.cs
+++ b/PowerForge.Tests/WebSiteStructuredDataProfilesTests.cs
@@ -80,7 +80,9 @@ public class WebSiteStructuredDataProfilesTests
                 meta.software.operating_system: Windows, Linux, macOS
                 meta.software.version: 1.4.0
                 meta.software.download_url: /downloads/ix-cli
-                meta.software.website_url: https://intelligencex.example/
+                meta.softwareapplication.sameAs:
+                  - https://intelligencex.example/
+                  - /projects/intelligencex/
                 meta.software.price: 0
                 meta.software.price_currency: USD
                 ---
@@ -105,7 +107,7 @@ public class WebSiteStructuredDataProfilesTests
             Assert.Contains("\"applicationCategory\":\"DeveloperApplication\"", html, StringComparison.Ordinal);
             Assert.Contains("\"downloadUrl\":\"https://example.test/downloads/ix-cli\"", html, StringComparison.Ordinal);
             Assert.Contains("\"publisher\":{\"@type\":\"Organization\",\"name\":\"Example Site\",\"url\":\"https://example.test\"}", html, StringComparison.Ordinal);
-            Assert.Contains("\"sameAs\":[\"https://intelligencex.example/\"]", html, StringComparison.Ordinal);
+            Assert.Contains("\"sameAs\":[\"https://intelligencex.example/\",\"https://example.test/projects/intelligencex/\"]", html, StringComparison.Ordinal);
         }
         finally
         {

--- a/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.Products.cs
+++ b/PowerForge.Web.Cli/WebPipelineRunner.Tasks.ProjectCatalog.Products.cs
@@ -463,6 +463,7 @@ internal static partial class WebPipelineRunner
         WriteMetaString(lines, "meta.software.operating_system", product.Platforms is { Length: > 0 } ? string.Join(", ", product.Platforms) : null);
         WriteMetaString(lines, "meta.software.version", project.Version);
         WriteMetaString(lines, "meta.software.download_url", TryGetProjectDictionaryValue(project.Links, "appStore") ?? TryGetProjectDictionaryValue(project.Links, "downloads"));
+        WriteMetaString(lines, "meta.software.website_url", project.ExternalUrl ?? TryGetProjectDictionaryValue(project.Links, "website"));
         WriteMetaString(lines, "meta.software.image", hero?.Src);
         WriteMetaString(lines, "meta.social_image", project.Brand?.SocialImage ?? hero?.Src);
         var socialImageWidth = project.Brand is { SocialImageWidth: > 0 } ? project.Brand.SocialImageWidth : hero?.Width ?? 0;

--- a/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
@@ -292,9 +292,13 @@ public static partial class WebSiteBuilder
             publisher["url"] = languageBaseUrl;
         appModel["publisher"] = publisher;
 
-        var websiteUrl = ReadMetaString(item.Meta, "software.website_url", "software.websiteUrl", "softwareapplication.sameAs");
-        if (!string.IsNullOrWhiteSpace(websiteUrl))
-            appModel["sameAs"] = new[] { ResolveAbsoluteUrl(languageBaseUrl, websiteUrl) };
+        var sameAs = ReadMetaStringList(item.Meta, "software.website_url", "software.websiteUrl", "softwareapplication.sameAs")
+            .Select(url => ResolveAbsoluteUrl(languageBaseUrl, url))
+            .Where(url => !string.IsNullOrWhiteSpace(url))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (sameAs.Length > 0)
+            appModel["sameAs"] = sameAs;
 
         var appImage = ReadMetaString(item.Meta, "software.image", "softwareapplication.image");
         if (string.IsNullOrWhiteSpace(appImage))

--- a/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
+++ b/PowerForge.Web/Services/WebSiteBuilder.StructuredDataProfiles.cs
@@ -283,6 +283,19 @@ public static partial class WebSiteBuilder
         if (!string.IsNullOrWhiteSpace(downloadUrl))
             appModel["downloadUrl"] = ResolveAbsoluteUrl(languageBaseUrl, downloadUrl);
 
+        var publisher = new Dictionary<string, object?>
+        {
+            ["@type"] = "Organization",
+            ["name"] = spec.Name
+        };
+        if (!string.IsNullOrWhiteSpace(languageBaseUrl))
+            publisher["url"] = languageBaseUrl;
+        appModel["publisher"] = publisher;
+
+        var websiteUrl = ReadMetaString(item.Meta, "software.website_url", "software.websiteUrl", "softwareapplication.sameAs");
+        if (!string.IsNullOrWhiteSpace(websiteUrl))
+            appModel["sameAs"] = new[] { ResolveAbsoluteUrl(languageBaseUrl, websiteUrl) };
+
         var appImage = ReadMetaString(item.Meta, "software.image", "softwareapplication.image");
         if (string.IsNullOrWhiteSpace(appImage))
             appImage = ReadMetaString(item.Meta, "social_image");


### PR DESCRIPTION
## Summary

- add the site organization as the `publisher` of generated `SoftwareApplication` schema
- allow software metadata to identify an official product website through application-level `sameAs`
- propagate dedicated product URLs from the shared project catalog into generated software metadata

## Why

A hub page can remain the canonical Evotec ownership and discovery page while search engines can still recognize the dedicated domain as the same software product. This keeps product websites connected to the Evotec publisher without incorrectly treating product domains as alternate identities of the organization itself.

## Validation

- focused structured-data and product-catalog tests: 17 passed
- generated CasaRay and Tactra pages verified with Evotec publisher, Evotec hub URL, and dedicated-domain `sameAs`
- independent read-only review: no actionable findings