### PR TITLE
Keep complete progress visible across release flows

### DIFF
--- a/PSPublishModule/PSPublishModule.csproj
+++ b/PSPublishModule/PSPublishModule.csproj
@@ -62,7 +62,7 @@
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
-    <Compile Include="..\PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreProgressLedger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" />

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -40,7 +40,7 @@
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
-    <Compile Include="..\PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreBoundedProgressLedger.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreProgressLedger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildSummaryWriter.cs" />

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -195,7 +195,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> _tasks;
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> _phaseNames;
         private readonly HashSet<PowerForgeReleaseProgressPhase> _failed = new();
-        private readonly SpectreBoundedProgressLedger _ledger;
+        private readonly SpectreProgressLedger _ledger;
 
         public Reporter(
             ProgressContext context,
@@ -205,7 +205,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             _context = context;
             _tasks = tasks;
             _phaseNames = phaseNames;
-            _ledger = new SpectreBoundedProgressLedger(context);
+            _ledger = new SpectreProgressLedger(context);
         }
 
         public void PhaseStarted(PowerForgeReleaseProgressPhase phase, int totalItems, string? detail = null)
@@ -296,7 +296,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         }
 
         public void WriteLedger()
-            => SpectreBoundedProgressLedger.WriteLedger(
+            => SpectreProgressLedger.WriteLedger(
                 AnsiConsole.Console,
                 _ledger.GetSnapshots(),
                 "Unified release details");

--- a/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -17,7 +18,8 @@ internal static class SpectreProgressDisplay
     internal static void Run(
         IAnsiConsole console,
         ProgressColumn[] columns,
-        Action<ProgressContext> action)
+        Action<ProgressContext> action,
+        Action<IReadOnlyList<ProgressTask>>? taskObserver = null)
     {
         if (console is null) throw new ArgumentNullException(nameof(console));
         if (columns is null) throw new ArgumentNullException(nameof(columns));
@@ -29,9 +31,10 @@ internal static class SpectreProgressDisplay
             .AutoClear(true)
             .HideCompleted(false)
             .Columns(columns)
-            .UseRenderHook((renderable, _) =>
+            .UseRenderHook((renderable, tasks) =>
             {
                 finalFrame = renderable;
+                taskObserver?.Invoke(tasks);
                 return renderable;
             })
             .Start(action);

--- a/PowerForge.ConsoleShared/SpectreProgressLedger.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressLedger.cs
@@ -7,23 +7,17 @@ using Spectre.Console;
 namespace PowerForge.ConsoleShared;
 
 /// <summary>
-/// Keeps detailed work visible without allowing a Spectre live region to grow with
-/// every planned item. The complete history is retained for a durable post-run ledger.
+/// Keeps every planned work item visible in the Spectre live region and retains the
+/// complete history for a durable post-run ledger.
 /// </summary>
-internal sealed class SpectreBoundedProgressLedger
+internal sealed class SpectreProgressLedger
 {
-    private const int RecentCompletedLimit = 3;
-    private const int ActiveLimit = 2;
-    private const int UpcomingLimit = 2;
-    private const int PinnedFailureLimit = 3;
-
     private readonly ProgressContext _context;
     private readonly Dictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, ProgressTask> _visibleTasks = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _sync = new();
-    private long _terminalSequence;
 
-    internal SpectreBoundedProgressLedger(ProgressContext context)
+    internal SpectreProgressLedger(ProgressContext context)
         => _context = context ?? throw new ArgumentNullException(nameof(context));
 
     internal void Plan(IEnumerable<SpectreProgressLedgerItem> items)
@@ -47,7 +41,7 @@ internal sealed class SpectreBoundedProgressLedger
                 _entries[item.Key] = new Entry(item);
             }
 
-            ReconcileVisibleTasks();
+            RefreshVisibleTasks();
         }
     }
 
@@ -71,36 +65,8 @@ internal sealed class SpectreBoundedProgressLedger
                 entry.Item = item;
             }
 
-            entry.State = state;
-            entry.Detail = detail;
-            entry.ProgressFraction = ResolveProgressFraction(item, state);
-
-            var task = EnsureVisibleTask(entry);
-            task.Description = BuildLiveLabel(entry);
-
-            if (state == SpectreProgressLedgerState.Started)
-            {
-                if (!task.IsStarted)
-                    task.StartTask();
-
-                task.IsIndeterminate = item.ProgressMaximum <= 0;
-                if (!task.IsIndeterminate)
-                    task.Value = task.MaxValue * entry.ProgressFraction;
-            }
-            else if (IsTerminal(state))
-            {
-                if (!task.IsStarted)
-                    task.StartTask();
-
-                task.IsIndeterminate = false;
-                task.Value = task.MaxValue;
-                task.StopTask();
-
-                entry.Duration = item.Duration ?? task.ElapsedTime ?? TimeSpan.Zero;
-                entry.TerminalSequence = ++_terminalSequence;
-            }
-
-            ReconcileVisibleTasks();
+            ApplyUpdate(entry, state, detail, moveStartedTaskToEnd: true);
+            RefreshVisibleTasks();
             _context.Refresh();
         }
     }
