### PR TITLE
Fix aggregated input types in generated help

### DIFF
--- a/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
+++ b/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
@@ -1,0 +1,100 @@
+using System.Xml.Linq;
+
+namespace PowerForge.Tests;
+
+public sealed class DocumentationInputTypeNormalizationTests
+{
+    [Fact]
+    public void Normalize_SplitsPowerShellAggregatedInputTypesForGeneratedHelp()
+    {
+        var aggregate = "System.String[]\r\nPowerForge.ManagedModuleVersionInfo[]\r\n";
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Install-ManagedModule",
+            Inputs =
+            [
+                new DocumentationTypeHelp
+                {
+                    Name = aggregate,
+                    ClrTypeName = aggregate
+                }
+            ]
+        };
+        var payload = new DocumentationExtractionPayload
+        {
+            ModuleName = "PSPublishModule",
+            Commands = [command]
+        };
+
+        DocumentationMetadataNormalizer.Normalize(payload);
+
+        Assert.Collection(
+            command.Inputs,
+            input =>
+            {
+                Assert.Equal("System.String[]", input.Name);
+                Assert.Equal("System.String[]", input.ClrTypeName);
+            },
+            input =>
+            {
+                Assert.Equal("PowerForge.ManagedModuleVersionInfo[]", input.Name);
+                Assert.Equal("PowerForge.ManagedModuleVersionInfo[]", input.ClrTypeName);
+            });
+
+        var markdown = MarkdownHelpWriter.RenderCommandMarkdown("PSPublishModule", command);
+        Assert.Contains(
+            "## INPUTS\r\n\r\n- `System.String[]`\r\n- `PowerForge.ManagedModuleVersionInfo[]`\r\n",
+            markdown,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("%u000D", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("%u000A", markdown, StringComparison.Ordinal);
+
+        var root = Path.Combine(Path.GetTempPath(), "pf-input-types-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var mamlPath = new MamlHelpWriter().WriteExternalHelpFile(payload, "PSPublishModule", root);
+            var document = XDocument.Load(mamlPath);
+            var inputNames = document.Descendants()
+                .Where(element => element.Name.LocalName == "inputType")
+                .Select(element => element.Descendants().First(child => child.Name.LocalName == "name").Value)
+                .ToArray();
+
+            Assert.Equal(
+                new[] { "System.String[]", "PowerForge.ManagedModuleVersionInfo[]" },
+                inputNames);
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Normalize_DoesNotSplitAnAuthoredInputDescription()
+    {
+        var aggregate = "First\r\nSecond";
+        var command = new DocumentationCommandHelp
+        {
+            Name = "Get-Demo",
+            Inputs =
+            [
+                new DocumentationTypeHelp
+                {
+                    Name = aggregate,
+                    ClrTypeName = aggregate,
+                    Description = "An explicitly authored input identity."
+                }
+            ]
+        };
+
+        DocumentationMetadataNormalizer.Normalize(new DocumentationExtractionPayload { Commands = [command] });
+
+        var input = Assert.Single(command.Inputs);
+        Assert.Equal(aggregate, input.Name);
+        Assert.Equal("An explicitly authored input identity.", input.Description);
+
+        var markdown = MarkdownHelpWriter.RenderCommandMarkdown("DemoModule", command);
+        Assert.Contains("- `First%u000D%u000ASecond`", markdown, StringComparison.Ordinal);
+    }
+}

--- a/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
+++ b/PowerForge.Tests/DocumentationInputTypeNormalizationTests.cs
@@ -18,6 +18,15 @@ public sealed class DocumentationInputTypeNormalizationTests
                     Name = aggregate,
                     ClrTypeName = aggregate
                 }
+            ],
+            RuntimeInputs =
+            [
+                new DocumentationTypeHelp { Name = "String[]", ClrTypeName = "System.String[]" },
+                new DocumentationTypeHelp
+                {
+                    Name = "ManagedModuleVersionInfo[]",
+                    ClrTypeName = "PowerForge.ManagedModuleVersionInfo[]"
+                }
             ]
         };
         var payload = new DocumentationExtractionPayload
@@ -71,9 +80,9 @@ public sealed class DocumentationInputTypeNormalizationTests
     }
 
     [Fact]
