### PR TITLE
Unify Spectre progress ordering and presentation

### DIFF
--- a/PSPublishModule/PSPublishModule.csproj
+++ b/PSPublishModule/PSPublishModule.csproj
@@ -61,7 +61,9 @@
     <Compile Include="..\PowerForge.ConsoleShared\PipelinePublishSummary.cs" Link="PowerForge.ConsoleShared\PipelinePublishSummary.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressPresentation.cs" Link="PowerForge.ConsoleShared\SpectreProgressPresentation.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressViewport.cs" Link="PowerForge.ConsoleShared\SpectreProgressViewport.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreProgressLedger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />

--- a/PowerForge.Cli/PowerForge.Cli.csproj
+++ b/PowerForge.Cli/PowerForge.Cli.csproj
@@ -39,7 +39,9 @@
     <Compile Include="..\PowerForge.ConsoleShared\PipelinePublishSummary.cs" Link="PowerForge.ConsoleShared\PipelinePublishSummary.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreConsoleLogger.cs" Link="PowerForge.ConsoleShared\SpectreConsoleLogger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" Link="PowerForge.ConsoleShared\SpectreBuildProgressColumns.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressPresentation.cs" Link="PowerForge.ConsoleShared\SpectreProgressPresentation.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressDisplay.cs" Link="PowerForge.ConsoleShared\SpectreProgressDisplay.cs" />
+    <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressViewport.cs" Link="PowerForge.ConsoleShared\SpectreProgressViewport.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProgressLedger.cs" Link="PowerForge.ConsoleShared\SpectreProgressLedger.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreModulePipelineConsoleUi.cs" />
     <Compile Include="..\PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" Link="PowerForge.ConsoleShared\SpectreProjectBuildConsoleUi.cs" />

--- a/PowerForge.ConsoleShared/SpectreBuildProgressColumns.cs
+++ b/PowerForge.ConsoleShared/SpectreBuildProgressColumns.cs
@@ -125,12 +125,24 @@ internal static class SpectreBuildProgressColumns
         public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
         {
             if (_done.TryGetValue(task, out var elapsed))
-                return new Markup($"[blue]{elapsed:mm\\:ss}[/]");
+                return new Markup($"[blue]{FormatElapsed(elapsed)}[/]");
 
             if (_start.TryGetValue(task, out var startedAt))
-                return new Markup($"[blue]{(DateTimeOffset.Now - startedAt):mm\\:ss}[/]");
+                return new Markup($"[blue]{FormatElapsed(DateTimeOffset.Now - startedAt)}[/]");
 
             return new Markup("[blue]00:00[/]");
         }
+    }
+
+    internal static string FormatElapsed(TimeSpan elapsed)
+    {
+        if (elapsed < TimeSpan.Zero)
+            elapsed = TimeSpan.Zero;
+
+        if (elapsed.TotalHours < 1)
+            return $"{elapsed.Minutes:00}:{elapsed.Seconds:00}";
+
+        var totalHours = (long)Math.Floor(elapsed.TotalHours);
+        return $"{totalHours:00}:{elapsed.Minutes:00}:{elapsed.Seconds:00}";
     }
 }

--- a/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectreModulePipelineConsoleUi.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.ExceptionServices;
 using PowerForge;
 using Spectre.Console;
@@ -35,74 +35,51 @@ internal static class SpectreModulePipelineConsoleUi
     {
         if (runner is null) throw new ArgumentNullException(nameof(runner));
         if (spec is null) throw new ArgumentNullException(nameof(spec));
+        return RunInteractive(
+            AnsiConsole.Console,
+            plan,
+            configLabel,
+            progress => runner.Run(spec, plan, progress));
+    }
+
+    internal static ModulePipelineResult RunInteractive(
+        IAnsiConsole console,
+        ModulePipelinePlan plan,
+        string? configLabel,
+        Func<IModulePipelineProgressReporter, ModulePipelineResult> run)
+    {
+        if (console is null) throw new ArgumentNullException(nameof(console));
         if (plan is null) throw new ArgumentNullException(nameof(plan));
+        if (run is null) throw new ArgumentNullException(nameof(run));
 
         var steps = ModulePipelineStep.Create(plan);
-        WriteHeader(plan, configLabel, steps);
-
-        int vw = 120;
-        try { vw = Math.Max(60, Console.WindowWidth); } catch { }
-
-        bool includeElapsed = vw >= 100;
-        int barWidth = ComputeBarWidth(vw);
-        bool includeBar = barWidth > 0;
-        int percentWidth = 5;
-        int elapsedWidth = includeElapsed ? 5 : 0;
-        int spinnerWidth = 2;
-        int iconWidth = 2;
-        int gaps = 10;
-        int descMax = Math.Max(24, vw - (iconWidth + barWidth + percentWidth + elapsedWidth + spinnerWidth + gaps));
-        int targetWidth = vw <= 100 ? 0 : 26;
-
-        var startLookup = new ConcurrentDictionary<ProgressTask, DateTimeOffset>();
-        var doneLookup = new ConcurrentDictionary<ProgressTask, TimeSpan>();
-        var iconLookup = new ConcurrentDictionary<ProgressTask, string>();
+        WriteHeader(console, plan, configLabel, steps);
+        var presentation = SpectreProgressPresentation.Create(console);
 
         Exception? failure = null;
         ModulePipelineResult? result = null;
         SpectreProgressDisplay.Run(
-            SpectreBuildProgressColumns.CreateDetailed(
-                includeBar,
-                includeElapsed,
-                barWidth,
-                iconLookup,
-                startLookup,
-                doneLookup),
+            console,
+            presentation.CreateColumns(),
             ctx =>
             {
-                var tasksByKey = new Dictionary<string, ProgressTask>(StringComparer.OrdinalIgnoreCase);
-                var labelsByKey = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-                var total = Math.Max(1, steps.Length);
-                var digits = Math.Max(2, total.ToString().Length);
-
-                for (int i = 0; i < steps.Length; i++)
-                {
-                    var step = steps[i];
-                    int ord = i + 1;
-
-                    var label = BuildLabel(step, ord, total, digits, descMax, targetWidth, plan);
-                    var task = ctx.AddTask(label, maxValue: 1, autoStart: false);
-
-                    tasksByKey[step.Key] = task;
-                    labelsByKey[step.Key] = label;
-                    iconLookup[task] = GetStepIcon(step);
-                }
-
+                var ledger = new SpectreProgressLedger(ctx, presentation);
+                var items = ModulePipelineProgressItemFactory.Create(plan)
+                    .Select(ToLedgerItem)
+                    .ToArray();
+                ledger.Plan(items);
                 var reporter = new SpectrePipelineProgressReporter(
-                    tasksByKey,
-                    labelsByKey,
-                    iconLookup,
-                    startLookup,
-                    doneLookup);
+                    ledger,
+                    items.ToDictionary(item => item.Key, StringComparer.OrdinalIgnoreCase));
                 try
                 {
-                    result = runner.Run(spec, plan, reporter);
+                    result = run(reporter);
+                    ledger.FinishRemaining(success: true);
                 }
                 catch (Exception ex)
                 {
                     failure = ex;
-                    AbortRemainingTasks(tasksByKey, labelsByKey, iconLookup, startLookup, doneLookup);
+                    ledger.FinishRemaining(success: false);
                 }
             });
 
@@ -112,28 +89,22 @@ internal static class SpectreModulePipelineConsoleUi
         return result!;
     }
 
-    private static int ComputeBarWidth(int viewportWidth)
-    {
-        if (viewportWidth >= 160) return 40;
-        if (viewportWidth >= 140) return 30;
-        if (viewportWidth >= 120) return 18;
-        if (viewportWidth >= 100) return 14;
-        if (viewportWidth >= 80) return 12;
-        return 10;
-    }
-
-    private static void WriteHeader(ModulePipelinePlan plan, string? configLabel, ModulePipelineStep[] steps)
+    private static void WriteHeader(
+        IAnsiConsole console,
+        ModulePipelinePlan plan,
+        string? configLabel,
+        ModulePipelineStep[] steps)
     {
         static string Esc(string? s) => Markup.Escape(s ?? string.Empty);
         static string Icon(string? s) => Esc(NormalizeIcon(s));
 
-        var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
+        var unicode = ConsoleEncoding.ShouldRenderUnicode(console.Profile.Capabilities.Unicode);
         var versionText = BuildServices.FormatVersionWithPreRelease(plan.ResolvedVersion, plan.PreRelease);
 
         var title = unicode
             ? $"🛠️ PowerForge • {plan.ModuleName} {versionText}"
             : $"PowerForge • {plan.ModuleName} {versionText}";
-        AnsiConsole.Write(new Rule($"[yellow bold underline]{Esc(title)}[/]") { Justification = Justify.Left });
+        console.Write(new Rule($"[yellow bold underline]{Esc(title)}[/]") { Justification = Justify.Left });
 
         var iconColWidth = unicode ? 2 : 3;
         var info = new Table()
@@ -175,8 +146,8 @@ internal static class SpectreModulePipelineConsoleUi
         AddInfoRow(unicode ? "📥" : "INS", "Install", plan.InstallEnabled ? Esc($"{plan.InstallStrategy}, keep {plan.InstallKeepVersions}") : "[grey]Disabled[/]");
 
         AddInfoRow(unicode ? "🧭" : "STP", "Steps", Esc(steps.Length.ToString()));
-        AnsiConsole.Write(info);
-        AnsiConsole.WriteLine();
+        console.Write(info);
+        console.WriteLine();
     }
 
     private static string NormalizeIcon(string? icon)
@@ -206,103 +177,21 @@ internal static class SpectreModulePipelineConsoleUi
         return col;
     }
 