@@ -152,11 +118,15 @@ internal sealed class SpectreBoundedProgressLedger
                 var state = entry.State == SpectreProgressLedgerState.Started && !success
                     ? SpectreProgressLedgerState.Failed
                     : SpectreProgressLedgerState.Skipped;
-                Update(
-                    entry.Item,
+                ApplyUpdate(
+                    entry,
                     state,
-                    success ? "not required" : "skipped after failure");
+                    success ? "not required" : "skipped after failure",
+                    moveStartedTaskToEnd: false);
             }
+
+            RefreshVisibleTasks();
+            _context.Refresh();
         }
     }
 
@@ -252,52 +222,58 @@ internal sealed class SpectreBoundedProgressLedger
         return task;
     }
 
-    private void ReconcileVisibleTasks()
+    private void ApplyUpdate(
+        Entry entry,
+        SpectreProgressLedgerState state,
+        string? detail,
+        bool moveStartedTaskToEnd)
     {
-        var desired = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        entry.State = state;
+        entry.Detail = detail;
+        entry.ProgressFraction = ResolveProgressFraction(entry.Item, state);
 
+        if (moveStartedTaskToEnd &&
+            state == SpectreProgressLedgerState.Started &&
+            _visibleTasks.TryGetValue(entry.Item.Key, out var plannedTask) &&
+            !plannedTask.IsStarted)
+        {
+            // Spectre crops overflowing live displays from the top. Re-adding the
+            // newly started task keeps the current work at the visible bottom while
+            // the full plan remains registered and is written durably after the run.
+            _context.RemoveTask(plannedTask);
+            _visibleTasks.Remove(entry.Item.Key);
+        }
+
+        var task = EnsureVisibleTask(entry);
+        task.Description = BuildLiveLabel(entry);
+
+        if (state == SpectreProgressLedgerState.Started)
+        {
+            if (!task.IsStarted)
+                task.StartTask();
+
+            task.IsIndeterminate = entry.Item.ProgressMaximum <= 0;
+            if (!task.IsIndeterminate)
+                task.Value = task.MaxValue * entry.ProgressFraction;
+        }
+        else if (IsTerminal(state))
+        {
+            if (!task.IsStarted)
+                task.StartTask();
+
+            task.IsIndeterminate = false;
+            task.Value = task.MaxValue;
+            task.StopTask();
+            entry.Duration = entry.Item.Duration ?? task.ElapsedTime ?? TimeSpan.Zero;
+        }
+    }
+
+    private void RefreshVisibleTasks()
+    {
         foreach (var entry in _entries.Values
-                     .Where(entry => entry.State == SpectreProgressLedgerState.Started)
                      .OrderBy(entry => entry.Item.GroupOrder)
                      .ThenBy(entry => entry.Item.Position <= 0 ? int.MaxValue : entry.Item.Position)
-                     .Take(ActiveLimit))
-        {
-            desired.Add(entry.Item.Key);
-        }
-
-        foreach (var entry in _entries.Values
-                     .Where(entry => entry.State == SpectreProgressLedgerState.Completed ||
-                                     entry.State == SpectreProgressLedgerState.Skipped)
-                     .OrderByDescending(entry => entry.TerminalSequence)
-                     .Take(RecentCompletedLimit))
-        {
-            desired.Add(entry.Item.Key);
-        }
-
-        foreach (var entry in _entries.Values
-                     .Where(entry => entry.State == SpectreProgressLedgerState.Failed)
-                     .OrderByDescending(entry => entry.TerminalSequence)
-                     .Take(PinnedFailureLimit))
-        {
-            desired.Add(entry.Item.Key);
-        }
-
-        foreach (var entry in _entries.Values
-                     .Where(entry => entry.State == SpectreProgressLedgerState.Planned)
-                     .OrderBy(entry => entry.Item.GroupOrder)
-                     .ThenBy(entry => entry.Item.Position <= 0 ? int.MaxValue : entry.Item.Position)
-                     .Take(UpcomingLimit))
-        {
-            desired.Add(entry.Item.Key);
-        }
-
-        foreach (var key in _visibleTasks.Keys.Where(key => !desired.Contains(key)).ToArray())
-        {
-            _context.RemoveTask(_visibleTasks[key]);
-            _visibleTasks.Remove(key);
-        }
-
-        foreach (var entry in _entries.Values.Where(entry => desired.Contains(entry.Item.Key)))
+                     .ThenBy(entry => entry.Item.Title, StringComparer.OrdinalIgnoreCase))
             EnsureVisibleTask(entry).Description = BuildLiveLabel(entry);
     }
 
