### PR TITLE
Keep reusable Apple workflows on private runners

### DIFF
--- a/.github/workflows/powerforge-apple-screenshot-approve.yml
+++ b/.github/workflows/powerforge-apple-screenshot-approve.yml
@@ -92,7 +92,7 @@ concurrency:
 
 jobs:
   resolve-source:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(inputs.runner_labels_json) }}
     timeout-minutes: 10
     permissions:
       actions: read

--- a/.github/workflows/powerforge-apple-screenshot-approve.yml
+++ b/.github/workflows/powerforge-apple-screenshot-approve.yml
@@ -147,7 +147,10 @@ jobs:
 
           artifact_prefix='powerforge-apple-screenshots-'
           provenance_prefix='powerforge-apple-screenshot-provenance-'
-          mapfile -t artifact_names < <(
+          artifact_names=()
+          while IFS= read -r artifact_name; do
+            artifact_names+=("$artifact_name")
+          done < <(
             gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/actions/runs/${CAPTURE_RUN_ID}/artifacts" \
               --jq '.artifacts[] | select(.expired == false) | .name'
@@ -156,10 +159,10 @@ jobs:
           provenance_refs=()
           for artifact_name in "${artifact_names[@]}"; do
             if [[ "$artifact_name" =~ ^${artifact_prefix}([0-9A-Fa-f]{40})$ ]]; then
-              source_refs+=("${BASH_REMATCH[1],,}")
+              source_refs+=("$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')")
             fi
             if [[ "$artifact_name" =~ ^${provenance_prefix}([0-9A-Fa-f]{40})$ ]]; then
-              provenance_refs+=("${BASH_REMATCH[1],,}")
+              provenance_refs+=("$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')")
             fi
           done
           [[ ${#source_refs[@]} -eq 1 ]] || {
@@ -202,7 +205,8 @@ jobs:
               echo 'source_ref must be blank or an exact 40-character commit SHA.' >&2
               exit 1
             }
-            [[ "${EXPECTED_SOURCE_REF,,}" == "$resolved_source_ref" ]] || {
+            expected_source_ref="$(printf '%s' "$EXPECTED_SOURCE_REF" | tr '[:upper:]' '[:lower:]')"
+            [[ "$expected_source_ref" == "$resolved_source_ref" ]] || {
               echo "Requested source_ref ${EXPECTED_SOURCE_REF} does not match capture source ${resolved_source_ref}." >&2
               exit 1
             }

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -490,6 +490,30 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
+    public void AppleReusableWorkflowsDoNotRequireGitHubHostedRunners()
+    {
+        var root = FindRepoRoot();
+        foreach (var workflowName in new[]
+                 {
+                     "powerforge-apple-screenshots.yml",
+                     "powerforge-apple-screenshot-capture.yml",
+                     "powerforge-apple-screenshot-approve.yml",
+                     "powerforge-apple-monitor.yml",
+                     "powerforge-apple-version-pr.yml",
+                     "powerforge-apple-advance.yml",
+                     "powerforge-apple-governance.yml",
+                     "powerforge-apple-approval.yml"
+                 })
+        {
+            var workflow = Read(root, ".github", "workflows", workflowName);
+            Assert.DoesNotContain("runs-on: ubuntu-", workflow, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("runs-on: windows-", workflow, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("runs-on: macos-", workflow, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("self-hosted", workflow, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
     public void AppleWorkflowRunScriptsDoNotInlineCallerControlledInputs()
     {
         var root = FindRepoRoot();

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -510,6 +510,10 @@ public sealed partial class AppleReleaseWorkflowTests
             Assert.DoesNotContain("runs-on: windows-", workflow, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("runs-on: macos-", workflow, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("self-hosted", workflow, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("mapfile ", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain("readarray ", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain(",,}", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain("declare -A", workflow, StringComparison.Ordinal);
         }
     }
 


### PR DESCRIPTION
Private repositories can now run the complete Apple screenshot approval path without consuming GitHub-hosted runner capacity.

The source-resolution job uses the caller-selected trusted runner labels, matching the protected approval job. A workflow contract covers every reusable Apple workflow and rejects hardcoded GitHub-hosted runner labels.

This is required before repinning the CasaRay, Tactra, EasyControlX, and EmailIMO Apple rollout PRs.