-    private static string GetStepIcon(ModulePipelineStep step)
+    private static SpectreProgressLedgerItem ToLedgerItem(
+        PowerForgeReleaseProgressItem item)
     {
-        var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
-        return step.Kind switch
+        return new SpectreProgressLedgerItem
         {
-            ModulePipelineStepKind.Build => unicode ? "[cyan]🔨[/]" : "[cyan]BL[/]",
-            ModulePipelineStepKind.Documentation => unicode ? "[deepskyblue1]📝[/]" : "[deepskyblue1]DC[/]",
-            ModulePipelineStepKind.Formatting => unicode ? "[mediumpurple3]🎨[/]" : "[mediumpurple3]FM[/]",
-            ModulePipelineStepKind.Signing => unicode ? "[gold3]🔏[/]" : "[gold3]SG[/]",
-            ModulePipelineStepKind.Validation => unicode ? "[lightskyblue1]🔎[/]" : "[lightskyblue1]VA[/]",
-            ModulePipelineStepKind.Tests => unicode ? "[orange3]🧪[/]" : "[orange3]TS[/]",
-            ModulePipelineStepKind.Artefact => unicode ? "[magenta]📦[/]" : "[magenta]PK[/]",
-            ModulePipelineStepKind.Publish => unicode ? "[yellow]🚀[/]" : "[yellow]PB[/]",
-            ModulePipelineStepKind.Install => unicode ? "[green]📥[/]" : "[green]IN[/]",
-            ModulePipelineStepKind.Cleanup => unicode ? "[grey]🧹[/]" : "[grey]CL[/]",
-            _ => unicode ? "[grey]•[/]" : "[grey]PF[/]"
+            Key = item.Key,
+            GroupKey = PowerForgeReleaseProgressPhase.Module.ToString(),
+            GroupTitle = "Build PowerShell module",
+            GroupOrder = (int)PowerForgeReleaseProgressPhase.Module,
+            Title = item.Title,
+            Kind = item.Kind,
+            Target = item.Target,
+            Position = item.Position,
+            Total = item.Total
         };
-    }
-
-    private static string BuildLabel(
-        ModulePipelineStep step,
-        int ord,
-        int total,
-        int digits,
-        int descMax,
-        int targetWidth,
-        ModulePipelinePlan plan)
-    {
-        static string FormatId(int n, int total, int digits)
-        {
-            var left = Math.Max(0, n).ToString(new string('0', Math.Max(1, digits)));
-            var right = Math.Max(0, total).ToString(new string('0', Math.Max(1, digits)));
-            return $"{left}/{right}";
-        }
-
-        static string PadOrEllipsis(string input, int width)
-        {
-            if (width <= 0) return string.Empty;
-            input ??= string.Empty;
-            if (input.Length == width) return input;
-            if (input.Length < width) return input.PadRight(width);
-            if (width <= 1) return "…";
-            return input.Substring(0, Math.Max(0, width - 1)) + "…";
-        }
-
-        string name = step.Kind switch
-        {
-            ModulePipelineStepKind.Build => step.Title,
-            ModulePipelineStepKind.Documentation => step.Title,
-            ModulePipelineStepKind.Tests => step.Title,
-            ModulePipelineStepKind.Artefact => "Pack artefact",
-            ModulePipelineStepKind.Publish => "Publish",
-            ModulePipelineStepKind.Install => "Install",
-            ModulePipelineStepKind.Cleanup => "Cleanup staging",
-            _ => step.Title
-        };
-
-        string target = step.Kind switch
-        {
-            ModulePipelineStepKind.Artefact => FormatArtefactTarget(step.ArtefactSegment),
-            ModulePipelineStepKind.Publish => FormatPublishTarget(step.PublishSegment),
-            ModulePipelineStepKind.Install => $"{plan.InstallStrategy}, keep {plan.InstallKeepVersions}",
-            _ => string.Empty
-        };
-
-        int safeTotal = Math.Max(1, total);
-        int idFieldWidth = (digits * 2) + 1;
-        string idField = PadOrEllipsis(FormatId(ord, safeTotal, digits), idFieldWidth);
-
-        if (targetWidth <= 0)
-        {
-            int nameWidthOnly = Math.Max(0, descMax - idFieldWidth - 1);
-            string nameFieldOnly = PadOrEllipsis(name, nameWidthOnly);
-            return $"{idField} {nameFieldOnly}".TrimEnd();
-        }
-
-        int nameWidth = Math.Max(0, descMax - idFieldWidth - 1 - targetWidth);
-        string nameField = PadOrEllipsis(name, nameWidth);
-        string targetField = PadOrEllipsis(target, targetWidth);
-        return $"{idField} {nameField} {targetField}".TrimEnd();
-
-        static string FormatArtefactTarget(ConfigurationArtefactSegment? seg)
-        {
-            if (seg is null) return string.Empty;
-            var id = seg.Configuration?.ID;
-            var label = seg.ArtefactType.ToString();
-            return string.IsNullOrWhiteSpace(id) ? label : $"{label} ({id})";
-        }
-
-        static string FormatPublishTarget(ConfigurationPublishSegment? seg)
-        {
-            if (seg is null) return string.Empty;
-            var cfg = seg.Configuration ?? new PublishConfiguration();
-            var repoName = cfg.Repository?.Name ?? cfg.RepositoryName;
-            if (!string.IsNullOrWhiteSpace(repoName)) return $"{cfg.Destination} ({repoName})";
-            return cfg.Destination.ToString();
-        }
     }
 
     private static ConsoleView ResolveView(ConsoleView requested)
@@ -312,162 +201,50 @@ internal static class SpectreModulePipelineConsoleUi
         return interactive ? ConsoleView.Standard : ConsoleView.Ansi;
     }
 
-    private static void AbortRemainingTasks(
-        IReadOnlyDictionary<string, ProgressTask> tasksByKey,
-        IReadOnlyDictionary<string, string> labelsByKey,
-        ConcurrentDictionary<ProgressTask, string> iconLookup,
-        ConcurrentDictionary<ProgressTask, DateTimeOffset> startLookup,
-        ConcurrentDictionary<ProgressTask, TimeSpan> doneLookup)
-    {
-        var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
-        foreach (var entry in tasksByKey)
-        {
-            var key = entry.Key;
-            var task = entry.Value;
-            if (task is null) continue;
-
-            if (startLookup.ContainsKey(task))
-            {
-                if (!doneLookup.ContainsKey(task))
-                {
-                    task.IsIndeterminate = false;
-                    task.Value = task.MaxValue;
-                    iconLookup[task] = StatusIcon(StepUiStatus.Failed, unicode);
-                    if (labelsByKey.TryGetValue(key, out var failedLabel))
-                        task.Description = $"{failedLabel.TrimEnd()} FAILED";
-                    try { task.StopTask(); } catch { }
-
-                    if (startLookup.TryGetValue(task, out var start))
-                        doneLookup[task] = DateTimeOffset.Now - start;
-                }
-
-                continue;
-            }
-
-            iconLookup[task] = StatusIcon(StepUiStatus.Skipped, unicode);
-            if (labelsByKey.TryGetValue(key, out var skippedLabel))
-                task.Description = $"{skippedLabel.TrimEnd()} SKIPPED";
-        }
-    }
-
     private sealed class SpectrePipelineProgressReporter : IModulePipelineProgressReporterV3
     {
-        private readonly IReadOnlyDictionary<string, ProgressTask> _tasks;
-        private readonly IReadOnlyDictionary<string, string> _labels;
-        private readonly ConcurrentDictionary<ProgressTask, string> _iconLookup;
-        private readonly ConcurrentDictionary<ProgressTask, DateTimeOffset> _startLookup;
-        private readonly ConcurrentDictionary<ProgressTask, TimeSpan> _doneLookup;
-        private readonly bool _unicode;
+        private readonly SpectreProgressLedger _ledger;
+        private readonly IReadOnlyDictionary<string, SpectreProgressLedgerItem> _items;
 
         public SpectrePipelineProgressReporter(
-            IReadOnlyDictionary<string, ProgressTask> tasks,
-            IReadOnlyDictionary<string, string> labels,
-            ConcurrentDictionary<ProgressTask, string> iconLookup,
-            ConcurrentDictionary<ProgressTask, DateTimeOffset> startLookup,
-            ConcurrentDictionary<ProgressTask, TimeSpan> doneLookup)
+            SpectreProgressLedger ledger,
+            IReadOnlyDictionary<string, SpectreProgressLedgerItem> items)
         {
-            _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
-            _labels = labels ?? throw new ArgumentNullException(nameof(labels));
-            _iconLookup = iconLookup ?? throw new ArgumentNullException(nameof(iconLookup));
-            _startLookup = startLookup ?? throw new ArgumentNullException(nameof(startLookup));
-            _doneLookup = doneLookup ?? throw new ArgumentNullException(nameof(doneLookup));
-            _unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
+            _ledger = ledger ?? throw new ArgumentNullException(nameof(ledger));
+            _items = items ?? throw new ArgumentNullException(nameof(items));
         }
 
         public void StepStarting(ModulePipelineStep step)
-        {
-            if (step is null) return;
-            if (!_tasks.TryGetValue(step.Key, out var task)) return;
-
-            task.IsIndeterminate = true;
-            task.StartTask();
-            _startLookup[task] = DateTimeOffset.Now;
-        }
+            => Update(step, SpectreProgressLedgerState.Started);
 
         public void StepCompleted(ModulePipelineStep step)
-        {
-            if (step is null) return;
-            if (!_tasks.TryGetValue(step.Key, out var task)) return;
-
-            task.IsIndeterminate = false;
-            task.Value = task.MaxValue;
-            task.StopTask();
-            _iconLookup[task] = StatusIcon(StepUiStatus.Completed, _unicode);
-
-            if (_startLookup.TryGetValue(task, out var start))
-                _doneLookup[task] = DateTimeOffset.Now - start;
-        }
+            => Update(step, SpectreProgressLedgerState.Completed);
 
         public void StepFailed(ModulePipelineStep step, Exception error)
-        {
-            if (step is null) return;
-            if (!_tasks.TryGetValue(step.Key, out var task)) return;
-
-            task.IsIndeterminate = false;
-            task.Value = task.MaxValue;
-            _iconLookup[task] = StatusIcon(StepUiStatus.Failed, _unicode);
-
-            if (_labels.TryGetValue(step.Key, out var label))
-                task.Description = $"{label.TrimEnd()} FAILED";
-
-            try { task.StopTask(); } catch { }
-
-            if (_startLookup.TryGetValue(task, out var start))
-                _doneLookup[task] = DateTimeOffset.Now - start;
-        }
+            => Update(step, SpectreProgressLedgerState.Failed, error?.Message);
 
         public void StepSkipped(ModulePipelineStep step)