@@ -360,7 +336,6 @@ internal sealed class SpectreBoundedProgressLedger
         internal string? Detail { get; set; }
         internal double ProgressFraction { get; set; }
         internal TimeSpan? Duration { get; set; }
-        internal long TerminalSequence { get; set; }
     }
 }
 

--- a/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreProjectBuildConsoleUi.cs
@@ -66,9 +66,9 @@ internal static class SpectreProjectBuildConsoleUi
                 }
             });
 
+        reporter?.WriteLedger(console);
         if (failure is not null)
         {
-            reporter?.WriteLedger(console);
             ExceptionDispatchInfo.Capture(failure).Throw();
         }
 
@@ -138,7 +138,7 @@ internal static class SpectreProjectBuildConsoleUi
         private readonly ProgressContext _context;
         private readonly IReadOnlyDictionary<ProjectBuildProgressPhase, ProgressTask> _tasks;
         private readonly HashSet<ProjectBuildProgressPhase> _failed = new();
-        private readonly SpectreBoundedProgressLedger _ledger;
+        private readonly SpectreProgressLedger _ledger;
 
         public SpectreProjectBuildProgressReporter(
             ProgressContext context,
@@ -146,7 +146,7 @@ internal static class SpectreProjectBuildConsoleUi
         {
             _context = context;
             _tasks = tasks;
-            _ledger = new SpectreBoundedProgressLedger(context);
+            _ledger = new SpectreProgressLedger(context);
         }
 
         public void PhaseStarted(ProjectBuildProgressPhase phase, int totalItems, string? detail = null)
@@ -231,7 +231,7 @@ internal static class SpectreProjectBuildConsoleUi
         }
 
         public void WriteLedger(IAnsiConsole console)
