### PR TITLE
Fix Apple reusable workflow startup validation

### DIFF
--- a/.github/workflows/powerforge-apple-governance.yml
+++ b/.github/workflows/powerforge-apple-governance.yml
@@ -57,11 +57,11 @@ on:
         type: number
     secrets:
       app_store_connect_issuer_id:
-        required: true
+        required: false
       app_store_connect_key_id:
-        required: true
+        required: false
       app_store_connect_private_key:
-        required: true
+        required: false
 
 concurrency:
   group: powerforge-apple-${{ github.repository }}

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -518,6 +518,38 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
+    public void AppleEnvironmentCredentialsRemainOptionalAtTheWorkflowCallBoundary()
+    {
+        var root = FindRepoRoot();
+        foreach (var workflowName in new[]
+                 {
+                     "powerforge-apple-screenshots.yml",
+                     "powerforge-apple-screenshot-approve.yml",
+                     "powerforge-apple-monitor.yml",
+                     "powerforge-apple-version-pr.yml",
+                     "powerforge-apple-advance.yml",
+                     "powerforge-apple-governance.yml",
+                     "powerforge-apple-approval.yml"
+                 })
+        {
+            var workflow = Read(root, ".github", "workflows", workflowName)
+                .Replace("\r\n", "\n", StringComparison.Ordinal);
+            foreach (var secretName in new[]
+                     {
+                         "app_store_connect_issuer_id",
+                         "app_store_connect_key_id",
+                         "app_store_connect_private_key"
+                     })
+            {
+                Assert.Contains(
+                    $"      {secretName}:\n        required: false",
+                    workflow,
+                    StringComparison.Ordinal);
+            }
+        }
+    }
+
+    [Fact]
     public void AppleWorkflowRunScriptsDoNotInlineCallerControlledInputs()
     {
         var root = FindRepoRoot();
@@ -527,7 +559,9 @@ public sealed partial class AppleReleaseWorkflowTests
                      "powerforge-apple-screenshot-capture.yml",
                      "powerforge-apple-screenshot-approve.yml",
                      "powerforge-apple-monitor.yml",
+                     "powerforge-apple-version-pr.yml",
                      "powerforge-apple-advance.yml",
+                     "powerforge-apple-governance.yml",
                      "powerforge-apple-approval.yml",
                      "pspublishmodule-public-release.yml"
                  })
@@ -550,7 +584,9 @@ public sealed partial class AppleReleaseWorkflowTests
                      "powerforge-apple-screenshot-capture.yml",
                      "powerforge-apple-screenshot-approve.yml",
                      "powerforge-apple-monitor.yml",
+                     "powerforge-apple-version-pr.yml",
                      "powerforge-apple-advance.yml",
+                     "powerforge-apple-governance.yml",
                      "powerforge-apple-approval.yml",
                      "pspublishmodule-public-release.yml"
                  })


### PR DESCRIPTION
## Summary

Apple Release Control could fail before creating any jobs because the governance reusable workflow required App Store Connect secrets at the caller boundary. Consumer workflows deliberately keep those credentials in protected environments, so GitHub rejected the nested workflow graph even for read-only Doctor runs.

This change:

- makes the governance caller secrets optional, matching the other Apple reusable workflows
- keeps credential enforcement inside the protected called jobs
- adds a cross-workflow contract preventing environment-backed credentials from becoming mandatory caller secrets
- includes governance and version-PR workflows in YAML, embedded PowerShell, and caller-input safety coverage

No Apple mutation or module publication is performed by this change.

## Validation

- 23 focused Apple release workflow tests pass
- all covered workflow YAML and embedded PowerShell parse
- build completes with zero warnings and zero errors