-        {
-            if (step is null) return;
-            if (!_tasks.TryGetValue(step.Key, out var task)) return;
-
-            task.IsIndeterminate = false;
-            try { task.StartTask(); } catch { }
-            task.Value = task.MaxValue;
-            _iconLookup[task] = StatusIcon(StepUiStatus.Skipped, _unicode);
-
-            if (_labels.TryGetValue(step.Key, out var label))
-                task.Description = $"{label.TrimEnd()} SKIPPED";
-
-            try { task.StopTask(); } catch { }
-        }
+            => Update(step, SpectreProgressLedgerState.Skipped);
 
         public void StepProgress(ModulePipelineStep step, double value, double maximum, string? detail = null)
         {
-            if (step is null || !_tasks.TryGetValue(step.Key, out var task)) return;
+            if (step is null || !_items.TryGetValue(step.Key, out var item))
+                return;
 
-            task.IsIndeterminate = maximum <= 0;
-            if (maximum > 0)
-            {
-                task.MaxValue = maximum;
-                task.Value = Math.Min(Math.Max(0, value), maximum);
-            }
+            item.ProgressValue = Math.Max(0, value);
+            item.ProgressMaximum = Math.Max(0, maximum);
+            _ledger.Update(item, SpectreProgressLedgerState.Started, detail);
+        }
 
-            if (_labels.TryGetValue(step.Key, out var label))
-            {
-                task.Description = string.IsNullOrWhiteSpace(detail)
-                    ? label
-                    : $"{label.TrimEnd()} [grey]— {Markup.Escape(detail!)}[/]";
-            }
+        private void Update(
+            ModulePipelineStep step,
+            SpectreProgressLedgerState state,
+            string? detail = null)
+        {
+            if (step is null || !_items.TryGetValue(step.Key, out var item))
+                return;
 
-            try { task.StartTask(); } catch { }
+            _ledger.Update(item, state, detail);
         }
     }
-
-    private enum StepUiStatus
-    {
-        Completed,
-        Failed,
-        Skipped
-    }
-
-    private static string StatusIcon(StepUiStatus status, bool unicode)
-        => status switch
-        {
-            StepUiStatus.Completed => unicode ? "[green]✅[/]" : "[green]OK[/]",
-            StepUiStatus.Failed => unicode ? "[red]❌[/]" : "[red]X[/]",
-            StepUiStatus.Skipped => unicode ? "[grey]⏭[/]" : "[grey]SK[/]",
-            _ => unicode ? "[grey]•[/]" : "[grey]?[/]"
-        };
-
 }

--- a/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
+++ b/PowerForge.ConsoleShared/SpectrePowerForgeReleaseConsoleUi.cs
@@ -13,7 +13,15 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         PowerForgeReleaseSpec spec,
         PowerForgeReleaseRequest request,
         Func<IPowerForgeReleaseProgressReporter, PowerForgeReleaseResult> run)
+        => RunInteractive(AnsiConsole.Console, spec, request, run);
+
+    internal static PowerForgeReleaseResult RunInteractive(
+        IAnsiConsole console,
+        PowerForgeReleaseSpec spec,
+        PowerForgeReleaseRequest request,
+        Func<IPowerForgeReleaseProgressReporter, PowerForgeReleaseResult> run)
     {
+        if (console is null) throw new ArgumentNullException(nameof(console));
         if (spec is null) throw new ArgumentNullException(nameof(spec));
         if (request is null) throw new ArgumentNullException(nameof(request));
         if (run is null) throw new ArgumentNullException(nameof(run));
@@ -22,19 +30,24 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         var phaseNames = phases.ToDictionary(
             phase => phase,
             phase => GetPhaseName(phase, spec, request));
-        WriteHeader(spec, request, phases, phaseNames);
+        WriteHeader(console, spec, request, phases, phaseNames);
         PowerForgeReleaseResult? result = null;
         Exception? failure = null;
         Reporter? reporter = null;
+        var presentation = SpectreProgressPresentation.Create(console);
 
         SpectreProgressDisplay.Run(
-            SpectreBuildProgressColumns.CreateStandard(),
+            console,
+            presentation.CreateColumns(),
             context =>
             {
                 var tasks = phases.ToDictionary(
                     phase => phase,
-                    phase => context.AddTask($"[grey]{Markup.Escape(phaseNames[phase])} — pending[/]", maxValue: 100, autoStart: false));
-                reporter = new Reporter(context, tasks, phaseNames);
+                    phase => context.AddTask($"{phaseNames[phase]} — pending", maxValue: 100, autoStart: false));
+                foreach (var entry in tasks)
+                    presentation.Register(entry.Value, entry.Key.ToString());
+
+                reporter = new Reporter(console, context, tasks, phaseNames, presentation);
                 try
                 {
                     result = run(reporter);
@@ -136,15 +149,16 @@ internal static class SpectrePowerForgeReleaseConsoleUi
     }
 
     private static void WriteHeader(
+        IAnsiConsole console,
         PowerForgeReleaseSpec spec,
         PowerForgeReleaseRequest request,
         IReadOnlyList<PowerForgeReleaseProgressPhase> phases,
         IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> phaseNames)
     {
         static string Esc(string? value) => Markup.Escape(value ?? string.Empty);
-        var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
+        var unicode = ConsoleEncoding.ShouldRenderUnicode(console.Profile.Capabilities.Unicode);
         var title = unicode ? "🚀 PowerForge • Unified release" : "PowerForge • Unified release";
-        AnsiConsole.Write(new Rule($"[yellow bold underline]{Esc(title)}[/]") { Justification = Justify.Left });
+        console.Write(new Rule($"[yellow bold underline]{Esc(title)}[/]") { Justification = Justify.Left });
 
         var toolOutputs = CountToolOutputs(spec.Tools);
         var versionPolicy = spec.Module?.SynchronizeVersionWithPackages == true
@@ -160,8 +174,8 @@ internal static class SpectrePowerForgeReleaseConsoleUi
         table.AddRow("[grey]Order[/]", Esc(string.Join(" → ", phases.Select(phase => phaseNames[phase]))));
         table.AddRow("[grey]Version[/]", Esc(versionPolicy));
         if (toolOutputs > 0) table.AddRow("[grey]Tool matrix[/]", Esc($"{spec.Tools!.Targets.Length} target(s), {toolOutputs} output(s)"));
-        AnsiConsole.Write(table);
-        AnsiConsole.WriteLine();
+        console.Write(table);
+        console.WriteLine();
     }
 
     private static int CountToolOutputs(PowerForgeToolReleaseSpec? tools)
@@ -192,37 +206,45 @@ internal static class SpectrePowerForgeReleaseConsoleUi
     private sealed class Reporter : IPowerForgeReleaseProgressReporterV2
     {
         private readonly ProgressContext _context;
+        private readonly IAnsiConsole _console;
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> _tasks;
         private readonly IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> _phaseNames;
         private readonly HashSet<PowerForgeReleaseProgressPhase> _failed = new();
         private readonly SpectreProgressLedger _ledger;
+        private readonly SpectreProgressPresentation _presentation;
 
         public Reporter(
+            IAnsiConsole console,
             ProgressContext context,
             IReadOnlyDictionary<PowerForgeReleaseProgressPhase, ProgressTask> tasks,
-            IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> phaseNames)
+            IReadOnlyDictionary<PowerForgeReleaseProgressPhase, string> phaseNames,
+            SpectreProgressPresentation presentation)
         {
+            _console = console;
             _context = context;
             _tasks = tasks;
             _phaseNames = phaseNames;
-            _ledger = new SpectreProgressLedger(context);
+            _presentation = presentation;
+            _ledger = new SpectreProgressLedger(context, presentation);
         }
 
         public void PhaseStarted(PowerForgeReleaseProgressPhase phase, int totalItems, string? detail = null)
         {
             if (!_tasks.TryGetValue(phase, out var task)) return;
             if (!task.IsStarted) task.StartTask();
+            _presentation.MarkStarted(task, phase.ToString());
             task.Value = 5;
-            task.Description = Label(phase, detail, "cyan");
+            task.Description = Label(phase, detail);
         }
 
         public void PhaseCompleted(PowerForgeReleaseProgressPhase phase, string? detail = null)
         {
             if (!_tasks.TryGetValue(phase, out var task)) return;
             if (!task.IsStarted) task.StartTask();
-            task.Description = Label(phase, detail, "green", "✓");
+            task.Description = Label(phase, detail, "✓");
             task.Value = 100;
             task.StopTask();
+            _presentation.MarkTerminal(task, SpectreProgressLedgerState.Completed);
         }
 
         public void PhaseFailed(PowerForgeReleaseProgressPhase phase, string? detail = null)
@@ -230,9 +252,10 @@ internal static class SpectrePowerForgeReleaseConsoleUi
             if (!_tasks.TryGetValue(phase, out var task)) return;
             _failed.Add(phase);
             if (!task.IsStarted) task.StartTask();
-            task.Description = Label(phase, detail, "red", "x");
+            task.Description = Label(phase, detail, "x");
             task.Value = 100;
             task.StopTask();
+            _presentation.MarkTerminal(task, SpectreProgressLedgerState.Failed);
         }
 
         public void ItemsPlanned(
@@ -247,7 +270,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 .Select(ToLedgerItem));
 
             if (_tasks.TryGetValue(phase, out var phaseTask))
-                phaseTask.Description = Label(phase, $"{CountItems(phase)} detailed step(s)", "cyan");
+                phaseTask.Description = Label(phase, $"{CountItems(phase)} detailed step(s)");
         }
 
         public void ItemUpdated(
@@ -285,9 +308,10 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 }
 
                 entry.Value.StartTask();