-            => SpectreBoundedProgressLedger.WriteLedger(
+            => SpectreProgressLedger.WriteLedger(
                 console,
                 _ledger.GetSnapshots(),
                 "Project build details");

--- a/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
+++ b/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
@@ -6,11 +6,11 @@ namespace PowerForge.Tests;
 public sealed class ProjectBuildProgressLedgerTests
 {
     [Fact]
-    public void BoundedLedger_KeepsLiveTasksSmallAndRetainsCompleteTimedHistory()
+    public void ProgressLedger_KeepsEveryLiveTaskVisibleAndRetainsCompleteTimedHistory()
     {
         using var writer = new StringWriter();
         var console = CreateConsole(writer, height: 12);
-        SpectreBoundedProgressLedger? ledger = null;
+        SpectreProgressLedger? ledger = null;
 
         SpectreProgressDisplay.Run(
             console,
@@ -22,7 +22,7 @@ public sealed class ProjectBuildProgressLedgerTests
             ],
             context =>
             {
-                ledger = new SpectreBoundedProgressLedger(context);
+                ledger = new SpectreProgressLedger(context);
                 var items = Enumerable.Range(1, 85)
                     .Select(index => new SpectreProgressLedgerItem
                     {
@@ -37,16 +37,16 @@ public sealed class ProjectBuildProgressLedgerTests
                     .ToArray();
 
                 ledger.Plan(items);
-                Assert.Equal(2, ledger.VisibleTaskCount);
+                Assert.Equal(85, ledger.VisibleTaskCount);
 
                 foreach (var item in items)
                 {
                     ledger.Update(item, SpectreProgressLedgerState.Started, "building");
-                    Assert.InRange(ledger.VisibleTaskCount, 1, 6);
+                    Assert.Equal(85, ledger.VisibleTaskCount);
 
                     item.Duration = TimeSpan.FromSeconds(item.Position);
                     ledger.Update(item, SpectreProgressLedgerState.Completed, "1 package, 1 archive");
-                    Assert.InRange(ledger.VisibleTaskCount, 1, 5);
+                    Assert.Equal(85, ledger.VisibleTaskCount);
                     if (item.Position == items.Length)
                     {
                         var stoppedAt = ledger.GetVisibleElapsedTime(item.Key);
@@ -57,7 +57,7 @@ public sealed class ProjectBuildProgressLedgerTests
 
                 Assert.Equal(85, ledger.GetItemCount("PackageBuild"));
                 Assert.Equal(1d, ledger.GetCompletionRatio("PackageBuild"), 5);
-                Assert.Equal(3, ledger.VisibleTaskCount);
+                Assert.Equal(85, ledger.VisibleTaskCount);
                 ledger.ClearLiveTasks();
                 Assert.Equal(0, ledger.VisibleTaskCount);
             });
@@ -69,7 +69,7 @@ public sealed class ProjectBuildProgressLedgerTests
         Assert.Equal(TimeSpan.FromSeconds(1), snapshots[0].Duration);
         Assert.Equal(TimeSpan.FromSeconds(85), snapshots[^1].Duration);
 
-        SpectreBoundedProgressLedger.WriteLedger(console, snapshots, "Project build details");
+        SpectreProgressLedger.WriteLedger(console, snapshots, "Project build details");
         var output = writer.ToString();
         Assert.Contains("Project.01", output, StringComparison.Ordinal);
         Assert.Contains("Project.85", output, StringComparison.Ordinal);
@@ -77,17 +77,18 @@ public sealed class ProjectBuildProgressLedgerTests
     }
 
     [Fact]
-    public void BoundedLedger_KeepsConcurrentBatchItemsBounded()
+    public void ProgressLedger_KeepsCurrentWorkVisibleWhenLiveRegionOverflows()
     {
         using var writer = new StringWriter();
         var console = CreateConsole(writer, height: 12);
+        IReadOnlyList<string>? finalTaskDescriptions = null;
 
         SpectreProgressDisplay.Run(
             console,
             SpectreBuildProgressColumns.CreateStandard(),
             context =>
             {
-                var ledger = new SpectreBoundedProgressLedger(context);
+                var ledger = new SpectreProgressLedger(context);
                 var items = Enumerable.Range(1, 85)
                     .Select(index => new SpectreProgressLedgerItem
                     {
@@ -102,11 +103,58 @@ public sealed class ProjectBuildProgressLedgerTests
                     .ToArray();
 
                 ledger.Plan(items);
-                foreach (var item in items)
-                    ledger.Update(item, SpectreProgressLedgerState.Started, "building in MSBuild batch");
+                ledger.Update(items[0], SpectreProgressLedgerState.Started, "building");
+                Assert.Equal(85, ledger.VisibleTaskCount);
+            },
+            tasks => finalTaskDescriptions = tasks.Select(task => task.Description).ToArray());
 
-                Assert.Equal(2, ledger.VisibleTaskCount);
+        Assert.NotNull(finalTaskDescriptions);
+        Assert.Contains("Project.01", finalTaskDescriptions![^1], StringComparison.Ordinal);
+        var output = writer.ToString();
+        Assert.Contains("Project.01", output, StringComparison.Ordinal);
+        Assert.Contains("Project.85", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StandaloneConsole_WritesDetailedLedgerAfterSuccess()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 12);
+
+        var result = SpectreProjectBuildConsoleUi.RunInteractive(
+            console,
+            new ProjectBuildConsolePlan
+            {
+                ConfigPath = "project.build.json",
+                RootPath = "repository",
+                Build = true
+            },
+            progress =>
+            {
+                var detailed = Assert.IsAssignableFrom<IProjectBuildProgressReporterV2>(progress);
+                var item = new ProjectBuildProgressItem
+                {
+                    Phase = ProjectBuildProgressPhase.PackageBuild,
+                    Key = "package:Sample.Project",
+                    Title = "Sample.Project",
+                    Position = 1,
+                    Total = 1,
+                    Duration = TimeSpan.FromSeconds(2)
+                };
+                detailed.ItemsPlanned(ProjectBuildProgressPhase.PackageBuild, [item]);
+                detailed.ItemUpdated(item, ProjectBuildProgressItemState.Started, "building");
+                detailed.ItemUpdated(item, ProjectBuildProgressItemState.Completed, "1 package, 1 archive");
+                return new ProjectBuildWorkflowResult
+                {
+                    Result = new ProjectBuildResult { Success = true }
+                };
             });
+
+        Assert.True(result.Result.Success);
+        var output = writer.ToString();
+        Assert.Contains("Project build details", output, StringComparison.Ordinal);
+        Assert.Contains("Sample.Project", output, StringComparison.Ordinal);
+        Assert.Contains("00:02.000", output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- keep every planned module, package, and executable step in the shared Spectre progress ledger instead of evicting older rows
- keep the current item visible when Spectre crops an oversized live region, while preserving canonical plan order in the durable ledger
- write complete project-build details on success and failure, and finish pending rows with a single refresh

## Behavior

Unified release and standalone project builds now follow the same retention model as direct module builds: no planned work is discarded. On terminals too short for the whole matrix, the active item remains in the visible tail and the completed ledger still contains the full ordered run.

## Validation

- focused progress and rendering contracts
- `PSPublishModule.Core.slnf` across .NET Framework 4.7.2, .NET 8, and .NET 10
- one independent local review plus targeted confirmation of the resolved findings