### PR TITLE
Preserve actionable Apple failures and environment credentials

### DIFF
--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -20,12 +20,23 @@ function Resolve-SafeReleaseOutputPath {
         [Parameter(Mandatory)] [string] $Name
     )
 
-    $root = [System.IO.Path]::GetFullPath($ProjectRoot).TrimEnd(
-        [System.IO.Path]::DirectorySeparatorChar,
-        [System.IO.Path]::AltDirectorySeparatorChar)
-    $candidate = Resolve-ReleasePath -ProjectRoot $root -Path $Path
     $comparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
-    $prefix = $root + [System.IO.Path]::DirectorySeparatorChar
+    $fullRoot = [System.IO.Path]::GetFullPath($ProjectRoot)
+    $filesystemRoot = [System.IO.Path]::GetPathRoot($fullRoot)
+    $root = if ($fullRoot.Equals($filesystemRoot, $comparison)) {
+        $fullRoot
+    } else {
+        $fullRoot.TrimEnd(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar)
+    }
+    $candidate = Resolve-ReleasePath -ProjectRoot $root -Path $Path
+    $prefix = if ($root.EndsWith([System.IO.Path]::DirectorySeparatorChar) -or
+        $root.EndsWith([System.IO.Path]::AltDirectorySeparatorChar)) {
+        $root
+    } else {
+        $root + [System.IO.Path]::DirectorySeparatorChar
+    }
     if (-not $candidate.StartsWith($prefix, $comparison)) {
         throw "$Name must resolve inside AppleApps.ProjectRoot: $candidate"
     }
@@ -46,7 +57,7 @@ function Resolve-SafeReleaseOutputPath {
             }
         }
         if ($current.Equals($root, $comparison)) { break }
-        $parent = Split-Path -Parent $current
+        $parent = [System.IO.Directory]::GetParent($current)?.FullName
         if ([string]::IsNullOrWhiteSpace($parent) -or $parent.Equals($current, $comparison)) {
             throw "$Name could not be bounded to AppleApps.ProjectRoot: $candidate"
         }

--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -13,6 +13,48 @@ function Resolve-ReleasePath {
     return [System.IO.Path]::GetFullPath((Join-Path $ProjectRoot $Path))
 }
 