-                entry.Value.Description = Label(entry.Key, success ? "not required" : "skipped after failure", "grey", "–");
+                entry.Value.Description = Label(entry.Key, success ? "not required" : "skipped after failure", "–");
                 entry.Value.Value = 100;
                 entry.Value.StopTask();
+                _presentation.MarkTerminal(entry.Value, SpectreProgressLedgerState.Skipped);
             }
 
             _ledger.FinishRemaining(success);
@@ -297,15 +321,15 @@ internal static class SpectrePowerForgeReleaseConsoleUi
 
         public void WriteLedger()
             => SpectreProgressLedger.WriteLedger(
-                AnsiConsole.Console,
+                _console,
                 _ledger.GetSnapshots(),
                 "Unified release details");
 
-        private string Label(PowerForgeReleaseProgressPhase phase, string? detail, string color, string? status = null)
+        private string Label(PowerForgeReleaseProgressPhase phase, string? detail, string? status = null)
         {
             var prefix = string.IsNullOrWhiteSpace(status) ? string.Empty : status + " ";
             var suffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : " — " + detail;
-            return $"[{color}]{Markup.Escape(prefix + _phaseNames[phase] + suffix)}[/]";
+            return prefix + _phaseNames[phase] + suffix;
         }
 
         private void UpdatePhaseProgress(PowerForgeReleaseProgressPhase phase)
@@ -336,6 +360,7 @@ internal static class SpectrePowerForgeReleaseConsoleUi
                 GroupOrder = (int)item.Phase,
                 Title = item.Title,
                 Kind = item.Kind,
+                Target = item.Target,
                 Position = item.Position,
                 Total = item.Total,
                 ProgressValue = item.ProgressValue,

--- a/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressDisplay.cs
@@ -35,7 +35,10 @@ internal static class SpectreProgressDisplay
             {
                 finalFrame = renderable;
                 taskObserver?.Invoke(tasks);
-                return renderable;
+                return SpectreProgressViewport.Project(
+                    renderable,
+                    tasks,
+                    Math.Max(1, console.Profile.Height - 2));
             })
             .Start(action);
 

--- a/PowerForge.ConsoleShared/SpectreProgressLedger.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressLedger.cs
@@ -7,18 +7,25 @@ using Spectre.Console;
 namespace PowerForge.ConsoleShared;
 
 /// <summary>
-/// Keeps every planned work item visible in the Spectre live region and retains the
-/// complete history for a durable post-run ledger.
+/// Registers the complete plan in canonical order and updates rows in place.
+/// The shared live viewport keeps current work visible without filtering, removing,
+/// or re-adding planned tasks.
 /// </summary>
 internal sealed class SpectreProgressLedger
 {
     private readonly ProgressContext _context;
+    private readonly SpectreProgressPresentation? _presentation;
     private readonly Dictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, ProgressTask> _visibleTasks = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _sync = new();
 
-    internal SpectreProgressLedger(ProgressContext context)
-        => _context = context ?? throw new ArgumentNullException(nameof(context));
+    internal SpectreProgressLedger(
+        ProgressContext context,
+        SpectreProgressPresentation? presentation = null)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _presentation = presentation;
+    }
 
     internal void Plan(IEnumerable<SpectreProgressLedgerItem> items)
     {
@@ -41,7 +48,7 @@ internal sealed class SpectreProgressLedger
                 _entries[item.Key] = new Entry(item);
             }
 
-            RefreshVisibleTasks();
+            RefreshTasks();
         }
     }
 
@@ -65,8 +72,10 @@ internal sealed class SpectreProgressLedger
                 entry.Item = item;
             }
 
-            ApplyUpdate(entry, state, detail, moveStartedTaskToEnd: true);
-            RefreshVisibleTasks();
+            // Spectre keeps task insertion order. The full plan is materialized
+            // before any updates so an out-of-order start cannot move a row.
+            RefreshTasks();
+            ApplyUpdate(entry, state, detail);
             _context.Refresh();
         }
     }
@@ -121,11 +130,10 @@ internal sealed class SpectreProgressLedger
                 ApplyUpdate(
                     entry,
                     state,
-                    success ? "not required" : "skipped after failure",
-                    moveStartedTaskToEnd: false);
+                    success ? "not required" : "skipped after failure");
             }
 
-            RefreshVisibleTasks();
+            RefreshTasks();
             _context.Refresh();
         }
     }
@@ -135,7 +143,10 @@ internal sealed class SpectreProgressLedger
         lock (_sync)
         {
             foreach (var task in _visibleTasks.Values.ToArray())
+            {
                 _context.RemoveTask(task);
+                _presentation?.Remove(task);
+            }
 
             _visibleTasks.Clear();
             _context.Refresh();
@@ -155,6 +166,7 @@ internal sealed class SpectreProgressLedger
                     entry.Item.Position,
                     entry.Item.Total,
                     entry.Item.Title,
+                    entry.Item.Target,
                     entry.State,
                     entry.Detail,
                     entry.Duration ?? entry.Item.Duration ?? TimeSpan.Zero))
@@ -199,10 +211,14 @@ internal sealed class SpectreProgressLedger
             var ordinal = snapshot.Position > 0 && snapshot.Total > 0
                 ? $"{snapshot.Position:00}/{snapshot.Total:00}"
                 : "–";
+            var result = string.Join(
+                " — ",
+                new[] { snapshot.Target, snapshot.Detail }
+                    .Where(value => !string.IsNullOrWhiteSpace(value)));
             table.AddRow(
                 $"[{color}]{icon}[/]",
                 $"[{color}]{Esc($"{ordinal} {snapshot.Title}")}[/]",
-                $"[{color}]{Esc(snapshot.Detail)}[/]",
+                $"[{color}]{Esc(result)}[/]",
                 $"[deepskyblue1]{Esc(FormatDuration(snapshot.Duration))}[/]");
         }
 
@@ -219,30 +235,18 @@ internal sealed class SpectreProgressLedger
             maxValue: 1,
             autoStart: false);
         _visibleTasks[entry.Item.Key] = task;
+        _presentation?.Register(task, entry.Item.Kind);
         return task;
     }
 
     private void ApplyUpdate(
         Entry entry,
         SpectreProgressLedgerState state,
-        string? detail,
-        bool moveStartedTaskToEnd)
+        string? detail)
     {
         entry.State = state;
         entry.Detail = detail;
         entry.ProgressFraction = ResolveProgressFraction(entry.Item, state);
-
-        if (moveStartedTaskToEnd &&
-            state == SpectreProgressLedgerState.Started &&
-            _visibleTasks.TryGetValue(entry.Item.Key, out var plannedTask) &&
-            !plannedTask.IsStarted)
-        {
-            // Spectre crops overflowing live displays from the top. Re-adding the
-            // newly started task keeps the current work at the visible bottom while
-            // the full plan remains registered and is written durably after the run.
-            _context.RemoveTask(plannedTask);
-            _visibleTasks.Remove(entry.Item.Key);
-        }
 
         var task = EnsureVisibleTask(entry);
         task.Description = BuildLiveLabel(entry);
@@ -252,6 +256,7 @@ internal sealed class SpectreProgressLedger
             if (!task.IsStarted)
                 task.StartTask();
 
+            _presentation?.MarkStarted(task, entry.Item.Kind);
             task.IsIndeterminate = entry.Item.ProgressMaximum <= 0;
             if (!task.IsIndeterminate)
                 task.Value = task.MaxValue * entry.ProgressFraction;
@@ -265,10 +270,11 @@ internal sealed class SpectreProgressLedger
             task.Value = task.MaxValue;
             task.StopTask();
             entry.Duration = entry.Item.Duration ?? task.ElapsedTime ?? TimeSpan.Zero;
+            _presentation?.MarkTerminal(task, state, entry.Duration);
         }
     }
 
