### PR TITLE
Fix wildcard metadata in native binary-module help

### DIFF
--- a/Module/Documentation/Templates/TASKS-DOCUMENTATION.MD
+++ b/Module/Documentation/Templates/TASKS-DOCUMENTATION.MD
@@ -1,4 +1,4 @@
-﻿Task: For every cmdlet class (PSCmdlet/Cmdlet) in this solution, add/normalize XML doc comments to generate PowerShell help with MatejKafka.XmlDoc2CmdletDoc.
+Task: For every cmdlet class (PSCmdlet/Cmdlet) in this solution, add or normalize XML doc comments so PowerForge can generate command Markdown and external PowerShell help.
 Rules:
 
 Each cmdlet must have exactly one <summary> (single sentence synopsis) and one or more <para> elements (description).
@@ -8,6 +8,8 @@ Add a <list type="alertSet"> with at least one note about behavior/side-effects 
 Provide at least two <example> blocks per cmdlet, each with <summary>, <prefix>PS&gt; </prefix>, <code> showing the invocation, and one or more <para> remarks.
 Add two <seealso> links per cmdlet: one to relevant MS Learn and one to project docs, using the href attribute.
 Preserve existing behavior; do not modify code outside of comments.
-Ensure the project has <GenerateDocumentationFile>true</GenerateDocumentationFile> and a PackageReference to MatejKafka.XmlDoc2CmdletDoc.
-If any cmdlet still lacks a synopsis/description, fail the build via -strict in <XmlDoc2CmdletDocArguments>.
-Output: Commit the updated code comments; do not touch build logic beyond the property/package reference.
+Ensure the binary cmdlet project has <GenerateDocumentationFile>true</GenerateDocumentationFile>.
+Configure the module build with New-ConfigurationDocumentation -Enable and New-ConfigurationBuild -NETBinaryModuleDocumentation.
+If migrating from MatejKafka.XmlDoc2CmdletDoc, remove its package reference, MSBuild properties, and package-specific copy targets.
+Use New-ConfigurationValidation with MinSynopsisPercent, MinParameterDescriptionPercent, and MinTypeDescriptionPercent set to 100 when complete documentation is a build requirement.
+Output: Commit the updated code comments and the minimal PowerForge build configuration required to generate and validate the documentation.

--- a/Module/Documentation/Templates/TASKS-DOCUMENTATION.MD
+++ b/Module/Documentation/Templates/TASKS-DOCUMENTATION.MD
@@ -7,9 +7,9 @@ For complex input/output types used by parameters or returned objects, ensure th
 Add a <list type="alertSet"> with at least one note about behavior/side-effects if relevant.
 Provide at least two <example> blocks per cmdlet, each with <summary>, <prefix>PS&gt; </prefix>, <code> showing the invocation, and one or more <para> remarks.
 Add two <seealso> links per cmdlet: one to relevant MS Learn and one to project docs, using the href attribute.
-Preserve existing behavior; do not modify code outside of comments.
+Preserve existing behavior; outside comments, make only the minimal project and PowerForge build-configuration edits described below.
 Ensure the binary cmdlet project has <GenerateDocumentationFile>true</GenerateDocumentationFile>.
-Configure the module build with New-ConfigurationDocumentation -Enable and New-ConfigurationBuild -NETBinaryModuleDocumentation.
+Configure the module build with New-ConfigurationDocumentation -Enable -Path 'Docs' -PathReadme 'Docs\Readme.md' and New-ConfigurationBuild -NETBinaryModuleDocumentation.
 If migrating from MatejKafka.XmlDoc2CmdletDoc, remove its package reference, MSBuild properties, and package-specific copy targets.
-Use New-ConfigurationValidation with MinSynopsisPercent, MinParameterDescriptionPercent, and MinTypeDescriptionPercent set to 100 when complete documentation is a build requirement.
+When complete documentation is a build requirement, use New-ConfigurationValidation -Enable -DocumentationSeverity Error -MinSynopsisPercent 100 -MinParameterDescriptionPercent 100 -MinTypeDescriptionPercent 100 -MinExamplesPerCommand 2.
 Output: Commit the updated code comments and the minimal PowerForge build configuration required to generate and validate the documentation.

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/Expected/BinaryDocFixture-help.xml
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/Expected/BinaryDocFixture-help.xml
@@ -16,7 +16,7 @@
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Get-BinaryDocSample</maml:name>
-        <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Mode</maml:name>
           <maml:description>
             <maml:para>Selects the sample rendering mode.</maml:para>
@@ -47,7 +47,7 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Mode</maml:name>
         <maml:description>
           <maml:para>Selects the sample rendering mode.</maml:para>

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/Expected/Get-BinaryDocSample.md
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/Expected/Get-BinaryDocSample.md
@@ -47,7 +47,7 @@ Required: False
 Position: named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -Name

--- a/PowerForge.Tests/Fixtures/BinaryDocFixture/GetBinaryDocSampleCommand.cs
+++ b/PowerForge.Tests/Fixtures/BinaryDocFixture/GetBinaryDocSampleCommand.cs
@@ -33,6 +33,7 @@ public sealed class GetBinaryDocSampleCommand : PSCmdlet
     /// <summary>Name of the requested sample object.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipelineByPropertyName = true)]
     [Alias("SampleName")]
+    [SupportsWildcards]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>Selects the sample rendering mode.</summary>

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -171,6 +171,9 @@ try {
                 if ($null -ne $value) { $possibleValues += [string]$value }
               }
             }
+            if ($attr -is [System.Management.Automation.SupportsWildcardsAttribute]) {
+              $acceptWild = $true
+            }
           }
         }
       } catch {
@@ -213,7 +216,19 @@ try {
           # best effort: ValidValues is not consistently present across Get-Help payloads
         }
         try { $defaultValue = [string]$hp.DefaultValue } catch { $defaultValue = '' }
-        try { $acceptWild = [bool]$hp.Globbing } catch { $acceptWild = $false }
+        try {
+          $globbingValue = $hp.Globbing
+          if ($globbingValue -is [bool]) {
+            $acceptWild = $globbingValue
+          } elseif ($null -ne $globbingValue) {
+            $parsedGlobbing = $false
+            if ([bool]::TryParse(([string]$globbingValue).Trim(), [ref]$parsedGlobbing)) {
+              $acceptWild = $parsedGlobbing
+            }
+          }
+        } catch {
+          # keep the metadata-derived default when Get-Help omits or reshapes Globbing
+        }
       }
       $possibleValuesNormalized = @()
       $seenPossibleValues = @{}


### PR DESCRIPTION
PowerForge already owns binary cmdlet documentation from compiler XML through generated Markdown and external MAML. This change updates the migration guidance to remove XmlDoc2CmdletDoc and use that native pipeline.

It also fixes wildcard metadata in generated help. PowerShell exposes Get-Help globbing values as text, where casting the string 'False' to bool produced True. The extractor now parses the value correctly, and the binary documentation fixture proves both an ordinary parameter and an explicitly SupportsWildcards parameter.