+function Resolve-SafeReleaseOutputPath {
+    param(
+        [Parameter(Mandatory)] [string] $ProjectRoot,
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $Name
+    )
+
+    $root = [System.IO.Path]::GetFullPath($ProjectRoot).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar)
+    $candidate = Resolve-ReleasePath -ProjectRoot $root -Path $Path
+    $comparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    $prefix = $root + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $candidate.StartsWith($prefix, $comparison)) {
+        throw "$Name must resolve inside AppleApps.ProjectRoot: $candidate"
+    }
+
+    $current = $candidate
+    while ($true) {
+        $item = Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue
+        if ($null -ne $item -and ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "$Name must not traverse a symbolic link or reparse point: $current"
+        }
+        if ($current.Equals($root, $comparison)) { break }
+        $parent = Split-Path -Parent $current
+        if ([string]::IsNullOrWhiteSpace($parent) -or $parent.Equals($current, $comparison)) {
+            throw "$Name could not be bounded to AppleApps.ProjectRoot: $candidate"
+        }
+        $current = $parent
+    }
+    return $candidate
+}
+
+function Get-ReleaseFileFingerprint {
+    param([Parameter(Mandatory)] [string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+    $item = Get-Item -LiteralPath $Path -Force
+    $hash = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+    return "$hash`:$($item.Length)`:$($item.LastWriteTimeUtc.Ticks)"
+}
+
 function Write-ReleaseOutput {
     param(
         [Parameter(Mandatory)] [string] $Name,
@@ -99,11 +141,29 @@ if ([string]::IsNullOrWhiteSpace($configuredReceiptPath)) {
         'build/powerforge/apple/release-receipt.json'
     }
 }
-$receiptPath = Resolve-ReleasePath -ProjectRoot $projectRoot -Path $configuredReceiptPath
+$defaultReceiptPath = if ($planOnly) {
+    'build/powerforge/apple/release-plan.json'
+} else {
+    'build/powerforge/apple/release-receipt.json'
+}
+try {
+    $receiptPath = Resolve-SafeReleaseOutputPath `
+        -ProjectRoot $projectRoot `
+        -Path $configuredReceiptPath `
+        -Name ($planOnly ? 'AppleApps.Automation.PlanReceiptPath' : 'AppleApps.Automation.ReceiptPath')
+} catch {
+    # The engine will report the invalid configured path. Keep the wrapper's
+    # fallback receipt inside the project so that failure remains actionable.
+    $receiptPath = Resolve-SafeReleaseOutputPath `
+        -ProjectRoot $projectRoot `
+        -Path $defaultReceiptPath `
+        -Name 'Apple failure fallback receipt path'
+}
 
 # Expose the expected artifact before invoking PowerForge. GitHub Actions then retains
 # the path even when the transition fails after PowerForge writes a failure receipt.
 Write-ReleaseOutput -Name 'receipt-path' -Value $receiptPath
+$receiptFingerprintBefore = Get-ReleaseFileFingerprint -Path $receiptPath
 
 $arguments = @('apple-release', $action, '--config', $env:INPUT_CONFIG_PATH, '--summary', '--output', 'json')
 if ($planOnly) { $arguments += '--plan' }
@@ -144,13 +204,16 @@ if (-not [string]::IsNullOrWhiteSpace($json)) {
 
 $result = $envelope.result
 $planSha256 = [string] $result.planSha256
-if ($planOnly -and $planSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
+if ($exitCode -eq 0 -and $planOnly -and $planSha256 -notmatch '^[0-9A-Fa-f]{64}$') {
     throw "PowerForge action '$action' did not return a valid exact plan SHA-256."
 }
 Write-ReleaseOutput -Name 'plan-sha256' -Value $planSha256
 $reportedReceiptPath = [string] $result.receiptPath
-if (-not [string]::IsNullOrWhiteSpace($reportedReceiptPath)) {
-    $receiptPath = Resolve-ReleasePath -ProjectRoot $projectRoot -Path $reportedReceiptPath
+if ($exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($reportedReceiptPath)) {
+    $receiptPath = Resolve-SafeReleaseOutputPath `
+        -ProjectRoot $projectRoot `
+        -Path $reportedReceiptPath `
+        -Name 'PowerForge reported receipt path'
     Write-ReleaseOutput -Name 'receipt-path' -Value $receiptPath
 }
 
@@ -173,7 +236,6 @@ if ($exitCode -ne 0) {
             retryable = [bool] $_.retryable
         }
     })
-    $engineReportedDiagnostics = $receiptDiagnostics.Count -gt 0
     $failureMessage = Get-FirstNonEmptyString @(
         $result.errorMessage,
         $envelope.PSObject.Properties['Error'].Value,
@@ -200,9 +262,12 @@ if ($exitCode -ne 0) {
             retryable = $false
         })
     }
-    # An early CLI/preflight failure has no engine receipt. Replace any stale file
-    # left by a previous invocation so monitoring can never upload old success state.
-    if (-not $engineReportedDiagnostics -or -not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) {
+    $receiptFingerprintAfter = Get-ReleaseFileFingerprint -Path $receiptPath
+    $engineWroteCurrentReceipt = $null -ne $receiptFingerprintAfter -and
+        $receiptFingerprintAfter -ne $receiptFingerprintBefore
+    # Replace missing or byte-for-byte stale state. Preserve a file changed by this
+    # invocation even when stdout was malformed or did not carry diagnostics.
+    if (-not $engineWroteCurrentReceipt) {
         $relativeReceiptPath = [System.IO.Path]::GetRelativePath($projectRoot, $receiptPath).Replace('\', '/')
         Write-AtomicJsonFile -Path $receiptPath -Value ([ordered]@{
             schemaVersion = 3

--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -31,10 +31,19 @@ function Resolve-SafeReleaseOutputPath {
     }
 
     $current = $candidate
+    $isCandidate = $true
     while ($true) {
         $item = Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue
         if ($null -ne $item -and ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
             throw "$Name must not traverse a symbolic link or reparse point: $current"
+        }
+        if ($null -ne $item) {
+            if ($isCandidate -and $item.PSIsContainer) {
+                throw "$Name must resolve to a file, not a directory: $candidate"
+            }
+            if (-not $isCandidate -and -not $item.PSIsContainer) {
+                throw "$Name must not traverse a file used as a parent path: $current"
+            }
         }
         if ($current.Equals($root, $comparison)) { break }
         $parent = Split-Path -Parent $current
@@ -42,6 +51,7 @@ function Resolve-SafeReleaseOutputPath {
             throw "$Name could not be bounded to AppleApps.ProjectRoot: $candidate"
         }
         $current = $parent
+        $isCandidate = $false
     }
     return $candidate
 }

--- a/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
+++ b/.github/actions/apple-release/Invoke-PowerForgeAppleRelease.ps1
@@ -24,6 +24,38 @@ function Write-ReleaseOutput {
     }
 }
 
+function Get-FirstNonEmptyString {
+    param([AllowNull()] [object[]] $Values)
+
+    foreach ($value in $Values) {
+        $text = [string] $value
+        if (-not [string]::IsNullOrWhiteSpace($text)) { return $text.Trim() }
+    }
+    return $null
+}
+
+function Write-AtomicJsonFile {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [object] $Value
+    )
+
+    $directory = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($directory)) {
+        [System.IO.Directory]::CreateDirectory($directory) | Out-Null
+    }
+    $temporaryPath = Join-Path $directory ".$(Split-Path -Leaf $Path).$([Guid]::NewGuid().ToString('N')).tmp"
+    try {
+        $json = $Value | ConvertTo-Json -Depth 32
+        [System.IO.File]::WriteAllText($temporaryPath, $json, [System.Text.UTF8Encoding]::new($false))
+        [System.IO.File]::Move($temporaryPath, $Path, $true)
+    } finally {
+        if (Test-Path -LiteralPath $temporaryPath -PathType Leaf) {
+            Remove-Item -LiteralPath $temporaryPath -Force
+        }
+    }
+}
+
 $allowedActions = @(
     'Status', 'Doctor', 'Version', 'Archive', 'Upload', 'UploadExisting', 'Prepare',
     'Screenshots', 'TestFlight', 'Advance', 'SubmitTestFlightReview',
@@ -126,7 +158,70 @@ if ($exitCode -ne 0) {
     # Never echo the complete CLI envelope here. The receipt can contain compact
     # tester feedback and diagnostic evidence that belongs in the retained artifact,
     # not the public Actions log.
-    $safeDiagnostics = @($result.diagnostics | ForEach-Object {
+    $receiptDiagnostics = @($result.diagnostics | Where-Object {
+        -not [string]::IsNullOrWhiteSpace([string] $_.code) -or
+        -not [string]::IsNullOrWhiteSpace([string] $_.summary) -or
+        -not [string]::IsNullOrWhiteSpace([string] $_.action)
+    } | ForEach-Object {
+        [ordered]@{
+            severity = (Get-FirstNonEmptyString @($_.severity, 'error'))
+            category = (Get-FirstNonEmptyString @($_.category, 'automation'))
+            code = (Get-FirstNonEmptyString @($_.code, 'APPLE_ACTION_FAILED'))
+            summary = (Get-FirstNonEmptyString @($_.summary, "PowerForge Apple action '$action' failed."))
+            evidence = [string] $_.evidence
+            action = (Get-FirstNonEmptyString @($_.action, 'Inspect the retained failure receipt and run logs, correct the reported condition, then retry.'))
+            retryable = [bool] $_.retryable
+        }
+    })
+    $engineReportedDiagnostics = $receiptDiagnostics.Count -gt 0
+    $failureMessage = Get-FirstNonEmptyString @(
+        $result.errorMessage,
+        $envelope.PSObject.Properties['Error'].Value,
+        "PowerForge Apple action '$action' failed with exit code $exitCode."
+    )
+    if ($receiptDiagnostics.Count -eq 0) {
+        $missingAppStoreCredentials =
+            $failureMessage -match 'App Store Connect.*requires.*AppStoreConnectApiKeyPath' -or
+            $failureMessage -match 'AppStoreConnectApiKeyPath.*AppStoreConnectApiKeyId.*AppStoreConnectApiIssuerId'
+        $failureCategory = if ($missingAppStoreCredentials) { 'credential' } else { 'automation' }
+        $failureCode = if ($missingAppStoreCredentials) { 'APPLE_APP_STORE_CONNECT_CREDENTIALS_MISSING' } else { 'APPLE_ACTION_FAILED' }
+        $failureAction = if ($missingAppStoreCredentials) {
+            'Configure app_store_connect_issuer_id, app_store_connect_key_id, and app_store_connect_private_key in the protected Apple environment.'
+        } else {
+            'Inspect the retained failure receipt and run logs, correct the reported preflight condition, then retry.'
+        }
+        $receiptDiagnostics = @([ordered]@{
+            severity = 'error'
+            category = $failureCategory
+            code = $failureCode
+            summary = $failureMessage
+            evidence = $null
+            action = $failureAction
+            retryable = $false
+        })
+    }
+    # An early CLI/preflight failure has no engine receipt. Replace any stale file
+    # left by a previous invocation so monitoring can never upload old success state.
+    if (-not $engineReportedDiagnostics -or -not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) {
+        $relativeReceiptPath = [System.IO.Path]::GetRelativePath($projectRoot, $receiptPath).Replace('\', '/')
+        Write-AtomicJsonFile -Path $receiptPath -Value ([ordered]@{
+            schemaVersion = 3
+            action = $action
+            sourceCommit = [string] $env:INPUT_SOURCE_COMMIT
+            planOnly = $planOnly
+            checkedAt = [DateTimeOffset]::UtcNow
+            planSha256 = $null
+            success = $false
+            errorMessage = $failureMessage
+            receiptPath = $relativeReceiptPath
+            versioning = $null
+            targets = @()
+            cleanup = [ordered]@{}
+            diagnostics = $receiptDiagnostics
+            nextActions = @($receiptDiagnostics | ForEach-Object { [string] $_.action } | Select-Object -Unique)
+        })
+    }
+    $safeDiagnostics = @($receiptDiagnostics | ForEach-Object {
         [ordered]@{
             severity = [string] $_.severity
             category = [string] $_.category

--- a/.github/workflows/powerforge-apple-advance.yml
+++ b/.github/workflows/powerforge-apple-advance.yml
@@ -42,11 +42,11 @@ on:
         default: apple-release
         type: string
     secrets:
-      app_store_connect_issuer_id:
+      caller_app_store_connect_issuer_id:
         required: false
-      app_store_connect_key_id:
+      caller_app_store_connect_key_id:
         required: false
-      app_store_connect_private_key:
+      caller_app_store_connect_private_key:
         required: false
 
 concurrency:
@@ -205,9 +205,9 @@ jobs:
           tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
           plan-only: "true"
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Advance through upload, preparation, screenshots, and configured TestFlight
         id: advance
@@ -221,9 +221,9 @@ jobs:
           plan-only: "false"
           confirm: "true"
           expected-plan-sha256: ${{ steps.plan.outputs.plan-sha256 }}
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Upload compact release plan receipt
         if: always()

--- a/.github/workflows/powerforge-apple-approval.yml
+++ b/.github/workflows/powerforge-apple-approval.yml
@@ -51,11 +51,11 @@ on:
         default: '[]'
         type: string
     secrets:
-      app_store_connect_issuer_id:
+      caller_app_store_connect_issuer_id:
         required: false
-      app_store_connect_key_id:
+      caller_app_store_connect_key_id:
         required: false
-      app_store_connect_private_key:
+      caller_app_store_connect_private_key:
         required: false
 
 concurrency:
@@ -139,9 +139,9 @@ jobs:
           tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
           plan-only: "true"
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Upload compact approval plan receipt
         if: always()
@@ -227,9 +227,9 @@ jobs:
           tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
           plan-only: "true"
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Bind execution to the reviewed plan
         shell: pwsh
@@ -256,9 +256,9 @@ jobs:
           plan-only: "false"
           confirm: "true"
           expected-plan-sha256: ${{ needs.plan.outputs.plan_sha256 }}
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Upload compact approved replan receipt
         if: always()

--- a/.github/workflows/powerforge-apple-governance.yml
+++ b/.github/workflows/powerforge-apple-governance.yml
@@ -56,11 +56,11 @@ on:
         default: 500
         type: number
     secrets:
-      app_store_connect_issuer_id:
+      caller_app_store_connect_issuer_id:
         required: false
-      app_store_connect_key_id:
+      caller_app_store_connect_key_id:
         required: false
-      app_store_connect_private_key:
+      caller_app_store_connect_private_key:
         required: false
 
 concurrency:
@@ -188,9 +188,9 @@ jobs:
           release-config-path: ${{ steps.paths.outputs.release-path }}
           receipt-path: ${{ runner.temp }}/powerforge-apple-governance-plan.json
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Upload governance plan for review
         if: always()
@@ -311,9 +311,9 @@ jobs:
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
           confirm: "true"
           maximum-changes: ${{ inputs.maximum_changes }}
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Upload compact governance apply receipt
         if: always()

--- a/.github/workflows/powerforge-apple-monitor.yml
+++ b/.github/workflows/powerforge-apple-monitor.yml
@@ -42,11 +42,11 @@ on:
         default: apple-release
         type: string
     secrets:
-      app_store_connect_issuer_id:
+      caller_app_store_connect_issuer_id:
         required: false
-      app_store_connect_key_id:
+      caller_app_store_connect_key_id:
         required: false
-      app_store_connect_private_key:
+      caller_app_store_connect_private_key:
         required: false
 
 concurrency:
@@ -107,9 +107,9 @@ jobs:
           tool-manifest-path: ${{ github.workspace }}/source/${{ inputs.tool_manifest_path }}
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
           plan-only: "false"
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Retain compact doctor receipt
         if: always() && steps.doctor.outputs.receipt-path != ''

--- a/.github/workflows/powerforge-apple-screenshot-approve.yml
+++ b/.github/workflows/powerforge-apple-screenshot-approve.yml
@@ -79,11 +79,11 @@ on:
         default: apple-production
         type: string
     secrets:
-      app_store_connect_issuer_id:
+      caller_app_store_connect_issuer_id:
         required: false
-      app_store_connect_key_id:
+      caller_app_store_connect_key_id:
         required: false
-      app_store_connect_private_key:
+      caller_app_store_connect_private_key:
         required: false
 
 concurrency:
@@ -436,9 +436,9 @@ jobs:
           target: ${{ inputs.target }}
           plan-only: "false"
           confirm: "true"
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Retain approved captures and manifests
         if: always()

--- a/.github/workflows/powerforge-apple-screenshots.yml
+++ b/.github/workflows/powerforge-apple-screenshots.yml
@@ -74,11 +74,11 @@ on:
         default: ""
         type: string
     secrets:
-      app_store_connect_issuer_id:
+      caller_app_store_connect_issuer_id:
         required: false
-      app_store_connect_key_id:
+      caller_app_store_connect_key_id:
         required: false
-      app_store_connect_private_key:
+      caller_app_store_connect_private_key:
         required: false
 
 jobs:
@@ -425,9 +425,9 @@ jobs:
           target: ${{ inputs.target }}
           plan-only: "false"
           confirm: "true"
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Retain approved captures and manifests
         if: always()

--- a/.github/workflows/powerforge-apple-version-pr.yml
+++ b/.github/workflows/powerforge-apple-version-pr.yml
@@ -42,11 +42,11 @@ on:
         default: apple-release
         type: string
     secrets:
-      app_store_connect_issuer_id:
+      caller_app_store_connect_issuer_id:
         required: false
-      app_store_connect_key_id:
+      caller_app_store_connect_key_id:
         required: false
-      app_store_connect_private_key:
+      caller_app_store_connect_private_key:
         required: false
       version_pr_token:
         description: GitHub App or PAT token that can create a PR and trigger downstream workflows. The repository GITHUB_TOKEN is intentionally unsupported.
@@ -128,9 +128,9 @@ jobs:
           tool-path: ${{ steps.build-powerforge.outputs.tool-path }}
           marketing-version: ${{ inputs.version }}
           plan-only: "true"
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Apply the version update
         id: version
@@ -144,9 +144,9 @@ jobs:
           plan-only: "false"
           confirm: "true"
           expected-plan-sha256: ${{ steps.plan.outputs.plan-sha256 }}
-          issuer-id: ${{ secrets.app_store_connect_issuer_id }}
-          key-id: ${{ secrets.app_store_connect_key_id }}
-          private-key: ${{ secrets.app_store_connect_private_key }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}
+          key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}
+          private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}
 
       - name: Create the release version pull request
         id: pull-request

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
@@ -283,6 +283,49 @@ public sealed partial class AppleReleaseWorkflowTests
         }
     }
 
+    [Fact]
+    public void AppleActionPreservesFilesystemRootWhenResolvingReceiptPath()
+    {
+        if (!CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = Path.Combine(root, ".test-temp", $"apple-root-receipt-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(sandbox);
+            var filesystemRoot = Path.GetPathRoot(sandbox)!;
+            var receiptPath = Path.Combine(sandbox, "root-configured-receipt.json");
+            var configuredPath = Path.GetRelativePath(filesystemRoot, receiptPath);
+            File.WriteAllText(
+                Path.Combine(sandbox, "powerforge.release.json"),
+                JsonSerializer.Serialize(new
+                {
+                    AppleApps = new
+                    {
+                        ProjectRoot = filesystemRoot,
+                        Automation = new { ReceiptPath = configuredPath }
+                    }
+                }));
+            var envelope = JsonSerializer.Serialize(new
+            {
+                success = false,
+                exitCode = 1,
+                result = new { success = false, errorMessage = "Root receipt test." }
+            });
+
+            var result = RunAppleWrapper(root, sandbox, CreateFailingTool(sandbox, envelope), writeConfig: false);
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.True(File.Exists(receiptPath), result.StandardOutput + result.StandardError);
+            using var receipt = JsonDocument.Parse(File.ReadAllText(receiptPath));
+            Assert.Equal("Root receipt test.", receipt.RootElement.GetProperty("errorMessage").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
     private static ProcessResult RunAppleWrapper(
         string root,
         string sandbox,

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
@@ -1,0 +1,143 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace PowerForge.Tests;
+
+public sealed partial class AppleReleaseWorkflowTests
+{
+    [Fact]
+    public void AppleActionPersistsActionableReceiptWhenCliPreflightFailsBeforeEngineReceipt()
+    {
+        if (!CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = Path.Combine(root, ".test-temp", $"apple-preflight-receipt-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(sandbox);
+            var configPath = Path.Combine(sandbox, "powerforge.release.json");
+            var receiptPath = Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json");
+            var outputPath = Path.Combine(sandbox, "github-output.txt");
+            Directory.CreateDirectory(Path.GetDirectoryName(receiptPath)!);
+            File.WriteAllText(receiptPath, """{"success":true,"action":"Status","stale":true}""");
+            File.WriteAllText(
+                configPath,
+                """{"AppleApps":{"ProjectRoot":".","Automation":{"ReceiptPath":"build/powerforge/apple/release-receipt.json"}}}""");
+
+            const string errorMessage =
+                "AppleApps App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.";
+            var envelope = JsonSerializer.Serialize(new
+            {
+                success = false,
+                exitCode = 1,
+                error = "Apple release workflow failed.",
+                result = new { success = false, errorMessage }
+            });
+            var toolPath = CreateFailingTool(sandbox, envelope);
+            var scriptPath = Path.Combine(
+                root,
+                ".github",
+                "actions",
+                "apple-release",
+                "Invoke-PowerForgeAppleRelease.ps1");
+            var environment = new Dictionary<string, string?>
+            {
+                ["INPUT_ACTION"] = "Doctor",
+                ["INPUT_CONFIG_PATH"] = configPath,
+                ["INPUT_MARKETING_VERSION"] = string.Empty,
+                ["INPUT_SOURCE_COMMIT"] = new string('a', 40),
+                ["INPUT_EXPECTED_PLAN_SHA256"] = string.Empty,
+                ["INPUT_TARGET"] = string.Empty,
+                ["INPUT_PLAN_ONLY"] = "false",
+                ["INPUT_CONFIRM"] = "false",
+                ["POWERFORGE_TOOL_PATH"] = toolPath,
+                ["POWERFORGE_VERSION"] = "test",
+                ["GITHUB_OUTPUT"] = outputPath
+            };
+
+            var result = RunWithEnvironment(
+                "pwsh",
+                sandbox,
+                environment,
+                "-NoProfile",
+                "-File",
+                scriptPath);
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.True(File.Exists(receiptPath), result.StandardOutput + result.StandardError);
+            using var receipt = JsonDocument.Parse(File.ReadAllText(receiptPath));
+            var rootElement = receipt.RootElement;
+            Assert.False(rootElement.GetProperty("success").GetBoolean());
+            Assert.Equal("Doctor", rootElement.GetProperty("action").GetString());
+            Assert.False(rootElement.TryGetProperty("stale", out _));
+            Assert.Equal(errorMessage, rootElement.GetProperty("errorMessage").GetString());
+            var diagnostic = Assert.Single(rootElement.GetProperty("diagnostics").EnumerateArray());
+            Assert.Equal("APPLE_APP_STORE_CONNECT_CREDENTIALS_MISSING", diagnostic.GetProperty("code").GetString());
+            Assert.Equal("credential", diagnostic.GetProperty("category").GetString());
+            Assert.Contains("protected Apple environment", diagnostic.GetProperty("action").GetString(), StringComparison.Ordinal);
+
+            var outputs = File.ReadAllText(outputPath);
+            Assert.Contains("receipt-path=", outputs, StringComparison.Ordinal);
+            Assert.Contains("APPLE_APP_STORE_CONNECT_CREDENTIALS_MISSING", outputs, StringComparison.Ordinal);
+            Assert.DoesNotContain(errorMessage, result.StandardOutput, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    private static string CreateFailingTool(string directory, string envelope)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var path = Path.Combine(directory, "failing-tool.cmd");
+            File.WriteAllText(path, $"@echo off{Environment.NewLine}echo {envelope}{Environment.NewLine}exit /b 1{Environment.NewLine}");
+            return path;
+        }
+
+        var shellPath = Path.Combine(directory, "failing-tool.sh");
+        File.WriteAllText(shellPath, $"#!/bin/sh{Environment.NewLine}printf '%s\\n' '{envelope}'{Environment.NewLine}exit 1{Environment.NewLine}");
+        File.SetUnixFileMode(
+            shellPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return shellPath;
+    }
+
+    private static ProcessResult RunWithEnvironment(
+        string fileName,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string?> environment,
+        params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var pair in environment)
+            startInfo.Environment[pair.Key] = pair.Value;
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Unable to start '{fileName}'.");
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return new ProcessResult(process.ExitCode, standardOutput, standardError);
+    }
+
+    private static bool CommandExists(string command)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { command + ".exe", command + ".cmd", command + ".bat", command }
+            : new[] { command };
+        return path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Any(directory => candidates.Any(candidate => File.Exists(Path.Combine(directory, candidate))));
+    }
+}

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
@@ -229,6 +229,60 @@ public sealed partial class AppleReleaseWorkflowTests
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AppleActionRedirectsUnusableConfiguredReceiptShapesToSafeFallback(bool targetIsDirectory)
+    {
+        if (!CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = Path.Combine(root, ".test-temp", $"apple-unusable-receipt-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(sandbox);
+            var configuredPath = targetIsDirectory
+                ? "configured-receipt"
+                : Path.Combine("blocked-parent", "receipt.json");
+            if (targetIsDirectory)
+            {
+                Directory.CreateDirectory(Path.Combine(sandbox, configuredPath));
+            }
+            else
+            {
+                File.WriteAllText(Path.Combine(sandbox, "blocked-parent"), "not-a-directory");
+            }
+            File.WriteAllText(
+                Path.Combine(sandbox, "powerforge.release.json"),
+                JsonSerializer.Serialize(new
+                {
+                    AppleApps = new
+                    {
+                        ProjectRoot = ".",
+                        Automation = new { ReceiptPath = configuredPath }
+                    }
+                }));
+            var envelope = JsonSerializer.Serialize(new
+            {
+                success = false,
+                exitCode = 1,
+                result = new { success = false, errorMessage = "Receipt path is unusable." }
+            });
+
+            var result = RunAppleWrapper(root, sandbox, CreateFailingTool(sandbox, envelope), writeConfig: false);
+
+            Assert.NotEqual(0, result.ExitCode);
+            var safeReceipt = Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json");
+            Assert.True(File.Exists(safeReceipt), result.StandardOutput + result.StandardError);
+            using var receipt = JsonDocument.Parse(File.ReadAllText(safeReceipt));
+            Assert.Equal("Receipt path is unusable.", receipt.RootElement.GetProperty("errorMessage").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
     private static ProcessResult RunAppleWrapper(
         string root,
         string sandbox,

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.MonitorFailureReceipt.cs
@@ -5,8 +5,10 @@ namespace PowerForge.Tests;
 
 public sealed partial class AppleReleaseWorkflowTests
 {
-    [Fact]
-    public void AppleActionPersistsActionableReceiptWhenCliPreflightFailsBeforeEngineReceipt()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AppleActionPersistsActionableReceiptWhenCliPreflightFailsBeforeEngineReceipt(bool planOnly)
     {
         if (!CommandExists("pwsh")) return;
 
@@ -16,13 +18,18 @@ public sealed partial class AppleReleaseWorkflowTests
         {
             Directory.CreateDirectory(sandbox);
             var configPath = Path.Combine(sandbox, "powerforge.release.json");
-            var receiptPath = Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json");
+            var receiptPath = Path.Combine(
+                sandbox,
+                "build",
+                "powerforge",
+                "apple",
+                planOnly ? "release-plan.json" : "release-receipt.json");
             var outputPath = Path.Combine(sandbox, "github-output.txt");
             Directory.CreateDirectory(Path.GetDirectoryName(receiptPath)!);
             File.WriteAllText(receiptPath, """{"success":true,"action":"Status","stale":true}""");
             File.WriteAllText(
                 configPath,
-                """{"AppleApps":{"ProjectRoot":".","Automation":{"ReceiptPath":"build/powerforge/apple/release-receipt.json"}}}""");
+                """{"AppleApps":{"ProjectRoot":".","Automation":{"ReceiptPath":"build/powerforge/apple/release-receipt.json","PlanReceiptPath":"build/powerforge/apple/release-plan.json"}}}""");
 
             const string errorMessage =
                 "AppleApps App Store Connect API-key authentication requires AppStoreConnectApiKeyPath, AppStoreConnectApiKeyId, and AppStoreConnectApiIssuerId.";
@@ -48,7 +55,7 @@ public sealed partial class AppleReleaseWorkflowTests
                 ["INPUT_SOURCE_COMMIT"] = new string('a', 40),
                 ["INPUT_EXPECTED_PLAN_SHA256"] = string.Empty,
                 ["INPUT_TARGET"] = string.Empty,
-                ["INPUT_PLAN_ONLY"] = "false",
+                ["INPUT_PLAN_ONLY"] = planOnly.ToString().ToLowerInvariant(),
                 ["INPUT_CONFIRM"] = "false",
                 ["POWERFORGE_TOOL_PATH"] = toolPath,
                 ["POWERFORGE_VERSION"] = "test",
@@ -87,17 +94,201 @@ public sealed partial class AppleReleaseWorkflowTests
         }
     }
 
-    private static string CreateFailingTool(string directory, string envelope)
+    [Fact]
+    public void AppleActionReplacesStaleReceiptEvenWhenFailedEnvelopeHasDiagnostics()
+    {
+        if (!CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = Path.Combine(root, ".test-temp", $"apple-diagnostic-receipt-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(sandbox);
+            var receiptPath = Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(receiptPath)!);
+            File.WriteAllText(receiptPath, """{"success":true,"stale":true}""");
+            var envelope = JsonSerializer.Serialize(new
+            {
+                success = false,
+                exitCode = 1,
+                result = new
+                {
+                    success = false,
+                    errorMessage = "Remote readiness failed.",
+                    diagnostics = new[]
+                    {
+                        new
+                        {
+                            severity = "error",
+                            category = "readiness",
+                            code = "APPLE_READINESS_FAILED",
+                            summary = "Remote readiness failed.",
+                            action = "Correct readiness and retry.",
+                            retryable = false
+                        }
+                    }
+                }
+            });
+
+            var result = RunAppleWrapper(root, sandbox, CreateFailingTool(sandbox, envelope));
+
+            Assert.NotEqual(0, result.ExitCode);
+            using var receipt = JsonDocument.Parse(File.ReadAllText(receiptPath));
+            Assert.False(receipt.RootElement.GetProperty("success").GetBoolean());
+            Assert.False(receipt.RootElement.TryGetProperty("stale", out _));
+            Assert.Equal(
+                "APPLE_READINESS_FAILED",
+                Assert.Single(receipt.RootElement.GetProperty("diagnostics").EnumerateArray()).GetProperty("code").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AppleActionPreservesReceiptWrittenByFailedInvocationWhenStdoutIsMalformed()
+    {
+        if (!CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = Path.Combine(root, ".test-temp", $"apple-engine-receipt-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(sandbox);
+            var receiptPath = Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(receiptPath)!);
+            File.WriteAllText(receiptPath, """{"success":true,"stale":true}""");
+            var currentReceipt = """{"success":false,"action":"Doctor","engineMarker":true,"diagnostics":[]}""";
+            var toolPath = CreateFailingTool(sandbox, "not-json", receiptPath, currentReceipt);
+
+            var result = RunAppleWrapper(root, sandbox, toolPath);
+
+            Assert.NotEqual(0, result.ExitCode);
+            using var receipt = JsonDocument.Parse(File.ReadAllText(receiptPath));
+            Assert.True(receipt.RootElement.GetProperty("engineMarker").GetBoolean());
+            Assert.False(receipt.RootElement.TryGetProperty("errorMessage", out _));
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AppleActionNeverWritesFallbackReceiptOutsideProjectRootOrThroughLink()
+    {
+        if (!CommandExists("pwsh")) return;
+
+        var root = FindRepoRoot();
+        var sandbox = Path.Combine(root, ".test-temp", $"apple-safe-receipt-{Guid.NewGuid():N}");
+        var outside = Path.Combine(root, ".test-temp", $"apple-safe-receipt-outside-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(sandbox);
+            Directory.CreateDirectory(outside);
+            var outsideReceipt = Path.Combine(outside, "receipt.json");
+            File.WriteAllText(outsideReceipt, "sentinel");
+            var configuredPath = outsideReceipt;
+            if (!OperatingSystem.IsWindows())
+            {
+                var linkedDirectory = Path.Combine(sandbox, "linked");
+                Directory.CreateSymbolicLink(linkedDirectory, outside);
+                configuredPath = Path.Combine(linkedDirectory, "receipt.json");
+            }
+            File.WriteAllText(
+                Path.Combine(sandbox, "powerforge.release.json"),
+                JsonSerializer.Serialize(new
+                {
+                    AppleApps = new
+                    {
+                        ProjectRoot = ".",
+                        Automation = new { ReceiptPath = configuredPath }
+                    }
+                }));
+            var envelope = JsonSerializer.Serialize(new
+            {
+                success = false,
+                exitCode = 1,
+                result = new { success = false, errorMessage = "Receipt path is invalid." }
+            });
+
+            var result = RunAppleWrapper(root, sandbox, CreateFailingTool(sandbox, envelope), writeConfig: false);
+
+            Assert.NotEqual(0, result.ExitCode);
+            Assert.Equal("sentinel", File.ReadAllText(outsideReceipt));
+            var safeReceipt = Path.Combine(sandbox, "build", "powerforge", "apple", "release-receipt.json");
+            Assert.True(File.Exists(safeReceipt), result.StandardOutput + result.StandardError);
+            using var receipt = JsonDocument.Parse(File.ReadAllText(safeReceipt));
+            Assert.Equal("Receipt path is invalid.", receipt.RootElement.GetProperty("errorMessage").GetString());
+        }
+        finally
+        {
+            if (Directory.Exists(sandbox)) Directory.Delete(sandbox, recursive: true);
+            if (Directory.Exists(outside)) Directory.Delete(outside, recursive: true);
+        }
+    }
+
+    private static ProcessResult RunAppleWrapper(
+        string root,
+        string sandbox,
+        string toolPath,
+        bool writeConfig = true)
+    {
+        var configPath = Path.Combine(sandbox, "powerforge.release.json");
+        if (writeConfig)
+        {
+            File.WriteAllText(
+                configPath,
+                """{"AppleApps":{"ProjectRoot":".","Automation":{"ReceiptPath":"build/powerforge/apple/release-receipt.json"}}}""");
+        }
+        var outputPath = Path.Combine(sandbox, "github-output.txt");
+        var scriptPath = Path.Combine(
+            root,
+            ".github",
+            "actions",
+            "apple-release",
+            "Invoke-PowerForgeAppleRelease.ps1");
+        var environment = new Dictionary<string, string?>
+        {
+            ["INPUT_ACTION"] = "Doctor",
+            ["INPUT_CONFIG_PATH"] = configPath,
+            ["INPUT_MARKETING_VERSION"] = string.Empty,
+            ["INPUT_SOURCE_COMMIT"] = new string('a', 40),
+            ["INPUT_EXPECTED_PLAN_SHA256"] = string.Empty,
+            ["INPUT_TARGET"] = string.Empty,
+            ["INPUT_PLAN_ONLY"] = "false",
+            ["INPUT_CONFIRM"] = "false",
+            ["POWERFORGE_TOOL_PATH"] = toolPath,
+            ["POWERFORGE_VERSION"] = "test",
+            ["GITHUB_OUTPUT"] = outputPath
+        };
+        return RunWithEnvironment("pwsh", sandbox, environment, "-NoProfile", "-File", scriptPath);
+    }
+
+    private static string CreateFailingTool(
+        string directory,
+        string envelope,
+        string? receiptPath = null,
+        string? receiptJson = null)
     {
         if (OperatingSystem.IsWindows())
         {
             var path = Path.Combine(directory, "failing-tool.cmd");
-            File.WriteAllText(path, $"@echo off{Environment.NewLine}echo {envelope}{Environment.NewLine}exit /b 1{Environment.NewLine}");
+            var windowsWriteReceipt = receiptPath is null
+                ? string.Empty
+                : $"> \"{receiptPath}\" echo {receiptJson}{Environment.NewLine}";
+            File.WriteAllText(path, $"@echo off{Environment.NewLine}{windowsWriteReceipt}echo {envelope}{Environment.NewLine}exit /b 1{Environment.NewLine}");
             return path;
         }
 
         var shellPath = Path.Combine(directory, "failing-tool.sh");
-        File.WriteAllText(shellPath, $"#!/bin/sh{Environment.NewLine}printf '%s\\n' '{envelope}'{Environment.NewLine}exit 1{Environment.NewLine}");
+        var escapedReceiptPath = receiptPath?.Replace("'", "'\\''", StringComparison.Ordinal);
+        var escapedReceiptJson = receiptJson?.Replace("'", "'\\''", StringComparison.Ordinal);
+        var writeReceipt = receiptPath is null
+            ? string.Empty
+            : $"printf '%s\\n' '{escapedReceiptJson}' > '{escapedReceiptPath}'{Environment.NewLine}";
+        File.WriteAllText(shellPath, $"#!/bin/sh{Environment.NewLine}{writeReceipt}printf '%s\\n' '{envelope}'{Environment.NewLine}exit 1{Environment.NewLine}");
         File.SetUnixFileMode(
             shellPath,
             UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -312,6 +312,58 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
+    public void AppleReusableWorkflowsPreferProtectedEnvironmentCredentialsWithCallerFallback()
+    {
+        var root = FindRepoRoot();
+        var workflows = new[]
+        {
+            "powerforge-apple-monitor.yml",
+            "powerforge-apple-version-pr.yml",
+            "powerforge-apple-advance.yml",
+            "powerforge-apple-approval.yml",
+            "powerforge-apple-governance.yml",
+            "powerforge-apple-screenshots.yml",
+            "powerforge-apple-screenshot-approve.yml"
+        };
+
+        foreach (var name in workflows)
+        {
+            var workflow = Read(root, ".github", "workflows", name);
+            Assert.Contains("environment:", workflow, StringComparison.Ordinal);
+            Assert.Contains("caller_app_store_connect_issuer_id:", workflow, StringComparison.Ordinal);
+            Assert.Contains("caller_app_store_connect_key_id:", workflow, StringComparison.Ordinal);
+            Assert.Contains("caller_app_store_connect_private_key:", workflow, StringComparison.Ordinal);
+            Assert.Contains(
+                "issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID || secrets.caller_app_store_connect_issuer_id }}",
+                workflow,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "key-id: ${{ secrets.APP_STORE_CONNECT_KEY_ID || secrets.caller_app_store_connect_key_id }}",
+                workflow,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY || secrets.caller_app_store_connect_private_key }}",
+                workflow,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("\n      app_store_connect_issuer_id:", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain("\n      app_store_connect_key_id:", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain("\n      app_store_connect_private_key:", workflow, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "issuer-id: ${{ secrets.app_store_connect_issuer_id }}",
+                workflow,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "key-id: ${{ secrets.app_store_connect_key_id }}",
+                workflow,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "private-key: ${{ secrets.app_store_connect_private_key }}",
+                workflow,
+                StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void GovernanceWorkflowPlansBeforeProtectedConfirmedApplyWithCompactReceipts()
     {
         var root = FindRepoRoot();
@@ -520,7 +572,7 @@ public sealed partial class AppleReleaseWorkflowTests
     }
 
     [Fact]
-    public void AppleEnvironmentCredentialsRemainOptionalAtTheWorkflowCallBoundary()
+    public void AppleCallerCredentialFallbacksRemainOptionalAtTheWorkflowCallBoundary()
     {
         var root = FindRepoRoot();
         foreach (var workflowName in new[]
@@ -538,9 +590,9 @@ public sealed partial class AppleReleaseWorkflowTests
                 .Replace("\r\n", "\n", StringComparison.Ordinal);
             foreach (var secretName in new[]
                      {
-                         "app_store_connect_issuer_id",
-                         "app_store_connect_key_id",
-                         "app_store_connect_private_key"
+                         "caller_app_store_connect_issuer_id",
+                         "caller_app_store_connect_key_id",
+                         "caller_app_store_connect_private_key"
                      })
             {
                 Assert.Contains(

--- a/PowerForge.Tests/AppleReleaseWorkflowTests.cs
+++ b/PowerForge.Tests/AppleReleaseWorkflowTests.cs
@@ -87,6 +87,8 @@ public sealed partial class AppleReleaseWorkflowTests
         Assert.DoesNotContain("$json | Write-Host", script, StringComparison.Ordinal);
         Assert.Contains("safeDiagnostics", script, StringComparison.Ordinal);
         Assert.DoesNotContain("$envelope.error", script, StringComparison.Ordinal);
+        Assert.Contains("APPLE_APP_STORE_CONNECT_CREDENTIALS_MISSING", script, StringComparison.Ordinal);
+        Assert.Contains("Write-AtomicJsonFile", script, StringComparison.Ordinal);
         var failureStart = script.IndexOf("if ($exitCode -ne 0)", StringComparison.Ordinal);
         var failureEnd = script.IndexOf("if (-not $envelope.success)", failureStart, StringComparison.Ordinal);
         Assert.True(failureStart >= 0 && failureEnd > failureStart);


### PR DESCRIPTION
## Summary

- preserve the CLI preflight error when an Apple action fails before the release engine can write its normal receipt
- emit a stable credential diagnostic and remediation for missing App Store Connect API-key configuration
- atomically replace stale receipts using before/after file identity while preserving receipts written by the current engine invocation
- cover both execution and plan failures, including WriteReceipt=false and malformed CLI output
- constrain fallback and reported receipt paths to usable, unlinked file locations inside AppleApps.ProjectRoot
- redirect configured directory targets and file-blocked parent paths to the safe default receipt
- preserve Unix, Windows drive, and UNC filesystem roots during receipt-path normalization
- make every Apple reusable workflow prefer canonical credentials from its selected protected environment
- retain an explicit, non-shadowing caller-secret fallback through distinct caller_app_store_connect_* names
- keep public Actions output redacted while retaining the complete failure reason in the private receipt

## Why

Live read-only Doctor runs in Tactra, EmailIMO, and CasaRay exposed two connected problems: an early credential failure produced no actionable receipt, and the cross-repository reusable workflow secret aliases shadowed the selected consumer environment credentials. This change makes the monitor incident and retained artifact actionable and restores protected environment credential resolution without broadening secrets to repository scope.

## Compatibility

Callers that explicitly pass App Store Connect credentials must use caller_app_store_connect_issuer_id, caller_app_store_connect_key_id, and caller_app_store_connect_private_key. Existing consumers rely on protected environments and require no caller-side secret mapping.

## Validation

- 32 Apple reusable-workflow contract tests
- executable plan and non-plan early-failure regressions using the real action wrapper
- stale receipt, WriteReceipt=false, malformed-output preservation, out-of-root, linked-path, directory-target, file-blocked-parent, and filesystem-root coverage
- all seven credential-bearing reusable workflows enforce canonical environment names plus distinct optional caller fallbacks
- workflow YAML and embedded PowerShell parser validation
- PowerForge net472, net8.0, and net10.0 builds
- PowerForge CLI net10.0 build
- independent receipt review plus targeted confirmation; all three receipt P1 findings were fixed and confirmed
- independent credential-boundary review found one P1 same-name shadowing flaw; the distinct-alias remediation was confirmed with no remaining actionable finding