-    private void RefreshVisibleTasks()
+    private void RefreshTasks()
     {
         foreach (var entry in _entries.Values
                      .OrderBy(entry => entry.Item.GroupOrder)
@@ -277,8 +283,11 @@ internal sealed class SpectreProgressLedger
             EnsureVisibleTask(entry).Description = BuildLiveLabel(entry);
     }
 
-    private static string BuildLiveLabel(Entry entry)
+    private string BuildLiveLabel(Entry entry)
     {
+        if (_presentation is not null)
+            return _presentation.BuildLabel(entry.Item, entry.Detail);
+
         var unicode = ConsoleEncoding.ShouldRenderUnicode(AnsiConsole.Profile.Capabilities.Unicode);
         var (icon, color) = GetStateVisual(entry.State, unicode);
         var ordinal = entry.Item.Position > 0 && entry.Item.Total > 0
@@ -347,6 +356,7 @@ internal sealed class SpectreProgressLedgerItem
     internal int GroupOrder { get; set; }
     internal string Title { get; set; } = string.Empty;
     internal string? Kind { get; set; }
+    internal string? Target { get; set; }
     internal int Position { get; set; }
     internal int Total { get; set; }
     internal double ProgressValue { get; set; }
@@ -370,6 +380,7 @@ internal sealed class SpectreProgressLedgerSnapshot
         int position,
         int total,
         string title,
+        string? target,
         SpectreProgressLedgerState state,
         string? detail,
         TimeSpan duration)
@@ -378,6 +389,7 @@ internal sealed class SpectreProgressLedgerSnapshot
         Position = position;
         Total = total;
         Title = title;
+        Target = target;
         State = state;
         Detail = detail;
         Duration = duration;
@@ -387,6 +399,7 @@ internal sealed class SpectreProgressLedgerSnapshot
     internal int Position { get; }
     internal int Total { get; }
     internal string Title { get; }
+    internal string? Target { get; }
     internal SpectreProgressLedgerState State { get; }
     internal string? Detail { get; }
     internal TimeSpan Duration { get; }

--- a/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Concurrent;
+using PowerForge;
+using Spectre.Console;
+
+namespace PowerForge.ConsoleShared;
+
+/// <summary>
+/// Owns the shared Spectre layout, labels, icons, and fixed timing state used by
+/// direct module builds and unified release progress.
+/// </summary>
+internal sealed class SpectreProgressPresentation
+{
+    private readonly ConcurrentDictionary<ProgressTask, string> _icons = new();
+    private readonly ConcurrentDictionary<ProgressTask, DateTimeOffset> _started = new();
+    private readonly ConcurrentDictionary<ProgressTask, TimeSpan> _completed = new();
+    private readonly bool _unicode;
+    private readonly bool _includeBar;
+    private readonly bool _includeElapsed;
+    private readonly int _barWidth;
+    private readonly int _descriptionWidth;
+    private readonly int _targetWidth;
+
+    internal SpectreProgressPresentation(int viewportWidth, bool unicode)
+    {
+        var width = Math.Max(60, viewportWidth);
+        _unicode = unicode;
+        _includeElapsed = width >= 100;
+        _barWidth = ComputeBarWidth(width);
+        _includeBar = _barWidth > 0;
+
+        const int percentWidth = 5;
+        var elapsedWidth = _includeElapsed ? 5 : 0;
+        const int spinnerWidth = 2;
+        const int iconWidth = 2;
+        const int gaps = 10;
+        _descriptionWidth = Math.Max(
+            24,
+            width - (iconWidth + _barWidth + percentWidth + elapsedWidth + spinnerWidth + gaps));
+        _targetWidth = width <= 100 ? 0 : 26;
+    }
+
+    internal static SpectreProgressPresentation Create(IAnsiConsole console)
+    {
+        if (console is null) throw new ArgumentNullException(nameof(console));
+        var unicode = ConsoleEncoding.ShouldRenderUnicode(console.Profile.Capabilities.Unicode);
+        return new SpectreProgressPresentation(console.Profile.Width, unicode);
+    }
+
+    internal ProgressColumn[] CreateColumns()
+        => SpectreBuildProgressColumns.CreateDetailed(
+            _includeBar,
+            _includeElapsed,
+            _barWidth,
+            _icons,
+            _started,
+            _completed);
+
+    internal string BuildLabel(SpectreProgressLedgerItem item, string? detail)
+    {
+        if (item is null) throw new ArgumentNullException(nameof(item));
+
+        var ordinal = item.Position > 0 && item.Total > 0
+            ? FormatOrdinal(item.Position, item.Total)
+            : string.Empty;
+        var idWidth = ordinal.Length;
+        var detailSuffix = string.IsNullOrWhiteSpace(detail) ? string.Empty : $" — {detail}";
+        var title = item.Title + detailSuffix;
+
+        if (idWidth == 0)
+            return PadOrEllipsis(title, _descriptionWidth);
+
+        if (_targetWidth <= 0)
+        {
+            var titleWidth = Math.Max(0, _descriptionWidth - idWidth - 1);
+            return $"{ordinal} {PadOrEllipsis(title, titleWidth)}".TrimEnd();
+        }
+
+        var titleWidthWithTarget = Math.Max(0, _descriptionWidth - idWidth - _targetWidth - 2);
+        var target = PadOrEllipsis(item.Target ?? string.Empty, _targetWidth);
+        return $"{ordinal} {PadOrEllipsis(title, titleWidthWithTarget)} {target}".TrimEnd();
+    }
+
+    internal void Register(ProgressTask task, string? kind)
+    {
+        if (task is null) throw new ArgumentNullException(nameof(task));
+        _icons[task] = GetKindIcon(kind, _unicode);
+    }
+
+    internal void MarkStarted(ProgressTask task, string? kind)
+    {
+        Register(task, kind);
+        _started.TryAdd(task, DateTimeOffset.Now);
+    }
+
+    internal void MarkTerminal(
+        ProgressTask task,
+        SpectreProgressLedgerState state,
+        TimeSpan? duration = null)
+    {
+        if (task is null) throw new ArgumentNullException(nameof(task));
+
+        _icons[task] = GetStateIcon(state, _unicode);
+        if (duration.HasValue)
+        {
+            _completed[task] = duration.Value;
+            return;
+        }
+
+        if (_started.TryGetValue(task, out var startedAt))
+            _completed[task] = DateTimeOffset.Now - startedAt;
+    }
+
+    internal void Remove(ProgressTask task)
+    {
+        if (task is null)
+            return;
+
+        _icons.TryRemove(task, out _);
+        _started.TryRemove(task, out _);
+        _completed.TryRemove(task, out _);
+    }
+
+    internal static string GetKindIcon(string? kind, bool unicode)
+    {
+        if (!Enum.TryParse(kind, ignoreCase: true, out ModulePipelineStepKind parsed))
+        {
+            return kind?.Trim().ToLowerInvariant() switch
+            {
+                "module" => unicode ? "[cyan]🔨[/]" : "[cyan]BL[/]",
+                "packages" => unicode ? "[magenta]📦[/]" : "[magenta]PK[/]",
+                "tools" => unicode ? "[deepskyblue1]🧰[/]" : "[deepskyblue1]TL[/]",
+                "github" => unicode ? "[yellow]🚀[/]" : "[yellow]GH[/]",
+                "versioning" => unicode ? "[lightskyblue1]🏷[/]" : "[lightskyblue1]VR[/]",
+                _ => unicode ? "[grey]•[/]" : "[grey]PF[/]"
+            };
+        }
+
+        return parsed switch
+        {
+            ModulePipelineStepKind.Versioning => unicode ? "[lightskyblue1]🏷[/]" : "[lightskyblue1]VR[/]",
+            ModulePipelineStepKind.Build => unicode ? "[cyan]🔨[/]" : "[cyan]BL[/]",
+            ModulePipelineStepKind.Documentation => unicode ? "[deepskyblue1]📝[/]" : "[deepskyblue1]DC[/]",
+            ModulePipelineStepKind.Formatting => unicode ? "[mediumpurple3]🎨[/]" : "[mediumpurple3]FM[/]",
+            ModulePipelineStepKind.Signing => unicode ? "[gold3]🔏[/]" : "[gold3]SG[/]",
+            ModulePipelineStepKind.Validation => unicode ? "[lightskyblue1]🔎[/]" : "[lightskyblue1]VA[/]",
+            ModulePipelineStepKind.Tests => unicode ? "[orange3]🧪[/]" : "[orange3]TS[/]",
+            ModulePipelineStepKind.Artefact => unicode ? "[magenta]📦[/]" : "[magenta]PK[/]",
+            ModulePipelineStepKind.Publish => unicode ? "[yellow]🚀[/]" : "[yellow]PB[/]",
+            ModulePipelineStepKind.Install => unicode ? "[green]📥[/]" : "[green]IN[/]",
+            ModulePipelineStepKind.Cleanup => unicode ? "[grey]🧹[/]" : "[grey]CL[/]",
+            ModulePipelineStepKind.Action => unicode ? "[steelblue1]⚙[/]" : "[steelblue1]AC[/]",
+            ModulePipelineStepKind.PackageBuild => unicode ? "[magenta]📦[/]" : "[magenta]PK[/]",
+            ModulePipelineStepKind.ExternalAsset => unicode ? "[deepskyblue1]📥[/]" : "[deepskyblue1]AS[/]",
+            _ => unicode ? "[grey]•[/]" : "[grey]PF[/]"
+        };
+    }
+
+    private static string GetStateIcon(SpectreProgressLedgerState state, bool unicode)
+        => state switch
+        {
+            SpectreProgressLedgerState.Completed => unicode ? "[green]✅[/]" : "[green]OK[/]",
+            SpectreProgressLedgerState.Failed => unicode ? "[red]❌[/]" : "[red]X[/]",
+            SpectreProgressLedgerState.Skipped => unicode ? "[grey]⏭[/]" : "[grey]SK[/]",
+            _ => unicode ? "[grey]•[/]" : "[grey]PF[/]"
+        };
+
+    private static int ComputeBarWidth(int viewportWidth)
+    {
+        if (viewportWidth >= 160) return 40;
+        if (viewportWidth >= 140) return 30;
+        if (viewportWidth >= 120) return 18;
+        if (viewportWidth >= 100) return 14;
+        if (viewportWidth >= 80) return 12;
+        return 10;
+    }
+
+    private static string FormatOrdinal(int position, int total)
+    {
+        var safeTotal = Math.Max(1, total);
+        var digits = Math.Max(2, safeTotal.ToString().Length);
+        var format = new string('0', digits);
+        return $"{Math.Max(0, position).ToString(format)}/{safeTotal.ToString(format)}";
+    }
+
+    private static string PadOrEllipsis(string input, int width)
+    {
+        if (width <= 0)
+            return string.Empty;
+
+        input ??= string.Empty;
+        if (input.Length == width)
+            return input;
+        if (input.Length < width)
+            return input.PadRight(width);
+        if (width == 1)
+            return "…";
+        return input.Substring(0, width - 1) + "…";
+    }
+}

--- a/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressPresentation.cs
@@ -30,7 +30,7 @@ internal sealed class SpectreProgressPresentation
         _includeBar = _barWidth > 0;
 
         const int percentWidth = 5;
-        var elapsedWidth = _includeElapsed ? 5 : 0;
+        var elapsedWidth = _includeElapsed ? 8 : 0;
         const int spinnerWidth = 2;
         const int iconWidth = 2;
         const int gaps = 10;
@@ -70,7 +70,7 @@ internal sealed class SpectreProgressPresentation
         if (idWidth == 0)
             return PadOrEllipsis(title, _descriptionWidth);
 
-        if (_targetWidth <= 0)
+        if (_targetWidth <= 0 || string.IsNullOrWhiteSpace(item.Target))
         {
             var titleWidth = Math.Max(0, _descriptionWidth - idWidth - 1);
             return $"{ordinal} {PadOrEllipsis(title, titleWidth)}".TrimEnd();

--- a/PowerForge.ConsoleShared/SpectreProgressViewport.cs
+++ b/PowerForge.ConsoleShared/SpectreProgressViewport.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace PowerForge.ConsoleShared;
+
+/// <summary>
+/// Projects a bounded live viewport over a complete, canonically ordered task list.
+/// The underlying task collection and the final frame remain unchanged.
+/// </summary>
+internal static class SpectreProgressViewport
+{
+    internal static IRenderable Project(
+        IRenderable renderable,
+        IReadOnlyList<ProgressTask> tasks,
+        int maximumRows)
+    {
+        if (renderable is null) throw new ArgumentNullException(nameof(renderable));
+        if (tasks is null) throw new ArgumentNullException(nameof(tasks));
+
+        maximumRows = Math.Max(1, maximumRows);
+        if (tasks.Count <= maximumRows)
+            return renderable;
+
+        var activeIndex = FindActiveIndex(tasks);
+        var startIndex = Math.Min(
+            tasks.Count - maximumRows,
+            Math.Max(0, activeIndex - maximumRows + 1));
+        return new WindowedRenderable(renderable, startIndex, maximumRows, tasks.Count);
+    }
+
+    private static int FindActiveIndex(IReadOnlyList<ProgressTask> tasks)
+    {
+        for (var index = tasks.Count - 1; index >= 0; index--)
+        {
+            if (tasks[index].IsStarted && !tasks[index].IsFinished)
+                return index;
+        }
+
+        for (var index = tasks.Count - 1; index >= 0; index--)
+        {
+            if (tasks[index].IsStarted)
+                return index;
+        }
+
+        return 0;
+    }
+
+    private sealed class WindowedRenderable : IRenderable
+    {
+        private readonly IRenderable _inner;
+        private readonly int _taskStartIndex;
+        private readonly int _maximumRows;
+        private readonly int _taskCount;
+
+        internal WindowedRenderable(
+            IRenderable inner,
+            int taskStartIndex,
+            int maximumRows,
+            int taskCount)
+        {
+            _inner = inner;
+            _taskStartIndex = taskStartIndex;
+            _maximumRows = maximumRows;
+            _taskCount = taskCount;
+        }
+
+        public Measurement Measure(RenderOptions options, int maxWidth)
+            => _inner.Measure(options, maxWidth);
+
+        public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            var lines = Segment.SplitLines(_inner.Render(options, maxWidth));
+            if (lines.Count <= _maximumRows)
+            {
+                foreach (var segment in _inner.Render(options, maxWidth))
+                    yield return segment;
+                yield break;
+            }
+
+            // Progress currently renders one line per task. Preserve any leading
+            // structural lines if Spectre adds them in a future release.
+            var taskLineOffset = Math.Max(0, lines.Count - _taskCount);
+            var startLine = Math.Min(
+                Math.Max(0, lines.Count - _maximumRows),
+                taskLineOffset + _taskStartIndex);
+            var selected = lines
+                .Skip(startLine)
+                .Take(_maximumRows)
+                .ToArray();
+
+            for (var lineIndex = 0; lineIndex < selected.Length; lineIndex++)
+            {
+                foreach (var segment in selected[lineIndex])
+                    yield return segment;
+
+                if (lineIndex < selected.Length - 1)
+                    yield return Segment.LineBreak;
+            }
+        }
+    }
+}

--- a/PowerForge.Tests/ModuleBuildHostServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildHostServiceTests.cs
@@ -524,6 +524,7 @@ public sealed class ModuleBuildHostServiceTests
                 Key = "build:stage",
                 Title = "Stage to staging",
                 Kind = ModulePipelineStepKind.Build.ToString(),
+                Target = "staging",
                 Position = 1,
                 Total = 1
             };
