### PR TITLE
Allow safe versioned-framework symlinks during Apple cleanup

### DIFF
--- a/PowerForge.Tests/AppleReleaseArtifactServiceTests.cs
+++ b/PowerForge.Tests/AppleReleaseArtifactServiceTests.cs
@@ -144,6 +144,205 @@ public sealed class AppleReleaseArtifactServiceTests
     }
 
     [Fact]
+    public void RemoveCurrentArtifacts_AllowsStandardVersionedFrameworkLinks()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleCleanup", Guid.NewGuid().ToString("N"));
+        var archive = Path.Combine(root, "archives", "App.xcarchive");
+        var framework = Path.Combine(archive, "Products", "Applications", "App.app", "Frameworks", "LiveKitWebRTC.framework");
+        var version = Path.Combine(framework, "Versions", "A");
+        Directory.CreateDirectory(Path.Combine(version, "Headers"));
+        Directory.CreateDirectory(Path.Combine(version, "Modules"));
+        Directory.CreateDirectory(Path.Combine(version, "Resources"));
+        File.WriteAllText(Path.Combine(version, "LiveKitWebRTC"), "signed-framework");
+        try
+        {
+            Directory.CreateSymbolicLink(Path.Combine(framework, "Versions", "Current"), "A");
+            Directory.CreateSymbolicLink(Path.Combine(framework, "Headers"), "Versions/Current/Headers");
+            Directory.CreateSymbolicLink(Path.Combine(framework, "Modules"), "Versions/Current/Modules");
+            Directory.CreateSymbolicLink(Path.Combine(framework, "Resources"), "Versions/Current/Resources");
+            File.CreateSymbolicLink(Path.Combine(framework, "LiveKitWebRTC"), "Versions/Current/LiveKitWebRTC");
+
+            var plan = new PowerForgeAppleReleasePlan
+            {
+                ProjectRoot = root,
+                Apps = new[]
+                {
+                    new PowerForgeAppleAppReleaseTargetPlan
+                    {
+                        ArchivePath = archive,
+                        ExportPath = Path.Combine(root, "exports", "App")
+                    }
+                }
+            };
+
+            var receipt = new AppleReleaseArtifactService(_ => long.MaxValue).RemoveCurrentArtifacts(plan);
+
+            Assert.False(Directory.Exists(archive));
+            Assert.Contains("archives/App.xcarchive", receipt.RemovedPaths);
+            Assert.Equal("signed-framework".Length, receipt.ReclaimedBytes);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveCurrentArtifacts_RejectsFrameworkLinkThatEscapesItsBundle()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleCleanup", Guid.NewGuid().ToString("N"));
+        var outside = Path.Combine(Path.GetTempPath(), "PowerForge.Outside", Guid.NewGuid().ToString("N"));
+        var archive = Path.Combine(root, "archives", "App.xcarchive");
+        var framework = Path.Combine(archive, "Products", "Applications", "App.app", "Frameworks", "LiveKitWebRTC.framework");
+        Directory.CreateDirectory(framework);
+        Directory.CreateDirectory(outside);
+        File.WriteAllText(Path.Combine(outside, "keep.bin"), "outside");
+        try
+        {
+            var target = Path.GetRelativePath(framework, Path.Combine(outside, "keep.bin"));
+            File.CreateSymbolicLink(Path.Combine(framework, "LiveKitWebRTC"), target);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseArtifactService(_ => long.MaxValue).RemoveCurrentArtifacts(CreatePlan(root, archive)));
+
+            Assert.Contains("escapes its bundle", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(Path.Combine(outside, "keep.bin")));
+            Assert.True(Directory.Exists(archive));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+            if (Directory.Exists(outside))
+                Directory.Delete(outside, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveCurrentArtifacts_RejectsAbsoluteFrameworkLink()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleCleanup", Guid.NewGuid().ToString("N"));
+        var archive = Path.Combine(root, "archives", "App.xcarchive");
+        var framework = Path.Combine(archive, "Products", "Applications", "App.app", "Frameworks", "LiveKitWebRTC.framework");
+        var version = Path.Combine(framework, "Versions", "A");
+        Directory.CreateDirectory(version);
+        try
+        {
+            Directory.CreateSymbolicLink(Path.Combine(framework, "Versions", "Current"), version);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseArtifactService(_ => long.MaxValue).RemoveCurrentArtifacts(CreatePlan(root, archive)));
+
+            Assert.Contains("absolute symbolic link", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(Directory.Exists(archive));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveCurrentArtifacts_RejectsFrameworkLinkChainThatEscapesItsBundle()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleCleanup", Guid.NewGuid().ToString("N"));
+        var outside = Path.Combine(Path.GetTempPath(), "PowerForge.Outside", Guid.NewGuid().ToString("N"));
+        var archive = Path.Combine(root, "archives", "App.xcarchive");
+        var framework = Path.Combine(archive, "Products", "Applications", "App.app", "Frameworks", "LiveKitWebRTC.framework");
+        var versions = Path.Combine(framework, "Versions");
+        Directory.CreateDirectory(versions);
+        Directory.CreateDirectory(Path.Combine(outside, "Headers"));
+        try
+        {
+            var target = Path.GetRelativePath(versions, outside);
+            Directory.CreateSymbolicLink(Path.Combine(versions, "Current"), target);
+            Directory.CreateSymbolicLink(Path.Combine(framework, "Headers"), "Versions/Current/Headers");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseArtifactService(_ => long.MaxValue).RemoveCurrentArtifacts(CreatePlan(root, archive)));
+
+            Assert.Contains("escapes its bundle", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(Directory.Exists(Path.Combine(outside, "Headers")));
+            Assert.True(Directory.Exists(archive));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+            if (Directory.Exists(outside))
+                Directory.Delete(outside, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveCurrentArtifacts_RejectsBrokenFrameworkLink()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleCleanup", Guid.NewGuid().ToString("N"));
+        var archive = Path.Combine(root, "archives", "App.xcarchive");
+        var framework = Path.Combine(archive, "Products", "Applications", "App.app", "Frameworks", "LiveKitWebRTC.framework");
+        Directory.CreateDirectory(framework);
+        try
+        {
+            File.CreateSymbolicLink(Path.Combine(framework, "LiveKitWebRTC"), "Versions/Current/LiveKitWebRTC");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseArtifactService(_ => long.MaxValue).RemoveCurrentArtifacts(CreatePlan(root, archive)));
+
+            Assert.Contains("broken symbolic link", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(Directory.Exists(archive));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void RemoveCurrentArtifacts_RejectsLinkOutsideFrameworkEvenWhenItStaysInsideArchive()
+    {
+        if (Path.DirectorySeparatorChar == '\\')
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), "PowerForge.AppleCleanup", Guid.NewGuid().ToString("N"));
+        var archive = Path.Combine(root, "archives", "App.xcarchive");
+        Directory.CreateDirectory(archive);
+        File.WriteAllText(Path.Combine(archive, "Info.plist"), "archive");
+        try
+        {
+            File.CreateSymbolicLink(Path.Combine(archive, "Info.current"), "Info.plist");
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new AppleReleaseArtifactService(_ => long.MaxValue).RemoveCurrentArtifacts(CreatePlan(root, archive)));
+
+            Assert.Contains("outside a framework bundle", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.True(Directory.Exists(archive));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
     public void RemoveCurrentArtifacts_UsesCaseSensitiveContainmentOnUnix()
     {
         if (Path.DirectorySeparatorChar == '\\')
@@ -180,4 +379,18 @@ public sealed class AppleReleaseArtifactServiceTests
                 Directory.Delete(parent, true);
         }
     }
+
+    private static PowerForgeAppleReleasePlan CreatePlan(string root, string archive)
+        => new()
+        {
+            ProjectRoot = root,
+            Apps = new[]
+            {
+                new PowerForgeAppleAppReleaseTargetPlan
+                {
+                    ArchivePath = archive,
+                    ExportPath = Path.Combine(root, "exports", "App")
+                }
+            }
+        };
 }

--- a/PowerForge/Services/AppleReleaseArtifactService.cs
+++ b/PowerForge/Services/AppleReleaseArtifactService.cs
@@ -91,7 +91,7 @@ internal sealed class AppleReleaseArtifactService
             if (!File.Exists(fullPath) && !Directory.Exists(fullPath))
                 continue;
             EnsureNoReparsePoints(plan.ProjectRoot, fullPath);
-            EnsureTreeContainsNoReparsePoints(fullPath);
+            EnsureTreeContainsOnlySafeLinks(fullPath);
 
             reclaimedBytes += GetSize(fullPath);
             if (File.Exists(fullPath))
@@ -163,7 +163,7 @@ internal sealed class AppleReleaseArtifactService
         }
     }
 
-    private static void EnsureTreeContainsNoReparsePoints(string path)
+    private static void EnsureTreeContainsOnlySafeLinks(string path)
     {
         var pending = new Stack<string>();
         pending.Push(path);
@@ -173,8 +173,8 @@ internal sealed class AppleReleaseArtifactService
             var attributes = File.GetAttributes(current);
             if ((attributes & FileAttributes.ReparsePoint) != 0)
             {
-                throw new InvalidOperationException(
-                    $"Refusing to recursively remove an Apple release artifact tree containing a symbolic link or reparse point: {current}");
+                EnsureSafeVersionedFrameworkLink(path, current, attributes);
+                continue;
             }
 
             if ((attributes & FileAttributes.Directory) == 0)
@@ -184,6 +184,97 @@ internal sealed class AppleReleaseArtifactService
         }
     }
 
+    private static void EnsureSafeVersionedFrameworkLink(
+        string artifactRoot,
+        string linkPath,
+        FileAttributes attributes)
+    {
+#if NET8_0_OR_GREATER
+        var frameworkRoot = FindContainingFrameworkRoot(artifactRoot, linkPath);
+        if (frameworkRoot is null)
+        {
+            throw new InvalidOperationException(
+                $"Refusing to recursively remove an Apple release artifact tree containing a symbolic link outside a framework bundle: {linkPath}");
+        }
+
+        var linkInfo = (attributes & FileAttributes.Directory) != 0
+            ? (FileSystemInfo)new DirectoryInfo(linkPath)
+            : new FileInfo(linkPath);
+        var linkTarget = linkInfo.LinkTarget;
+        if (string.IsNullOrWhiteSpace(linkTarget))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to remove an Apple framework containing an unreadable symbolic link: {linkPath}");
+        }
+        if (Path.IsPathRooted(linkTarget))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to remove an Apple framework containing an absolute symbolic link: {linkPath} -> {linkTarget}");
+        }
+
+        var linkDirectory = Path.GetDirectoryName(linkPath)
+            ?? throw new InvalidOperationException($"Unable to resolve the Apple framework link parent: {linkPath}");
+        var declaredTarget = Path.GetFullPath(Path.Combine(linkDirectory, linkTarget));
+        if (!IsWithinRoot(declaredTarget, frameworkRoot))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to remove an Apple framework containing a symbolic link that escapes its bundle: {linkPath} -> {linkTarget}");
+        }
+
+        FileSystemInfo? resolvedTarget;
+        try
+        {
+            resolvedTarget = linkInfo.ResolveLinkTarget(returnFinalTarget: true);
+        }
+        catch (Exception exception) when (
+            exception is IOException ||
+            exception is UnauthorizedAccessException ||
+            exception is NotSupportedException)
+        {
+            throw new InvalidOperationException(
+                $"Refusing to remove an Apple framework containing an invalid symbolic link: {linkPath} -> {linkTarget}",
+                exception);
+        }
+
+        if (resolvedTarget is null ||
+            (!File.Exists(resolvedTarget.FullName) && !Directory.Exists(resolvedTarget.FullName)))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to remove an Apple framework containing a broken symbolic link: {linkPath} -> {linkTarget}");
+        }
+        if (!IsWithinRoot(resolvedTarget.FullName, frameworkRoot))
+        {
+            throw new InvalidOperationException(
+                $"Refusing to remove an Apple framework containing a symbolic link that resolves outside its bundle: {linkPath} -> {linkTarget}");
+        }
+#else
+        throw new InvalidOperationException(
+            $"Refusing to recursively remove an Apple release artifact tree containing a symbolic link or reparse point: {linkPath}");
+#endif
+    }
+
+    private static string? FindContainingFrameworkRoot(string artifactRoot, string linkPath)
+    {
+        var root = Path.GetFullPath(artifactRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var current = Path.GetDirectoryName(Path.GetFullPath(linkPath));
+        while (!string.IsNullOrWhiteSpace(current) && IsWithinRoot(current, root))
+        {
+            if (Path.GetFileName(current).EndsWith(".framework", StringComparison.OrdinalIgnoreCase) &&
+                Directory.Exists(current) &&
+                (File.GetAttributes(current) & FileAttributes.ReparsePoint) == 0)
+            {
+                return current;
+            }
+
+            if (current.Equals(root, PathComparison))
+                break;
+            current = Path.GetDirectoryName(current);
+        }
+
+        return null;
+    }
+
     private static DateTime GetLastWriteTimeUtc(string path)
         => File.Exists(path)
             ? File.GetLastWriteTimeUtc(path)
@@ -191,10 +282,30 @@ internal sealed class AppleReleaseArtifactService
 
     private static long GetSize(string path)
     {
-        if (File.Exists(path))
+        var attributes = File.GetAttributes(path);
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+            return 0;
+        if ((attributes & FileAttributes.Directory) == 0)
             return new FileInfo(path).Length;
-        return Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
-            .Sum(static file => new FileInfo(file).Length);
+
+        long size = 0;
+        var pending = new Stack<string>();
+        pending.Push(path);
+        while (pending.Count > 0)
+        {
+            foreach (var entry in Directory.EnumerateFileSystemEntries(pending.Pop()))
+            {
+                attributes = File.GetAttributes(entry);
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                    continue;
+                if ((attributes & FileAttributes.Directory) != 0)
+                    pending.Push(entry);
+                else
+                    size += new FileInfo(entry).Length;
+            }
+        }
+
+        return size;
     }
 
     private static long GetAvailableBytes(string path)


### PR DESCRIPTION
## Summary

- allow standard macOS versioned-framework symlinks during Apple archive cleanup when every link is relative, readable, unbroken, and contained within the same physical `.framework` bundle
- keep cleanup fail-closed for absolute links, broken links, bundle escapes, artifact-root links, and links elsewhere in the archive
- avoid following framework links while calculating reclaimed size, and delete the archive without rewriting its signed framework contents

## Why this matters

CasaRay's valid `LiveKitWebRTC.framework` contains the normal `Versions/Current` layout plus top-level links for headers, modules, resources, and the framework binary. Cleanup previously rejected those signed links after a successful Apple upload.

The regression coverage exercises the complete accepted layout and rejects direct escapes, chained escapes, absolute targets, broken targets, non-framework links, and linked artifact roots.

## Release state

PSPublishModule 3.0.81 was signed and published manually before this fix. The next manually signed public release will be the first version containing it.

Fixes #632