-    public void Normalize_DoesNotSplitAnAuthoredInputDescription()
+    public void Normalize_PreservesAuthoredInputDescriptionEmbeddedByPowerShell()
     {
-        var aggregate = "First\r\nSecond";
+        var aggregate = "System.String\r\nThis is string input.";
         var command = new DocumentationCommandHelp
         {
             Name = "Get-Demo",
@@ -82,19 +91,24 @@ public sealed class DocumentationInputTypeNormalizationTests
                 new DocumentationTypeHelp
                 {
                     Name = aggregate,
-                    ClrTypeName = aggregate,
-                    Description = "An explicitly authored input identity."
+                    ClrTypeName = aggregate
                 }
+            ],
+            RuntimeInputs =
+            [
+                new DocumentationTypeHelp { Name = "String", ClrTypeName = "System.String" }
             ]
         };
 
         DocumentationMetadataNormalizer.Normalize(new DocumentationExtractionPayload { Commands = [command] });
 
         var input = Assert.Single(command.Inputs);
-        Assert.Equal(aggregate, input.Name);
-        Assert.Equal("An explicitly authored input identity.", input.Description);
+        Assert.Equal("System.String", input.Name);
+        Assert.Equal("System.String", input.ClrTypeName);
+        Assert.Equal("This is string input.", input.Description);
+        Assert.Empty(command.RuntimeInputs);
 
         var markdown = MarkdownHelpWriter.RenderCommandMarkdown("DemoModule", command);
-        Assert.Contains("- `First%u000D%u000ASecond`", markdown, StringComparison.Ordinal);
+        Assert.Contains("- `System.String` — This is string input.", markdown, StringComparison.Ordinal);
     }
 }