@@ -562,6 +563,7 @@ public sealed class ModuleBuildHostServiceTests
         Assert.NotNull(captured.OutputLineReceived);
         var plannedItem = Assert.Single(progress.Planned);
         Assert.Equal("build:stage", plannedItem.Key);
+        Assert.Equal("staging", plannedItem.Target);
         var update = Assert.Single(progress.Updates);
         Assert.Equal(PowerForgeReleaseProgressItemState.Completed, update.State);
     }

--- a/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
@@ -1,4 +1,6 @@
 using PowerForge;
+using PowerForge.ConsoleShared;
+using Spectre.Console;
 
 namespace PowerForge.Tests;
 
@@ -86,6 +88,114 @@ public sealed class ModuleBuildWorkflowServiceTests
         Assert.Same(result, summaries[0]);
     }
 
+    [Fact]
+    public void ModuleStepPresentation_ProvidesCanonicalTitlesAndSemanticTargets()
+    {
+        var artefact = new ConfigurationArtefactSegment
+        {
+            ArtefactType = ArtefactType.Unpacked,
+            Configuration = new ArtefactConfiguration { ID = "ToGitHub" }
+        };
+        var publish = new ConfigurationPublishSegment
+        {
+            Configuration = new PublishConfiguration
+            {
+                Destination = PublishDestination.GitHub,
+                RepositoryName = "SampleModule"
+            }
+        };
+        var plan = CreatePlan(
+            artefacts: [artefact],
+            publishes: [publish],
+            installEnabled: true);
+        var steps = ModulePipelineStep.Create(plan);
+
+        var artefactDisplay = ModulePipelineStepPresentation.Create(
+            Assert.Single(steps, step => step.Kind == ModulePipelineStepKind.Artefact),
+            plan);
+        var publishDisplay = ModulePipelineStepPresentation.Create(
+            Assert.Single(steps, step => step.Kind == ModulePipelineStepKind.Publish),
+            plan);
+        var installDisplay = ModulePipelineStepPresentation.Create(
+            Assert.Single(steps, step => step.Kind == ModulePipelineStepKind.Install),
+            plan);
+
+        Assert.Equal("Pack artefact", artefactDisplay.Title);
+        Assert.Equal("Unpacked (ToGitHub)", artefactDisplay.Target);
+        Assert.Equal("Publish", publishDisplay.Title);
+        Assert.Equal("GitHub (SampleModule)", publishDisplay.Target);
+        Assert.Equal("Install", installDisplay.Title);
+        Assert.Equal("AutoRevision, keep 3", installDisplay.Target);
+
+        var transportedItems = ModulePipelineProgressItemFactory.Create(plan);
+        var transportedArtefact = Assert.Single(
+            transportedItems,
+            item => item.Kind == ModulePipelineStepKind.Artefact.ToString());
+        Assert.Equal(artefactDisplay.Title, transportedArtefact.Title);
+        Assert.Equal(artefactDisplay.Target, transportedArtefact.Target);
+    }
+
+    [Fact]
+    public void DirectModuleConsole_UsesSharedRichRowsInCanonicalOrder()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer);
+        var plan = CreatePlan(
+            artefacts:
+            [
+                new ConfigurationArtefactSegment
+                {
+                    ArtefactType = ArtefactType.Unpacked,
+                    Configuration = new ArtefactConfiguration { ID = "ToGitHub" }
+                }
+            ],
+            publishes:
+            [
+                new ConfigurationPublishSegment
+                {
+                    Configuration = new PublishConfiguration
+                    {
+                        Destination = PublishDestination.GitHub,
+                        RepositoryName = "SampleModule"
+                    }
+                }
+            ],
+            installEnabled: true);
+        var steps = ModulePipelineStep.Create(plan);
+
+        var result = SpectreModulePipelineConsoleUi.RunInteractive(
+            console,
+            plan,
+            "powerforge.json",
+            progress =>
+            {
+                foreach (var step in steps)
+                {
+                    progress.StepStarting(step);
+                    progress.StepCompleted(step);
+                }
+
+                return CreateResult(plan);
+            });
+
+        Assert.Same(plan, result.Plan);
+        var output = writer.ToString();
+        Assert.Contains("PowerForge", output, StringComparison.Ordinal);
+        Assert.Contains("SampleModule 1.0.0", output, StringComparison.Ordinal);
+        Assert.Contains("Unpacked (ToGitHub)", output, StringComparison.Ordinal);
+        Assert.Contains("GitHub (SampleModule)", output, StringComparison.Ordinal);
+        Assert.Contains("AutoRevision, keep 3", output, StringComparison.Ordinal);
+
+        var stage = output.LastIndexOf("Stage to staging", StringComparison.Ordinal);
+        var artefact = output.LastIndexOf("Pack artefact", StringComparison.Ordinal);
+        var publish = output.LastIndexOf("Publish", StringComparison.Ordinal);
+        var install = output.LastIndexOf("Install", StringComparison.Ordinal);
+        Assert.True(stage >= 0, output);
+        Assert.True(artefact > stage, output);
+        Assert.True(publish > artefact, output);
+        Assert.True(install > publish, output);
+    }
+
     private static ModuleBuildPreparedContext CreatePreparedContext()
     {
         return new ModuleBuildPreparedContext
@@ -105,7 +215,10 @@ public sealed class ModuleBuildWorkflowServiceTests
         };
     }
 
-    private static ModulePipelinePlan CreatePlan()
+    private static ModulePipelinePlan CreatePlan(
+        ConfigurationArtefactSegment[]? artefacts = null,
+        ConfigurationPublishSegment[]? publishes = null,
+        bool installEnabled = false)
     {
         return new ModulePipelinePlan(
             moduleName: "SampleModule",
@@ -147,9 +260,9 @@ public sealed class ModuleBuildWorkflowServiceTests
             moduleSkip: null,
             signModule: false,
             signing: null,
-            publishes: Array.Empty<ConfigurationPublishSegment>(),
-            artefacts: Array.Empty<ConfigurationArtefactSegment>(),
-            installEnabled: false,
+            publishes: publishes ?? Array.Empty<ConfigurationPublishSegment>(),
+            artefacts: artefacts ?? Array.Empty<ConfigurationArtefactSegment>(),
+            installEnabled: installEnabled,
             installStrategy: InstallationStrategy.AutoRevision,
             installKeepVersions: 3,
             installRoots: Array.Empty<string>(),
@@ -185,5 +298,26 @@ public sealed class ModuleBuildWorkflowServiceTests
             diagnosticsPolicy: null,
             publishResults: Array.Empty<ModulePublishResult>(),
             artefactResults: Array.Empty<ArtefactBuildResult>());
+    }
+
+    private static IAnsiConsole CreateConsole(TextWriter writer)
+        => AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new TestConsoleOutput(writer),
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Interactive = InteractionSupport.Yes
+        });
+
+    private sealed class TestConsoleOutput : IAnsiConsoleOutput
+    {
+        internal TestConsoleOutput(TextWriter writer)
+            => Writer = writer;
+
+        public TextWriter Writer { get; }
+        public bool IsTerminal => true;
+        public int Width => 140;
+        public int Height => 24;
+        public void SetEncoding(System.Text.Encoding encoding) { }
     }
 }