--- a/PowerForge.Tests/DocumentationPowerShellInputCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationPowerShellInputCompatibilityTests.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using System.Xml.Linq;
+
+namespace PowerForge.Tests;
+
+public sealed partial class DocumentationPowerShellCollectorTests
+{
+    [Fact]
+    public void DocumentationEngine_SplitsAggregatedInputTypesAcrossPowerShellHosts()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pf-doc-inputs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            var manifestPath = Path.Combine(root, "InputFixture.psd1");
+            File.WriteAllText(manifestPath, """
+@{
+    RootModule = 'InputFixture.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '88888888-8888-8888-8888-888888888888'
+    FunctionsToExport = @('Install-InputFixture')
+    CmdletsToExport = @()
+    AliasesToExport = @()
+    VariablesToExport = @()
+}
+""", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.WriteAllText(Path.Combine(root, "InputFixture.psm1"), """
+function Install-InputFixture {
+    [CmdletBinding(DefaultParameterSetName = 'ByName')]
+    param(
+        [Parameter(ValueFromPipeline = $true, ParameterSetName = 'ByName')]
+        [string[]] $Name,
+
+        [Parameter(ValueFromPipeline = $true, ParameterSetName = 'ByInfo')]
+        [psobject[]] $Info
+    )
+
+    process { }
+}
+
+Export-ModuleMember -Function Install-InputFixture
+""", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            var hosts = OperatingSystem.IsWindows()
+                ? new[] { "pwsh.exe", "powershell.exe" }
+                : new[] { "pwsh" };
+            foreach (var host in hosts)
+            {
+                var engine = new DocumentationEngine(new ExecutablePowerShellRunner(host, root), new NullLogger());
+                var payload = engine.ExtractHelpPayload(root, manifestPath, TimeSpan.FromMinutes(1));
+                var command = Assert.Single(payload.Commands);
+
+                Assert.Collection(
+                    command.Inputs,
+                    input => Assert.Equal("System.String[]", input.Name),
+                    input => Assert.Equal("System.Management.Automation.PSObject[]", input.Name));
+
+                var docsPath = Path.Combine(root, "Docs-" + Path.GetFileNameWithoutExtension(host));
+                new MarkdownHelpWriter().WriteCommandHelpFiles(payload, "InputFixture", docsPath);
+                var markdown = File.ReadAllText(Path.Combine(docsPath, "Install-InputFixture.md"));
+                Assert.Contains("- `System.String[]`\r\n", markdown, StringComparison.Ordinal);
+                Assert.Contains("- `System.Management.Automation.PSObject[]`\r\n", markdown, StringComparison.Ordinal);
+                Assert.DoesNotContain("%u000D", markdown, StringComparison.Ordinal);
+                Assert.DoesNotContain("%u000A", markdown, StringComparison.Ordinal);
+
+                var mamlPath = new MamlHelpWriter().WriteExternalHelpFile(payload, "InputFixture", root);
+                var maml = XDocument.Load(mamlPath);
+                var inputNames = maml.Descendants()
+                    .Where(element => element.Name.LocalName == "inputType")
+                    .Select(element => element.Descendants().First(child => child.Name.LocalName == "name").Value)
+                    .ToArray();
+                Assert.Equal(
+                    new[] { "System.String[]", "System.Management.Automation.PSObject[]" },
+                    inputNames);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/PowerForge.Tests/DocumentationPowerShellInputCompatibilityTests.cs
+++ b/PowerForge.Tests/DocumentationPowerShellInputCompatibilityTests.cs
@@ -19,7 +19,7 @@ public sealed partial class DocumentationPowerShellCollectorTests
     RootModule = 'InputFixture.psm1'
     ModuleVersion = '1.0.0'
     GUID = '88888888-8888-8888-8888-888888888888'
-    FunctionsToExport = @('Install-InputFixture')
+    FunctionsToExport = @('Install-InputFixture', 'Get-AuthoredInputFixture')
     CmdletsToExport = @()
     AliasesToExport = @()
     VariablesToExport = @()
@@ -39,7 +39,25 @@ function Install-InputFixture {
     process { }
 }
 
-Export-ModuleMember -Function Install-InputFixture
+function Get-AuthoredInputFixture {
+    <#
+    .SYNOPSIS
+    Gets an authored input fixture.
+
+    .INPUTS
+    System.String
+    This is string input.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [string] $InputObject
+    )
+
+    process { }
+}
+
+Export-ModuleMember -Function Install-InputFixture, Get-AuthoredInputFixture
 """, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
             var hosts = OperatingSystem.IsWindows()
@@ -49,7 +67,7 @@ Export-ModuleMember -Function Install-InputFixture
             {
                 var engine = new DocumentationEngine(new ExecutablePowerShellRunner(host, root), new NullLogger());
                 var payload = engine.ExtractHelpPayload(root, manifestPath, TimeSpan.FromMinutes(1));
-                var command = Assert.Single(payload.Commands);
+                var command = Assert.Single(payload.Commands, item => item.Name == "Install-InputFixture");
 
                 Assert.Collection(
                     command.Inputs,
@@ -66,13 +84,24 @@ Export-ModuleMember -Function Install-InputFixture
 
                 var mamlPath = new MamlHelpWriter().WriteExternalHelpFile(payload, "InputFixture", root);
                 var maml = XDocument.Load(mamlPath);
-                var inputNames = maml.Descendants()
+                var installCommand = maml.Descendants()
+                    .Single(element =>
+                        element.Name.LocalName == "command" &&
+                        element.Descendants().Any(child =>
+                            child.Name.LocalName == "name" &&
+                            child.Value == "Install-InputFixture"));
+                var inputNames = installCommand.Descendants()
                     .Where(element => element.Name.LocalName == "inputType")
                     .Select(element => element.Descendants().First(child => child.Name.LocalName == "name").Value)
                     .ToArray();
                 Assert.Equal(
                     new[] { "System.String[]", "System.Management.Automation.PSObject[]" },
                     inputNames);
+
+                var authored = Assert.Single(payload.Commands, item => item.Name == "Get-AuthoredInputFixture");
+                var authoredInput = Assert.Single(authored.Inputs);
+                Assert.Equal("System.String", authoredInput.Name);
+                Assert.Equal("This is string input.", authoredInput.Description);
             }
         }
         finally

--- a/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
+++ b/PowerForge/Scripts/Documentation/Export-HelpJson.ps1
@@ -654,9 +654,9 @@ try {
     } catch {
       # best effort: older hosts can omit or reshape InputTypes entirely
     }
-    if (-not $inputs -or $inputs.Count -eq 0) {
-      $seenInputs = @{}
-      foreach ($pn in $paramNames) {
+    $runtimeInputs = @()
+    $seenInputs = @{}
+    foreach ($pn in $paramNames) {
         $pmeta = $null
         try { $pmeta = $c.Parameters[$pn] } catch { $pmeta = $null }
         if (-not $pmeta) { continue }
@@ -691,8 +691,10 @@ try {
         $key = if ($inputTypeClrName) { $inputTypeClrName } else { $inputTypeName }
         if ($seenInputs.ContainsKey($key)) { continue }
         $seenInputs[$key] = $true
-        $inputs += [ordered]@{ name = $inputTypeName; clrTypeName = $inputTypeClrName; description = '' }
-      }
+        $runtimeInputs += [ordered]@{ name = $inputTypeName; clrTypeName = $inputTypeClrName; description = '' }
+    }
+    if (-not $inputs -or $inputs.Count -eq 0) {
+      $inputs = @($runtimeInputs)
     }
 
     $helpOutputs = @()
@@ -786,6 +788,7 @@ try {
       parameters = @($parameters)
       examples = @($examples)
       inputs = @($inputs)
+      runtimeInputs = @($runtimeInputs)
       outputs = @()
       authoredOutputs = @($helpOutputs)
       runtimeOutputs = @($runtimeOutputs)

--- a/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
+++ b/PowerForge/Services/Documentation/DocumentationExtractionPayload.cs
@@ -94,6 +94,10 @@ internal sealed class DocumentationCommandHelp
     [DataMember(Name = "inputs")]
     public List<DocumentationTypeHelp> Inputs { get; set; } = new();
 
+    /// <summary>Runtime pipeline input metadata captured from CommandInfo before reconciliation.</summary>
+    [DataMember(Name = "runtimeInputs")]
+    public List<DocumentationTypeHelp> RuntimeInputs { get; set; } = new();
+
     /// <summary>Return/output types (from Get-Help).</summary>
     [DataMember(Name = "outputs")]
     public List<DocumentationTypeHelp> Outputs { get; set; } = new();

--- a/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
@@ -16,58 +16,112 @@ internal static class DocumentationInputNormalizer
         if (command is null) throw new ArgumentNullException(nameof(command));
 
         var inputs = command.Inputs ?? new List<DocumentationTypeHelp>();
-        if (inputs.Count == 0) return;
+        var runtimeInputs = command.RuntimeInputs ?? new List<DocumentationTypeHelp>();
+        if (inputs.Count == 0)
+        {
+            command.Inputs = runtimeInputs;
+            command.RuntimeInputs = new List<DocumentationTypeHelp>();
+            return;
+        }
 
         var normalized = new List<DocumentationTypeHelp>(inputs.Count);
         foreach (var input in inputs)
         {
-            if (input is null || !TrySplitPowerShellInputAggregate(input, out var splitInputs))
+            if (input is null || !TryParsePowerShellInputAggregate(input, runtimeInputs, out var parsedInputs))
             {
                 if (input is not null) normalized.Add(input);
                 continue;
             }
 
-            normalized.AddRange(splitInputs);
+            normalized.AddRange(parsedInputs);
         }
 
         command.Inputs = normalized;
+        command.RuntimeInputs = new List<DocumentationTypeHelp>();
     }
 
-    private static bool TrySplitPowerShellInputAggregate(
+    private static bool TryParsePowerShellInputAggregate(
         DocumentationTypeHelp input,
-        out IReadOnlyList<DocumentationTypeHelp> splitInputs)
+        IReadOnlyList<DocumentationTypeHelp> runtimeInputs,
+        out IReadOnlyList<DocumentationTypeHelp> parsedInputs)
     {
-        splitInputs = Array.Empty<DocumentationTypeHelp>();
+        parsedInputs = Array.Empty<DocumentationTypeHelp>();
         if (!string.IsNullOrWhiteSpace(input.Description) ||
             !string.IsNullOrEmpty(input.CanonicalTypeName) ||
             !string.IsNullOrEmpty(input.RuntimeIdentity) ||
-            !string.IsNullOrEmpty(input.AssemblyQualifiedName))
+            !string.IsNullOrEmpty(input.AssemblyQualifiedName) ||
+            runtimeInputs.Count == 0)
             return false;
 
-        var names = SplitPowerShellHelpLines(input.Name);
-        if (names.Length < 2 || names.Any(string.IsNullOrEmpty)) return false;
+        var lines = SplitPowerShellHelpLines(input.Name);
+        if (lines.Length < 2 || lines.Any(string.IsNullOrEmpty)) return false;
 
-        string[] clrTypeNames;
-        if (string.IsNullOrEmpty(input.ClrTypeName))
-        {
-            clrTypeNames = Enumerable.Repeat(string.Empty, names.Length).ToArray();
-        }
-        else
-        {
-            clrTypeNames = SplitPowerShellHelpLines(input.ClrTypeName);
-            if (clrTypeNames.Length != names.Length || clrTypeNames.Any(string.IsNullOrEmpty)) return false;
-        }
+        var usedRuntimeInputs = new HashSet<int>();
+        var result = new List<DocumentationTypeHelp>();
+        DocumentationTypeHelp? current = null;
+        List<string>? descriptionLines = null;
 
-        splitInputs = names
-            .Select((name, index) => new DocumentationTypeHelp
+        foreach (var line in lines)
+        {
+            if (TryFindRuntimeInput(line, runtimeInputs, usedRuntimeInputs, out var runtimeIndex))
             {
-                Name = name,
-                ClrTypeName = clrTypeNames[index],
-                LookupName = name,
-                LookupClrTypeName = clrTypeNames[index]
-            })
-            .ToArray();
+                CompleteCurrent(result, current, descriptionLines);
+                var runtimeInput = runtimeInputs[runtimeIndex];
+                var clrTypeName = string.IsNullOrEmpty(runtimeInput.ClrTypeName)
+                    ? line
+                    : runtimeInput.ClrTypeName;
+                current = new DocumentationTypeHelp
+                {
+                    Name = line,
+                    ClrTypeName = clrTypeName,
+                    LookupName = line,
+                    LookupClrTypeName = clrTypeName
+                };
+                descriptionLines = new List<string>();
+                usedRuntimeInputs.Add(runtimeIndex);
+                continue;
+            }
+
+            if (current is null) return false;
+            descriptionLines!.Add(line);
+        }
+
+        CompleteCurrent(result, current, descriptionLines);
+        if (result.Count == 0) return false;
+        parsedInputs = result;
         return true;
+    }
+
+    private static bool TryFindRuntimeInput(
+        string line,
+        IReadOnlyList<DocumentationTypeHelp> runtimeInputs,
+        ISet<int> usedRuntimeInputs,
+        out int runtimeIndex)
+    {
+        for (var index = 0; index < runtimeInputs.Count; index++)
+        {
+            if (usedRuntimeInputs.Contains(index)) continue;
+            var runtimeInput = runtimeInputs[index];
+            if (string.Equals(line, runtimeInput.Name, StringComparison.Ordinal) ||
+                string.Equals(line, runtimeInput.ClrTypeName, StringComparison.Ordinal))
+            {
+                runtimeIndex = index;
+                return true;
+            }
+        }
+
+        runtimeIndex = -1;
+        return false;
+    }
+
+    private static void CompleteCurrent(
+        ICollection<DocumentationTypeHelp> result,
+        DocumentationTypeHelp? current,
+        IReadOnlyCollection<string>? descriptionLines)
+    {
+        if (current is null) return;
+        current.Description = string.Join("\n", descriptionLines ?? Array.Empty<string>());
+        result.Add(current);
     }
 
     private static string[] SplitPowerShellHelpLines(string value)

--- a/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationInputNormalizer.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PowerForge;
+
+/// <summary>
+/// Converts PowerShell's newline-aggregated Get-Help input type snapshot into
+/// individual documentation type entries without weakening identity escaping.
+/// </summary>
+internal static class DocumentationInputNormalizer
+{
+    /// <summary>Normalizes collected input metadata for one command.</summary>
+    internal static void Normalize(DocumentationCommandHelp command)
+    {
+        if (command is null) throw new ArgumentNullException(nameof(command));
+
+        var inputs = command.Inputs ?? new List<DocumentationTypeHelp>();
+        if (inputs.Count == 0) return;
+
+        var normalized = new List<DocumentationTypeHelp>(inputs.Count);
+        foreach (var input in inputs)
+        {
+            if (input is null || !TrySplitPowerShellInputAggregate(input, out var splitInputs))
+            {
+                if (input is not null) normalized.Add(input);
+                continue;
+            }
+
+            normalized.AddRange(splitInputs);
+        }
+
+        command.Inputs = normalized;
+    }
+
+    private static bool TrySplitPowerShellInputAggregate(
+        DocumentationTypeHelp input,
+        out IReadOnlyList<DocumentationTypeHelp> splitInputs)
+    {
+        splitInputs = Array.Empty<DocumentationTypeHelp>();
+        if (!string.IsNullOrWhiteSpace(input.Description) ||
+            !string.IsNullOrEmpty(input.CanonicalTypeName) ||
+            !string.IsNullOrEmpty(input.RuntimeIdentity) ||
+            !string.IsNullOrEmpty(input.AssemblyQualifiedName))
+            return false;
+
+        var names = SplitPowerShellHelpLines(input.Name);
+        if (names.Length < 2 || names.Any(string.IsNullOrEmpty)) return false;
+
+        string[] clrTypeNames;
+        if (string.IsNullOrEmpty(input.ClrTypeName))
+        {
+            clrTypeNames = Enumerable.Repeat(string.Empty, names.Length).ToArray();
+        }
+        else
+        {
+            clrTypeNames = SplitPowerShellHelpLines(input.ClrTypeName);
+            if (clrTypeNames.Length != names.Length || clrTypeNames.Any(string.IsNullOrEmpty)) return false;
+        }
+
+        splitInputs = names
+            .Select((name, index) => new DocumentationTypeHelp
+            {
+                Name = name,
+                ClrTypeName = clrTypeNames[index],
+                LookupName = name,
+                LookupClrTypeName = clrTypeNames[index]
+            })
+            .ToArray();
+        return true;
+    }
+
+    private static string[] SplitPowerShellHelpLines(string value)
+    {
+        var parts = (value ?? string.Empty).Split(
+            new[] { "\r\n", "\r", "\n" },
+            StringSplitOptions.None);
+        var count = parts.Length;
+        while (count > 0 && parts[count - 1].Length == 0) count--;
+        return count == parts.Length ? parts : parts.Take(count).ToArray();
+    }
+}

--- a/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
@@ -26,6 +26,7 @@ internal static class DocumentationMetadataNormalizer
             NormalizeBindableIdentities(command);
             NormalizeParameterSetIdentities(command);
             RestoreTypeIdentityText(command.Inputs);
+            RestoreTypeIdentityText(command.RuntimeInputs);
             RestoreTypeIdentityText(command.Outputs);
             RestoreTypeIdentityText(command.AuthoredOutputs);
             RestoreTypeIdentityText(command.RuntimeOutputs);

--- a/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
+++ b/PowerForge/Services/Documentation/DocumentationMetadataNormalizer.cs
@@ -29,6 +29,7 @@ internal static class DocumentationMetadataNormalizer
             RestoreTypeIdentityText(command.Outputs);
             RestoreTypeIdentityText(command.AuthoredOutputs);
             RestoreTypeIdentityText(command.RuntimeOutputs);
+            DocumentationInputNormalizer.Normalize(command);
             NormalizeParameters(command);
             NormalizeOutputs(command);
         }


### PR DESCRIPTION
## Summary

PowerShell Get-Help can expose both multiple pipeline input types and authored .INPUTS prose in one CR/LF-delimited type field. Escaping that aggregate as one identity produced %u000D/%u000A text in generated Markdown, while blindly splitting every line would misclassify authored descriptions as types.

This change transports runtime pipeline input identities separately and reconciles the raw host snapshot in typed C#. Known type lines become individual input entries; prose following an authored type remains its description. Identity escaping remains unchanged.

## Result

Generated Markdown and MAML render each real input type separately and preserve comment-based help descriptions, including through PowerShell 7 and Windows PowerShell 5.1 collectors.