--- a/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
+++ b/PowerForge.Tests/ModuleBuildWorkflowServiceTests.cs
@@ -100,6 +100,7 @@ public sealed class ModuleBuildWorkflowServiceTests
         {
             Configuration = new PublishConfiguration
             {
+                ID = "Release",
                 Destination = PublishDestination.GitHub,
                 RepositoryName = "SampleModule"
             }
@@ -123,7 +124,7 @@ public sealed class ModuleBuildWorkflowServiceTests
         Assert.Equal("Pack artefact", artefactDisplay.Title);
         Assert.Equal("Unpacked (ToGitHub)", artefactDisplay.Target);
         Assert.Equal("Publish", publishDisplay.Title);
-        Assert.Equal("GitHub (SampleModule)", publishDisplay.Target);
+        Assert.Equal("GitHub (Release, SampleModule)", publishDisplay.Target);
         Assert.Equal("Install", installDisplay.Title);
         Assert.Equal("AutoRevision, keep 3", installDisplay.Target);
 
@@ -133,6 +134,10 @@ public sealed class ModuleBuildWorkflowServiceTests
             item => item.Kind == ModulePipelineStepKind.Artefact.ToString());
         Assert.Equal(artefactDisplay.Title, transportedArtefact.Title);
         Assert.Equal(artefactDisplay.Target, transportedArtefact.Target);
+        var transportedPublish = Assert.Single(
+            transportedItems,
+            item => item.Kind == ModulePipelineStepKind.Publish.ToString());
+        Assert.Equal(publishDisplay.Target, transportedPublish.Target);
     }
 
     [Fact]

--- a/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
+++ b/PowerForge.Tests/ProjectBuildProgressLedgerTests.cs
@@ -6,7 +6,7 @@ namespace PowerForge.Tests;
 public sealed class ProjectBuildProgressLedgerTests
 {
     [Fact]
-    public void ProgressLedger_KeepsEveryLiveTaskVisibleAndRetainsCompleteTimedHistory()
+    public void ProgressLedger_RegistersCompletePlanAndRetainsCompleteTimedHistory()
     {
         using var writer = new StringWriter();
         var console = CreateConsole(writer, height: 12);
@@ -77,7 +77,7 @@ public sealed class ProjectBuildProgressLedgerTests
     }
 
     [Fact]
-    public void ProgressLedger_KeepsCurrentWorkVisibleWhenLiveRegionOverflows()
+    public void ProgressLedger_UpdatesFullPlanTopToBottomWithoutMovingRows()
     {
         using var writer = new StringWriter();
         var console = CreateConsole(writer, height: 12);
@@ -103,16 +103,141 @@ public sealed class ProjectBuildProgressLedgerTests
                     .ToArray();
 
                 ledger.Plan(items);
-                ledger.Update(items[0], SpectreProgressLedgerState.Started, "building");
+                ledger.Update(items[6], SpectreProgressLedgerState.Started, "building");
+                ledger.Update(items[3], SpectreProgressLedgerState.Started, "building");
                 Assert.Equal(85, ledger.VisibleTaskCount);
             },
             tasks => finalTaskDescriptions = tasks.Select(task => task.Description).ToArray());
 
         Assert.NotNull(finalTaskDescriptions);
-        Assert.Contains("Project.01", finalTaskDescriptions![^1], StringComparison.Ordinal);
+        Assert.Equal(85, finalTaskDescriptions!.Count);
+        Assert.Contains("Project.01", finalTaskDescriptions[0], StringComparison.Ordinal);
+        Assert.Contains("Project.04", finalTaskDescriptions[3], StringComparison.Ordinal);
+        Assert.Contains("Project.07", finalTaskDescriptions[6], StringComparison.Ordinal);
+        Assert.Contains("Project.85", finalTaskDescriptions[^1], StringComparison.Ordinal);
         var output = writer.ToString();
         Assert.Contains("Project.01", output, StringComparison.Ordinal);
+        Assert.Contains("Project.07", output, StringComparison.Ordinal);
         Assert.Contains("Project.85", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProgressLedger_RendersSharedDetailedTitleTargetKindAndTimingLayout()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 12);
+        var presentation = new SpectreProgressPresentation(viewportWidth: 140, unicode: false);
+        IReadOnlyList<string>? finalTaskDescriptions = null;
+
+        SpectreProgressDisplay.Run(
+            console,
+            presentation.CreateColumns(),
+            context =>
+            {
+                var ledger = new SpectreProgressLedger(context, presentation);
+                var item = new SpectreProgressLedgerItem
+                {
+                    Key = "artefact:unpacked",
+                    GroupKey = "Module",
+                    GroupTitle = "Build PowerShell module",
+                    GroupOrder = 1,
+                    Title = "Pack artefact",
+                    Target = "Unpacked",
+                    Kind = ModulePipelineStepKind.Artefact.ToString(),
+                    Position = 1,
+                    Total = 2
+                };
+
+                ledger.Plan([item]);
+                ledger.Update(item, SpectreProgressLedgerState.Started, "packing");
+            },
+            tasks => finalTaskDescriptions = tasks.Select(task => task.Description).ToArray());
+
+        var description = Assert.Single(finalTaskDescriptions!);
+        Assert.StartsWith("01/02 Pack artefact", description, StringComparison.Ordinal);
+        Assert.Contains("packing", description, StringComparison.Ordinal);
+        Assert.EndsWith("Unpacked", description, StringComparison.Ordinal);
+        Assert.Contains("PK", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnifiedReleaseConsole_UsesSharedModuleRowsInCanonicalOrder()
+    {
+        using var writer = new StringWriter();
+        var console = CreateConsole(writer, height: 20);
+        var spec = new PowerForgeReleaseSpec
+        {
+            Module = new PowerForgeModuleReleaseOptions
+            {
+                ModuleName = "SampleProgress",
+                ModuleVersion = "1.0.0"
+            }
+        };
+        var request = new PowerForgeReleaseRequest
+        {
+            ConfigPath = "release.json",
+            ModuleOnly = true
+        };
+        var items = new[]
+        {
+            new PowerForgeReleaseProgressItem
+            {
+                Phase = PowerForgeReleaseProgressPhase.Module,
+                Key = "build:stage",
+                Title = "Stage to staging",
+                Kind = ModulePipelineStepKind.Build.ToString(),
+                Position = 1,
+                Total = 3
+            },
+            new PowerForgeReleaseProgressItem
+            {
+                Phase = PowerForgeReleaseProgressPhase.Module,
+                Key = "artefact:unpacked",
+                Title = "Pack artefact",
+                Target = "Unpacked (Local)",
+                Kind = ModulePipelineStepKind.Artefact.ToString(),
+                Position = 2,
+                Total = 3
+            },
+            new PowerForgeReleaseProgressItem
+            {
+                Phase = PowerForgeReleaseProgressPhase.Module,
+                Key = "publish:gallery",
+                Title = "Publish",
+                Target = "PowerShellGallery",
+                Kind = ModulePipelineStepKind.Publish.ToString(),
+                Position = 3,
+                Total = 3
+            }
+        };
+
+        var result = SpectrePowerForgeReleaseConsoleUi.RunInteractive(
+            console,
+            spec,
+            request,
+            progress =>
+            {
+                var detailed = Assert.IsAssignableFrom<IPowerForgeReleaseProgressReporterV2>(progress);
+                progress.PhaseStarted(PowerForgeReleaseProgressPhase.Module, items.Length);
+                detailed.ItemsPlanned(PowerForgeReleaseProgressPhase.Module, items);
+                detailed.ItemUpdated(items[2], PowerForgeReleaseProgressItemState.Started, "publishing");
+                detailed.ItemUpdated(items[0], PowerForgeReleaseProgressItemState.Completed, "staged");
+                detailed.ItemUpdated(items[1], PowerForgeReleaseProgressItemState.Completed, "packed");
+                detailed.ItemUpdated(items[2], PowerForgeReleaseProgressItemState.Completed, "published");
+                progress.PhaseCompleted(PowerForgeReleaseProgressPhase.Module, "complete");
+                return new PowerForgeReleaseResult { Success = true };
+            });
+
+        Assert.True(result.Success);
+        var output = writer.ToString();
+        var first = output.LastIndexOf("01/03 Stage to staging", StringComparison.Ordinal);
+        var second = output.LastIndexOf("02/03 Pack artefact", StringComparison.Ordinal);
+        var third = output.LastIndexOf("03/03 Publish", StringComparison.Ordinal);
+        Assert.True(first >= 0, output);
+        Assert.True(second > first, output);
+        Assert.True(third > second, output);
+        Assert.Contains("Unpacked (Local)", output, StringComparison.Ordinal);
+        Assert.Contains("PowerShellGallery", output, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
+++ b/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using PowerForge.ConsoleShared;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace PowerForge.Tests;
 
@@ -75,6 +76,49 @@ public sealed class SpectreBuildProgressColumnsTests
 
         var output = writer.ToString().TrimEnd();
         Assert.EndsWith("Retained build step 100%", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Viewport_ProjectsAContiguousWindowAroundActiveTaskWithoutReordering()
+    {
+        var tasks = Enumerable.Range(1, 12)
+            .Select(index => new ProgressTask(
+                index,
+                $"Task.{index:00}",
+                maxValue: 1,
+                autoStart: false,
+                TimeProvider.System))
+            .ToArray();
+        tasks[8].StartTask();
+
+        var rows = new Rows(tasks.Select(task => (IRenderable)new Text(task.Description)));
+        var projected = SpectreProgressViewport.Project(rows, tasks, maximumRows: 5);
+
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new TerminalConsoleOutput(writer),
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Interactive = InteractionSupport.Yes
+        });
+        console.Write(projected);
+
+        var output = writer.ToString();
+        Assert.DoesNotContain("Task.04", output, StringComparison.Ordinal);
+        AssertOrdered(output, "Task.05", "Task.06", "Task.07", "Task.08", "Task.09");
+        Assert.DoesNotContain("Task.10", output, StringComparison.Ordinal);
+    }
+
+    private static void AssertOrdered(string output, params string[] values)
+    {
+        var previous = -1;
+        foreach (var value in values)
+        {
+            var current = output.IndexOf(value, StringComparison.Ordinal);
+            Assert.True(current > previous, output);
+            previous = current;
+        }
     }
 
     private sealed class TerminalConsoleOutput : IAnsiConsoleOutput

--- a/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
+++ b/PowerForge.Tests/SpectreBuildProgressColumnsTests.cs
@@ -46,6 +46,42 @@ public sealed class SpectreBuildProgressColumnsTests
             column => Assert.IsType<SpinnerColumn>(column));
     }
 
+    [Theory]
+    [InlineData(0, "00:00")]
+    [InlineData(3599, "59:59")]
+    [InlineData(3900, "01:05:00")]
+    [InlineData(90061, "25:01:01")]
+    public void FormatElapsed_PreservesHoursWithoutWrapping(long seconds, string expected)
+        => Assert.Equal(
+            expected,
+            SpectreBuildProgressColumns.FormatElapsed(TimeSpan.FromSeconds(seconds)));
+
+    [Fact]
+    public void Presentation_DoesNotReserveTargetWidthForTargetlessRows()
+    {
+        var presentation = new SpectreProgressPresentation(viewportWidth: 120, unicode: false);
+        var targetless = new SpectreProgressLedgerItem
+        {
+            Title = "Publish PowerForgeWeb net10.0 win-x64 SingleContained",
+            Position = 1,
+            Total = 2
+        };
+        var targeted = new SpectreProgressLedgerItem
+        {
+            Title = "Publish",
+            Target = "PowerShellGallery",
+            Position = 2,
+            Total = 2
+        };
+
+        var targetlessLabel = presentation.BuildLabel(targetless, "packing");
+        var targetedLabel = presentation.BuildLabel(targeted, null);
+
+        Assert.Contains("SingleContained", targetlessLabel, StringComparison.Ordinal);
+        Assert.Contains("packing", targetlessLabel, StringComparison.Ordinal);
+        Assert.EndsWith("PowerShellGallery", targetedLabel, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Run_WritesCompletedProgressFrameAfterLiveDisplayCloses()
     {

--- a/PowerForge/Models/ModulePipelineStepPresentation.cs
+++ b/PowerForge/Models/ModulePipelineStepPresentation.cs
@@ -71,8 +71,11 @@ internal sealed class ModulePipelineStepPresentation
 
         var configuration = segment.Configuration ?? new PublishConfiguration();
         var repositoryName = configuration.Repository?.Name ?? configuration.RepositoryName;
-        return string.IsNullOrWhiteSpace(repositoryName)
+        var qualifiers = new[] { configuration.ID, repositoryName }
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .ToArray();
+        return qualifiers.Length == 0
             ? configuration.Destination.ToString()
-            : $"{configuration.Destination} ({repositoryName})";
+            : $"{configuration.Destination} ({string.Join(", ", qualifiers)})";
     }
 }

--- a/PowerForge/Models/ModulePipelineStepPresentation.cs
+++ b/PowerForge/Models/ModulePipelineStepPresentation.cs
@@ -1,0 +1,78 @@
+namespace PowerForge;
+
+/// <summary>
+/// Describes the host-neutral title and target shown for a module pipeline step.
+/// </summary>
+internal sealed class ModulePipelineStepPresentation
+{
+    private ModulePipelineStepPresentation(
+        string title,
+        string target,
+        ModulePipelineStepKind kind)
+    {
+        Title = title;
+        Target = target;
+        Kind = kind;
+    }
+
+    /// <summary>Concise action title shared by direct and unified build hosts.</summary>
+    internal string Title { get; }
+
+    /// <summary>Optional semantic destination or artifact target.</summary>
+    internal string Target { get; }
+
+    /// <summary>Pipeline kind used by presentation hosts to select an icon.</summary>
+    internal ModulePipelineStepKind Kind { get; }
+
+    /// <summary>
+    /// Creates the canonical display data for a planned module step.
+    /// </summary>
+    internal static ModulePipelineStepPresentation Create(
+        ModulePipelineStep step,
+        ModulePipelinePlan plan)
+    {
+        if (step is null) throw new ArgumentNullException(nameof(step));
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        var title = step.Kind switch
+        {
+            ModulePipelineStepKind.Artefact => "Pack artefact",
+            ModulePipelineStepKind.Publish => "Publish",
+            ModulePipelineStepKind.Install => "Install",
+            ModulePipelineStepKind.Cleanup => "Cleanup staging",
+            _ => step.Title
+        };
+
+        var target = step.Kind switch
+        {
+            ModulePipelineStepKind.Artefact => FormatArtefactTarget(step.ArtefactSegment),
+            ModulePipelineStepKind.Publish => FormatPublishTarget(step.PublishSegment),
+            ModulePipelineStepKind.Install => $"{plan.InstallStrategy}, keep {plan.InstallKeepVersions}",
+            _ => string.Empty
+        };
+
+        return new ModulePipelineStepPresentation(title, target, step.Kind);
+    }
+
+    private static string FormatArtefactTarget(ConfigurationArtefactSegment? segment)
+    {
+        if (segment is null)
+            return string.Empty;
+
+        var id = segment.Configuration?.ID;
+        var label = segment.ArtefactType.ToString();
+        return string.IsNullOrWhiteSpace(id) ? label : $"{label} ({id})";
+    }
+
+    private static string FormatPublishTarget(ConfigurationPublishSegment? segment)
+    {
+        if (segment is null)
+            return string.Empty;
+
+        var configuration = segment.Configuration ?? new PublishConfiguration();
+        var repositoryName = configuration.Repository?.Name ?? configuration.RepositoryName;
+        return string.IsNullOrWhiteSpace(repositoryName)
+            ? configuration.Destination.ToString()
+            : $"{configuration.Destination} ({repositoryName})";
+    }
+}

--- a/PowerForge/Models/PowerForgeReleaseProgress.cs
+++ b/PowerForge/Models/PowerForgeReleaseProgress.cs
@@ -58,6 +58,9 @@ public sealed class PowerForgeReleaseProgressItem
     /// <summary>Optional work item kind used by presentation hosts.</summary>
     public string? Kind { get; set; }
 
+    /// <summary>Optional semantic destination or artifact target shown separately from the action title.</summary>
+    public string? Target { get; set; }
+
     /// <summary>One-based position in the owning plan.</summary>
     public int Position { get; set; }
 

--- a/PowerForge/Services/ModulePipelineProgressItemFactory.cs
+++ b/PowerForge/Services/ModulePipelineProgressItemFactory.cs
@@ -1,0 +1,41 @@
+namespace PowerForge;
+
+/// <summary>
+/// Creates the canonical ordered progress items shared by direct module builds,
+/// isolated-host transport, and unified release presentation.
+/// </summary>
+internal static class ModulePipelineProgressItemFactory
+{
+    /// <summary>
+    /// Maps a module plan to the single title, target, kind, and ordinal model used
+    /// by every progress host.
+    /// </summary>
+    internal static PowerForgeReleaseProgressItem[] Create(ModulePipelinePlan plan)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        var steps = ModulePipelineStep.Create(plan);
+        return steps
+            .Select((step, index) => CreateItem(step, plan, index + 1, steps.Length))
+            .ToArray();
+    }
+
+    private static PowerForgeReleaseProgressItem CreateItem(
+        ModulePipelineStep step,
+        ModulePipelinePlan plan,
+        int position,
+        int total)
+    {
+        var presentation = ModulePipelineStepPresentation.Create(step, plan);
+        return new PowerForgeReleaseProgressItem
+        {
+            Phase = PowerForgeReleaseProgressPhase.Module,
+            Key = step.Key,
+            Title = presentation.Title,
+            Kind = presentation.Kind.ToString(),
+            Target = presentation.Target,
+            Position = position,
+            Total = total
+        };
+    }
+}

--- a/PowerForge/Services/ModulePipelineProgressProtocol.cs
+++ b/PowerForge/Services/ModulePipelineProgressProtocol.cs
@@ -62,18 +62,7 @@ internal static class ModulePipelineProgressProtocol
 
         internal ProtocolReporter(ModulePipelinePlan plan)
         {
-            var steps = ModulePipelineStep.Create(plan);
-            var items = steps
-                .Select((step, index) => new PowerForgeReleaseProgressItem
-                {
-                    Phase = PowerForgeReleaseProgressPhase.Module,
-                    Key = step.Key,
-                    Title = step.Title,
-                    Kind = step.Kind.ToString(),
-                    Position = index + 1,
-                    Total = steps.Length
-                })
-                .ToArray();
+            var items = ModulePipelineProgressItemFactory.Create(plan);
             _items = items.ToDictionary(item => item.Key, StringComparer.OrdinalIgnoreCase);
             Write(new ModulePipelineProgressProtocolMessage { Items = items });
         }


### PR DESCRIPTION
## Summary

- keep every planned progress row in canonical top-to-bottom order, including when work starts out of sequence
- use one shared rich Spectre presentation for direct module builds and unified releases, including step icons, semantic targets, progress, and hour-aware elapsed time
- project a bounded live viewport around active work without removing or re-adding tasks, while retaining the complete final history
- carry module step presentation metadata, including publish IDs, through the isolated progress protocol
- use the full description width for rows without a semantic target

## Validation

- Release solution build across net472, net8.0, and net10.0
- 44 focused progress, protocol, renderer, ordering, width, and timing tests
- independent local review plus targeted confirmation of the viewport/order remediation
- required Windows, Linux, macOS, dependency audit, package smoke, and focused publishing checks

No breaking configuration or command-line changes.